### PR TITLE
Improvement/gh 634 use product version

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,8 @@ set -eu -o pipefail
 
 RC=0
 
+source /vagrant/_build/root/product.txt
+
 die() {
     echo 1>&2 $@
     exit 1
@@ -17,8 +19,8 @@ die() {
 echo "Installing build artifacts on the host"
 
 mkdir -p /srv/scality || die "Failed to create /srv/scality"
-rm -f /srv/scality/metalk8s-dev || die "Failed to unlink symlink destination"
-ln -s /vagrant/_build/root /srv/scality/metalk8s-dev || die "Failed to create symlink"
+rm -f "/srv/scality/metalk8s-$SHORT_VERSION" || die "Failed to unlink symlink destination"
+ln -s /vagrant/_build/root "/srv/scality/metalk8s-$SHORT_VERSION" || die "Failed to create symlink"
 
 echo "Installed build artifacts on the host"
 
@@ -30,14 +32,16 @@ BOOTSTRAP = <<-SCRIPT
 
 set -eu -o pipefail
 
-if ! test -x /srv/scality/metalk8s-dev/bootstrap.sh; then
+source /vagrant/_build/root/product.txt
+
+if ! test -x "/srv/scality/metalk8s-$SHORT_VERSION/bootstrap.sh"; then
     echo 1>&2 "Bootstrap script not found in build directory."
     echo 1>&2 "Did you run 'make'?"
     exit 1
 fi
 
 echo "Launching bootstrap"
-exec /srv/scality/metalk8s-dev/bootstrap.sh
+exec "/srv/scality/metalk8s-$SHORT_VERSION/bootstrap.sh"
 SCRIPT
 
 # To support VirtualBox linked clones

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -61,10 +61,10 @@ configure_salt_minion_local_mode() {
 file_client: local
 file_roots:
   metalk8s-@VERSION@:
-    - /srv/scality/metalk8s-dev/salt
+    - /srv/scality/metalk8s-@VERSION@/salt
 pillar_roots:
   metalk8s-@VERSION@:
-    - /srv/scality/metalk8s-dev/pillar
+    - /srv/scality/metalk8s-@VERSION@/pillar
 
 # use new module.run format
 use_superseded:
@@ -106,10 +106,10 @@ EOF
         cat > "${SALT_MASTER_FILE_CONF}" << EOF
 file_roots:
   metalk8s-@VERSION@:
-    - /srv/scality/metalk8s-dev/salt
+    - /srv/scality/metalk8s-@VERSION@/salt
 pillar_roots:
   metalk8s-@VERSION@:
-    - /srv/scality/metalk8s-dev/pillar
+    - /srv/scality/metalk8s-@VERSION@/pillar
 peer:
   .*:
     - x509.sign_remote_certificate


### PR DESCRIPTION
#### WHY

I forgot to include these changes in #645 . Bootstrap script and VagrantFile have hardcoded ISO mountpoint as `/srv/scality/metalk8s-dev`, we want `/srv/scality/metalk8s-${MAJOR}.${MINOR}`

#### WHAT

Replace the hardcoded paths by a source of `product.txt` and the usage of `$SHORT_VERSION`.

#### TEST
\#itworksonmymachine. Test with `make vagrantup`.

Fixes GH-634.