### PR TITLE
Update third-party chart versions

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -19,6 +19,9 @@ Features added
 :ghpull:`327` - support 'external values' in `kube_heapster` and
 `kube_metrics_server`
 
+:ghpull:`373` - update third-party chart versions and use the `RollingUpdate`
+deployment strategy for Elasticsearch `data` and `master` daemons
+
 Bugs Fixed
 ----------
 :ghissue:`224` - variabilize the Kibana index pattern and service name in

--- a/roles/cluster_logging/defaults/main.yml
+++ b/roles/cluster_logging/defaults/main.yml
@@ -9,7 +9,7 @@ es_addon_dir: '{{ kube_config_dir }}/addons/elasticsearch'
 es_namespace: 'kube-ops'
 
 elasticsearch_chart: 'elasticsearch'
-elasticsearch_version: '1.4.0'
+elasticsearch_version: '1.7.2'
 elasticsearch_repo: 'https://kubernetes-charts-incubator.storage.googleapis.com'
 elasticsearch_namespace: 'kube-ops'
 elasticsearch_release_name: 'elasticsearch'

--- a/roles/cluster_logging/defaults/main.yml
+++ b/roles/cluster_logging/defaults/main.yml
@@ -16,7 +16,7 @@ elasticsearch_release_name: 'elasticsearch'
 elasticsearch_external_values: []
 
 elasticsearch_curator_chart: 'elasticsearch-curator'
-elasticsearch_curator_version: '0.3.0'
+elasticsearch_curator_version: '0.4.1'
 elasticsearch_curator_repo: 'https://kubernetes-charts-incubator.storage.googleapis.com'
 elasticsearch_curator_namespace: 'kube-ops'
 elasticsearch_curator_release_name: 'elasticsearch-curator'
@@ -24,18 +24,18 @@ elasticsearch_curator_external_values: []
 
 fluentd_release_name: 'fluentd'
 fluentd_chart: 'fluentd'
-fluentd_version: '0.1.4'
+fluentd_version: '0.1.5'
 fluentd_repo: 'https://kubernetes-charts-incubator.storage.googleapis.com'
 fluentd_namespace: 'kube-ops'
 
 fluent_bit_release_name: 'fluent-bit'
 fluent_bit_chart: 'fluent-bit'
-fluent_bit_version: '0.8.0'
+fluent_bit_version: '0.11.1'
 fluent_bit_repo: 'https://kubernetes-charts.storage.googleapis.com'
 fluent_bit_namespace: 'kube-ops'
 
 kibana_chart: 'kibana'
-kibana_version: '0.10.0'
+kibana_version: '0.13.1'
 kibana_repo: 'https://kubernetes-charts.storage.googleapis.com'
 kibana_namespace: 'kube-ops'
 kibana_release_name: 'kibana'
@@ -43,7 +43,7 @@ kibana_addons_dir: '/etc/kubernetes/addons/kibana'
 kibana_index_pattern: 'logstash-*'
 
 elasticsearch_exporter_chart: 'elasticsearch-exporter'
-elasticsearch_exporter_version: '0.2.0'
+elasticsearch_exporter_version: '0.2.2'
 elasticsearch_exporter_repo: 'https://kubernetes-charts.storage.googleapis.com'
 # Note: When changing this name, the 'ServiceMonitor' manifest needs to be
 # updated as well
@@ -54,7 +54,7 @@ elasticsearch_exporter_release_name: 'es-exporter'
 elasticsearch_exporter_external_values: []
 
 cerebro_repo: 'https://kubernetes-charts.storage.googleapis.com'
-cerebro_version: '0.3.0'
+cerebro_version: '0.3.1'
 cerebro_namespace: 'kube-ops'
 cerebro_release_name: 'cerebro'
 cerebro_chart: 'cerebro'

--- a/roles/cluster_logging/files/elasticsearch/values.yml
+++ b/roles/cluster_logging/files/elasticsearch/values.yml
@@ -24,6 +24,8 @@ master:
       cpu: 2
   podDisruptionBudget:
     enabled: true
+  updateStrategy:
+    type: RollingUpdate
 
 data:
   replicas: 3
@@ -39,3 +41,5 @@ data:
       cpu: 2
   podDisruptionBudget:
     enabled: true
+  updateStrategy:
+    type: RollingUpdate

--- a/roles/kube_heapster/defaults/main.yml
+++ b/roles/kube_heapster/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 debug: False
 
-heapster_version: '0.3.0'
+heapster_version: '0.3.1'
 # For kubernetes-dashboard to find Heapster, it needs to be installed in
 # `kube-system`.
 heapster_namespace: 'kube-system'

--- a/roles/kube_metrics_server/defaults/main.yml
+++ b/roles/kube_metrics_server/defaults/main.yml
@@ -2,7 +2,7 @@
 debug: false
 
 metrics_server_repo: 'https://kubernetes-charts.storage.googleapis.com'
-metrics_server_version: 1.1.0
+metrics_server_version: '2.0.2'
 metrics_server_namespace: kube-system
 metrics_server_release_name: metrics-server
 metrics_server_chart: metrics-server

--- a/roles/kube_metrics_server/tasks/main.yml
+++ b/roles/kube_metrics_server/tasks/main.yml
@@ -41,6 +41,7 @@
     binary: '{{ bin_dir }}/helm'
     values: >-
       {{ [kube_metrics_server__default_values] + metrics_server_external_values }}
+    state: latest
   register: metrics_server_helm_install
   run_once: true
 

--- a/roles/kube_metrics_server/vars/main.yml
+++ b/roles/kube_metrics_server/vars/main.yml
@@ -2,6 +2,9 @@
 kube_metrics_server__default_values:
   args:
   # Default:
-  #- --source=kubernetes.summary_api:''
-  # For https://github.com/scality/metalk8s/issues/36:
-  - "--source=kubernetes.summary_api:''?useServiceAccount=true&kubeletHttps=true&kubeletPort=10250&insecure=true"
+  - --logtostderr
+  # MetalK8s-specific:
+  - --kubelet-insecure-tls
+  # Required to make sure node hostnames aren't resolved through DNS
+  # See https://github.com/kubernetes-incubator/metrics-server/issues/131
+  - --kubelet-preferred-address-types=InternalIP,Hostname,InternalDNS,ExternalDNS,ExternalIP

--- a/roles/kube_nginx_ingress/defaults/main.yml
+++ b/roles/kube_nginx_ingress/defaults/main.yml
@@ -2,7 +2,7 @@ debug: False
 
 remove_metal_k8s_temporary_file: True
 
-nginx_ingress_version: '0.23.0'
+nginx_ingress_version: '0.28.2'
 nginx_ingress_namespace: 'kube-ingress'
 nginx_ingress_repo: 'https://kubernetes-charts.storage.googleapis.com'
 nginx_ingress_release_name: 'nginx-ingress'

--- a/roles/kube_prometheus/defaults/main.yml
+++ b/roles/kube_prometheus/defaults/main.yml
@@ -2,7 +2,7 @@ debug: False
 
 remove_metal_k8s_temporary_file: True
 
-prometheus_operator_version: '0.0.28'
+prometheus_operator_version: '0.0.29'
 prometheus_operator_namespace: 'kube-ops'
 prometheus_operator_repo: 'https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/'
 prometheus_operator_release_name: 'prometheus-operator'
@@ -10,7 +10,7 @@ prometheus_operator_release_name: 'prometheus-operator'
 # https://github.com/scality/metalk8s/issues/237
 prometheus_operator_timeout: 600
 
-kube_prometheus_version: '0.0.102'
+kube_prometheus_version: '0.0.105'
 kube_prometheus_namespace: 'kube-ops'
 kube_prometheus_repo: 'https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/'
 kube_prometheus_release_name: 'kube-prometheus'

--- a/tests/post/features/metrics_server.feature
+++ b/tests/post/features/metrics_server.feature
@@ -1,0 +1,7 @@
+Feature: metrics-server deployed in the cluster
+
+    Scenario: Check node statistics can be retrieved
+    Given an installed platform
+    When I wait for metrics-server to be initialized
+    And I GET a NodeMetricsList from /apis/metrics.k8s.io/v1beta1/nodes
+    Then I should count as many nodes as k8s-cluster hosts

--- a/tests/post/test_metrics_server.py
+++ b/tests/post/test_metrics_server.py
@@ -1,0 +1,52 @@
+import json
+
+import kubernetes.config
+
+import pytest_bdd
+import pytest_bdd.parsers
+
+import utils.helper
+
+pytest_bdd.scenarios('features/metrics_server.feature')
+
+
+@pytest_bdd.when('I wait for metrics-server to be initialized')
+def wait_until_initialized(kubeconfig):
+    client = kubernetes.config.new_client_from_config(config_file=kubeconfig)
+
+    # It can take up to a minute before metrics-server scraped some stats, see
+    # https://github.com/kubernetes-incubator/metrics-server/issues/134 and
+    # https://github.com/kubernetes-incubator/metrics-server/issues/136
+    for _ in utils.helper.retry(90, wait=1):
+        try:
+            (_, response_code, _) = client.call_api(
+                '/api/v1/namespaces/kube-system/services'
+                '/https:metrics-server:443/proxy/healthz',
+                'GET', _preload_content=False)
+        except kubernetes.client.rest.ApiException as exc:
+            response_code = exc.status
+
+        if response_code == 200:
+            break
+
+
+@pytest_bdd.when(pytest_bdd.parsers.parse('I GET a {kind} from {path}'))
+def raw_request(request, kubeconfig, kind, path):
+    client = kubernetes.config.new_client_from_config(config_file=kubeconfig)
+
+    (response, response_code, response_headers) = client.call_api(
+        path, 'GET', _preload_content=False)
+
+    assert response_code == 200
+    assert response_headers['content-type'] == 'application/json'
+
+    request.raw_response = json.loads(response.data.decode('utf-8'))
+
+    assert request.raw_response['kind'] == kind
+
+
+@pytest_bdd.then(pytest_bdd.parsers.parse(
+    'I should count as many nodes as {group_name} hosts'))
+def node_count_match(request, inventory_obj, group_name):
+    assert len(request.raw_response['items']) == \
+        len(inventory_obj.get_groups_dict()[group_name])


### PR DESCRIPTION
- Basic test for `metrics-server`
- Updates of various chart versions
- Update Elasticsearch to use `RollingUpdate` deployments