### PR TITLE
node-access-checks: Add role

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -15,6 +15,9 @@ partition existence on specificied drives (:ghissue:`231`)
 
 :ghpull:`337` - assert `ansible_user` is not `root` (:ghissue:`329`)
 
+:ghpull:`368` - add more `ansible_user` assertions and cross-node connectivity
+checks (:ghissue:`128`, :ghissue:`329`, :ghissue:`367`, :ghpull:`337`)
+
 Bugs fixed
 ----------
 :ghissue:`50` - raise default `etcd` memory limits (:ghpull:`331`)

--- a/playbooks/init.yml
+++ b/playbooks/init.yml
@@ -1,3 +1,4 @@
+---
 - hosts: localhost
   gather_facts: False
   any_errors_fatal: True
@@ -6,10 +7,17 @@
   tags:
     - preflight-checks
 
-- hosts: k8s-cluster:etcd
-  gather_facts: False
-  tasks:
-    - ping:
+- name: Check node access
+  hosts: k8s-cluster:etcd
+  gather_facts: true
+  any_errors_fatal: '{{ any_errors_fatal | default(true) }}'
+  roles:
+    - role: node-access-checks
+      vars:
+        node_access_checks__remote_groups:
+          - k8s-cluster
+          - etcd
+  tags: ['role::node-access-checks']
 
 - hosts: k8s-cluster:etcd
   roles:

--- a/roles/node-access-checks/defaults/main.yml
+++ b/roles/node-access-checks/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+node_access_checks__remote_groups: []

--- a/roles/node-access-checks/tasks/main.yml
+++ b/roles/node-access-checks/tasks/main.yml
@@ -1,0 +1,64 @@
+---
+- name: Ping nodes from deployment host
+  ping:
+
+- name: Ping nodes from deployment host, and 'become'
+  ping:
+  become: true
+
+- name: Assert remote SSH user is not 'root'
+  block:
+    - name: Assert 'ansible_become_method' is 'sudo'
+      block:
+        - name: Lookup 'become' '$SUDO_COMMAND'
+          shell: 'echo -n "$SUDO_COMMAND"'
+          become: true
+          register: env_become_sudo_command
+          changed_when: false
+        - name: Assert 'ansible_become_method' is 'sudo'
+          assert:
+            that:
+              - 'env_become_sudo_command.stdout != ""'
+            msg: Using non-'sudo' 'ansible_become_method'
+          when: not ansible_check_mode
+
+    - name: Lookup '$USER'
+      shell: 'echo -n "$USER"'
+      become: false
+      register: env_user
+      changed_when: false
+    - name: Lookup 'become' '$USER'
+      shell: 'echo -n "$USER"'
+      become: true
+      register: env_become_user
+      changed_when: false
+    - name: Lookup '$SUDO_USER'
+      shell: 'echo -n "$SUDO_USER"'
+      become: true
+      register: env_sudo_user
+      changed_when: false
+    - name: Lookup '$SUDO_UID'
+      shell: 'echo -n "$SUDO_UID"'
+      become: true
+      register: env_sudo_uid
+      changed_when: false
+    - name: Assert 'ansible_user' is not 'root'
+      assert:
+        that:
+          - 'env_user.stdout != ""'
+          - 'env_user.stdout != "root"'
+          - 'env_become_user.stdout == "root"'
+          - 'env_sudo_user.stdout != ""'
+          - 'env_sudo_user.stdout != "root"'
+          - 'env_sudo_uid.stdout != ""'
+          - 'env_sudo_uid.stdout != "0"'
+        msg: Using 'root' as SSH user. This is not permitted.
+      when: not ansible_check_mode
+  when:
+    - 'ansible_connection != "local"'
+
+- name: Check inter-node connectivity using 'ping'
+  command: 'ping -4 -n -W 5 -c 1 "{{ hostvars[item]["ansible_default_ipv4"]["address"] }}"'
+  changed_when: false
+  with_inventory_hostnames: '{{ node_access_checks__remote_groups }}'
+  tags: ['role::node-access-checks::ping']


### PR DESCRIPTION
This adds a new role which performs various checks before starting
deployment:

- Assert the deployment host can access all `k8s-cluster` and `etcd`
  nodes
- Assert the SSH user is not `root`, or at least to a certain extent
- Assert all nodes can ICMP `ping` all other nodes

See: #367
See: https://github.com/scality/metalk8s/issues/367
See: #329
See: https://github.com/scality/metalk8s/issues/329
See: #128
See: https://github.com/scality/metalk8s/issues/128