### PR TITLE
docs: add Kube Heapster and Kube metrics server to advanced configuration

### DIFF
--- a/docs/usage/advanced_configuration.rst
+++ b/docs/usage/advanced_configuration.rst
@@ -44,5 +44,7 @@ Services which support this way of configuration
 - Elasticsearch
 - Elasticsearch curator
 - Elasticsearch exporter
+- Kube Heapster
+- Kube metrics server
 - Nginx ingress
 


### PR DESCRIPTION
see #372 