### PR TITLE
CI: restrict control and workload plane networks on the single node env to avoid confusion while picking IPs

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -130,8 +130,8 @@ stages:
             apiVersion: metalk8s.scality.com/v1alpha1
             kind: BootstrapConfiguration
             networks:
-              controlPlane: 10.0.0.0/8
-              workloadPlane: 10.0.0.0/8
+              controlPlane: 10.100.0.0/16
+              workloadPlane: 10.100.0.0/16
             END
             EOF
       - ShellCommand:


### PR DESCRIPTION
Fixes #920

Our ranges were too wide and could include other IPs that were not part of those networks.
By narrowing them down, we are sure we pick the right IP.