### PR TITLE
INTEGRATION [PR#354 > development/1.1] Doc has hability to fail CI run if not succeeded

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -68,4 +68,5 @@ stages:
     - Git: *git_pull
     - ShellCommand:
         name: 'Build doc'
+        haltOnFailure: true
         command: tox --workdir /tmp/tox -e docs -- html latexpdf

--- a/eve/workers/doc-builder.yaml
+++ b/eve/workers/doc-builder.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "metal-k8s-doc-buider"
+  name: "metalk8s-doc-buider"
 spec:
   containers:
   - name: worker


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #354.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/1.1/feature/failing_doc_is_failing_ci`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/1.1/feature/failing_doc_is_failing_ci
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/1.1/feature/failing_doc_is_failing_ci
```

Please always comment pull request #354 instead of this one.