### PR TITLE
INTEGRATION [PR#421 > development/1.1] docs: Fix link to Quickstart Guide in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An opinionated Kubernetes distribution with a focus on long-term on-prem deploym
 ## Quickstart
 For the really impatient, there's a [quickstart] available.
 
-[quickstart]: https://metal-k8s.readthedocs.io/en/latest/usage/quickstart.html
+[quickstart]: https://metal-k8s.readthedocs.io/en/latest/installation-guide/quickstart.html
 
 ## Documentation
 The project documentation is available at https://metal-k8s.readthedocs.io.


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #421.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/1.1/improvement/quickstart-link-in-readme`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/1.1/improvement/quickstart-link-in-readme
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/1.1/improvement/quickstart-link-in-readme
```

Please always comment pull request #421 instead of this one.