### PR TITLE
salt: restart kubelet on kubelet.conf modification

### DIFF
--- a/salt/metalk8s/kubeadm/init/kubeconfig/kubelet.sls
+++ b/salt/metalk8s/kubeadm/init/kubeconfig/kubelet.sls
@@ -42,3 +42,4 @@ Restart kubelet:
     - watch:
       - file: Configure kubelet service
       - file: Ensure CA cert is present
+      - metalk8s_kubeconfig: Create kubeconf file for kubelet


### PR DESCRIPTION
Even though `Configure kubelet service` requires `Create kubeconf file
for kubelet` and `Restart kubelet` watches `Configure kubelet service`,
we still need to explicitly watch for `Create kubeconf file for kubelet`
in case `Configure kubelet service` changes nothing (but `Create
kubeconf file for kubelet` does).

Closes: #765
Signed-off-by: Sylvain Laperche <sylvain.laperche@scality.com>