### PR TITLE
CI: increase timeout while waiting for Docker daemon

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -40,7 +40,7 @@ stages:
           name: Wait for Docker daemon to be ready
           command: |
             bash -c '
-            for i in {1..10}
+            for i in {1..150}
             do
               docker info &> /dev/null && exit
               sleep 2


### PR DESCRIPTION
As requested by @Zempashi , let's try to update the timeout.

Fixes #690

We have no guarantee the Docker daemon will become available in the CI
in less than 20s.
Let's wait 5min instead by step of 2s.