### PR TITLE
Improvement/saltify kubeadm certs phase root ca

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,11 @@ ALL = \
 	$(ISO_ROOT)/salt/metalk8s/defaults.yaml \
 	\
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/apiserver.sls \
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/apiserver-kubelet-client.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/ca.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/init.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/installed.sls \
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/sa.sls \
 	\
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/init.sls \
 	\

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,9 @@ ALL = \
 	$(ISO_ROOT)/salt/metalk8s/runc/init.sls \
 	$(ISO_ROOT)/salt/metalk8s/runc/installed.sls \
 	\
+	$(ISO_ROOT)/salt/metalk8s/salt/minion/init.sls \
+	$(ISO_ROOT)/salt/metalk8s/salt/minion/running.sls \
+	\
 	$(ISO_ROOT)/salt/_modules/containerd.py \
 	$(ISO_ROOT)/salt/_modules/cri.py \
 	\

--- a/salt/metalk8s/defaults.yaml
+++ b/salt/metalk8s/defaults.yaml
@@ -55,15 +55,14 @@ kubelet:
 
 ca:
   cert:
-    private_key_size: 2048
     days_valid: 3650
   signing_policy:
     days_valid: 365
 
 kube_api:
   cert:
-    private_key_size: 2048
-    signing_policy: kube_apiserver_policy
+    server_signing_policy: kube_apiserver_server_policy
+    client_signing_policy: kube_apiserver_client_policy
   service_ip: "10.96.0.1"
 
 upgrade: False        # define if we're on an upgrade case

--- a/salt/metalk8s/kubeadm/init/certs/apiserver-kubelet-client.sls
+++ b/salt/metalk8s/kubeadm/init/certs/apiserver-kubelet-client.sls
@@ -1,0 +1,42 @@
+{%- from "metalk8s/map.jinja" import kube_api with context %}
+
+{%- set ca_server = salt['mine.get']('*', 'kubernetes_ca_server').keys() %}
+{%- if ca_server %}
+
+include:
+  - .installed
+
+Create kube-apiserver kubelet client private key:
+  x509.private_key_managed:
+    - name: /etc/kubernetes/pki/apiserver-kubelet-client.key
+    - bits: 2048
+    - user: root
+    - group: root
+    - mode: 600
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - pkg: Install m2crypto
+
+Generate kube-apiserver kubelet client certificate:
+  x509.certificate_managed:
+    - name: /etc/kubernetes/pki/apiserver-kubelet-client.crt
+    - public_key: /etc/kubernetes/pki/apiserver-kubelet-client.key
+    - ca_server: {{ ca_server[0] }}
+    - signing_policy: {{ kube_api.cert.client_signing_policy }}
+    - CN: kube-apiserver-kubelet-client
+    - O: "system:masters"
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - x509: Create kube-apiserver kubelet client private key
+
+{%- else %}
+
+Unable to generate kube-apiserver kubelet client certificate, no CA Server available:
+  test.fail_without_changes: []
+
+{%- endif %}

--- a/salt/metalk8s/kubeadm/init/certs/apiserver.sls
+++ b/salt/metalk8s/kubeadm/init/certs/apiserver.sls
@@ -10,7 +10,7 @@ include:
 Create kube-apiserver private key:
   x509.private_key_managed:
     - name: /etc/kubernetes/pki/apiserver.key
-    - bits: {{ kube_api.cert.private_key_size }}
+    - bits: 2048
     - user: root
     - group: root
     - mode: 600
@@ -24,7 +24,7 @@ Generate kube-apiserver certificate:
     - name: /etc/kubernetes/pki/apiserver.crt
     - public_key: /etc/kubernetes/pki/apiserver.key
     - ca_server: {{ ca_server[0] }}
-    - signing_policy: {{ kube_api.cert.signing_policy }}
+    - signing_policy: {{ kube_api.cert.server_signing_policy }}
     - CN: kube-apiserver
     - subjectAltName: "DNS:{{ grains['fqdn'] }}, DNS:kubernetes, DNS:kubernetes.default, DNS:kubernetes.default.svc, DNS:kubernetes.default.svc.cluster.local, IP:{{ kube_api.service_ip }}, IP:{{ salt['network.ip_addrs'](cidr=networks.control_plane) | join(', IP:') }}"
     - user: root

--- a/salt/metalk8s/kubeadm/init/certs/ca.sls
+++ b/salt/metalk8s/kubeadm/init/certs/ca.sls
@@ -47,7 +47,7 @@ Advertise CA in the mine:
 
 Create CA salt signing_policies:
   file.serialize:
-    - name: /etc/salt/minion.d/30-metalk8s_ca_signing_policies.conf
+    - name: /etc/salt/minion.d/30-metalk8s-ca-signing-policies.conf
     - user: root
     - group: root
     - mode: 644

--- a/salt/metalk8s/kubeadm/init/certs/ca.sls
+++ b/salt/metalk8s/kubeadm/init/certs/ca.sls
@@ -7,6 +7,7 @@
 
 include:
   - .installed
+  - metalk8s.salt.minion.running
 
 Create CA private key:
   x509.private_key_managed:
@@ -70,19 +71,7 @@ Create CA salt signing_policies:
             - keyUsage: "critical digitalSignature, keyEncipherment"
             - extendedKeyUsage: "clientAuth"
             - days_valid: {{ ca.signing_policy.days_valid }}
-
-Restart salt-minion:
-  cmd.run:
-    - name: 'salt-call --local service.restart salt-minion'
-    - bg: true
-    - onchanges:
-      - file: Create CA salt signing_policies
-
-Wait until salt-minion restarted:
-  module.wait:
-    - test.sleep:
-      - length: 5
-    - watch:
+    - watch_in:
       - cmd: Restart salt-minion
 
 {%- else %}

--- a/salt/metalk8s/kubeadm/init/certs/ca.sls
+++ b/salt/metalk8s/kubeadm/init/certs/ca.sls
@@ -11,7 +11,7 @@ include:
 Create CA private key:
   x509.private_key_managed:
     - name: /etc/kubernetes/pki/ca.key
-    - bits: {{ ca.cert.private_key_size }}
+    - bits: 4096
     - user: root
     - group: root
     - mode: 600
@@ -56,12 +56,19 @@ Create CA salt signing_policies:
     - formatter: yaml
     - dataset:
         x509_signing_policies:
-          kube_apiserver_policy:
+          kube_apiserver_server_policy:
             - minions: '*'
             - signing_private_key: /etc/kubernetes/pki/ca.key
             - signing_cert: /etc/kubernetes/pki/ca.crt
             - keyUsage: "critical digitalSignature, keyEncipherment"
             - extendedKeyUsage: "serverAuth"
+            - days_valid: {{ ca.signing_policy.days_valid }}
+          kube_apiserver_client_policy:
+            - minions: '*'
+            - signing_private_key: /etc/kubernetes/pki/ca.key
+            - signing_cert: /etc/kubernetes/pki/ca.crt
+            - keyUsage: "critical digitalSignature, keyEncipherment"
+            - extendedKeyUsage: "clientAuth"
             - days_valid: {{ ca.signing_policy.days_valid }}
 
 Restart salt-minion:

--- a/salt/metalk8s/kubeadm/init/certs/init.sls
+++ b/salt/metalk8s/kubeadm/init/certs/init.sls
@@ -6,8 +6,11 @@
 # Available states
 # ================
 #
-# * ca        -> create the root CA server and advertise it
-# * apiserver -> create the kube API server certificate using root CA
+# * ca                          -> create the root CA server and advertise it
+# * apiserver                   -> create the kube API server certificate using root CA
+# * apiserver-kubelet-client    -> create the kube API client certificate using root CA
+# * sa                          -> create the SA private and public key
+#
 
 include:
   - .ca

--- a/salt/metalk8s/kubeadm/init/certs/sa.sls
+++ b/salt/metalk8s/kubeadm/init/certs/sa.sls
@@ -1,0 +1,26 @@
+include:
+  - .installed
+
+Create SA private key:
+  x509.private_key_managed:
+    - name: /etc/kubernetes/pki/sa.key
+    - bits: 2048
+    - user: root
+    - group: root
+    - mode: 600
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - pkg: Install m2crypto
+
+Store SA public key:
+  file.managed:
+    - name: /etc/kubernetes/pki/sa.pub
+    - contents: __slot__:salt:x509.get_public_key("/etc/kubernetes/pki/sa.key")
+    - user: root
+    - group: root
+    - mode: 600
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - x509: Create SA private key

--- a/salt/metalk8s/salt/minion/init.sls
+++ b/salt/metalk8s/salt/minion/init.sls
@@ -1,0 +1,15 @@
+#
+# State to manage salt minion.
+#
+# To restart salt-minion:
+#   watch_in:
+#     - cmd: Restart salt-minion
+#
+# Available states
+# ================
+#
+# * running   -> Ensure salt minion running
+#
+
+include:
+  - .running

--- a/salt/metalk8s/salt/minion/running.sls
+++ b/salt/metalk8s/salt/minion/running.sls
@@ -1,0 +1,18 @@
+Restart salt-minion:
+  cmd.wait:
+    - name: 'salt-call --local service.restart salt-minion'
+    - bg: true
+
+Wait until salt-minion restarted:
+  module.wait:
+    - test.sleep:
+      - length: 5
+    - watch:
+      - cmd: Restart salt-minion
+
+Ensure salt-minion running:
+  service.running:
+    - name: salt-minion
+    - enable: True
+    - require:
+      - module: Wait until salt-minion restarted

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -129,6 +129,8 @@ sync_salt() {
 run_certs() {
         ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.ca saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
         ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.apiserver saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
+        ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.apiserver-kubelet-client saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
+        ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.sa saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
 }
 
 main() {


### PR DESCRIPTION
Add a generic state to restart salt-minion
Certs generation for apiserver-kubelet-client and SA private and public key.
```
salt-call state.sls metalk8s.kubeadm.init.certs.apiserver-kubelet-client
salt-call state.sls metalk8s.kubeadm.init.certs.sa
```

Fixes: #557 #633 #635 