### PR TITLE
INTEGRATION [PR#523 > development/1.1] Should let enough time to tiller to come up

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -37,6 +37,8 @@ capital letters
 
 :ghpull:`472` - update Python `requests` library version
 
+:ghpull:`523` - reduce tiller wait timeout to reduce CI time to failure
+
 Release 1.0.0
 =============
 This marks the first production-ready release of `MetalK8s`_. Deployments using

--- a/roles/helm_common/tasks/main.yml
+++ b/roles/helm_common/tasks/main.yml
@@ -2,7 +2,7 @@
   command: '{{ bin_dir }}/helm version'
   register: helm_version
   until: not helm_version|failed
-  retries: 50000
+  retries: 50
   delay: 10
   changed_when: False
   check_mode: False


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #523.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/1.1/improvement/helm_wait_too_long`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/1.1/improvement/helm_wait_too_long
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/1.1/improvement/helm_wait_too_long
```

Please always comment pull request #523 instead of this one.