### PR TITLE
Use vagrant snapshots to shorten dev env launching.

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -43,6 +43,7 @@ Available options are:
   repository)
 - `VAGRANT_PROVIDER`: type of machine to spawn with Vagrant
 - `VAGRANT_UP_ARGS`: command line arguments to pass to `vagrant up`
+- `VAGRANT_SNAPSHOT_NAME`: name of auto generated Vagrant snapshot
 - `DOCKER_BIN`: Docker binary (name or path to the binary)
 - `GIT_BIN`: Git binary (name or path to the binary)
 - `MKISOFS_BIN`: mkisofs binary (name or path to the binary)

--- a/buildchain/buildchain/config.py
+++ b/buildchain/buildchain/config.py
@@ -37,6 +37,8 @@ _DEFAULT_VAGRANT_UP_ARGS : str = ' '.join((
     '--provider', VAGRANT_PROVIDER
 ))
 
+VAGRANT_SNAPSHOT_NAME: str = 'bootstrap.autosnapshot'
+
 VAGRANT_UP_ARGS : Tuple[str, ...] = tuple(shlex.split(
     os.getenv('VAGRANT_UP_ARGS', _DEFAULT_VAGRANT_UP_ARGS)
 ))

--- a/buildchain/buildchain/vagrant.py
+++ b/buildchain/buildchain/vagrant.py
@@ -19,7 +19,6 @@ from buildchain import constants
 from buildchain import types
 from buildchain import utils
 
-
 def task__vagrantkey() -> types.TaskDict:
     """Generate a SSH key pair in the .vagrant folder."""
     def mkdir_dot_vagrant() -> None:
@@ -40,16 +39,57 @@ def task__vagrantkey() -> types.TaskDict:
         'uptodate': [True],
     }
 
-def task_vagrantup() -> types.TaskDict:
-    """Run `vagrant up` to (re-)provision a development environment."""
-    vagrant = [config.VAGRANT, 'up']
-    vagrant.extend(map(shlex.quote, config.VAGRANT_UP_ARGS))
+def task__vagrant_up_noprov() -> types.TaskDict:
+    """Run `vagrant up` without provisioning a development environment."""
+    cmd = [config.VAGRANT, 'up']
+    cmd.extend(map(shlex.quote, config.VAGRANT_UP_ARGS))
+    cmd.append('--no-provision')
+
     return {
-        'actions': [doit.tools.LongRunning(' '.join(vagrant))],
-        'file_dep': [constants.VAGRANT_SSH_KEY_PAIR],
-        'task_dep': ['populate_iso'],
+        'actions': [doit.tools.LongRunning(' '.join(cmd))],
+        'file_dep': [],
+        'task_dep': [],
         'uptodate': [False],
     }
 
+def task__vagrant_snapshot() -> types.TaskDict:
+    """Snapshot development environment."""
+    vagranthalt = [config.VAGRANT, 'halt', 'bootstrap']
+    vagrantsnap = [config.VAGRANT, 'snapshot', 'save', '--force', 'bootstrap',
+        config.VAGRANT_SNAPSHOT_NAME]
+
+    return {
+        'actions': [vagranthalt, vagrantsnap],
+        'task_dep': ['_vagrant_up_noprov'],
+        'uptodate': [doit.tools.run_once],
+        'verbosity': 2
+    }
+
+def task_vagrant_restore() -> types.TaskDict:
+    """Restore development environment snapshot."""
+    cmd = [config.VAGRANT, 'snapshot', 'restore', 'bootstrap',
+        config.VAGRANT_SNAPSHOT_NAME]
+
+    return {
+        'actions': [cmd],
+        'uptodate': [False],
+        'verbosity': 2
+    }
+
+def task_vagrant_up() -> types.TaskDict:
+    """Run `vagrant up` to (re-)provision a development environment."""
+    vagrantup = [config.VAGRANT, 'up']
+    vagrantup.extend(map(shlex.quote, config.VAGRANT_UP_ARGS))
+
+    vagrantdestroy = [config.VAGRANT, 'destroy', '--force']
+
+    return {
+        'actions': [doit.tools.LongRunning(' '.join(vagrantup))],
+        'file_dep': [constants.VAGRANT_SSH_KEY_PAIR],
+        'task_dep': ['populate_iso', '_vagrant_snapshot'],
+        'uptodate': [False],
+        'clean': [vagrantdestroy],
+        'verbosity': 2
+    }
 
 __all__ = utils.export_only_tasks(__name__)


### PR DESCRIPTION
Use vagrant snapshots to shorten dev env launching.
    
Automatically makes a snapshot after the first `doit vagrant_up` is made
(VM created and Virtualbox Guest Additions installed). Then you can use:
* `doit vagrant_restore` to restore snapshot.
* `doit vagrant_restore vagrant_up` to restore snapshot and re-provision VM.
* `doit clean vagrant_up` to destroy all vagrant environment (aka: `vagrant destroy --force`) and clean up project.
    
Note: `vagrantup` task renamed `vagrant_up` for consistency.
    
Fixes: #880