### PR TITLE
docs: Share introduction between HTML and LaTeX

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -157,7 +157,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'MetalK8s.tex', 'MetalK8s Documentation',
+    ('index-latex', 'MetalK8s.tex', 'MetalK8s Documentation',
      'Scality', 'manual', True),
 ]
 

--- a/docs/index-latex.rst
+++ b/docs/index-latex.rst
@@ -1,0 +1,16 @@
+:orphan:
+
+.. note: Keep this in sync with the toctree in `index.rst`...
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   introduction
+   usage/quickstart
+   architecture/index
+
+   faq
+
+   changes
+
+   glossary

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,18 +9,14 @@
 
 Welcome to the MetalK8s documentation!
 ======================================
-MetalK8s_ is an opinionated Kubernetes_ distribution with a focus on long-term
-on-prem deployments. See :doc:`introduction` to learn more about the project,
-or :doc:`usage/quickstart` to get started.
+.. include:: introduction.rst
 
-.. _MetalK8s: https://github.com/scality/metalk8s/
-.. _Kubernetes: https://kubernetes.io
 
+.. note: Keep this in sync with the toctree in `index-latex.rst`...
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
-   introduction
    usage/quickstart
    architecture/index
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -1,5 +1,8 @@
-Introduction
-============
+.. only:: latex
+
+   Introduction
+   ============
+
 MetalK8s_ is an opinionated Kubernetes_ distribution with a focus on long-term
 on-prem deployments, launched by Scality_ to deploy its Zenko_ solution in
 customer datacenters.
@@ -33,6 +36,8 @@ environments where MetalK8s is deployed. As such, we focus on managing
 node-local storage, and exposing these volumes to containers managed in the
 cluster. See :doc:`architecture/storage` for more information.
 
-Getting started
----------------
-See our :doc:`usage/quickstart` to deploy a cluster.
+.. only:: not latex
+
+   Getting started
+   ---------------
+   See our :doc:`usage/quickstart` to deploy a cluster.


### PR DESCRIPTION
In 639c7d13e6e, the introduction text was moved into a separate
document, and replaced by a short description in the generated HTML
index page. This is somewhat sub-optimal.

These changes rearrange the documents to share the text. However, due to
how Sphinx TOC trees work, there's no way to conditionally include or
exclude documents, so a new entry-point document for the LaTeX rendering
is required, and the TOC trees need to be kept in sync.

See: 639c7d13e6ee750e80e2252e335cf1c1bf601ba4
See: #378
See: https://github.com/scality/metalk8s/pull/378