### PR TITLE
Run tests in the CI

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -201,6 +201,11 @@ stages:
             # TF_VAR_worker_uuid: "%(prop:worker_uuid)s"
             TF_VAR_nodes_count: "2"
           haltOnFailure: true
+      - SetPropertyFromCommand:
+          name: Save spawned bootstrap IP
+          workdir: build/eve/workers/openstack-multiple-nodes/terraform/
+          property: bootstrap_ip
+          command: terraform output bootstrap_ip
       - ShellCommand:
           name: Configure SSH config for bootstrap node
           command: >
@@ -255,6 +260,25 @@ stages:
             sudo bash
             /srv/scality/metalk8s-%(prop:metalk8s_short_version)s/bootstrap.sh
           workdir: "build/eve/workers/openstack-multiple-nodes/terraform/"
+          haltOnFailure: true
+      - ShellCommand:
+          name: Install kubectl on the boostrap node
+          command: >
+            ssh -F bootstrap_ssh_config bootstrap
+            sudo yum install -y kubectl --disablerepo=*
+            --enablerepo=metalk8s-kubernetes
+          workdir: build/eve/workers/openstack-multiple-nodes/terraform/
+      - ShellCommand:
+          name: Run tests on the bootstrap node
+          env:
+            SSH_CONFIG_FILE: >-
+              eve/workers/openstack-multiple-nodes/terraform/bootstrap_ssh_config
+            ISO_MOUNTPOINT: >-
+              /srv/scality/metalk8s-%(prop:metalk8s_short_version)s
+            TEST_HOSTS_LIST: bootstrap
+          command: >
+            tox -e tests --
+            --bootstrap-ip=%(prop:bootstrap_ip)s --skip-tls-verify
           haltOnFailure: true
       - ShellCommand:
           name: Destroy openstack virtual infra

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -145,6 +145,18 @@ stages:
             /srv/scality/metalk8s-%(prop:metalk8s_short_version)s/bootstrap.sh
           haltOnFailure: true
       - ShellCommand:
+          name: Install kubectl for running tests
+          command: >
+            sudo yum install -y kubectl --disablerepo=*
+            --enablerepo=metalk8s-kubernetes
+      - ShellCommand:
+          name: Run tests on the bootstrap node
+          env:
+            ISO_MOUNTPOINT: >
+              /srv/scality/metalk8s-%(prop:metalk8s_short_version)s
+          command: tox -e tests-local
+          haltOnFailure: true
+      - ShellCommand:
           name: Debug step - report IPs, add SSH keys, wait 1 hour
           timeout: 3600
           command: >

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -134,6 +134,11 @@ stages:
             END
             EOF
       - ShellCommand:
+          # This step is needed so Kubelet registration doesn't fail for DNS
+          # entries longer than 63 characters
+          name: Change hostname to a shorter value
+          command: sudo hostnamectl set-hostname bootstrap
+      - ShellCommand:
           name: Start the bootstrap process
           command: >
             sudo bash
@@ -180,7 +185,8 @@ stages:
             OS_USERNAME: "%(secret:scality_cloud_username)s"
             OS_PASSWORD: "%(secret:scality_cloud_password)s"
             OS_TENANT_NAME: "%(secret:scality_cloud_tenant_name)s"
-            TF_VAR_worker_uuid: "%(prop:worker_uuid)s"
+            # FIXME: this makes hostnames too long
+            # TF_VAR_worker_uuid: "%(prop:worker_uuid)s"
             TF_VAR_nodes_count: "2"
           haltOnFailure: true
       - ShellCommand:

--- a/eve/workers/openstack-multiple-nodes/terraform/network.tf
+++ b/eve/workers/openstack-multiple-nodes/terraform/network.tf
@@ -21,6 +21,16 @@ resource "openstack_networking_secgroup_rule_v2" "nodes_ssh" {
   security_group_id = "${openstack_networking_secgroup_v2.nodes.id}"
 }
 
+resource "openstack_networking_secgroup_rule_v2" "apiserver" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 6443
+  port_range_max    = 6443
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = "${openstack_networking_secgroup_v2.nodes.id}"
+}
+
 resource "openstack_networking_secgroup_rule_v2" "nodes_icmp" {
   direction         = "ingress"
   ethertype         = "IPv4"

--- a/eve/workers/openstack-multiple-nodes/terraform/network.tf
+++ b/eve/workers/openstack-multiple-nodes/terraform/network.tf
@@ -45,6 +45,7 @@ resource "openstack_networking_subnet_v2" "internal_main" {
   network_id = "${openstack_networking_network_v2.internal.id}"
   cidr       = "${var.internal_network_range}"
   ip_version = 4
+  no_gateway = true
 }
 
 resource "openstack_compute_secgroup_v2" "nodes_openbar" {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import pathlib
+
+
+# Pytest command-line options
+def pytest_addoption(parser):
+    parser.addoption(
+        "--iso-root",
+        action="store",
+        default="_build/root",
+        type=pathlib.Path,
+        help="Root of the ISO file tree."
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,3 +10,17 @@ def pytest_addoption(parser):
         type=pathlib.Path,
         help="Root of the ISO file tree."
     )
+
+    parser.addoption(
+        "--bootstrap-ip",
+        action="store",
+        default=None,
+        help="Reachable IP of the bootstrap node."
+    )
+
+    parser.addoption(
+        "--skip-tls-verify",
+        action="store_true",
+        default=False,
+        help="Skip TLS verification when calling kube-apiserver."
+    )

--- a/tests/post/features/pods_alive.feature
+++ b/tests/post/features/pods_alive.feature
@@ -4,10 +4,6 @@ Feature: Pods should be alive
         Given the Kubernetes API is available
         Then the 'pods' list should not be empty in the 'kube-system' namespace
 
-    Scenario: Exec in Pods
-        Given the Kubernetes API is available
-        Then we can exec 'true' in the 'salt-master-bootstrap' pod in the 'kube-system' namespace
-
     Scenario: Expected Pods
         Given the Kubernetes API is available
         Then we have at least 1 running pod labeled 'component=kube-controller-manager'
@@ -20,3 +16,7 @@ Feature: Pods should be alive
         And we have at least 1 running pod labeled 'app=registry'
         And we have at least 1 running pod labeled 'app=salt-master'
         And we have at least 1 running pod labeled 'app=package-repositories'
+
+    Scenario: Exec in Pods
+        Given the Kubernetes API is available
+        Then we can exec 'true' in the pod labeled 'app=salt-master' in the 'kube-system' namespace

--- a/tox.ini
+++ b/tox.ini
@@ -55,6 +55,14 @@ commands =
              --iso-root={env:ISO_MOUNTPOINT:/vagrant/_build/root} \
              {posargs} tests"
 
+[testenv:tests-local]
+description =
+    Run tests suite on the bootstrap node of an installation.
+deps = {[testenv:tests]deps}
+passenv =
+    ISO_MOUNTPOINT
+commands = pytest --iso-root={env:ISO_MOUNTPOINT:_build/root} {posargs} tests
+
 [pytest]
 filterwarnings =
     ignore:encode_point has been deprecated on EllipticCurvePublicNumbers and will be removed in a future version. Please use EllipticCurvePublicKey.public_bytes to obtain both compressed and uncompressed point encoding.:UserWarning

--- a/tox.ini
+++ b/tox.ini
@@ -35,8 +35,15 @@ deps =
 passenv =
     SSH_CONFIG_FILE
     TEST_HOSTS_LIST
+    ISO_MOUNTPOINT
 commands =
-    bash -c "pytest --ssh-config={env:SSH_CONFIG_FILE:<(VAGRANT_CWD={toxinidir} vagrant ssh-config bootstrap)} --hosts={env:TEST_HOSTS_LIST:bootstrap} {posargs} tests"
+    bash -c "pytest \
+             --ssh-config={env:SSH_CONFIG_FILE:<( \
+                 VAGRANT_CWD={toxinidir} vagrant ssh-config bootstrap)} \
+             --hosts={env:TEST_HOSTS_LIST:bootstrap} \
+             --iso-root={env:ISO_MOUNTPOINT:/vagrant/_build/root} \
+             {posargs} tests"
+
 [pytest]
 filterwarnings =
     ignore:encode_point has been deprecated on EllipticCurvePublicNumbers and will be removed in a future version. Please use EllipticCurvePublicKey.public_bytes to obtain both compressed and uncompressed point encoding.:UserWarning

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,9 @@ setenv =
     VIRTUALENV_NO_DOWNLOAD=1
 
 [testenv:lint-python]
+description =
+    Lint Python files using pylint and mypy (buildchain-related files only for
+    now).
 deps =
     -r{toxinidir}/buildchain/requirements.txt
     -r{toxinidir}/buildchain/requirements-dev.txt
@@ -17,19 +20,27 @@ commands =
     mypy --strict buildchain/dodo.py buildchain/buildchain
 
 [testenv:lint-shell]
-whitelist_externals += shellcheck
+description =
+    Lint Shell files and templates using shellcheck.
+whitelist_externals =
+    {[testenv]whitelist_externals}
+    shellcheck
 commands =
-    bash -c "shellcheck doit.sh"
+    shellcheck doit.sh
     bash -c "shellcheck **/*.sh"
     bash -c "shellcheck **/*.sh.in"
 
 [testenv:lint-yaml]
+description =
+    Lint Salt and Eve YAML files using yamllint.
 deps =
     yamllint==1.15.0
 commands =
     bash -c "yamllint eve/main.yml salt/**/*.yaml"
 
 [testenv:tests]
+description =
+    Run tests suite remotely (uses local Vagrant configuration by default).
 deps =
     -r{toxinidir}/tests/requirements.txt
 passenv =


### PR DESCRIPTION
# What

This PR introduces a run of the post-install test suite on both the single-node and multiple-nodes deployment scenarios in the CI. It is now a blocking condition in the pre-merge build.
Most of the modifications introduced were only made to cope with the CI context: long hostnames created issues with kubelet registration (see cdb5343d075d93124d9af2d76e710bb262edeea3), and the "bastion" VM used to orchestrate the multi-nodes deployment, **and tests**, could not be a part of the control-plane network (which it created). Review through the commit messages to find more details.

# How to test

While a green build is the main goal of these changes (and took some time to achieve), you should still be able to run the test suite locally as before.

If you want to reproduce the single-node tests conditions:

```
# On your host
./doit.sh vagrantup
vagrant ssh
# On your bootstrap node
sudo yum install -y epel-release
sudo yum install -y python34-pip
sudo pip3 install tox
sudo yum install -y --enablerepo=metalk8s-kubernetes kubectl
cd /vagrant
tox -e tests-local
```

The multi-nodes tests are the same as a simple `tox -e tests` on your host.


---

Fixes: GH-781.