### PR TITLE
Registry: fix IP binding bug with localhost as hostname

### DIFF
--- a/salt/metalk8s/registry/files/registry-pod.yaml.j2
+++ b/salt/metalk8s/registry/files/registry-pod.yaml.j2
@@ -48,7 +48,7 @@ spec:
         - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
           value: '/var/lib/registry'
         - name: REGISTRY_HTTP_ADDR
-          value: 'localhost:5000'
+          value: '127.0.0.1:5000'
         - name: REGISTRY_HEALTH_STORAGEDRIVER_ENABLED
           value: 'true'
       volumeMounts:


### PR DESCRIPTION
Fixes #798

Using localhost as hostname could lead to a registry trying to bind on random IP addresses whether we want it to bind on localhost (127.0.0.1) only.

Using the IP address directly to fix the issue.