### PR TITLE
Add Salt state to manage etcd PKI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,13 @@ ALL = \
 	$(ISO_ROOT)/salt/metalk8s/defaults.yaml \
 	\
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/apiserver.sls \
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/apiserver-etcd-client.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/apiserver-kubelet-client.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/ca.sls \
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/etcd-ca.sls \
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/etcd-healthcheck-client.sls \
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/etcd-peer.sls \
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/etcd-server.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/front-proxy-ca.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/front-proxy-client.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/init.sls \

--- a/salt/metalk8s/defaults.yaml
+++ b/salt/metalk8s/defaults.yaml
@@ -68,6 +68,18 @@ kube_api:
     client_signing_policy: kube_apiserver_client_policy
   service_ip: "10.96.0.1"
 
+etcd:
+  ca:
+    cert:
+      days_valid: 3650
+    signing_policy:
+      days_valid: 365
+  cert:
+    apiserver_client_signing_policy: etcd_client_policy
+    healthcheck_client_signing_policy: etcd_client_policy
+    peer_signing_policy: etcd_server_client_policy
+    server_signing_policy: etcd_server_client_policy
+
 front_proxy:
   ca:
     cert:

--- a/salt/metalk8s/kubeadm/init/certs/apiserver-etcd-client.sls
+++ b/salt/metalk8s/kubeadm/init/certs/apiserver-etcd-client.sls
@@ -1,0 +1,42 @@
+{%- from "metalk8s/map.jinja" import etcd with context %}
+
+{%- set etcd_ca_server = salt['mine.get']('*', 'kubernetes_etcd_ca_server').keys() %}
+{%- if etcd_ca_server %}
+
+include:
+  - .installed
+
+Create apiserver etcd client private key:
+  x509.private_key_managed:
+    - name: /etc/kubernetes/pki/apiserver-etcd-client.key
+    - bits: 2048
+    - user: root
+    - group: root
+    - mode: 600
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - pkg: Install m2crypto
+
+Generate apiserver etcd client certificate:
+  x509.certificate_managed:
+    - name: /etc/kubernetes/pki/apiserver-etcd-client.crt
+    - public_key: /etc/kubernetes/pki/apiserver-etcd-client.key
+    - ca_server: {{ etcd_ca_server[0] }}
+    - signing_policy: {{ etcd.cert.apiserver_client_signing_policy }}
+    - CN: kube-apiserver-etcd-client
+    - O: "system:masters"
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - x509: Create apiserver etcd client private key
+
+{%- else %}
+
+Unable to generate apiserver etcd client certificate, no CA server available:
+  test.fail_without_changes: []
+
+{%- endif %}

--- a/salt/metalk8s/kubeadm/init/certs/etcd-ca.sls
+++ b/salt/metalk8s/kubeadm/init/certs/etcd-ca.sls
@@ -1,0 +1,83 @@
+{%- from "metalk8s/map.jinja" import etcd with context %}
+
+{%- set etcd_ca_server = salt['mine.get']('*', 'kubernetes_etcd_ca_server') %}
+
+{#- Check if we have no CA server or only current minion as CA #}
+{%- if not etcd_ca_server or etcd_ca_server.keys() == [grains['id']] %}
+
+include:
+  - .installed
+  - metalk8s.salt.minion.running
+
+Create etcd CA private key:
+  x509.private_key_managed:
+    - name: /etc/kubernetes/pki/etcd/ca.key
+    - bits: 4096
+    - user: root
+    - group: root
+    - mode: 600
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - pkg: Install m2crypto
+
+Generate etcd CA certificate:
+  x509.certificate_managed:
+    - name: /etc/kubernetes/pki/etcd/ca.crt
+    - signing_private_key: /etc/kubernetes/pki/etcd/ca.key
+    - CN: etcd-ca
+    - keyUsage: "critical digitalSignature, keyEncipherment, keyCertSign"
+    - basicConstraints: "critical CA:true"
+    - days_valid: {{ etcd.ca.cert.days_valid }}
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - x509: Create etcd CA private key
+
+# TODO: Find a better way to advertise CA server
+Advertise etcd CA in the mine:
+  module.wait:
+    - mine.send:
+      - func: 'kubernetes_etcd_ca_server'
+      - mine_function: hashutil.base64_encodefile
+      - /etc/kubernetes/pki/etcd/ca.crt
+    - watch:
+      - x509: Generate etcd CA certificate
+
+Create etcd CA salt signing policies:
+  file.serialize:
+    - name: /etc/salt/minion.d/30-metalk8s-etcd-ca-signing-policies.conf
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - dir_mode: 755
+    - formatter: yaml
+    - dataset:
+        x509_signing_policies:
+          etcd_client_policy:
+            - minions: '*'
+            - signing_private_key: /etc/kubernetes/pki/etcd/ca.key
+            - signing_cert: /etc/kubernetes/pki/etcd/ca.crt
+            - keyUsage: "critical digitalSignature, keyEncipherment"
+            - extendedKeyUsage: "clientAuth"
+            - days_valid: {{ etcd.ca.signing_policy.days_valid }}
+          etcd_server_client_policy:
+            - minions: '*'
+            - signing_private_key: /etc/kubernetes/pki/etcd/ca.key
+            - signing_cert: /etc/kubernetes/pki/etcd/ca.crt
+            - keyUsage: "critical digitalSignature, keyEncipherment"
+            - extendedKeyUsage: "serverAuth, clientAuth"
+            - days_valid: {{ etcd.ca.signing_policy.days_valid }}
+    - watch_in:
+      - cmd: Restart salt-minion
+
+{%- else %}
+
+{{ etcd_ca_server.keys()|join(', ') }} already configured as Kubernetes etcd CA server, only one can be declared:
+  test.fail_without_changes: []
+
+{%- endif %}

--- a/salt/metalk8s/kubeadm/init/certs/etcd-healthcheck-client.sls
+++ b/salt/metalk8s/kubeadm/init/certs/etcd-healthcheck-client.sls
@@ -1,0 +1,42 @@
+{%- from "metalk8s/map.jinja" import etcd with context %}
+
+{%- set etcd_ca_server = salt['mine.get']('*', 'kubernetes_etcd_ca_server').keys() %}
+{%- if etcd_ca_server %}
+
+include:
+  - .installed
+
+Create etcd healthcheck client private key:
+  x509.private_key_managed:
+    - name: /etc/kubernetes/pki/etcd/healthcheck-client.key
+    - bits: 2048
+    - user: root
+    - group: root
+    - mode: 600
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - pkg: Install m2crypto
+
+Generate etcd healthcheck client certificate:
+  x509.certificate_managed:
+    - name: /etc/kubernetes/pki/etcd/healthcheck-client.crt
+    - public_key: /etc/kubernetes/pki/etcd/healthcheck-client.key
+    - ca_server: {{ etcd_ca_server[0] }}
+    - signing_policy: {{ etcd.cert.healthcheck_client_signing_policy }}
+    - CN: kube-etcd-healthcheck-client
+    - O: "system:masters"
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - x509: Create etcd healthcheck client private key
+
+{%- else %}
+
+Unable to generate etcd healthcheck client certificate, no CA server available:
+  test.fail_without_changes: []
+
+{%- endif %}

--- a/salt/metalk8s/kubeadm/init/certs/etcd-peer.sls
+++ b/salt/metalk8s/kubeadm/init/certs/etcd-peer.sls
@@ -1,0 +1,43 @@
+{%- from "metalk8s/map.jinja" import etcd with context %}
+{%- from "metalk8s/map.jinja" import networks with context %}
+
+{%- set etcd_ca_server = salt['mine.get']('*', 'kubernetes_etcd_ca_server').keys() %}
+{%- if etcd_ca_server %}
+
+include:
+  - .installed
+
+Create etcd peer private key:
+  x509.private_key_managed:
+    - name: /etc/kubernetes/pki/etcd/peer.key
+    - bits: 2048
+    - user: root
+    - group: root
+    - mode: 600
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - pkg: Install m2crypto
+
+Generate etcd peer certificate:
+  x509.certificate_managed:
+    - name: /etc/kubernetes/pki/etcd/peer.crt
+    - public_key: /etc/kubernetes/pki/etcd/peer.key
+    - ca_server: {{ etcd_ca_server[0] }}
+    - signing_policy: {{ etcd.cert.peer_signing_policy }}
+    - CN: "{{ grains['fqdn'] }}"
+    - subjectAltName: "DNS:{{ grains['fqdn'] }}, DNS:localhost, IP:{{ salt['network.ip_addrs'](cidr=networks.control_plane) | join(', IP:') }}, IP:127.0.0.1"
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - x509: Create etcd peer private key
+
+{%- else %}
+
+Unable to generate etcd peer certificate, no CA server available:
+  test.fail_without_changes: []
+
+{%- endif %}

--- a/salt/metalk8s/kubeadm/init/certs/etcd-server.sls
+++ b/salt/metalk8s/kubeadm/init/certs/etcd-server.sls
@@ -1,0 +1,43 @@
+{%- from "metalk8s/map.jinja" import etcd with context %}
+{%- from "metalk8s/map.jinja" import networks with context %}
+
+{%- set etcd_ca_server = salt['mine.get']('*', 'kubernetes_etcd_ca_server').keys() %}
+{%- if etcd_ca_server %}
+
+include:
+  - .installed
+
+Create etcd server private key:
+  x509.private_key_managed:
+    - name: /etc/kubernetes/pki/etcd/server.key
+    - bits: 2048
+    - user: root
+    - group: root
+    - mode: 600
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - pkg: Install m2crypto
+
+Generate etcd server certificate:
+  x509.certificate_managed:
+    - name: /etc/kubernetes/pki/etcd/server.crt
+    - public_key: /etc/kubernetes/pki/etcd/server.key
+    - ca_server: {{ etcd_ca_server[0] }}
+    - signing_policy: {{ etcd.cert.server_signing_policy }}
+    - CN: "{{ grains['fqdn'] }}"
+    - subjectAltName: "DNS:{{ grains['fqdn'] }}, DNS:localhost, IP:{{ salt['network.ip_addrs'](cidr=networks.control_plane) | join(', IP:') }}, IP:127.0.0.1"
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - x509: Create etcd server private key
+
+{%- else %}
+
+Unable to generate etcd server certificate, no CA server available:
+  test.fail_without_changes: []
+
+{%- endif %}

--- a/salt/metalk8s/map.jinja
+++ b/salt/metalk8s/map.jinja
@@ -51,6 +51,10 @@
   'default': {}
 }, merge=defaults.get('kube_api')) %}
 
+{% set etcd = salt['grains.filter_by']({
+  'default': {}
+}, merge=defaults.get('etcd')) %}
+
 {% set front_proxy = salt['grains.filter_by']({
   'default': {}
 }, merge=defaults.get('front_proxy')) %}

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -119,6 +119,11 @@ run_certs() {
     ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.apiserver saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
     ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.apiserver-kubelet-client saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
     ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.sa saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
+    ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.etcd-ca saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
+    ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.etcd-healthcheck-client saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
+    ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.etcd-peer saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
+    ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.etcd-server saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
+    ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.apiserver-etcd-client saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
     ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.front-proxy-ca saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
     ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.certs.front-proxy-client saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
 }


### PR DESCRIPTION
Generate certificates for the whole etcd stack as described in #630.

To test:

Either go full auto and execute:
```
make clean && make vagrant up && vagrant ssh
```
```
[vagrant@bootstrap ~]$ ls -1l /etc/kubernetes/pki/*etcd*
-rw-r--r--. 1 root root 1440 févr. 27 10:03 /etc/kubernetes/pki/apiserver-etcd-client.crt
-rw-------. 1 root root 1675 févr. 27 10:03 /etc/kubernetes/pki/apiserver-etcd-client.key

/etc/kubernetes/pki/etcd:
total 32
-rw-r--r--. 1 root root 1720 févr. 27 10:03 ca.crt
-rw-------. 1 root root 3243 févr. 27 10:03 ca.key
-rw-r--r--. 1 root root 1440 févr. 27 10:03 healthcheck-client.crt
-rw-------. 1 root root 1679 févr. 27 10:03 healthcheck-client.key
-rw-r--r--. 1 root root 1456 févr. 27 10:03 peer.crt
-rw-------. 1 root root 1675 févr. 27 10:03 peer.key
-rw-r--r--. 1 root root 1456 févr. 27 10:03 server.crt
-rw-------. 1 root root 1675 févr. 27 10:03 server.key
```

OR

Call manually the CA state:
```
salt <ca serv id> state.sls metalk8s.kubeadm.init.certs.etcd-ca
```
This should generate 2 files:
```
/etc/kubernetes/pki/etcd/ca.crt (autosigned)
/etc/kubernetes/pki/etcd/ca.key
```

Then call manually the certificate states:
```
salt <ca serv id> state.sls metalk8s.kubeadm.init.certs.etcd-healthcheck-client
salt <ca serv id> state.sls metalk8s.kubeadm.init.certs.etcd-peer
salt <ca serv id> state.sls metalk8s.kubeadm.init.certs.etcd-server
```
This should generate 6 files:
```
/etc/kubernetes/pki/etcd/healthcheck-client.crt
/etc/kubernetes/pki/etcd/healthcheck-client.key
/etc/kubernetes/pki/etcd/peer.crt
/etc/kubernetes/pki/etcd/peer.key
/etc/kubernetes/pki/etcd/server.crt
/etc/kubernetes/pki/etcd/server.key
```

Then finally call manually the apiserver certificate state:
```
salt <ca serv id> state.sls metalk8s.kubeadm.init.certs.apiserver-etcd-client
```
This should generate 2 files:
```
/etc/kubernetes/pki/apiserver-etcd-client.crt
/etc/kubernetes/pki/apiserver-etcd-client.key
```

Closes: #630 