### PR TITLE
kube_prometheus: Fix Prometheus UI URL

### DIFF
--- a/roles/kube_prometheus/templates/prometheus_values.yml
+++ b/roles/kube_prometheus/templates/prometheus_values.yml
@@ -8,7 +8,7 @@ grafana:
       kubernetes.io/name: "Grafana"
 
 prometheus:
-  externalUrl: '/api/v1/namespaces/kube-ops/services/kube-prometheus-prometheus:http/proxy/'
+  externalUrl: '/api/v1/namespaces/kube-ops/services/kube-prometheus:http/proxy/'
   service:
     labels:
       kubernetes.io/cluster-service: "true"


### PR DESCRIPTION
The name of the *Service* deployed by *kube-prometheus* was changed due
to 4f64e84328 (*kube-prometheus* 0.0.74) which we introduced in 431262.

See: 43126297d16ebc83c92374da88b45f118568df05
See: https://github.com/scality/metal-k8s/commit/43126297d16ebc83c92374da88b45f118568df05
See: https://github.com/scality/metal-k8s/pull/78
See: https://github.com/coreos/prometheus-operator/commit/4f64e84328f9a81e320f5ff9ab8f8a3900a51f19
See: https://github.com/coreos/prometheus-operator/pull/1398