### PR TITLE
Improvement/546 deploy salt master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,12 +66,21 @@ ALL = \
 	$(ISO_ROOT)/salt/metalk8s/runc/init.sls \
 	$(ISO_ROOT)/salt/metalk8s/runc/installed.sls \
 	\
-	$(ISO_ROOT)/salt/metalk8s/salt/minion/init.sls \
-	$(ISO_ROOT)/salt/metalk8s/salt/minion/running.sls \
-	\
 	$(ISO_ROOT)/salt/metalk8s/registry/init.sls \
 	$(ISO_ROOT)/salt/metalk8s/registry/populated.sls \
 	$(ISO_ROOT)/salt/metalk8s/registry/files/registry-pod.yaml.j2 \
+	\
+	$(ISO_ROOT)/salt/metalk8s/salt/master/files/master_99-metalk8s.conf.j2 \
+	$(ISO_ROOT)/salt/metalk8s/salt/master/files/salt-master-pod.yaml.j2 \
+	$(ISO_ROOT)/salt/metalk8s/salt/master/configured.sls \
+	$(ISO_ROOT)/salt/metalk8s/salt/master/deployed.sls \
+	$(ISO_ROOT)/salt/metalk8s/salt/master/init.sls \
+	\
+	$(ISO_ROOT)/salt/metalk8s/salt/minion/files/minion_99-metalk8s.conf.j2 \
+	$(ISO_ROOT)/salt/metalk8s/salt/minion/configured.sls \
+	$(ISO_ROOT)/salt/metalk8s/salt/minion/installed.sls \
+	$(ISO_ROOT)/salt/metalk8s/salt/minion/running.sls \
+	$(ISO_ROOT)/salt/metalk8s/salt/minion/init.sls \
 	\
 	$(ISO_ROOT)/salt/_modules/containerd.py \
 	$(ISO_ROOT)/salt/_modules/cri.py \

--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ vagrantup: $(ALL) ## Run 'vagrant up' to (re-)provision a development environmen
 help: ## Show this help message
 	@echo "The following targets are available:"
 	@echo
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@grep -Eh '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
 
 

--- a/salt/metalk8s/repo/online.sls
+++ b/salt/metalk8s/repo/online.sls
@@ -24,3 +24,12 @@ Configure Kubernetes repository:
     - repo_gpg_check: 1
     - gpgkey: "https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg"
     - enabled: 0
+
+Configure SaltStack repository:
+  pkgrepo.managed:
+    - name: "SaltStack"
+    - humanname: SaltStack
+    - baseurl: "https://repo.saltstack.com/yum/redhat/\\$releasever/\\$basearch/archive/2018.3.3"
+    - gpgcheck: 1
+    - gpgkey: "https://repo.saltstack.com/yum/redhat/\\$releasever/\\$basearch/archive/2018.3.3/SALTSTACK-GPG-KEY.pub"
+    - enabled: 1

--- a/salt/metalk8s/salt/master/configured.sls
+++ b/salt/metalk8s/salt/master/configured.sls
@@ -1,0 +1,14 @@
+{% set metal_version = '2.0' %}
+
+Configure salt master:
+  file.managed:
+    - name: /etc/salt/master.d/99-metalk8s.conf
+    - source: salt://metalk8s/salt/master/files/master_99-metalk8s.conf.j2
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: '0644'
+    - makedirs: true
+    - backup: false
+    - defaults:
+      metal_version: {{ metal_version }}

--- a/salt/metalk8s/salt/master/deployed.sls
+++ b/salt/metalk8s/salt/master/deployed.sls
@@ -1,0 +1,33 @@
+{% set salt_master_image = 'salt-master' %}
+{% set salt_master_version = '2018.3.3-1' %}
+{% set registry_prefix = 'localhost:5000/metalk8s-2.0/' %}
+{% set version = 'dev' %}
+
+Create salt master directories:
+  file.directory:
+    - user: root
+    - group: root
+    - mode: '0700'
+    - makedirs: true
+    - names:
+      - /etc/salt
+      - /var/cache/salt
+      - /var/run/salt
+
+Install and start salt master manifest:
+  file.managed:
+    - name: /etc/kubernetes/manifests/salt-master-pod.yaml
+    - source: salt://metalk8s/salt/master/files/salt-master-pod.yaml.j2
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: '0644'
+    - makedirs: false
+    - backup: false
+    - defaults:
+      path_version: {{ version }}
+      registry_prefix: {{ registry_prefix }}
+      salt_master_image: {{ salt_master_image }}
+      salt_master_version: {{ salt_master_version }}
+    - require:
+      - file: Create salt master directories

--- a/salt/metalk8s/salt/master/files/master_99-metalk8s.conf.j2
+++ b/salt/metalk8s/salt/master/files/master_99-metalk8s.conf.j2
@@ -1,0 +1,9 @@
+file_roots:
+  metalk8s-{{ metal_version }}:
+    - /srv/scality/metalk8s-dev/salt
+pillar_roots:
+  metalk8s-{{ metal_version }}:
+    - /srv/scality/metalk8s-dev/pillar
+peer:
+  .*:
+    - x509.sign_remote_certificate

--- a/salt/metalk8s/salt/master/files/salt-master-pod.yaml.j2
+++ b/salt/metalk8s/salt/master/files/salt-master-pod.yaml.j2
@@ -1,0 +1,84 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: salt-master
+  namespace: kube-system
+  labels:
+    app: salt-master
+    app.kubernetes.io/name: salt-master
+    app.kubernetes.io/version: '{{ salt_master_version }}'
+    app.kubernetes.io/component: salt
+    heritage: metalk8s
+    app.kubernertes.io/part-of: metalk8s
+    app.kubernetes.io/managed-by: salt
+spec:
+  hostNetwork: true
+  priorityClassName: system-cluster-critical
+  securityContext:
+    runAsUser: 0
+    fsGroup: 0
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+  containers:
+    - name: salt-master
+      image: {{ registry_prefix }}{{salt_master_image}}:{{salt_master_version}}
+      ports:
+        - name: publisher
+          containerPort: 4505
+          protocol: TCP
+        - name: requestserver
+          containerPort: 4506
+          protocol: TCP
+      livenessProbe:
+        exec:
+          command:
+          - pgrep
+          - salt-master
+        periodSeconds: 10
+        initialDelaySeconds: 5
+      readinessProbe:
+        exec:
+          command:
+          - salt-run
+          - event.send
+          - test
+        periodSeconds: 20
+        timeoutSeconds: 2
+        initialDelaySeconds: 10
+      volumeMounts:
+        - name: config
+          mountPath: '/etc/salt'
+        - name: cache
+          mountPath: '/var/cache/salt'
+        - name: run
+          mountPath: '/var/run/salt'
+        - name: states
+          mountPath: '/srv/scality/metalk8s-{{ path_version }}/salt'
+          readOnly: true
+        - name: pillar
+          mountPath: '/srv/scality/metalk8s-{{ path_version }}/pillar'
+          readOnly: true
+  volumes:
+    - name: config
+      hostPath:
+        path: '/etc/salt'
+        type: Directory
+    - name: cache
+      hostPath:
+        path: '/var/cache/salt'
+        type: Directory
+    - name: run
+      hostPath:
+        path: '/var/run/salt'
+        type: Directory
+    - name: states
+      hostPath:
+        path: '/srv/scality/metalk8s-{{ path_version }}/salt'
+        type: Directory
+    - name: pillar
+      hostPath:
+        path: '/srv/scality/metalk8s-{{ path_version }}/pillar'
+        type: Directory

--- a/salt/metalk8s/salt/master/init.sls
+++ b/salt/metalk8s/salt/master/init.sls
@@ -1,0 +1,3 @@
+include:
+  - .configured
+  - .deployed

--- a/salt/metalk8s/salt/minion/configured.sls
+++ b/salt/metalk8s/salt/minion/configured.sls
@@ -1,0 +1,19 @@
+include:
+  - .installed
+  - .running
+
+
+Configure salt minion:
+  file.managed:
+    - name: /etc/salt/minion.d/99-metalk8s.conf
+    - source: salt://metalk8s/salt/minion/files/minion_99-metalk8s.conf.j2
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: '0644'
+    - makedirs: true
+    - backup: false
+    - defaults:
+      master_hostname: localhost
+    - watch_in:
+      - cmd: Restart salt-minion

--- a/salt/metalk8s/salt/minion/files/minion_99-metalk8s.conf.j2
+++ b/salt/metalk8s/salt/minion/files/minion_99-metalk8s.conf.j2
@@ -1,0 +1,5 @@
+master: {{ master_hostname }}
+
+# use new module.run format
+use_superseded:
+  - module.run

--- a/salt/metalk8s/salt/minion/init.sls
+++ b/salt/metalk8s/salt/minion/init.sls
@@ -12,4 +12,5 @@
 #
 
 include:
+  - .installed
   - .running

--- a/salt/metalk8s/salt/minion/installed.sls
+++ b/salt/metalk8s/salt/minion/installed.sls
@@ -1,0 +1,8 @@
+{% set salt_minion_version = '2018.3.3'%}
+include :
+  - metalk8s.repo
+
+Install salt-minion:
+  pkg.installed:
+    - name: salt-minion
+    - version: {{ salt_minion_version }}

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -88,49 +88,37 @@ run_kubelet_start() {
         ${SALT_CALL} --local --retcode-passthrough state.apply metalk8s.kubeadm.init.kubelet-start saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
 }
 
-install_salt_master() {
-        # TODO: Create pod using kubelet with master image
-        ${YUM} install -y salt-master
+configure_salt() {
+    ${SALT_CALL} --retcode-passthrough state.apply metalk8s.salt.minion.configured saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
+    rm -f "${SALT_MINION_FILE_CLIENT_LOCAL_CONF}"
 }
 
-configure_salt() {
-        # TODO: Use a salt state and maybe other stuff
-        cat > "${SALT_MINION_FILE_CONF}" << EOF
-master: localhost
+deploy_salt_master() {
+    # Run deployment
+    ${SALT_CALL} --retcode-passthrough state.apply metalk8s.salt.master saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
+    # Allow some time for the image to be pulled instead of looping later
+    sleep 5
+}
 
-# use new module.run format
-use_superseded:
-  - module.run
-EOF
-        rm "${SALT_MINION_FILE_CLIENT_LOCAL_CONF}"
-        cat > "${SALT_MASTER_FILE_CONF}" << EOF
-file_roots:
-  metalk8s-@VERSION@:
-    - /srv/scality/metalk8s-@VERSION@/salt
-pillar_roots:
-  metalk8s-@VERSION@:
-    - /srv/scality/metalk8s-@VERSION@/pillar
-peer:
-  .*:
-    - x509.sign_remote_certificate
-EOF
-        ${SYSTEMCTL} restart salt-master.service
-        ${SYSTEMCTL} enable salt-master.service
-        ${SYSTEMCTL} restart salt-minion.service
-        ${SYSTEMCTL} enable salt-minion.service
-        sleep 20
-        salt-key -A -y
+accept_keys() {
+    echo "Accepting keys"
+    crictl exec -i $(crictl ps -q --pod $(crictl pods --name salt-master\* -q)) salt-key -Ay
+}
+
+set_salt_command() {
+    echo "setting salt master command"
+    SALT_MASTER_CALL="crictl exec -i $(crictl ps -q --pod $(crictl pods --name salt-master-bootstrap -q)) salt"
 }
 
 sync_salt() {
-        ${SALT_CALL} --retcode-passthrough saltutil.sync_all saltenv=metalk8s-@VERSION@
+    ${SALT_MASTER_CALL} '*' saltutil.sync_all refresh=True saltenv=metalk8s-@VERSION@
 }
 
 run_certs() {
-        ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.ca saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
-        ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.apiserver saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
-        ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.apiserver-kubelet-client saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
-        ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.sa saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
+    ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.ca saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
+    ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.apiserver saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
+    ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.apiserver-kubelet-client saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
+    ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.sa saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
 }
 
 run_kubeconfig() {
@@ -138,6 +126,7 @@ run_kubeconfig() {
 }
 
 deploy_registry() {
+        ${SALT_CALL} --retcode-passthrough saltutil.sync_all saltenv=metalk8s-@VERSION@
         ${SALT_CALL} --retcode-passthrough state.apply metalk8s.registry saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
 }
 
@@ -153,16 +142,23 @@ main() {
         install_salt_minion
         configure_salt_minion_local_mode
         run_bootstrap_prechecks
+
         install_kubelet
         run_preflight
         run_kubelet_start
-        install_salt_master
+
+        deploy_registry
+        populate_registry
+
+        deploy_salt_master
         configure_salt
+
+        set_salt_command
+        accept_keys
+
         sync_salt
         run_certs
         run_kubeconfig
-        deploy_registry
-        populate_registry
 }
 
 main


### PR DESCRIPTION
Fixes: #546 
**WHY this PR**
the goal is to deploy the salt-master pod and use it instead of local salt-call or an in-system installed salt-master

**WHAT has been done**
Salt states added that:
- Create a salt-master pod manifest file
- Configure salt-master and salt-minions

Bootstrap commands that:
- Accept keys for the minions
- Run the rest of the actions using the in-pod salt-master

**HOW to test**
Run `make vagrantup`
check pods and containers `crictl pods` and `crictl ps`
send commands to the salt pod by `crictl exec -it $(crictl ps -q --pod $(crictl pods --name salt-master-bootstrap)) salt `

**PS**
- ~~salt-master image is injected 'manually' into the containerd cache, the code will be removed once
this PR https://github.com/scality/metalk8s/pull/604 lands~~
- ~~Liveness and Readiness are not implemented yet~~