### PR TITLE
Improve default Calico config

### DIFF
--- a/salt/metalk8s/calico/deployed.sls
+++ b/salt/metalk8s/calico/deployed.sls
@@ -74,6 +74,8 @@ Deploy calico-node (DaemonSet):
                     value: "k8s,bgp"
                   - name: IP
                     value: "autodetect"
+                  - name: IP_AUTODETECTION_METHOD
+                    value: can-reach={{ networks.workload_plane.split('/')[0] }}
                   - name: CALICO_IPV4POOL_IPIP
                     value: "Always"
                   - name: FELIX_IPINIPMTU

--- a/salt/metalk8s/calico/deployed.sls
+++ b/salt/metalk8s/calico/deployed.sls
@@ -77,7 +77,7 @@ Deploy calico-node (DaemonSet):
                   - name: IP_AUTODETECTION_METHOD
                     value: can-reach={{ networks.workload_plane.split('/')[0] }}
                   - name: CALICO_IPV4POOL_IPIP
-                    value: "Always"
+                    value: "CrossSubnet"
                   - name: FELIX_IPINIPMTU
                     valueFrom:
                       configMapKeyRef:


### PR DESCRIPTION
- Ensure Calico uses the node workload-plane IPs instead of something random
- Disable IPIP for non-cross-subnet communication