### PR TITLE
Upgrade metrics-server chart to deploy metrics-server 3.0.1

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -37,6 +37,9 @@ the index provisioning job (:ghpull:`233`).
 
 :ghpull:`251` - tag Grafana dashboards (:ghissue:`208`)
 
+:ghpull:`478` - metrics-server: ensure that missing pod/node data doesn't invalidate an entire node's results
+
+
 Release 1.0.1 (in development)
 ==============================
 Features added

--- a/roles/kube_metrics_server/defaults/main.yml
+++ b/roles/kube_metrics_server/defaults/main.yml
@@ -2,7 +2,7 @@
 debug: false
 
 metrics_server_repo: 'https://kubernetes-charts.storage.googleapis.com'
-metrics_server_version: '2.0.2'
+metrics_server_version: '2.0.3'
 metrics_server_namespace: kube-system
 metrics_server_release_name: metrics-server
 metrics_server_chart: metrics-server


### PR DESCRIPTION
From https://github.com/kubernetes-incubator/metrics-server/releases/tag/v0.3.1
"ensure that missing pod/node data doesn't invalidate an entire
 node's results".
This was triggered is the CI by elasticsearch external values test.