### PR TITLE
docs: Windows compatibility fixes

### DIFF
--- a/docs/build.cmd
+++ b/docs/build.cmd
@@ -1,0 +1,11 @@
+#!/bin/bash -eE
+:<<"::batch"
+@echo off
+.\docs\make.bat %*
+goto :end
+::batch
+make -C docs $*
+exit $?
+:<<"::done"
+:end
+::done

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -10,8 +10,11 @@ if "%SPHINXBUILD%" == "" (
 set SOURCEDIR=.
 set BUILDDIR=_build
 set SPHINXPROJ=MetalK8s
+set SPHINXAUTOBUILD=sphinx-autobuild
+set SPHINXAUTOBUILDOPTS=--watch %SOURCEDIR%\.. --ignore "*~" --ignore "*.swp" --re-ignore "4913$" --re-ignore "\.git/"
 
 if "%1" == "" goto help
+if "%1" == "livehtml" goto livehtml
 
 %SPHINXBUILD% >NUL 2>NUL
 if errorlevel 9009 (
@@ -27,6 +30,10 @@ if errorlevel 9009 (
 )
 
 %SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+goto end
+
+:livehtml
+%SPHINXAUTOBUILD% %SPHINXAUTOBUILDOPTS% %SPHINXOPTS% %SOURCEDIR% %BUILDDIR%
 goto end
 
 :help

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -1,3 +1,6 @@
+# Required by Sphinx on Windows
+# Added here because `pip-compile` doesn't work cross-platform.
+colorama >= 0.3.9
 Sphinx >= 1.7
 sphinx_rtd_theme >= 0.3
 sphinxcontrib_github_alt >= 1.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -20,14 +20,17 @@ backports-abc==0.5 \
     --hash=sha256:033be54514a03e255df75c5aee8f9e672f663f93abb723444caec8fe43437bde \
     --hash=sha256:52089f97fe7a9aa0d3277b220c1d730a85aefd64e1b2664696fe35317c5470a7 \
     # via tornado
-certifi==2018.8.13 \
-    --hash=sha256:4c1d68a1408dd090d2f3a869aa94c3947cc1d967821d1ed303208c9f41f0f2f4 \
-    --hash=sha256:b6e8b28b2b7e771a41ecdd12d4d43262ecab52adebbafa42c77d6b57fb6ad3a4 \
+certifi==2018.8.24 \
+    --hash=sha256:376690d6f16d32f9d1fe8932551d80b23e9d393a8578c5633a2ed39a64861638 \
+    --hash=sha256:456048c7e371c089d0a77a5212fb37a2c2dce1e24146e3b7e0261736aaeaa22a \
     # via requests
 chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
     # via doc8, requests
+colorama==0.3.9 \
+    --hash=sha256:463f8483208e921368c9f306094eb6f725c6ca42b0f97e313cb5d5512459feda \
+    --hash=sha256:48eb22f4f8461b1df5734a074b57042430fb06e1d61bd1e11b078c0fe6d7a1f1
 doc8==0.8.0 \
     --hash=sha256:2df89f9c1a5abfb98ab55d0175fed633cae0cf45025b8b1e0ee5ea772be28543 \
     --hash=sha256:d12f08aa77a4a65eb28752f4bc78f41f611f9412c4155e2b03f1f5d4a45efe04
@@ -44,9 +47,9 @@ idna==2.7 \
     --hash=sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e \
     --hash=sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16 \
     # via requests
-imagesize==1.0.0 \
-    --hash=sha256:3620cc0cadba3f7475f9940d22431fc4d407269f1be59ec9b8edcca26440cf18 \
-    --hash=sha256:5b326e4678b6925158ccc66a9fa3122b6106d7c876ee32d7de6ce59385b96315 \
+imagesize==1.1.0 \
+    --hash=sha256:3f349de3eb99145973fefb7dbe38554414e5c30abd0c8e4b970a7c9d09f3a1d8 \
+    --hash=sha256:f3832918bc3c66617f92e35f5d70729187676313caa60c187eb0f28b8fe5e3b5 \
     # via sphinx
 jinja2==2.10 \
     --hash=sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd \
@@ -128,9 +131,9 @@ sphinx-autobuild==0.7.1 \
 sphinx-rtd-theme==0.4.1 \
     --hash=sha256:3b49758a64f8a1ebd8a33cb6cc9093c3935a908b716edfaa5772fd86aac27ef6 \
     --hash=sha256:80e01ec0eb711abacb1fa507f3eae8b805ae8fa3e8b057abfdf497e3f644c82c
-sphinx==1.7.6 \
-    --hash=sha256:217ad9ece2156ed9f8af12b5d2c82a499ddf2c70a33c5f81864a08d8c67b9efc \
-    --hash=sha256:a765c6db1e5b62aae857697cd4402a5c1a315a7b0854bbcd0fc8cdc524da5896
+sphinx==1.7.9 \
+    --hash=sha256:217a7705adcb573da5bbe1e0f5cab4fa0bd89fd9342c9159121746f593c2d5a4 \
+    --hash=sha256:a602513f385f1d5785ff1ca420d9c7eb1a1b63381733b2f0ea8188a391314a86
 sphinxcontrib-github-alt==1.0 \
     --hash=sha256:41666fbea5a7bb318363d45e39a1b3f01502ebb734e9acef332e34bf655448db
 sphinxcontrib-googleanalytics==0.1 \
@@ -155,15 +158,15 @@ tornado==5.1 \
     --hash=sha256:c58757e37c4a3172949c99099d4d5106e4d7b63aa0617f9bb24bfbff712c7866 \
     --hash=sha256:d8984742ce86c0855cccecd5c6f54a9f7532c983947cff06f3a0e2115b47f85c \
     # via livereload, sphinx-autobuild
-typing==3.6.4 \
-    --hash=sha256:3a887b021a77b292e151afb75323dea88a7bc1b3dfa92176cff8e44c8b68bddf \
-    --hash=sha256:b2c689d54e1144bbcfd191b0832980a21c2dbcf7b5ff7a66248a60c90e951eb8 \
-    --hash=sha256:d400a9344254803a2368533e4533a4200d21eb7b6b729c173bc38201a74db3f2 \
+typing==3.6.6 \
+    --hash=sha256:4027c5f6127a6267a435201981ba156de91ad0d1d98e9ddc2aa173453453492d \
+    --hash=sha256:57dcf675a99b74d64dacf6fba08fb17cf7e3d5fdff53d4a30ea2a5e7e52543d4 \
+    --hash=sha256:a4c8473ce11a65999c8f59cb093e70686b6c84c98df58c1dae9b3b196089858a \
     # via sphinx
 urllib3==1.23 \
     --hash=sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf \
     --hash=sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5 \
     # via requests
-watchdog==0.8.3 \
-    --hash=sha256:7e65882adb7746039b6f3876ee174952f8eaaa34491ba34333ddf1fe35de4162 \
+watchdog==0.9.0 \
+    --hash=sha256:965f658d0732de3188211932aeb0bb457587f04f63ab4c1e33eab878e9de961d \
     # via sphinx-autobuild

--- a/tox.ini
+++ b/tox.ini
@@ -34,9 +34,10 @@ deps =
     -r{toxinidir}/docs/requirements.txt
 commands =
     doc8 docs/
-    make -C docs {posargs:html} SPHINXOPTS="-j 4 -n -W"
-whitelist_externals =
-    make
+    {toxinidir}/docs/build.cmd {posargs:html}
+setenv =
+    O=-j4 -n -W
+    SPHINXOPTS=-j4 -n -W
 
 [doc8]
 ignore-path = docs/_build,docs/requirements.txt


### PR DESCRIPTION
- Add `colorama` to docs requirements: this is required by Sphinx on Windows, but `pip-compile` doesn't take platform markers into account, so building `requirements.txt` on Linux generates a file which doesn't include all dependencies required on a Windows host.
- Add a kludge to support building on Windows and Linux
- Support `livehtml` on Windows