### PR TITLE
Kubeadm init: kubeconfig phase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,13 @@ ALL = \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/preflight/mandatory.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/preflight/recommended.sls \
 	\
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/kubeconfig/admin.sls \
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/kubeconfig/controller-manager.sls \
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/kubeconfig/init.sls \
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/kubeconfig/kubelet.sls \
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/kubeconfig/lib.sls \
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/kubeconfig/scheduler.sls \
+	\
 	$(ISO_ROOT)/salt/metalk8s/kubelet/init.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubelet/installed.sls \
 	\
@@ -65,6 +72,7 @@ ALL = \
 	$(ISO_ROOT)/salt/_modules/cri.py \
 	\
 	$(ISO_ROOT)/salt/_states/containerd.py \
+	$(ISO_ROOT)/salt/_states/kubeconfig.py \
 	\
 	$(ISO_ROOT)/pillar/networks.sls \
 	$(ISO_ROOT)/pillar/repositories.sls \

--- a/salt/_states/kubeconfig.py
+++ b/salt/_states/kubeconfig.py
@@ -1,0 +1,195 @@
+# -*- coding: utf-8 -*-
+
+from base64 import b64encode, b64decode
+from datetime import datetime, timedelta
+import os
+import stat
+import yaml
+
+__virtualname__ = 'metalk8s_kubeconfig'
+
+
+def __virtual__():
+    return __virtualname__
+
+
+def _validateKubeConfig(filename,
+                        expected_ca_data,
+                        expected_api_server,
+                        expected_cn):
+    """Validate a kubeconfig filename.
+
+    Validate that the kubeconfig provided by filename
+    is conform with config.
+
+    This function is used for managed idempotency.
+
+    :return: True if the kubeconfig file matches expectation
+             False otherwise (ie need to be regenerated)
+    """
+    # Verify if the file exists
+    if not os.path.isfile(filename):
+        return False
+
+    # Verify that the mode is 600
+    if stat.S_IMODE(os.stat(filename).st_mode) != 0o600:
+        return False
+
+    try:
+        with open(filename, 'r') as fd:
+            kubeconfig = yaml.safe_load(fd)
+    except Exception:
+        return False
+
+    # Verify that the current CA cert on disk matches the expected CA cert
+    # and the API Server on the existing file match with the expected
+    try:
+        cluster_info = kubeconfig['clusters'][0]['cluster']
+        current_ca_data = cluster_info['certificate-authority-data']
+        current_api_server = cluster_info['server']
+    except (KeyError, IndexError):
+        return False
+
+    if current_ca_data != expected_ca_data:
+        return False
+
+    if current_api_server != expected_api_server:
+        return False
+
+    # Client Key and certificate verification
+    try:
+        b64_client_key = kubeconfig['users'][0]['user']['client-key-data']
+        b64_client_cert = kubeconfig['users'][0][
+            'user']['client-certificate-data']
+    except (KeyError, IndexError):
+        return False
+
+    try:
+        client_key = b64decode(b64_client_key)
+        client_cert = b64decode(b64_client_cert)
+    except TypeError:
+        return False
+
+    ca_pem_cert = b64decode(current_ca_data)
+
+    client_cert_detail = __salt__['x509.read_certificate'](client_cert)
+
+    # Verify client cn
+    try:
+        current_cn = client_cert_detail['Subject']['CN']
+    except KeyError:
+        return False
+    else:
+        if current_cn != expected_cn:
+            return False
+
+    # Verify client client cert expiration date is > 30days
+    try:
+        expiration_date = client_cert_detail['Not After']
+    except KeyError:
+        return False
+    else:
+        if datetime.strptime(expiration_date, "%Y-%m-%d %H:%M:%S") \
+                - timedelta(days=30) < datetime.now():
+            return False
+
+    if __salt__['x509.verify_signature'](
+            client_cert, ca_pem_cert) is not True:
+        return False
+
+    if __salt__['x509.verify_private_key'](
+            client_key, client_cert) is not True:
+        return False
+
+    return True
+
+
+def managed(name,
+            ca_server,
+            signing_policy,
+            client_cert_info,
+            apiserver,
+            cluster,
+            **kwargs):
+    """Generate kubeconfig file with identities for control plane components"""
+    ret = {
+        'name': name,
+        'changes': {},
+        'comment': "",
+        'result': True,
+    }
+
+    # Get the CA cert from mine
+    try:
+        b64_ca_cert = __salt__['mine.get'](
+            ca_server,
+            'kubernetes_ca_server'
+        )[ca_server]
+    except KeyError:
+        ret.update({
+            'comment':
+                '{0} CA server is not advertized in mine'.format(ca_server),
+            'result': False
+        })
+        return ret
+    else:
+        b64_ca_cert = b64_ca_cert.replace('\n', '')
+
+    user = client_cert_info.get('CN')
+
+    # Validate if a kubeconfig already exists (idempotency)
+    if _validateKubeConfig(name, b64_ca_cert, apiserver, user):
+        ret.update({'comment': 'kubeconfig file exists and is up-to-date'})
+        return ret
+
+    client_priv_key = __salt__['x509.create_private_key'](text=True)
+
+    client_cert = __salt__['x509.create_certificate'](
+        text=True,
+        public_key=client_priv_key,  # pub key is sourced from priv key
+        ca_server=ca_server,
+        signing_policy=signing_policy,
+        **client_cert_info
+    )
+
+    dataset = {
+        'apiVersion': 'v1',
+        'clusters': [
+            {
+                'cluster': {
+                    'certificate-authority-data': b64_ca_cert,
+                    'server': apiserver,
+                },
+                'name': cluster
+            }
+        ],
+        'contexts': [
+            {
+                'context': {
+                    'cluster': cluster,
+                    'user': user,
+                },
+                'name': '{0}@{1}'.format(user, cluster),
+            }
+        ],
+        'current-context': '{0}@{1}'.format(user, cluster),
+        'kind': 'Config',
+        'preferences': {},
+        'users': [
+            {
+                'name': user,
+                'user': {
+                    'client-certificate-data': b64encode(client_cert),
+                    'client-key-data': b64encode(client_priv_key)
+                }
+            }
+        ]
+    }
+
+    return __states__['file.serialize'](
+        name=name,
+        dataset=dataset,
+        formatter="yaml",
+        mode="600",
+        makedirs=True
+    )

--- a/salt/metalk8s/defaults.yaml
+++ b/salt/metalk8s/defaults.yaml
@@ -1,3 +1,5 @@
+cluster: kubernetes
+
 kubeadm_preflight:
   mandatory:
     packages:

--- a/salt/metalk8s/kubeadm/init/certs/ca.sls
+++ b/salt/metalk8s/kubeadm/init/certs/ca.sls
@@ -42,7 +42,8 @@ Advertise CA in the mine:
   module.wait:
     - mine.send:
       - func: 'kubernetes_ca_server'
-      - mine_function: test.ping
+      - mine_function: hashutil.base64_encodefile
+      - /etc/kubernetes/pki/ca.crt
     - watch:
       - x509: Generate CA certificate
 

--- a/salt/metalk8s/kubeadm/init/init.sls
+++ b/salt/metalk8s/kubeadm/init/init.sls
@@ -2,3 +2,4 @@ include:
   - .preflight
   - .kubelet-start
   - .certs
+  - .kubeconfig

--- a/salt/metalk8s/kubeadm/init/kubeconfig/admin.sls
+++ b/salt/metalk8s/kubeadm/init/kubeconfig/admin.sls
@@ -1,0 +1,5 @@
+{%- from 'metalk8s/kubeadm/init/kubeconfig/lib.sls' import kubeconfig with context %}
+
+{%- set cert_info = {'CN': 'kubernetes-admin', 'O': 'system:masters'} %}
+
+{{ kubeconfig('admin', cert_info) }}

--- a/salt/metalk8s/kubeadm/init/kubeconfig/controller-manager.sls
+++ b/salt/metalk8s/kubeadm/init/kubeconfig/controller-manager.sls
@@ -1,0 +1,5 @@
+{%- from 'metalk8s/kubeadm/init/kubeconfig/lib.sls' import kubeconfig with context %}
+
+{%- set cert_info = {'CN': 'system:kube-controller-manager'} %}
+
+{{ kubeconfig('controller-manager', cert_info) }}

--- a/salt/metalk8s/kubeadm/init/kubeconfig/init.sls
+++ b/salt/metalk8s/kubeadm/init/kubeconfig/init.sls
@@ -1,0 +1,5 @@
+include:
+  - .admin
+  - .kubelet
+  - .controller-manager
+  - .scheduler

--- a/salt/metalk8s/kubeadm/init/kubeconfig/kubelet.sls
+++ b/salt/metalk8s/kubeadm/init/kubeconfig/kubelet.sls
@@ -1,0 +1,7 @@
+{%- from 'metalk8s/kubeadm/init/kubeconfig/lib.sls' import kubeconfig with context %}
+
+{%- set hostname = salt.network.get_hostname() %}
+
+{%- set cert_info = {'CN': 'system:node:' ~ hostname, 'O': 'system:nodes'} %}
+
+{{ kubeconfig('kubelet', cert_info) }}

--- a/salt/metalk8s/kubeadm/init/kubeconfig/lib.sls
+++ b/salt/metalk8s/kubeadm/init/kubeconfig/lib.sls
@@ -1,0 +1,29 @@
+{%- from "metalk8s/map.jinja" import defaults with context %}
+{%- from "metalk8s/map.jinja" import kube_api with context %}
+
+{% macro kubeconfig(name, cert_info) %}
+
+{%- set ca_server = salt['mine.get']('*', 'kubernetes_ca_server').keys() %}
+{%- set apiserver = 'https://' ~ salt['grains.get']('master') ~ ':6443' %}
+
+{%- if ca_server %}
+
+Create kubeconf file for {{ name }}:
+  metalk8s_kubeconfig.managed:
+    - name: /etc/kubernetes/{{ name }}.conf
+    - ca_server: {{ ca_server[0] }}
+    - signing_policy: {{ kube_api.cert.client_signing_policy }}
+    - client_cert_info:
+        {%- for key, value in cert_info.items() %}
+        {{ key }}: {{ value }}
+        {%- endfor %}
+    - apiserver: {{ apiserver }}
+    - cluster: {{ defaults.cluster }}
+
+{%- else %}
+
+Unable to generate {{ name }} kubeconf file, no CA Server available:
+  test.fail_without_changes: []
+
+{%- endif %}
+{%- endmacro %}

--- a/salt/metalk8s/kubeadm/init/kubeconfig/scheduler.sls
+++ b/salt/metalk8s/kubeadm/init/kubeconfig/scheduler.sls
@@ -1,0 +1,5 @@
+{%- from 'metalk8s/kubeadm/init/kubeconfig/lib.sls' import kubeconfig with context %}
+
+{%- set cert_info = {'CN': 'system:kube-scheduler'} %}
+
+{{ kubeconfig('scheduler', cert_info) }}

--- a/salt/metalk8s/map.jinja
+++ b/salt/metalk8s/map.jinja
@@ -50,3 +50,7 @@
 {% set kube_api = salt['grains.filter_by']({
   'default': {}
 }, merge=defaults.get('kube_api')) %}
+
+{% set kubeadm_kubeconfig = salt['grains.filter_by']({
+  'default': {}
+}, merge=defaults.get('kubeadm_kubeconfig')) %}

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -133,6 +133,10 @@ run_certs() {
         ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.sa saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
 }
 
+run_kubeconfig() {
+        ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.kubeconfig saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
+}
+
 main() {
         pre_minion_checks
         disable_salt_minion_service
@@ -148,6 +152,7 @@ main() {
         configure_salt
         sync_salt
         run_certs
+        run_kubeconfig
 }
 
 main


### PR DESCRIPTION
Generate kubeconfig files for control plane components.

The goal of this PR is to generate 4 kubeconfig files as describe here: https://kubernetes.io/docs/reference/setup-tools/kubeadm/implementation-details/#generate-kubeconfig-files-for-control-plane-components

ie salt state implementation of `kubeadm init phase kubeconfig`

The CA cert need to be generated and advertised first with the procedure described here: https://github.com/scality/metalk8s/pull/607#issue-254014586

After that the salt state could be called with:
```
salt <client id> state.sls metalk8s.kubeadm.init.kubeconfig
```