### PR TITLE
CI: upgrade RAM for build worker

### DIFF
--- a/eve/workers/pod-builder/pod.yaml
+++ b/eve/workers/pod-builder/pod.yaml
@@ -12,10 +12,10 @@ spec:
       resources:
         requests:
           cpu: 500m
-          memory: 500Mi
+          memory: 1Gi
         limits:
           cpu: 500m
-          memory: 500Mi
+          memory: 1Gi
       env:
         - name: DOCKER_HOST
           value: localhost


### PR DESCRIPTION
Building the ISO is very memory-consuming.
500MB limit was hit a few times.