### PR TITLE
salt: store CA minion in `BootstrapConfiguration`

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -119,11 +119,13 @@ fi
 
 echo "Creating bootstrap configuration"
 cat > /etc/metalk8s/bootstrap.yaml << EOF
-apiVersion: metalk8s.scality.com/v1alpha1
+apiVersion: metalk8s.scality.com/v1alpha2
 kind: BootstrapConfiguration
 networks:
   controlPlane: #{CONTROL_PLANE_IP}/#{prefixlen(CONTROL_PLANE_NETMASK)}
   workloadPlane: #{WORKLOAD_PLANE_IP}/#{prefixlen(WORKLOAD_PLANE_NETMASK)}
+ca:
+  minion: bootstrap
 EOF
 
 echo "Launching bootstrap"

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -127,11 +127,13 @@ stages:
             sudo bash << EOF
             mkdir -p /etc/metalk8s
             cat > /etc/metalk8s/bootstrap.yaml << END
-            apiVersion: metalk8s.scality.com/v1alpha1
+            apiVersion: metalk8s.scality.com/v1alpha2
             kind: BootstrapConfiguration
             networks:
               controlPlane: 10.100.0.0/16
               workloadPlane: 10.100.0.0/16
+            ca:
+              minion: $(hostname)
             END
             EOF
       - ShellCommand:
@@ -243,11 +245,8 @@ stages:
       - ShellCommand:
           name: Copy bootstrap configuration file in bootstrap node
           command: >
-            ssh -F bootstrap_ssh_config bootstrap
-            sudo mkdir -p /etc/metalk8s &&
-            scp -F bootstrap_ssh_config bootstrap.yaml bootstrap: &&
-            ssh -F bootstrap_ssh_config bootstrap
-            sudo mv bootstrap.yaml /etc/metalk8s
+            scp -F bootstrap_ssh_config bootstrap-config.sh bootstrap: &&
+            ssh -F bootstrap_ssh_config bootstrap sudo bash bootstrap-config.sh
           workdir: build/eve/workers/openstack-multiple-nodes/terraform/
           haltOnFailure: true
       - ShellCommand:

--- a/eve/workers/openstack-multiple-nodes/terraform/bootstrap-config.sh
+++ b/eve/workers/openstack-multiple-nodes/terraform/bootstrap-config.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -xue -o pipefail
+
+OUTPUT_FILE="/etc/metalk8s/bootstrap.yaml"
+
+mkdir -p "$(dirname $OUTPUT_FILE)"
+
+cat > "$OUTPUT_FILE" << EOF
+apiVersion: metalk8s.scality.com/v1alpha2
+kind: BootstrapConfiguration
+networks:
+  controlPlane: 192.168.42.0/24
+  workloadPlane: 192.168.42.0/24
+ca:
+  minion: $(hostname)
+EOF
+
+ls "$(dirname $OUTPUT_FILE)"
+cat "$OUTPUT_FILE"

--- a/eve/workers/openstack-multiple-nodes/terraform/bootstrap.yaml
+++ b/eve/workers/openstack-multiple-nodes/terraform/bootstrap.yaml
@@ -1,5 +1,0 @@
-apiVersion: metalk8s.scality.com/v1alpha1
-kind: BootstrapConfiguration
-networks:
-  controlPlane: 192.168.42.0/24
-  workloadPlane: 192.168.42.0/24

--- a/salt/_pillar/metalk8s.py
+++ b/salt/_pillar/metalk8s.py
@@ -18,7 +18,7 @@ def _load_config(path):
     with salt.utils.files.fopen(path, 'rb') as fd:
         config = salt.utils.yaml.safe_load(fd)
 
-    assert config.get('apiVersion') == 'metalk8s.scality.com/v1alpha1'
+    assert config.get('apiVersion') == 'metalk8s.scality.com/v1alpha2'
     assert config.get('kind') == 'BootstrapConfiguration'
 
     return config
@@ -61,10 +61,24 @@ def _get_labels(config="/etc/kubernetes/admin.conf",
     return labels
 
 
+def _load_ca(config_data):
+    assert 'ca' in config_data
+
+    ca_data = config_data['ca']
+    assert 'minion' in ca_data
+
+    return {
+        'minion': ca_data['minion'],
+    }
+
+
 def ext_pillar(minion_id, pillar, bootstrap_config):
     config = _load_config(bootstrap_config)
 
     return {
         'networks': _load_networks(config),
-        'k8s_labels': _get_labels()
+        'k8s_labels': _get_labels(),
+        'metalk8s': {
+            'ca': _load_ca(config),
+        },
     }

--- a/salt/metalk8s/calico/configured.sls
+++ b/salt/metalk8s/calico/configured.sls
@@ -1,17 +1,13 @@
 {%- from "metalk8s/map.jinja" import kube_api with context %}
 {%- from "metalk8s/map.jinja" import defaults with context %}
 
-{%- set ca_server = salt['mine.get']('*', 'kubernetes_ca_server').keys() %}
-
-{%- if ca_server %}
-
 include:
   - metalk8s.kubeadm.init.certs.installed
 
 Create kubeconf file for calico:
   metalk8s_kubeconfig.managed:
     - name: /etc/kubernetes/calico.conf
-    - ca_server: {{ ca_server[0] }}
+    - ca_server: {{ pillar['metalk8s']['ca']['minion'] }}
     - signing_policy: {{ kube_api.cert.client_signing_policy }}
     - client_cert_info:
         CN: {{ salt['network.get_hostname']() }}
@@ -52,10 +48,3 @@ Create CNI calico configuration file:
               portMappings: true
     - require:
       - metalk8s_kubeconfig: Create kubeconf file for calico
-
-{%- else %}
-
-Unable to generate calico kubeconf file, no CA server available:
-  test.fail_without_changes: []
-
-{%- endif %}

--- a/salt/metalk8s/kubeadm/init/certs/apiserver-etcd-client.sls
+++ b/salt/metalk8s/kubeadm/init/certs/apiserver-etcd-client.sls
@@ -1,8 +1,5 @@
 {%- from "metalk8s/map.jinja" import etcd with context %}
 
-{%- set etcd_ca_server = salt['mine.get']('*', 'kubernetes_etcd_ca_b64').keys() %}
-{%- if etcd_ca_server %}
-
 include:
   - .installed
 
@@ -23,7 +20,7 @@ Generate apiserver etcd client certificate:
   x509.certificate_managed:
     - name: /etc/kubernetes/pki/apiserver-etcd-client.crt
     - public_key: /etc/kubernetes/pki/apiserver-etcd-client.key
-    - ca_server: {{ etcd_ca_server[0] }}
+    - ca_server: {{ pillar['metalk8s']['ca']['minion'] }}
     - signing_policy: {{ etcd.cert.apiserver_client_signing_policy }}
     - CN: kube-apiserver-etcd-client
     - O: "system:masters"
@@ -34,10 +31,3 @@ Generate apiserver etcd client certificate:
     - dir_mode: 755
     - require:
       - x509: Create apiserver etcd client private key
-
-{%- else %}
-
-Unable to generate apiserver etcd client certificate, no CA server available:
-  test.fail_without_changes: []
-
-{%- endif %}

--- a/salt/metalk8s/kubeadm/init/certs/apiserver-kubelet-client.sls
+++ b/salt/metalk8s/kubeadm/init/certs/apiserver-kubelet-client.sls
@@ -1,8 +1,5 @@
 {%- from "metalk8s/map.jinja" import kube_api with context %}
 
-{%- set ca_server = salt['mine.get']('*', 'kubernetes_ca_server').keys() %}
-{%- if ca_server %}
-
 include:
   - .installed
 
@@ -23,7 +20,7 @@ Generate kube-apiserver kubelet client certificate:
   x509.certificate_managed:
     - name: /etc/kubernetes/pki/apiserver-kubelet-client.crt
     - public_key: /etc/kubernetes/pki/apiserver-kubelet-client.key
-    - ca_server: {{ ca_server[0] }}
+    - ca_server: {{ pillar['metalk8s']['ca']['minion'] }}
     - signing_policy: {{ kube_api.cert.client_signing_policy }}
     - CN: kube-apiserver-kubelet-client
     - O: "system:masters"
@@ -34,10 +31,3 @@ Generate kube-apiserver kubelet client certificate:
     - dir_mode: 755
     - require:
       - x509: Create kube-apiserver kubelet client private key
-
-{%- else %}
-
-Unable to generate kube-apiserver kubelet client certificate, no CA Server available:
-  test.fail_without_changes: []
-
-{%- endif %}

--- a/salt/metalk8s/kubeadm/init/certs/apiserver.sls
+++ b/salt/metalk8s/kubeadm/init/certs/apiserver.sls
@@ -1,9 +1,6 @@
 {%- from "metalk8s/map.jinja" import kube_api with context %}
 {%- from "metalk8s/map.jinja" import networks with context %}
 
-{%- set ca_server = salt['mine.get']('*', 'kubernetes_ca_server').keys() %}
-{%- if ca_server %}
-
 include:
   - .installed
 
@@ -24,7 +21,7 @@ Generate kube-apiserver certificate:
   x509.certificate_managed:
     - name: /etc/kubernetes/pki/apiserver.crt
     - public_key: /etc/kubernetes/pki/apiserver.key
-    - ca_server: {{ ca_server[0] }}
+    - ca_server: {{ pillar['metalk8s']['ca']['minion'] }}
     - signing_policy: {{ kube_api.cert.server_signing_policy }}
     - CN: kube-apiserver
     - subjectAltName: "DNS:{{ grains['fqdn'] }}, DNS:kubernetes, DNS:kubernetes.default, DNS:kubernetes.default.svc, DNS:kubernetes.default.svc.cluster.local, IP:{{ kube_api.service_ip }}, IP:{{ salt['network.ip_addrs'](cidr=networks.control_plane) | join(', IP:') }}"
@@ -35,10 +32,3 @@ Generate kube-apiserver certificate:
     - dir_mode: 755
     - require:
       - x509: Create kube-apiserver private key
-
-{%- else %}
-
-Unable to generate kube-apiserver certificate, no CA Server available:
-  test.fail_without_changes: []
-
-{%- endif %}

--- a/salt/metalk8s/kubeadm/init/certs/ca.sls
+++ b/salt/metalk8s/kubeadm/init/certs/ca.sls
@@ -1,10 +1,5 @@
 {%- from "metalk8s/map.jinja" import ca with context %}
 
-{%- set ca_server = salt['mine.get']('*', 'kubernetes_ca_server') %}
-
-{#- Check if we have no CA server or only current minion as CA #}
-{%- if not ca_server or ca_server.keys() == [grains['id']] %}
-
 include:
   - .installed
   - metalk8s.salt.minion.running
@@ -38,8 +33,7 @@ Generate CA certificate:
     - require:
       - x509: Create CA private key
 
-# TODO: Find a better way to advetise CA server
-Advertise CA in the mine:
+Advertise CA certificate in the mine:
   module.wait:
     - mine.send:
       - func: 'kubernetes_ca_server'
@@ -75,10 +69,3 @@ Create CA salt signing_policies:
             - days_valid: {{ ca.signing_policy.days_valid }}
     - watch_in:
       - cmd: Restart salt-minion
-
-{%- else %}
-
-{{ ca_server.keys()|join(', ') }} already configured as Kubernetes CA server, only one can be declared:
-  test.fail_without_changes: []
-
-{%- endif %}

--- a/salt/metalk8s/kubeadm/init/certs/etcd-ca.sls
+++ b/salt/metalk8s/kubeadm/init/certs/etcd-ca.sls
@@ -1,10 +1,5 @@
 {%- from "metalk8s/map.jinja" import etcd with context %}
 
-{%- set etcd_ca_server = salt['mine.get']('*', 'kubernetes_etcd_ca_b64') %}
-
-{#- Check if we have no etcd CA server or if it is the current minion #}
-{%- if not etcd_ca_server or etcd_ca_server.keys() == [grains['id']] %}
-
 include:
   - .installed
   - metalk8s.salt.minion.running
@@ -38,8 +33,7 @@ Generate etcd CA certificate:
     - require:
       - x509: Create etcd CA private key
 
-# TODO: Find a better way to advertise CA server
-Advertise etcd CA in the mine:
+Advertise etcd CA certificate in the mine:
   module.wait:
     - mine.send:
       - func: kubernetes_etcd_ca_b64
@@ -75,10 +69,3 @@ Create etcd CA salt signing policies:
             - days_valid: {{ etcd.ca.signing_policy.days_valid }}
     - watch_in:
       - cmd: Restart salt-minion
-
-{%- else %}
-
-{{ etcd_ca_server.keys()|join(', ') }} already configured as Kubernetes etcd CA server, only one can be declared:
-  test.fail_without_changes: []
-
-{%- endif %}

--- a/salt/metalk8s/kubeadm/init/certs/etcd-deploy-ca-cert.sls
+++ b/salt/metalk8s/kubeadm/init/certs/etcd-deploy-ca-cert.sls
@@ -1,8 +1,6 @@
-{%- set etcd_ca_server = salt['mine.get']('*', 'kubernetes_etcd_ca_b64') %}
+{%- set etcd_ca_server = salt['mine.get'](pillar['metalk8s']['ca']['minion'], 'kubernetes_etcd_ca_b64') %}
 
-{%- if etcd_ca_server %}
-
-{%- set etcd_ca_b64 = etcd_ca_server.values()[0] %}
+{%- set etcd_ca_b64 = etcd_ca_server[pillar['metalk8s']['ca']['minion']] %}
 {%- set etcd_ca = salt['hashutil.base64_b64decode'](etcd_ca_b64) %}
 
 Ensure etcd CA cert is present:
@@ -14,5 +12,3 @@ Ensure etcd CA cert is present:
     - makedirs: True
     - dir_mode: 755
     - contents: {{ etcd_ca.splitlines() }}
-
-{%- endif %}

--- a/salt/metalk8s/kubeadm/init/certs/etcd-healthcheck-client.sls
+++ b/salt/metalk8s/kubeadm/init/certs/etcd-healthcheck-client.sls
@@ -1,8 +1,5 @@
 {%- from "metalk8s/map.jinja" import etcd with context %}
 
-{%- set etcd_ca_server = salt['mine.get']('*', 'kubernetes_etcd_ca_b64').keys() %}
-{%- if etcd_ca_server %}
-
 include:
   - .installed
 
@@ -23,7 +20,7 @@ Generate etcd healthcheck client certificate:
   x509.certificate_managed:
     - name: /etc/kubernetes/pki/etcd/healthcheck-client.crt
     - public_key: /etc/kubernetes/pki/etcd/healthcheck-client.key
-    - ca_server: {{ etcd_ca_server[0] }}
+    - ca_server: {{ pillar['metalk8s']['ca']['minion'] }}
     - signing_policy: {{ etcd.cert.healthcheck_client_signing_policy }}
     - CN: kube-etcd-healthcheck-client
     - O: "system:masters"
@@ -34,10 +31,3 @@ Generate etcd healthcheck client certificate:
     - dir_mode: 755
     - require:
       - x509: Create etcd healthcheck client private key
-
-{%- else %}
-
-Unable to generate etcd healthcheck client certificate, no CA server available:
-  test.fail_without_changes: []
-
-{%- endif %}

--- a/salt/metalk8s/kubeadm/init/certs/etcd-peer.sls
+++ b/salt/metalk8s/kubeadm/init/certs/etcd-peer.sls
@@ -1,9 +1,6 @@
 {%- from "metalk8s/map.jinja" import etcd with context %}
 {%- from "metalk8s/map.jinja" import networks with context %}
 
-{%- set etcd_ca_server = salt['mine.get']('*', 'kubernetes_etcd_ca_b64').keys() %}
-{%- if etcd_ca_server %}
-
 include:
   - .installed
 
@@ -24,7 +21,7 @@ Generate etcd peer certificate:
   x509.certificate_managed:
     - name: /etc/kubernetes/pki/etcd/peer.crt
     - public_key: /etc/kubernetes/pki/etcd/peer.key
-    - ca_server: {{ etcd_ca_server[0] }}
+    - ca_server: {{ pillar['metalk8s']['ca']['minion'] }}
     - signing_policy: {{ etcd.cert.peer_signing_policy }}
     - CN: "{{ grains['fqdn'] }}"
     - subjectAltName: "DNS:{{ grains['fqdn'] }}, DNS:localhost, IP:{{ salt['network.ip_addrs'](cidr=networks.control_plane) | join(', IP:') }}, IP:127.0.0.1"
@@ -35,10 +32,3 @@ Generate etcd peer certificate:
     - dir_mode: 755
     - require:
       - x509: Create etcd peer private key
-
-{%- else %}
-
-Unable to generate etcd peer certificate, no CA server available:
-  test.fail_without_changes: []
-
-{%- endif %}

--- a/salt/metalk8s/kubeadm/init/certs/etcd-server.sls
+++ b/salt/metalk8s/kubeadm/init/certs/etcd-server.sls
@@ -1,9 +1,6 @@
 {%- from "metalk8s/map.jinja" import etcd with context %}
 {%- from "metalk8s/map.jinja" import networks with context %}
 
-{%- set etcd_ca_server = salt['mine.get']('*', 'kubernetes_etcd_ca_b64').keys() %}
-{%- if etcd_ca_server %}
-
 include:
   - .installed
 
@@ -24,7 +21,7 @@ Generate etcd server certificate:
   x509.certificate_managed:
     - name: /etc/kubernetes/pki/etcd/server.crt
     - public_key: /etc/kubernetes/pki/etcd/server.key
-    - ca_server: {{ etcd_ca_server[0] }}
+    - ca_server: {{ pillar['metalk8s']['ca']['minion'] }}
     - signing_policy: {{ etcd.cert.server_signing_policy }}
     - CN: "{{ grains['fqdn'] }}"
     - subjectAltName: "DNS:{{ grains['fqdn'] }}, DNS:localhost, IP:{{ salt['network.ip_addrs'](cidr=networks.control_plane) | join(', IP:') }}, IP:127.0.0.1"
@@ -35,10 +32,3 @@ Generate etcd server certificate:
     - dir_mode: 755
     - require:
       - x509: Create etcd server private key
-
-{%- else %}
-
-Unable to generate etcd server certificate, no CA server available:
-  test.fail_without_changes: []
-
-{%- endif %}

--- a/salt/metalk8s/kubeadm/init/certs/front-proxy-ca.sls
+++ b/salt/metalk8s/kubeadm/init/certs/front-proxy-ca.sls
@@ -1,10 +1,5 @@
 {%- from "metalk8s/map.jinja" import front_proxy with context %}
 
-{%- set front_proxy_ca_server = salt['mine.get']('*', 'kubernetes_front_proxy_ca_b64') %}
-
-{#- Check if we have no CA server or only current minion as CA #}
-{%- if not front_proxy_ca_server or front_proxy_ca_server.keys() == [grains['id']] %}
-
 include:
   - .installed
   - metalk8s.salt.minion.running
@@ -38,8 +33,7 @@ Generate front proxy CA certificate:
     - require:
       - x509: Create front proxy CA private key
 
-# TODO: Find a better way to advertise CA server
-Advertise front proxy CA in the mine:
+Advertise front proxy CA certificate in the mine:
   module.wait:
     - mine.send:
       - func: kubernetes_front_proxy_ca_b64
@@ -68,10 +62,3 @@ Create front proxy CA salt signing policies:
             - days_valid: {{ front_proxy.ca.signing_policy.days_valid }}
     - watch_in:
       - cmd: Restart salt-minion
-
-{%- else %}
-
-{{ front_proxy_ca_server.keys()|join(', ') }} already configured as Kubernetes front proxy CA server, only one can be declared:
-  test.fail_without_changes: []
-
-{%- endif %}

--- a/salt/metalk8s/kubeadm/init/certs/front-proxy-client.sls
+++ b/salt/metalk8s/kubeadm/init/certs/front-proxy-client.sls
@@ -1,8 +1,5 @@
 {%- from "metalk8s/map.jinja" import front_proxy with context %}
 
-{%- set front_proxy_ca_server = salt['mine.get']('*', 'kubernetes_front_proxy_ca_b64').keys() %}
-{%- if front_proxy_ca_server %}
-
 include:
   - .installed
 
@@ -23,7 +20,7 @@ Generate front proxy client certificate:
   x509.certificate_managed:
     - name: /etc/kubernetes/pki/front-proxy-client.crt
     - public_key: /etc/kubernetes/pki/front-proxy-client.key
-    - ca_server: {{ front_proxy_ca_server[0] }}
+    - ca_server: {{ pillar['metalk8s']['ca']['minion'] }}
     - signing_policy: {{ front_proxy.cert.client_signing_policy }}
     - CN: front-proxy-client
     - user: root
@@ -33,10 +30,3 @@ Generate front proxy client certificate:
     - dir_mode: 755
     - require:
       - x509: Create front proxy client private key
-
-{%- else %}
-
-Unable to generate front proxy client certificate, no CA server available:
-  test.fail_without_changes: []
-
-{%- endif %}

--- a/salt/metalk8s/kubeadm/init/certs/front-proxy-deploy-ca-cert.sls
+++ b/salt/metalk8s/kubeadm/init/certs/front-proxy-deploy-ca-cert.sls
@@ -1,8 +1,6 @@
-{%- set front_proxy_ca_server = salt['mine.get']('*', 'kubernetes_front_proxy_ca_b64') %}
+{%- set front_proxy_ca_server = salt['mine.get'](pillar['metalk8s']['ca']['minion'], 'kubernetes_front_proxy_ca_b64') %}
 
-{%- if front_proxy_ca_server %}
-
-{%- set ca_cert_b64 = front_proxy_ca_server.values()[0] %}
+{%- set ca_cert_b64 = front_proxy_ca_server[pillar['metalk8s']['ca']['minion']] %}
 {%- set ca_cert = salt['hashutil.base64_b64decode'](ca_cert_b64) %}
 
 Ensure front-proxy CA cert is present:
@@ -14,5 +12,3 @@ Ensure front-proxy CA cert is present:
     - makedirs: True
     - dir_mode: 755
     - contents: {{ ca_cert.splitlines() }}
-
-{%- endif %}

--- a/salt/metalk8s/kubeadm/init/certs/sa-deploy-pub-key.sls
+++ b/salt/metalk8s/kubeadm/init/certs/sa-deploy-pub-key.sls
@@ -1,8 +1,6 @@
-{%- set sa_pub_key_server = salt['mine.get']('*', 'kubernetes_sa_pub_key_b64') %}
+{%- set sa_pub_key_server = salt['mine.get'](pillar['metalk8s']['ca']['minion'], 'kubernetes_sa_pub_key_b64') %}
 
-{%- if sa_pub_key_server %}
-
-{%- set sa_pub_key_b64 = sa_pub_key_server.values()[0] %}
+{%- set sa_pub_key_b64 = sa_pub_key_server[pillar['metalk8s']['ca']['minion']] %}
 {%- set sa_pub_key = salt['hashutil.base64_b64decode'](sa_pub_key_b64) %}
 
 Ensure SA pub key is present:
@@ -14,5 +12,3 @@ Ensure SA pub key is present:
     - makedirs: True
     - dir_mode: 755
     - contents: {{ sa_pub_key.splitlines() }}
-
-{%- endif %}

--- a/salt/metalk8s/kubeadm/init/etcd/local.sls
+++ b/salt/metalk8s/kubeadm/init/etcd/local.sls
@@ -10,7 +10,7 @@
 
 {% set endpoint  = host_name ~ '=https://' ~ host ~ ':2380' %}
 
-{%- set ca_cert = salt['mine.get']('*', 'kubernetes_etcd_ca_b64').values()[0] %}
+{%- set ca_cert = salt['mine.get'](pillar['metalk8s']['ca']['minion'], 'kubernetes_etcd_ca_b64')[pillar['metalk8s']['ca']['minion']] %}
 {%- set ca_cert_b64 = salt['hashutil.base64_b64decode'](ca_cert) %}
 
 {#- Get the list of existing etcd node. #}

--- a/salt/metalk8s/kubeadm/init/kubeconfig/kubelet.sls
+++ b/salt/metalk8s/kubeadm/init/kubeconfig/kubelet.sls
@@ -2,7 +2,7 @@
 
 {%- set hostname = salt.network.get_hostname() %}
 
-{%- set ca_cert_b64 = salt['mine.get']('*', 'kubernetes_ca_server').values()[0] %}
+{%- set ca_cert_b64 = salt['mine.get'](pillar['metalk8s']['ca']['minion'], 'kubernetes_ca_server')[pillar['metalk8s']['ca']['minion']] %}
 {%- set ca_cert = salt['hashutil.base64_b64decode'](ca_cert_b64) %}
 
 {%- set cert_info = {'CN': 'system:node:' ~ hostname, 'O': 'system:nodes'} %}


### PR DESCRIPTION
Add a new field in the `BootstrapConfiguration` to specify the Salt
minion to use as a CA server, instead of mine-based guesswork.

Also remove the checks for 'existing CAs', which don't really make
sense: in a way, multiple servers may be in a CA 'state', as long as
only one of them (in our case, the one from the configuration) is being
used.

Over time, we could implement an orchestration playbook to 'migrate' a
CA from one node to another.

Fixes: #632
See: https://github.com/scality/metalk8s/issues/632