### PR TITLE
INTEGRATION [PR#532 > development/1.3] Raise error at the end of the warmup countdown period of metrics server

### DIFF
--- a/tests/post/test_metrics_server.py
+++ b/tests/post/test_metrics_server.py
@@ -17,7 +17,7 @@ def wait_until_initialized(kubeconfig):
     # It can take up to a minute before metrics-server scraped some stats, see
     # https://github.com/kubernetes-incubator/metrics-server/issues/134 and
     # https://github.com/kubernetes-incubator/metrics-server/issues/136
-    for _ in utils.helper.retry(90, wait=1):
+    while next(utils.helper.retry(90, wait=1)):
         try:
             (_, response_code, _) = client.call_api(
                 '/api/v1/namespaces/kube-system/services'

--- a/tests/utils/helper.py
+++ b/tests/utils/helper.py
@@ -45,15 +45,12 @@ def run_ansible_playbook(playbook, env=None, tags=None, skip_tags=None,
     )
 
 
-class RetryCountExceededError(StopIteration):
-    "Exception to finish retry"
-
-
 def retry(count, wait=2, msg=None):
-    for _ in range(count):
-        yield True
+    for nb_call in range(1, count + 1, 1):
+        logging.warning('call retry {} time(s)'.format(nb_call))
+        yield nb_call
         time.sleep(wait)
-    raise RetryCountExceededError(msg)
+    return msg
 
 
 def create_version_archive(version, tmpdir):


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #532.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/1.3/improvement/retry_metric_server`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/1.3/improvement/retry_metric_server
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/1.3/improvement/retry_metric_server
```

Please always comment pull request #532 instead of this one.