### PR TITLE
Update Kubernetes version to 1.12.3

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,6 +2,9 @@
 
 Release 1.2.0 (in development)
 ==============================
+This version updates the Kubernetes version to 1.12.3 to handle
+CVE-2018-100210.
+
 Features added
 --------------
 :ghpull:`462` - update vendored Kubespray version
@@ -12,6 +15,9 @@ Features added
 
 :ghpull:`499` - use helm_cli to install prometheus (:ghissue:`496`)
 
+Bugs Fixed
+----------
+:ghpull:`517` - update Kubernetes version to 1.12.3 to include a fix for CVE-2018-100210
 
 Release 1.1.0 (in development)
 ==============================

--- a/playbooks/group_vars/k8s-cluster/10-metal-k8s.yml
+++ b/playbooks/group_vars/k8s-cluster/10-metal-k8s.yml
@@ -5,6 +5,12 @@ kubeconfig_localhost: True
 dns_mode: 'coredns'
 kube_proxy_mode: 'ipvs'
 
+kube_version: 'v1.12.3'
+hyperkube_checksums:
+  v1.12.3: 600aad3f0d016716abd85931239806193ffbe95f2edfdcea11532d518ae5cdb1
+kubeadm_checksums:
+  v1.12.3: c675aa3be82754b3f8dfdde2a1526a72986713312d46d898e65cb564c6aa8ad4
+
 # Request usage of the `overlay2` storage driver, even on pre-18.03 Docker
 # installs.
 # Whilst this is not guaranteed to work on 'old' kernels, we check whether we're


### PR DESCRIPTION
On Dec 3th CVE-2018-1002105 was published, a critical security issue
present in all previous versions of the Kubernetes API Server.

This vulnerability allows specially crafted requests to establish a
connection through the Kubernetes API server to backend servers (such
as aggregated API servers and kubelets), then send arbitrary requests
over the same connection directly to the backend, authenticated with
the Kubernetes API server’s TLS credentials used to establish the
backend connection.

See: https://github.com/kubernetes/kubernetes/issues/71411
See: https://github.com/scality/metalk8s/pull/511
See: https://github.com/scality/metalk8s/pull/514