### PR TITLE
Stop returning `None` if no taints exist on a node

### DIFF
--- a/salt/_modules/kubernetes.py
+++ b/salt/_modules/kubernetes.py
@@ -2239,7 +2239,7 @@ def node_taints(node_name, **kwargs):
     match = node(node_name, **kwargs)
 
     if match is not None:
-        return match['spec']['taints']
+        return match['spec']['taints'] or []
 
     return []
 


### PR DESCRIPTION
Fixes GH-730. Introduced by #692 (issue GH-582)