### PR TITLE
Improvement/724 add multiple vms in ci

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -92,13 +92,13 @@ stages:
       - ShellCommand:
           name: Retrieve ISO image
           command: >
-            curl -XGET -o metalk8s.iso
+            curl -s -XGET -o metalk8s.iso
             "%(prop:artifacts_private_url)s/metalk8s.iso"
           haltOnFailure: true
       - ShellCommand:
           name: Retrieve ISO image checksum
           command: >
-            curl -XGET -o SHA256SUM
+            curl -s -XGET -o SHA256SUM
             "%(prop:artifacts_private_url)s/SHA256SUM"
           haltOnFailure: true
       - ShellCommand:

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -177,6 +177,7 @@ stages:
             OS_PASSWORD: "%(secret:scality_cloud_password)s"
             OS_TENANT_NAME: "%(secret:scality_cloud_tenant_name)s"
             TF_VAR_worker_uuid: "%(prop:worker_uuid)s"
+            TF_VAR_nodes_count: "2"
           haltOnFailure: true
       - ShellCommand:
           name: Configure SSH config for bootstrap node

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -24,9 +24,10 @@ stages:
             . <(curl -s "%(prop:artifacts_private_url)s/product.txt") &&
             echo $SHORT_VERSION'
       - TriggerStages:
-          name: Trigger single-node deployment with built ISO
+          name: Trigger single-node and multiple-nodes steps with built ISO
           stage_names:
             - single-node
+            - multiple-nodes
 
   build:
     worker:
@@ -142,4 +143,71 @@ stages:
             mkdir -p ~/.ssh &&
             echo "%(secret:ssh_pub_keys)s" >> ~/.ssh/authorized_keys &&
             sleep 3600
+          doStepIf: false
+
+  multiple-nodes:
+    worker:
+      type: openstack
+      image: CentOS 7 (PVHVM)
+      flavor: m1.medium
+      path: eve/workers/openstack-multiple-nodes
+    steps:
+      - Git: *git_pull
+      - ShellCommand:
+          name: Init terraform
+          command: "terraform init"
+          workdir: "build/eve/workers/openstack-multiple-nodes/terraform/"
+          haltOnFailure: true
+      - ShellCommand:
+          name: Validate terraform definition
+          command: "terraform validate"
+          workdir: "build/eve/workers/openstack-multiple-nodes/terraform/"
+          haltOnFailure: true
+      - ShellCommand:
+          name: Spawn openstack virtual infra
+          command: 'terraform apply -auto-approve'
+          workdir: "build/eve/workers/openstack-multiple-nodes/terraform/"
+          env: &terraform_spawn_multiple_nodes
+            OS_AUTH_URL: "%(secret:scality_cloud_auth_url)s"
+            OS_REGION_NAME: "%(secret:scality_cloud_region)s"
+            OS_USERNAME: "%(secret:scality_cloud_username)s"
+            OS_PASSWORD: "%(secret:scality_cloud_password)s"
+            OS_TENANT_NAME: "%(secret:scality_cloud_tenant_name)s"
+            TF_VAR_worker_uuid: "%(prop:worker_uuid)s"
+          haltOnFailure: true
+      - ShellCommand:
+          name: Configure SSH config for bootstrap node
+          command: >
+            sed -i s/IP_ADDRESS/$(terraform output bootstrap_ip)/
+            bootstrap_ssh_config
+          workdir: "build/eve/workers/openstack-multiple-nodes/terraform/"
+          haltOnFailure: true
+      - ShellCommand:
+          name: Check SSH config for bootstrap node
+          command: |-
+            for _ in $(seq 1 12); do
+              sleep 5
+              ssh -F bootstrap_ssh_config bootstrap id && break
+            done;
+          workdir: "build/eve/workers/openstack-multiple-nodes/terraform/"
+          haltOnFailure: true
+      - ShellCommand:
+          name: Destroy openstack virtual infra
+          command: |-
+            for _ in $(seq 1 3); do
+               terraform destroy -auto-approve && break
+            done;
+          workdir: "build/eve/workers/openstack-multiple-nodes/terraform/"
+          env: *terraform_spawn_multiple_nodes
+          alwaysRun: true
+          sigtermTime: 600
+      - ShellCommand:
+          name: Debug step - report IPs, add SSH keys, wait 4 hours
+          timeout: 14400
+          command: >
+            ip a &&
+            mkdir -p ~/.ssh &&
+            echo "%(secret:ssh_pub_keys)s" >> ~/.ssh/authorized_keys &&
+            sleep 14400
+          alwaysRun: true
           doStepIf: false

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -217,6 +217,16 @@ stages:
           workdir: "build/eve/workers/openstack-multiple-nodes/terraform/"
           haltOnFailure: true
       - ShellCommand:
+          name: Copy bootstrap configuration file in bootstrap node
+          command: >
+            ssh -F bootstrap_ssh_config bootstrap
+            sudo mkdir -p /etc/metalk8s &&
+            scp -F bootstrap_ssh_config bootstrap.yaml bootstrap: &&
+            ssh -F bootstrap_ssh_config bootstrap
+            sudo mv bootstrap.yaml /etc/metalk8s
+          workdir: "build/eve/workers/openstack-multiple-nodes/terraform/"
+          haltOnFailure: true
+      - ShellCommand:
           name: Start the bootstrap process in bootstrap node
           command: >
             ssh -F bootstrap_ssh_config bootstrap

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -90,19 +90,19 @@ stages:
       flavor: m1.medium
       path: eve/workers/openstack-single-node
     steps:
-      - ShellCommand:
+      - ShellCommand: &retrieve_iso
           name: Retrieve ISO image
           command: >
             curl -s -XGET -o metalk8s.iso
             "%(prop:artifacts_private_url)s/metalk8s.iso"
           haltOnFailure: true
-      - ShellCommand:
+      - ShellCommand: &retrieve_iso_checksum
           name: Retrieve ISO image checksum
           command: >
             curl -s -XGET -o SHA256SUM
             "%(prop:artifacts_private_url)s/SHA256SUM"
           haltOnFailure: true
-      - ShellCommand:
+      - ShellCommand: &check_iso_checksum
           name: Check image with checksum
           command: sha256sum -c SHA256SUM
           haltOnFailure: true
@@ -153,6 +153,9 @@ stages:
       path: eve/workers/openstack-multiple-nodes
     steps:
       - Git: *git_pull
+      - ShellCommand: *retrieve_iso
+      - ShellCommand: *retrieve_iso_checksum
+      - ShellCommand: *check_iso_checksum
       - ShellCommand:
           name: Init terraform
           command: "terraform init"
@@ -189,6 +192,35 @@ stages:
               sleep 5
               ssh -F bootstrap_ssh_config bootstrap id && break
             done;
+          workdir: "build/eve/workers/openstack-multiple-nodes/terraform/"
+          haltOnFailure: true
+      - ShellCommand:
+          name: Copy ISO to bootstrap node
+          command: >
+            scp -F bootstrap_ssh_config ../../../../metalk8s.iso bootstrap:
+          workdir: "build/eve/workers/openstack-multiple-nodes/terraform/"
+          haltOnFailure: true
+      - ShellCommand:
+          name: Create mountpoint in bootstrap node
+          command: >
+            ssh -F bootstrap_ssh_config bootstrap
+            sudo mkdir -p /srv/scality/metalk8s-%(prop:metalk8s_short_version)s
+          workdir: "build/eve/workers/openstack-multiple-nodes/terraform/"
+          haltOnFailure: true
+      - ShellCommand:
+          name: Mount ISO image in bootstrap node
+          command: >
+            ssh -F bootstrap_ssh_config bootstrap
+            sudo mount -o loop metalk8s.iso
+            /srv/scality/metalk8s-%(prop:metalk8s_short_version)s
+          workdir: "build/eve/workers/openstack-multiple-nodes/terraform/"
+          haltOnFailure: true
+      - ShellCommand:
+          name: Start the bootstrap process in bootstrap node
+          command: >
+            ssh -F bootstrap_ssh_config bootstrap
+            sudo bash
+            /srv/scality/metalk8s-%(prop:metalk8s_short_version)s/bootstrap.sh
           workdir: "build/eve/workers/openstack-multiple-nodes/terraform/"
           haltOnFailure: true
       - ShellCommand:

--- a/eve/workers/openstack-multiple-nodes/requirements.sh
+++ b/eve/workers/openstack-multiple-nodes/requirements.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+PACKAGES=(
+    curl
+    git
+    unzip
+)
+
+yum install -y "${PACKAGES[@]}"
+
+yum clean all
+
+TERRAFORM_VERSION=0.11.13
+
+curl -O https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/local/sbin/
+rm -f terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+
+sudo -u eve mkdir -p /home/eve/.ssh/
+sudo -u eve ssh-keygen -t rsa -b 4096 -N '' -f /home/eve/.ssh/terraform

--- a/eve/workers/openstack-multiple-nodes/terraform/bootstrap.yaml
+++ b/eve/workers/openstack-multiple-nodes/terraform/bootstrap.yaml
@@ -1,0 +1,5 @@
+apiVersion: metalk8s.scality.com/v1alpha1
+kind: BootstrapConfiguration
+networks:
+  controlPlane: 192.168.42.0/24
+  workloadPlane: 192.168.42.0/24

--- a/eve/workers/openstack-multiple-nodes/terraform/bootstrap_ssh_config
+++ b/eve/workers/openstack-multiple-nodes/terraform/bootstrap_ssh_config
@@ -1,0 +1,7 @@
+Host bootstrap
+    User centos
+    Port 22
+    Hostname IP_ADDRESS
+    IdentityFile /home/eve/.ssh/terraform
+    IdentitiesOnly yes
+    StrictHostKeyChecking no

--- a/eve/workers/openstack-multiple-nodes/terraform/common.tf
+++ b/eve/workers/openstack-multiple-nodes/terraform/common.tf
@@ -1,0 +1,15 @@
+variable "worker_uuid" {
+  type    = "string"
+  default = ""
+}
+
+resource "random_string" "current" {
+  length  = 5
+  special = false
+}
+
+locals {
+  prefix = "metalk8s-${
+    var.worker_uuid != "" ? var.worker_uuid : random_string.current.result
+  }"
+}

--- a/eve/workers/openstack-multiple-nodes/terraform/image.tf
+++ b/eve/workers/openstack-multiple-nodes/terraform/image.tf
@@ -1,0 +1,9 @@
+variable "openstack_image_name" {
+  type    = "string"
+  default = "CentOS-7-x86_64-GenericCloud-1809.qcow2"
+}
+
+variable "openstack_flavour_name" {
+  type    = "string"
+  default = "m1.medium"
+}

--- a/eve/workers/openstack-multiple-nodes/terraform/network.tf
+++ b/eve/workers/openstack-multiple-nodes/terraform/network.tf
@@ -28,3 +28,33 @@ resource "openstack_networking_secgroup_rule_v2" "nodes_icmp" {
   remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = "${openstack_networking_secgroup_v2.nodes.id}"
 }
+
+# Main network for nodes
+variable "internal_network_range" {
+  type = "string"
+  default = "192.168.42.0/24"
+}
+
+resource "openstack_networking_network_v2" "internal" {
+  name           = "${local.prefix}-internal"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnet_v2" "internal_main" {
+  name       = "${local.prefix}-internal-main"
+  network_id = "${openstack_networking_network_v2.internal.id}"
+  cidr       = "${var.internal_network_range}"
+  ip_version = 4
+}
+
+resource "openstack_compute_secgroup_v2" "nodes_openbar" {
+  name        = "${local.prefix}-nodes-openbar"
+  description = "security group for metalk8s nodes communicating together"
+
+  rule {
+    from_port   = 1
+    to_port     = 65535
+    ip_protocol = "tcp"
+    cidr        = "${var.internal_network_range}"
+  }
+}

--- a/eve/workers/openstack-multiple-nodes/terraform/network.tf
+++ b/eve/workers/openstack-multiple-nodes/terraform/network.tf
@@ -1,0 +1,30 @@
+# Default CI network
+variable "openstack_network" {
+  type = "map"
+  default = {
+    name = "tenantnetwork1"
+  }
+}
+
+resource "openstack_networking_secgroup_v2" "nodes" {
+  name        = "${local.prefix}-nodes"
+  description = "security group for reaching out metalk8s nodes"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "nodes_ssh" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = "${openstack_networking_secgroup_v2.nodes.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "nodes_icmp" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "icmp"
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = "${openstack_networking_secgroup_v2.nodes.id}"
+}

--- a/eve/workers/openstack-multiple-nodes/terraform/nodes.tf
+++ b/eve/workers/openstack-multiple-nodes/terraform/nodes.tf
@@ -6,6 +6,21 @@ resource "openstack_compute_instance_v2" "bootstrap" {
   security_groups = ["${openstack_networking_secgroup_v2.nodes.name}"]
 
   network = ["${var.openstack_network}"]
+
+  network {
+    name = "${openstack_networking_network_v2.internal.name}"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo chattr +i /etc/resolv.conf &&",
+      "sudo dhclient eth1"
+    ]
+    connection {
+      user     = "centos"
+      private_key = "${file("/home/eve/.ssh/terraform")}"
+    }
+  }
 }
 
 output "bootstrap_ip" {
@@ -25,6 +40,21 @@ resource "openstack_compute_instance_v2" "nodes" {
   security_groups = ["${openstack_networking_secgroup_v2.nodes.name}"]
 
   network = ["${var.openstack_network}"]
+
+  network {
+    name = "${openstack_networking_network_v2.internal.name}"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo chattr +i /etc/resolv.conf &&",
+      "sudo dhclient eth1"
+    ]
+    connection {
+      user     = "centos"
+      private_key = "${file("/home/eve/.ssh/terraform")}"
+    }
+  }
 
   count = "${var.nodes_count}"
 }

--- a/eve/workers/openstack-multiple-nodes/terraform/nodes.tf
+++ b/eve/workers/openstack-multiple-nodes/terraform/nodes.tf
@@ -11,3 +11,20 @@ resource "openstack_compute_instance_v2" "bootstrap" {
 output "bootstrap_ip" {
   value = "${openstack_compute_instance_v2.bootstrap.network.0.fixed_ip_v4}"
 }
+
+variable "nodes_count" {
+  type    = "string"
+  default = "1"
+}
+
+resource "openstack_compute_instance_v2" "nodes" {
+  name        = "${local.prefix}-node-${count.index+1}"
+  image_name  = "${var.openstack_image_name}"
+  flavor_name = "${var.openstack_flavour_name}"
+  key_pair    = "${openstack_compute_keypair_v2.local_ssh_key.name}"
+  security_groups = ["${openstack_networking_secgroup_v2.nodes.name}"]
+
+  network = ["${var.openstack_network}"]
+
+  count = "${var.nodes_count}"
+}

--- a/eve/workers/openstack-multiple-nodes/terraform/nodes.tf
+++ b/eve/workers/openstack-multiple-nodes/terraform/nodes.tf
@@ -1,0 +1,13 @@
+resource "openstack_compute_instance_v2" "bootstrap" {
+  name        = "${local.prefix}-bootstrap"
+  image_name  = "${var.openstack_image_name}"
+  flavor_name = "${var.openstack_flavour_name}"
+  key_pair    = "${openstack_compute_keypair_v2.local_ssh_key.name}"
+  security_groups = ["${openstack_networking_secgroup_v2.nodes.name}"]
+
+  network = ["${var.openstack_network}"]
+}
+
+output "bootstrap_ip" {
+  value = "${openstack_compute_instance_v2.bootstrap.network.0.fixed_ip_v4}"
+}

--- a/eve/workers/openstack-multiple-nodes/terraform/provider.tf
+++ b/eve/workers/openstack-multiple-nodes/terraform/provider.tf
@@ -1,0 +1,1 @@
+provider "openstack" {}

--- a/eve/workers/openstack-multiple-nodes/terraform/ssh.tf
+++ b/eve/workers/openstack-multiple-nodes/terraform/ssh.tf
@@ -1,0 +1,9 @@
+variable "ssh_key_path" {
+  type    = "string"
+  default = "~/.ssh/terraform.pub"
+}
+
+resource "openstack_compute_keypair_v2" "local_ssh_key" {
+  name       = "${local.prefix}"
+  public_key = "${file(var.ssh_key_path)}"
+}


### PR DESCRIPTION
This PR provides a new stage in the CI with multi-VMs spawning.

Fixes #724 

In the single VM environment, the CI worker is also the bootstrap node. Now we spawn thanks to terraform a whole new infra in the PTF9 tenant on which we run the bootstrap script (we run it on one node only of course).

Limitations:

- All nodes can communicate freely on an internal network (192.168.42.0/24); that may be not enough after Nicolas's PR related to the control and workload plane networks; it seems without running a `dhclient` command the IPs are not attributed on this network so the command is run but that may not be a best practice
- Nodes are all identical in sizing, but we can change this later
- The bootstrap node does not contain the SSH private key in order to SSH into the other nodes, but that's easy to do if we want to do it

How to test it?

Just check the steps in the build, or you can edit the debug step in the `eve/main.yaml` file to enable it and then connect into the VM worker. But you won't be able to use terraform commands since they need to be launched by the worker to use the env variables.