### PR TITLE
Makefile: Don't force interactive shells

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ $(BASHRC): $(SHELL_ENV_EXISTS) hack/shell-bashrc
 	$(V)sed s:@VENV_ACTIVATE@:$(VENV_ACTIVATE):g < hack/shell-bashrc > $@ || (rm -f $@; exit 1)
 
 shell: $(VENV_EXISTS) $(REQUIREMENTS_INSTALLED) $(KUBECTL) $(HELM) $(BASHRC) ## Run a shell with `ansible-playbook`, `kubectl` and `helm` pre-installed
-	$(V)if test -z "$(C)"; then \
+	$(V)BASH_ENV="$(BASHRC)"; export BASH_ENV; if test -z "$(C)"; then \
 		# Interactive shell \
 		echo "Launching MetalK8s shell environment. Run 'exit' to quit."; \
 		bash --rcfile $(BASHRC) ||:; \
@@ -138,10 +138,10 @@ shell: $(VENV_EXISTS) $(REQUIREMENTS_INSTALLED) $(KUBECTL) $(HELM) $(BASHRC) ## 
 		bash --rcfile $(BASHRC); \
 	elif test -e "$(C)"; then \
 		# A script \
-		bash --rcfile $(BASHRC) -i "$(C)"; \
+		bash --rcfile $(BASHRC) "$(C)"; \
 	else \
 		# A command \
-		bash --rcfile $(BASHRC) -i -c "$(C)"; \
+		bash --rcfile $(BASHRC) -c "$(C)"; \
 	fi
 .PHONY: shell
 

--- a/hack/shell-bashrc
+++ b/hack/shell-bashrc
@@ -1,8 +1,12 @@
-if [ -r ~/.bashrc ]; then
+# Only load `~/.bashrc` in interactive shells
+if [[ $- == *i* && -r ~/.bashrc ]]; then
     . ~/.bashrc
 fi
 
 . @VENV_ACTIVATE@
 
-. <(kubectl completion bash)
-. <(helm completion bash)
+# Only set up completion in interactive shells
+if [[ $- == *i* ]]; then
+    . <(kubectl completion bash)
+    . <(helm completion bash)
+fi


### PR DESCRIPTION
The change introduced in 0e63d42b seemed right, but wasn't the correct
solution to the problem. Also, it broke behaviour of `echo foo | make
shell C=-`.

After closer inspection of the Bash man-page, it looks like we should
instead be using `BASH_ENV` to modify the environment of a
non-interactive shell.

See: 0e63d42b3d2df1e4208778d901bea91c2d9058c6
See: https://github.com/scality/metal-k8s/commit/0e63d42b3d2df1e4208778d901bea91c2d9058c6#diff-b67911656ef5d18c4ae36cb6741b7965
See: https://github.com/scality/metal-k8s/pull/90
See: https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html
See: https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html#Bash-Startup-Files
See: https://github.com/scality/metal-k8s/pull/79