### PR TITLE
Bugfix: define templated image names

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -121,7 +121,6 @@ SALT_FILES : Tuple[Union[Path, targets.FileTarget], ...] = (
     Path('salt/metalk8s/kubeadm/init/control-plane/files/htpasswd'),
     Path('salt/metalk8s/kubeadm/init/control-plane/files/manifest.yaml'),
     Path('salt/metalk8s/kubeadm/init/control-plane/init.sls'),
-    Path('salt/metalk8s/kubeadm/init/control-plane/lib.sls'),
     Path('salt/metalk8s/kubeadm/init/control-plane/scheduler.sls'),
 
     Path('salt/metalk8s/kubeadm/init/etcd/init.sls'),
@@ -180,6 +179,7 @@ SALT_FILES : Tuple[Union[Path, targets.FileTarget], ...] = (
     Path('salt/metalk8s/runc/installed.sls'),
 
     Path('salt/metalk8s/registry/init.sls'),
+    Path('salt/metalk8s/registry/macro.sls'),
     Path('salt/metalk8s/registry/populated.sls'),
     Path('salt/metalk8s/registry/files/registry-pod.yaml.j2'),
 

--- a/packages/packages.list
+++ b/packages/packages.list
@@ -1,7 +1,7 @@
 containerd
 cri-tools
 ftp://ftp.scientificlinux.org/linux/scientific/7x/external_products/extras/x86_64/container-selinux-2.77-1.el7_6.noarch.rpm
-kubectl
+kubectl-1.11.7-0
 kubelet-1.11.7-0
 m2crypto
 python2-kubernetes

--- a/salt/metalk8s/calico/deployed.sls
+++ b/salt/metalk8s/calico/deployed.sls
@@ -1,6 +1,7 @@
+{%- from "metalk8s/registry/macro.sls" import build_image_name with context %}
 {%- from "metalk8s/map.jinja" import networks with context %}
 
-{%- set image = "localhost:5000/" ~ saltenv ~ "/calico-node:3.5.1" -%}
+{%- set image = build_image_name("calico-node", "3.5.1") -%}
 
 {% set kubeconfig = "/etc/kubernetes/admin.conf" %}
 {% set context = "kubernetes-admin@kubernetes" %}

--- a/salt/metalk8s/defaults.yaml
+++ b/salt/metalk8s/defaults.yaml
@@ -3,6 +3,9 @@ cluster: kubernetes
 
 metalk8s: {}
 
+kubernetes:
+  version: 1.11.7  # NOTE: remember to update kubelet version as well
+
 kubeadm_preflight:
   mandatory:
     packages:

--- a/salt/metalk8s/kubeadm/init/addons/files/coredns_deployment.yaml.j2
+++ b/salt/metalk8s/kubeadm/init/addons/files/coredns_deployment.yaml.j2
@@ -1,3 +1,4 @@
+{%- from "metalk8s/registry/macro.sls" import build_image_name with context -%}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -29,7 +30,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: localhost:5000/{{ saltenv }}/coredns:1.3.1
+        image: {{ build_image_name('coredns', '1.3.1') }}
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/salt/metalk8s/kubeadm/init/addons/kube-proxy.sls
+++ b/salt/metalk8s/kubeadm/init/addons/kube-proxy.sls
@@ -1,6 +1,7 @@
+{% from "metalk8s/registry/macro.sls" import kubernetes_image with context %}
 {%- from "metalk8s/map.jinja" import networks with context %}
 
-{%- set image = "localhost:5000/" ~ saltenv ~ "/kube-proxy:1.11.7" -%}
+{%- set image = kubernetes_image("kube-proxy") -%}
 
 {% set kubeconfig = "/etc/kubernetes/admin.conf" %}
 {% set context = "kubernetes-admin@kubernetes" %}

--- a/salt/metalk8s/kubeadm/init/control-plane/apiserver.sls
+++ b/salt/metalk8s/kubeadm/init/control-plane/apiserver.sls
@@ -1,5 +1,5 @@
+{%- from "metalk8s/registry/macro.sls" import kubernetes_image with context -%}
 {% from "metalk8s/map.jinja" import networks with context %}
-{% from "metalk8s/kubeadm/init/control-plane/lib.sls" import get_image_name with context %}
 {% set htpasswd_path = "/etc/kubernetes/htpasswd" %}
 
 Set up default basic auth htpasswd:
@@ -28,7 +28,7 @@ Create kube-apiserver Pod manifest:
     - context:
         name: kube-apiserver
         host: {{ host }}
-        image_name: {{ get_image_name("kube-apiserver") }}
+        image_name: {{ kubernetes_image("kube-apiserver") }}
         port: 6443
         scheme: HTTPS
         command:

--- a/salt/metalk8s/kubeadm/init/control-plane/controller-manager.sls
+++ b/salt/metalk8s/kubeadm/init/control-plane/controller-manager.sls
@@ -1,5 +1,5 @@
+{% from "metalk8s/registry/macro.sls" import kubernetes_image with context %}
 {% from "metalk8s/map.jinja" import networks with context %}
-{% from "metalk8s/kubeadm/init/control-plane/lib.sls" import get_image_name with context %}
 
 Create kube-controller-manager Pod manifest:
   file.managed:
@@ -13,7 +13,7 @@ Create kube-controller-manager Pod manifest:
     - dir_mode: 750
     - context:
         name: kube-controller-manager
-        image_name: {{ get_image_name("kube-controller-manager") }}
+        image_name: {{ kubernetes_image("kube-controller-manager") }}
         host: 127.0.0.1
         port: 10252
         scheme: HTTP

--- a/salt/metalk8s/kubeadm/init/control-plane/lib.sls
+++ b/salt/metalk8s/kubeadm/init/control-plane/lib.sls
@@ -1,7 +1,0 @@
-# Share macro for building image names for each control-plane component
-{%- set registry_host = "localhost:5000" -%}
-{%- set kubernetes_version = "1.11.7" -%}
-
-{%- macro get_image_name(component) -%}
-"{{ registry_host }}/{{ saltenv }}/{{ component }}:{{ kubernetes_version }}"
-{%- endmacro -%}

--- a/salt/metalk8s/kubeadm/init/control-plane/scheduler.sls
+++ b/salt/metalk8s/kubeadm/init/control-plane/scheduler.sls
@@ -1,4 +1,4 @@
-{% from "metalk8s/kubeadm/init/control-plane/lib.sls" import get_image_name with context %}
+{% from "metalk8s/registry/macro.sls" import kubernetes_image with context %}
 
 Create kube-scheduler Pod manifest:
   file.managed:
@@ -12,7 +12,7 @@ Create kube-scheduler Pod manifest:
     - dir_mode: 750
     - context:
         name: kube-scheduler
-        image_name: {{ get_image_name("kube-scheduler") }}
+        image_name: {{ kubernetes_image("kube-scheduler") }}
         host: 127.0.0.1
         port: 10251
         scheme: HTTP

--- a/salt/metalk8s/kubeadm/init/etcd/local.sls
+++ b/salt/metalk8s/kubeadm/init/etcd/local.sls
@@ -1,6 +1,7 @@
+{% from "metalk8s/registry/macro.sls" import build_image_name with context %}
 {% from "metalk8s/map.jinja" import networks with context %}
 
-{% set image_name="localhost:5000/" ~ saltenv ~ "/etcd:3.2.18" %}
+{% set image_name = build_image_name('etcd', '3.2.18') %}
 
 {% set host_name = salt.network.get_hostname() %}
 {% set ip_candidates = salt.network.ip_addrs(cidr=networks.control_plane) %}

--- a/salt/metalk8s/map.jinja
+++ b/salt/metalk8s/map.jinja
@@ -8,6 +8,10 @@
   'default': {}
 }, merge=defaults.get('metalk8s')) %}
 
+{% set kubernetes = salt['grains.filter_by']({
+  'default': {}
+}, merge=defaults.get('kubernetes')) %}
+
 {% set kubeadm_preflight = salt['grains.filter_by']({
   'default': {}
 }, merge=defaults.get('kubeadm_preflight')) %}

--- a/salt/metalk8s/metalk8s-ui/deployed.sls
+++ b/salt/metalk8s/metalk8s-ui/deployed.sls
@@ -8,6 +8,7 @@ Create metalk8s-ui deployment:
     - kubeconfig: {{ kubeconfig }}
     - context: {{ context }}
     - source: salt://metalk8s/metalk8s-ui/files/metalk8s-ui_deployment.yaml
+    - template: jinja
   require:
     - pkg: Install Python Kubernetes client
 

--- a/salt/metalk8s/metalk8s-ui/files/metalk8s-ui_deployment.yaml
+++ b/salt/metalk8s/metalk8s-ui/files/metalk8s-ui_deployment.yaml
@@ -1,3 +1,4 @@
+{%- from "metalk8s/registry/macro.sls" import build_image_name with context -%}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -21,7 +22,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
         - name: metalk8s-ui
-          image: localhost:5000/metalk8s-2.0/metalk8s-ui:0.2
+          image: {{ build_image_name('metalk8s-ui', '0.2') }}
           resources:
             limits:
               memory: 170Mi

--- a/salt/metalk8s/registry/macro.sls
+++ b/salt/metalk8s/registry/macro.sls
@@ -1,0 +1,12 @@
+{%- from "metalk8s/map.jinja" import kubernetes with context %}
+
+{# FIXME: this won't work except on bootstrap node #}
+{%- set registry_host = "localhost:5000" %}
+
+{%- macro build_image_name(name='', tag='') -%}
+"{{ registry_host }}/{{ saltenv }}/{{ name }}:{{ tag }}"
+{%- endmacro -%}
+
+{%- macro kubernetes_image(component) -%}
+{{ build_image_name(component, kubernetes.version) }}
+{%- endmacro -%}

--- a/salt/metalk8s/registry/populated.sls
+++ b/salt/metalk8s/registry/populated.sls
@@ -1,4 +1,5 @@
 {%- from "metalk8s/macro.sls" import pkg_installed with context %}
+{%- from "metalk8s/map.jinja" import kubernetes with context %}
 {%- from "metalk8s/map.jinja" import metalk8s with context %}
 
 {% set images = [
@@ -12,19 +13,19 @@
     },
     {
         'name': 'kube-apiserver',
-        'tag': '1.11.7',
+        'tag': kubernetes.version,
     },
     {
         'name': 'kube-controller-manager',
-        'tag': '1.11.7',
+        'tag': kubernetes.version,
     },
     {
         'name': 'kube-proxy',
-        'tag': '1.11.7',
+        'tag': kubernetes.version,
     },
     {
         'name': 'kube-scheduler',
-        'tag': '1.11.7',
+        'tag': kubernetes.version,
     },
     {
         'name': 'calico-node',

--- a/salt/metalk8s/registry/populated.sls
+++ b/salt/metalk8s/registry/populated.sls
@@ -1,4 +1,5 @@
 {%- from "metalk8s/macro.sls" import pkg_installed with context %}
+{%- from "metalk8s/registry/macro.sls" import build_image_name with context %}
 {%- from "metalk8s/map.jinja" import kubernetes with context %}
 {%- from "metalk8s/map.jinja" import metalk8s with context %}
 
@@ -56,7 +57,7 @@ Install skopeo:
 {% for image in images %}
 Import {{ image.name }} image:
   docker_registry.image_managed:
-    - name: localhost:5000/{{ saltenv }}/{{ image.name }}:{{ image.tag }}
+    - name: {{ build_image_name(image.name, image.tag) }}
     - archive_path: {{ metalk8s.iso_root_path }}/images/{{ image.name }}-{{ image.tag }}.tar.gz
     - tls_verify: false
     - require:

--- a/salt/metalk8s/repo/deployed.sls
+++ b/salt/metalk8s/repo/deployed.sls
@@ -1,9 +1,10 @@
+{%- from "metalk8s/registry/macro.sls" import build_image_name with context %}
 {%- from "metalk8s/map.jinja" import metalk8s with context %}
 {%- from "metalk8s/map.jinja" import repo with context %}
 
 {%- set package_repositories_name = 'package-repositories' %}
 {%- set package_repositories_version = '1.0.0' %}
-{%- set package_repositories_image = 'localhost:5000/' ~ saltenv ~ '/nginx:1.15.8' %}
+{%- set package_repositories_image = build_image_name('nginx', '1.15.8') %}
 {%- set nginx_configuration_path = '/var/lib/metalk8s/package-repositories/nginx.conf' %}
 
 Generate package repositories nginx configuration:

--- a/salt/metalk8s/salt/master/deployed.sls
+++ b/salt/metalk8s/salt/master/deployed.sls
@@ -2,7 +2,6 @@
 
 {% set salt_master_image = 'salt-master' %}
 {% set salt_master_version = '2018.3.4-1' %}
-{% set registry_url = 'localhost:5000' %}
 
 Create salt master directories:
   file.directory:
@@ -26,7 +25,6 @@ Install and start salt master manifest:
     - makedirs: false
     - backup: false
     - defaults:
-        registry_url: {{ registry_url }}
         salt_master_image: {{ salt_master_image }}
         salt_master_version: {{ salt_master_version }}
         iso_root_path: {{ metalk8s.iso_root_path }}

--- a/salt/metalk8s/salt/master/files/salt-master-pod.yaml.j2
+++ b/salt/metalk8s/salt/master/files/salt-master-pod.yaml.j2
@@ -1,3 +1,4 @@
+{%- from "metalk8s/registry/macro.sls" import build_image_name with context -%}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -24,7 +25,7 @@ spec:
         - ALL
   containers:
     - name: salt-master
-      image: {{registry_url}}/{{saltenv}}/{{salt_master_image}}:{{salt_master_version}}
+      image: {{ build_image_name(salt_master_image, salt_master_version) }}
       ports:
         - name: publisher
           containerPort: 4505


### PR DESCRIPTION
# What

This PR introduces helper macros for Salt formulas to use when generating image names for use in Pod manifests. It allows for a centralized source of constants (`salt/metalk8s/defaults.yaml`) and reduces the risk of oversight when updating, for instance, version of Kubernetes.

The integration PRs for `development/2.1` and `2.2` will receive more commits to bump the Kubernetes version.

# How to test

Make sure you can still run a fresh local deployment and the test suite passes.

---

Fixes GH-856