### PR TITLE
spot-fix lint errors reported by recent shellcheck

### DIFF
--- a/eve/workers/pod-linter/Dockerfile
+++ b/eve/workers/pod-linter/Dockerfile
@@ -1,22 +1,21 @@
-# CI lint container
-FROM centos:7
+# CI lint container - Fedora for recent ShellCheck version
+FROM fedora:29
 
 ARG BUILDBOT_VERSION=0.9.12
 
 WORKDIR /home/eve/workspace
 
-RUN yum install -y epel-release \
-  && yum install -y git \
+RUN dnf install -y git \
   gcc \
   make \
-  python-twisted-core \
+  python2-twisted \
   python \
   python-devel \
   python-pip \
-  python36 \
-  python36-devel \
+  python3 \
+  python3-devel \
   ShellCheck \
-  && yum clean all \
+  && dnf clean all \
   && adduser -u 1042 --home /home/eve eve \
   && chown eve:eve /home/eve/workspace \
   && pip install tox \

--- a/packages/entrypoint.sh
+++ b/packages/entrypoint.sh
@@ -78,12 +78,12 @@ download_packages() {
     local -r releasever=${RELEASEVER:-7}
     local -r basearch=${BASEARCH:-x86_64}
     local -r repo_cache_root=/install_root/var/cache/yum/$basearch/$releasever
-    local -a packages=($@)
+    local -a packages=("$@")
     local -a yum_opts=(
-        --assumeyes
-        --downloadonly
-        --releasever="$releasever"
-        --installroot=/install_root
+        "--assumeyes"
+        "--downloadonly"
+        "--releasever=$releasever"
+        "--installroot=/install_root"
     )
     local repo_name repo_dest
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ skipsdist = true
 
 [testenv]
 whitelist_externals = bash
-basepython = python3.6
+basepython = python3
 skip_install = true
 setenv =
     VIRTUALENV_NO_DOWNLOAD=1


### PR DESCRIPTION
Spotted by @slaperche-scality 

* spot-fix for differing ShellCheck versions between CI and dev laptops
* use a Fedora base image instead of CentOS to get a recent version of ShellCheck

Issue: GH-699