### PR TITLE
Tests: Fix 're-deploy' test

### DIFF
--- a/tests/single-node/test.sh
+++ b/tests/single-node/test.sh
@@ -38,7 +38,7 @@ setup_suite() {
 }
 
 test_deploy_again() {
-        assert make_shell ansible-playbook -i "$(pwd)/inventory" metal-k8s.yml --skip elasticsearch
+        assert "make_shell ansible-playbook -i '$(pwd)/inventory' playbooks/deploy.yml"
 }
 
 test_reclaim_storage() {


### PR DESCRIPTION
While adding a new test-case, I noticed `test_deploy_again` was still
using the `metal-k8s.yml` playbook, yet not causing failures in CI.

Turns out `assert` was used incorrectly: it expects at least one
argument which is used as the command to execute. We were passing
`make_shell ansible-playbook ...` as-is, i.e. the tested command was
`make_shell` without the other arguments.

Fix is simple: quote the command appropriately.

See: 2028eff73ca6a3716b48e97cd86b1e8997b752f1
See: https://github.com/scality/metal-k8s/commit/2028eff73ca6a3716b48e97cd86b1e8997b752f1
See: #99
See: https://github.com/scality/metal-k8s/pull/99