### PR TITLE
Upgrade etcd to 3.2.24

### DIFF
--- a/buildchain/buildchain/image.py
+++ b/buildchain/buildchain/image.py
@@ -94,8 +94,8 @@ TO_PULL : Tuple[targets.RemoteImage, ...] = (
     targets.RemoteImage(
         registry=constants.GOOGLE_REGISTRY,
         name='etcd',
-        version='3.2.18',
-        digest='sha256:b960569ade5f37205a033dcdc3191fe99dc95b15c6795a6282859070ec2c6124',
+        version='3.2.24',
+        digest='sha256:905d7ca17fd02bc24c0eba9a062753aba15db3e31422390bc3238eb762339b20',
         destination=ISO_IMAGE_ROOT,
         task_dep=['_image_mkdir_root'],
     ),

--- a/salt/metalk8s/kubeadm/init/etcd/local.sls
+++ b/salt/metalk8s/kubeadm/init/etcd/local.sls
@@ -1,6 +1,6 @@
 {% from "metalk8s/map.jinja" import networks with context %}
 
-{% set image_name="localhost:5000/" ~ saltenv ~ "/etcd:3.2.18" %}
+{% set image_name="localhost:5000/" ~ saltenv ~ "/etcd:3.2.24" %}
 
 {% set host_name = salt.network.get_hostname() %}
 {% set ip_candidates = salt.network.ip_addrs(cidr=networks.control_plane) %}

--- a/salt/metalk8s/registry/populated.sls
+++ b/salt/metalk8s/registry/populated.sls
@@ -4,7 +4,7 @@
 {% set images = [
     {
         'name': 'etcd',
-        'tag': '3.2.18',
+        'tag': '3.2.24',
     },
     {
         'name': 'coredns',


### PR DESCRIPTION
Upgrade etcd to 3.2.24

```
[root@bootstrap ~]# crictl exec -i $(crictl ps -q --pod $(crictl pods --name etcd\* -q)) etcd --version
etcd Version: 3.2.24
Git SHA: 420a45226
Go Version: go1.8.7
Go OS/Arch: linux/amd64
```

Fixes: #824 