### PR TITLE
salt: ensure that Salt IDs match k8s IDs

### DIFF
--- a/salt/metalk8s/salt/minion/configured.sls
+++ b/salt/metalk8s/salt/minion/configured.sls
@@ -16,5 +16,6 @@ Configure salt minion:
     - backup: false
     - defaults:
       master_hostname: {{ defaults.salt.master.host }}
+      minion_id: {{ grains.id }}
     - watch_in:
       - cmd: Restart salt-minion

--- a/salt/metalk8s/salt/minion/files/minion_99-metalk8s.conf.j2
+++ b/salt/metalk8s/salt/minion/files/minion_99-metalk8s.conf.j2
@@ -1,4 +1,5 @@
 master: {{ master_hostname }}
+id: {{ minion_id }}
 
 retry_dns_count: 5
 


### PR DESCRIPTION
How to test:
- follow the [procedure](https://docs.google.com/document/d/1GAMbSTIFhCypBUITg_SunCOeoMdbEfBK_XZZJIw3Wdw/edit) up to the step 6 (deploying a salt minion)
- connect to the new node (`vagrant ssh node1`)
- check the content of `/etc/salt/minion.d/99-metalk8s.conf`: it should contains an `id` that match the node name

(You can also check the value on the bootstrap node).