### PR TITLE
Redirect restarting salt-minion command output to /dev/null

### DIFF
--- a/salt/metalk8s/salt/minion/running.sls
+++ b/salt/metalk8s/salt/minion/running.sls
@@ -1,6 +1,6 @@
 Restart salt-minion:
   cmd.wait:
-    - name: 'salt-call --local service.restart salt-minion'
+    - name: 'salt-call --local service.restart salt-minion > /dev/null'
     - bg: true
 
 Wait until salt-minion restarted:


### PR DESCRIPTION
Execute this:
`salt-run state.orch metalk8s.orchestrate.deploy_salt_minion_on_new_node saltenv=metalk8s-2.0 pillar='{"bootstrap_id": "bootstrap", "node_name": "node1"}'`

Before this PR:
```
[ERROR   ] No JSON object could be decoded
[...]
Summary for bootstrap_master
------------
Succeeded: 0 (changed=1)
Failed:    1
------------
```
because of the output of the salt-call at the beginning of the state result
```
local:
  True
```

Now:

```
Summary for bootstrap_master
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
```

Fixes: #888