### PR TITLE
Elasticsearch metrics are being captured

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -37,5 +37,3 @@ indices
 
 :ghissue:`107` - the dashboard for Etcd monitoring isn't properly loaded by
 Grafana
-
-:ghissue:`108` - Elasticsearch metrics are not properly scraped by Prometheus


### PR DESCRIPTION
Likely due to an update of `kube-prometheus`, the `es-exporter` metrics
are again being captured, hence the Grafana dashboard works again.

See: #108
See: https://github.com/scality/metal-k8s/issues/108