### PR TITLE
Improvement/724 add multiple vms local env vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -52,18 +52,19 @@ SCRIPT
 Vagrant.require_version(">= 1.8")
 
 Vagrant.configure("2") do |config|
+  config.vm.box = "centos/7"
+  config.vm.box_version = "1811.02"
+
+  config.vm.provider "virtualbox" do |v|
+    v.linked_clone = true
+    v.memory = 2048
+    v.cpus = 2
+  end
+
   config.vm.define :bootstrap do |bootstrap|
-    bootstrap.vm.box = "centos/7"
-    bootstrap.vm.box_version = "1811.02"
     bootstrap.vm.hostname = "bootstrap"
 
-    bootstrap.vm.provider "virtualbox" do |v|
-      v.linked_clone = true
-      v.memory = 2048
-      v.cpus = 2
-
-      bootstrap.vm.synced_folder ".", "/vagrant", type: "virtualbox"
-    end
+    bootstrap.vm.synced_folder ".", "/vagrant", type: "virtualbox"
 
     bootstrap.vm.provision "import-release",
       type: "shell",

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,7 +61,7 @@ Vagrant.configure("2") do |config|
     v.cpus = 2
   end
 
-  config.vm.define :bootstrap do |bootstrap|
+  config.vm.define :bootstrap, primary: true do |bootstrap|
     bootstrap.vm.hostname = "bootstrap"
 
     bootstrap.vm.synced_folder ".", "/vagrant", type: "virtualbox"
@@ -73,5 +73,18 @@ Vagrant.configure("2") do |config|
     bootstrap.vm.provision "bootstrap",
       type: "shell",
       inline: BOOTSTRAP
+  end
+
+  (1..9).each do |i|
+    node_name = "node#{i}"
+
+    config.vm.define node_name, autostart: false do |node|
+      node.vm.hostname = node_name
+
+      node.vm.synced_folder ".", "/vagrant", disabled: true
+
+      # No need for Guest Additions since there is no synced folder
+      node.vbguest.auto_update = false
+    end
   end
 end


### PR DESCRIPTION
Hint: you may want to read this PR commit by commit to understand better the changes.

**Warning**: I didn't test yet this PR to see if the bootstrap node is still working as expected. Changes can happen since there is a new network in place.

Be careful since any new node will take 2GB in your laptop RAM.

Fixes: #724 for the local environment (not the CI one).

On this branch, just perform a `vagrant status`, you should see 9 new VMs available:

```bash

$ vagrant status
Current machine states:

bootstrap                 running (virtualbox)
node1                     not created (virtualbox)
node2                     not created (virtualbox)
node3                     not created (virtualbox)
node4                     not created (virtualbox)
node5                     not created (virtualbox)
node6                     not created (virtualbox)
node7                     not created (virtualbox)
node8                     not created (virtualbox)
node9                     not created (virtualbox)
```

By default they are not started when performing a `vagrant up`, neither there is a conflict when performing a `vagrant ssh` since the bootstrap node stays the main one.

Any action related to these extra nodes needs to be explicit:

- `vagrant up node1`
- `vagrant ssh node1`
- `vagrant destroy -f node1`

All nodes (including the bootstrap one) have now a new interface to communicate on the same network `192.168.42.0/24`.
The bootstrap node is `192.168.42.10`.
Others are incremental: `192.168.42.11` for `node1`, `.12` for `node2`, etc.

With this PR, it will be easy for an E2E test to call for a new VM instantiation.

