### PR TITLE
INTEGRATION [PR#425 > development/1.1] Fix duplicate key in the kube_nginx_ingress default variable

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -29,6 +29,8 @@ Bugs fixed
 
 :ghissue:`192` - `make shell` failing to start on OS X (:ghpull:`418`)
 
+:ghissue:`424` - remove warning related to kube_nginx_ingress roles (:ghpull:`425`)
+
 Release 1.0.0
 =============
 This marks the first production-ready release of `MetalK8s`_. Deployments using

--- a/roles/kube_nginx_ingress/defaults/main.yml
+++ b/roles/kube_nginx_ingress/defaults/main.yml
@@ -7,7 +7,5 @@ nginx_ingress_namespace: 'kube-ingress'
 nginx_ingress_repo: 'https://kubernetes-charts.storage.googleapis.com'
 nginx_ingress_release_name: 'nginx-ingress'
 
-debug: False
 nginx_ingress_prometheus_monitoring: True
 nginx_ingress_addons_dir: /etc/kubernetes/addons/nginx_ingress
-


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #425.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/1.1/bugfix/remove_warning_deublicate_default`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/1.1/bugfix/remove_warning_deublicate_default
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/1.1/bugfix/remove_warning_deublicate_default
```

Please always comment pull request #425 instead of this one.