### PR TITLE
Grafana: Fix `etcd` dashboard

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -34,6 +34,3 @@ Known issues
 ------------
 :ghissue:`62` - Elasticsearch Curator may not properly prune old `logstash-*`
 indices
-
-:ghissue:`107` - the dashboard for Etcd monitoring isn't properly loaded by
-Grafana

--- a/roles/kube_prometheus/files/additionnal_dashboard.yml
+++ b/roles/kube_prometheus/files/additionnal_dashboard.yml
@@ -13,7 +13,6 @@ grafana:
         "overwrite": true,
         "dashboard":
           {
-              "etcd.json": {
                   "annotations": {
                       "list": [
                       ]
@@ -22,7 +21,7 @@ grafana:
                   "editable": true,
                   "gnetId": null,
                   "hideControls": false,
-                  "id": 6,
+                  "id": null,
                   "links": [
                   ],
                   "refresh": false,
@@ -1170,7 +1169,6 @@ grafana:
                   "timezone": "browser",
                   "title": "etcd",
                   "version": 215
-              }
           }
       }
     elasticsearch-exporter-dashboard.json: |+


### PR DESCRIPTION
Temporary manual fix to get the `etcd` dashboard properly deployed. This
would be overwritten by a `Makefile` invocation, so beware.

A proper solution is under development.

See: #107
See: https://github.com/scality/metal-k8s/issues/107
See: https://github.com/scality/metal-k8s/issues/107#issuecomment-402778206