### PR TITLE
Update Kubernetes version to 1.10.11

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,6 +2,9 @@
 
 Release 1.0.1 (in development)
 ==============================
+This version updates the Kubernetes version to 1.10.11 to handle
+CVE-2018-100210.
+
 Features added
 --------------
 :ghpull:`232` - Add more storage checks regarding the device presence and the
@@ -36,6 +39,8 @@ capital letters
 (:ghpull:`409`)
 
 :ghpull:`472` - update Python `requests` library version
+
+:ghpull:`511` - update Kubernetes version to 1.10.11 to include a fix for CVE-2018-100210
 
 Release 1.0.0
 =============

--- a/playbooks/group_vars/k8s-cluster/10-metal-k8s.yml
+++ b/playbooks/group_vars/k8s-cluster/10-metal-k8s.yml
@@ -5,6 +5,8 @@ kubeconfig_localhost: True
 dns_mode: 'coredns'
 kube_proxy_mode: 'ipvs'
 
+kube_version: 'v1.10.11'
+
 # Request usage of the `overlay2` storage driver, even on pre-18.03 Docker
 # installs.
 # Whilst this is not guaranteed to work on 'old' kernels, we check whether we're


### PR DESCRIPTION
On Dec 3th CVE-2018-1002105 was published, a critical security issue
present in all previous versions of the Kubernetes API Server.

This vulnerability allows specially crafted requests to establish a
connection through the Kubernetes API server to backend servers (such
as aggregated API servers and kubelets), then send arbitrary requests
over the same connection directly to the backend, authenticated with
the Kubernetes API server’s TLS credentials used to establish the
backend connection.

See: https://github.com/kubernetes/kubernetes/issues/71411