### PR TITLE
Update Kubernetes version to 1.11.5

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,6 +2,9 @@
 
 Release 1.1.0 (in development)
 ==============================
+This version updates the Kubernetes version to 1.11.5 to handle
+CVE-2018-100210.
+
 Features added
 --------------
 :ghpull:`346` - add Elasticsearch external values capability (:ghissue:`340`)
@@ -41,6 +44,7 @@ the index provisioning job (:ghpull:`233`).
 
 :ghpull:`478` - metrics-server: ensure that missing pod/node data doesn't invalidate an entire node's results
 
+:ghpull:`514` - update Kubernetes version to 1.11.5 to include a fix for CVE-2018-100210
 
 Release 1.0.1 (in development)
 ==============================

--- a/playbooks/group_vars/k8s-cluster/10-metal-k8s.yml
+++ b/playbooks/group_vars/k8s-cluster/10-metal-k8s.yml
@@ -5,6 +5,12 @@ kubeconfig_localhost: True
 dns_mode: 'coredns'
 kube_proxy_mode: 'ipvs'
 
+kube_version: 'v1.11.5'
+hyperkube_checksums:
+  v1.11.5: 88e17abcc821e4895184e64d4b136095263b147c6d679b6e5177b0f58a2629cc
+kubeadm_checksums:
+  v1.11.5: b28ec97875cad94ef9d554d9fb1170674e6588c97e1746f2026e0795aecabc40
+
 # Request usage of the `overlay2` storage driver, even on pre-18.03 Docker
 # installs.
 # Whilst this is not guaranteed to work on 'old' kernels, we check whether we're


### PR DESCRIPTION
On Dec 3th CVE-2018-1002105 was published, a critical security issue
present in all previous versions of the Kubernetes API Server.

This vulnerability allows specially crafted requests to establish a
connection through the Kubernetes API server to backend servers (such
as aggregated API servers and kubelets), then send arbitrary requests
over the same connection directly to the backend, authenticated with
the Kubernetes API server’s TLS credentials used to establish the
backend connection.

See: https://github.com/kubernetes/kubernetes/issues/71411
See: https://github.com/scality/metalk8s/pull/511