### PR TITLE
Remove hard dependency to python3.6

### DIFF
--- a/eve/tests/single-node/init.sh
+++ b/eve/tests/single-node/init.sh
@@ -15,5 +15,5 @@ iptables -F || die
 iptables -X || die
 
 yum install -y epel-release
-yum install -y python2-pip python2-devel python36 python36-devel
-pip2 install tox
+yum install -y python36 python36-devel
+pip3 install tox

--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,6 @@ whitelist_externals =
     sh
 
 [testenv:tests]
-basepython = python3.6
 skip_install = true
 deps =
     -r{toxinidir}/tests/requirements.txt


### PR DESCRIPTION
It works fine one python3.7, I would like  to loosen the python dependency without setting up envlist. (If someone has another idea)