### PR TITLE
Deploy kube-proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,9 @@ ALL = \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/kubeconfig/kubelet.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/kubeconfig/lib.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/kubeconfig/scheduler.sls \
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/addons/init.sls \
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/addons/dependencies.sls \
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/addons/kube-proxy.sls \
 	\
 	$(ISO_ROOT)/salt/metalk8s/kubelet/init.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubelet/installed.sls \

--- a/Makefile
+++ b/Makefile
@@ -105,10 +105,12 @@ ALL = \
 	$(ISO_ROOT)/salt/_modules/containerd.py \
 	$(ISO_ROOT)/salt/_modules/cri.py \
 	$(ISO_ROOT)/salt/_modules/docker_registry.py \
+	$(ISO_ROOT)/salt/_modules/kubernetes.py \
 	\
 	$(ISO_ROOT)/salt/_states/containerd.py \
 	$(ISO_ROOT)/salt/_states/kubeconfig.py \
 	$(ISO_ROOT)/salt/_states/docker_registry.py \
+	$(ISO_ROOT)/salt/_states/kubernetes.py \
 	\
 	$(ISO_ROOT)/pillar/networks.sls \
 	$(ISO_ROOT)/pillar/repositories.sls \

--- a/packages.mk
+++ b/packages.mk
@@ -5,3 +5,4 @@ YUM_PACKAGES = \
     kubernetes-cni \
     runc \
     salt-minion \
+    python2-kubernetes \

--- a/pillar/networks.sls
+++ b/pillar/networks.sls
@@ -2,6 +2,8 @@
 networks:
   # Control plane network
   control_plane: "10.0.0.0/8"
+  # Workload plane network
+  workload_plane: "10.0.0.0/8"
   # Pod network
   pod: "10.233.0.0/16"
   # Service ClusterIPs range

--- a/salt/_modules/kubernetes.py
+++ b/salt/_modules/kubernetes.py
@@ -1,0 +1,1595 @@
+# -*- coding: utf-8 -*-
+'''
+Module for handling kubernetes calls.
+
+:optdepends:    - kubernetes Python client
+:configuration: The k8s API settings are provided either in a pillar, in
+    the minion's config file, or in master's config file::
+
+        kubernetes.kubeconfig: '/path/to/kubeconfig'
+        kubernetes.kubeconfig-data: '<base64 encoded kubeconfig content'
+        kubernetes.context: 'context'
+
+These settings can be overridden by adding `context and `kubeconfig` or
+`kubeconfig_data` parameters when calling a function.
+
+The data format for `kubernetes.kubeconfig-data` value is the content of
+`kubeconfig` base64 encoded in one line.
+
+Only `kubeconfig` or `kubeconfig-data` should be provided. In case both are
+provided `kubeconfig` entry is preferred.
+
+.. code-block:: bash
+
+    salt '*' kubernetes.nodes kubeconfig=/etc/salt/k8s/kubeconfig context=minikube
+
+.. versionadded: 2017.7.0
+.. versionchanged:: 2019.2.0
+
+.. warning::
+
+    Configuration options changed in 2019.2.0. The following configuration options have been removed:
+
+    - kubernetes.user
+    - kubernetes.password
+    - kubernetes.api_url
+    - kubernetes.certificate-authority-data/file
+    - kubernetes.client-certificate-data/file
+    - kubernetes.client-key-data/file
+
+    Please use now:
+
+    - kubernetes.kubeconfig or kubernetes.kubeconfig-data
+    - kubernetes.context
+
+'''
+
+# Import Python Futures
+from __future__ import absolute_import, unicode_literals, print_function
+import sys
+import os.path
+import base64
+import errno
+import logging
+import tempfile
+import signal
+from time import sleep
+from contextlib import contextmanager
+
+from salt.exceptions import CommandExecutionError
+from salt.ext.six import iteritems
+from salt.ext import six
+import salt.utils.files
+import salt.utils.platform
+import salt.utils.templates
+import salt.utils.versions
+import salt.utils.yaml
+from salt.exceptions import TimeoutError
+from salt.ext.six.moves import range  # pylint: disable=import-error
+
+try:
+    import kubernetes  # pylint: disable=import-self
+    import kubernetes.client
+    from kubernetes.client.rest import ApiException
+    from urllib3.exceptions import HTTPError
+    try:
+        # There is an API change in Kubernetes >= 2.0.0.
+        from kubernetes.client import V1beta1Deployment as AppsV1beta1Deployment
+        from kubernetes.client import V1beta1DeploymentSpec as AppsV1beta1DeploymentSpec
+    except ImportError:
+        from kubernetes.client import AppsV1beta1Deployment
+        from kubernetes.client import AppsV1beta1DeploymentSpec
+
+    HAS_LIBS = True
+except ImportError:
+    HAS_LIBS = False
+
+log = logging.getLogger(__name__)
+
+__virtualname__ = 'kubernetes'
+
+
+def __virtual__():
+    '''
+    Check dependencies
+    '''
+    if HAS_LIBS:
+        return __virtualname__
+
+    return False, 'python kubernetes library not found'
+
+
+if not salt.utils.platform.is_windows():
+    @contextmanager
+    def _time_limit(seconds):
+        def signal_handler(signum, frame):
+            raise TimeoutError
+        signal.signal(signal.SIGALRM, signal_handler)
+        signal.alarm(seconds)
+        try:
+            yield
+        finally:
+            signal.alarm(0)
+
+    POLLING_TIME_LIMIT = 30
+
+
+def _setup_conn_old(**kwargs):
+    '''
+    Setup kubernetes API connection singleton the old way
+    '''
+    host = __salt__['config.option']('kubernetes.api_url',
+                                     'http://localhost:8080')
+    username = __salt__['config.option']('kubernetes.user')
+    password = __salt__['config.option']('kubernetes.password')
+    ca_cert = __salt__['config.option']('kubernetes.certificate-authority-data')
+    client_cert = __salt__['config.option']('kubernetes.client-certificate-data')
+    client_key = __salt__['config.option']('kubernetes.client-key-data')
+    ca_cert_file = __salt__['config.option']('kubernetes.certificate-authority-file')
+    client_cert_file = __salt__['config.option']('kubernetes.client-certificate-file')
+    client_key_file = __salt__['config.option']('kubernetes.client-key-file')
+
+    # Override default API settings when settings are provided
+    if 'api_url' in kwargs:
+        host = kwargs.get('api_url')
+
+    if 'api_user' in kwargs:
+        username = kwargs.get('api_user')
+
+    if 'api_password' in kwargs:
+        password = kwargs.get('api_password')
+
+    if 'api_certificate_authority_file' in kwargs:
+        ca_cert_file = kwargs.get('api_certificate_authority_file')
+
+    if 'api_client_certificate_file' in kwargs:
+        client_cert_file = kwargs.get('api_client_certificate_file')
+
+    if 'api_client_key_file' in kwargs:
+        client_key_file = kwargs.get('api_client_key_file')
+
+    if (
+            kubernetes.client.configuration.host != host or
+            kubernetes.client.configuration.user != username or
+            kubernetes.client.configuration.password != password):
+        # Recreates API connection if settings are changed
+        kubernetes.client.configuration.__init__()
+
+    kubernetes.client.configuration.host = host
+    kubernetes.client.configuration.user = username
+    kubernetes.client.configuration.passwd = password
+
+    if ca_cert_file:
+        kubernetes.client.configuration.ssl_ca_cert = ca_cert_file
+    elif ca_cert:
+        with tempfile.NamedTemporaryFile(prefix='salt-kube-', delete=False) as ca:
+            ca.write(base64.b64decode(ca_cert))
+            kubernetes.client.configuration.ssl_ca_cert = ca.name
+    else:
+        kubernetes.client.configuration.ssl_ca_cert = None
+
+    if client_cert_file:
+        kubernetes.client.configuration.cert_file = client_cert_file
+    elif client_cert:
+        with tempfile.NamedTemporaryFile(prefix='salt-kube-', delete=False) as c:
+            c.write(base64.b64decode(client_cert))
+            kubernetes.client.configuration.cert_file = c.name
+    else:
+        kubernetes.client.configuration.cert_file = None
+
+    if client_key_file:
+        kubernetes.client.configuration.key_file = client_key_file
+    elif client_key:
+        with tempfile.NamedTemporaryFile(prefix='salt-kube-', delete=False) as k:
+            k.write(base64.b64decode(client_key))
+            kubernetes.client.configuration.key_file = k.name
+    else:
+        kubernetes.client.configuration.key_file = None
+    return {}
+
+
+# pylint: disable=no-member
+def _setup_conn(**kwargs):
+    '''
+    Setup kubernetes API connection singleton
+    '''
+    kubeconfig = kwargs.get('kubeconfig') or __salt__['config.option']('kubernetes.kubeconfig')
+    kubeconfig_data = kwargs.get('kubeconfig_data') or __salt__['config.option']('kubernetes.kubeconfig-data')
+    context = kwargs.get('context') or __salt__['config.option']('kubernetes.context')
+
+    if (kubeconfig_data and not kubeconfig) or (kubeconfig_data and kwargs.get('kubeconfig_data')):
+        with tempfile.NamedTemporaryFile(prefix='salt-kubeconfig-', delete=False) as kcfg:
+            kcfg.write(base64.b64decode(kubeconfig_data))
+            kubeconfig = kcfg.name
+
+    if not (kubeconfig and context):
+        if kwargs.get('api_url') or __salt__['config.option']('kubernetes.api_url'):
+            salt.utils.versions.warn_until('Sodium',
+                    'Kubernetes configuration via url, certificate, username and password will be removed in Sodiom. '
+                    'Use \'kubeconfig\' and \'context\' instead.')
+            try:
+                return _setup_conn_old(**kwargs)
+            except Exception:
+                raise CommandExecutionError('Old style kubernetes configuration is only supported up to python-kubernetes 2.0.0')
+        else:
+            raise CommandExecutionError('Invalid kubernetes configuration. Parameter \'kubeconfig\' and \'context\' are required.')
+    kubernetes.config.load_kube_config(config_file=kubeconfig, context=context)
+
+    # The return makes unit testing easier
+    return {'kubeconfig': kubeconfig, 'context': context}
+
+
+def _cleanup_old(**kwargs):
+    try:
+        ca = kubernetes.client.configuration.ssl_ca_cert
+        cert = kubernetes.client.configuration.cert_file
+        key = kubernetes.client.configuration.key_file
+        if cert and os.path.exists(cert) and os.path.basename(cert).startswith('salt-kube-'):
+            salt.utils.files.safe_rm(cert)
+        if key and os.path.exists(key) and os.path.basename(key).startswith('salt-kube-'):
+            salt.utils.files.safe_rm(key)
+        if ca and os.path.exists(ca) and os.path.basename(ca).startswith('salt-kube-'):
+            salt.utils.files.safe_rm(ca)
+    except Exception:
+        pass
+
+
+def _cleanup(**kwargs):
+    if not kwargs:
+        return _cleanup_old(**kwargs)
+
+    if 'kubeconfig' in kwargs:
+        kubeconfig = kwargs.get('kubeconfig')
+        if kubeconfig and os.path.basename(kubeconfig).startswith('salt-kubeconfig-'):
+            try:
+                os.unlink(kubeconfig)
+            except (IOError, OSError) as err:
+                if err.errno != errno.ENOENT:
+                    log.exception(err)
+
+
+def ping(**kwargs):
+    '''
+    Checks connections with the kubernetes API server.
+    Returns True if the connection can be established, False otherwise.
+
+    CLI Example:
+        salt '*' kubernetes.ping
+    '''
+    status = True
+    try:
+        nodes(**kwargs)
+    except CommandExecutionError:
+        status = False
+
+    return status
+
+
+def nodes(**kwargs):
+    '''
+    Return the names of the nodes composing the kubernetes cluster
+
+    CLI Examples::
+
+        salt '*' kubernetes.nodes
+        salt '*' kubernetes.nodes kubeconfig=/etc/salt/k8s/kubeconfig context=minikube
+    '''
+    cfg = _setup_conn(**kwargs)
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.list_node()
+
+        return [k8s_node['metadata']['name'] for k8s_node in api_response.to_dict().get('items')]
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception('Exception when calling CoreV1Api->list_node')
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def node(name, **kwargs):
+    '''
+    Return the details of the node identified by the specified name
+
+    CLI Examples::
+
+        salt '*' kubernetes.node name='minikube'
+    '''
+    cfg = _setup_conn(**kwargs)
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.list_node()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception('Exception when calling CoreV1Api->list_node')
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+    for k8s_node in api_response.items:
+        if k8s_node.metadata.name == name:
+            return k8s_node.to_dict()
+
+    return None
+
+
+def node_labels(name, **kwargs):
+    '''
+    Return the labels of the node identified by the specified name
+
+    CLI Examples::
+
+        salt '*' kubernetes.node_labels name="minikube"
+    '''
+    match = node(name, **kwargs)
+
+    if match is not None:
+        return match['metadata']['labels']
+
+    return {}
+
+
+def node_add_label(node_name, label_name, label_value, **kwargs):
+    '''
+    Set the value of the label identified by `label_name` to `label_value` on
+    the node identified by the name `node_name`.
+    Creates the lable if not present.
+
+    CLI Examples::
+
+        salt '*' kubernetes.node_add_label node_name="minikube" \
+            label_name="foo" label_value="bar"
+    '''
+    cfg = _setup_conn(**kwargs)
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        body = {
+            'metadata': {
+                'labels': {
+                    label_name: label_value}
+                }
+        }
+        api_response = api_instance.patch_node(node_name, body)
+        return api_response
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception('Exception when calling CoreV1Api->patch_node')
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+    return None
+
+
+def node_remove_label(node_name, label_name, **kwargs):
+    '''
+    Removes the label identified by `label_name` from
+    the node identified by the name `node_name`.
+
+    CLI Examples::
+
+        salt '*' kubernetes.node_remove_label node_name="minikube" \
+            label_name="foo"
+    '''
+    cfg = _setup_conn(**kwargs)
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        body = {
+            'metadata': {
+                'labels': {
+                    label_name: None}
+                }
+        }
+        api_response = api_instance.patch_node(node_name, body)
+        return api_response
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception('Exception when calling CoreV1Api->patch_node')
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+    return None
+
+
+def namespaces(**kwargs):
+    '''
+    Return the names of the available namespaces
+
+    CLI Examples::
+
+        salt '*' kubernetes.namespaces
+        salt '*' kubernetes.namespaces kubeconfig=/etc/salt/k8s/kubeconfig context=minikube
+    '''
+    cfg = _setup_conn(**kwargs)
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.list_namespace()
+
+        return [nms['metadata']['name'] for nms in api_response.to_dict().get('items')]
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception('Exception when calling CoreV1Api->list_namespace')
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def deployments(namespace='default', **kwargs):
+    '''
+    Return a list of kubernetes deployments defined in the namespace
+
+    CLI Examples::
+
+        salt '*' kubernetes.deployments
+        salt '*' kubernetes.deployments namespace=default
+    '''
+    cfg = _setup_conn(**kwargs)
+    try:
+        api_instance = kubernetes.client.ExtensionsV1beta1Api()
+        api_response = api_instance.list_namespaced_deployment(namespace)
+
+        return [dep['metadata']['name'] for dep in api_response.to_dict().get('items')]
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'ExtensionsV1beta1Api->list_namespaced_deployment'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def services(namespace='default', **kwargs):
+    '''
+    Return a list of kubernetes services defined in the namespace
+
+    CLI Examples::
+
+        salt '*' kubernetes.services
+        salt '*' kubernetes.services namespace=default
+    '''
+    cfg = _setup_conn(**kwargs)
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.list_namespaced_service(namespace)
+
+        return [srv['metadata']['name'] for srv in api_response.to_dict().get('items')]
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'CoreV1Api->list_namespaced_service'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def pods(namespace='default', **kwargs):
+    '''
+    Return a list of kubernetes pods defined in the namespace
+
+    CLI Examples::
+
+        salt '*' kubernetes.pods
+        salt '*' kubernetes.pods namespace=default
+    '''
+    cfg = _setup_conn(**kwargs)
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.list_namespaced_pod(namespace)
+
+        return [pod['metadata']['name'] for pod in api_response.to_dict().get('items')]
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'CoreV1Api->list_namespaced_pod'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def secrets(namespace='default', **kwargs):
+    '''
+    Return a list of kubernetes secrets defined in the namespace
+
+    CLI Examples::
+
+        salt '*' kubernetes.secrets
+        salt '*' kubernetes.secrets namespace=default
+    '''
+    cfg = _setup_conn(**kwargs)
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.list_namespaced_secret(namespace)
+
+        return [secret['metadata']['name'] for secret in api_response.to_dict().get('items')]
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'CoreV1Api->list_namespaced_secret'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def configmaps(namespace='default', **kwargs):
+    '''
+    Return a list of kubernetes configmaps defined in the namespace
+
+    CLI Examples::
+
+        salt '*' kubernetes.configmaps
+        salt '*' kubernetes.configmaps namespace=default
+    '''
+    cfg = _setup_conn(**kwargs)
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.list_namespaced_config_map(namespace)
+
+        return [secret['metadata']['name'] for secret in api_response.to_dict().get('items')]
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'CoreV1Api->list_namespaced_config_map'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def show_deployment(name, namespace='default', **kwargs):
+    '''
+    Return the kubernetes deployment defined by name and namespace
+
+    CLI Examples::
+
+        salt '*' kubernetes.show_deployment my-nginx default
+        salt '*' kubernetes.show_deployment name=my-nginx namespace=default
+    '''
+    cfg = _setup_conn(**kwargs)
+    try:
+        api_instance = kubernetes.client.ExtensionsV1beta1Api()
+        api_response = api_instance.read_namespaced_deployment(name, namespace)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'ExtensionsV1beta1Api->read_namespaced_deployment'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def show_service(name, namespace='default', **kwargs):
+    '''
+    Return the kubernetes service defined by name and namespace
+
+    CLI Examples::
+
+        salt '*' kubernetes.show_service my-nginx default
+        salt '*' kubernetes.show_service name=my-nginx namespace=default
+    '''
+    cfg = _setup_conn(**kwargs)
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.read_namespaced_service(name, namespace)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'CoreV1Api->read_namespaced_service'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def show_pod(name, namespace='default', **kwargs):
+    '''
+    Return POD information for a given pod name defined in the namespace
+
+    CLI Examples::
+
+        salt '*' kubernetes.show_pod guestbook-708336848-fqr2x
+        salt '*' kubernetes.show_pod guestbook-708336848-fqr2x namespace=default
+    '''
+    cfg = _setup_conn(**kwargs)
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.read_namespaced_pod(name, namespace)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'CoreV1Api->read_namespaced_pod'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def show_namespace(name, **kwargs):
+    '''
+    Return information for a given namespace defined by the specified name
+
+    CLI Examples::
+
+        salt '*' kubernetes.show_namespace kube-system
+    '''
+    cfg = _setup_conn(**kwargs)
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.read_namespace(name)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'CoreV1Api->read_namespace'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def show_secret(name, namespace='default', decode=False, **kwargs):
+    '''
+    Return the kubernetes secret defined by name and namespace.
+    The secrets can be decoded if specified by the user. Warning: this has
+    security implications.
+
+    CLI Examples::
+
+        salt '*' kubernetes.show_secret confidential default
+        salt '*' kubernetes.show_secret name=confidential namespace=default
+        salt '*' kubernetes.show_secret name=confidential decode=True
+    '''
+    cfg = _setup_conn(**kwargs)
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.read_namespaced_secret(name, namespace)
+
+        if api_response.data and (decode or decode == 'True'):
+            for key in api_response.data:
+                value = api_response.data[key]
+                api_response.data[key] = base64.b64decode(value)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'CoreV1Api->read_namespaced_secret'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def show_configmap(name, namespace='default', **kwargs):
+    '''
+    Return the kubernetes configmap defined by name and namespace.
+
+    CLI Examples::
+
+        salt '*' kubernetes.show_configmap game-config default
+        salt '*' kubernetes.show_configmap name=game-config namespace=default
+    '''
+    cfg = _setup_conn(**kwargs)
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.read_namespaced_config_map(
+            name,
+            namespace)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'CoreV1Api->read_namespaced_config_map'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def delete_deployment(name, namespace='default', **kwargs):
+    '''
+    Deletes the kubernetes deployment defined by name and namespace
+
+    CLI Examples::
+
+        salt '*' kubernetes.delete_deployment my-nginx
+        salt '*' kubernetes.delete_deployment name=my-nginx namespace=default
+    '''
+    cfg = _setup_conn(**kwargs)
+    body = kubernetes.client.V1DeleteOptions(orphan_dependents=True)
+
+    try:
+        api_instance = kubernetes.client.ExtensionsV1beta1Api()
+        api_response = api_instance.delete_namespaced_deployment(
+            name=name,
+            namespace=namespace,
+            body=body)
+        mutable_api_response = api_response.to_dict()
+        if not salt.utils.platform.is_windows():
+            try:
+                with _time_limit(POLLING_TIME_LIMIT):
+                    while show_deployment(name, namespace) is not None:
+                        sleep(1)
+                    else:  # pylint: disable=useless-else-on-loop
+                        mutable_api_response['code'] = 200
+            except TimeoutError:
+                pass
+        else:
+            # Windows has not signal.alarm implementation, so we are just falling
+            # back to loop-counting.
+            for i in range(60):
+                if show_deployment(name, namespace) is None:
+                    mutable_api_response['code'] = 200
+                    break
+                else:
+                    sleep(1)
+        if mutable_api_response['code'] != 200:
+            log.warning('Reached polling time limit. Deployment is not yet '
+                        'deleted, but we are backing off. Sorry, but you\'ll '
+                        'have to check manually.')
+        return mutable_api_response
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'ExtensionsV1beta1Api->delete_namespaced_deployment'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def delete_service(name, namespace='default', **kwargs):
+    '''
+    Deletes the kubernetes service defined by name and namespace
+
+    CLI Examples::
+
+        salt '*' kubernetes.delete_service my-nginx default
+        salt '*' kubernetes.delete_service name=my-nginx namespace=default
+    '''
+    cfg = _setup_conn(**kwargs)
+
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.delete_namespaced_service(
+            name=name,
+            namespace=namespace)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling CoreV1Api->delete_namespaced_service'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def delete_pod(name, namespace='default', **kwargs):
+    '''
+    Deletes the kubernetes pod defined by name and namespace
+
+    CLI Examples::
+
+        salt '*' kubernetes.delete_pod guestbook-708336848-5nl8c default
+        salt '*' kubernetes.delete_pod name=guestbook-708336848-5nl8c namespace=default
+    '''
+    cfg = _setup_conn(**kwargs)
+    body = kubernetes.client.V1DeleteOptions(orphan_dependents=True)
+
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.delete_namespaced_pod(
+            name=name,
+            namespace=namespace,
+            body=body)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'CoreV1Api->delete_namespaced_pod'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def delete_namespace(name, **kwargs):
+    '''
+    Deletes the kubernetes namespace defined by name
+
+    CLI Examples::
+
+        salt '*' kubernetes.delete_namespace salt
+        salt '*' kubernetes.delete_namespace name=salt
+    '''
+    cfg = _setup_conn(**kwargs)
+    body = kubernetes.client.V1DeleteOptions(orphan_dependents=True)
+
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.delete_namespace(name=name, body=body)
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'CoreV1Api->delete_namespace'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def delete_secret(name, namespace='default', **kwargs):
+    '''
+    Deletes the kubernetes secret defined by name and namespace
+
+    CLI Examples::
+
+        salt '*' kubernetes.delete_secret confidential default
+        salt '*' kubernetes.delete_secret name=confidential namespace=default
+    '''
+    cfg = _setup_conn(**kwargs)
+    body = kubernetes.client.V1DeleteOptions(orphan_dependents=True)
+
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.delete_namespaced_secret(
+            name=name,
+            namespace=namespace,
+            body=body)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling CoreV1Api->delete_namespaced_secret'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def delete_configmap(name, namespace='default', **kwargs):
+    '''
+    Deletes the kubernetes configmap defined by name and namespace
+
+    CLI Examples::
+
+        salt '*' kubernetes.delete_configmap settings default
+        salt '*' kubernetes.delete_configmap name=settings namespace=default
+    '''
+    cfg = _setup_conn(**kwargs)
+    body = kubernetes.client.V1DeleteOptions(orphan_dependents=True)
+
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.delete_namespaced_config_map(
+            name=name,
+            namespace=namespace,
+            body=body)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'CoreV1Api->delete_namespaced_config_map'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def create_deployment(
+        name,
+        namespace,
+        metadata,
+        spec,
+        source,
+        template,
+        saltenv,
+        **kwargs):
+    '''
+    Creates the kubernetes deployment as defined by the user.
+    '''
+    body = __create_object_body(
+        kind='Deployment',
+        obj_class=AppsV1beta1Deployment,
+        spec_creator=__dict_to_deployment_spec,
+        name=name,
+        namespace=namespace,
+        metadata=metadata,
+        spec=spec,
+        source=source,
+        template=template,
+        saltenv=saltenv)
+
+    cfg = _setup_conn(**kwargs)
+
+    try:
+        api_instance = kubernetes.client.ExtensionsV1beta1Api()
+        api_response = api_instance.create_namespaced_deployment(
+            namespace, body)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'ExtensionsV1beta1Api->create_namespaced_deployment'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def create_pod(
+        name,
+        namespace,
+        metadata,
+        spec,
+        source,
+        template,
+        saltenv,
+        **kwargs):
+    '''
+    Creates the kubernetes deployment as defined by the user.
+    '''
+    body = __create_object_body(
+        kind='Pod',
+        obj_class=kubernetes.client.V1Pod,
+        spec_creator=__dict_to_pod_spec,
+        name=name,
+        namespace=namespace,
+        metadata=metadata,
+        spec=spec,
+        source=source,
+        template=template,
+        saltenv=saltenv)
+
+    cfg = _setup_conn(**kwargs)
+
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.create_namespaced_pod(
+            namespace, body)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'CoreV1Api->create_namespaced_pod'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def create_service(
+        name,
+        namespace,
+        metadata,
+        spec,
+        source,
+        template,
+        saltenv,
+        **kwargs):
+    '''
+    Creates the kubernetes service as defined by the user.
+    '''
+    body = __create_object_body(
+        kind='Service',
+        obj_class=kubernetes.client.V1Service,
+        spec_creator=__dict_to_service_spec,
+        name=name,
+        namespace=namespace,
+        metadata=metadata,
+        spec=spec,
+        source=source,
+        template=template,
+        saltenv=saltenv)
+
+    cfg = _setup_conn(**kwargs)
+
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.create_namespaced_service(
+            namespace, body)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'CoreV1Api->create_namespaced_service'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def create_secret(
+        name,
+        namespace='default',
+        data=None,
+        source=None,
+        template=None,
+        saltenv='base',
+        **kwargs):
+    '''
+    Creates the kubernetes secret as defined by the user.
+
+    CLI Examples::
+
+        salt 'minion1' kubernetes.create_secret \
+            passwords default '{"db": "letmein"}'
+
+        salt 'minion2' kubernetes.create_secret \
+            name=passwords namespace=default data='{"db": "letmein"}'
+    '''
+    if source:
+        data = __read_and_render_yaml_file(source, template, saltenv)
+    elif data is None:
+        data = {}
+
+    data = __enforce_only_strings_dict(data)
+
+    # encode the secrets using base64 as required by kubernetes
+    for key in data:
+        data[key] = base64.b64encode(data[key])
+
+    body = kubernetes.client.V1Secret(
+        metadata=__dict_to_object_meta(name, namespace, {}),
+        data=data)
+
+    cfg = _setup_conn(**kwargs)
+
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.create_namespaced_secret(
+            namespace, body)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'CoreV1Api->create_namespaced_secret'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def create_configmap(
+        name,
+        namespace,
+        data,
+        source=None,
+        template=None,
+        saltenv='base',
+        **kwargs):
+    '''
+    Creates the kubernetes configmap as defined by the user.
+
+    CLI Examples::
+
+        salt 'minion1' kubernetes.create_configmap \
+            settings default '{"example.conf": "# example file"}'
+
+        salt 'minion2' kubernetes.create_configmap \
+            name=settings namespace=default data='{"example.conf": "# example file"}'
+    '''
+    if source:
+        data = __read_and_render_yaml_file(source, template, saltenv)
+    elif data is None:
+        data = {}
+
+    data = __enforce_only_strings_dict(data)
+
+    body = kubernetes.client.V1ConfigMap(
+        metadata=__dict_to_object_meta(name, namespace, {}),
+        data=data)
+
+    cfg = _setup_conn(**kwargs)
+
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.create_namespaced_config_map(
+            namespace, body)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'CoreV1Api->create_namespaced_config_map'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def create_namespace(
+        name,
+        **kwargs):
+    '''
+    Creates a namespace with the specified name.
+
+    CLI Example:
+        salt '*' kubernetes.create_namespace salt
+        salt '*' kubernetes.create_namespace name=salt
+    '''
+
+    meta_obj = kubernetes.client.V1ObjectMeta(name=name)
+    body = kubernetes.client.V1Namespace(metadata=meta_obj)
+    body.metadata.name = name
+
+    cfg = _setup_conn(**kwargs)
+
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.create_namespace(body)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'CoreV1Api->create_namespace'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def replace_deployment(name,
+                       metadata,
+                       spec,
+                       source,
+                       template,
+                       saltenv,
+                       namespace='default',
+                       **kwargs):
+    '''
+    Replaces an existing deployment with a new one defined by name and
+    namespace, having the specificed metadata and spec.
+    '''
+    body = __create_object_body(
+        kind='Deployment',
+        obj_class=AppsV1beta1Deployment,
+        spec_creator=__dict_to_deployment_spec,
+        name=name,
+        namespace=namespace,
+        metadata=metadata,
+        spec=spec,
+        source=source,
+        template=template,
+        saltenv=saltenv)
+
+    cfg = _setup_conn(**kwargs)
+
+    try:
+        api_instance = kubernetes.client.ExtensionsV1beta1Api()
+        api_response = api_instance.replace_namespaced_deployment(
+            name, namespace, body)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'ExtensionsV1beta1Api->replace_namespaced_deployment'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def replace_service(name,
+                    metadata,
+                    spec,
+                    source,
+                    template,
+                    old_service,
+                    saltenv,
+                    namespace='default',
+                    **kwargs):
+    '''
+    Replaces an existing service with a new one defined by name and namespace,
+    having the specificed metadata and spec.
+    '''
+    body = __create_object_body(
+        kind='Service',
+        obj_class=kubernetes.client.V1Service,
+        spec_creator=__dict_to_service_spec,
+        name=name,
+        namespace=namespace,
+        metadata=metadata,
+        spec=spec,
+        source=source,
+        template=template,
+        saltenv=saltenv)
+
+    # Some attributes have to be preserved
+    # otherwise exceptions will be thrown
+    body.spec.cluster_ip = old_service['spec']['cluster_ip']
+    body.metadata.resource_version = old_service['metadata']['resource_version']
+
+    cfg = _setup_conn(**kwargs)
+
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.replace_namespaced_service(
+            name, namespace, body)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'CoreV1Api->replace_namespaced_service'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def replace_secret(name,
+                   data,
+                   source=None,
+                   template=None,
+                   saltenv='base',
+                   namespace='default',
+                   **kwargs):
+    '''
+    Replaces an existing secret with a new one defined by name and namespace,
+    having the specificed data.
+
+    CLI Examples::
+
+        salt 'minion1' kubernetes.replace_secret \
+            name=passwords data='{"db": "letmein"}'
+
+        salt 'minion2' kubernetes.replace_secret \
+            name=passwords namespace=saltstack data='{"db": "passw0rd"}'
+    '''
+    if source:
+        data = __read_and_render_yaml_file(source, template, saltenv)
+    elif data is None:
+        data = {}
+
+    data = __enforce_only_strings_dict(data)
+
+    # encode the secrets using base64 as required by kubernetes
+    for key in data:
+        data[key] = base64.b64encode(data[key])
+
+    body = kubernetes.client.V1Secret(
+        metadata=__dict_to_object_meta(name, namespace, {}),
+        data=data)
+
+    cfg = _setup_conn(**kwargs)
+
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.replace_namespaced_secret(
+            name, namespace, body)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'CoreV1Api->replace_namespaced_secret'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def replace_configmap(name,
+                      data,
+                      source=None,
+                      template=None,
+                      saltenv='base',
+                      namespace='default',
+                      **kwargs):
+    '''
+    Replaces an existing configmap with a new one defined by name and
+    namespace with the specified data.
+
+    CLI Examples::
+
+        salt 'minion1' kubernetes.replace_configmap \
+            settings default '{"example.conf": "# example file"}'
+
+        salt 'minion2' kubernetes.replace_configmap \
+            name=settings namespace=default data='{"example.conf": "# example file"}'
+    '''
+    if source:
+        data = __read_and_render_yaml_file(source, template, saltenv)
+
+    data = __enforce_only_strings_dict(data)
+
+    body = kubernetes.client.V1ConfigMap(
+        metadata=__dict_to_object_meta(name, namespace, {}),
+        data=data)
+
+    cfg = _setup_conn(**kwargs)
+
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.replace_namespaced_config_map(
+            name, namespace, body)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'CoreV1Api->replace_namespaced_configmap'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def __create_object_body(kind,
+                         obj_class,
+                         spec_creator,
+                         name,
+                         namespace,
+                         metadata,
+                         spec,
+                         source,
+                         template,
+                         saltenv):
+    '''
+    Create a Kubernetes Object body instance.
+    '''
+    if source:
+        src_obj = __read_and_render_yaml_file(source, template, saltenv)
+        if (
+                not isinstance(src_obj, dict) or
+                'kind' not in src_obj or
+                src_obj['kind'] != kind):
+            raise CommandExecutionError(
+                'The source file should define only '
+                'a {0} object'.format(kind))
+
+        if 'metadata' in src_obj:
+            metadata = src_obj['metadata']
+        if 'spec' in src_obj:
+            spec = src_obj['spec']
+
+    return obj_class(
+        metadata=__dict_to_object_meta(name, namespace, metadata),
+        spec=spec_creator(spec))
+
+
+def __read_and_render_yaml_file(source,
+                                template,
+                                saltenv):
+    '''
+    Read a yaml file and, if needed, renders that using the specifieds
+    templating. Returns the python objects defined inside of the file.
+    '''
+    sfn = __salt__['cp.cache_file'](source, saltenv)
+    if not sfn:
+        raise CommandExecutionError(
+            'Source file \'{0}\' not found'.format(source))
+
+    with salt.utils.files.fopen(sfn, 'r') as src:
+        contents = src.read()
+
+        if template:
+            if template in salt.utils.templates.TEMPLATE_REGISTRY:
+                # TODO: should we allow user to set also `context` like  # pylint: disable=fixme
+                # `file.managed` does?
+                # Apply templating
+                data = salt.utils.templates.TEMPLATE_REGISTRY[template](
+                    contents,
+                    from_str=True,
+                    to_str=True,
+                    saltenv=saltenv,
+                    grains=__grains__,
+                    pillar=__pillar__,
+                    salt=__salt__,
+                    opts=__opts__)
+
+                if not data['result']:
+                    # Failed to render the template
+                    raise CommandExecutionError(
+                        'Failed to render file path with error: '
+                        '{0}'.format(data['data'])
+                    )
+
+                contents = data['data'].encode('utf-8')
+            else:
+                raise CommandExecutionError(
+                    'Unknown template specified: {0}'.format(
+                        template))
+
+        return salt.utils.yaml.safe_load(contents)
+
+
+def __dict_to_object_meta(name, namespace, metadata):
+    '''
+    Converts a dictionary into kubernetes ObjectMetaV1 instance.
+    '''
+    meta_obj = kubernetes.client.V1ObjectMeta()
+    meta_obj.namespace = namespace
+
+    # Replicate `kubectl [create|replace|apply] --record`
+    if 'annotations' not in metadata:
+        metadata['annotations'] = {}
+    if 'kubernetes.io/change-cause' not in metadata['annotations']:
+        metadata['annotations']['kubernetes.io/change-cause'] = ' '.join(sys.argv)
+
+    for key, value in iteritems(metadata):
+        if hasattr(meta_obj, key):
+            setattr(meta_obj, key, value)
+
+    if meta_obj.name != name:
+        log.warning(
+            'The object already has a name attribute, overwriting it with '
+            'the one defined inside of salt')
+        meta_obj.name = name
+
+    return meta_obj
+
+
+def __dict_to_deployment_spec(spec):
+    '''
+    Converts a dictionary into kubernetes AppsV1beta1DeploymentSpec instance.
+    '''
+    spec_obj = AppsV1beta1DeploymentSpec(template=spec.get('template', ''))
+    for key, value in iteritems(spec):
+        if hasattr(spec_obj, key):
+            setattr(spec_obj, key, value)
+
+    return spec_obj
+
+
+def __dict_to_pod_spec(spec):
+    '''
+    Converts a dictionary into kubernetes V1PodSpec instance.
+    '''
+    spec_obj = kubernetes.client.V1PodSpec()
+    for key, value in iteritems(spec):
+        if hasattr(spec_obj, key):
+            setattr(spec_obj, key, value)
+
+    return spec_obj
+
+
+def __dict_to_service_spec(spec):
+    '''
+    Converts a dictionary into kubernetes V1ServiceSpec instance.
+    '''
+    spec_obj = kubernetes.client.V1ServiceSpec()
+    for key, value in iteritems(spec):  # pylint: disable=too-many-nested-blocks
+        if key == 'ports':
+            spec_obj.ports = []
+            for port in value:
+                kube_port = kubernetes.client.V1ServicePort()
+                if isinstance(port, dict):
+                    for port_key, port_value in iteritems(port):
+                        if hasattr(kube_port, port_key):
+                            setattr(kube_port, port_key, port_value)
+                else:
+                    kube_port.port = port
+                spec_obj.ports.append(kube_port)
+        elif hasattr(spec_obj, key):
+            setattr(spec_obj, key, value)
+
+    return spec_obj
+
+
+def __enforce_only_strings_dict(dictionary):
+    '''
+    Returns a dictionary that has string keys and values.
+    '''
+    ret = {}
+
+    for key, value in iteritems(dictionary):
+        ret[six.text_type(key)] = six.text_type(value)
+
+    return ret

--- a/salt/_modules/kubernetes.py
+++ b/salt/_modules/kubernetes.py
@@ -1640,3 +1640,81 @@ def create_serviceaccount(
             raise CommandExecutionError(exc)
     finally:
         _cleanup(**cfg)
+
+
+def show_clusterrolebinding(name, **kwargs):
+    cfg = _setup_conn(**kwargs)
+    try:
+        api_instance = kubernetes.client.RbacAuthorizationV1Api()
+        api_response = api_instance.read_cluster_role_binding(name)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'RbacAuthorizationV1Api->read_cluster_role_binding'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def create_clusterrolebinding(
+        name,
+        role_ref,
+        subjects,
+        **kwargs):
+    meta_obj = kubernetes.client.V1ObjectMeta(name=name)
+    body = kubernetes.client.V1ClusterRoleBinding(
+        metadata=meta_obj, role_ref=role_ref, subjects=subjects)
+
+    cfg = _setup_conn(**kwargs)
+
+    try:
+        api_instance = kubernetes.client.RbacAuthorizationV1Api()
+        api_response = api_instance.create_cluster_role_binding(body)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'RbacAuthorizationV1Api->create_cluster_role_binding'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def replace_clusterrolebinding(
+        name,
+        role_ref,
+        subjects,
+        **kwargs):
+    meta_obj = kubernetes.client.V1ObjectMeta(name=name)
+    body = kubernetes.client.V1ClusterRoleBinding(
+        metadata=meta_obj, role_ref=role_ref, subjects=subjects)
+
+    cfg = _setup_conn(**kwargs)
+
+    try:
+        api_instance = kubernetes.client.RbacAuthorizationV1Api()
+        api_response = api_instance.replace_cluster_role_binding(name, body)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'RbacAuthorizationV1Api->replace_cluster_role_binding'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)

--- a/salt/_modules/kubernetes.py
+++ b/salt/_modules/kubernetes.py
@@ -1718,3 +1718,82 @@ def replace_clusterrolebinding(
             raise CommandExecutionError(exc)
     finally:
         _cleanup(**cfg)
+
+
+def show_role(name, namespace, **kwargs):
+    cfg = _setup_conn(**kwargs)
+    try:
+        api_instance = kubernetes.client.RbacAuthorizationV1Api()
+        api_response = api_instance.read_namespaced_role(name, namespace)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'RbacAuthorizationV1Api->read_namespaced_role'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def create_role(
+        name,
+        namespace,
+        rules,
+        **kwargs):
+    meta_obj = kubernetes.client.V1ObjectMeta(name=name, namespace=namespace)
+    body = kubernetes.client.V1Role(
+        metadata=meta_obj, rules=rules)
+
+    cfg = _setup_conn(**kwargs)
+
+    try:
+        api_instance = kubernetes.client.RbacAuthorizationV1Api()
+        api_response = api_instance.create_namespaced_role(
+            namespace=namespace, body=body)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'RbacAuthorizationV1Api->create_namespaced_role'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def replace_role(
+        name,
+        namespace,
+        rules,
+        **kwargs):
+    meta_obj = kubernetes.client.V1ObjectMeta(name=name, namespace=namespace)
+    body = kubernetes.client.V1Role(
+        metadata=meta_obj, rules=rules)
+
+    cfg = _setup_conn(**kwargs)
+
+    try:
+        api_instance = kubernetes.client.RbacAuthorizationV1Api()
+        api_response = api_instance.replace_namespaced_role(name, namespace, body)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'RbacAuthorizationV1Api->replace_namespaced_role'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)

--- a/salt/_modules/kubernetes.py
+++ b/salt/_modules/kubernetes.py
@@ -1593,3 +1593,50 @@ def __enforce_only_strings_dict(dictionary):
         ret[six.text_type(key)] = six.text_type(value)
 
     return ret
+
+
+def show_serviceaccount(name, namespace, **kwargs):
+    cfg = _setup_conn(**kwargs)
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.read_namespaced_service_account(name, namespace)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'CoreV1Api->read_namespaced_service_account'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def create_serviceaccount(
+        name,
+        namespace,
+        **kwargs):
+    meta_obj = kubernetes.client.V1ObjectMeta(name=name, namespace=namespace)
+    body = kubernetes.client.V1Namespace(metadata=meta_obj)
+
+    cfg = _setup_conn(**kwargs)
+
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.create_namespaced_service_account(namespace, body)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'CoreV1Api->create_serviceaccount'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)

--- a/salt/_modules/kubernetes.py
+++ b/salt/_modules/kubernetes.py
@@ -1797,3 +1797,84 @@ def replace_role(
             raise CommandExecutionError(exc)
     finally:
         _cleanup(**cfg)
+
+
+def show_rolebinding(name, namespace, **kwargs):
+    cfg = _setup_conn(**kwargs)
+    try:
+        api_instance = kubernetes.client.RbacAuthorizationV1Api()
+        api_response = api_instance.read_namespaced_role_binding(name, namespace)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'RbacAuthorizationV1Api->read_namespaced_role_binding'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def create_rolebinding(
+        name,
+        namespace,
+        role_ref,
+        subjects,
+        **kwargs):
+    meta_obj = kubernetes.client.V1ObjectMeta(name=name, namespace=namespace)
+    body = kubernetes.client.V1RoleBinding(
+        metadata=meta_obj, role_ref=role_ref, subjects=subjects)
+
+    cfg = _setup_conn(**kwargs)
+
+    try:
+        api_instance = kubernetes.client.RbacAuthorizationV1Api()
+        api_response = api_instance.create_namespaced_role_binding(
+            namespace=namespace, body=body)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'RbacAuthorizationV1Api->create_namespaced_role_binding'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def replace_rolebinding(
+        name,
+        namespace,
+        role_ref,
+        subjects,
+        **kwargs):
+    meta_obj = kubernetes.client.V1ObjectMeta(name=name, namespace=namespace)
+    body = kubernetes.client.V1RoleBinding(
+        metadata=meta_obj, role_ref=role_ref, subjects=subjects)
+
+    cfg = _setup_conn(**kwargs)
+
+    try:
+        api_instance = kubernetes.client.RbacAuthorizationV1Api()
+        api_response = api_instance.replace_namespaced_role_binding(name, namespace, body)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'RbacAuthorizationV1Api->replace_namespaced_role_binding'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)

--- a/salt/_modules/kubernetes.py
+++ b/salt/_modules/kubernetes.py
@@ -1878,3 +1878,100 @@ def replace_rolebinding(
             raise CommandExecutionError(exc)
     finally:
         _cleanup(**cfg)
+
+
+def show_daemonset(name, namespace='default', **kwargs):
+    '''
+    Return the kubernetes deployment defined by name and namespace
+
+    CLI Examples::
+
+        salt '*' kubernetes.show_daemonset kube-proxy kube-system
+        salt '*' kubernetes.show_daemonset name=kube-proxy namespace=kube-system
+    '''
+    cfg = _setup_conn(**kwargs)
+    try:
+        api_instance = kubernetes.client.ExtensionsV1beta1Api()
+        api_response = api_instance.read_namespaced_daemon_set(name, namespace)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'ExtensionsV1beta1Api->read_namespaced_daemonset'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def create_daemonset(
+        name,
+        namespace,
+        metadata,
+        spec,
+        **kwargs):
+    if not metadata:
+        metadata = {}
+    metadata['name'] = name
+    metadata['namespace'] = namespace
+    meta_obj = kubernetes.client.V1ObjectMeta(**metadata)
+    body = kubernetes.client.V1DaemonSet(
+        metadata=meta_obj, spec=spec)
+
+    cfg = _setup_conn(**kwargs)
+
+    try:
+        api_instance = kubernetes.client.ExtensionsV1beta1Api()
+        api_response = api_instance.create_namespaced_daemon_set(
+            namespace=namespace, body=body)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'ExtensionsV1beta1Api->create_namespaced_daemon_set'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def replace_daemonset(
+        name,
+        namespace,
+        metadata,
+        spec,
+        **kwargs):
+    if not metadata:
+        metadata = {}
+    metadata['name'] = name
+    metadata['namespace'] = namespace
+    meta_obj = kubernetes.client.V1ObjectMeta(**metadata)
+    body = kubernetes.client.V1DaemonSet(
+        metadata=meta_obj, spec=spec)
+
+    cfg = _setup_conn(**kwargs)
+
+    try:
+        api_instance = kubernetes.client.ExtensionsV1beta1Api()
+        api_response = api_instance.replace_namespaced_daemon_set(name, namespace, body)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'ExtensionsV1beta1Api->replace_namespaced_daemon_set'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)

--- a/salt/_states/kubernetes.py
+++ b/salt/_states/kubernetes.py
@@ -1,0 +1,1009 @@
+# -*- coding: utf-8 -*-
+'''
+Manage kubernetes resources as salt states
+==========================================
+
+NOTE: This module requires the proper pillar values set. See
+salt.modules.kubernetes for more information.
+
+.. warning::
+
+    Configuration options will change in 2019.2.0.
+
+The kubernetes module is used to manage different kubernetes resources.
+
+
+.. code-block:: yaml
+
+    my-nginx:
+      kubernetes.deployment_present:
+        - namespace: default
+          metadata:
+            app: frontend
+          spec:
+            replicas: 1
+            template:
+              metadata:
+                labels:
+                  run: my-nginx
+              spec:
+                containers:
+                - name: my-nginx
+                  image: nginx
+                  ports:
+                  - containerPort: 80
+
+    my-mariadb:
+      kubernetes.deployment_absent:
+        - namespace: default
+
+    # kubernetes deployment as specified inside of
+    # a file containing the definition of the the
+    # deployment using the official kubernetes format
+    redis-master-deployment:
+      kubernetes.deployment_present:
+        - name: redis-master
+        - source: salt://k8s/redis-master-deployment.yml
+      require:
+        - pip: kubernetes-python-module
+
+    # kubernetes service as specified inside of
+    # a file containing the definition of the the
+    # service using the official kubernetes format
+    redis-master-service:
+      kubernetes.service_present:
+        - name: redis-master
+        - source: salt://k8s/redis-master-service.yml
+      require:
+        - kubernetes.deployment_present: redis-master
+
+    # kubernetes deployment as specified inside of
+    # a file containing the definition of the the
+    # deployment using the official kubernetes format
+    # plus some jinja directives
+     nginx-source-template:
+      kubernetes.deployment_present:
+        - source: salt://k8s/nginx.yml.jinja
+        - template: jinja
+      require:
+        - pip: kubernetes-python-module
+
+
+    # Kubernetes secret
+    k8s-secret:
+      kubernetes.secret_present:
+        - name: top-secret
+          data:
+            key1: value1
+            key2: value2
+            key3: value3
+
+.. versionadded: 2017.7.0
+'''
+from __future__ import absolute_import
+
+import copy
+import logging
+
+# Import 3rd-party libs
+from salt.ext import six
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    '''
+    Only load if the kubernetes module is available in __salt__
+    '''
+    return 'kubernetes.ping' in __salt__
+
+
+def _error(ret, err_msg):
+    '''
+    Helper function to propagate errors to
+    the end user.
+    '''
+    ret['result'] = False
+    ret['comment'] = err_msg
+    return ret
+
+
+def deployment_absent(name, namespace='default', **kwargs):
+    '''
+    Ensures that the named deployment is absent from the given namespace.
+
+    name
+        The name of the deployment
+
+    namespace
+        The name of the namespace
+    '''
+
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    deployment = __salt__['kubernetes.show_deployment'](name, namespace, **kwargs)
+
+    if deployment is None:
+        ret['result'] = True if not __opts__['test'] else None
+        ret['comment'] = 'The deployment does not exist'
+        return ret
+
+    if __opts__['test']:
+        ret['comment'] = 'The deployment is going to be deleted'
+        ret['result'] = None
+        return ret
+
+    res = __salt__['kubernetes.delete_deployment'](name, namespace, **kwargs)
+    if res['code'] == 200:
+        ret['result'] = True
+        ret['changes'] = {
+            'kubernetes.deployment': {
+                'new': 'absent', 'old': 'present'}}
+        ret['comment'] = res['message']
+    else:
+        ret['comment'] = 'Something went wrong, response: {0}'.format(res)
+
+    return ret
+
+
+def deployment_present(
+        name,
+        namespace='default',
+        metadata=None,
+        spec=None,
+        source='',
+        template='',
+        **kwargs):
+    '''
+    Ensures that the named deployment is present inside of the specified
+    namespace with the given metadata and spec.
+    If the deployment exists it will be replaced.
+
+    name
+        The name of the deployment.
+
+    namespace
+        The namespace holding the deployment. The 'default' one is going to be
+        used unless a different one is specified.
+
+    metadata
+        The metadata of the deployment object.
+
+    spec
+        The spec of the deployment object.
+
+    source
+        A file containing the definition of the deployment (metadata and
+        spec) in the official kubernetes format.
+
+    template
+        Template engine to be used to render the source file.
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    if (metadata or spec) and source:
+        return _error(
+            ret,
+            '\'source\' cannot be used in combination with \'metadata\' or '
+            '\'spec\''
+        )
+
+    if metadata is None:
+        metadata = {}
+
+    if spec is None:
+        spec = {}
+
+    deployment = __salt__['kubernetes.show_deployment'](name, namespace, **kwargs)
+
+    if deployment is None:
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'The deployment is going to be created'
+            return ret
+        res = __salt__['kubernetes.create_deployment'](name=name,
+                                                       namespace=namespace,
+                                                       metadata=metadata,
+                                                       spec=spec,
+                                                       source=source,
+                                                       template=template,
+                                                       saltenv=__env__,
+                                                       **kwargs)
+        ret['changes']['{0}.{1}'.format(namespace, name)] = {
+            'old': {},
+            'new': res}
+    else:
+        if __opts__['test']:
+            ret['result'] = None
+            return ret
+
+        # TODO: improve checks  # pylint: disable=fixme
+        log.info('Forcing the recreation of the deployment')
+        ret['comment'] = 'The deployment is already present. Forcing recreation'
+        res = __salt__['kubernetes.replace_deployment'](
+            name=name,
+            namespace=namespace,
+            metadata=metadata,
+            spec=spec,
+            source=source,
+            template=template,
+            saltenv=__env__,
+            **kwargs)
+
+    ret['changes'] = {
+        'metadata': metadata,
+        'spec': spec
+    }
+    ret['result'] = True
+    return ret
+
+
+def service_present(
+        name,
+        namespace='default',
+        metadata=None,
+        spec=None,
+        source='',
+        template='',
+        **kwargs):
+    '''
+    Ensures that the named service is present inside of the specified namespace
+    with the given metadata and spec.
+    If the deployment exists it will be replaced.
+
+    name
+        The name of the service.
+
+    namespace
+        The namespace holding the service. The 'default' one is going to be
+        used unless a different one is specified.
+
+    metadata
+        The metadata of the service object.
+
+    spec
+        The spec of the service object.
+
+    source
+        A file containing the definition of the service (metadata and
+        spec) in the official kubernetes format.
+
+    template
+        Template engine to be used to render the source file.
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    if (metadata or spec) and source:
+        return _error(
+            ret,
+            '\'source\' cannot be used in combination with \'metadata\' or '
+            '\'spec\''
+        )
+
+    if metadata is None:
+        metadata = {}
+
+    if spec is None:
+        spec = {}
+
+    service = __salt__['kubernetes.show_service'](name, namespace, **kwargs)
+
+    if service is None:
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'The service is going to be created'
+            return ret
+        res = __salt__['kubernetes.create_service'](name=name,
+                                                    namespace=namespace,
+                                                    metadata=metadata,
+                                                    spec=spec,
+                                                    source=source,
+                                                    template=template,
+                                                    saltenv=__env__,
+                                                    **kwargs)
+        ret['changes']['{0}.{1}'.format(namespace, name)] = {
+            'old': {},
+            'new': res}
+    else:
+        if __opts__['test']:
+            ret['result'] = None
+            return ret
+
+        # TODO: improve checks  # pylint: disable=fixme
+        log.info('Forcing the recreation of the service')
+        ret['comment'] = 'The service is already present. Forcing recreation'
+        res = __salt__['kubernetes.replace_service'](
+            name=name,
+            namespace=namespace,
+            metadata=metadata,
+            spec=spec,
+            source=source,
+            template=template,
+            old_service=service,
+            saltenv=__env__,
+            **kwargs)
+
+    ret['changes'] = {
+        'metadata': metadata,
+        'spec': spec
+    }
+    ret['result'] = True
+    return ret
+
+
+def service_absent(name, namespace='default', **kwargs):
+    '''
+    Ensures that the named service is absent from the given namespace.
+
+    name
+        The name of the service
+
+    namespace
+        The name of the namespace
+    '''
+
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    service = __salt__['kubernetes.show_service'](name, namespace, **kwargs)
+
+    if service is None:
+        ret['result'] = True if not __opts__['test'] else None
+        ret['comment'] = 'The service does not exist'
+        return ret
+
+    if __opts__['test']:
+        ret['comment'] = 'The service is going to be deleted'
+        ret['result'] = None
+        return ret
+
+    res = __salt__['kubernetes.delete_service'](name, namespace, **kwargs)
+    if res['code'] == 200:
+        ret['result'] = True
+        ret['changes'] = {
+            'kubernetes.service': {
+                'new': 'absent', 'old': 'present'}}
+        ret['comment'] = res['message']
+    else:
+        ret['comment'] = 'Something went wrong, response: {0}'.format(res)
+
+    return ret
+
+
+def namespace_absent(name, **kwargs):
+    '''
+    Ensures that the named namespace is absent.
+
+    name
+        The name of the namespace
+    '''
+
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    namespace = __salt__['kubernetes.show_namespace'](name, **kwargs)
+
+    if namespace is None:
+        ret['result'] = True if not __opts__['test'] else None
+        ret['comment'] = 'The namespace does not exist'
+        return ret
+
+    if __opts__['test']:
+        ret['comment'] = 'The namespace is going to be deleted'
+        ret['result'] = None
+        return ret
+
+    res = __salt__['kubernetes.delete_namespace'](name, **kwargs)
+    if (
+            res['code'] == 200 or
+            (
+                isinstance(res['status'], six.string_types) and
+                'Terminating' in res['status']
+            ) or
+            (
+                isinstance(res['status'], dict) and
+                res['status']['phase'] == 'Terminating'
+            )):
+        ret['result'] = True
+        ret['changes'] = {
+            'kubernetes.namespace': {
+                'new': 'absent', 'old': 'present'}}
+        if res['message']:
+            ret['comment'] = res['message']
+        else:
+            ret['comment'] = 'Terminating'
+    else:
+        ret['comment'] = 'Something went wrong, response: {0}'.format(res)
+
+    return ret
+
+
+def namespace_present(name, **kwargs):
+    '''
+    Ensures that the named namespace is present.
+
+    name
+        The name of the namespace.
+
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    namespace = __salt__['kubernetes.show_namespace'](name, **kwargs)
+
+    if namespace is None:
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'The namespace is going to be created'
+            return ret
+
+        res = __salt__['kubernetes.create_namespace'](name, **kwargs)
+        ret['result'] = True
+        ret['changes']['namespace'] = {
+            'old': {},
+            'new': res}
+    else:
+        ret['result'] = True if not __opts__['test'] else None
+        ret['comment'] = 'The namespace already exists'
+
+    return ret
+
+
+def secret_absent(name, namespace='default', **kwargs):
+    '''
+    Ensures that the named secret is absent from the given namespace.
+
+    name
+        The name of the secret
+
+    namespace
+        The name of the namespace
+    '''
+
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    secret = __salt__['kubernetes.show_secret'](name, namespace, **kwargs)
+
+    if secret is None:
+        ret['result'] = True if not __opts__['test'] else None
+        ret['comment'] = 'The secret does not exist'
+        return ret
+
+    if __opts__['test']:
+        ret['comment'] = 'The secret is going to be deleted'
+        ret['result'] = None
+        return ret
+
+    __salt__['kubernetes.delete_secret'](name, namespace, **kwargs)
+
+    # As for kubernetes 1.6.4 doesn't set a code when deleting a secret
+    # The kubernetes module will raise an exception if the kubernetes
+    # server will return an error
+    ret['result'] = True
+    ret['changes'] = {
+        'kubernetes.secret': {
+            'new': 'absent', 'old': 'present'}}
+    ret['comment'] = 'Secret deleted'
+    return ret
+
+
+def secret_present(
+        name,
+        namespace='default',
+        data=None,
+        source=None,
+        template=None,
+        **kwargs):
+    '''
+    Ensures that the named secret is present inside of the specified namespace
+    with the given data.
+    If the secret exists it will be replaced.
+
+    name
+        The name of the secret.
+
+    namespace
+        The namespace holding the secret. The 'default' one is going to be
+        used unless a different one is specified.
+
+    data
+        The dictionary holding the secrets.
+
+    source
+        A file containing the data of the secret in plain format.
+
+    template
+        Template engine to be used to render the source file.
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    if data and source:
+        return _error(
+            ret,
+            '\'source\' cannot be used in combination with \'data\''
+        )
+
+    secret = __salt__['kubernetes.show_secret'](name, namespace, **kwargs)
+
+    if secret is None:
+        if data is None:
+            data = {}
+
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'The secret is going to be created'
+            return ret
+        res = __salt__['kubernetes.create_secret'](name=name,
+                                                   namespace=namespace,
+                                                   data=data,
+                                                   source=source,
+                                                   template=template,
+                                                   saltenv=__env__,
+                                                   **kwargs)
+        ret['changes']['{0}.{1}'.format(namespace, name)] = {
+            'old': {},
+            'new': res}
+    else:
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'The secret is going to be replaced'
+            return ret
+
+        # TODO: improve checks  # pylint: disable=fixme
+        log.info('Forcing the recreation of the service')
+        ret['comment'] = 'The secret is already present. Forcing recreation'
+        res = __salt__['kubernetes.replace_secret'](
+            name=name,
+            namespace=namespace,
+            data=data,
+            source=source,
+            template=template,
+            saltenv=__env__,
+            **kwargs)
+
+    ret['changes'] = {
+        # Omit values from the return. They are unencrypted
+        # and can contain sensitive data.
+        'data': list(res['data'])
+    }
+    ret['result'] = True
+
+    return ret
+
+
+def configmap_absent(name, namespace='default', **kwargs):
+    '''
+    Ensures that the named configmap is absent from the given namespace.
+
+    name
+        The name of the configmap
+
+    namespace
+        The namespace holding the configmap. The 'default' one is going to be
+        used unless a different one is specified.
+    '''
+
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    configmap = __salt__['kubernetes.show_configmap'](name, namespace, **kwargs)
+
+    if configmap is None:
+        ret['result'] = True if not __opts__['test'] else None
+        ret['comment'] = 'The configmap does not exist'
+        return ret
+
+    if __opts__['test']:
+        ret['comment'] = 'The configmap is going to be deleted'
+        ret['result'] = None
+        return ret
+
+    __salt__['kubernetes.delete_configmap'](name, namespace, **kwargs)
+    # As for kubernetes 1.6.4 doesn't set a code when deleting a configmap
+    # The kubernetes module will raise an exception if the kubernetes
+    # server will return an error
+    ret['result'] = True
+    ret['changes'] = {
+        'kubernetes.configmap': {
+            'new': 'absent', 'old': 'present'}}
+    ret['comment'] = 'ConfigMap deleted'
+
+    return ret
+
+
+def configmap_present(
+        name,
+        namespace='default',
+        data=None,
+        source=None,
+        template=None,
+        **kwargs):
+    '''
+    Ensures that the named configmap is present inside of the specified namespace
+    with the given data.
+    If the configmap exists it will be replaced.
+
+    name
+        The name of the configmap.
+
+    namespace
+        The namespace holding the configmap. The 'default' one is going to be
+        used unless a different one is specified.
+
+    data
+        The dictionary holding the configmaps.
+
+    source
+        A file containing the data of the configmap in plain format.
+
+    template
+        Template engine to be used to render the source file.
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    if data and source:
+        return _error(
+            ret,
+            '\'source\' cannot be used in combination with \'data\''
+        )
+    elif data is None:
+        data = {}
+
+    configmap = __salt__['kubernetes.show_configmap'](name, namespace, **kwargs)
+
+    if configmap is None:
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'The configmap is going to be created'
+            return ret
+        res = __salt__['kubernetes.create_configmap'](name=name,
+                                                      namespace=namespace,
+                                                      data=data,
+                                                      source=source,
+                                                      template=template,
+                                                      saltenv=__env__,
+                                                      **kwargs)
+        ret['changes']['{0}.{1}'.format(namespace, name)] = {
+            'old': {},
+            'new': res}
+    else:
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'The configmap is going to be replaced'
+            return ret
+
+        # TODO: improve checks  # pylint: disable=fixme
+        log.info('Forcing the recreation of the service')
+        ret['comment'] = 'The configmap is already present. Forcing recreation'
+        res = __salt__['kubernetes.replace_configmap'](
+            name=name,
+            namespace=namespace,
+            data=data,
+            source=source,
+            template=template,
+            saltenv=__env__,
+            **kwargs)
+
+    ret['changes'] = {
+        'data': res['data']
+    }
+    ret['result'] = True
+    return ret
+
+
+def pod_absent(name, namespace='default', **kwargs):
+    '''
+    Ensures that the named pod is absent from the given namespace.
+
+    name
+        The name of the pod
+
+    namespace
+        The name of the namespace
+    '''
+
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    pod = __salt__['kubernetes.show_pod'](name, namespace, **kwargs)
+
+    if pod is None:
+        ret['result'] = True if not __opts__['test'] else None
+        ret['comment'] = 'The pod does not exist'
+        return ret
+
+    if __opts__['test']:
+        ret['comment'] = 'The pod is going to be deleted'
+        ret['result'] = None
+        return ret
+
+    res = __salt__['kubernetes.delete_pod'](name, namespace, **kwargs)
+    if res['code'] == 200 or res['code'] is None:
+        ret['result'] = True
+        ret['changes'] = {
+            'kubernetes.pod': {
+                'new': 'absent', 'old': 'present'}}
+        if res['code'] is None:
+            ret['comment'] = 'In progress'
+        else:
+            ret['comment'] = res['message']
+    else:
+        ret['comment'] = 'Something went wrong, response: {0}'.format(res)
+
+    return ret
+
+
+def pod_present(
+        name,
+        namespace='default',
+        metadata=None,
+        spec=None,
+        source='',
+        template='',
+        **kwargs):
+    '''
+    Ensures that the named pod is present inside of the specified
+    namespace with the given metadata and spec.
+    If the pod exists it will be replaced.
+
+    name
+        The name of the pod.
+
+    namespace
+        The namespace holding the pod. The 'default' one is going to be
+        used unless a different one is specified.
+
+    metadata
+        The metadata of the pod object.
+
+    spec
+        The spec of the pod object.
+
+    source
+        A file containing the definition of the pod (metadata and
+        spec) in the official kubernetes format.
+
+    template
+        Template engine to be used to render the source file.
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    if (metadata or spec) and source:
+        return _error(
+            ret,
+            '\'source\' cannot be used in combination with \'metadata\' or '
+            '\'spec\''
+        )
+
+    if metadata is None:
+        metadata = {}
+
+    if spec is None:
+        spec = {}
+
+    pod = __salt__['kubernetes.show_pod'](name, namespace, **kwargs)
+
+    if pod is None:
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'The pod is going to be created'
+            return ret
+        res = __salt__['kubernetes.create_pod'](name=name,
+                                                namespace=namespace,
+                                                metadata=metadata,
+                                                spec=spec,
+                                                source=source,
+                                                template=template,
+                                                saltenv=__env__,
+                                                **kwargs)
+        ret['changes']['{0}.{1}'.format(namespace, name)] = {
+            'old': {},
+            'new': res}
+    else:
+        if __opts__['test']:
+            ret['result'] = None
+            return ret
+
+        # TODO: fix replace_namespaced_pod validation issues
+        ret['comment'] = 'salt is currently unable to replace a pod without ' \
+            'deleting it. Please perform the removal of the pod requiring ' \
+            'the \'pod_absent\' state if this is the desired behaviour.'
+        ret['result'] = False
+        return ret
+
+    ret['changes'] = {
+        'metadata': metadata,
+        'spec': spec
+    }
+    ret['result'] = True
+    return ret
+
+
+def node_label_absent(name, node, **kwargs):
+    '''
+    Ensures that the named label is absent from the node.
+
+    name
+        The name of the label
+
+    node
+        The name of the node
+    '''
+
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    labels = __salt__['kubernetes.node_labels'](node, **kwargs)
+
+    if name not in labels:
+        ret['result'] = True if not __opts__['test'] else None
+        ret['comment'] = 'The label does not exist'
+        return ret
+
+    if __opts__['test']:
+        ret['comment'] = 'The label is going to be deleted'
+        ret['result'] = None
+        return ret
+
+    __salt__['kubernetes.node_remove_label'](
+        node_name=node,
+        label_name=name,
+        **kwargs)
+
+    ret['result'] = True
+    ret['changes'] = {
+        'kubernetes.node_label': {
+            'new': 'absent', 'old': 'present'}}
+    ret['comment'] = 'Label removed from node'
+
+    return ret
+
+
+def node_label_folder_absent(name, node, **kwargs):
+    '''
+    Ensures the label folder doesn't exist on the specified node.
+
+    name
+        The name of label folder
+
+    node
+        The name of the node
+    '''
+
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+    labels = __salt__['kubernetes.node_labels'](node, **kwargs)
+
+    folder = name.strip("/") + "/"
+    labels_to_drop = []
+    new_labels = []
+    for label in labels:
+        if label.startswith(folder):
+            labels_to_drop.append(label)
+        else:
+            new_labels.append(label)
+
+    if not labels_to_drop:
+        ret['result'] = True if not __opts__['test'] else None
+        ret['comment'] = 'The label folder does not exist'
+        return ret
+
+    if __opts__['test']:
+        ret['comment'] = 'The label folder is going to be deleted'
+        ret['result'] = None
+        return ret
+
+    for label in labels_to_drop:
+        __salt__['kubernetes.node_remove_label'](
+            node_name=node,
+            label_name=label,
+            **kwargs)
+
+    ret['result'] = True
+    ret['changes'] = {
+        'kubernetes.node_label_folder_absent': {
+            'old': list(labels),
+            'new': new_labels,
+        }
+    }
+    ret['comment'] = 'Label folder removed from node'
+
+    return ret
+
+
+def node_label_present(
+        name,
+        node,
+        value,
+        **kwargs):
+    '''
+    Ensures that the named label is set on the named node
+    with the given value.
+    If the label exists it will be replaced.
+
+    name
+        The name of the label.
+
+    value
+        Value of the label.
+
+    node
+        Node to change.
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    labels = __salt__['kubernetes.node_labels'](node, **kwargs)
+
+    if name not in labels:
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'The label is going to be set'
+            return ret
+        __salt__['kubernetes.node_add_label'](label_name=name,
+                                              label_value=value,
+                                              node_name=node,
+                                              **kwargs)
+    elif labels[name] == value:
+        ret['result'] = True
+        ret['comment'] = 'The label is already set and has the specified value'
+        return ret
+    else:
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'The label is going to be updated'
+            return ret
+
+        ret['comment'] = 'The label is already set, changing the value'
+        __salt__['kubernetes.node_add_label'](
+            node_name=node,
+            label_name=name,
+            label_value=value,
+            **kwargs)
+
+    old_labels = copy.copy(labels)
+    labels[name] = value
+
+    ret['changes']['{0}.{1}'.format(node, name)] = {
+        'old': old_labels,
+        'new': labels}
+    ret['result'] = True
+
+    return ret

--- a/salt/_states/kubernetes.py
+++ b/salt/_states/kubernetes.py
@@ -1007,3 +1007,34 @@ def node_label_present(
     ret['result'] = True
 
     return ret
+
+
+def serviceaccount_present(
+        name,
+        namespace='default',
+        **kwargs):
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    serviceaccount = __salt__['kubernetes.show_serviceaccount'](name, namespace, **kwargs)
+
+    if serviceaccount is None:
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'The serviceaccount is going to be created'
+            return ret
+
+        res = __salt__['kubernetes.create_serviceaccount'](name=name,
+                                                           namespace=namespace,
+                                                           **kwargs)
+        ret['result'] = True
+        ret['changes']['{0}.{1}'.format(namespace, name)] = {
+            'old': {},
+            'new': res}
+    else:
+        ret['result'] = True if not __opts__['test'] else None
+        ret['comment'] = 'The serviceaccount already exists'
+
+    return ret

--- a/salt/_states/kubernetes.py
+++ b/salt/_states/kubernetes.py
@@ -1087,3 +1087,52 @@ def clusterrolebinding_present(
             'new': res}
 
     return ret
+
+
+def role_present(
+        name,
+        namespace,
+        rules,
+        **kwargs):
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    role = __salt__['kubernetes.show_role'](name, namespace, **kwargs)
+
+    if role is None:
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'The role is going to be created'
+            return ret
+
+        res = __salt__['kubernetes.create_role'](name=name,
+                                                 namespace=namespace,
+                                                 rules=rules,
+                                                 **kwargs)
+        ret['result'] = True
+        ret['changes']['{0}.{1}'.format(namespace, name)] = {
+            'old': {},
+            'new': res}
+    else:
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'The role is going to be replaced'
+            return ret
+
+        # TODO: improve checks  # pylint: disable=fixme
+        log.info('Forcing the recreation of the role')
+        ret['comment'] = 'The role is already present. Forcing recreation'
+        res = __salt__['kubernetes.replace_role'](
+            name=name,
+            namespace=namespace,
+            rules=rules,
+            **kwargs)
+
+        ret['result'] = True
+        ret['changes']['{0}.{1}'.format(namespace, name)] = {
+            'old': role,
+            'new': res}
+
+    return ret

--- a/salt/metalk8s/kubeadm/init/addons/dependencies.sls
+++ b/salt/metalk8s/kubeadm/init/addons/dependencies.sls
@@ -1,0 +1,4 @@
+Install Python Kubernetes client:
+  pkg.installed:
+    - name: python2-kubernetes
+    - reload_modules: true

--- a/salt/metalk8s/kubeadm/init/addons/init.sls
+++ b/salt/metalk8s/kubeadm/init/addons/init.sls
@@ -1,0 +1,3 @@
+include:
+  - .dependencies
+  - .kube-proxy

--- a/salt/metalk8s/kubeadm/init/addons/kube-proxy.sls
+++ b/salt/metalk8s/kubeadm/init/addons/kube-proxy.sls
@@ -1,0 +1,202 @@
+{%- from "metalk8s/map.jinja" import networks with context %}
+
+{%- set image = "localhost:5000/metalk8s-2.0/kube-proxy:1.11.7" -%}
+
+{% set kubeconfig = "/etc/kubernetes/admin.conf" %}
+{% set context = "kubernetes-admin@kubernetes" %}
+
+{#- TODO: Not always use local machine as apiserver #}
+{%- set apiserver = 'https://' ~ salt['network.ip_addrs'](cidr=networks.control_plane)[0] ~ ':6443' %}
+{% set host_name = salt.network.get_hostname() %}
+
+Deploy kube-proxy (ServiceAccount):
+  kubernetes.serviceaccount_present:
+    - name: kube-proxy
+    - kubeconfig: {{ kubeconfig }}
+    - context: {{ context }}
+    - namespace: kube-system
+
+Deploy kube-proxy (ClusterRoleBinding):
+  kubernetes.clusterrolebinding_present:
+    - name: kubeadm:node-proxier
+    - kubeconfig: {{ kubeconfig }}
+    - context: {{ context }}
+    - role_ref:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: system:node-proxier
+    - subjects:
+      - kind: ServiceAccount
+        name: kube-proxy
+        namespace: kube-system
+
+    - require:
+      - kubernetes: Deploy kube-proxy (ServiceAccount)
+
+Deploy kube-proxy (ConfigMap):
+  kubernetes.configmap_present:
+    - name: kube-proxy
+    - kubeconfig: {{ kubeconfig }}
+    - context: {{ context }}
+    - namespace: kube-system
+    - labels:
+        app: kube-proxy
+    - data:
+        config.conf: |-
+          apiVersion: kubeproxy.config.k8s.io/v1alpha1
+          bindAddress: 0.0.0.0
+          clientConnection:
+            acceptContentTypes: ""
+            burst: 10
+            contentType: application/vnd.kubernetes.protobuf
+            kubeconfig: /var/lib/kube-proxy/kubeconfig.conf
+            qps: 5
+          clusterCIDR: {{ networks.pod }}
+          configSyncPeriod: 15m0s
+          conntrack:
+            max: null
+            maxPerCore: 32768
+            min: 131072
+            tcpCloseWaitTimeout: 1h0m0s
+            tcpEstablishedTimeout: 24h0m0s
+          enableProfiling: false
+          healthzBindAddress: 0.0.0.0:10256
+          hostnameOverride: {{ host_name }}
+          iptables:
+            masqueradeAll: false
+            masqueradeBit: 14
+            minSyncPeriod: 0s
+            syncPeriod: 30s
+          ipvs:
+            excludeCIDRs: null
+            minSyncPeriod: 0s
+            scheduler: ""
+            syncPeriod: 30s
+          kind: KubeProxyConfiguration
+          metricsBindAddress: 127.0.0.1:10249
+          mode: ""
+          nodePortAddresses:
+{%- for address in salt['network.ip_addrs'](cidr=networks.workload_plane) %}
+          - {{ address }}/32
+{%- endfor %}
+          oomScoreAdj: -999
+          portRange: ""
+          resourceContainer: /kube-proxy
+          udpIdleTimeout: 250ms
+        kubeconfig.conf: |-
+          apiVersion: v1
+          kind: Config
+          clusters:
+          - cluster:
+              certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              server: {{ apiserver }}
+            name: default
+          contexts:
+          - context:
+              cluster: default
+              namespace: default
+              user: default
+            name: default
+          current-context: default
+          users:
+          - name: default
+            user:
+              tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+Deploy kube-proxy (DaemonSet):
+  kubernetes.daemonset_present:
+    - name: kube-proxy
+    - kubeconfig: {{ kubeconfig }}
+    - context: {{ context }}
+    - namespace: kube-system
+    - metadata:
+        labels:
+          k8s-app: kube-proxy
+    - spec:
+        selector:
+          matchLabels:
+            k8s-app: kube-proxy
+        template:
+          metadata:
+            annotations:
+              scheduler.alpha.kubernetes.io/critical-pod: ""
+            creationTimestamp: null
+            labels:
+              k8s-app: kube-proxy
+          spec:
+            containers:
+            - command:
+              - /usr/local/bin/kube-proxy
+              - --config=/var/lib/kube-proxy/config.conf
+              image: {{ image }}
+              imagePullPolicy: IfNotPresent
+              name: kube-proxy
+              resources: {}
+              securityContext:
+                privileged: true
+              volumeMounts:
+              - mountPath: /var/lib/kube-proxy
+                name: kube-proxy
+              - mountPath: /run/xtables.lock
+                name: xtables-lock
+              - mountPath: /lib/modules
+                name: lib-modules
+                readOnly: true
+            hostNetwork: true
+            priorityClassName: system-node-critical
+            serviceAccountName: kube-proxy
+            tolerations:
+            - key: CriticalAddonsOnly
+              operator: Exists
+            - operator: Exists
+            volumes:
+            - configMap:
+                name: kube-proxy
+              name: kube-proxy
+            - hostPath:
+                path: /run/xtables.lock
+                type: FileOrCreate
+              name: xtables-lock
+            - hostPath:
+                path: /lib/modules
+              name: lib-modules
+        updateStrategy:
+          type: RollingUpdate
+
+    - require:
+      - kubernetes: Deploy kube-proxy (ServiceAccount)
+      - kubernetes: Deploy kube-proxy (ClusterRoleBinding)
+      - kubernetes: Deploy kube-proxy (ConfigMap)
+
+Deploy kube-proxy (Role):
+  kubernetes.role_present:
+    - name: kube-proxy
+    - kubeconfig: {{ kubeconfig }}
+    - context: {{ context }}
+    - namespace: kube-system
+    - rules:
+      - apiGroups:
+        - ""
+        resourceNames:
+        - kube-proxy
+        resources:
+        - configmaps
+        verbs:
+        - get
+
+Deploy kube-proxy (RoleBinding):
+  kubernetes.rolebinding_present:
+    - name: kube-proxy
+    - kubeconfig: {{ kubeconfig }}
+    - context: {{ context }}
+    - namespace: kube-system
+    - role_ref:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: kube-proxy
+    - subjects:
+      - kind: Group
+        name: system:bootstrappers:kubeadm:default-node-token
+
+    - require:
+      - kubernetes: Deploy kube-proxy (Role)

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -153,6 +153,11 @@ run_etcd() {
     ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.etcd saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
 }
 
+install_addons() {
+    ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.addons.dependencies saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
+    ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.addons saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
+}
+
 main() {
     pre_minion_checks
     disable_salt_minion_service
@@ -180,6 +185,8 @@ main() {
     run_kubeconfig
     run_control_plane
     run_etcd
+
+    install_addons
 }
 
 main


### PR DESCRIPTION
This set of patches implements deployment of `kube-proxy` as a `DaemonSet`. It adds the `kubernetes` state and module from SaltStack v2019.2.0, and extends these with some code to manage `ClusterRoleBinding`s, `ServiceAccount`s, `Role`s and `RoleBinding`s, as needed to deploy `kube-proxy`.

Fixes: #685