### PR TITLE
docs: Add `doc8`

### DIFF
--- a/docs/architecture/cluster-services.rst
+++ b/docs/architecture/cluster-services.rst
@@ -136,8 +136,8 @@ tuned for production-grade settings.
 
 Cerebro
 *******
-The Cerebro_ dashboard is a monitoring and administration tool for Elasticsearch
-clusters.
+The Cerebro_ dashboard is a monitoring and administration tool for
+Elasticsearch clusters.
 
 .. _Cerebro: https://github.com/lmenezes/cerebro
 

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -4,3 +4,5 @@ sphinxcontrib_github_alt >= 1.0
 sphinxcontrib-spelling >= 4.1
 sphinxcontrib-googleanalytics >= 0.1
 sphinx-autobuild >= 0.7.1
+
+doc8 >= 0.8.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -20,19 +20,22 @@ backports-abc==0.5 \
     --hash=sha256:033be54514a03e255df75c5aee8f9e672f663f93abb723444caec8fe43437bde \
     --hash=sha256:52089f97fe7a9aa0d3277b220c1d730a85aefd64e1b2664696fe35317c5470a7 \
     # via tornado
-certifi==2018.4.16 \
-    --hash=sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7 \
-    --hash=sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0 \
+certifi==2018.8.13 \
+    --hash=sha256:4c1d68a1408dd090d2f3a869aa94c3947cc1d967821d1ed303208c9f41f0f2f4 \
+    --hash=sha256:b6e8b28b2b7e771a41ecdd12d4d43262ecab52adebbafa42c77d6b57fb6ad3a4 \
     # via requests
 chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
-    # via requests
+    # via doc8, requests
+doc8==0.8.0 \
+    --hash=sha256:2df89f9c1a5abfb98ab55d0175fed633cae0cf45025b8b1e0ee5ea772be28543 \
+    --hash=sha256:d12f08aa77a4a65eb28752f4bc78f41f611f9412c4155e2b03f1f5d4a45efe04
 docutils==0.14 \
     --hash=sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6 \
     --hash=sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274 \
     --hash=sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6 \
-    # via sphinx
+    # via doc8, restructuredtext-lint, sphinx
 futures==3.2.0 \
     --hash=sha256:9ec02aa7d674acb8618afb127e27fde7fc68994c0437ad759fa094a574adb265 \
     --hash=sha256:ec0a6cb848cc212002b9828c3e34c675e0c9ff6741dc445cab6fdd4e1085d1f1 \
@@ -63,6 +66,10 @@ packaging==17.1 \
 pathtools==0.1.2 \
     --hash=sha256:7c35c5421a39bb82e58018febd90e3b6e5db34c5443aaaf742b3f33d4655f1c0 \
     # via sphinx-autobuild, watchdog
+pbr==4.2.0 \
+    --hash=sha256:1b8be50d938c9bb75d0eaf7eda111eec1bf6dc88a62a6412e33bf077457e0f45 \
+    --hash=sha256:b486975c0cafb6beeb50ca0e17ba047647f229087bd74e37f4a7e2cac17d2caa \
+    # via stevedore
 port-for==0.3.1 \
     --hash=sha256:b16a84bb29c2954db44c29be38b17c659c9c27e33918dec16b90d375cc596f1c \
     # via sphinx-autobuild
@@ -100,6 +107,9 @@ requests==2.19.1 \
     --hash=sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1 \
     --hash=sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a \
     # via sphinx
+restructuredtext-lint==1.1.3 \
+    --hash=sha256:c48ca9a84c312b262809f041fe47dcfaedc9ee4879b3e1f9532f745c182b4037 \
+    # via doc8
 singledispatch==3.4.0.3 \
     --hash=sha256:5b06af87df13818d14f08a028e42f566640aef80805c3b50c5056b086e3c2b9c \
     --hash=sha256:833b46966687b3de7f438c761ac475213e53b306740f1abfaa86e1d1aae56aa8 \
@@ -107,7 +117,7 @@ singledispatch==3.4.0.3 \
 six==1.11.0 \
     --hash=sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9 \
     --hash=sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb \
-    # via livereload, packaging, singledispatch, sphinx, sphinxcontrib-spelling
+    # via doc8, livereload, packaging, singledispatch, sphinx, sphinxcontrib-spelling, stevedore
 snowballstemmer==1.2.1 \
     --hash=sha256:919f26a68b2c17a7634da993d91339e288964f93c274f1343e3bbbe2096e1128 \
     --hash=sha256:9f3bcd3c401c3e862ec0ebe6d2c069ebc012ce142cce209c098ccb5b09136e89 \
@@ -132,6 +142,10 @@ sphinxcontrib-websupport==1.1.0 \
     --hash=sha256:68ca7ff70785cbe1e7bccc71a48b5b6d965d79ca50629606c7861a21b206d9dd \
     --hash=sha256:9de47f375baf1ea07cdb3436ff39d7a9c76042c10a769c52353ec46e4e8fc3b9 \
     # via sphinx
+stevedore==1.29.0 \
+    --hash=sha256:1e153545aca7a6a49d8337acca4f41c212fbfa60bf864ecd056df0cafb9627e8 \
+    --hash=sha256:c7eac1c0d95824c88b655273da5c17cdde6482b2739f47c30bf851dcc9d3c2c0 \
+    # via doc8
 tornado==5.1 \
     --hash=sha256:1c0816fc32b7d31b98781bd8ebc7a9726d7dce67407dc353a2e66e697e138448 \
     --hash=sha256:4f66a2172cb947387193ca4c2c3e19131f1c70fa8be470ddbbd9317fd0801582 \

--- a/docs/usage/quickstart.rst
+++ b/docs/usage/quickstart.rst
@@ -7,10 +7,10 @@
 
 Quickstart Guide
 ================
-To quickly set up a testing cluster using MetalK8s_, you need 3 machines running
-CentOS_ 7.4 to which you have SSH access (these can be VMs). Each machine
-acting as a Kubernetes_ node (all of them, in this example) also need to have at
-least one disk available to provision storage volumes.
+To quickly set up a testing cluster using MetalK8s_, you need 3 machines
+running CentOS_ 7.4 to which you have SSH access (these can be VMs). Each
+machine acting as a Kubernetes_ node (all of them, in this example) also
+need to have at least one disk available to provision storage volumes.
 
 .. todo:: Give some sizing examples
 
@@ -147,9 +147,9 @@ Entering the MetalK8s Shell
 ---------------------------
 To easily install a supported version of Ansible and its dependencies, as well
 as some Kubernetes tools (:program:`kubectl` and :program:`helm`), we provide a
-:program:`make` target which installs these in a local environment. To enter this
-environment, run :command:`make shell` (this takes a couple of seconds on first
-run)::
+:program:`make` target which installs these in a local environment. To enter
+this environment, run :command:`make shell` (this takes a couple of seconds on
+first run)::
 
     $ make shell
     Creating virtualenv...
@@ -167,16 +167,16 @@ Grab a coffee and wait for deployment to end.
 
 Inspecting the cluster
 ----------------------
-Once deployment finished, a file containing credentials to access the cluster is
-created: :file:`inventory/quickstart-cluster/artifacts/admin.conf`. We can
+Once deployment finished, a file containing credentials to access the cluster
+is created: :file:`inventory/quickstart-cluster/artifacts/admin.conf`. We can
 export this location in the shell such that the :program:`kubectl` and
 :program:`helm` tools know how to contact the cluster *kube-master* nodes, and
 authenticate properly::
 
     (metal-k8s) $ export KUBECONFIG=`pwd`/inventory/quickstart-cluster/artifacts/admin.conf
 
-Now, assuming port *6443* on the first *kube-master* node is reachable from your
-system, we can e.g. list the nodes::
+Now, assuming port *6443* on the first *kube-master* node is reachable from
+your system, we can e.g. list the nodes::
 
     (metal-k8s) $ kubectl get nodes
     NAME        STATUS    ROLES            AGE       VERSION
@@ -219,8 +219,8 @@ Cluster Services
 ----------------
 Various services to operate and monitor your MetalK8s cluster are provided. To
 access these, first create a secure tunnel into your cluster by running
-``kubectl proxy``. Then, while the tunnel is up and running, the following tools
-are available:
+``kubectl proxy``. Then, while the tunnel is up and running, the following
+tools are available:
 
 +-------------------------+---------------------------------------------------------+-------------------------------------------------------------------------------------------------+
 | Service                 | Role                                                    | Link                                                                                            |

--- a/tox.ini
+++ b/tox.ini
@@ -33,9 +33,15 @@ basepython = python2.7
 deps =
     -r{toxinidir}/docs/requirements.txt
 commands =
+    doc8 docs/
     make -C docs {posargs:html} SPHINXOPTS="-j 4 -n -W"
 whitelist_externals =
     make
+
+[doc8]
+ignore-path = docs/_build,docs/requirements.txt
+# For now...
+ignore-path-errors=docs/usage/quickstart.rst;D001
 
 [testenv:molecule]
 description = Run Ansible role tests using Molecule


### PR DESCRIPTION
Sadly enough, need to disable D001 for the `Quickstart` document because
of the wide table of services at the end.

See: https://pypi.org/project/doc8/