### PR TITLE
docs: Fix PDF outline

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -158,7 +158,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (master_doc, 'MetalK8s.tex', 'MetalK8s Documentation',
-     'Scality', 'manual'),
+     'Scality', 'manual', True),
 ]
 
 latex_logo = '../artwork/generated/metalk8s-logo-wide-black.pdf'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,46 +10,17 @@
 Welcome to the MetalK8s documentation!
 ======================================
 MetalK8s_ is an opinionated Kubernetes_ distribution with a focus on long-term
-on-prem deployments, launched by Scality_ to deploy its Zenko_ solution in
-customer datacenters.
+on-prem deployments. See :doc:`introduction` to learn more about the project,
+or :doc:`usage/quickstart` to get started.
 
 .. _MetalK8s: https://github.com/scality/metalk8s/
 .. _Kubernetes: https://kubernetes.io
-.. _Scality: https://www.scality.com
-.. _Zenko: https://www.zenko.io
-
-It is based on the Kubespray_ project to reliably install a base Kubernetes
-cluster, including all dependencies (like etcd_), using the Ansible_
-provisioning tool. This installation is further augmented with operational
-tools for monitoring and metering, including Prometheus_, Grafana_,
-ElasticSearch_ and Kibana_. Furthermore, an "ingress controller" is deployed
-by default, based on Nginx_. All of these are managed as Helm_ packages. See
-:doc:`architecture/cluster-services` for a whole listing.
-
-.. _Kubespray: https://github.com/kubernetes-incubator/kubespray/
-.. _etcd: https://coreos.com/etcd/
-.. _Ansible: https://www.ansible.com
-.. _Prometheus: https://prometheus.io
-.. _Grafana: https://grafana.com
-.. _ElasticSearch: https://www.elastic.co/products/elasticsearch/
-.. _Kibana: https://www.elastic.co/products/kibana/
-.. _Nginx: http://nginx.org
-.. _Helm: https://www.helm.sh
-
-Unlike hosted Kubernetes solutions, where network-attached storage is available
-and managed by the provider, we assume no such system to be available in
-environments where MetalK8s is deployed. As such, we focus on managing
-node-local storage, and exposing these volumes to containers managed in the
-cluster. See :doc:`architecture/storage` for more information.
-
-Getting started
----------------
-See our :doc:`usage/quickstart` to deploy a cluster.
 
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
+   introduction
    usage/quickstart
    architecture/index
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -1,0 +1,38 @@
+Introduction
+============
+MetalK8s_ is an opinionated Kubernetes_ distribution with a focus on long-term
+on-prem deployments, launched by Scality_ to deploy its Zenko_ solution in
+customer datacenters.
+
+.. _MetalK8s: https://github.com/scality/metalk8s/
+.. _Kubernetes: https://kubernetes.io
+.. _Scality: https://www.scality.com
+.. _Zenko: https://www.zenko.io
+
+It is based on the Kubespray_ project to reliably install a base Kubernetes
+cluster, including all dependencies (like etcd_), using the Ansible_
+provisioning tool. This installation is further augmented with operational
+tools for monitoring and metering, including Prometheus_, Grafana_,
+ElasticSearch_ and Kibana_. Furthermore, an "ingress controller" is deployed
+by default, based on Nginx_. All of these are managed as Helm_ packages. See
+:doc:`architecture/cluster-services` for a whole listing.
+
+.. _Kubespray: https://github.com/kubernetes-incubator/kubespray/
+.. _etcd: https://coreos.com/etcd/
+.. _Ansible: https://www.ansible.com
+.. _Prometheus: https://prometheus.io
+.. _Grafana: https://grafana.com
+.. _ElasticSearch: https://www.elastic.co/products/elasticsearch/
+.. _Kibana: https://www.elastic.co/products/kibana/
+.. _Nginx: http://nginx.org
+.. _Helm: https://www.helm.sh
+
+Unlike hosted Kubernetes solutions, where network-attached storage is available
+and managed by the provider, we assume no such system to be available in
+environments where MetalK8s is deployed. As such, we focus on managing
+node-local storage, and exposing these volumes to containers managed in the
+cluster. See :doc:`architecture/storage` for more information.
+
+Getting started
+---------------
+See our :doc:`usage/quickstart` to deploy a cluster.


### PR DESCRIPTION
Before these changes, the outline of the PDF rendering of the documentation would result in a top-level chapter called `Getting started`, which has all actual chapters as listed in the main `toctree` as sub-sections. This is, obviously, not the intent.

These changes set up Sphinx to discard content in `index.rst` and only use its `toctree` to create the PDF outline. Since this results in the introduction text to be no longer part of the rendered PDF, this text is moved into a separate section. Now the HTML rendering would be very sparse on the index page, hence adding some content with some initial pointers above the `toctree`.

I'll send a PDF rendering to @lucieleonard and others for validation.