### PR TITLE
Salt'ify mark-control-plane phase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,9 @@ ALL = \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/addons/dependencies.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/addons/kube-proxy.sls \
 	\
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/mark-control-plane/init.sls \
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/mark-control-plane/configured.sls \
+	\
 	$(ISO_ROOT)/salt/metalk8s/kubelet/init.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubelet/installed.sls \
 	\

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ ALL = \
 	\
 	$(ISO_ROOT)/salt/metalk8s/defaults.yaml \
 	\
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/addons/init.sls \
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/addons/kube-proxy.sls \
+	\
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/apiserver.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/apiserver-etcd-client.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/certs/apiserver-kubelet-client.sls \
@@ -77,9 +80,6 @@ ALL = \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/kubeconfig/kubelet.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/kubeconfig/lib.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/kubeconfig/scheduler.sls \
-	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/addons/init.sls \
-	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/addons/dependencies.sls \
-	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/addons/kube-proxy.sls \
 	\
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/mark-control-plane/init.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/mark-control-plane/configured.sls \
@@ -88,6 +88,10 @@ ALL = \
 	$(ISO_ROOT)/salt/metalk8s/kubelet/installed.sls \
 	\
 	$(ISO_ROOT)/salt/metalk8s/map.jinja \
+	\
+	$(ISO_ROOT)/salt/metalk8s/python-kubernetes/init.sls \
+	$(ISO_ROOT)/salt/metalk8s/python-kubernetes/installed.sls \
+	$(ISO_ROOT)/salt/metalk8s/python-kubernetes/removed.sls \
 	\
 	$(ISO_ROOT)/salt/metalk8s/repo/configured.sls \
 	$(ISO_ROOT)/salt/metalk8s/repo/init.sls \

--- a/salt/metalk8s/kubeadm/init/addons/init.sls
+++ b/salt/metalk8s/kubeadm/init/addons/init.sls
@@ -1,3 +1,3 @@
 include:
-  - .dependencies
+  - metalk8s.python-kubernetes
   - .kube-proxy

--- a/salt/metalk8s/kubeadm/init/mark-control-plane/configured.sls
+++ b/salt/metalk8s/kubeadm/init/mark-control-plane/configured.sls
@@ -1,0 +1,31 @@
+{% set hostname = salt['network.get_hostname']() %}
+
+{% set kubeconfig = "/etc/kubernetes/admin.conf" %}
+{% set context = "kubernetes-admin@kubernetes" %}
+
+Apply control-plane role label:
+  kubernetes.node_label_present:
+    - name: "node-role.kubernetes.io/master"
+    - kubeconfig: {{ kubeconfig }}
+    - context: {{ context }}
+    - node: {{ hostname }}
+    - value: ""
+
+Apply control-plane taints:
+  kubernetes.node_taints_present:
+    - name: {{ hostname }}
+    - kubeconfig: {{ kubeconfig }}
+    - context: {{ context }}
+    - taints:
+        - key: "node-role.kubernetes.io/master"
+          effect: "NoSchedule"
+
+Annotate with CRI socket information:
+  kubernetes.node_annotation_present:
+    - name: "kubeadm.alpha.kubernetes.io/cri-socket"
+    - kubeconfig: {{ kubeconfig }}
+    - context: {{ context }}
+    - node: {{ hostname }}
+    # TODO: the socket location may become configurable, we should make sure
+    #       this value is accurate (hardcoded to the default value for now)
+    - value: "/run/containerd/containerd.sock"

--- a/salt/metalk8s/kubeadm/init/mark-control-plane/init.sls
+++ b/salt/metalk8s/kubeadm/init/mark-control-plane/init.sls
@@ -1,0 +1,13 @@
+#
+# State for kubeadm init mark-control-plane phase.
+#
+#
+#
+# Available states
+# ================
+#
+# * configured    -> Applies label and taints to the node
+#
+
+include:
+  - .configured

--- a/salt/metalk8s/kubeadm/init/mark-control-plane/init.sls
+++ b/salt/metalk8s/kubeadm/init/mark-control-plane/init.sls
@@ -10,4 +10,5 @@
 #
 
 include:
+  - metalk8s.python-kubernetes
   - .configured

--- a/salt/metalk8s/python-kubernetes/init.sls
+++ b/salt/metalk8s/python-kubernetes/init.sls
@@ -1,0 +1,2 @@
+include:
+  - .installed

--- a/salt/metalk8s/python-kubernetes/installed.sls
+++ b/salt/metalk8s/python-kubernetes/installed.sls
@@ -1,3 +1,6 @@
+include:
+  - metalk8s.repo
+
 Install Python Kubernetes client:
   pkg.installed:
     - name: python2-kubernetes

--- a/salt/metalk8s/python-kubernetes/removed.sls
+++ b/salt/metalk8s/python-kubernetes/removed.sls
@@ -1,0 +1,4 @@
+Remove Python Kubernetes client:
+  pkg.removed:
+    - name: python2-kubernetes
+    - reload_modules: true

--- a/salt/metalk8s/repo/online.sls
+++ b/salt/metalk8s/repo/online.sls
@@ -2,7 +2,7 @@
 
 Configure EPEL repository:
   pkg.installed:
-  {%- if grains["os"] == "CentOs" %}
+  {%- if grains["os"] == "CentOS" %}
     - name: epel-release
   {%- else %}
     - sources:

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -153,6 +153,10 @@ run_etcd() {
     ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.etcd saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
 }
 
+run_mark_control_plane() {
+    ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.mark-control-plane saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
+}
+
 install_addons() {
     ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.addons.dependencies saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
     ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.addons saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
@@ -190,6 +194,7 @@ main() {
     run_kubeconfig
     run_control_plane
     run_etcd
+    run_mark_control_plane
 
     install_addons
 

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -77,6 +77,10 @@ run_bootstrap_prechecks() {
         return
 }
 
+install_python_kubernetes_client() {
+    ${SALT_CALL} --local --retcode-passthrough state.apply metalk8s.python-kubernetes saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
+}
+
 install_kubelet() {
         ${SALT_CALL} --local --retcode-passthrough state.apply metalk8s.kubelet saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
 }
@@ -158,7 +162,6 @@ run_mark_control_plane() {
 }
 
 install_addons() {
-    ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.addons.dependencies saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
     ${SALT_CALL} --retcode-passthrough state.apply metalk8s.kubeadm.init.addons saltenv=metalk8s-@VERSION@ pillarenv=metalk8s-@VERSION@
 }
 
@@ -175,6 +178,7 @@ main() {
     install_salt_minion
     configure_salt_minion_local_mode
     run_bootstrap_prechecks
+    install_python_kubernetes_client
 
     install_kubelet
     run_preflight


### PR DESCRIPTION
Note that we also added an annotation for specifying the CRI socket used, as can be seen in the [kubeadm dry-run output](https://github.com/NicolasT/kubeadm-dry-run/blob/master/kubeadm-dry-run.txt#L518-L524).

Fixes GH-582.