### PR TITLE
Fix #98: allow elasticsearch to be disabled via configuration flag

### DIFF
--- a/metal-k8s.yml
+++ b/metal-k8s.yml
@@ -52,6 +52,7 @@
       tags: ['heapster']
     - role: kube_elasticsearch
       tags: ['elasticsearch']
+      when: metalk8s_elasticsearch_enabled|bool
     - role: kube_metrics_server
       tags: ['metrics-server']
 

--- a/roles/kube_elasticsearch/defaults/main.yml
+++ b/roles/kube_elasticsearch/defaults/main.yml
@@ -1,3 +1,6 @@
+metalk8s_elasticsearch_enabled: True
+
+
 debug: false
 
 remove_metal_k8s_temporary_file: true

--- a/tests/single-node/inventory/group_vars/k8s-cluster/single_node.yml
+++ b/tests/single-node/inventory/group_vars/k8s-cluster/single_node.yml
@@ -22,3 +22,5 @@ metal_k8s_storage_class:
             size: 11G
           lv02:
             size: 8G
+
+metalk8s_elasticsearch_enabled: False

--- a/tests/single-node/test.sh
+++ b/tests/single-node/test.sh
@@ -26,7 +26,7 @@ setup_suite() {
         make_shell true
 
         echo "Deploy the cluster"
-        make_shell ansible-playbook -i "$(pwd)/inventory" metal-k8s.yml --skip elasticsearch || die
+        make_shell ansible-playbook -i "$(pwd)/inventory" metal-k8s.yml|| die
 
         KUBECONFIG=$(pwd)/inventory/artifacts/admin.conf
         export KUBECONFIG


### PR DESCRIPTION
Installation with flag to metalk8s_elasticsearch_enabled=False will
skip elasticsearch installation.
Setting to flag to true and rerun the playbook will install es.
Disabling the flag and rerun the playbook will not remove elasticsearch.
Should be done manually.