### PR TITLE
Elasticsearch: Set up Pod anti-affinity

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -3,6 +3,10 @@
 Release 0.1.1 (in development)
 ==============================
 
+Bugs fixed
+----------
+:ghissue:`103` - set up host anti-affinity for Elasticsearch service scheduling
+(:ghpull:`113`)
 
 Release 0.1.0
 =============

--- a/vendor/kubernetes-elasticsearch-cluster/es-ingest.yaml
+++ b/vendor/kubernetes-elasticsearch-cluster/es-ingest.yaml
@@ -75,6 +75,22 @@ spec:
         volumeMounts:
         - name: storage
           mountPath: /data
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                  - elasticsearch
+                - key: role
+                  operator: In
+                  values:
+                  - ingest
+              topologyKey: kubernetes.io/hostname
       volumes:
           - emptyDir:
               medium: ""

--- a/vendor/kubernetes-elasticsearch-cluster/es-master.yaml
+++ b/vendor/kubernetes-elasticsearch-cluster/es-master.yaml
@@ -69,6 +69,22 @@ spec:
         volumeMounts:
         - name: storage
           mountPath: /data
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                  - elasticsearch
+                - key: role
+                  operator: In
+                  values:
+                  - master
+              topologyKey: kubernetes.io/hostname
       volumes:
           - emptyDir:
               medium: ""

--- a/vendor/kubernetes-elasticsearch-cluster/stateful/es-data-stateful.yaml
+++ b/vendor/kubernetes-elasticsearch-cluster/stateful/es-data-stateful.yaml
@@ -74,6 +74,22 @@ spec:
         volumeMounts:
         - name: storage
           mountPath: /data
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                  - elasticsearch
+                - key: role
+                  operator: In
+                  values:
+                  - data
+              topologyKey: kubernetes.io/hostname
   volumeClaimTemplates:
   - metadata:
       name: storage


### PR DESCRIPTION
Fixes: #103
See: https://github.com/scality/metal-k8s/issues/103
See: https://github.com/pires/kubernetes-elasticsearch-cluster/tree/3053cdda99cdc6f67e6fee892119929d701b4e7e#pod-anti-affinity
See: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity-beta-feature