### PR TITLE
Add basic auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ ALL = \
 	\
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/control-plane/apiserver.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/control-plane/controller-manager.sls \
+	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/control-plane/files/htpasswd \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/control-plane/files/manifest.yaml \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/control-plane/init.sls \
 	$(ISO_ROOT)/salt/metalk8s/kubeadm/init/control-plane/lib.sls \

--- a/salt/metalk8s/kubeadm/init/control-plane/apiserver.sls
+++ b/salt/metalk8s/kubeadm/init/control-plane/apiserver.sls
@@ -1,5 +1,16 @@
 {% from "metalk8s/map.jinja" import networks with context %}
 {% from "metalk8s/kubeadm/init/control-plane/lib.sls" import get_image_name with context %}
+{% set htpasswd_path = "/etc/kubernetes/htpasswd" %}
+
+Set up default basic auth htpasswd:
+  file.managed:
+    - name: {{ htpasswd_path }}
+    - source: salt://metalk8s/kubeadm/init/control-plane/files/htpasswd
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - dir_mode: 750
 
 {% set ip_candidates = salt.network.ip_addrs(cidr=networks.control_plane) %}
 {% if ip_candidates %}
@@ -25,6 +36,7 @@ Create kube-apiserver Pod manifest:
           - --authorization-mode=Node,RBAC
           - --advertise-address={{ host }}
           - --allow-privileged=true
+          - --basic-auth-file={{ htpasswd_path }}
           - --client-ca-file=/etc/kubernetes/pki/ca.crt
           - --enable-admission-plugins=NodeRestriction
           - --enable-bootstrap-token-auth=true
@@ -56,6 +68,9 @@ Create kube-apiserver Pod manifest:
             name: k8s-certs
           - path: /etc/ssl/certs
             name: ca-certs
+          - path: {{ htpasswd_path }}
+            type: File
+            name: htpasswd
 {% else %}
 No available advertise IP for kube-apiserver:
   test.fail_without_changes:

--- a/salt/metalk8s/kubeadm/init/control-plane/apiserver.sls
+++ b/salt/metalk8s/kubeadm/init/control-plane/apiserver.sls
@@ -8,7 +8,7 @@ Set up default basic auth htpasswd:
     - source: salt://metalk8s/kubeadm/init/control-plane/files/htpasswd
     - user: root
     - group: root
-    - mode: 644
+    - mode: 600
     - makedirs: True
     - dir_mode: 750
 

--- a/salt/metalk8s/kubeadm/init/control-plane/files/htpasswd
+++ b/salt/metalk8s/kubeadm/init/control-plane/files/htpasswd
@@ -1,0 +1,1 @@
+admin,admin,123,"system:masters"


### PR DESCRIPTION
-https://github.com/scality/metalk8s/issues/828

To test:
-add "bootstrap.vm.network "forwarded_port", guest: 6443, host: 8080" in the vagrantFile
-make vagrantup
-launch "curl --header "Authorization: Basic YWRtaW46YWRtaW4=" --insecure https://localhost:8080/api/v1/nodes"
=> get the nodes list
"YWRtaW46YWRtaW4=" is the default encoded login.
