### PR TITLE
playbooks: Fix `services` playbook

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -8,6 +8,9 @@ Bugs fixed
 :ghissue:`103` - set up host anti-affinity for Elasticsearch service scheduling
 (:ghpull:`113`)
 
+:ghissue:`120` - required facts not gathered when running the `services`
+playbook in isolation (:ghpull:`132`)
+
 :ghpull:`134` - fix `bash-completion` in the MetalK8s Docker image
 
 Release 0.1.0

--- a/playbooks/services.yml
+++ b/playbooks/services.yml
@@ -1,3 +1,9 @@
+# https://github.com/scality/metal-k8s/issues/120
+- hosts: k8s-cluster:etcd
+  tasks:
+    - setup:
+  gather_facts: false
+
 - hosts: kube-master
   gather_facts: False
   roles:

--- a/tests/single-node/test.sh
+++ b/tests/single-node/test.sh
@@ -123,3 +123,7 @@ test_prometheus_node_exporter_metrics() {
         echo "Found ${NB_TARGET} targets"
         assert_not_equals 0 "${NB_TARGET}"
 }
+
+test_services_playbook() {
+        assert "make_shell ansible-playbook -i '$(pwd)/inventory' playbooks/services.yml"
+}


### PR DESCRIPTION
Because not all node facts were gathered when only running the
`services` playbook, the `kube_prometheus` role failed since it couldn't
find the IP addresses of all `etcd` and `k8s-cluster` nodes.

This is somewhat of a band-aid which ensures facts *are* gathered. Maybe
adding this to the code which 'requires' these values (i.e. somewhere in
the `kube_prometheus` role) would be better...

Fixes: #120
See: https://github.com/scality/metal-k8s/issues/120