### PR TITLE
GH-556: Bootstrap deployment in Eve

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,8 @@ set -eu -o pipefail
 
 RC=0
 
+source /vagrant/_build/root/product.txt
+
 die() {
     echo 1>&2 $@
     exit 1
@@ -17,8 +19,8 @@ die() {
 echo "Installing build artifacts on the host"
 
 mkdir -p /srv/scality || die "Failed to create /srv/scality"
-rm -f /srv/scality/metalk8s-dev || die "Failed to unlink symlink destination"
-ln -s /vagrant/_build/root /srv/scality/metalk8s-dev || die "Failed to create symlink"
+rm -f /srv/scality/metalk8s-${SHORT_VERSION} || die "Failed to unlink symlink destination"
+ln -s /vagrant/_build/root /srv/scality/metalk8s-${SHORT_VERSION} || die "Failed to create symlink"
 
 echo "Installed build artifacts on the host"
 
@@ -30,14 +32,16 @@ BOOTSTRAP = <<-SCRIPT
 
 set -eu -o pipefail
 
-if ! test -x /srv/scality/metalk8s-dev/bootstrap.sh; then
+source /vagrant/_build/root/product.txt
+
+if ! test -x /srv/scality/metalk8s-${SHORT_VERSION}/bootstrap.sh; then
     echo 1>&2 "Bootstrap script not found in build directory."
     echo 1>&2 "Did you run 'make'?"
     exit 1
 fi
 
 echo "Launching bootstrap"
-exec /srv/scality/metalk8s-dev/bootstrap.sh
+exec /srv/scality/metalk8s-${SHORT_VERSION}/bootstrap.sh
 SCRIPT
 
 # To support VirtualBox linked clones

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -45,6 +45,10 @@ stages:
         urls:
           - "*.iso"
           - "SHA256SUM"
+    - SetPropertyFromCommand:
+        name: Set short version property
+        property: metalk8s-short-version
+        command: source _build/root/product.txt && echo $SHORT_VERSION
 
   lint:
     worker:
@@ -87,10 +91,10 @@ stages:
         name: Mount ISO image
         command: >
           sudo mount -o loop metalk8s.iso
-          /srv/scality/metalk8s-%(prop:product_version)s
+          /srv/scality/metalk8s-%(prop:metalk8s_short_version)s
         haltOnFailure: true
     - ShellCommand:
         name: Start the bootstrap process
         command: >
-          bash /srv/scality/metalk8s-%(prop:product_version)s/bootstrap.sh
+          bash /srv/scality/metalk8s-%(prop:metalk8s_short_version)s/bootstrap.sh
         haltOnFailure: true

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -93,6 +93,10 @@ stages:
         command: sha256sum -c SHA256SUM
         haltOnFailure: true
     - ShellCommand:
+        name: Create mountpoint
+        command: >
+          sudo mkdir -p /srv/scality/metalk8s-%(prop:metalk8s_short_version)s
+    - ShellCommand:
         name: Mount ISO image
         command: >
           sudo mount -o loop metalk8s.iso

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -105,5 +105,6 @@ stages:
     - ShellCommand:
         name: Start the bootstrap process
         command: >
-          bash /srv/scality/metalk8s-%(prop:metalk8s_short_version)s/bootstrap.sh
+          sudo bash
+          /srv/scality/metalk8s-%(prop:metalk8s_short_version)s/bootstrap.sh
         haltOnFailure: true

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -10,18 +10,22 @@ stages:
     worker:
       type: local
     steps:
-      - TriggerStages:
-          name: Trigger build and lint stages simultaneously
-          stage_names:
-            - build
-            - lint
+    - TriggerStages:
+        name: Trigger build and lint stages simultaneously
+        stage_names:
+        - build
+        - lint
+    - TriggerStages:
+        name: Trigger single-node deployment with built ISO
+        stage_names:
+        - single-node
 
   build:
     worker:
       type: kube_pod
       path: eve/workers/pod-builder/pod.yaml
       images:
-          docker-builder: eve/workers/pod-builder
+        docker-builder: eve/workers/pod-builder
     steps:
     - Git: &git_pull
         name: git pull
@@ -55,3 +59,38 @@ stages:
         command: make lint
         flunkOnFailure: false
         haltOnFailure: false
+
+  single-node:
+    worker:
+      type: openstack
+      image: CentOS 7 (PVHVM)
+      flavor: io1-30
+      path: eve/workers/openstack-single-node
+    steps:
+    - ShellCommand:
+        name: Retrieve ISO image
+        command: >
+          curl -XGET -o metalk8s.iso
+          "%(prop:artifacts_private_url)s/metalk8s.iso"
+        haltOnFailure: true
+    - ShellCommand:
+        name: Retrieve ISO image checksum
+        command: >
+          curl -XGET -o SHA256SUM
+          "%(prop:artifacts_private_url)s/SHA256SUM"
+        haltOnFailure: true
+    - ShellCommand:
+        name: Check image with checksum
+        command: sha256sum -c SHA256SUM
+        haltOnFailure: true
+    - ShellCommand:
+        name: Mount ISO image
+        command: >
+          sudo mount -o loop metalk8s.iso
+          /srv/scality/metalk8s-%(prop:product_version)s
+        haltOnFailure: true
+    - ShellCommand:
+        name: Start the bootstrap process
+        command: >
+          bash /srv/scality/metalk8s-%(prop:product_version)s/bootstrap.sh
+        haltOnFailure: true

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -15,6 +15,12 @@ stages:
         stage_names:
         - build
         - lint
+    - SetPropertyFromCommand:
+        name: Set short version as property from built artifacts
+        property: metalk8s_short_version
+        command: >
+          bash -c '. <(curl -s "%(prop:artifacts_private_url)s/product.txt") &&
+          echo $SHORT_VERSION'
     - TriggerStages:
         name: Trigger single-node deployment with built ISO
         stage_names:
@@ -38,17 +44,16 @@ stages:
         command: make
     - ShellCommand:
         name: Put the iso file in a separate folder
-        command: mkdir iso && cp _build/metalk8s.iso _build/SHA256SUM iso
+        command: >
+          mkdir iso &&
+          cp _build/metalk8s.iso _build/SHA256SUM _build/root/product.txt iso
     - Upload:
         name: upload artifacts
         source: iso/
         urls:
           - "*.iso"
           - "SHA256SUM"
-    - SetPropertyFromCommand:
-        name: Set short version property
-        property: metalk8s-short-version
-        command: source _build/root/product.txt && echo $SHORT_VERSION
+          - "product.txt"
 
   lint:
     worker:

--- a/eve/workers/openstack-single-node/requirements.sh
+++ b/eve/workers/openstack-single-node/requirements.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+PACKAGES=(
+    curl
+)
+
+yum install -y "${PACKAGES[@]}"
+
+yum clean all

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -61,10 +61,10 @@ configure_salt_minion_local_mode() {
 file_client: local
 file_roots:
   metalk8s-@VERSION@:
-    - /srv/scality/metalk8s-dev/salt
+    - /srv/scality/metalk8s-@VERSION@/salt
 pillar_roots:
   metalk8s-@VERSION@:
-    - /srv/scality/metalk8s-dev/pillar
+    - /srv/scality/metalk8s-@VERSION@/pillar
 
 # use new module.run format
 use_superseded:
@@ -106,10 +106,10 @@ EOF
         cat > "${SALT_MASTER_FILE_CONF}" << EOF
 file_roots:
   metalk8s-@VERSION@:
-    - /srv/scality/metalk8s-dev/salt
+    - /srv/scality/metalk8s-@VERSION@/salt
 pillar_roots:
   metalk8s-@VERSION@:
-    - /srv/scality/metalk8s-dev/pillar
+    - /srv/scality/metalk8s-@VERSION@/pillar
 peer:
   .*:
     - x509.sign_remote_certificate


### PR DESCRIPTION
Using results from the build step, we mount the ISO and execute the bootstrap script on a fresh OpenStack VM worker (using CentOS 7).

Fixes GH-556.