### PR TITLE
build: use `True` instad of `run_once`

### DIFF
--- a/buildchain/buildchain/packaging.py
+++ b/buildchain/buildchain/packaging.py
@@ -29,8 +29,6 @@ Overview;
 from pathlib import Path
 from typing import Dict, Iterator, List, Tuple
 
-import doit  # type: ignore
-
 from buildchain import config
 from buildchain import constants
 from buildchain import coreutils
@@ -110,7 +108,7 @@ def task__download_packages() -> types.TaskDict:
         'file_dep': [BUILDER.destination, pkg_list],
         'task_dep': ['_package_mkdir_root', '_package_mkdir_iso_root'],
         'clean': [clean],
-        'uptodate': [doit.tools.run_once],
+        'uptodate': [True],
         # Prevent Docker from polluting our output.
         'verbosity': 0,
     }

--- a/buildchain/buildchain/targets/directory.py
+++ b/buildchain/buildchain/targets/directory.py
@@ -7,8 +7,6 @@
 from pathlib import Path
 from typing import Any
 
-import doit  # type: ignore
-
 from buildchain import types
 from buildchain import utils
 
@@ -36,7 +34,7 @@ class Mkdir(base.Target, base.AtomicTarget):
         task.update({
             'title': lambda task: utils.title_with_target1('MKDIR', task),
             'actions': [(self._run, [task['targets'][0]])],
-            'uptodate': [doit.tools.run_once],
+            'uptodate': [True],
         })
         return task
 

--- a/buildchain/buildchain/targets/file_tree.py
+++ b/buildchain/buildchain/targets/file_tree.py
@@ -32,8 +32,6 @@ import operator
 from pathlib import Path
 from typing import Any, List, Sequence, Set, Union
 
-import doit  # type: ignore
-
 from buildchain import constants
 from buildchain import coreutils
 from buildchain import types
@@ -121,7 +119,7 @@ class FileTree(base.Target, base.CompositeTarget):
             'title': lambda task: utils.title_with_target1('MKTREE', task),
             'actions': [mkdirs],
             'targets': self.directories,
-            'uptodate': [doit.tools.run_once],
+            'uptodate': [True],
         })
         return task
 

--- a/buildchain/buildchain/targets/remote_image.py
+++ b/buildchain/buildchain/targets/remote_image.py
@@ -14,8 +14,6 @@ import operator
 from pathlib import Path
 from typing import Any, Optional, List
 
-import doit  # type: ignore
-
 from buildchain import config
 from buildchain import coreutils
 from buildchain import types
@@ -82,7 +80,7 @@ class RemoteImage(image.ContainerImage):
             'title': self._show,
             'doc': 'Download {} container image.'.format(self.name),
             'actions': self._build_actions(),
-            'uptodate': [doit.tools.run_once],
+            'uptodate': [True],
         })
         return task
 

--- a/buildchain/buildchain/targets/repository.py
+++ b/buildchain/buildchain/targets/repository.py
@@ -35,8 +35,6 @@ import operator
 from pathlib import Path
 from typing import Any, List, Optional, Sequence
 
-import doit  # type: ignore
-
 from buildchain import config
 from buildchain import coreutils
 from buildchain import constants
@@ -134,7 +132,7 @@ class Repository(base.Target, base.CompositeTarget):
             'doc': 'Build the {} repository metadata.'.format(self.name),
             'title': lambda task: utils.title_with_target1('BUILD REPO', task),
             'targets': targets,
-            'uptodate': [doit.tools.run_once],
+            'uptodate': [True],
             'clean': [clean],
             # Prevent Docker from polluting our output.
             'verbosity': 0,
@@ -184,7 +182,7 @@ class Repository(base.Target, base.CompositeTarget):
             ),
             'title': mkdir['title'],
             'actions': mkdir['actions'],
-            'uptodate': [doit.tools.run_once],
+            'uptodate': [True],
             'targets': mkdir['targets'],
         })
         return task
@@ -200,7 +198,7 @@ class Repository(base.Target, base.CompositeTarget):
             ),
             'title': mkdir['title'],
             'actions': mkdir['actions'],
-            'uptodate': [doit.tools.run_once],
+            'uptodate': [True],
             'targets': mkdir['targets'],
         })
         task['task_dep'].append('{base}:{name}'.format(

--- a/buildchain/buildchain/vagrant.py
+++ b/buildchain/buildchain/vagrant.py
@@ -37,7 +37,7 @@ def task__vagrantkey() -> types.TaskDict:
     return {
         'actions': [mkdir_dot_vagrant, keygen],
         'targets': [constants.VAGRANT_SSH_KEY_PAIR],
-        'uptodate': [doit.tools.run_once]
+        'uptodate': [True],
     }
 
 def task_vagrantup() -> types.TaskDict:


### PR DESCRIPTION
Unlike what I thought at first, `True` and `doit.tools.run_once` are not
equivalent for `uptodate`:

- `True`: the computation of `uptodate` only depends on the presence of
  the target(s).
- `run_once`: ditto BUT it forces at least one execution managed by
  doit.

In most cases, we only care about the existence of the file, the fact
that if was created by `doit` or not doesn't matter, hence this commit
to reflect that.

Closes: #887
Signed-off-by: Sylvain Laperche <sylvain.laperche@scality.com>