### PR TITLE
Improvement/717 have test framework available in ci

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -90,6 +90,7 @@ stages:
       flavor: m1.medium
       path: eve/workers/openstack-single-node
     steps:
+      - Git: *git_pull
       - ShellCommand: &retrieve_iso
           name: Retrieve ISO image
           command: >

--- a/eve/workers/openstack-multiple-nodes/requirements.sh
+++ b/eve/workers/openstack-multiple-nodes/requirements.sh
@@ -1,14 +1,19 @@
 #!/bin/bash
 
+yum install -y epel-release
+
 PACKAGES=(
     curl
     git
+    python34-pip
     unzip
 )
 
 yum install -y "${PACKAGES[@]}"
 
 yum clean all
+
+pip3 install tox
 
 TERRAFORM_VERSION=0.11.13
 

--- a/eve/workers/openstack-single-node/requirements.sh
+++ b/eve/workers/openstack-single-node/requirements.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 
+yum install -y epel-release
+
 PACKAGES=(
     curl
     git
+    python34-pip
 )
 
 yum install -y "${PACKAGES[@]}"
 
 yum clean all
+
+pip3 install tox

--- a/eve/workers/openstack-single-node/requirements.sh
+++ b/eve/workers/openstack-single-node/requirements.sh
@@ -2,6 +2,7 @@
 
 PACKAGES=(
     curl
+    git
 )
 
 yum install -y "${PACKAGES[@]}"


### PR DESCRIPTION
Fixes #717

We want to make sure that the `tox` command and the tests suite are available on OpenStack workers otherwise we can not launch the E2E tests.

Source code was already available in the multiple vms environment.

We may want to freeze the tox version but we don't do it in the linter nor in the README on how to run the tests. So it may be part of a debt ticket if need to?