### PR TITLE
Add salt states for kubeadm init certs first iteration (ca, apiserver)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,13 @@ ALL = \
 	\
 	$(ISO_ROOT)/salt/metalk8s/defaults.yaml \
 	\
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/apiserver.sls \
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/ca.sls \
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/init.sls \
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/installed.sls \
+	\
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/init.sls \
+	\
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/kubelet-start/configured.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/kubelet-start/files/kubeadm.env \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/kubelet-start/files/service-kubelet-systemd.conf \
@@ -55,6 +61,7 @@ ALL = \
 	\
 	$(ISO_ROOT)/salt/_states/containerd.py \
 	\
+	$(ISO_ROOT)/pillar/networks.sls \
 	$(ISO_ROOT)/pillar/repositories.sls \
 	$(ISO_ROOT)/pillar/top.sls \
 	\

--- a/pillar/networks.sls
+++ b/pillar/networks.sls
@@ -1,0 +1,4 @@
+# Network information
+networks:
+  # Control plane network
+  control_plane: "10.0.0.0/8"

--- a/pillar/top.sls.in
+++ b/pillar/top.sls.in
@@ -1,3 +1,4 @@
 metalk8s-@VERSION@:
   '*':
+    - networks
     - repositories

--- a/salt/metalk8s/defaults.yaml
+++ b/salt/metalk8s/defaults.yaml
@@ -31,6 +31,8 @@ repo:
   kubernetes:
     version: latest
 
+networks: {}
+
 kubelet:
   config_file: "/var/lib/kubelet/config.yaml"
   container_engine: "containerd"
@@ -50,5 +52,18 @@ kubelet:
         enabled: False
     authorization:
       mode: AlwaysAllow
+
+ca:
+  cert:
+    private_key_size: 2048
+    days_valid: 3650
+  signing_policy:
+    days_valid: 365
+
+kube_api:
+  cert:
+    private_key_size: 2048
+    signing_policy: kube_apiserver_policy
+  service_ip: "10.96.0.1"
 
 upgrade: False        # define if we're on an upgrade case

--- a/salt/metalk8s/kubeadm/init/certs/apiserver.sls
+++ b/salt/metalk8s/kubeadm/init/certs/apiserver.sls
@@ -1,0 +1,43 @@
+{%- from "metalk8s/map.jinja" import kube_api with context %}
+{%- from "metalk8s/map.jinja" import networks with context %}
+
+{%- set ca_server = salt['mine.get']('*', 'kubernetes_ca_server').keys() %}
+{%- if ca_server %}
+
+include:
+  - .installed
+
+Create kube-apiserver private key:
+  x509.private_key_managed:
+    - name: /etc/kubernetes/pki/apiserver.key
+    - bits: {{ kube_api.cert.private_key_size }}
+    - user: root
+    - group: root
+    - mode: 600
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - pkg: Install m2crypto
+
+Generate kube-apiserver certificate:
+  x509.certificate_managed:
+    - name: /etc/kubernetes/pki/apiserver.crt
+    - public_key: /etc/kubernetes/pki/apiserver.key
+    - ca_server: {{ ca_server[0] }}
+    - signing_policy: {{ kube_api.cert.signing_policy }}
+    - CN: kube-apiserver
+    - subjectAltName: "DNS:{{ grains['fqdn'] }}, DNS:kubernetes, DNS:kubernetes.default, DNS:kubernetes.default.svc, DNS:kubernetes.default.svc.cluster.local, IP:{{ kube_api.service_ip }}, IP:{{ salt['network.ip_addrs'](cidr=networks.control_plane) | join(', IP:') }}"
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - x509: Create kube-apiserver private key
+
+{%- else %}
+
+Unable to generate kube-apiserver certificate, no CA Server available:
+  test.fail_without_changes: []
+
+{%- endif %}

--- a/salt/metalk8s/kubeadm/init/certs/ca.sls
+++ b/salt/metalk8s/kubeadm/init/certs/ca.sls
@@ -1,0 +1,86 @@
+{%- from "metalk8s/map.jinja" import ca with context %}
+
+{%- set ca_server = salt['mine.get']('*', 'kubernetes_ca_server') %}
+
+{#- Check if we have no CA server or only current minion as CA #}
+{%- if not ca_server or ca_server.keys() == [grains['id']] %}
+
+include:
+  - .installed
+
+Create CA private key:
+  x509.private_key_managed:
+    - name: /etc/kubernetes/pki/ca.key
+    - bits: {{ ca.cert.private_key_size }}
+    - user: root
+    - group: root
+    - mode: 600
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - pkg: Install m2crypto
+
+Generate CA certificate:
+  x509.certificate_managed:
+    - name: /etc/kubernetes/pki/ca.crt
+    - signing_private_key: /etc/kubernetes/pki/ca.key
+    - CN: kubernetes
+    - keyUsage: "critical digitalSignature, keyEncipherment, keyCertSign"
+    - basicConstraints: "critical CA:true"
+    - days_valid: {{ ca.cert.days_valid }}
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - x509: Create CA private key
+
+# TODO: Find a better way to advetise CA server
+Advertise CA in the mine:
+  module.wait:
+    - mine.send:
+      - func: 'kubernetes_ca_server'
+      - mine_function: test.ping
+    - watch:
+      - x509: Generate CA certificate
+
+Create CA salt signing_policies:
+  file.serialize:
+    - name: /etc/salt/minion.d/30-metalk8s_ca_signing_policies.conf
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - dir_mode: 755
+    - formatter: yaml
+    - dataset:
+        x509_signing_policies:
+          kube_apiserver_policy:
+            - minions: '*'
+            - signing_private_key: /etc/kubernetes/pki/ca.key
+            - signing_cert: /etc/kubernetes/pki/ca.crt
+            - keyUsage: "critical digitalSignature, keyEncipherment"
+            - extendedKeyUsage: "serverAuth"
+            - days_valid: {{ ca.signing_policy.days_valid }}
+
+Restart salt-minion:
+  cmd.run:
+    - name: 'salt-call --local service.restart salt-minion'
+    - bg: true
+    - onchanges:
+      - file: Create CA salt signing_policies
+
+Wait until salt-minion restarted:
+  module.wait:
+    - test.sleep:
+      - length: 5
+    - watch:
+      - cmd: Restart salt-minion
+
+{%- else %}
+
+{{ ca_server.keys()|join(', ') }} already configured as Kubernetes CA server, only one can be declared:
+  test.fail_without_changes: []
+
+{%- endif %}

--- a/salt/metalk8s/kubeadm/init/certs/init.sls
+++ b/salt/metalk8s/kubeadm/init/certs/init.sls
@@ -1,0 +1,13 @@
+#
+# State for kubeadm init certs phase.
+#
+# The goal is to have all the CA and certs for all services.
+#
+# Available states
+# ================
+#
+# * ca        -> create the root CA server and advertise it
+# * apiserver -> create the kube API server certificate using root CA
+
+include:
+  - .ca

--- a/salt/metalk8s/kubeadm/init/certs/installed.sls
+++ b/salt/metalk8s/kubeadm/init/certs/installed.sls
@@ -1,0 +1,3 @@
+Install m2crypto:
+  pkg.installed:
+    - name: m2crypto

--- a/salt/metalk8s/kubeadm/init/init.sls
+++ b/salt/metalk8s/kubeadm/init/init.sls
@@ -1,3 +1,4 @@
 include:
   - .preflight
   - .kubelet-start
+  - .certs

--- a/salt/metalk8s/map.jinja
+++ b/salt/metalk8s/map.jinja
@@ -4,6 +4,10 @@
   'default': defaults
 }, merge=salt['pillar.items']()) %}
 
+{% set kubeadm_preflight = salt['grains.filter_by']({
+  'default': {}
+}, merge=defaults.get('kubeadm_preflight')) %}
+
 {% set repo = salt['grains.filter_by']({
   'RedHat': {
     'containerd': {
@@ -14,6 +18,10 @@
     }
   }
 }, merge=defaults.get('repo')) %}
+
+{% set networks = salt['grains.filter_by']({
+  'default': {}
+}, merge=defaults.get('networks')) %}
 
 {% set runc = salt['grains.filter_by']({
   'default': {}
@@ -35,6 +43,10 @@
   }
 }, grain='init', merge=kubelet) %}
 
-{% set kubeadm_preflight = salt['grains.filter_by']({
+{% set ca = salt['grains.filter_by']({
   'default': {}
-}, merge=defaults.get('kubeadm_preflight')) %}
+}, merge=defaults.get('ca')) %}
+
+{% set kube_api = salt['grains.filter_by']({
+  'default': {}
+}, merge=defaults.get('kube_api')) %}

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -13,6 +13,8 @@ YUM=${YUM:-$(command -v yum)}
 SALT_CALL=${SALT_CALL:-salt-call}
 
 SALT_MINION_FILE_CLIENT_LOCAL_CONF=/etc/salt/minion.d/99-file-client-local.conf
+SALT_MASTER_FILE_CONF=/etc/salt/master.d/99-metalk8s.conf
+SALT_MINION_FILE_CONF=/etc/salt/minion.d/99-metalk8s.conf
 
 die() {
         echo 1>&2 "$@"
@@ -78,9 +80,55 @@ install_kubelet() {
         ${SALT_CALL} --local --retcode-passthrough state.apply metalk8s.kubelet saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
 }
 
-run_kubeadm_init() {
-        ${SALT_CALL} --local --retcode-passthrough state.apply metalk8s.kubeadm.init saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
+run_preflight() {
+        ${SALT_CALL} --local --retcode-passthrough state.apply metalk8s.kubeadm.init.preflight saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
+}
 
+run_kubelet_start() {
+        ${SALT_CALL} --local --retcode-passthrough state.apply metalk8s.kubeadm.init.kubelet-start saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
+}
+
+install_salt_master() {
+        # TODO: Create pod using kubelet with master image
+        ${YUM} install -y salt-master
+}
+
+configure_salt() {
+        # TODO: Use a salt state and maybe other stuff
+        cat > "${SALT_MINION_FILE_CONF}" << EOF
+master: localhost
+
+# use new module.run format
+use_superseded:
+  - module.run
+EOF
+        rm "${SALT_MINION_FILE_CLIENT_LOCAL_CONF}"
+        cat > "${SALT_MASTER_FILE_CONF}" << EOF
+file_roots:
+  metalk8s-@VERSION@:
+    - /srv/scality/metalk8s-dev/salt
+pillar_roots:
+  metalk8s-@VERSION@:
+    - /srv/scality/metalk8s-dev/pillar
+peer:
+  .*:
+    - x509.sign_remote_certificate
+EOF
+        ${SYSTEMCTL} restart salt-master.service
+        ${SYSTEMCTL} enable salt-master.service
+        ${SYSTEMCTL} restart salt-minion.service
+        ${SYSTEMCTL} enable salt-minion.service
+        sleep 20
+        salt-key -A -y
+}
+
+sync_salt() {
+        ${SALT_CALL} --retcode-passthrough saltutil.sync_all saltenv=metalk8s-@VERSION@
+}
+
+run_certs() {
+        ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.ca saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
+        ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.apiserver saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
 }
 
 main() {
@@ -92,7 +140,12 @@ main() {
         configure_salt_minion_local_mode
         run_bootstrap_prechecks
         install_kubelet
-        run_kubeadm_init
+        run_preflight
+        run_kubelet_start
+        install_salt_master
+        configure_salt
+        sync_salt
+        run_certs
 }
 
 main


### PR DESCRIPTION
First iteration of certs generation (only generate a root ca and kube api certs)

Create a file `/etc/salt/master.d/peer.conf` (or edit another master conf) on the salt master
```
peer:
  .*:
    - x509.sign_remote_certificate
```

First run `ca` state on one server
```
salt '<ca server>' state.sls metalk8s.kubeadm.init.certs.ca
```

Then you can generate the kube api cert on one server (the same as ca or another server)
```
salt '<kube api server>' state.sls metalk8s.kubeadm.init.certs.apiserver
```

Fixes: #577