### PR TITLE
Should let enough time to tiller to come up

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -42,6 +42,9 @@ capital letters
 
 :ghpull:`511` - update Kubernetes version to 1.10.11 to include a fix for CVE-2018-100210
 
+:ghpull:`523` - reduce Tiller wait timeout to reduce CI time to failure
+
+
 Release 1.0.0
 =============
 This marks the first production-ready release of `MetalK8s`_. Deployments using

--- a/roles/helm_common/tasks/main.yml
+++ b/roles/helm_common/tasks/main.yml
@@ -2,7 +2,7 @@
   command: '{{ bin_dir }}/helm version'
   register: helm_version
   until: not helm_version|failed
-  retries: 50000
+  retries: 50
   delay: 10
   changed_when: False
   check_mode: False


### PR DESCRIPTION
and reduce CI time to failure (and avoid nasty garbage collection)