### PR TITLE
Add pod manifest to run metalk8s-ui

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -196,6 +196,10 @@ SALT_FILES : Tuple[Union[Path, targets.FileTarget], ...] = (
     Path('salt/metalk8s/salt/minion/running.sls'),
     Path('salt/metalk8s/salt/minion/init.sls'),
 
+    Path('salt/metalk8s/metalk8s-ui/files/metalk8s-ui_deployment.yaml'),
+    Path('salt/metalk8s/metalk8s-ui/deployed.sls'),
+    Path('salt/metalk8s/metalk8s-ui/init.sls'),
+
     Path('salt/_modules/containerd.py'),
     Path('salt/_modules/cri.py'),
     Path('salt/_modules/docker_registry.py'),

--- a/salt/metalk8s/metalk8s-ui/deployed.sls
+++ b/salt/metalk8s/metalk8s-ui/deployed.sls
@@ -21,5 +21,13 @@ Create metalk8s-ui service:
         labels:
           run: metalk8s-ui
         name: metalk8s-ui
+    - spec:
+        ports:
+        - port: 80
+          protocol: TCP
+          targetPort: 80
+        selector:
+          k8s-app: ui
+        type: NodePort
   require:
     - pkg: Install Python Kubernetes client

--- a/salt/metalk8s/metalk8s-ui/deployed.sls
+++ b/salt/metalk8s/metalk8s-ui/deployed.sls
@@ -1,0 +1,41 @@
+{% set salt_master_image = 'salt-master' %}
+{% set salt_master_version = '2018.3.3-1' %}
+{% set registry_prefix = 'localhost:5000/metalk8s-2.0/' %}
+{% set version = '2.0' %}
+
+{% set kubeconfig = "/etc/kubernetes/admin.conf" %}
+{% set context = "kubernetes-admin@kubernetes" %}
+
+Create metalk8s-ui deployment:
+  kubernetes.deployment_present:
+    - name: metalk8s-ui
+    - namespace: kube-system
+    - kubeconfig: {{ kubeconfig }}
+    - context: {{ context }}
+    - source: salt://metalk8s/metalk8s-ui/files/metalk8s-ui_deployment.yaml
+  require:
+    - pkg: Install Python Kubernetes client
+
+Create coredns service:
+  kubernetes.service_present:
+    - name: metalk8s-ui
+    - namespace: kube-system
+    - kubeconfig: {{ kubeconfig }}
+    - context: {{ context }}
+    - metadata:
+        labels:
+          run: metalk8s-ui
+        name: metalk8s-ui
+    - spec:
+        externalTrafficPolicy: Cluster
+        ports:
+        - port: 80
+          protocol: TCP
+          targetPort: 80
+        selector:
+          k8s-app: ui
+        sessionAffinity: None
+        type: NodePort
+  require:
+    - kubernetes: Create metalk8s-ui deployment
+    - pkg: Install Python Kubernetes client

--- a/salt/metalk8s/metalk8s-ui/deployed.sls
+++ b/salt/metalk8s/metalk8s-ui/deployed.sls
@@ -1,8 +1,3 @@
-{% set salt_master_image = 'salt-master' %}
-{% set salt_master_version = '2018.3.3-1' %}
-{% set registry_prefix = 'localhost:5000/metalk8s-2.0/' %}
-{% set version = '2.0' %}
-
 {% set kubeconfig = "/etc/kubernetes/admin.conf" %}
 {% set context = "kubernetes-admin@kubernetes" %}
 
@@ -16,7 +11,7 @@ Create metalk8s-ui deployment:
   require:
     - pkg: Install Python Kubernetes client
 
-Create coredns service:
+Create metalk8s-ui service:
   kubernetes.service_present:
     - name: metalk8s-ui
     - namespace: kube-system
@@ -26,16 +21,5 @@ Create coredns service:
         labels:
           run: metalk8s-ui
         name: metalk8s-ui
-    - spec:
-        externalTrafficPolicy: Cluster
-        ports:
-        - port: 80
-          protocol: TCP
-          targetPort: 80
-        selector:
-          k8s-app: ui
-        sessionAffinity: None
-        type: NodePort
   require:
-    - kubernetes: Create metalk8s-ui deployment
     - pkg: Install Python Kubernetes client

--- a/salt/metalk8s/metalk8s-ui/files/metalk8s-ui_deployment.yaml
+++ b/salt/metalk8s/metalk8s-ui/files/metalk8s-ui_deployment.yaml
@@ -5,6 +5,12 @@ metadata:
     k8s-app: ui
     kubernetes.io/name: "MetalK8sUI"
 spec:
+  tolerations:
+  - key: "node-role.kubernetes.io/master"
+    operator: "Exists"
+    effect: "NoSchedule"
+  nodeSelector:
+    beta.kubernetes.io/os: linux
   containers:
   - name: metalk8s-ui
     image: localhost:5000/metalk8s-2.0/metalk8s-ui:0.2

--- a/salt/metalk8s/metalk8s-ui/files/metalk8s-ui_deployment.yaml
+++ b/salt/metalk8s/metalk8s-ui/files/metalk8s-ui_deployment.yaml
@@ -5,32 +5,40 @@ metadata:
     k8s-app: ui
     kubernetes.io/name: "MetalK8sUI"
 spec:
-  tolerations:
-  - key: "node-role.kubernetes.io/master"
-    operator: "Exists"
-    effect: "NoSchedule"
-  nodeSelector:
-    beta.kubernetes.io/os: linux
-  containers:
-  - name: metalk8s-ui
-    image: localhost:5000/metalk8s-2.0/metalk8s-ui:0.2
-    resources:
-      limits:
-        memory: 170Mi
-      requests:
-        cpu: 100m
-        memory: 70Mi
-    ports:
-    - containerPort: 80
-      name: http
-      protocol: TCP
-    livenessProbe:
-      httpGet:
-        path: /
-        port: http
-        scheme: HTTP
-    readinessProbe:
-      httpGet:
-        path: /
-        port: http
-        scheme: HTTP
+  selector:
+    matchLabels:
+      k8s-app: ui
+  template:
+    metadata:
+      labels:
+        k8s-app: ui
+    spec:
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      containers:
+        - name: metalk8s-ui
+          image: localhost:5000/metalk8s-2.0/metalk8s-ui:0.2
+          resources:
+            limits:
+              memory: 170Mi
+            requests:
+              cpu: 100m
+              memory: 70Mi
+          ports:
+          - containerPort: 80
+            name: http
+            protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+              scheme: HTTP
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+              scheme: HTTP

--- a/salt/metalk8s/metalk8s-ui/files/metalk8s-ui_deployment.yaml
+++ b/salt/metalk8s/metalk8s-ui/files/metalk8s-ui_deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: ui
+    kubernetes.io/name: "MetalK8sUI"
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      k8s-app: ui
+  template:
+    metadata:
+      labels:
+        k8s-app: ui
+    spec:
+      tolerations:
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      containers:
+      - name: metalk8s-ui
+        image: localhost:5000/metalk8s-2.0/metalk8s-ui:0.2
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            memory: 500Mi
+          requests:
+            cpu: 100m
+            memory: 70Mi
+        ports:
+        - containerPort: 80
+          name: nginx-ui
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+            scheme: HTTP

--- a/salt/metalk8s/metalk8s-ui/files/metalk8s-ui_deployment.yaml
+++ b/salt/metalk8s/metalk8s-ui/files/metalk8s-ui_deployment.yaml
@@ -5,50 +5,26 @@ metadata:
     k8s-app: ui
     kubernetes.io/name: "MetalK8sUI"
 spec:
-  replicas: 1
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
-  selector:
-    matchLabels:
-      k8s-app: ui
-  template:
-    metadata:
-      labels:
-        k8s-app: ui
-    spec:
-      tolerations:
-        - key: "node-role.kubernetes.io/master"
-          operator: "Exists"
-          effect: "NoSchedule"
-      nodeSelector:
-        beta.kubernetes.io/os: linux
-      containers:
-      - name: metalk8s-ui
-        image: localhost:5000/metalk8s-2.0/metalk8s-ui:0.2
-        imagePullPolicy: IfNotPresent
-        resources:
-          limits:
-            memory: 500Mi
-          requests:
-            cpu: 100m
-            memory: 70Mi
-        ports:
-        - containerPort: 80
-          name: nginx-ui
-          protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 80
-            scheme: HTTP
-          initialDelaySeconds: 60
-          timeoutSeconds: 5
-          successThreshold: 1
-          failureThreshold: 5
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 80
-            scheme: HTTP
+  containers:
+  - name: metalk8s-ui
+    image: localhost:5000/metalk8s-2.0/metalk8s-ui:0.2
+    resources:
+      limits:
+        memory: 170Mi
+      requests:
+        cpu: 100m
+        memory: 70Mi
+    ports:
+    - containerPort: 80
+      name: http
+      protocol: TCP
+    livenessProbe:
+      httpGet:
+        path: /
+        port: http
+        scheme: HTTP
+    readinessProbe:
+      httpGet:
+        path: /
+        port: http
+        scheme: HTTP

--- a/salt/metalk8s/metalk8s-ui/init.sls
+++ b/salt/metalk8s/metalk8s-ui/init.sls
@@ -1,0 +1,3 @@
+include:
+  - metalk8s.python-kubernetes
+  - .deployed

--- a/salt/metalk8s/registry/populated.sls
+++ b/salt/metalk8s/registry/populated.sls
@@ -38,6 +38,10 @@
         'name': 'salt-master',
         'tag': '2018.3.4-1',
     },
+    {
+        'name': 'metalk8s-ui',
+        'tag': '0.2',
+    },
 ] %}
 
 include:

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -175,8 +175,8 @@ orchestrate_bootstrap() {
 
 deploy_metalk8s_ui() {
     "$SALT_CALL" --retcode-passthrough state.apply \
-        metalk8s.metalk8s-ui saltenv=metalk8s-@VERSION@ \
-        pillarenv=metalk8s-@VERSION@
+        metalk8s.metalk8s-ui saltenv=metalk8s-@@VERSION \
+        pillarenv=metalk8s-@@VERSION
 }
 
 

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -173,6 +173,13 @@ orchestrate_bootstrap() {
     ${SALT_MASTER_CALL}-run --state-output=mixed state.orchestrate metalk8s.orchestrate.bootstrap_with_master saltenv=metalk8s-@@VERSION pillarenv=metalk8s-@@VERSION pillar="{'bootstrap_id': '$(cat /etc/salt/minion_id)'}"
 }
 
+deploy_metalk8s_ui() {
+    "$SALT_CALL" --retcode-passthrough state.apply \
+        metalk8s.metalk8s-ui saltenv=metalk8s-@VERSION@ \
+        pillarenv=metalk8s-@VERSION@
+}
+
+
 main() {
     pre_minion_checks
     disable_salt_minion_service
@@ -181,7 +188,10 @@ main() {
     install_salt_minion
     configure_salt_minion_local_mode
 
+    sync_local
+    
     orchestrate_bootstrap
+    deploy_metalk8s_ui
 }
 
 main

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -187,8 +187,6 @@ main() {
     configure_yum_repositories
     install_salt_minion
     configure_salt_minion_local_mode
-
-    sync_local
     
     orchestrate_bootstrap
     deploy_metalk8s_ui


### PR DESCRIPTION
##### WHAT ? #####

- [x] We create a pod manifest to run the UI #726
- [x] We create the service that make the UI accessible from outside #729

##### HOW ? #####

`doit vagrantup`
`vagrant ssh`
`sudo su`
`export KUBECONFIG=/etc/kubernetes/admin.conf`

Get your eth2 ip with `ip a` 
```
 4: eth2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
    link/ether 08:00:27:05:59:d3 brd ff:ff:ff:ff:ff:ff
    inet 172.21.254.35/27 brd 172.21.254.63 scope global noprefixroute dynamic eth2
       valid_lft 1118sec preferred_lft 1118sec
    inet6 fe80::a00:27ff:fe05:59d3/64 scope link
       valid_lft forever preferred_lft forever 
```
`<ip> = 172.21.254.35`

Get the right port with `kubectl -n kube-system get svc`
```
metalk8s-ui   NodePort    10.106.142.24   <none>        80:31966/TCP             21h
```
`<port> = 31966`

You can normally reach the UI with `http://<ip>:<port>`
