### PR TITLE
INTEGRATION [PR#331 > development/1.1] etcd: Raise default memory limits

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -12,6 +12,8 @@ Features added
 
 Bugs fixed
 ----------
+:ghissue:`50` - raise default `etcd` memory limits (:ghpull:`331`)
+
 :ghissue:`237` - increase timeout of `prometheus-operator` deployment
 (:ghpull:`244`)
 

--- a/playbooks/group_vars/etcd/10-metal-k8s.yml
+++ b/playbooks/group_vars/etcd/10-metal-k8s.yml
@@ -6,3 +6,17 @@ docker_dns_servers_strict: False
 # running CentOS 7.4 or higher, with a kernel which contains all required
 # backports.
 docker_storage_options: -s overlay2 --storage-opt overlay2.override_kernel_check=true
+
+# Relax default memory limits for etcd processes.
+# The Kubespray default for this value is 0 (unlimited) when a system has
+# >= 4096MB of memory available, otherwise it's set to 512MB. Our recommended
+# memory sizing for etcd nodes is 4GB. However, even if a system has 4GB of
+# physical memory available, some kernels will report a slightly lower amount of
+# total memory available, hence the etcd process would be restricted to 512MB of
+# RAM (including kmem), and leave a large amount of memory allocated to this
+# role unused.
+# Instead of falling back to 512MB, let's assume that if an etcd node has less
+# than 4096MB RAM available it's a dedicated etcd node, and the process can use
+# up to 80% of the available memory.
+# See: https://github.com/scality/metalk8s/issues/50
+etcd_memory_limit: '{% if ansible_memtotal_mb < 4096 %}{{ (ansible_memtotal_mb * 0.80) | round(0, "floor") | int }}M{% else %}0{% endif %}'


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #331.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/1.1/improvement/no-etcd-memory-limits`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/1.1/improvement/no-etcd-memory-limits
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/1.1/improvement/no-etcd-memory-limits
```

Please always comment pull request #331 instead of this one.