### PR TITLE
Dockerfile: Fix `bash-completion`

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -8,6 +8,8 @@ Bugs fixed
 :ghissue:`103` - set up host anti-affinity for Elasticsearch service scheduling
 (:ghpull:`113`)
 
+:ghpull:`134` - fix `bash-completion` in the MetalK8s Docker image
+
 Release 0.1.0
 =============
 This marks the first release of `MetalK8s`_.

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,10 +39,13 @@ ENV KUBECONFIG=/inventory/artifacts/admin.conf
 # Runtime dependencies of `make shell`
 RUN apk --no-cache add \
         bash \
+        bash-completion \
         libffi \
         make \
         openssl \
         python
+
+RUN echo "source /etc/profile.d/bash_completion.sh" | tee ~/.bashrc
 
 # Be able to run `make shell`
 COPY Makefile requirements.txt ./


### PR DESCRIPTION
Completion for `kubectl` and `helm` wasn't working before.