### PR TITLE
add an orchestrate to upgrade the workload plane node to a control plane node

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -113,6 +113,7 @@ SALT_FILES : Tuple[Union[Path, targets.FileTarget], ...] = (
     Path('salt/metalk8s/kubeadm/init/certs/etcd-peer.sls'),
     Path('salt/metalk8s/kubeadm/init/certs/etcd-server.sls'),
     Path('salt/metalk8s/kubeadm/init/certs/front-proxy-ca.sls'),
+    Path('salt/metalk8s/kubeadm/init/certs/front-proxy-deploy-ca-cert.sls'),
     Path('salt/metalk8s/kubeadm/init/certs/front-proxy-client.sls'),
     Path('salt/metalk8s/kubeadm/init/certs/init.sls'),
     Path('salt/metalk8s/kubeadm/init/certs/installed.sls'),

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -76,6 +76,7 @@ SALT_FILES : Tuple[Union[Path, targets.FileTarget], ...] = (
     Path('salt/metalk8s/orchestrate/bootstrap_without_master.sls'),
     Path('salt/metalk8s/orchestrate/bootstrap_with_master.sls'),
     Path('salt/metalk8s/orchestrate/deploy_salt_minion_on_new_node.sls'),
+    Path('salt/metalk8s/orchestrate/control_plane.sls'),
     Path('salt/metalk8s/orchestrate/worker_plane.sls'),
     Path('salt/metalk8s/bootstrap/addons.sls'),
     Path('salt/metalk8s/bootstrap/calico.sls'),

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -109,6 +109,7 @@ SALT_FILES : Tuple[Union[Path, targets.FileTarget], ...] = (
     Path('salt/metalk8s/kubeadm/init/certs/apiserver-kubelet-client.sls'),
     Path('salt/metalk8s/kubeadm/init/certs/ca.sls'),
     Path('salt/metalk8s/kubeadm/init/certs/etcd-ca.sls'),
+    Path('salt/metalk8s/kubeadm/init/certs/etcd-deploy-ca-cert.sls'),
     Path('salt/metalk8s/kubeadm/init/certs/etcd-healthcheck-client.sls'),
     Path('salt/metalk8s/kubeadm/init/certs/etcd-peer.sls'),
     Path('salt/metalk8s/kubeadm/init/certs/etcd-server.sls'),

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -117,6 +117,7 @@ SALT_FILES : Tuple[Union[Path, targets.FileTarget], ...] = (
     Path('salt/metalk8s/kubeadm/init/certs/init.sls'),
     Path('salt/metalk8s/kubeadm/init/certs/installed.sls'),
     Path('salt/metalk8s/kubeadm/init/certs/sa.sls'),
+    Path('salt/metalk8s/kubeadm/init/certs/sa-deploy-pub-key.sls'),
 
     Path('salt/metalk8s/kubeadm/init/control-plane/apiserver.sls'),
     Path('salt/metalk8s/kubeadm/init/control-plane/controller-manager.sls'),

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -130,8 +130,8 @@ stages:
             apiVersion: metalk8s.scality.com/v1alpha1
             kind: BootstrapConfiguration
             networks:
-              controlPlane: 10.0.0.0/8
-              workloadPlane: 10.0.0.0/8
+              controlPlane: 10.100.0.0/16
+              workloadPlane: 10.100.0.0/16
             END
             EOF
       - ShellCommand:

--- a/salt/metalk8s/defaults.yaml
+++ b/salt/metalk8s/defaults.yaml
@@ -186,4 +186,4 @@ coredns:
 upgrade: false        # define if we're on an upgrade case
 
 # TODO: Move it into mine
-registry_ip: localhost
+registry_ip: 127.0.0.1

--- a/salt/metalk8s/kubeadm/init/certs/apiserver-etcd-client.sls
+++ b/salt/metalk8s/kubeadm/init/certs/apiserver-etcd-client.sls
@@ -1,6 +1,6 @@
 {%- from "metalk8s/map.jinja" import etcd with context %}
 
-{%- set etcd_ca_server = salt['mine.get']('*', 'kubernetes_etcd_ca_server').keys() %}
+{%- set etcd_ca_server = salt['mine.get']('*', 'kubernetes_etcd_ca_b64').keys() %}
 {%- if etcd_ca_server %}
 
 include:

--- a/salt/metalk8s/kubeadm/init/certs/etcd-ca.sls
+++ b/salt/metalk8s/kubeadm/init/certs/etcd-ca.sls
@@ -1,8 +1,8 @@
 {%- from "metalk8s/map.jinja" import etcd with context %}
 
-{%- set etcd_ca_server = salt['mine.get']('*', 'kubernetes_etcd_ca_server') %}
+{%- set etcd_ca_server = salt['mine.get']('*', 'kubernetes_etcd_ca_b64') %}
 
-{#- Check if we have no CA server or only current minion as CA #}
+{#- Check if we have no etcd CA server or if it is the current minion #}
 {%- if not etcd_ca_server or etcd_ca_server.keys() == [grains['id']] %}
 
 include:
@@ -42,7 +42,7 @@ Generate etcd CA certificate:
 Advertise etcd CA in the mine:
   module.wait:
     - mine.send:
-      - func: 'kubernetes_etcd_ca_server'
+      - func: kubernetes_etcd_ca_b64
       - mine_function: hashutil.base64_encodefile
       - /etc/kubernetes/pki/etcd/ca.crt
     - watch:

--- a/salt/metalk8s/kubeadm/init/certs/etcd-deploy-ca-cert.sls
+++ b/salt/metalk8s/kubeadm/init/certs/etcd-deploy-ca-cert.sls
@@ -1,0 +1,18 @@
+{%- set etcd_ca_server = salt['mine.get']('*', 'kubernetes_etcd_ca_b64') %}
+
+{%- if etcd_ca_server %}
+
+{%- set etcd_ca_b64 = etcd_ca_server.values()[0] %}
+{%- set etcd_ca = salt['hashutil.base64_b64decode'](etcd_ca_b64) %}
+
+Ensure etcd CA cert is present:
+  file.managed:
+    - name: /etc/kubernetes/pki/etcd/ca.crt
+    - user: root
+    - group : root
+    - mode: 644
+    - makedirs: True
+    - dir_mode: 755
+    - contents: {{ etcd_ca.splitlines() }}
+
+{%- endif %}

--- a/salt/metalk8s/kubeadm/init/certs/etcd-healthcheck-client.sls
+++ b/salt/metalk8s/kubeadm/init/certs/etcd-healthcheck-client.sls
@@ -1,6 +1,6 @@
 {%- from "metalk8s/map.jinja" import etcd with context %}
 
-{%- set etcd_ca_server = salt['mine.get']('*', 'kubernetes_etcd_ca_server').keys() %}
+{%- set etcd_ca_server = salt['mine.get']('*', 'kubernetes_etcd_ca_b64').keys() %}
 {%- if etcd_ca_server %}
 
 include:

--- a/salt/metalk8s/kubeadm/init/certs/etcd-peer.sls
+++ b/salt/metalk8s/kubeadm/init/certs/etcd-peer.sls
@@ -1,7 +1,7 @@
 {%- from "metalk8s/map.jinja" import etcd with context %}
 {%- from "metalk8s/map.jinja" import networks with context %}
 
-{%- set etcd_ca_server = salt['mine.get']('*', 'kubernetes_etcd_ca_server').keys() %}
+{%- set etcd_ca_server = salt['mine.get']('*', 'kubernetes_etcd_ca_b64').keys() %}
 {%- if etcd_ca_server %}
 
 include:

--- a/salt/metalk8s/kubeadm/init/certs/etcd-server.sls
+++ b/salt/metalk8s/kubeadm/init/certs/etcd-server.sls
@@ -1,7 +1,7 @@
 {%- from "metalk8s/map.jinja" import etcd with context %}
 {%- from "metalk8s/map.jinja" import networks with context %}
 
-{%- set etcd_ca_server = salt['mine.get']('*', 'kubernetes_etcd_ca_server').keys() %}
+{%- set etcd_ca_server = salt['mine.get']('*', 'kubernetes_etcd_ca_b64').keys() %}
 {%- if etcd_ca_server %}
 
 include:

--- a/salt/metalk8s/kubeadm/init/certs/front-proxy-ca.sls
+++ b/salt/metalk8s/kubeadm/init/certs/front-proxy-ca.sls
@@ -1,6 +1,6 @@
 {%- from "metalk8s/map.jinja" import front_proxy with context %}
 
-{%- set front_proxy_ca_server = salt['mine.get']('*', 'kubernetes_front_proxy_ca_server') %}
+{%- set front_proxy_ca_server = salt['mine.get']('*', 'kubernetes_front_proxy_ca_b64') %}
 
 {#- Check if we have no CA server or only current minion as CA #}
 {%- if not front_proxy_ca_server or front_proxy_ca_server.keys() == [grains['id']] %}
@@ -42,7 +42,7 @@ Generate front proxy CA certificate:
 Advertise front proxy CA in the mine:
   module.wait:
     - mine.send:
-      - func: 'kubernetes_front_proxy_ca_server'
+      - func: kubernetes_front_proxy_ca_b64
       - mine_function: hashutil.base64_encodefile
       - /etc/kubernetes/pki/front-proxy-ca.crt
     - watch:

--- a/salt/metalk8s/kubeadm/init/certs/front-proxy-client.sls
+++ b/salt/metalk8s/kubeadm/init/certs/front-proxy-client.sls
@@ -1,6 +1,6 @@
 {%- from "metalk8s/map.jinja" import front_proxy with context %}
 
-{%- set front_proxy_ca_server = salt['mine.get']('*', 'kubernetes_front_proxy_ca_server').keys() %}
+{%- set front_proxy_ca_server = salt['mine.get']('*', 'kubernetes_front_proxy_ca_b64').keys() %}
 {%- if front_proxy_ca_server %}
 
 include:

--- a/salt/metalk8s/kubeadm/init/certs/front-proxy-deploy-ca-cert.sls
+++ b/salt/metalk8s/kubeadm/init/certs/front-proxy-deploy-ca-cert.sls
@@ -1,0 +1,18 @@
+{%- set front_proxy_ca_server = salt['mine.get']('*', 'kubernetes_front_proxy_ca_b64') %}
+
+{%- if front_proxy_ca_server %}
+
+{%- set ca_cert_b64 = front_proxy_ca_server.values()[0] %}
+{%- set ca_cert = salt['hashutil.base64_b64decode'](ca_cert_b64) %}
+
+Ensure front-proxy CA cert is present:
+  file.managed:
+    - name: /etc/kubernetes/pki/front-proxy-ca.crt
+    - user: root
+    - group : root
+    - mode: 644
+    - makedirs: True
+    - dir_mode: 755
+    - contents: {{ ca_cert.splitlines() }}
+
+{%- endif %}

--- a/salt/metalk8s/kubeadm/init/certs/sa-deploy-pub-key.sls
+++ b/salt/metalk8s/kubeadm/init/certs/sa-deploy-pub-key.sls
@@ -1,0 +1,18 @@
+{%- set sa_pub_key_server = salt['mine.get']('*', 'kubernetes_sa_pub_key_b64') %}
+
+{%- if sa_pub_key_server %}
+
+{%- set sa_pub_key_b64 = sa_pub_key_server.values()[0] %}
+{%- set sa_pub_key = salt['hashutil.base64_b64decode'](sa_pub_key_b64) %}
+
+Ensure SA pub key is present:
+  file.managed:
+    - name: /etc/kubernetes/pki/sa.pub
+    - user: root
+    - group : root
+    - mode: 644
+    - makedirs: True
+    - dir_mode: 755
+    - contents: {{ sa_pub_key.splitlines() }}
+
+{%- endif %}

--- a/salt/metalk8s/kubeadm/init/certs/sa.sls
+++ b/salt/metalk8s/kubeadm/init/certs/sa.sls
@@ -25,3 +25,12 @@ Store SA public key:
     - dir_mode: 755
     - require:
       - x509: Create SA private key
+
+Advertise SA pub key in the mine:
+  module.wait:
+    - mine.send:
+      - func: kubernetes_sa_pub_key_b64
+      - mine_function: hashutil.base64_encodefile
+      - /etc/kubernetes/pki/sa.pub
+    - watch:
+      - file: Store SA public key

--- a/salt/metalk8s/kubeadm/init/control-plane/apiserver.sls
+++ b/salt/metalk8s/kubeadm/init/control-plane/apiserver.sls
@@ -3,6 +3,9 @@
 {% from "metalk8s/map.jinja" import defaults with context %}
 {% set htpasswd_path = "/etc/kubernetes/htpasswd" %}
 
+include:
+  - metalk8s.kubeadm.init.certs.sa-deploy-pub-key
+
 Set up default basic auth htpasswd:
   file.managed:
     - name: {{ htpasswd_path }}
@@ -73,6 +76,8 @@ Create kube-apiserver Pod manifest:
           - path: {{ htpasswd_path }}
             type: File
             name: htpasswd
+    - require:
+      - file: Ensure SA pub key is present
 
 Make sure kube-apiserver container is up:
   module.wait:

--- a/salt/metalk8s/kubeadm/init/control-plane/apiserver.sls
+++ b/salt/metalk8s/kubeadm/init/control-plane/apiserver.sls
@@ -5,6 +5,7 @@
 
 include:
   - metalk8s.kubeadm.init.certs.sa-deploy-pub-key
+  - metalk8s.kubeadm.init.certs.front-proxy-deploy-ca-cert
 
 Set up default basic auth htpasswd:
   file.managed:
@@ -78,6 +79,7 @@ Create kube-apiserver Pod manifest:
             name: htpasswd
     - require:
       - file: Ensure SA pub key is present
+      - file: Ensure front-proxy CA cert is present
 
 Make sure kube-apiserver container is up:
   module.wait:

--- a/salt/metalk8s/kubeadm/init/control-plane/apiserver.sls
+++ b/salt/metalk8s/kubeadm/init/control-plane/apiserver.sls
@@ -1,5 +1,6 @@
 {%- from "metalk8s/registry/macro.sls" import kubernetes_image with context -%}
 {% from "metalk8s/map.jinja" import networks with context %}
+{% from "metalk8s/map.jinja" import defaults with context %}
 {% set htpasswd_path = "/etc/kubernetes/htpasswd" %}
 
 Set up default basic auth htpasswd:
@@ -44,7 +45,7 @@ Create kube-apiserver Pod manifest:
           - --etcd-cafile=/etc/kubernetes/pki/etcd/ca.crt
           - --etcd-certfile=/etc/kubernetes/pki/apiserver-etcd-client.crt
           - --etcd-keyfile=/etc/kubernetes/pki/apiserver-etcd-client.key
-          - --etcd-servers=https://127.0.0.1:2379
+          - --etcd-servers=https://{{ defaults.registry_ip }}:2379
           - --insecure-port=0
           - --kubelet-client-certificate=/etc/kubernetes/pki/apiserver-kubelet-client.crt
           - --kubelet-client-key=/etc/kubernetes/pki/apiserver-kubelet-client.key

--- a/salt/metalk8s/kubeadm/init/control-plane/apiserver.sls
+++ b/salt/metalk8s/kubeadm/init/control-plane/apiserver.sls
@@ -6,6 +6,7 @@
 include:
   - metalk8s.kubeadm.init.certs.sa-deploy-pub-key
   - metalk8s.kubeadm.init.certs.front-proxy-deploy-ca-cert
+  - metalk8s.kubeadm.init.certs.etcd-deploy-ca-cert
 
 Set up default basic auth htpasswd:
   file.managed:
@@ -80,6 +81,7 @@ Create kube-apiserver Pod manifest:
     - require:
       - file: Ensure SA pub key is present
       - file: Ensure front-proxy CA cert is present
+      - file: Ensure etcd CA cert is present
 
 Make sure kube-apiserver container is up:
   module.wait:

--- a/salt/metalk8s/kubeadm/init/mark-control-plane/configured.sls
+++ b/salt/metalk8s/kubeadm/init/mark-control-plane/configured.sls
@@ -1,4 +1,4 @@
-{% set hostname = salt['network.get_hostname']() %}
+{% set hostname = pillar.get('mark_control_plane_hostname', salt['network.get_hostname']()) %}
 
 {% set kubeconfig = "/etc/kubernetes/admin.conf" %}
 {% set context = "kubernetes-admin@kubernetes" %}

--- a/salt/metalk8s/orchestrate/control_plane.sls
+++ b/salt/metalk8s/orchestrate/control_plane.sls
@@ -1,0 +1,50 @@
+{%- set control_plane_ips = salt.saltutil.runner('mine.get', tgt='*', fun='control_plane_ips') %}
+{%- if pillar['bootstrap_id'] in control_plane_ips.keys() and control_plane_ips[pillar['bootstrap_id']] %}
+{%- set control_plane_ip = control_plane_ips[pillar['bootstrap_id']][0] %}
+{%- else %}
+{%- set control_plane_ip = 'localhost' %}
+{%- endif %}
+
+{% set node = pillar['node_name'] %}
+
+Bootstrap client certs:
+  salt.state:
+    - tgt: {{ node }}
+    - saltenv: {{ saltenv }}
+    - sls:
+      - metalk8s.kubeadm.init.certs.apiserver
+      - metalk8s.kubeadm.init.certs.apiserver-etcd-client
+      - metalk8s.kubeadm.init.certs.apiserver-kubelet-client
+      - metalk8s.kubeadm.init.certs.front-proxy-client
+    - pillar:
+        repo:
+          host: {{ control_plane_ip }}
+        registry_ip: {{ control_plane_ip }}
+
+Bootstrap control plane:
+  salt.state:
+    - tgt: {{ node }}
+    - saltenv: {{ saltenv }}
+    - sls:
+      - metalk8s.bootstrap.kubeconfig
+      - metalk8s.bootstrap.control-plane
+    - require:
+      - salt: Bootstrap client certs
+    - pillar:
+        repo:
+          host: {{ control_plane_ip }}
+        registry_ip: {{ control_plane_ip }}
+
+Bootstrap node:
+  salt.state:
+    - tgt: {{ pillar['bootstrap_id'] }}
+    - saltenv: {{ saltenv }}
+    - sls:
+      - metalk8s.bootstrap.mark_control_plane
+    - require:
+      - salt: Bootstrap control plane
+    - pillar:
+        mark_control_plane_hostname: {{ node }}
+        repo:
+          host: {{ control_plane_ip }}
+        registry_ip: {{ control_plane_ip }}


### PR DESCRIPTION
Execute this orchestrate after the one from #735 and you'll have your new node integrated into the control plane.

For this, execute on the salt-master container:
```
salt-run state.orch metalk8s.orchestrate.control_plane saltenv=metalk8s-2.0 pillar='{"bootstrap_id": "bootstrap", "node_name": "node1"}'
```

Then execute on the bootstrap node:

```
kubectl -n kube-system get pods -o wide|grep node1
kubectl -n kube-system get nodes node1
```

Make sure you have 5 pods running on node1, node status is `Ready` and node role is `master`.

Issues to solve/to check:

* Make sure the node1 apiserver pod is targeting the bootstrap etcd pod
* Make sure the node1 kubelet is targeting the node1 apiserver pod