### PR TITLE
Add file to help debug etcd

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -30,6 +30,8 @@ deployment strategy for Elasticsearch `data` and `master` daemons
 
 :ghpull:`457` - update vendored Kubespray version
 
+:ghpull:`420` - add file to help debug etcd (:ghissue:`398`)
+
 Bugs Fixed
 ----------
 :ghissue:`224` - variabilize the Kibana index pattern and service name in

--- a/docs/operations-guide/index.rst
+++ b/docs/operations-guide/index.rst
@@ -7,4 +7,4 @@ Operations Guide
 
    advanced_configuration
    workload_storage
-
+   managing-etcd

--- a/docs/operations-guide/managing-etcd.rst
+++ b/docs/operations-guide/managing-etcd.rst
@@ -1,0 +1,37 @@
+Managing etcd
+=============
+`etcd`_ is a distributed key value store that provides a reliable way to store
+data across a cluster of machines. This database is the cornerstone of any
+Kubernetes installation, keeping records of all objects in the cluster.
+
+.. _etcd: https://coreos.com/etcd/
+
+As part of a MetalK8s deployment, an :program:`etcd` cluster is installed on
+members of the ``etcd`` group of your inventory.
+
+Access to the :program:`etcd` cluster is secured by TLS and client
+certificates. The :command:`etcdctl` tool is available on :program:`etcd`
+cluster nodes in :file:`/usr/local/bin` to interact with the service. To ease
+management of the :program:`etcd` cluster, a script to setup the shell
+environment to include :file:`/usr/local/bin` in :envvar:`PATH` and export the
+required TLS CA, certificate and key file paths and cluster endpoints is
+created on every ``etcd`` node as :file:`/etc/metalk8s/etcd.env.sh`.
+
+To use :command:`etcdctl`, get a ``root`` shell, and run
+
+.. code-block:: shell
+
+   source /etc/metalk8s/etcd.env.sh
+
+.. note:: Kubernetes uses version 3 of the :program:`etcd` protocol to store and
+   retrieve data. To access these objects using :command:`etcdctl`, you need to
+   set the environment variable :envvar:`ETCDCTL_API` to `3`, e.g. using
+
+   .. code-block:: shell
+
+      export ETCDCTL_API=3
+
+Refer to `the etcd documentation
+<https://github.com/etcd-io/etcd/blob/master/Documentation/dev-guide/interacting_v3.md>`_
+for more information about :command:`etcdctl` and how to interact with an
+:program:`etcd` cluster.

--- a/docs/reference-guide/glossary.rst
+++ b/docs/reference-guide/glossary.rst
@@ -36,7 +36,17 @@ Common Environment Variables
    logging is disabled. See :ref:`ansible:DEFAULT_LOG_PATH` for more
    information.
 
+.. envvar:: ETCDCTL_API
+
+   Version of the :program:`etcd` protocol :command:`etcdctl` will use when
+   connecting to the cluster.
+
 .. envvar:: KUBECONFIG
 
    Path to a file used to configure access to a Kubernetes cluster when using
    :command:`kubectl` or other tools.
+
+.. envvar:: PATH
+
+   Variable specifying a set of directories where executable  programs are
+   located.

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -10,6 +10,9 @@
 - import_playbook: '../vendor/kubespray/cluster.yml'
   tags: kubespray
 
+- import_playbook: 'kubespray-post.yml'
+  tags: ['kubespray-post']
+
 - import_playbook: 'storage-post.yml'
   tags: ['storage']
 

--- a/playbooks/kubespray-post.yml
+++ b/playbooks/kubespray-post.yml
@@ -1,0 +1,6 @@
+- hosts: etcd
+  any_errors_fatal: '{{ any_errors_fatal | default(true) }}'
+  gather_facts: False
+  roles:
+  - role: etcd_env_file
+    tags: ['etcd_env_file']

--- a/roles/etcd_env_file/defaults/main.yml
+++ b/roles/etcd_env_file/defaults/main.yml
@@ -1,0 +1,3 @@
+etcd_base_dir: /etc/ssl/etcd/ssl
+
+etcd_env_file_path: /etc/metalk8s/etcd.env.sh

--- a/roles/etcd_env_file/meta/main.yml
+++ b/roles/etcd_env_file/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - role: kubespray_module

--- a/roles/etcd_env_file/tasks/main.yml
+++ b/roles/etcd_env_file/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+
+- name: create env file directory
+  file:
+    path: '{{ etcd_env_file_path | dirname }}'
+    state: directory
+
+- name: 'deploy env file'
+  template:
+    src: etcd.env.sh.j2
+    dest: '{{ etcd_env_file_path }}'

--- a/roles/etcd_env_file/templates/etcd.env.sh.j2
+++ b/roles/etcd_env_file/templates/etcd.env.sh.j2
@@ -1,0 +1,5 @@
+export PATH=$PATH:/usr/local/bin
+export ETCDCTL_CA_FILE={{ etcd_base_dir }}/ca.pem
+export ETCDCTL_KEY_FILE={{ etcd_base_dir }}/admin-{{ inventory_hostname }}-key.pem
+export ETCDCTL_CERT_FILE={{ etcd_base_dir }}/admin-{{ inventory_hostname }}.pem
+export ETCDCTL_ENDPOINTS='{{ etcd_access_addresses }}'


### PR DESCRIPTION
I create the file only if I detect etcd files. The other possibility is to add the file no matter what. but only doing export PATH=$(PATH):/usr/local/bin => it seems a bit overkill to create the file just for that