### PR TITLE
INTEGRATION [PR#478 > development/1.2] Upgrade metrics-server chart to deploy metrics-server 3.0.1

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -37,6 +37,9 @@ the index provisioning job (:ghpull:`233`).
 
 :ghpull:`251` - tag Grafana dashboards (:ghissue:`208`)
 
+:ghpull:`478` - metrics-server: ensure that missing pod/node data doesn't invalidate an entire node's results
+
+
 Release 1.0.1 (in development)
 ==============================
 Features added

--- a/roles/kube_metrics_server/defaults/main.yml
+++ b/roles/kube_metrics_server/defaults/main.yml
@@ -2,7 +2,7 @@
 debug: false
 
 metrics_server_repo: 'https://kubernetes-charts.storage.googleapis.com'
-metrics_server_version: '2.0.2'
+metrics_server_version: '2.0.3'
 metrics_server_namespace: kube-system
 metrics_server_release_name: metrics-server
 metrics_server_chart: metrics-server


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #478.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/1.2/bugfix/metrics_server_node_invalidation`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/1.2/bugfix/metrics_server_node_invalidation
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/1.2/bugfix/metrics_server_node_invalidation
```

Please always comment pull request #478 instead of this one.