### PR TITLE
Limit pre-merge to list of branch prefixes

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -2,7 +2,7 @@
 version: "0.2"
 
 branches:
-  default:
+  user/*, feature/*, improvement/*, bugfix/*, w/*, q/*, hotfix/*:
     stage: pre-merge
 
 stages:


### PR DESCRIPTION
We want to avoid rebuilding and testing development/2.X when the
branch builds and q/ branches have already validated the state of
development/2.X after the merge.

Tackles #883