### PR TITLE
INTEGRATION [PR#305 > development/1.1] Enable persistent logs by default

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -8,6 +8,8 @@ Features added
 
 :ghpull:`274` - add support for python3.7
 
+:ghull:`305` - ensure that journald logs are persisted across reboot (:ghissue:`303`)
+
 Bugs fixed
 ----------
 :ghissue:`237` - increase timeout of `prometheus-operator` deployment

--- a/roles/prepare_os/defaults/main.yml
+++ b/roles/prepare_os/defaults/main.yml
@@ -1,0 +1,3 @@
+persistent_logs: True
+
+persistent_logs_dir: /var/log/journal

--- a/roles/prepare_os/tasks/main.yml
+++ b/roles/prepare_os/tasks/main.yml
@@ -5,3 +5,5 @@
   with_items:
     - ipvsadm
   when: ansible_os_family == 'RedHat'
+
+- import_tasks: persistent_logs.yml

--- a/roles/prepare_os/tasks/persistent_logs.yml
+++ b/roles/prepare_os/tasks/persistent_logs.yml
@@ -1,0 +1,24 @@
+- name: 'check existence of {{ persistent_logs_dir }}'
+  stat:
+    path: '{{ persistent_logs_dir }}'
+  register: persistent_logs_dir_test
+
+- name: 'create {{ persistent_logs_dir }} if required'
+  file:
+    path: '{{ persistent_logs_dir }}'
+    state: directory
+  when:
+    - not persistent_logs_dir_test.stat.isdir|default(False)
+    - persistent_logs|bool
+
+- name: 'fail if {{ persistent_logs_dir }} exists and persistent_logs disabled'
+  fail:
+    msg: >-
+      By default journald enables persistent logs if {{ persistent_logs_dir }}
+      is present. We see that {{ persistent_logs_dir }} is present, but that
+      you have disabled persistent_logs. As we are cautious with your logs,
+      MetalK8s will not attempt to fix this. Please move or remove the
+      directory manually.
+  when:
+   - persistent_logs_dir_test.stat.isdir|default(False)
+   - not persistent_logs|bool


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #305.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/1.1/feature/enable_persistent_logs`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/1.1/feature/enable_persistent_logs
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/1.1/feature/enable_persistent_logs
```

Please always comment pull request #305 instead of this one.