### PR TITLE
build: always forget execution of cleaned tasks

### DIFF
--- a/buildchain/dodo.py
+++ b/buildchain/dodo.py
@@ -41,4 +41,5 @@ DOIT_CONFIG = {
     'default_tasks': ['iso'],
     'reporter': PrivateReporter,
     'cleandep': True,
+    'cleanforget': True,
 }


### PR DESCRIPTION
This should solve issues where we have stale information in doit.db
after a `clean` (after a call to `clean` we expect to start anew).

If this doesn't solve our problems, we will take more drastic measures.

Refs: #838
Signed-off-by: Sylvain Laperche <sylvain.laperche@scality.com>