### PR TITLE
Prevent `kubeadm init phase preflight` failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ ALL = \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/kubelet-start/files/service-kubelet-systemd.conf \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/kubelet-start/init.sls \
 	\
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/preflight/init.sls \
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/preflight/mandatory.sls \
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/preflight/recommended.sls \
+	\
 	$(ISO_ROOT)/salt/metalk8s/kubelet/init.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubelet/installed.sls \
 	\

--- a/salt/metalk8s/defaults.yaml
+++ b/salt/metalk8s/defaults.yaml
@@ -1,3 +1,27 @@
+kubeadm_preflight:
+  mandatory:
+    packages:
+      - util-linux            # provides nsenter, mount
+      - iproute               # provides ip
+      - iptables              # provides iptables
+    ports:
+      - 10250
+      - 10251
+      - 10252
+      - 2379
+      - 2380
+    sysctl_values:
+      net.bridge.bridge-nf-call-ip6tables: 1
+      net.bridge.bridge-nf-call-iptables: 1
+      net.ipv4.ip_forward: 1
+  recommended:
+    packages:
+      - ebtables              # provides ebtables
+      - ethtool               # provides ethtool
+      - socat                 # provides socat
+      - iproute               # provides tc
+      - coreutils             # provides touch
+
 repo:
   online_mode: True
   runc:
@@ -26,3 +50,5 @@ kubelet:
         enabled: False
     authorization:
       mode: AlwaysAllow
+
+upgrade: False        # define if we're on an upgrade case

--- a/salt/metalk8s/kubeadm/init/init.sls
+++ b/salt/metalk8s/kubeadm/init/init.sls
@@ -1,2 +1,3 @@
 include:
+  - .preflight
   - .kubelet-start

--- a/salt/metalk8s/kubeadm/init/preflight/init.sls
+++ b/salt/metalk8s/kubeadm/init/preflight/init.sls
@@ -1,0 +1,20 @@
+#
+# State preparation for kubeadm init preflight phase.
+#
+# The goal is to satisfy the checks executed by preflight:
+#
+# https://kubernetes.io/docs/reference/setup-tools/kubeadm/implementation-details/#preflight-checks
+#
+# Available states
+# ================
+#
+# * mandatory   -> prevent ERROR in preflight phase
+# * recommended -> prevent WARNING in preflight phase
+#
+# List of checks
+#
+#
+
+include:
+  - .mandatory
+  - .recommended

--- a/salt/metalk8s/kubeadm/init/preflight/mandatory.sls
+++ b/salt/metalk8s/kubeadm/init/preflight/mandatory.sls
@@ -1,0 +1,70 @@
+{%- from "metalk8s/map.jinja" import defaults with context %}
+{%- from "metalk8s/map.jinja" import kubeadm_preflight with context %}
+{%- from "metalk8s/map.jinja" import kubelet with context %}
+
+Install mandatory packages:
+  pkg.installed:
+    - pkgs: {{ kubeadm_preflight.mandatory.packages }}
+
+{%- if kubelet.container_engine %}
+Enable {{ kubelet.container_engine }} service:
+  service.running:
+    - name: {{ kubelet.container_engine }}
+    - enable: true
+    - require_in:
+      - test: Check that the crictl socket answer
+{%- endif %}
+
+# required to set sysctl net.bridge.bridge-nf-call-iptables
+Add the module br_netfilter to kernel:
+  kmod.present:
+    - name: br_netfilter
+    - persist: True
+
+{%- for item, value in kubeadm_preflight.mandatory.sysctl_values.items() %}
+Set sysctl {{ item }} value to {{ value }}:
+  sysctl.present:
+    - name: {{ item }}
+    - value: {{ value }}
+    - config: /etc/sysctl.d/60-metalk8s.conf
+    {%- if item in ("net.bridge.bridge-nf-call-ip6tables", "net.bridge.bridge-nf-call-iptables") %}
+    - require:
+      - kmod: Add the module br_netfilter to kernel
+    {%- endif %}
+{%- endfor %}
+
+{%- for swap_device in salt.mount.swaps().keys() %}
+Disable swap device {{ swap_device }}:
+  module.run:
+    - mount.swapoff:
+      - name: {{ swap_device  }}
+{%- endfor %}
+
+Prevent swap mount from fstab:
+  file.comment:
+    - name: /etc/fstab
+    - regex: .+\s+.+\s+swap\s+.+
+    - onlyif:
+      # Add a condition to avoid the state failure
+      # in case we don t have swap in /etc/fstab
+      - test -n "$(awk '$3=="swap" {print}' /etc/fstab)"
+
+Check that the crictl socket answer:
+  # use test.succeed_without_changes instead of cmd.run for idempotency
+  test.succeed_without_changes:
+    - name: crictl --runtime-endpoint {{ kubelet.service.options.get("container-runtime-endpoint") }} info
+    - check_cmd:
+      - crictl --runtime-endpoint {{ kubelet.service.options.get("container-runtime-endpoint") }} info
+
+{%- if not defaults.upgrade %}
+  {%- for port in kubeadm_preflight.mandatory.ports %}
+    {%- set res = salt.network.connect('127.0.0.1', port)['result'] %}
+    {%- if res == false %}
+The port {{ port }} is free:
+  test.succeed_without_changes: []
+    {%- else %}
+The port {{ port }} is not free:
+  test.succeed_without_changes: []
+    {%- endif %}
+  {%- endfor %}
+{%- endif %}

--- a/salt/metalk8s/kubeadm/init/preflight/recommended.sls
+++ b/salt/metalk8s/kubeadm/init/preflight/recommended.sls
@@ -1,0 +1,13 @@
+{%- from "metalk8s/map.jinja" import kubeadm_preflight with context %}
+
+Install recommended packages:
+  pkg.installed:
+    - pkgs: {{ kubeadm_preflight.recommended.packages }}
+
+{%- if salt.pkg.version('kubelet') %}
+Kubelet package is installed:
+  test.succeed_without_changes: []
+{%- else %}
+Kubelet package is not installed:
+  test.fail_without_changes: []
+{%- endif %}

--- a/salt/metalk8s/map.jinja
+++ b/salt/metalk8s/map.jinja
@@ -34,3 +34,7 @@
     }
   }
 }, grain='init', merge=kubelet) %}
+
+{% set kubeadm_preflight = salt['grains.filter_by']({
+  'default': {}
+}, merge=defaults.get('kubeadm_preflight')) %}

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -63,6 +63,10 @@ file_roots:
 pillar_roots:
   metalk8s-@VERSION@:
     - /srv/scality/metalk8s-dev/pillar
+
+# use new module.run format
+use_superseded:
+  - module.run
 EOF
 }
 


### PR DESCRIPTION
Add a state file that perform maximum of fixes on the system in order to
make the preflight phase to success

List of checks to prevent for failure:
https://kubernetes.io/docs/reference/setup-tools/kubeadm/implementation-details/#preflight-checks

Note:
* I did not include kubelet and containerd package installation as we already have one state for that
* Some checks can't fixed automatically like:
  - run the script as root
  - make hostname as DNS subdomain
  - checks related to port

Test:
Run the state locally
```
salt-call --local --file-root salt/ state.sls preflight
```
