### PR TITLE
docs: Fix Google Analytics Sphinx extension

### DIFF
--- a/docs/_lib/metalk8s_sphinxext_googleanalytics.py
+++ b/docs/_lib/metalk8s_sphinxext_googleanalytics.py
@@ -1,0 +1,75 @@
+# Based on the original sphinxcontrib.googleanalytics, see
+# https://github.com/sphinx-contrib/googleanalytics/blob/b0ee38b542ed5cd748fc640d27ab60383ac3e02c/sphinxcontrib/googleanalytics.py
+
+import sphinx.errors
+
+
+def ga_string(ua_id):
+    return '\n'.join([
+        "<!-- Google Analytics -->",
+        "<script>",
+        "window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;",  # noqa
+        "ga('create', '{ua_id}', 'auto');".format(ua_id=ua_id),
+        "ga('send', 'pageview');",
+        "</script>",
+        "<script async src='https://www.google-analytics.com/analytics.js'></script>",  # noqa
+        "<!-- End Google Analytics -->",
+    ])
+
+
+def add_ga_javascript(app, pagename, templatename, context, doctree):
+    if not app.config.googleanalytics_enabled:
+        return
+
+    metatags = context.get('metatags', '')
+    metatags += ga_string(app.config.googleanalytics_id)
+
+    context['metatags'] = metatags
+
+
+def check_config(app):
+    if app.config.googleanalytics_enabled \
+            and not app.config.googleanalytics_id:
+        raise sphinx.errors.ExtensionError(
+            "'googleanalytics_id' config value must be set for GA statistics "
+            "to function properly.")
+
+
+def setup(app):
+    app.add_config_value('googleanalytics_id', '', 'html')
+    app.add_config_value('googleanalytics_enabled', True, 'html')
+
+    app.connect('html-page-context', add_ga_javascript)
+    app.connect('builder-inited', check_config)
+
+    return {
+        'version': '0.1',
+    }
+
+
+if __name__ == '__main__':
+    import unittest
+
+    class TestExtension(unittest.TestCase):
+        def test_ga_string(self):
+            code = ga_string('UA-XXXXX-Y')
+            # https://developers.google.com/analytics/devguides/collection/analyticsjs/
+            expected = r'''
+<!-- Google Analytics -->
+<script>
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga('create', 'UA-XXXXX-Y', 'auto');
+ga('send', 'pageview');
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+<!-- End Google Analytics -->
+'''.strip()  # noqa
+
+            self.assertEqual(code, expected)
+
+        def test_ga_string_ua_id(self):
+            code = ga_string('UA-12345-67')
+
+            self.assertIn('UA-12345-67', code)
+
+    unittest.main()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,12 +11,17 @@
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
 
 import os
+import sys
+
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        '_lib',
+    )
+)
 
 ON_RTD = os.environ.get('READTHEDOCS') == 'True'
 
@@ -52,7 +57,7 @@ extensions = [
 
 if ON_RTD:
     extensions.extend([
-        'sphinxcontrib.googleanalytics',
+        'metalk8s_sphinxext_googleanalytics',
     ])
 
 # Add any paths that contain templates here, relative to this directory.
@@ -199,8 +204,8 @@ todo_include_todos = True
 # See http://sphinxcontrib-spelling.readthedocs.io/en/latest/customize.html
 spelling_word_list_filename = 'spelling-wordlist.txt'
 
-# -- Options for sphinxcontrib-googleanalytics -------------------------------
-# See https://pypi.org/project/sphinxcontrib-googleanalytics/
+# -- Options for metalk8s_sphinxext_googleanalytics --------------------------
+# See _lib/metalk8s_sphinxext_googleanalytics.py
 googleanalytics_id = 'UA-78443762-1'
 googleanalytics_enabled = ON_RTD
 

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -98,6 +98,9 @@ stages:
         name: 'Build doc'
         haltOnFailure: true
         command: tox --workdir /tmp/tox -e docs -- html latexpdf
+        env:
+          # Fake we're building in a ReadTheDocs environment
+          READTHEDOCS: 'True'
 
   pep8:
     worker:


### PR DESCRIPTION
The extension we used to use is broken when using Sphinx 1.8, but seems no longer maintained. As such, replacing it with a site-local version.

Also enabling it in CI.

Fixes: #430
Fixes: https://github.com/scality/metalk8s/issues/430
See: https://github.com/sphinx-doc/sphinx/commit/3d8cb12497dfa9a044e4b4eaa98b39c4000c1915#commitcomment-30845327