### PR TITLE
Add simple loop to wait for Docker daemon in worker

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -23,6 +23,18 @@ stages:
       images:
           docker-builder: eve/workers/pod-builder
     steps:
+    - ShellCommand:
+        name: Wait for Docker daemon to be ready
+        command: |
+          bash -c '
+          for i in {1..10}
+          do
+            docker --version &> /dev/null && exit
+            sleep 2
+          done
+          echo "Could not reach Docker daemon from buildbot worker" >&2
+          exit 1'
+        haltOnFailure: true
     - Git: &git_pull
         name: git pull
         repourl: "%(prop:git_reference)s"


### PR DESCRIPTION
We didn't find a simple way to make sure the buildbot-worker container
starts after the docker-in-docker container within the Pod definition,
so we add a waiting step in the build definition instead.

Fixes GH-641.