### PR TITLE
kube_prometheus: Monitor CoreDNS

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -17,6 +17,11 @@ security hardening configurations from the
 
 .. _Cerebro: https://github.com/lmenezes/cerebro
 
+:ghpull:`140` - set up kube-prometheus_ to monitor CoreDNS_ (cfr. :ghpull:`104`)
+
+.. _kube-prometheus: https://github.com/coreos/prometheus-operator/tree/master/contrib/kube-prometheus
+.. _CoreDNS: https://coredns.io/
+
 Bugs fixed
 ----------
 :ghissue:`103` - set up host anti-affinity for Elasticsearch service scheduling

--- a/roles/kube_prometheus/templates/prometheus_values.yml
+++ b/roles/kube_prometheus/templates/prometheus_values.yml
@@ -51,3 +51,6 @@ exporter-kube-etcd:
 exporter-node:
   enableDaemonSet: false
   endpoints: {{ groups.etcd | union(groups['k8s-cluster']) | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | list | to_json }}
+
+deployKubeDNS: false
+deployCoreDNS: true


### PR DESCRIPTION
In 1d8418780ecf6, we switched KubeDNS for CoreDNS. The appropriate
changes to the configuration of the `kube_prometheus` deployment were,
however, not made accordingly.

See: 1d8418780ecf69940f7da5321f4bb8650f826e81