### PR TITLE
Remove unneeded mount for Docker-in-Docker sidecar

### DIFF
--- a/eve/workers/pod-builder/pod.yaml
+++ b/eve/workers/pod-builder/pod.yaml
@@ -34,12 +34,8 @@ spec:
       securityContext:
         privileged: true
       volumeMounts:
-        - name: docker-storage
-          mountPath: /var/lib/docker
         - name: worker-workspace
           mountPath: /home/eve/workspace
   volumes:
-    - name: docker-storage
-      emptyDir: {}
     - name: worker-workspace
       emptyDir: {}


### PR DESCRIPTION
There is no need to mount /var/lib/docker as a volume, the Docker socket
is exposed through the network, using the DOCKER_HOST environment
variable.

Fixes GH-964.