### PR TITLE
INTEGRATION [PR#382 > development/1.1] shell: Warn when Bash completion is not available

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -24,6 +24,9 @@ Bugs fixed
 
 :ghissue:`321` - retry until PV creation succeeds in `reclaim-storage` playbook (:ghpull:`319`)
 
+:ghissue:`381` - warn when Bash completion is not available in `make shell`
+(:ghpull:`382`)
+
 Release 1.0.0
 =============
 This marks the first production-ready release of `MetalK8s`_. Deployments using

--- a/hack/shell-bashrc
+++ b/hack/shell-bashrc
@@ -7,6 +7,15 @@ fi
 
 # Only set up completion in interactive shells
 if [[ $- == *i* ]]; then
-    . <(kubectl completion bash)
-    . <(helm completion bash)
+    if type -t _get_comp_words_by_ref > /dev/null; then
+        . <(kubectl completion bash)
+        . <(helm completion bash)
+    else
+        cat 1>&2 << EOF
+
+Shell completion for 'kubectl' and 'helm' not available. Consider installing
+the 'bash-completion' package.
+
+EOF
+    fi
 fi


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #382.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/1.1/improvement/bash-completion`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/1.1/improvement/bash-completion
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/1.1/improvement/bash-completion
```

Please always comment pull request #382 instead of this one.