### PR TITLE
Fix pytest filtering

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 skipsdist = true
+minversion = 3.4.0
 
 [testenv]
 whitelist_externals = bash
@@ -47,13 +48,16 @@ passenv =
     SSH_CONFIG_FILE
     TEST_HOSTS_LIST
     ISO_MOUNTPOINT
+setenv =
+    VAGRANT_CWD={toxinidir}
+commands_pre =
+    - bash -c "vagrant ssh-config bootstrap > {envdir}/vagrant_ssh_config"
 commands =
-    bash -c "pytest \
-             --ssh-config={env:SSH_CONFIG_FILE:<( \
-                 VAGRANT_CWD={toxinidir} vagrant ssh-config bootstrap)} \
-             --hosts={env:TEST_HOSTS_LIST:bootstrap} \
-             --iso-root={env:ISO_MOUNTPOINT:/vagrant/_build/root} \
-             {posargs} tests"
+    pytest \
+         --ssh-config={env:SSH_CONFIG_FILE:{envdir}/vagrant_ssh_config} \
+         --hosts={env:TEST_HOSTS_LIST:bootstrap} \
+         --iso-root={env:ISO_MOUNTPOINT:/vagrant/_build/root} \
+         {posargs} tests
 
 [testenv:tests-local]
 description =


### PR DESCRIPTION
Test call was made with bash command instead of pytest.
The reason is the need of pre-compute ssh-config from vagrant.
Now we pre-compute the ssh-config with tox commands_pre option
and store it in a file before running the tests

Closes #879

Test: run the following command:
```
tox -r -e tests -- --collect-only -k "not logs"
```
without the fix, all tests are deselected, with the fix, only one test is deselected

PS: this pr introduce also a minimum version for tox
