### PR TITLE
INTEGRATION [PR#486 > development/1.1] docs: Add `docker`-based targets

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -16,6 +16,10 @@ SPHINXAUTOBUILDOPTS = \
 	--re-ignore '4913$$' \
 	--re-ignore '\.git/'
 
+DOCKER        = docker
+DOCKERIMAGE   = metalk8s-docs:latest
+SED           = sed
+
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
@@ -24,6 +28,10 @@ help:
 
 livehtml:
 	@$(SPHINXAUTOBUILD) $(SPHINXAUTOBUILDOPTS) $(SPHINXOPTS) $(O) "$(SOURCEDIR)" "$(BUILDDIR)"
+
+docker-%:
+	cd $(SOURCEDIR)/.. && $(DOCKER) build -t $(DOCKERIMAGE) -f docs/Dockerfile .
+	$(DOCKER) run -v $(shell python $(SOURCEDIR)/../hack/realpath.py $(SOURCEDIR)/..):/usr/src/metalk8s --rm $(DOCKERIMAGE) -- $(shell echo "$@" | $(SED) s/^docker-//)
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #486.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/1.1/improvement/doc-pdf-container`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/1.1/improvement/doc-pdf-container
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/1.1/improvement/doc-pdf-container
```

Please always comment pull request #486 instead of this one.