### PR TITLE
Branding - Theme ConfigMap

### DIFF
--- a/salt/metalk8s/ui/deployed.sls
+++ b/salt/metalk8s/ui/deployed.sls
@@ -46,5 +46,7 @@ Create metalk8s-ui ConfigMap:
     - data:
         config.json: |
           {"url": "https://{{ control_plane_ip }}:6443"}
+        theme.json: |
+          {"brand": {"primary": "#21157A"}}
   require:
     - pkg: Install Python Kubernetes client

--- a/ui/conf/nginx.conf
+++ b/ui/conf/nginx.conf
@@ -15,8 +15,8 @@ server {
     }
 
     location ~ /brand/(.+) {
-        alias /usr/share/nginx/html;
-        try_files /override-brand/$1 /brand/$1 =404;
+        alias /;
+        try_files /etc/metalk8s/ui/$1 /usr/share/nginx/html/brand/$1 =404;
     }   
 }
 


### PR DESCRIPTION
-Add theme.json in the config map and update nginx conf to use it in order to overrride the theme of the application.
PS: We will develop a tool to allow users to mount branding images in the target folder

How to test:
-Checkout and build the branch
-Launch the UI
-Login
-Check the response of /theme.json that contains ``` {"brand": {"primary": "#21157A"}}``` and the primary color of the layout is "#21157A" 