### PR TITLE
Add Salt states to install kubelet and its prerequisites

### DIFF
--- a/pillar/repositories.sls
+++ b/pillar/repositories.sls
@@ -1,0 +1,4 @@
+# Repositories informations
+repo:
+  # Configure online repositories
+  online_mode: True

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -1,0 +1,3 @@
+metalk8s-2.0:
+  '*':
+    - repositories

--- a/salt/metalk8s/containerd/configured.sls
+++ b/salt/metalk8s/containerd/configured.sls
@@ -1,0 +1,9 @@
+include:
+  - .installed
+
+Start and enable containerd:
+  service.running:
+    - name: containerd
+    - enable: True
+    - require:
+      - pkg: Install containerd

--- a/salt/metalk8s/containerd/init.sls
+++ b/salt/metalk8s/containerd/init.sls
@@ -1,0 +1,2 @@
+include:
+  - .configured

--- a/salt/metalk8s/containerd/installed.sls
+++ b/salt/metalk8s/containerd/installed.sls
@@ -1,0 +1,20 @@
+{%- from "metalk8s/map.jinja" import repo with context %}
+
+include:
+  - metalk8s.repo
+  - metalk8s.runc
+
+Install container-selinux:
+  pkg.installed:
+    - name: container-selinux
+
+Install containerd:
+  pkg.installed:
+    - name: containerd
+    - version: {{ repo.containerd.version }}
+    - fromrepo: {{ repo.containerd.name }}
+    - require:
+      - pkgrepo: Configure Kubernetes repository
+      - pkg: Install runc
+      - pkg: Install container-selinux
+

--- a/salt/metalk8s/defaults.yaml
+++ b/salt/metalk8s/defaults.yaml
@@ -1,0 +1,8 @@
+repo:
+  online_mode: True
+  runc:
+    version: latest
+  containerd:
+    version: latest
+  kubernetes:
+    version: latest

--- a/salt/metalk8s/kubelet/init.sls
+++ b/salt/metalk8s/kubelet/init.sls
@@ -1,0 +1,2 @@
+include:
+  - .installed

--- a/salt/metalk8s/kubelet/installed.sls
+++ b/salt/metalk8s/kubelet/installed.sls
@@ -1,0 +1,20 @@
+{%- from "metalk8s/map.jinja" import repo with context %}
+
+include:
+  - metalk8s.repo
+
+# TODO: Maybe not needed in offline because embedded in the kubernetes repository
+Install kubelet dependencies:
+  pkg.installed:
+    - pkgs:
+      - ebtables
+      - socat
+      - conntrack-tools
+
+Install kubelet:
+  pkg.installed:
+    - name: kubelet
+    - version: {{ repo.kubernetes.version }}
+    - fromrepo: {{ repo.kubernetes.name }}
+    - require:
+      - pkgrepo: Configure Kubernetes repository

--- a/salt/metalk8s/map.jinja
+++ b/salt/metalk8s/map.jinja
@@ -1,0 +1,28 @@
+{% import_yaml 'metalk8s/defaults.yaml' as defaults with context %}
+
+{% set defaults = salt['grains.filter_by']({
+  'default': defaults
+}, merge=salt['pillar.items']()) %}
+
+{% set repo = salt['grains.filter_by']({
+  'RedHat': {
+    'containerd': {
+      'name': 'epel'
+    },
+    'kubernetes': {
+      'name': 'kubernetes'
+    }
+  }
+}, merge=defaults.get('repo')) %}
+
+{% set containerd = salt['grains.filter_by']({
+  'default': {}
+}, merge=defaults.get('containerd')) %}
+
+{% set kubelet = salt['grains.filter_by']({
+  'default': {}
+}, merge=defaults.get('kubelet')) %}
+
+{% set runc = salt['grains.filter_by']({
+  'default': {}
+}, merge=defaults.get('runc')) %}

--- a/salt/metalk8s/repo/configured.sls
+++ b/salt/metalk8s/repo/configured.sls
@@ -1,0 +1,8 @@
+{%- from "metalk8s/map.jinja" import repo with context %}
+
+include:
+{%- if repo.online_mode %}
+  - .online
+{%- else %}
+  - .offline
+{%- endif %}

--- a/salt/metalk8s/repo/init.sls
+++ b/salt/metalk8s/repo/init.sls
@@ -1,0 +1,2 @@
+include:
+  - .configured

--- a/salt/metalk8s/repo/offline.sls
+++ b/salt/metalk8s/repo/offline.sls
@@ -1,0 +1,3 @@
+offline mode not yet implemented:
+  test.fail_without_changes:
+    - failhard: True

--- a/salt/metalk8s/repo/online.sls
+++ b/salt/metalk8s/repo/online.sls
@@ -1,0 +1,26 @@
+{%- from "metalk8s/map.jinja" import repo with context %}
+
+Configure EPEL repository:
+  pkg.installed:
+  {%- if grains["os"] == "CentOs" %}
+    - name: epel-release
+  {%- else %}
+    - sources:
+      - epel-release: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ grains['osmajorrelease'] }}.noarch.rpm
+  {%- endif %}
+
+{%- if grains["os"] == "RedHat" %}
+check that the system is registered:
+  cmd.run:
+    - name: subscription-manager status
+{%- endif %}
+
+Configure Kubernetes repository:
+  pkgrepo.managed:
+    - name: {{ repo.kubernetes.name }}
+    - humanname: Kubernetes
+    - baseurl: "https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64"
+    - gpgcheck: 1
+    - repo_gpg_check: 1
+    - gpgkey: "https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg"
+    - enabled: 0

--- a/salt/metalk8s/runc/init.sls
+++ b/salt/metalk8s/runc/init.sls
@@ -1,0 +1,2 @@
+include:
+  - .installed

--- a/salt/metalk8s/runc/installed.sls
+++ b/salt/metalk8s/runc/installed.sls
@@ -1,0 +1,10 @@
+{% from "metalk8s/map.jinja" import repo with context %}
+
+include:
+  - metalk8s.repo
+
+# TODO: Add a fromrepo for offline
+Install runc:
+  pkg.installed:
+    - name: runc
+    - version: {{ repo.runc.version }}


### PR DESCRIPTION
To test using a `salt-minion` in local mode, assuming MetalK8s is cloned in `$HOME`:

- Execute `salt-call --local --pillar-root $HOME/metalk8s/pillar/ --file-root $HOME/metalk8s/salt/ state.sls containerd` to install `runc`, `containerd`, and enable/start `containerd`.
- Execute `salt-call --local --pillar-root $HOME/metalk8s/pillar/ --file-root $HOME/metalk8s/salt/ state.sls kubelet` to install `kubelet`.

Only 'online' installation is currently supported.

See: #545