### PR TITLE
Fix `var` clause of `debug` steps

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -3,6 +3,9 @@
 Release 0.1.2 (in development)
 ==============================
 
+Bugs fixed
+----------
+:ghpull:`151` - fix `debug` clause `var` scoping
 
 Release 0.1.1
 =============

--- a/roles/kube_elasticsearch/tasks/main.yml
+++ b/roles/kube_elasticsearch/tasks/main.yml
@@ -61,7 +61,7 @@
   register: fluentd_values_file
 
 - debug:
-  var: fluentd_values_file.path
+    var: fluentd_values_file.path
   when: debug|bool
 
 - name: 'copy Fluentd values into temporary file'
@@ -109,7 +109,7 @@
   register: kibana_values_file
 
 - debug:
-  var: kibana_values_file.path
+    var: kibana_values_file.path
   when: debug|bool
 
 - name: 'copy Kibana values into temporary file'
@@ -145,7 +145,7 @@
   register: es_exporter_values_file
 
 - debug:
-  var: es_exporter_values_file.path
+    var: es_exporter_values_file.path
   when: debug|bool
 
 - name: 'copy ElasticSearch Exporter values into temporary file'

--- a/roles/kube_heapster/tasks/main.yml
+++ b/roles/kube_heapster/tasks/main.yml
@@ -5,7 +5,7 @@
   register: heapster_values_file
 
 - debug:
-  var: heapster_values_file.path
+    var: heapster_values_file.path
   when: debug|bool
 
 - name: 'copy Heapster values into temporary file'


### PR DESCRIPTION
This removes an ugly warning at the start of the playbook.