### PR TITLE
Improvement/remove error message while waiting for running container

### DIFF
--- a/salt/metalk8s/repo/deployed.sls
+++ b/salt/metalk8s/repo/deployed.sls
@@ -41,11 +41,9 @@ Install package repositories manifest:
       - file: Generate package repositories nginx configuration
 
 Ensure package repositories container is up:
-  cmd.run:
-    - name: "[[ -n $(crictl ps --state RUNNING --label io.kubernetes.container.name='{{ package_repositories_name }}' -q) ]]"
-    - retry:
-        attempts: 10
-        interval: 3
-        until: True
+  module.wait:
+    - cri.wait_container:
+      - name: {{ package_repositories_name }}
+      - state: running
     - require:
       - file: Install package repositories manifest

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -122,6 +122,9 @@ install_salt_minion() {
 }
 
 configure_salt_minion_local_mode() {
+    "$SALT_CALL" --file-root=/srv/scality/metalk8s-@@VERSION/salt \
+        --local --retcode-passthrough saltutil.sync_all
+
     cat > "${SALT_MINION_FILE_CLIENT_LOCAL_CONF}" << EOF
 file_roots:
   metalk8s-@@VERSION:
@@ -139,9 +142,6 @@ ext_pillar:
 
 retry_dns_count: 3
 EOF
-
-  "$SALT_CALL" --local --retcode-passthrough saltutil.sync_all \
-      saltenv=metalk8s-@@VERSION
 }
 
 set_salt_command() {


### PR DESCRIPTION
Little clean-up of errors dropped by salt when running bootstrap.

Test: Run the bootstrap

Expected result: bootstrap run successfully and the should not see the 2 following errors:
```
bootstrap: [CRITICAL] Specified ext_pillar interface metalk8s is unavailable
```
and
```
bootstrap: [ERROR   ] Command '[[ -n $(crictl ps --state RUNNING --label io.kubernetes.container.name='package-repositories' -q) ]]' failed with return code: 1
    bootstrap: [ERROR   ] retcode: 1
    bootstrap: [ERROR   ] {u'pid': 10983, u'retcode': 1, u'stderr': u'', u'stdout': u''}
    bootstrap: [ERROR   ] Command '[[ -n $(crictl ps --state RUNNING --label io.kubernetes.container.name='package-repositories' -q) ]]' failed with return code: 1
    bootstrap: [ERROR   ] retcode: 1
    bootstrap: [ERROR   ] {u'pid': 11114, u'retcode': 1, u'stderr': u'', u'stdout': u''}
```
