### PR TITLE
Improvement: Remove hardcoded version in Salt formulas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,7 @@ ALL = \
 	$(ISO_ROOT)/salt/_states/docker_registry.py \
 	$(ISO_ROOT)/salt/_states/kubernetes.py \
 	\
+	$(ISO_ROOT)/pillar/metalk8s.sls \
 	$(ISO_ROOT)/pillar/repositories.sls \
 	$(ISO_ROOT)/pillar/top.sls \
 	\
@@ -221,6 +222,11 @@ $(ISO_ROOT)/salt/%: salt/%
 	mkdir -p $(shell dirname $@)
 	rm -f $@
 	cp -a $< $@
+
+$(ISO_ROOT)/pillar/metalk8s.sls: pillar/metalk8s.sls.in $(ISO_ROOT)/product.txt
+	mkdir -p $(@D)
+	rm -f $@
+	sed s/@VERSION@/$(shell source $(ISO_ROOT)/product.txt && echo $$SHORT_VERSION)/g < $< > $@ || (rm -f $@; false)
 
 $(ISO_ROOT)/pillar/top.sls: pillar/top.sls.in $(ISO_ROOT)/product.txt
 	mkdir -p $(shell dirname $@)

--- a/Makefile
+++ b/Makefile
@@ -213,13 +213,13 @@ all-local: $(ALL) ## Build all artifacts in the build tree
 .PHONY: all-local
 
 $(ISO_ROOT)/bootstrap.sh: scripts/bootstrap.sh.in $(ISO_ROOT)/product.txt
-	mkdir -p $(shell dirname $@)
+	mkdir -p $(@D)
 	rm -f $@
 	sed s/@VERSION@/$(shell source $(ISO_ROOT)/product.txt && echo $$SHORT_VERSION)/g < $< > $@ || (rm -f $@; false)
 	chmod a+x $@
 
 $(ISO_ROOT)/salt/%: salt/%
-	mkdir -p $(shell dirname $@)
+	mkdir -p $(@D)
 	rm -f $@
 	cp -a $< $@
 
@@ -229,18 +229,18 @@ $(ISO_ROOT)/pillar/metalk8s.sls: pillar/metalk8s.sls.in $(ISO_ROOT)/product.txt
 	sed s/@VERSION@/$(shell source $(ISO_ROOT)/product.txt && echo $$SHORT_VERSION)/g < $< > $@ || (rm -f $@; false)
 
 $(ISO_ROOT)/pillar/top.sls: pillar/top.sls.in $(ISO_ROOT)/product.txt
-	mkdir -p $(shell dirname $@)
+	mkdir -p $(@D)
 	rm -f $@
 	sed s/@VERSION@/$(shell source $(ISO_ROOT)/product.txt && echo $$SHORT_VERSION)/g < $< > $@ || (rm -f $@; false)
 
 $(ISO_ROOT)/pillar/%: pillar/%
-	mkdir -p $(shell dirname $@)
+	mkdir -p $(@D)
 	rm -f $@
 	cp -a $< $@
 
 $(ISO_ROOT)/product.txt: scripts/product.sh VERSION FORCE
 	rm -f $@
-	mkdir -p $(shell dirname $@)
+	mkdir -p $(@D)
 	env \
 		VERSION_MAJOR=$(VERSION_MAJOR) \
 		VERSION_MINOR=$(VERSION_MINOR) \

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ ALL = \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/addons/init.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/addons/kube-proxy.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/addons/coredns.sls \
-	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/addons/files/coredns_deployment.yaml \
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/addons/files/coredns_deployment.yaml.j2 \
 	\
 	$(ISO_ROOT)/salt/metalk8s/kubelet/init.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubelet/installed.sls \

--- a/pillar/metalk8s.sls.in
+++ b/pillar/metalk8s.sls.in
@@ -1,0 +1,4 @@
+# Configuration values for this MetalK8s environment
+metalk8s:
+  # The mountpoint used for this environment's ISO
+  iso_root_path: /srv/scality/metalk8s-@VERSION@

--- a/pillar/top.sls.in
+++ b/pillar/top.sls.in
@@ -1,3 +1,4 @@
 metalk8s-@VERSION@:
   '*':
+    - metalk8s
     - repositories

--- a/salt/metalk8s/calico/deployed.sls
+++ b/salt/metalk8s/calico/deployed.sls
@@ -1,6 +1,6 @@
 {%- from "metalk8s/map.jinja" import networks with context %}
 
-{%- set image = "localhost:5000/metalk8s-2.0/calico-node:3.5.1" -%}
+{%- set image = "localhost:5000/" ~ saltenv ~ "/calico-node:3.5.1" -%}
 
 {% set kubeconfig = "/etc/kubernetes/admin.conf" %}
 {% set context = "kubernetes-admin@kubernetes" %}

--- a/salt/metalk8s/containerd/configured.sls
+++ b/salt/metalk8s/containerd/configured.sls
@@ -1,6 +1,8 @@
+{% from "metalk8s/map.jinja" import metalk8s with context %}
+
 {# One day this should be transferred from the fileserver #}
 {% set pause_image_archive =
-    '/srv/scality/metalk8s-2.0/salt/metalk8s/containerd/files/pause-3.1.tar'
+    metalk8s.iso_root_path ~ '/salt/metalk8s/containerd/files/pause-3.1.tar'
 %}
 
 include:

--- a/salt/metalk8s/defaults.yaml
+++ b/salt/metalk8s/defaults.yaml
@@ -1,6 +1,8 @@
 ---
 cluster: kubernetes
 
+metalk8s: {}
+
 kubeadm_preflight:
   mandatory:
     packages:
@@ -28,7 +30,7 @@ kubeadm_preflight:
 repo:
   online_mode: true
   local_mode: false
-  base_path: /srv/scality/metalk8s-2.0/packages
+  relative_path: packages     # relative to ISO root (configured in pillar)
   host: 127.0.0.1
   port: 8080
   repositories:

--- a/salt/metalk8s/kubeadm/init/addons/coredns.sls
+++ b/salt/metalk8s/kubeadm/init/addons/coredns.sls
@@ -35,7 +35,8 @@ Create coredns deployment:
     - namespace: kube-system
     - kubeconfig: {{ kubeconfig }}
     - context: {{ context }}
-    - source: salt://metalk8s/kubeadm/init/addons/files/coredns_deployment.yaml
+    - source: salt://metalk8s/kubeadm/init/addons/files/coredns_deployment.yaml.j2
+    - template: jinja
   require:
     - kubernetes: Create coredns ConfigMap
     - pkg: Install Python Kubernetes client

--- a/salt/metalk8s/kubeadm/init/addons/files/coredns_deployment.yaml.j2
+++ b/salt/metalk8s/kubeadm/init/addons/files/coredns_deployment.yaml.j2
@@ -29,7 +29,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: localhost:5000/metalk8s-2.0/coredns:1.3.1
+        image: localhost:5000/{{ saltenv }}/coredns:1.3.1
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/salt/metalk8s/kubeadm/init/addons/kube-proxy.sls
+++ b/salt/metalk8s/kubeadm/init/addons/kube-proxy.sls
@@ -1,6 +1,6 @@
 {%- from "metalk8s/map.jinja" import networks with context %}
 
-{%- set image = "localhost:5000/metalk8s-2.0/kube-proxy:1.11.7" -%}
+{%- set image = "localhost:5000/" ~ saltenv ~ "/kube-proxy:1.11.7" -%}
 
 {% set kubeconfig = "/etc/kubernetes/admin.conf" %}
 {% set context = "kubernetes-admin@kubernetes" %}

--- a/salt/metalk8s/kubeadm/init/control-plane/lib.sls
+++ b/salt/metalk8s/kubeadm/init/control-plane/lib.sls
@@ -1,7 +1,7 @@
 # Share macro for building image names for each control-plane component
-{% set repository = "localhost:5000/metalk8s-2.0" %}
-{% set kubernetes_version = "1.11.7" %}
+{%- set registry_host = "localhost:5000" -%}
+{%- set kubernetes_version = "1.11.7" -%}
 
-{% macro get_image_name(component) -%}
-"{{ repository }}/{{ component }}:{{ kubernetes_version }}"
-{%- endmacro %}
+{%- macro get_image_name(component) -%}
+"{{ registry_host }}/{{ saltenv }}/{{ component }}:{{ kubernetes_version }}"
+{%- endmacro -%}

--- a/salt/metalk8s/kubeadm/init/etcd/local.sls
+++ b/salt/metalk8s/kubeadm/init/etcd/local.sls
@@ -1,6 +1,6 @@
 {% from "metalk8s/map.jinja" import networks with context %}
 
-{% set image_name="localhost:5000/metalk8s-2.0/etcd:3.2.18" %}
+{% set image_name="localhost:5000/" ~ saltenv ~ "/etcd:3.2.18" %}
 
 {% set host_name = salt.network.get_hostname() %}
 {% set ip_candidates = salt.network.ip_addrs(cidr=networks.control_plane) %}

--- a/salt/metalk8s/map.jinja
+++ b/salt/metalk8s/map.jinja
@@ -4,6 +4,10 @@
   'default': defaults
 }, merge=salt['pillar.items']()) %}
 
+{% set metalk8s = salt['grains.filter_by']({
+  'default': {}
+}, merge=defaults.get('metalk8s')) %}
+
 {% set kubeadm_preflight = salt['grains.filter_by']({
   'default': {}
 }, merge=defaults.get('kubeadm_preflight')) %}

--- a/salt/metalk8s/registry/init.sls
+++ b/salt/metalk8s/registry/init.sls
@@ -1,3 +1,5 @@
+{% from "metalk8s/map.jinja" import metalk8s with context %}
+
 {% set registry_image = 'docker.io/registry' %}
 {% set registry_version = '2.7.1' %}
 {% set registry_user = 'metalk8s-registry' %}
@@ -6,7 +8,7 @@
 Inject OCI registry image:
   containerd.image_managed:
     - name: docker.io/library/registry:2.7.1
-    - archive_path: /srv/scality/metalk8s-2.0/images/registry-2.7.1.tar
+    - archive_path: {{ metalk8s.iso_root_path }}/images/registry-2.7.1.tar
 
 Create OCI registry user:
   group.present:

--- a/salt/metalk8s/registry/populated.sls
+++ b/salt/metalk8s/registry/populated.sls
@@ -1,4 +1,5 @@
 {%- from "metalk8s/macro.sls" import pkg_installed with context %}
+{%- from "metalk8s/map.jinja" import metalk8s with context %}
 
 {% set images = [
     {
@@ -51,7 +52,7 @@ Install skopeo:
 Import {{ image.name }} image:
   docker_registry.image_managed:
     - name: localhost:5000/{{ saltenv }}/{{ image.name }}:{{ image.tag }}
-    - archive_path: /srv/scality/{{ saltenv }}/images/{{ image.name }}-{{ image.tag }}.tar.gz
+    - archive_path: {{ metalk8s.iso_root_path }}/images/{{ image.name }}-{{ image.tag }}.tar.gz
     - tls_verify: false
     - require:
       - pkg: Install skopeo

--- a/salt/metalk8s/registry/populated.sls
+++ b/salt/metalk8s/registry/populated.sls
@@ -38,7 +38,6 @@
         'tag': '2018.3.3-1',
     },
 ] %}
-{% set images_path = '/srv/scality/metalk8s-2.0/images' %}
 
 include:
   - metalk8s.repo
@@ -51,8 +50,8 @@ Install skopeo:
 {% for image in images %}
 Import {{ image.name }} image:
   docker_registry.image_managed:
-    - name: localhost:5000/metalk8s-2.0/{{ image.name }}:{{ image.tag }}
-    - archive_path: /srv/scality/metalk8s-2.0/images/{{ image.name }}-{{ image.tag }}.tar.gz
+    - name: localhost:5000/{{ saltenv }}/{{ image.name }}:{{ image.tag }}
+    - archive_path: /srv/scality/{{ saltenv }}/images/{{ image.name }}-{{ image.tag }}.tar.gz
     - tls_verify: false
     - require:
       - pkg: Install skopeo

--- a/salt/metalk8s/repo/deployed.sls
+++ b/salt/metalk8s/repo/deployed.sls
@@ -2,7 +2,7 @@
 
 {%- set package_repositories_name = 'package-repositories' %}
 {%- set package_repositories_version = '1.0.0' %}
-{%- set package_repositories_image = 'localhost:5000/' ~ saltenv ~ '/' ~ 'nginx:1.15.8' %}
+{%- set package_repositories_image = 'localhost:5000/' ~ saltenv ~ '/nginx:1.15.8' %}
 {%- set nginx_configuration_path = '/var/lib/metalk8s/package-repositories/nginx.conf' %}
 
 Generate package repositories nginx configuration:

--- a/salt/metalk8s/repo/deployed.sls
+++ b/salt/metalk8s/repo/deployed.sls
@@ -1,3 +1,4 @@
+{%- from "metalk8s/map.jinja" import metalk8s with context %}
 {%- from "metalk8s/map.jinja" import repo with context %}
 
 {%- set package_repositories_name = 'package-repositories' %}
@@ -33,7 +34,7 @@ Install package repositories manifest:
         image: {{ package_repositories_image }}
         name: {{ package_repositories_name }}
         version: {{ package_repositories_version }}
-        packages_path: {{ repo.base_path }}
+        packages_path: {{ metalk8s.iso_root_path }}/{{ repo.relative_path }}
         nginx_configuration_path: {{ nginx_configuration_path }}
     - require:
       - file: Generate package repositories nginx configuration

--- a/salt/metalk8s/repo/offline.sls
+++ b/salt/metalk8s/repo/offline.sls
@@ -1,3 +1,4 @@
+{%- from "metalk8s/map.jinja" import metalk8s with context %}
 {%- from "metalk8s/map.jinja" import repo with context %}
 
 {%- if not repo.local_mode %}
@@ -14,7 +15,8 @@ Install yum-plugin-versionlock:
 
 {%- for repo_name, repo_config in repo.repositories.items() %}
   {%- if repo.local_mode %}
-    {%- set repo_base_url = "file://" ~ repo.base_path %}
+    {%- set iso_root = metalk8s.iso_root_path %}
+    {%- set repo_base_url = "file://" ~ iso_root ~ "/" ~ repo.relative_path %}
   {%- else %}
     {%- set repo_base_url = "http://" ~ repo.host ~ ':' ~ repo.port %}
   {%- endif %}

--- a/salt/metalk8s/salt/master/configured.sls
+++ b/salt/metalk8s/salt/master/configured.sls
@@ -1,4 +1,4 @@
-{% set metal_version = '2.0' %}
+{%- from "metalk8s/map.jinja" import metalk8s with context %}
 
 Configure salt master:
   file.managed:
@@ -11,4 +11,4 @@ Configure salt master:
     - makedirs: true
     - backup: false
     - defaults:
-      metal_version: {{ metal_version }}
+        iso_root_path: {{ metalk8s.iso_root_path }}

--- a/salt/metalk8s/salt/master/deployed.sls
+++ b/salt/metalk8s/salt/master/deployed.sls
@@ -1,3 +1,5 @@
+{% from "metalk8s/map.jinja" import metalk8s with context %}
+
 {% set salt_master_image = 'salt-master' %}
 {% set salt_master_version = '2018.3.3-1' %}
 {% set registry_url = 'localhost:5000' %}
@@ -25,8 +27,9 @@ Install and start salt master manifest:
     - backup: false
     - defaults:
         registry_url: {{ registry_url }}
-      salt_master_image: {{ salt_master_image }}
-      salt_master_version: {{ salt_master_version }}
+        salt_master_image: {{ salt_master_image }}
+        salt_master_version: {{ salt_master_version }}
+        iso_root_path: {{ metalk8s.iso_root_path }}
     - require:
       - file: Create salt master directories
 

--- a/salt/metalk8s/salt/master/deployed.sls
+++ b/salt/metalk8s/salt/master/deployed.sls
@@ -1,7 +1,6 @@
 {% set salt_master_image = 'salt-master' %}
 {% set salt_master_version = '2018.3.3-1' %}
-{% set registry_prefix = 'localhost:5000/metalk8s-2.0/' %}
-{% set version = '2.0' %}
+{% set registry_url = 'localhost:5000' %}
 
 Create salt master directories:
   file.directory:
@@ -25,8 +24,7 @@ Install and start salt master manifest:
     - makedirs: false
     - backup: false
     - defaults:
-      path_version: {{ version }}
-      registry_prefix: {{ registry_prefix }}
+        registry_url: {{ registry_url }}
       salt_master_image: {{ salt_master_image }}
       salt_master_version: {{ salt_master_version }}
     - require:

--- a/salt/metalk8s/salt/master/files/master_99-metalk8s.conf.j2
+++ b/salt/metalk8s/salt/master/files/master_99-metalk8s.conf.j2
@@ -1,9 +1,9 @@
 file_roots:
-  metalk8s-{{ metal_version }}:
-    - /srv/scality/metalk8s-2.0/salt
+  {{ saltenv }}:
+    - /srv/scality/{{ saltenv }}/salt
 pillar_roots:
-  metalk8s-{{ metal_version }}:
-    - /srv/scality/metalk8s-2.0/pillar
+  {{ saltenv }}:
+    - /srv/scality/{{ saltenv }}/pillar
 peer:
   .*:
     - x509.sign_remote_certificate

--- a/salt/metalk8s/salt/master/files/master_99-metalk8s.conf.j2
+++ b/salt/metalk8s/salt/master/files/master_99-metalk8s.conf.j2
@@ -1,9 +1,9 @@
 file_roots:
   {{ saltenv }}:
-    - /srv/scality/{{ saltenv }}/salt
+    - {{ iso_root_path }}/salt
 pillar_roots:
   {{ saltenv }}:
-    - /srv/scality/{{ saltenv }}/pillar
+    - {{ iso_root_path }}/pillar
 peer:
   .*:
     - x509.sign_remote_certificate

--- a/salt/metalk8s/salt/master/files/salt-master-pod.yaml.j2
+++ b/salt/metalk8s/salt/master/files/salt-master-pod.yaml.j2
@@ -56,10 +56,10 @@ spec:
         - name: run
           mountPath: '/var/run/salt'
         - name: states
-          mountPath: '/srv/scality/{{ saltenv }}/salt'
+          mountPath: '{{ iso_root_path }}/salt'
           readOnly: true
         - name: pillar
-          mountPath: '/srv/scality/{{ saltenv }}/pillar'
+          mountPath: '{{ iso_root_path }}/pillar'
           readOnly: true
         - name: metalk8s-config
           mountPath: '/etc/metalk8s'
@@ -79,11 +79,11 @@ spec:
         type: Directory
     - name: states
       hostPath:
-        path: '/srv/scality/{{ saltenv }}/salt'
+        path: '{{ iso_root_path }}/salt'
         type: Directory
     - name: pillar
       hostPath:
-        path: '/srv/scality/{{ saltenv }}/pillar'
+        path: '{{ iso_root_path }}/pillar'
         type: Directory
     - name: metalk8s-config
       hostPath:

--- a/salt/metalk8s/salt/master/files/salt-master-pod.yaml.j2
+++ b/salt/metalk8s/salt/master/files/salt-master-pod.yaml.j2
@@ -24,7 +24,7 @@ spec:
         - ALL
   containers:
     - name: salt-master
-      image: {{ registry_prefix }}{{salt_master_image}}:{{salt_master_version}}
+      image: {{registry_url}}/{{saltenv}}/{{salt_master_image}}:{{salt_master_version}}
       ports:
         - name: publisher
           containerPort: 4505
@@ -56,10 +56,10 @@ spec:
         - name: run
           mountPath: '/var/run/salt'
         - name: states
-          mountPath: '/srv/scality/metalk8s-{{ path_version }}/salt'
+          mountPath: '/srv/scality/{{ saltenv }}/salt'
           readOnly: true
         - name: pillar
-          mountPath: '/srv/scality/metalk8s-{{ path_version }}/pillar'
+          mountPath: '/srv/scality/{{ saltenv }}/pillar'
           readOnly: true
         - name: metalk8s-config
           mountPath: '/etc/metalk8s'
@@ -79,11 +79,11 @@ spec:
         type: Directory
     - name: states
       hostPath:
-        path: '/srv/scality/metalk8s-{{ path_version }}/salt'
+        path: '/srv/scality/{{ saltenv }}/salt'
         type: Directory
     - name: pillar
       hostPath:
-        path: '/srv/scality/metalk8s-{{ path_version }}/pillar'
+        path: '/srv/scality/{{ saltenv }}/pillar'
         type: Directory
     - name: metalk8s-config
       hostPath:


### PR DESCRIPTION
Here is a simplistic solution to the multiple versions problem: we wanted to use multiple Salt environments for having multiple product versions living next to one another. To know which version is being used then, we can simply rely on the `{{ saltenv }}` Jinja variable.

Along the way, we realized another hardcoded info, i.e. *where we mount the ISO*, could not be inferred completely from the active `saltenv`, but instead was a fully customizable value without any implications for the product well-being. We use the newly introduced configuration file to add such info.

Fixes: GH-651