### PR TITLE
Improvement/orchestrate runner to bootstrap worker node

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -75,6 +75,7 @@ SALT_FILES : Tuple[Union[Path, targets.FileTarget], ...] = (
     Path('salt/metalk8s/orchestrate/bootstrap_without_master.sls'),
     Path('salt/metalk8s/orchestrate/bootstrap_with_master.sls'),
     Path('salt/metalk8s/orchestrate/deploy_salt_minion_on_new_node.sls'),
+    Path('salt/metalk8s/orchestrate/worker_plane.sls'),
     Path('salt/metalk8s/bootstrap/addons.sls'),
     Path('salt/metalk8s/bootstrap/calico.sls'),
     Path('salt/metalk8s/bootstrap/certs/ca.sls'),

--- a/salt/_modules/containerd.py
+++ b/salt/_modules/containerd.py
@@ -2,10 +2,8 @@
 Various functions to interact with :program:`containerd` using :command:`ctr`.
 '''
 
-import re
 import logging
-
-import salt.utils.path
+import re
 
 log = logging.getLogger(__name__)
 

--- a/salt/metalk8s/calico/configured.sls
+++ b/salt/metalk8s/calico/configured.sls
@@ -5,6 +5,9 @@
 
 {%- if ca_server %}
 
+include:
+  - metalk8s.kubeadm.init.certs.installed
+
 Create kubeconf file for calico:
   metalk8s_kubeconfig.managed:
     - name: /etc/kubernetes/calico.conf
@@ -15,6 +18,8 @@ Create kubeconf file for calico:
         O: metalk8s:calico-node
     - apiserver: https://{{ kube_api.service_ip }}:443
     - cluster: {{ defaults.cluster }}
+    - require:
+      - pkg: Install m2crypto
 
 Create CNI calico configuration file:
   file.serialize:

--- a/salt/metalk8s/containerd/configured.sls
+++ b/salt/metalk8s/containerd/configured.sls
@@ -1,10 +1,5 @@
 {% from "metalk8s/map.jinja" import metalk8s with context %}
 
-{# One day this should be transferred from the fileserver #}
-{% set pause_image_archive =
-    metalk8s.iso_root_path ~ '/salt/metalk8s/containerd/files/pause-3.1.tar'
-%}
-
 include:
   - .installed
 
@@ -17,12 +12,19 @@ Start and enable containerd:
 
 Inject pause image:
   # The `containerd` states require the `cri` module, which requires `crictl`
-  cmd.run:
-    - name: >-
-        ctr -n k8s.io image import \
-            --base-name k8s.gcr.io/pause \
-            {{ pause_image_archive }}
+  file.managed:
+    - name: /tmp/pause-3.1.tar
+    - source: salt://metalk8s/containerd/files/pause-3.1.tar
     - unless: >-
         ctr -n k8s.io image ls -q | grep k8s.gcr.io/pause | grep 3\\.1
     - require:
       - service: Start and enable containerd
+  cmd.run:
+    - name: >-
+        ctr -n k8s.io image import \
+            --base-name k8s.gcr.io/pause \
+            /tmp/pause-3.1.tar
+    - unless: >-
+        ctr -n k8s.io image ls -q | grep k8s.gcr.io/pause | grep 3\\.1
+    - require:
+      - file: Inject pause image

--- a/salt/metalk8s/containerd/configured.sls
+++ b/salt/metalk8s/containerd/configured.sls
@@ -9,6 +9,8 @@ Start and enable containerd:
     - enable: True
     - require:
       - pkg: Install containerd
+    - watch:
+      - file: Configure registry IP in containerd conf
 
 Inject pause image:
   # The `containerd` states require the `cri` module, which requires `crictl`

--- a/salt/metalk8s/containerd/installed.sls
+++ b/salt/metalk8s/containerd/installed.sls
@@ -1,5 +1,6 @@
 {%- from "metalk8s/macro.sls" import pkg_installed with context %}
 {%- from "metalk8s/map.jinja" import repo with context %}
+{%- from "metalk8s/map.jinja" import defaults with context %}
 
 include:
   - metalk8s.repo
@@ -22,3 +23,17 @@ Install containerd:
       - test: Repositories configured
       - pkg: Install runc
       - pkg: Install container-selinux
+
+Configure registry IP in containerd conf:
+  file.managed:
+    - name: /etc/containerd/config.toml
+    - makedirs: true
+    - contents: |
+        [plugins]
+          [plugins.cri]
+            [plugins.cri.registry]
+              [plugins.cri.registry.mirrors]
+                [plugins.cri.registry.mirrors."{{ defaults.registry_ip }}"]
+                  endpoint = ["http://{{ defaults.registry_ip }}:5000"]
+    - require:
+      - pkg: Install containerd

--- a/salt/metalk8s/defaults.yaml
+++ b/salt/metalk8s/defaults.yaml
@@ -184,3 +184,6 @@ coredns:
   reverse_cidrs: in-addr.arpa ip6.arpa
 
 upgrade: false        # define if we're on an upgrade case
+
+# TODO: Move it into mine
+registry_ip: localhost

--- a/salt/metalk8s/kubeadm/init/kubeconfig/lib.sls
+++ b/salt/metalk8s/kubeadm/init/kubeconfig/lib.sls
@@ -15,6 +15,9 @@
 
 {%- if ca_server %}
 
+include:
+  - metalk8s.kubeadm.init.certs.installed
+
 Create kubeconf file for {{ name }}:
   metalk8s_kubeconfig.managed:
     - name: /etc/kubernetes/{{ name }}.conf
@@ -26,6 +29,8 @@ Create kubeconf file for {{ name }}:
         {%- endfor %}
     - apiserver: {{ apiserver }}
     - cluster: {{ defaults.cluster }}
+    - require:
+      - pkg: Install m2crypto
 
 {%- else %}
 

--- a/salt/metalk8s/kubeadm/init/kubeconfig/lib.sls
+++ b/salt/metalk8s/kubeadm/init/kubeconfig/lib.sls
@@ -5,8 +5,13 @@
 {% macro kubeconfig(name, cert_info) %}
 
 {%- set ca_server = salt['mine.get']('*', 'kubernetes_ca_server').keys() %}
-{#- TODO: Not always use local machine as apiserver #}
+
+{%- set apiserver_addr = pillar.get('apiserver_addr') %}
+{%- if apiserver_addr %}
+{%- set apiserver = 'https://' ~ apiserver_addr ~ ':6443' %}
+{%- else %}
 {%- set apiserver = 'https://' ~ salt['network.ip_addrs'](cidr=networks.control_plane)[0] ~ ':6443' %}
+{%- endif %}
 
 {%- if ca_server %}
 

--- a/salt/metalk8s/map.jinja
+++ b/salt/metalk8s/map.jinja
@@ -2,7 +2,7 @@
 
 {% set defaults = salt['grains.filter_by']({
   'default': defaults
-}, merge=salt['pillar.items']()) %}
+}, merge=pillar) %}
 
 {% set metalk8s = salt['grains.filter_by']({
   'default': {}

--- a/salt/metalk8s/orchestrate/bootstrap_with_master.sls
+++ b/salt/metalk8s/orchestrate/bootstrap_with_master.sls
@@ -31,6 +31,8 @@ Bootstrap control plane:
       - metalk8s.bootstrap.etcd
     - require:
       - salt: Bootstrap client certs
+    - pillar:
+        registry_ip: {{ pillar.get('registry_ip') }}
 
 Bootstrap node:
   salt.state:
@@ -42,3 +44,5 @@ Bootstrap node:
       - metalk8s.bootstrap.calico
     - require:
       - salt: Bootstrap control plane
+    - pillar:
+        registry_ip: {{ pillar.get('registry_ip') }}

--- a/salt/metalk8s/orchestrate/worker_plane.sls
+++ b/salt/metalk8s/orchestrate/worker_plane.sls
@@ -1,0 +1,73 @@
+{%- set control_plane_ips = salt.saltutil.runner('mine.get', tgt='*', fun='control_plane_ips') %}
+{%- if pillar['bootstrap_id'] in control_plane_ips.keys() and control_plane_ips[pillar['bootstrap_id']] %}
+{%- set control_plane_ip = control_plane_ips[pillar['bootstrap_id']][0] %}
+{%- else %}
+{%- set control_plane_ip = 'localhost' %}
+{%- endif %}
+
+{% set node = pillar['node_name'] %}
+
+Run bootstrap prechecks:
+  salt.state:
+    - tgt: {{ node }}
+    - saltenv: {{ saltenv }}
+    - sls: metalk8s.bootstrap.precheck
+
+Run bootstrap kubelet:
+  salt.state:
+    - tgt: {{ node }}
+    - saltenv: {{ saltenv }}
+    - sls:
+      - metalk8s.bootstrap.kubelet_install
+    - pillar:
+        repo:
+          host: {{ control_plane_ip }}
+        registry_ip: {{ control_plane_ip }}
+
+Run bootstrap preflight:
+  salt.state:
+    - tgt: {{ node }}
+    - saltenv: {{ saltenv }}
+    - sls: metalk8s.bootstrap.preflight
+    - pillar:
+        repo:
+          host: {{ control_plane_ip }}
+        registry_ip: {{ control_plane_ip }}
+
+Run bootstrap kubelet start:
+  salt.state:
+    - tgt: {{ node }}
+    - saltenv: {{ saltenv }}
+    - sls:
+      - metalk8s.bootstrap.kubelet_start
+      - metalk8s.kubeadm.init.kubeconfig.kubelet
+    - pillar:
+        apiserver_addr: {{ control_plane_ip }}
+        repo:
+          host: {{ control_plane_ip }}
+        registry_ip: {{ control_plane_ip }}
+
+Install calico:
+  salt.state:
+    - saltenv: {{ saltenv }}
+    - tgt: {{ node }}
+    - sls:
+      -  metalk8s.calico.installed
+      -  metalk8s.calico.configured
+    - pillar:
+        repo:
+          host: {{ control_plane_ip }}
+        registry_ip: {{ control_plane_ip }}
+
+# TODO: Investigate why we have to reload systemd and restart kubelet
+Run sysctemctl reload:
+  salt.function:
+    - tgt: {{ node }}
+    - name: service.systemctl_reload
+
+Restart kubelet:
+  salt.function:
+    - tgt: {{ node }}
+    - name: service.restart
+    - arg:
+        - kubelet

--- a/salt/metalk8s/registry/files/registry-pod.yaml.j2
+++ b/salt/metalk8s/registry/files/registry-pod.yaml.j2
@@ -36,19 +36,19 @@ spec:
           protocol: TCP
       livenessProbe:
         httpGet:
-          host: localhost
+          host: {{ registry_ip }}
           port: registry
           path: /
       readinessProbe:
         httpGet:
-          host: localhost
+          host: {{ registry_ip }}
           port: registry
           path: /
       env:
         - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
           value: '/var/lib/registry'
         - name: REGISTRY_HTTP_ADDR
-          value: 'localhost:5000'
+          value: '{{ registry_ip }}:5000'
         - name: REGISTRY_HEALTH_STORAGEDRIVER_ENABLED
           value: 'true'
       volumeMounts:

--- a/salt/metalk8s/registry/init.sls
+++ b/salt/metalk8s/registry/init.sls
@@ -1,4 +1,5 @@
 {% from "metalk8s/map.jinja" import metalk8s with context %}
+{%- from "metalk8s/map.jinja" import defaults with context %}
 
 {% set registry_image = 'docker.io/registry' %}
 {% set registry_version = '2.7.1' %}
@@ -47,5 +48,6 @@ Install OCI registry manifest:
     - defaults:
         registry_image: {{ registry_image }}
         registry_version: {{ registry_version }}
+        registry_ip: {{ defaults.registry_ip }}
         registry_user: {{ registry_user }}
         registry_group: {{ registry_group }}

--- a/salt/metalk8s/registry/macro.sls
+++ b/salt/metalk8s/registry/macro.sls
@@ -1,10 +1,12 @@
 {%- from "metalk8s/map.jinja" import kubernetes with context %}
+{%- from "metalk8s/map.jinja" import defaults with context %}
 
-{# FIXME: this won't work except on bootstrap node #}
-{%- set registry_host = "localhost:5000" %}
-
-{%- macro build_image_name(name='', tag='') -%}
-"{{ registry_host }}/{{ saltenv }}/{{ name }}:{{ tag }}"
+{%- macro build_image_name(name='', tag='', include_port=False) -%}
+{%- if include_port -%}
+"{{ defaults.registry_ip }}:5000/{{ saltenv }}/{{ name }}:{{ tag }}"
+{%- else -%}
+"{{ defaults.registry_ip }}/{{ saltenv }}/{{ name }}:{{ tag }}"
+{%- endif -%}
 {%- endmacro -%}
 
 {%- macro kubernetes_image(component) -%}

--- a/salt/metalk8s/registry/populated.sls
+++ b/salt/metalk8s/registry/populated.sls
@@ -57,7 +57,7 @@ Install skopeo:
 {% for image in images %}
 Import {{ image.name }} image:
   docker_registry.image_managed:
-    - name: {{ build_image_name(image.name, image.tag) }}
+    - name: {{ build_image_name(image.name, image.tag, include_port=True) }}
     - archive_path: {{ metalk8s.iso_root_path }}/images/{{ image.name }}-{{ image.tag }}.tar.gz
     - tls_verify: false
     - require:

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -166,18 +166,33 @@ sync_salt() {
 }
 
 orchestrate_bootstrap() {
-    ${SALT_CALL} --local --retcode-passthrough --state-output=mixed state.orchestrate metalk8s.orchestrate.bootstrap_without_master saltenv=metalk8s-@@VERSION pillarenv=metalk8s-@@VERSION
+    # TODO: FIX register IP
+    local cidr
+    local registry_ip
+    cidr=$(salt-call --local pillar.get networks:control_plane --out=txt | cut -f 2 -d ' ')
+    registry_ip=$(salt-call --local network.ip_addrs cidr="$cidr" --out=txt | sed "s/.*'\(\([0-9]\{1,3\}\.\)\{3\}[0-9]\{1,3\}\)'.*/\1/")
+    ${SALT_CALL} --local --retcode-passthrough --state-output=mixed state.orchestrate \
+        metalk8s.orchestrate.bootstrap_without_master \
+        saltenv=metalk8s-@@VERSION \
+        pillarenv=metalk8s-@@VERSION \
+        pillar="{'registry_ip': $registry_ip}"
     set_salt_command
     sync_salt
     # shellcheck disable=SC2086
-    ${SALT_MASTER_CALL} salt-run state.orchestrate metalk8s.orchestrate.bootstrap_with_master saltenv=metalk8s-@@VERSION pillarenv=metalk8s-@@VERSION pillar="{'bootstrap_id': '$(cat /etc/salt/minion_id)'}"
+    ${SALT_MASTER_CALL} salt-run state.orchestrate \
+        metalk8s.orchestrate.bootstrap_with_master \
+        saltenv=metalk8s-@@VERSION \
+        pillarenv=metalk8s-@@VERSION \
+        pillar="{'bootstrap_id': '$(cat /etc/salt/minion_id)', 'registry_ip': $registry_ip}"
 }
 
 deploy_metalk8s_ui() {
+    bootstrap_id=$(cat /etc/salt/minion_id)
+    registry_ip=$(salt-call mine.get "$bootstrap_id" control_plane_ips --out txt | sed "s/.*'\(\([0-9]\{1,3\}\.\)\{3\}[0-9]\{1,3\}\)'.*/\1/")
     "$SALT_CALL" --retcode-passthrough state.apply \
         metalk8s.ui saltenv=metalk8s-@@VERSION \
         pillarenv=metalk8s-@@VERSION \
-        pillar="{'bootstrap_id': '$(cat /etc/salt/minion_id)'}"
+        pillar="{'bootstrap_id': $bootstrap_id, 'registry_ip': $registry_ip}"
 }
 
 
@@ -188,7 +203,7 @@ main() {
     configure_yum_repositories
     install_salt_minion
     configure_salt_minion_local_mode
-    
+
     orchestrate_bootstrap
     deploy_metalk8s_ui
 }


### PR DESCRIPTION
WIP but with this PR we should be able to bootstrap without hardcoding IPs everywhere:

Step to tests:
Follow the procedure described here to create bootstrap and node1: https://github.com/scality/metalk8s/pull/815

On the bootstrap node, add a label to the previously created node 1:
```
apiVersion: v1
kind: Node
metadata:
  name: node1
  annotations:
    metalk8s.scality.com/ssh-user: vagrant
    metalk8s.scality.com/ssh-port: "22"
    metalk8s.scality.com/ssh-host: 172.21.254.7
    metalk8s.scality.com/ssh-key-path: /etc/metalk8s/pki/preshared_key_for_k8s_nodes
    metalk8s.scality.com/ssh-sudo: "true"
  labels:
    beta.kubernetes.io/os: linux
```

In the salt master container
```
salt '*' saltutil.sync_all saltenv=metalk8s-2.0
salt-run state.orch metalk8s.orchestrate.worker_plane saltenv=metalk8s-2.0 pillar='{"bootstrap_id": "bootstrap", "node_name": "node1"}'
```

On the bootstrap node:
Restart kube-proxy:
```
kubectl -n kube-system delete pods $(kubectl -n kube-system get pods|grep proxy|awk '{print$1}')
systemctl restart kubelet
```