### PR TITLE
Kibana: Bump chart version

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -3,6 +3,9 @@
 Release 0.1.2 (in development)
 ==============================
 
+Features added
+--------------
+:ghpull:`144` - update Kibana chart version
 
 Release 0.1.1
 =============

--- a/roles/kube_elasticsearch/defaults/main.yml
+++ b/roles/kube_elasticsearch/defaults/main.yml
@@ -15,7 +15,7 @@ fluentd_elasticsearch_namespace: 'kube-ops'
 fluentd_elasticsearch_release_name: 'fluentd'
 
 kibana_chart: 'kibana'
-kibana_version: '0.6.0'
+kibana_version: '0.8.0'
 kibana_repo: 'https://kubernetes-charts.storage.googleapis.com'
 kibana_namespace: 'kube-ops'
 kibana_release_name: 'kibana'

--- a/roles/kube_elasticsearch/files/kibana-values.yml
+++ b/roles/kube_elasticsearch/files/kibana-values.yml
@@ -1,6 +1,3 @@
-image:
-  tag: '6.3.1'
-
 service:
   labels:
     kubernetes.io/cluster-service: "true"


### PR DESCRIPTION
- Remove the version-override, 6.3.1 is now upstream
- Custom labels on the Service are now properly propagated

See: https://github.com/kubernetes/charts/commit/654226f88babf5ef10641b04e8f22eb3064fbd50
See: https://github.com/kubernetes/charts/pull/6585
See: https://github.com/kubernetes/charts/commit/b81c2e292c8584d63ebcbcd15714929b18e6c0b2
See: https://github.com/kubernetes/charts/pull/5901