### PR TITLE
Prepare Kubernetes 1.11

### DIFF
--- a/group_vars/k8s-cluster/10-metal-k8s.yml
+++ b/group_vars/k8s-cluster/10-metal-k8s.yml
@@ -3,6 +3,8 @@ helm_enabled: True
 kube_basic_auth: True
 kubeconfig_localhost: True
 
+dns_mode: 'coredns'
+
 # Request usage of the `overlay2` storage driver, even on pre-18.03 Docker
 # installs.
 # Whilst this is not guaranteed to work on 'old' kernels, we check whether we're

--- a/group_vars/k8s-cluster/10-metal-k8s.yml
+++ b/group_vars/k8s-cluster/10-metal-k8s.yml
@@ -4,6 +4,7 @@ kube_basic_auth: True
 kubeconfig_localhost: True
 
 dns_mode: 'coredns'
+kube_proxy_mode: 'ipvs'
 
 # Request usage of the `overlay2` storage driver, even on pre-18.03 Docker
 # installs.

--- a/metal-k8s.yml
+++ b/metal-k8s.yml
@@ -15,6 +15,10 @@
   roles:
     - role: check_os
 
+- hosts: k8s-cluster
+  roles:
+    - role: prepare_os
+
 - hosts: kube-node
   tags:
     - lvm-storage

--- a/roles/prepare_os/meta/main.yml
+++ b/roles/prepare_os/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/roles/prepare_os/tasks/main.yml
+++ b/roles/prepare_os/tasks/main.yml
@@ -1,0 +1,7 @@
+- name: Install packages
+  yum:
+    name: '{{ item }}'
+    state: latest
+  with_items:
+    - ipvsadm
+  when: ansible_os_family == 'RedHat'


### PR DESCRIPTION
Bite the bullet and upgrade to use CoreDNS and IPVS.