### PR TITLE
buildchain: enforce strict Dockerfile COPY/ADD filedeps

### DIFF
--- a/.pylint-dict
+++ b/.pylint-dict
@@ -19,7 +19,9 @@ mkdir
 mkisofs
 mypy
 prebuilt
+py
 rpmspec
+repo
 scality
 sls
 timestamp

--- a/buildchain/buildchain/packaging.py
+++ b/buildchain/buildchain/packaging.py
@@ -135,7 +135,10 @@ BUILDER : targets.LocalImage = targets.LocalImage(
     destination=config.BUILD_ROOT,
     save_on_disk=False,
     task_dep=['_build_root'],
-    file_dep=list(constants.ROOT.glob('packages/yum_repositories/*.repo')),
+    file_dep=[
+        constants.ROOT/'packages/yum_repositories/kubernetes.repo',
+        constants.ROOT/'packages/yum_repositories/saltstack.repo'
+    ],
 )
 
 

--- a/buildchain/buildchain/targets/local_image.py
+++ b/buildchain/buildchain/targets/local_image.py
@@ -14,8 +14,11 @@ All of these actions are done by a single task.
 
 
 import operator
+import re
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Match, Optional, Union
+
+from doit.exceptions import TaskError # type: ignore
 
 from buildchain import config
 from buildchain import constants
@@ -23,6 +26,55 @@ from buildchain import coreutils
 from buildchain import types
 
 from . import image
+
+
+class DockerFileDep:
+    """A Dockerfile directive line creating external file dependencies."""
+
+    def __init__(
+        self,
+        line_no: int,
+        line_contents: str,
+        line_match: Match[str],
+        dockerfile_path: Path
+    ):
+        self.line_no = line_no
+        self.line_contents = line_contents
+        self.match = line_match
+        self.dockerfile_path = dockerfile_path
+
+    def expand_dep(self) -> List[Path]:
+        """Expand the Dockerfile path dependency to regular files."""
+        source = self.match.group('src')
+        path = self.dockerfile_path.parent/Path(source)
+        # Simple file
+        if path.is_file():
+            return [path]
+        # Directory or `.`
+        if path.is_dir():
+            return list(coreutils.ls_files_rec(path))
+        # Globs - `*` or specific e.g. `*.py`, `*.repo`
+        return [
+            sub_path
+            for sub_path in path.parent.glob(path.name)
+            if sub_path.is_file()
+        ]
+
+    def format_errors(self, error_paths: List[Path]) -> List[str]:
+        """Format paths in error with relevant information."""
+        error_line = "l.{}: '{}' - missing {}"
+        return [
+            error_line.format(self.line_no, self.line_contents, error_path)
+            for error_path in error_paths
+        ]
+
+    def verify(self, file_deps: List[Path]) -> List[str]:
+        """Verify Dockerfile dependencies against external dependency list."""
+        missing_deps = []
+        for dependency in self.expand_dep():
+            if not dependency in file_deps:
+                missing_deps.append(dependency)
+        return self.format_errors(missing_deps)
 
 
 class LocalImage(image.ContainerImage):
@@ -62,10 +114,56 @@ class LocalImage(image.ContainerImage):
             **kwargs
         )
 
-
     dockerfile   = property(operator.attrgetter('_dockerfile'))
     save_on_disk = property(operator.attrgetter('_save'))
     build_args   = property(operator.attrgetter('_build_args'))
+    dep_re = re.compile(
+        r'^\s*(COPY|ADD)( --[^ ]+)* (?P<src>[^ ]+) (?P<dst>[^ ]+)\s*$'
+    )
+
+    def load_deps_from_dockerfile(self) -> List[DockerFileDep]:
+        """Compute file dependencies from Dockerfile."""
+        dep_keywords = ('COPY', 'ADD')
+
+        with self.dockerfile.open('r', encoding='utf8') as dockerfile:
+            docker_lines = dockerfile.readlines()
+
+        dep_lines = [
+            (pos, line.strip(), self.dep_re.match(line.strip()))
+            for (pos, line) in enumerate(docker_lines, 1)
+            if line.lstrip().startswith(dep_keywords)
+        ]
+        deps = []
+        for (pos, line, match) in dep_lines:
+            if match is None:
+                continue
+            deps.append(
+                DockerFileDep(
+                    line_no=pos,
+                    line_contents=line,
+                    line_match=match,
+                    dockerfile_path=self.dockerfile
+                )
+            )
+        return deps
+
+    def check_dockerfile_dependencies(self) -> Union[TaskError, bool]:
+        """Verify task file dependencies against computed file dependencies."""
+        error_tplt = (
+            'Missing Dockerfile file dependencies in'
+            ' build target: \n{dockerfile}:\n\t{errors}'
+        )
+        deps = self.load_deps_from_dockerfile()
+        errors: List[str] = []
+        for dep in deps:
+            errors.extend(dep.verify(self.file_dep))
+        if errors:
+            error_message = error_tplt.format(
+                dockerfile=self.dockerfile,
+                errors='\n\t'.join(errors)
+            )
+            return TaskError(msg=error_message)
+        return None
 
     @property
     def task(self) -> types.TaskDict:
@@ -84,6 +182,10 @@ class LocalImage(image.ContainerImage):
 
     def _build_actions(self) -> List[types.Action]:
         """Build a container image locally."""
+        actions: List[types.Action] = []
+
+        actions.append((self.check_dockerfile_dependencies, [], {}))
+
         build_cmd = [
             config.DOCKER, 'build',
             '--tag', self.tag,
@@ -92,8 +194,8 @@ class LocalImage(image.ContainerImage):
         for arg, value in self.build_args.items():
             build_cmd.extend(['--build-arg', '{}={}'.format(arg, value)])
         build_cmd.append(self.dockerfile.parent)
+        actions.append(build_cmd)
 
-        actions : List[types.Action] = [build_cmd]
         # If a destination is defined, let's save the image there.
         if self.save_on_disk:
             filepath = self.uncompressed_filename


### PR DESCRIPTION
Aggressively abort a `LocalImage` container build when the task's Dockerfile contains file dependencies (through `COPY` or `ADD` directives) that are not reflected by the task's advertised `file_dep` field in its specification.

This encourages including only necessary files, and prevents desyncs between support files and images.

Play around with it by removing dependencies from any existing `LocalImage` task in the buildchain, and observe the mayhem unfold.