### PR TITLE
Documentation PDF improvements

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -3,26 +3,35 @@
 # Note: the MetalK8s repository root is supposed to be mounted at
 # `/usr/src/metalk8s` when running the container
 
-FROM docker.io/alpine:3.8
+FROM docker.io/ubuntu:18.04
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install --no-install-recommends -y \
+        enchant \
+        git \
+        latexmk \
+        make \
+        python2.7 \
+        python3-buildbot-worker \
+        texlive-fonts-extra \
+        texlive-fonts-recommended \
+        texlive-latex-extra \
+        texlive-latex-recommended \
+        tox \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/metalk8s
 
 RUN mkdir docs
 
-RUN apk --no-cache add \
-        enchant \
-        git \
-        make \
-        py-twisted \
-        py2-pip \
-        && \
-    pip install \
-        tox \
-        buildbot-worker==0.9.12
-
 COPY tox.ini .
 COPY docs/requirements.txt docs/
 
-RUN tox --workdir /tmp/tox --notest -e docs
+RUN tox --workdir /tmp/tox --notest -e docs && \
+    rm -rf ~/.cache/pip
 
-ENTRYPOINT ["tox", "--workdir", "/tmp/tox", "-e", "docs"]
+ENTRYPOINT ["tox", "--workdir", "/tmp/tox", "-e", "docs", "--"]
+CMD ["html"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -134,15 +134,19 @@ htmlhelp_basename = 'MetalK8sdoc'
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #
-    # 'papersize': 'letterpaper',
+    'papersize': 'a4paper',
 
     # The font size ('10pt', '11pt' or '12pt').
     #
-    # 'pointsize': '10pt',
+    'pointsize': '10pt',
 
     # Additional stuff for the LaTeX preamble.
     #
-    # 'preamble': '',
+    'preamble': r'''
+        \usepackage{charter}
+        \usepackage[defaultsans]{lato}
+        \usepackage{inconsolata}
+    ''',
 
     # Latex figure (float) alignment
     #

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -68,4 +68,4 @@ stages:
     - Git: *git_pull
     - ShellCommand:
         name: 'Build doc'
-        command: tox -e docs
+        command: tox --workdir /tmp/tox -e docs -- html latexpdf


### PR DESCRIPTION
- Some styling tweaks
- Rework the `Dockerfile` to include what's needed to build a PDF
- Add PDF build step to CI

The `Dockerfile` changes make the image grow a lot (roughly 1.6GB...), but this makes building a PDF version of the docs significantly easier compared to somehow gathering all required LaTeX packages on a host system.