### PR TITLE
registry: fix readiness and liveness checks

### DIFF
--- a/salt/metalk8s/registry/files/registry-pod.yaml.j2
+++ b/salt/metalk8s/registry/files/registry-pod.yaml.j2
@@ -36,12 +36,14 @@ spec:
           protocol: TCP
       livenessProbe:
         httpGet:
-          path: /
+          host: localhost
           port: registry
+          path: /
       readinessProbe:
         httpGet:
-          path: /
+          host: localhost
           port: registry
+          path: /
       env:
         - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
           value: '/var/lib/registry'


### PR DESCRIPTION
The HTTP checks will query the `podIP`, which is the `hostIP` because
the `Pods` run in the host network. However, we bind the registry to
`localhost` only, so the checks fail.

Fixes: #678