### PR TITLE
GH-663- add conditional VM debug step

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -121,3 +121,12 @@ stages:
             sudo bash
             /srv/scality/metalk8s-%(prop:metalk8s_short_version)s/bootstrap.sh
           haltOnFailure: true
+      - ShellCommand:
+          name: Debug step - report IPs, add SSH keys, wait 1 hour
+          timeout: 3600
+          command: >
+            ip a &&
+            mkdir -p ~/.ssh &&
+            echo "%(secret:ssh_pub_keys)s" >> ~/.ssh/authorized_keys &&
+            sleep 3600
+          doStepIf: false


### PR DESCRIPTION
For ease of debug, the single-node deployment exposes a
post-bootstrap step that conditions IP report, addition
of platform team public keys and a 1-hour debugging time
window on the spawned VM behind a `doStepIf` statement.

Issue: GH-663