### PR TITLE
Generate certificates for front-proxy-ca and front-proxy-client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,8 @@ ALL = \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/apiserver.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/apiserver-kubelet-client.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/ca.sls \
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/front-proxy-ca.sls \
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/front-proxy-client.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/init.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/installed.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/sa.sls \

--- a/salt/metalk8s/defaults.yaml
+++ b/salt/metalk8s/defaults.yaml
@@ -67,4 +67,13 @@ kube_api:
     client_signing_policy: kube_apiserver_client_policy
   service_ip: "10.96.0.1"
 
+front_proxy:
+  ca:
+    cert:
+      days_valid: 3650
+    signing_policy:
+      days_valid: 365
+  cert:
+    client_signing_policy: front_proxy_client_policy
+
 upgrade: False        # define if we're on an upgrade case

--- a/salt/metalk8s/kubeadm/init/certs/front-proxy-ca.sls
+++ b/salt/metalk8s/kubeadm/init/certs/front-proxy-ca.sls
@@ -1,0 +1,76 @@
+{%- from "metalk8s/map.jinja" import front_proxy with context %}
+
+{%- set front_proxy_ca_server = salt['mine.get']('*', 'kubernetes_front_proxy_ca_server') %}
+
+{#- Check if we have no CA server or only current minion as CA #}
+{%- if not front_proxy_ca_server or front_proxy_ca_server.keys() == [grains['id']] %}
+
+include:
+  - .installed
+  - metalk8s.salt.minion.running
+
+Create front proxy CA private key:
+  x509.private_key_managed:
+    - name: /etc/kubernetes/pki/front-proxy-ca.key
+    - bits: 4096
+    - user: root
+    - group: root
+    - mode: 600
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - pkg: Install m2crypto
+
+Generate front proxy CA certificate:
+  x509.certificate_managed:
+    - name: /etc/kubernetes/pki/front-proxy-ca.crt
+    - signing_private_key: /etc/kubernetes/pki/front-proxy-ca.key
+    - CN: front-proxy-ca
+    - keyUsage: "critical digitalSignature, keyEncipherment, keyCertSign"
+    - basicConstraints: "critical CA:true"
+    - days_valid: {{ front_proxy.ca.cert.days_valid }}
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - x509: Create front proxy CA private key
+
+# TODO: Find a better way to advertise CA server
+Advertise front proxy CA in the mine:
+  module.wait:
+    - mine.send:
+      - func: 'kubernetes_front_proxy_ca_server'
+      - mine_function: hashutil.base64_encodefile
+      - /etc/kubernetes/pki/front-proxy-ca.crt
+    - watch:
+      - x509: Generate front proxy CA certificate
+
+Create front proxy CA salt signing policies:
+  file.serialize:
+    - name: /etc/salt/minion.d/30-metalk8s-front-proxy-ca-signing-policies.conf
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - dir_mode: 755
+    - formatter: yaml
+    - dataset:
+        x509_signing_policies:
+          front_proxy_client_policy:
+            - minions: '*'
+            - signing_private_key: /etc/kubernetes/pki/front-proxy-ca.key
+            - signing_cert: /etc/kubernetes/pki/front-proxy-ca.crt
+            - keyUsage: "critical digitalSignature, keyEncipherment"
+            - extendedKeyUsage: "clientAuth"
+            - days_valid: {{ front_proxy.ca.signing_policy.days_valid }}
+    - watch_in:
+      - cmd: Restart salt-minion
+
+{%- else %}
+
+{{ front_proxy_ca_server.keys()|join(', ') }} already configured as Kubernetes front proxy CA server, only one can be declared:
+  test.fail_without_changes: []
+
+{%- endif %}

--- a/salt/metalk8s/kubeadm/init/certs/front-proxy-client.sls
+++ b/salt/metalk8s/kubeadm/init/certs/front-proxy-client.sls
@@ -1,0 +1,41 @@
+{%- from "metalk8s/map.jinja" import front_proxy with context %}
+
+{%- set front_proxy_ca_server = salt['mine.get']('*', 'kubernetes_front_proxy_ca_server').keys() %}
+{%- if front_proxy_ca_server %}
+
+include:
+  - .installed
+
+Create front proxy client private key:
+  x509.private_key_managed:
+    - name: /etc/kubernetes/pki/front-proxy-client.key
+    - bits: 2048
+    - user: root
+    - group: root
+    - mode: 600
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - pkg: Install m2crypto
+
+Generate front proxy client certificate:
+  x509.certificate_managed:
+    - name: /etc/kubernetes/pki/front-proxy-client.crt
+    - public_key: /etc/kubernetes/pki/front-proxy-client.key
+    - ca_server: {{ front_proxy_ca_server[0] }}
+    - signing_policy: {{ front_proxy.cert.client_signing_policy }}
+    - CN: front-proxy-client
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - x509: Create front proxy client private key
+
+{%- else %}
+
+Unable to generate front proxy client certificate, no CA server available:
+  test.fail_without_changes: []
+
+{%- endif %}

--- a/salt/metalk8s/map.jinja
+++ b/salt/metalk8s/map.jinja
@@ -51,6 +51,10 @@
   'default': {}
 }, merge=defaults.get('kube_api')) %}
 
+{% set front_proxy = salt['grains.filter_by']({
+  'default': {}
+}, merge=defaults.get('front_proxy')) %}
+
 {% set kubeadm_kubeconfig = salt['grains.filter_by']({
   'default': {}
 }, merge=defaults.get('kubeadm_kubeconfig')) %}

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -119,6 +119,8 @@ run_certs() {
     ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.apiserver saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
     ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.apiserver-kubelet-client saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
     ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.sa saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
+    ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.front-proxy-ca saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
+    ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.front-proxy-client saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
 }
 
 run_kubeconfig() {


### PR DESCRIPTION
Generate certificates for front-proxy-ca and front-proxy-client as described here: https://kubernetes.io/docs/reference/setup-tools/kubeadm/implementation-details/#generate-the-necessary-certificates

To test:
Call the state:
```
salt <ca serv id> state.sls metalk8s.kubeadm.init.certs.front-proxy-ca
```
This should generate 2 files:
```
/etc/kubernetes/pki/front-proxy-ca.crt (autosigned)
/etc/kubernetes/pki/front-proxy-ca.key
```

Then call the salt state:
```
salt <proxy srv id> state.sls metalk8s.kubeadm.init.certs.front-proxy-client
```
This should generate 2 files:
```
/etc/kubernetes/pki/front-proxy-client.crt (signed by front-proxy-ca)
/etc/kubernetes/pki/front-proxy-client.key
```

Closes: #629