### PR TITLE
GH-556: Bootstrap deployment in Eve

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -106,6 +106,10 @@ stages:
           command: sha256sum -c SHA256SUM
           haltOnFailure: true
       - ShellCommand:
+          name: Create mountpoint
+          command: >
+            sudo mkdir -p /srv/scality/metalk8s-%(prop:metalk8s_short_version)s
+      - ShellCommand:
           name: Mount ISO image
           command: >
             sudo mount -o loop metalk8s.iso

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -11,15 +11,15 @@ stages:
     worker:
       type: local
     steps:
-    - TriggerStages:
-        name: Trigger build and lint stages simultaneously
-        stage_names:
-        - build
-        - lint
-    - TriggerStages:
-        name: Trigger single-node deployment with built ISO
-        stage_names:
-        - single-node
+      - TriggerStages:
+          name: Trigger build and lint stages simultaneously
+          stage_names:
+            - build
+            - lint
+      - TriggerStages:
+          name: Trigger single-node deployment with built ISO
+          stage_names:
+            - single-node
 
   build:
     worker:
@@ -39,7 +39,7 @@ stages:
             done
             echo "Could not reach Docker daemon from buildbot worker" >&2
             exit 1'
-          haltOnFailure: true
+        haltOnFailure: true
       - Git: &git_pull
           name: git pull
           repourl: "%(prop:git_reference)s"
@@ -58,6 +58,10 @@ stages:
           urls:
             - "*.iso"
             - "SHA256SUM"
+      - SetPropertyFromCommand:
+          name: Set short version property
+          property: metalk8s-short-version
+          command: source _build/root/product.txt && echo $SHORT_VERSION
 
   lint:
     worker:
@@ -79,30 +83,31 @@ stages:
       flavor: io1-30
       path: eve/workers/openstack-single-node
     steps:
-    - ShellCommand:
-        name: Retrieve ISO image
-        command: >
-          curl -XGET -o metalk8s.iso
-          "%(prop:artifacts_private_url)s/metalk8s.iso"
-        haltOnFailure: true
-    - ShellCommand:
-        name: Retrieve ISO image checksum
-        command: >
-          curl -XGET -o SHA256SUM
-          "%(prop:artifacts_private_url)s/SHA256SUM"
-        haltOnFailure: true
-    - ShellCommand:
-        name: Check image with checksum
-        command: sha256sum -c SHA256SUM
-        haltOnFailure: true
-    - ShellCommand:
-        name: Mount ISO image
-        command: >
-          sudo mount -o loop metalk8s.iso
-          /srv/scality/metalk8s-%(prop:product_version)s
-        haltOnFailure: true
-    - ShellCommand:
-        name: Start the bootstrap process
-        command: >
-          bash /srv/scality/metalk8s-%(prop:product_version)s/bootstrap.sh
-        haltOnFailure: true
+      - ShellCommand:
+          name: Retrieve ISO image
+          command: >
+            curl -XGET -o metalk8s.iso
+            "%(prop:artifacts_private_url)s/metalk8s.iso"
+          haltOnFailure: true
+      - ShellCommand:
+          name: Retrieve ISO image checksum
+          command: >
+            curl -XGET -o SHA256SUM
+            "%(prop:artifacts_private_url)s/SHA256SUM"
+          haltOnFailure: true
+      - ShellCommand:
+          name: Check image with checksum
+          command: sha256sum -c SHA256SUM
+          haltOnFailure: true
+      - ShellCommand:
+          name: Mount ISO image
+          command: >
+            sudo mount -o loop metalk8s.iso
+            /srv/scality/metalk8s-%(prop:metalk8s_short_version)s
+          haltOnFailure: true
+      - ShellCommand:
+          name: Start the bootstrap process
+          command: >
+            bash
+            /srv/scality/metalk8s-%(prop:metalk8s_short_version)s/bootstrap.sh
+          haltOnFailure: true

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -15,6 +15,7 @@ stages:
           stage_names:
             - build
             - lint
+          haltOnFailure: true
       - SetPropertyFromCommand:
           name: Set short version as property from built artifacts
           property: metalk8s_short_version

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -86,7 +86,7 @@ stages:
     worker:
       type: openstack
       image: CentOS 7 (PVHVM)
-      flavor: io1-30
+      flavor: m1.medium
       path: eve/workers/openstack-single-node
     steps:
       - ShellCommand:

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -11,11 +11,15 @@ stages:
     worker:
       type: local
     steps:
-      - TriggerStages:
-          name: Trigger build and lint stages simultaneously
-          stage_names:
-            - build
-            - lint
+    - TriggerStages:
+        name: Trigger build and lint stages simultaneously
+        stage_names:
+        - build
+        - lint
+    - TriggerStages:
+        name: Trigger single-node deployment with built ISO
+        stage_names:
+        - single-node
 
   build:
     worker:
@@ -67,3 +71,38 @@ stages:
           name: Run all linting targets
           command: make lint
           haltOnFailure: false
+
+  single-node:
+    worker:
+      type: openstack
+      image: CentOS 7 (PVHVM)
+      flavor: io1-30
+      path: eve/workers/openstack-single-node
+    steps:
+    - ShellCommand:
+        name: Retrieve ISO image
+        command: >
+          curl -XGET -o metalk8s.iso
+          "%(prop:artifacts_private_url)s/metalk8s.iso"
+        haltOnFailure: true
+    - ShellCommand:
+        name: Retrieve ISO image checksum
+        command: >
+          curl -XGET -o SHA256SUM
+          "%(prop:artifacts_private_url)s/SHA256SUM"
+        haltOnFailure: true
+    - ShellCommand:
+        name: Check image with checksum
+        command: sha256sum -c SHA256SUM
+        haltOnFailure: true
+    - ShellCommand:
+        name: Mount ISO image
+        command: >
+          sudo mount -o loop metalk8s.iso
+          /srv/scality/metalk8s-%(prop:product_version)s
+        haltOnFailure: true
+    - ShellCommand:
+        name: Start the bootstrap process
+        command: >
+          bash /srv/scality/metalk8s-%(prop:product_version)s/bootstrap.sh
+        haltOnFailure: true

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -120,5 +120,4 @@ stages:
           command: >
             sudo bash
             /srv/scality/metalk8s-%(prop:metalk8s_short_version)s/bootstrap.sh
-          usePTY: true
           haltOnFailure: true

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -1,12 +1,11 @@
 ---
-version: '0.2'
+version: "0.2"
 
 branches:
   default:
     stage: pre-merge
 
 stages:
-
   pre-merge:
     worker:
       type: local
@@ -20,8 +19,8 @@ stages:
           name: Set short version as property from built artifacts
           property: metalk8s_short_version
           command: >
-            bash -c
-            '. <(curl -s "%(prop:artifacts_private_url)s/product.txt") &&
+            bash -c '
+            . <(curl -s "%(prop:artifacts_private_url)s/product.txt") &&
             echo $SHORT_VERSION'
       - TriggerStages:
           name: Trigger single-node deployment with built ISO

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -120,4 +120,5 @@ stages:
           command: >
             sudo bash
             /srv/scality/metalk8s-%(prop:metalk8s_short_version)s/bootstrap.sh
+          usePTY: true
           haltOnFailure: true

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -16,6 +16,13 @@ stages:
           stage_names:
             - build
             - lint
+      - SetPropertyFromCommand:
+          name: Set short version as property from built artifacts
+          property: metalk8s_short_version
+          command: >
+            bash -c
+            '. <(curl -s "%(prop:artifacts_private_url)s/product.txt") &&
+            echo $SHORT_VERSION'
       - TriggerStages:
           name: Trigger single-node deployment with built ISO
           stage_names:
@@ -39,7 +46,7 @@ stages:
             done
             echo "Could not reach Docker daemon from buildbot worker" >&2
             exit 1'
-        haltOnFailure: true
+          haltOnFailure: true
       - Git: &git_pull
           name: git pull
           repourl: "%(prop:git_reference)s"
@@ -51,17 +58,16 @@ stages:
           command: make
       - ShellCommand:
           name: Put the iso file in a separate folder
-          command: mkdir iso && cp _build/metalk8s.iso _build/SHA256SUM iso
+          command: >
+            mkdir iso &&
+            cp _build/metalk8s.iso _build/SHA256SUM _build/root/product.txt iso
       - Upload:
           name: upload artifacts
           source: iso/
           urls:
             - "*.iso"
             - "SHA256SUM"
-      - SetPropertyFromCommand:
-          name: Set short version property
-          property: metalk8s-short-version
-          command: source _build/root/product.txt && echo $SHORT_VERSION
+            - "product.txt"
 
   lint:
     worker:

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -118,6 +118,6 @@ stages:
       - ShellCommand:
           name: Start the bootstrap process
           command: >
-            bash
+            sudo bash
             /srv/scality/metalk8s-%(prop:metalk8s_short_version)s/bootstrap.sh
           haltOnFailure: true

--- a/eve/workers/openstack-single-node/requirements.sh
+++ b/eve/workers/openstack-single-node/requirements.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+PACKAGES=(
+    curl
+)
+
+yum install -y "${PACKAGES[@]}"
+
+yum clean all

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -117,9 +117,9 @@ accept_keys() {
 }
 
 set_salt_command() {
-    echo "setting salt master command"
+    echo "Setting salt master command"
     # shellcheck disable=SC2046
-    SALT_MASTER_CALL="crictl exec -i $(crictl ps -q --pod $(crictl pods --name salt-master-bootstrap -q)) salt"
+    SALT_MASTER_CALL="crictl exec -i $(crictl ps -q --pod $(crictl pods --name salt-master\* -q)) salt"
 }
 
 sync_salt() {


### PR DESCRIPTION
Using results from the build step, we mount the ISO and execute the bootstrap script on a fresh OpenStack VM worker (using CentOS 7).

Fixes GH-556.