### PR TITLE
Improvement/896 add pillar for bootstrap services ip

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -209,6 +209,7 @@ SALT_FILES : Tuple[Union[Path, targets.FileTarget], ...] = (
     Path('salt/metalk8s/repo/init.sls'),
     Path('salt/metalk8s/repo/offline.sls'),
     Path('salt/metalk8s/repo/online.sls'),
+    Path('salt/metalk8s/repo/service_deployed.sls'),
 
     Path('salt/metalk8s/runc/init.sls'),
     Path('salt/metalk8s/runc/installed.sls'),

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -115,6 +115,7 @@ SALT_FILES : Tuple[Union[Path, targets.FileTarget], ...] = (
     Path('salt/metalk8s/bootstrap/preflight.sls'),
     Path('salt/metalk8s/bootstrap/registry.sls'),
     Path('salt/metalk8s/bootstrap/salt_master.sls'),
+    Path('salt/metalk8s/bootstrap/services.sls'),
 
     Path('salt/metalk8s/calico/configured.sls'),
     Path('salt/metalk8s/calico/deployed.sls'),
@@ -221,6 +222,7 @@ SALT_FILES : Tuple[Union[Path, targets.FileTarget], ...] = (
     Path('salt/metalk8s/salt/master/files/salt-master-pod.yaml.j2'),
     Path('salt/metalk8s/salt/master/configured.sls'),
     Path('salt/metalk8s/salt/master/deployed.sls'),
+    Path('salt/metalk8s/salt/master/service_deployed.sls'),
     Path('salt/metalk8s/salt/master/init.sls'),
     Path('salt/metalk8s/salt/master/accept_keys.sls'),
 

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -216,6 +216,7 @@ SALT_FILES : Tuple[Union[Path, targets.FileTarget], ...] = (
     Path('salt/metalk8s/registry/init.sls'),
     Path('salt/metalk8s/registry/macro.sls'),
     Path('salt/metalk8s/registry/populated.sls'),
+    Path('salt/metalk8s/registry/service_deployed.sls'),
     Path('salt/metalk8s/registry/files/registry-pod.yaml.j2'),
 
     Path('salt/metalk8s/salt/master/files/master_99-metalk8s.conf.j2'),

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -243,6 +243,7 @@ SALT_FILES : Tuple[Union[Path, targets.FileTarget], ...] = (
     Path('salt/_modules/metalk8s.py'),
 
     Path('salt/_pillar/metalk8s.py'),
+    Path('salt/_pillar/metalk8s_endpoints.py'),
     Path('salt/_pillar/metalk8s_nodes.py'),
 
     Path('salt/_roster/kubernetes_nodes.py'),

--- a/salt/_modules/metalk8s_kubernetes.py
+++ b/salt/_modules/metalk8s_kubernetes.py
@@ -639,6 +639,34 @@ def show_service(name, namespace='default', **kwargs):
         _cleanup(**cfg)
 
 
+def show_endpoint(name, namespace='default', **kwargs):
+    '''
+    Return the kubernetes endpoint defined by name and namespace
+
+    CLI Examples::
+
+        salt '*' kubernetes.show_endpoint my-nginx default
+        salt '*' kubernetes.show_endpoint name=my-nginx namespace=default
+    '''
+    cfg = _setup_conn(**kwargs)
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.read_namespaced_endpoints(name, namespace)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'CoreV1Api->read_namespaced_endpoints'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
 def show_pod(name, namespace='default', **kwargs):
     '''
     Return POD information for a given pod name defined in the namespace

--- a/salt/_modules/metalk8s_kubernetes.py
+++ b/salt/_modules/metalk8s_kubernetes.py
@@ -212,14 +212,14 @@ def _setup_conn(**kwargs):
     '''
     kubeconfig = kwargs.get('kubeconfig') or __salt__['config.option']('kubernetes.kubeconfig')
     kubeconfig_data = kwargs.get('kubeconfig_data') or __salt__['config.option']('kubernetes.kubeconfig-data')
-    context = kwargs.get('context') or __salt__['config.option']('kubernetes.context')
+    context = kwargs.get('context') or __salt__['config.option']('kubernetes.context') or None
 
     if (kubeconfig_data and not kubeconfig) or (kubeconfig_data and kwargs.get('kubeconfig_data')):
         with tempfile.NamedTemporaryFile(prefix='salt-kubeconfig-', delete=False) as kcfg:
             kcfg.write(base64.b64decode(kubeconfig_data))
             kubeconfig = kcfg.name
 
-    if not (kubeconfig and context):
+    if not kubeconfig:
         if kwargs.get('api_url') or __salt__['config.option']('kubernetes.api_url'):
             salt.utils.versions.warn_until('Sodium',
                     'Kubernetes configuration via url, certificate, username and password will be removed in Sodiom. '
@@ -229,7 +229,7 @@ def _setup_conn(**kwargs):
             except Exception:
                 raise CommandExecutionError('Old style kubernetes configuration is only supported up to python-kubernetes 2.0.0')
         else:
-            raise CommandExecutionError('Invalid kubernetes configuration. Parameter \'kubeconfig\' and \'context\' are required.')
+            raise CommandExecutionError('Invalid kubernetes configuration. Parameter \'kubeconfig\' is required.')
     kubernetes.config.load_kube_config(config_file=kubeconfig, context=context)
 
     # The return makes unit testing easier

--- a/salt/_pillar/metalk8s.py
+++ b/salt/_pillar/metalk8s.py
@@ -1,4 +1,5 @@
 import logging
+
 import salt.utils.files
 import salt.utils.yaml
 

--- a/salt/_pillar/metalk8s_endpoints.py
+++ b/salt/_pillar/metalk8s_endpoints.py
@@ -1,0 +1,66 @@
+"""Store data about bootstrap services ip/port in pillar"""
+
+import logging
+import os.path
+
+
+log = logging.getLogger(__name__)
+
+__virtualname__ = 'metalk8s_endpoints'
+
+
+def __virtual__():
+    if 'metalk8s_kubernetes.show_endpoint' not in __salt__:
+        return False, 'Missing metalk8s_kubernetes module'
+    else:
+        return __virtualname__
+
+
+def service_endpoints(service, kubeconfig):
+    try:
+        endpoint = __salt__['metalk8s_kubernetes.show_endpoint'](
+            name=service,
+            namespace="kube-system",
+            kubeconfig=kubeconfig,
+        )
+
+        # Extract hostname, ip and node_name
+        res = {
+            k: v
+            for k, v in endpoint['subsets'][0]['addresses'][0].items()
+            if k in ['hostname', 'ip', 'node_name']
+        }
+
+        # Add ports info to res dict
+        ports = {
+            port['name']: port['port']
+            for port in endpoint['subsets'][0]['ports']
+        }
+        res['ports'] = ports
+    except Exception as exc:  # pylint: disable=broad-except
+        log.exception(
+            'Unable to get kubernetes endpoints for %s:\n%s', service, exc
+        )
+        return {}
+    else:
+        return res
+
+
+def ext_pillar(minion_id, pillar, kubeconfig):
+    endpoints = {}
+
+    if not os.path.isfile(kubeconfig):
+        log.warning(
+            '%s: kubeconfig not found at %s', __virtualname__, kubeconfig)
+        return endpoints
+
+    for service in ['salt-master', 'registry', 'package-repositories']:
+        endpoints.update({
+            service: service_endpoints(service, kubeconfig)
+        })
+
+    return {
+        'metalk8s': {
+            'endpoints': endpoints,
+        },
+    }

--- a/salt/metalk8s/bootstrap/services.sls
+++ b/salt/metalk8s/bootstrap/services.sls
@@ -1,2 +1,3 @@
 include:
   - metalk8s.salt.master.service_deployed
+  - metalk8s.registry.service_deployed

--- a/salt/metalk8s/bootstrap/services.sls
+++ b/salt/metalk8s/bootstrap/services.sls
@@ -1,0 +1,2 @@
+include:
+  - metalk8s.salt.master.service_deployed

--- a/salt/metalk8s/bootstrap/services.sls
+++ b/salt/metalk8s/bootstrap/services.sls
@@ -1,3 +1,4 @@
 include:
   - metalk8s.salt.master.service_deployed
   - metalk8s.registry.service_deployed
+  - metalk8s.repo.service_deployed

--- a/salt/metalk8s/orchestrate/bootstrap_with_master.sls
+++ b/salt/metalk8s/orchestrate/bootstrap_with_master.sls
@@ -27,6 +27,15 @@ Bootstrap control plane:
     - pillar:
         registry_ip: {{ pillar.get('registry_ip') }}
 
+Bootstrap services:
+  salt.state:
+    - tgt: {{ pillar['bootstrap_id'] }}
+    - saltenv: {{ saltenv }}
+    - sls:
+      - metalk8s.bootstrap.services
+    - require:
+      - salt: Bootstrap control plane
+
 Bootstrap node:
   salt.state:
     - tgt: {{ pillar['bootstrap_id'] }}

--- a/salt/metalk8s/registry/service_deployed.sls
+++ b/salt/metalk8s/registry/service_deployed.sls
@@ -1,0 +1,30 @@
+{% set kubeconfig = "/etc/kubernetes/admin.conf" %}
+{% set context = "kubernetes-admin@kubernetes" %}
+
+
+Deploy registry service object:
+  metalk8s_kubernetes.service_present:
+    - name: registry
+    - kubeconfig: {{ kubeconfig }}
+    - context: {{ context }}
+    - namespace: kube-system
+    - metadata:
+        namespace: kube-system
+        labels:
+          app: registry
+          app.kubernetes.io/name: registry
+          app.kubernetes.io/component: registry
+          heritage: metalk8s
+          app.kubernetes.io/part-of: metalk8s
+          app.kubernetes.io/managed-by: salt
+    - spec:
+        clusterIP: None
+        ports:
+        - name: registry
+          port: 5000
+          protocol: TCP
+          targetPort: registry
+        selector:
+          app.kubernetes.io/component: registry
+          app.kubernetes.io/name: registry
+        type: ClusterIP

--- a/salt/metalk8s/repo/service_deployed.sls
+++ b/salt/metalk8s/repo/service_deployed.sls
@@ -1,0 +1,30 @@
+{%- from "metalk8s/map.jinja" import repo with context %}
+
+{% set kubeconfig = "/etc/kubernetes/admin.conf" %}
+{% set context = "kubernetes-admin@kubernetes" %}
+
+
+Deploy repo service object:
+  metalk8s_kubernetes.service_present:
+    - name: package-repositories
+    - kubeconfig: {{ kubeconfig }}
+    - context: {{ context }}
+    - namespace: kube-system
+    - metadata:
+        namespace: kube-system
+        labels:
+          app: package-repositories
+          app.kubernetes.io/name: package-repositories
+          heritage: metalk8s
+          app.kubernetes.io/part-of: metalk8s
+          app.kubernetes.io/managed-by: salt
+    - spec:
+        clusterIP: None
+        ports:
+        - name: http
+          port: {{ repo.port }}
+          protocol: TCP
+          targetPort: http
+        selector:
+          app.kubernetes.io/name: package-repositories
+        type: ClusterIP

--- a/salt/metalk8s/salt/master/files/master_99-metalk8s.conf.j2
+++ b/salt/metalk8s/salt/master/files/master_99-metalk8s.conf.j2
@@ -4,6 +4,7 @@ peer:
 
 ext_pillar:
   - metalk8s: /etc/metalk8s/bootstrap.yaml
+  - metalk8s_endpoints: /etc/kubernetes/admin.conf
   - metalk8s_nodes: /etc/kubernetes/admin.conf
 
 roster_defaults:

--- a/salt/metalk8s/salt/master/service_deployed.sls
+++ b/salt/metalk8s/salt/master/service_deployed.sls
@@ -1,0 +1,38 @@
+{% set kubeconfig = "/etc/kubernetes/admin.conf" %}
+{% set context = "kubernetes-admin@kubernetes" %}
+
+
+Install and start salt master service manifest:
+  metalk8s_kubernetes.service_present:
+    - name: salt-master
+    - kubeconfig: {{ kubeconfig }}
+    - context: {{ context }}
+    - namespace: kube-system
+    - metadata:
+        namespace: kube-system
+        labels:
+          app: salt-master
+          app.kubernetes.io/name: salt-master
+          app.kubernetes.io/component: salt
+          heritage: metalk8s
+          app.kubernetes.io/part-of: metalk8s
+          app.kubernetes.io/managed-by: salt
+    - spec:
+        clusterIP: None
+        ports:
+        - name: publisher
+          port: 4505
+          protocol: TCP
+          targetPort: publisher
+        - name: requestserver
+          port: 4506
+          protocol: TCP
+          targetPort: requestserver
+        - name: api
+          port: 4507
+          protocol: TCP
+          targetPort: api
+        selector:
+          app.kubernetes.io/component: salt
+          app.kubernetes.io/name: salt-master
+        type: ClusterIP


### PR DESCRIPTION
The goal of this PR is to create a pillar named `endpoints` that will contain the IP of pods, running on the bootstrap.
To perform that, we create a service that map to these pods, and we get the pods IP from the endpoints object created with the service.

To test: run the bootstrap, an then query the pillar `metalk8s:endpoints`
```
# crictl exec -ti $(crictl ps | awk '/salt-master/{print $1}') salt "bootstrap" pillar.get metalk8s:endpoints saltenv=metalk8s-2.0
bootstrap:
    ----------
    package-repositories:
        ----------
        hostname:
            None
        ip:
            172.21.254.3
        node_name:
            bootstrap
        ports:
            ----------
            http:
                8080
    registry:
        ----------
        hostname:
            None
        ip:
            172.21.254.3
        node_name:
            bootstrap
        ports:
            ----------
            registry:
                5000
    salt-master:
        ----------
        hostname:
            None
        ip:
            172.21.254.3
        node_name:
            bootstrap
        ports:
            ----------
            api:
                4507
            publisher:
                4505
            requestserver:
                4506

```