### PR TITLE
fix: install recent version of `container-selinux`

### DIFF
--- a/salt/metalk8s/containerd/installed.sls
+++ b/salt/metalk8s/containerd/installed.sls
@@ -6,7 +6,8 @@ include:
 
 Install container-selinux:
   pkg.installed:
-    - name: container-selinux
+    - sources:
+      - container-selinux: ftp://ftp.pbone.net/mirror/ftp.scientificlinux.org/linux/scientific/7x/external_products/extras/x86_64/container-selinux-2.77-1.el7_6.noarch.rpm
 
 Install containerd:
   pkg.installed:

--- a/tests/test-containerd.sh
+++ b/tests/test-containerd.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+set -xue -o pipefail
+
+cat > /etc/cni/net.d/98-containerd-test-bridge.conf << EOF
+{
+    "cniVersion": "0.3.1",
+    "name": "bridge",
+    "type": "bridge",
+    "bridge": "cnio0",
+    "isGateway": true,
+    "ipMasq": true,
+    "ipam": {
+        "type": "host-local",
+        "ranges": [
+          [{"subnet": "192.168.123.0/24"}]
+        ],
+        "routes": [{"dst": "0.0.0.0/0"}]
+    }
+}
+EOF
+
+cat > /etc/cni/net.d/99-containerd-test-loopback.conf << EOF
+{
+    "cniVersion": "0.3.1",
+    "type": "loopback"
+}
+EOF
+
+systemctl restart containerd
+
+cat > /tmp/sandbox.json << EOF
+{
+    "metadata": {
+        "name": "nginx-sandbox",
+        "namespace": "default",
+        "attempt": 1,
+        "uid": "hdishd83djaidwnduwk28bcsb"
+    },
+    "linux": {
+    }
+}
+EOF
+cat > /tmp/container.json << EOF
+{
+  "metadata": {
+      "name": "busybox"
+  },
+  "image":{
+      "image": "busybox"
+  },
+  "command": [
+      "top"
+  ],
+  "linux": {
+  }
+}
+EOF
+
+export CONTAINER_RUNTIME_ENDPOINT=unix:///run/containerd/containerd.sock
+
+crictl version
+
+PODID=$(crictl runp /tmp/sandbox.json)
+crictl pods
+crictl inspectp "${PODID}"
+
+crictl pull busybox
+
+CONTAINERID=$(crictl create "${PODID}" /tmp/container.json /tmp/sandbox.json)
+
+crictl ps -a
+crictl start "${CONTAINERID}"
+crictl ps
+crictl inspect "${CONTAINERID}"
+crictl exec -i -t "${CONTAINERID}" ls
+crictl exec -i -t "${CONTAINERID}" ps ax
+
+crictl stats
+
+crictl stop "${CONTAINERID}"
+crictl rm "${CONTAINERID}"
+
+crictl stopp "${PODID}"
+crictl rmp "${PODID}"
+
+rm -f /etc/cni/net.d/98-containerd-test-bridge.conf
+rm -f /etc/cni/net.d/99-containerd-test-loopback.conf
+rm -f /tmp/sandbox.json
+rm -f /tmp/container.json
+
+systemctl restart containerd


### PR DESCRIPTION
The default `container-selinux` policies as provided by CentOS (2.74) are not compatible with `containerd`/`runc` (AVC denials when `runc` attempts to `setattr` on `fifo_file` resources, see links below).

This PR forces the install of a third-party package (so this introduces some technical debt...), and includes a simple test-script (to be invoked manually) to check `containerd` is working correctly.

Fixes: https://github.com/scality/metalk8s/issues/573
See: https://github.com/containers/libpod/issues/1980
See: https://github.com/containers/container-selinux/commit/ae6e25bc789d305c4fdebe063b40fafe49614323