### PR TITLE
Node Management: Salt API integration

### DIFF
--- a/salt/metalk8s/ui/deployed.sls
+++ b/salt/metalk8s/ui/deployed.sls
@@ -45,7 +45,7 @@ Create metalk8s-ui ConfigMap:
     - context: {{ context }} 
     - data:
         config.json: |
-          {"url": "https://{{ control_plane_ip }}:6443"}
+          {"url": "https://{{ control_plane_ip }}:6443", "url_salt": "http://{{ control_plane_ip }}:4507"}
         theme.json: |
           {"brand": {"primary": "#21157A"}}
   require:

--- a/ui/public/config.json
+++ b/ui/public/config.json
@@ -1,3 +1,4 @@
 {
-    "url": "https://localhost:8080"
+    "url": "https://localhost:8080",
+    "salt_url": "http://localhost:8081"
 }

--- a/ui/public/config.json
+++ b/ui/public/config.json
@@ -1,4 +1,4 @@
 {
-    "url": "https://localhost:8080",
-    "salt_url": "http://localhost:8081"
+    "url": "https://172.21.254.13:6443", 
+    "url_salt": "http://172.21.254.13:4507"
 }

--- a/ui/src/containers/NodeCreateForm.js
+++ b/ui/src/containers/NodeCreateForm.js
@@ -21,6 +21,7 @@ const CreateNodeLayout = styled.div`
   padding: ${padding.larger};
   form {
     width: 450px;
+    padding: 0 ${padding.larger};
   }
 `;
 
@@ -222,7 +223,7 @@ class NodeCreateForm extends React.Component {
                   label={intl.messages.workload_plane}
                   checked={values.workload_plane}
                   value={values.workload_plane}
-                  disabled
+                  onChange={handleChange}
                 />
                 <TextInput
                   type="checkbox"

--- a/ui/src/containers/NodeCreateForm.js
+++ b/ui/src/containers/NodeCreateForm.js
@@ -160,9 +160,7 @@ const initialValues = {
 };
 
 const validationSchema = Yup.object().shape({
-  name: Yup.string()
-    .min(1)
-    .required(),
+  name: Yup.string().required(),
   ssh_user: Yup.string().required(),
   hostName_ip: Yup.string().required(),
   ssh_port: Yup.string().required(),

--- a/ui/src/containers/NodeList.js
+++ b/ui/src/containers/NodeList.js
@@ -8,6 +8,9 @@ import { injectIntl, FormattedDate, FormattedTime } from 'react-intl';
 import { Table, Button } from 'core-ui';
 import { padding } from 'core-ui/dist/style/theme';
 
+import { fetchNodesAction } from '../ducks/app/nodes';
+import { authenticateSaltApiAction } from '../ducks/login';
+
 const PageContainer = styled.div`
   display: flex;
   flex-direction: column;
@@ -90,6 +93,13 @@ class NodeList extends React.Component {
     return sortedList;
   });
 
+  testSaltApi() {
+    this.props.authenticateSalt({
+      username: 'admin',
+      password: 'admin'
+    });
+  }
+
   render() {
     const { intl } = this.props;
 
@@ -128,6 +138,7 @@ class NodeList extends React.Component {
             text={intl.messages.create_new_node}
             onClick={() => this.props.history.push('/nodes/create')}
           />
+          <Button text={'test'} onClick={() => this.testSaltApi()} />
         </ActionContainer>
         <TableContainer>
           <Table
@@ -162,4 +173,18 @@ function mapStateToProps(state) {
   };
 }
 
-export default injectIntl(withRouter(connect(mapStateToProps)(NodeList)));
+const mapDispatchToProps = dispatch => {
+  return {
+    fetchNodes: () => dispatch(fetchNodesAction()),
+    authenticateSalt: payload => dispatch(authenticateSaltApiAction(payload))
+  };
+};
+
+export default injectIntl(
+  withRouter(
+    connect(
+      mapStateToProps,
+      mapDispatchToProps
+    )(NodeList)
+  )
+);

--- a/ui/src/containers/NodeList.js
+++ b/ui/src/containers/NodeList.js
@@ -111,11 +111,15 @@ class NodeList extends React.Component {
 
     const nodesSortedListWithRoles = nodesSortedList.map(node => {
       let roles = [];
-      if (node.control_plane) {
-        roles.push(intl.messages.control_plane);
-      }
-      if (node.workload_plane) {
-        roles.push(intl.messages.workload_plane);
+      if (node.bootstrap) {
+        roles.push(intl.messages.bootstrap);
+      } else {
+        if (node.control_plane) {
+          roles.push(intl.messages.control_plane);
+        }
+        if (node.workload_plane) {
+          roles.push(intl.messages.workload_plane);
+        }
       }
       node.roles = roles.join(' / ');
 

--- a/ui/src/containers/NodeList.js
+++ b/ui/src/containers/NodeList.js
@@ -105,13 +105,12 @@ class NodeList extends React.Component {
       let roles = [];
       if (node.bootstrap) {
         roles.push(intl.messages.bootstrap);
-      } else {
-        if (node.control_plane) {
-          roles.push(intl.messages.control_plane);
-        }
-        if (node.workload_plane) {
-          roles.push(intl.messages.workload_plane);
-        }
+      }
+      if (node.control_plane) {
+        roles.push(intl.messages.control_plane);
+      }
+      if (node.workload_plane) {
+        roles.push(intl.messages.workload_plane);
       }
       node.roles = roles.join(' / ');
 

--- a/ui/src/containers/NodeList.js
+++ b/ui/src/containers/NodeList.js
@@ -9,7 +9,6 @@ import { Table, Button } from 'core-ui';
 import { padding } from 'core-ui/dist/style/theme';
 
 import { fetchNodesAction, deployNodeAction } from '../ducks/app/nodes';
-import { authenticateSaltApiAction } from '../ducks/login';
 
 const PageContainer = styled.div`
   display: flex;
@@ -93,13 +92,6 @@ class NodeList extends React.Component {
     return sortedList;
   });
 
-  testSaltApi() {
-    this.props.authenticateSalt({
-      username: 'admin',
-      password: 'admin'
-    });
-  }
-
   render() {
     const { intl } = this.props;
 
@@ -157,7 +149,6 @@ class NodeList extends React.Component {
             text={intl.messages.create_new_node}
             onClick={() => this.props.history.push('/nodes/create')}
           />
-          <Button text={'test'} onClick={() => this.testSaltApi()} />
         </ActionContainer>
         <TableContainer>
           <Table
@@ -195,8 +186,7 @@ function mapStateToProps(state) {
 const mapDispatchToProps = dispatch => {
   return {
     fetchNodes: () => dispatch(fetchNodesAction()),
-    deployNode: payload => dispatch(deployNodeAction(payload)),
-    authenticateSalt: payload => dispatch(authenticateSaltApiAction(payload))
+    deployNode: payload => dispatch(deployNodeAction(payload))
   };
 };
 

--- a/ui/src/containers/NodeList.js
+++ b/ui/src/containers/NodeList.js
@@ -8,7 +8,7 @@ import { injectIntl, FormattedDate, FormattedTime } from 'react-intl';
 import { Table, Button } from 'core-ui';
 import { padding } from 'core-ui/dist/style/theme';
 
-import { fetchNodesAction } from '../ducks/app/nodes';
+import { fetchNodesAction, deployNodeAction } from '../ducks/app/nodes';
 import { authenticateSaltApiAction } from '../ducks/login';
 
 const PageContainer = styled.div`
@@ -135,6 +135,21 @@ class NodeList extends React.Component {
       return node;
     });
 
+    const nodesWithActions = nodesSortedListWithRoles.map(node => {
+      return {
+        ...node,
+        actions:
+          !node.status || node.status === 'Unknown'
+            ? [
+                {
+                  label: this.props.intl.messages.deploy,
+                  onClick: this.props.deployNode
+                }
+              ]
+            : null
+      };
+    });
+
     return (
       <PageContainer>
         <ActionContainer>
@@ -146,7 +161,7 @@ class NodeList extends React.Component {
         </ActionContainer>
         <TableContainer>
           <Table
-            list={nodesSortedListWithRoles}
+            list={nodesWithActions}
             columns={this.state.columns}
             disableHeader={false}
             headerHeight={40}
@@ -180,6 +195,7 @@ function mapStateToProps(state) {
 const mapDispatchToProps = dispatch => {
   return {
     fetchNodes: () => dispatch(fetchNodesAction()),
+    deployNode: payload => dispatch(deployNodeAction(payload)),
     authenticateSalt: payload => dispatch(authenticateSaltApiAction(payload))
   };
 };

--- a/ui/src/ducks/app/nodes.js
+++ b/ui/src/ducks/app/nodes.js
@@ -68,16 +68,16 @@ export function* fetchNodes() {
             cpu: node.status.capacity && node.status.capacity.cpu,
             control_plane:
               node.metadata &&
-              node.metadata.annotations &&
-              node.metadata.annotations[
-                'metalk8s.scality.com/control-plane'
-              ] === 'true',
+              node.metadata.labels &&
+              node.metadata.labels[Api.ROLE_MASTER] !== undefined,
             workload_plane:
               node.metadata &&
-              node.metadata.annotations &&
-              node.metadata.annotations[
-                'metalk8s.scality.com/workload-plane'
-              ] === 'true',
+              node.metadata.labels &&
+              node.metadata.labels[Api.ROLE_NODE] !== undefined,
+            bootstrap:
+              node.metadata &&
+              node.metadata.labels &&
+              node.metadata.labels[Api.ROLE_BOOTSTRAP] !== undefined,
             memory:
               node.status.capacity &&
               prettifyBytes(

--- a/ui/src/ducks/app/nodes.js
+++ b/ui/src/ducks/app/nodes.js
@@ -16,6 +16,14 @@ const defaultState = {
   list: []
 };
 
+const isRolePresentInLabels = (node, role) => {
+  return (
+    node.metadata &&
+    node.metadata.labels &&
+    node.metadata.labels[role] !== undefined
+  );
+};
+
 export default function reducer(state = defaultState, action = {}) {
   switch (action.type) {
     case SET_NODES:
@@ -71,18 +79,9 @@ export function* fetchNodes() {
             name: node.metadata.name,
             statusType: statusType,
             cpu: node.status.capacity && node.status.capacity.cpu,
-            control_plane:
-              node.metadata &&
-              node.metadata.labels &&
-              node.metadata.labels[Api.ROLE_MASTER] !== undefined,
-            workload_plane:
-              node.metadata &&
-              node.metadata.labels &&
-              node.metadata.labels[Api.ROLE_NODE] !== undefined,
-            bootstrap:
-              node.metadata &&
-              node.metadata.labels &&
-              node.metadata.labels[Api.ROLE_BOOTSTRAP] !== undefined,
+            control_plane: isRolePresentInLabels(node, Api.ROLE_MASTER),
+            workload_plane: isRolePresentInLabels(node, Api.ROLE_NODE),
+            bootstrap: isRolePresentInLabels(node, Api.ROLE_BOOTSTRAP),
             memory:
               node.status.capacity &&
               prettifyBytes(

--- a/ui/src/ducks/app/nodes.js
+++ b/ui/src/ducks/app/nodes.js
@@ -1,4 +1,4 @@
-import { call, put, takeLatest, takeEvery } from 'redux-saga/effects';
+import { call, put, takeLatest, takeEvery, select } from 'redux-saga/effects';
 import * as Api from '../../services/api';
 import { convertK8sMemoryToBytes, prettifyBytes } from '../../services/utils';
 import history from '../../history';
@@ -9,6 +9,7 @@ export const SET_NODES = 'SET_NODES';
 const CREATE_NODE = 'CREATE_NODE';
 export const CREATE_NODE_FAILED = 'CREATE_NODE_FAILED';
 const CLEAR_CREATE_NODE_ERROR = 'CLEAR_CREATE_NODE_ERROR';
+const DEPLOY_NODE = 'DEPLOY_NODE';
 
 // Reducer
 const defaultState = {
@@ -49,6 +50,10 @@ export const createNodeAction = payload => {
 
 export const clearCreateNodeErrorAction = () => {
   return { type: CLEAR_CREATE_NODE_ERROR };
+};
+
+export const deployNodeAction = payload => {
+  return { type: DEPLOY_NODE, payload };
 };
 
 // Sagas
@@ -106,7 +111,22 @@ export function* createNode({ payload }) {
   }
 }
 
+export function* deployNode({ payload }) {
+  const salt = yield select(state => state.login.salt);
+  const api = yield select(state => state.config.api);
+  const result = yield call(
+    Api.deployNode,
+    api.url_salt,
+    salt.data.return[0].token,
+    payload.name
+  );
+  if (!result.error) {
+    alert('PING SALT OK');
+  }
+}
+
 export function* nodesSaga() {
   yield takeLatest(FETCH_NODES, fetchNodes);
   yield takeEvery(CREATE_NODE, createNode);
+  yield takeEvery(DEPLOY_NODE, deployNode);
 }

--- a/ui/src/ducks/app/nodes.js
+++ b/ui/src/ducks/app/nodes.js
@@ -121,7 +121,7 @@ export function* deployNode({ payload }) {
     payload.name
   );
   if (!result.error) {
-    alert('PING SALT OK');
+    alert(JSON.stringify(result.data.return[0].data.bootstrap_master));
   }
 }
 

--- a/ui/src/ducks/app/nodes.test.js
+++ b/ui/src/ducks/app/nodes.test.js
@@ -3,7 +3,7 @@ import { fetchNodes, createNode, SET_NODES, CREATE_NODE_FAILED } from './nodes';
 import * as Api from '../../services/api';
 import history from '../../history';
 
-it('update the nodes state when fetchNodes', () => {
+it('update the control plane nodes state when fetchNodes', () => {
   const gen = fetchNodes();
 
   expect(gen.next().value).toEqual(call(Api.getNodes));
@@ -22,10 +22,87 @@ it('update the nodes state when fetchNodes', () => {
               'metalk8s.scality.com/ssh-key-path':
                 '/etc/metalk8s/pki/preshared_key_for_k8s_nodes',
               'metalk8s.scality.com/ssh-sudo': 'true'
+            },
+            labels: {
+              'node-role.kubernetes.io/etcd': '',
+              'node-role.kubernetes.io/master': ''
             }
           },
-          label: {
-            'node-role.kubernetes.io/bootstrap': ''
+          status: {
+            capacity: {
+              cpu: '2',
+              memory: '1000ki'
+            },
+            conditions: [
+              {
+                type: 'Ready',
+                status: 'True'
+              }
+            ]
+          },
+          spec: {
+            taints: [
+              {
+                key: 'node-role.kubernetes.io/master',
+                effect: 'NoSchedule'
+              },
+              {
+                key: 'node-role.kubernetes.io/etcd',
+                effect: 'NoSchedule'
+              }
+            ]
+          }
+        }
+      ]
+    }
+  };
+
+  const nodes = [
+    {
+      name: 'boostrap',
+      cpu: '2',
+      memory: '1000 KiB',
+      creationDate: '2019-29-03',
+      workload_plane: false,
+      control_plane: true,
+      bootstrap: false,
+      statusType: {
+        status: 'True',
+        type: 'Ready'
+      }
+    }
+  ];
+
+  expect(gen.next(result).value).toEqual(
+    put({ type: SET_NODES, payload: nodes })
+  );
+});
+
+it('update the bootstrap nodes state when fetchNodes', () => {
+  const gen = fetchNodes();
+
+  expect(gen.next().value).toEqual(call(Api.getNodes));
+
+  const result = {
+    body: {
+      items: [
+        {
+          metadata: {
+            name: 'boostrap',
+            creationTimestamp: '2019-29-03',
+            annotations: {
+              'metalk8s.scality.com/ssh-user': 'vagrant',
+              'metalk8s.scality.com/ssh-port': '22',
+              'metalk8s.scality.com/ssh-host': '172.21.254.7',
+              'metalk8s.scality.com/ssh-key-path':
+                '/etc/metalk8s/pki/preshared_key_for_k8s_nodes',
+              'metalk8s.scality.com/ssh-sudo': 'true'
+            },
+            labels: {
+              'node-role.kubernetes.io/bootstrap': '',
+              'node-role.kubernetes.io/etcd': '',
+              'node-role.kubernetes.io/master': ''
+            }
           },
           status: {
             capacity: {
@@ -50,13 +127,139 @@ it('update the nodes state when fetchNodes', () => {
       cpu: '2',
       memory: '1000 KiB',
       creationDate: '2019-29-03',
-      control_plane: false,
-      bootstrap: '',
+      workload_plane: false,
+      control_plane: true,
+      bootstrap: true,
       statusType: {
         status: 'True',
         type: 'Ready'
-      },
-      workload_plane: true
+      }
+    }
+  ];
+
+  expect(gen.next(result).value).toEqual(
+    put({ type: SET_NODES, payload: nodes })
+  );
+});
+
+it('update the workload plane nodes state when fetchNodes', () => {
+  const gen = fetchNodes();
+
+  expect(gen.next().value).toEqual(call(Api.getNodes));
+
+  const result = {
+    body: {
+      items: [
+        {
+          metadata: {
+            name: 'boostrap',
+            creationTimestamp: '2019-29-03',
+            annotations: {
+              'metalk8s.scality.com/ssh-user': 'vagrant',
+              'metalk8s.scality.com/ssh-port': '22',
+              'metalk8s.scality.com/ssh-host': '172.21.254.7',
+              'metalk8s.scality.com/ssh-key-path':
+                '/etc/metalk8s/pki/preshared_key_for_k8s_nodes',
+              'metalk8s.scality.com/ssh-sudo': 'true'
+            },
+            labels: {
+              'node-role.kubernetes.io/node': ''
+            }
+          },
+          status: {
+            capacity: {
+              cpu: '2',
+              memory: '1000ki'
+            },
+            conditions: [
+              {
+                type: 'Ready',
+                status: 'True'
+              }
+            ]
+          }
+        }
+      ]
+    }
+  };
+
+  const nodes = [
+    {
+      name: 'boostrap',
+      cpu: '2',
+      memory: '1000 KiB',
+      creationDate: '2019-29-03',
+      workload_plane: true,
+      control_plane: false,
+      bootstrap: false,
+      statusType: {
+        status: 'True',
+        type: 'Ready'
+      }
+    }
+  ];
+
+  expect(gen.next(result).value).toEqual(
+    put({ type: SET_NODES, payload: nodes })
+  );
+});
+
+it('update the control plane/workload plane nodes state when fetchNodes', () => {
+  const gen = fetchNodes();
+
+  expect(gen.next().value).toEqual(call(Api.getNodes));
+
+  const result = {
+    body: {
+      items: [
+        {
+          metadata: {
+            name: 'boostrap',
+            creationTimestamp: '2019-29-03',
+            annotations: {
+              'metalk8s.scality.com/ssh-user': 'vagrant',
+              'metalk8s.scality.com/ssh-port': '22',
+              'metalk8s.scality.com/ssh-host': '172.21.254.7',
+              'metalk8s.scality.com/ssh-key-path':
+                '/etc/metalk8s/pki/preshared_key_for_k8s_nodes',
+              'metalk8s.scality.com/ssh-sudo': 'true'
+            },
+            labels: {
+              'node-role.kubernetes.io/node': '',
+              'node-role.kubernetes.io/etcd': '',
+              'node-role.kubernetes.io/master': ''
+            }
+          },
+          status: {
+            capacity: {
+              cpu: '2',
+              memory: '1000ki'
+            },
+            conditions: [
+              {
+                type: 'Ready',
+                status: 'True'
+              }
+            ]
+          }
+        }
+      ]
+    }
+  };
+
+  const nodes = [
+    {
+      name: 'boostrap',
+      cpu: '2',
+      memory: '1000 KiB',
+      creationDate: '2019-29-03',
+      workload_plane: true,
+      control_plane: true,
+      bootstrap: false,
+      statusType: {
+        status: 'True',
+        type: 'Ready'
+      }
     }
   ];
 

--- a/ui/src/ducks/app/nodes.test.js
+++ b/ui/src/ducks/app/nodes.test.js
@@ -21,10 +21,11 @@ it('update the nodes state when fetchNodes', () => {
               'metalk8s.scality.com/ssh-host': '172.21.254.7',
               'metalk8s.scality.com/ssh-key-path':
                 '/etc/metalk8s/pki/preshared_key_for_k8s_nodes',
-              'metalk8s.scality.com/ssh-sudo': 'true',
-              'metalk8s.scality.com/workload-plane': 'true',
-              'metalk8s.scality.com/control-plane:': 'true'
+              'metalk8s.scality.com/ssh-sudo': 'true'
             }
+          },
+          label: {
+            'node-role.kubernetes.io/bootstrap': ''
           },
           status: {
             capacity: {
@@ -50,6 +51,7 @@ it('update the nodes state when fetchNodes', () => {
       memory: '1000 KiB',
       creationDate: '2019-29-03',
       control_plane: false,
+      bootstrap: '',
       statusType: {
         status: 'True',
         type: 'Ready'

--- a/ui/src/ducks/login.js
+++ b/ui/src/ducks/login.js
@@ -11,6 +11,7 @@ export const FETCH_USER_INFO = 'FETCH_USER_INFO';
 export const SET_USER_INFO_LOADED = 'SET_USER_INFO_LOADED';
 
 export const HASH_KEY = 'token';
+const AUTHENTICATE_SALT = 'AUTHENTICATE_SALT';
 
 // Reducer
 const defaultState = {
@@ -66,6 +67,10 @@ export const setAuthenticationSuccessAction = payload => {
   };
 };
 
+export const authenticateSaltApiAction = payload => {
+  return { type: AUTHENTICATE_SALT, payload };
+};
+
 // Sagas
 export function* authenticate({ payload }) {
   const { username, password } = payload;
@@ -90,6 +95,17 @@ export function* authenticate({ payload }) {
     yield call(history.push, '/');
   }
   yield put(setUserInfoLoadedAction(true));
+}
+
+function* authenticateSaltApi({ payload }) {
+  console.log('payload', payload);
+  const { username, password } = payload;
+  const token = btoa(username + ':' + password); //base64Encode
+  console.log('token', token);
+  const saltApi = yield select(state => state.config.api); // change a bit
+  const result = yield call(Api.authenticateSaltApi, token, saltApi);
+
+  console.log('authenticateSaltApi Saga', result);
 }
 
 export function* logout() {
@@ -124,4 +140,5 @@ export function* authenticateSaga() {
   yield takeEvery(AUTHENTICATE, authenticate);
   yield takeEvery(LOGOUT, logout);
   yield takeEvery(FETCH_USER_INFO, fetchUserInfo);
+  yield takeEvery(AUTHENTICATE_SALT, authenticateSaltApi);
 }

--- a/ui/src/ducks/login.js
+++ b/ui/src/ducks/login.js
@@ -106,7 +106,7 @@ export function* authenticate({ payload }) {
   yield put(setUserInfoLoadedAction(true));
 }
 
-function* authenticateSaltApi() {
+export function* authenticateSaltApi() {
   const api = yield select(state => state.config.api);
   const user = yield select(state => state.login.user);
   const result = yield call(Api.authenticateSaltApi, api.url_salt, user);

--- a/ui/src/ducks/login.js
+++ b/ui/src/ducks/login.js
@@ -6,6 +6,8 @@ import history from '../history';
 const AUTHENTICATE = 'AUTHENTICATE';
 export const AUTHENTICATION_SUCCESS = 'AUTHENTICATION_SUCCESS';
 export const AUTHENTICATION_FAILED = 'AUTHENTICATION_FAILED';
+export const SALT_AUTHENTICATION_SUCCESS = 'SALT_AUTHENTICATION_SUCCESS';
+export const SALT_AUTHENTICATION_FAILED = 'SALT_AUTHENTICATION_FAILED';
 const LOGOUT = 'LOGOUT';
 export const FETCH_USER_INFO = 'FETCH_USER_INFO';
 export const SET_USER_INFO_LOADED = 'SET_USER_INFO_LOADED';
@@ -26,6 +28,11 @@ export default function reducer(state = defaultState, action = {}) {
       return {
         ...state,
         user: action.payload
+      };
+    case SALT_AUTHENTICATION_SUCCESS:
+      return {
+        ...state,
+        salt: action.payload
       };
     case AUTHENTICATION_FAILED:
       return {
@@ -67,6 +74,13 @@ export const setAuthenticationSuccessAction = payload => {
   };
 };
 
+export const setSaltAuthenticationSuccessAction = payload => {
+  return {
+    type: SALT_AUTHENTICATION_SUCCESS,
+    payload
+  };
+};
+
 export const authenticateSaltApiAction = payload => {
   return { type: AUTHENTICATE_SALT, payload };
 };
@@ -98,14 +112,10 @@ export function* authenticate({ payload }) {
 }
 
 function* authenticateSaltApi({ payload }) {
-  console.log('payload', payload);
-  const { username, password } = payload;
-  const token = btoa(username + ':' + password); //base64Encode
-  console.log('token', token);
-  const saltApi = yield select(state => state.config.api); // change a bit
-  const result = yield call(Api.authenticateSaltApi, token, saltApi);
-
-  console.log('authenticateSaltApi Saga', result);
+  const api = yield select(state => state.config.api);
+  const user = yield select(state => state.login.user);
+  const result = yield call(Api.authenticateSaltApi, api.url_salt, user);
+  yield put(setSaltAuthenticationSuccessAction(result));
 }
 
 export function* logout() {

--- a/ui/src/ducks/login.test.js
+++ b/ui/src/ducks/login.test.js
@@ -6,7 +6,8 @@ import {
   AUTHENTICATION_FAILED,
   AUTHENTICATION_SUCCESS,
   SET_USER_INFO_LOADED,
-  fetchUserInfo
+  fetchUserInfo,
+  authenticateSaltApi
 } from './login';
 import * as Api from '../services/api';
 
@@ -54,6 +55,7 @@ it('authentication success', () => {
   const result = {
     data: {}
   };
+
   expect(gen.next(result).value).toEqual(
     put({
       type: AUTHENTICATION_SUCCESS,
@@ -65,7 +67,7 @@ it('authentication success', () => {
     })
   );
 
-  expect(gen.next().value).toEqual(call(history.push, '/'));
+  expect(gen.next().value).toEqual(call(authenticateSaltApi));
 
   expect(gen.next(result).value).toEqual(
     put({
@@ -97,6 +99,8 @@ it('fetchUserInfo success', () => {
       }
     })
   );
+
+  expect(gen.next().value).toEqual(call(authenticateSaltApi));
 
   expect(gen.next(result).value).toEqual(
     put({

--- a/ui/src/services/api.js
+++ b/ui/src/services/api.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { Config, Core_v1Api } from '@kubernetes/client-node';
 
-let config, coreV1;
+let config, coreV1, saltAPI;
 
 //Basic Auth
 export async function authenticate(token, api_server) {
@@ -22,6 +22,38 @@ export const updateApiServerConfig = (url, token) => {
   config = new Config(url, token, 'Basic');
   coreV1 = config.makeApiClient(Core_v1Api);
 };
+
+export async function authenticateSaltApi(token) {
+  // TODO
+
+  try {
+    // const response = await axios.get(api_server.url + '/api/v1', {
+    //   headers: {
+    //     Authorization: 'Basic ' + token
+    //   }
+    // });
+    // config = new Config(api_server.url, token, 'Basic');
+    // coreV1 = config.makeApiClient(Core_v1Api);
+
+    // const url = api_server.url;
+    // const token = '';
+
+    const response = await axios.post('http://172.21.254.14:4507/login', {
+      headers: {
+        Authorization: 'Basic ' + token
+      },
+      eauth: 'kubernetes_rbac',
+      username: 'admin',
+      token: token,
+      token_type: 'Basic'
+    });
+
+    return response;
+  } catch (error) {
+    return { error };
+  }
+  return true;
+}
 
 export async function getNodes() {
   try {

--- a/ui/src/services/api.js
+++ b/ui/src/services/api.js
@@ -1,6 +1,10 @@
 import axios from 'axios';
 import { Config, Core_v1Api } from '@kubernetes/client-node';
 
+const ROLE_MASTER = 'node-role.kubernetes.io/master';
+const ROLE_NODE = 'node-role.kubernetes.io/node';
+const ROLE_ETCD = 'node-role.kubernetes.io/etcd';
+
 let config, coreV1, saltAPI;
 
 //Basic Auth
@@ -91,17 +95,43 @@ export async function createNode(payload) {
   const body = {
     metadata: {
       name: payload.name,
+      labels: {
+        'metalk8s.scality.com/version': '2.0'
+      },
       annotations: {
         'metalk8s.scality.com/ssh-user': payload.ssh_user,
         'metalk8s.scality.com/ssh-port': payload.ssh_port,
         'metalk8s.scality.com/ssh-host': payload.hostName_ip,
         'metalk8s.scality.com/ssh-key-path': payload.ssh_key_path,
-        'metalk8s.scality.com/ssh-sudo': payload.sudo_required.toString(),
-        'metalk8s.scality.com/workload-plane': payload.workload_plane.toString(),
-        'metalk8s.scality.com/control-plane': payload.control_plane.toString()
+        'metalk8s.scality.com/ssh-sudo': payload.sudo_required.toString()
       }
+    },
+    spec: {
+      taints: []
     }
   };
+
+  if (payload.workload_plane && payload.control_plane) {
+    body.metadata.labels[ROLE_MASTER] = '';
+    body.metadata.labels[ROLE_NODE] = '';
+    body.metadata.labels[ROLE_ETCD] = '';
+  } else if (!payload.workload_plane && payload.control_plane) {
+    body.metadata.labels[ROLE_MASTER] = '';
+    body.metadata.labels[ROLE_ETCD] = '';
+
+    body.spec.taints = body.spec.taints.concat([
+      {
+        key: ROLE_MASTER,
+        effect: 'NoSchedule'
+      },
+      {
+        key: ROLE_ETCD,
+        effect: 'NoSchedule'
+      }
+    ]);
+  } else if (payload.workload_plane && !payload.control_plane) {
+    body.metadata.labels[ROLE_NODE] = '';
+  }
 
   try {
     return await coreV1.createNode(body);

--- a/ui/src/services/api.js
+++ b/ui/src/services/api.js
@@ -127,9 +127,14 @@ export async function deployNode(url, token, node) {
     return await axios.post(
       url,
       {
-        client: 'local',
-        tgt: node,
-        fun: 'test.ping'
+        client: 'runner',
+        fun: 'state.orch',
+        arg: ['metalk8s.orchestrate.deploy_salt_minion_on_new_node'],
+        kwarg: {
+          saltenv: 'metalk8s-2.0',
+          // FIXME We need to remove the hardcoded the boostrap id.
+          pillar: { bootstrap_id: 'boostrap', node_name: node }
+        }
       },
       {
         headers: { 'X-Auth-Token': token }

--- a/ui/src/services/api.js
+++ b/ui/src/services/api.js
@@ -1,9 +1,10 @@
 import axios from 'axios';
 import { Config, Core_v1Api } from '@kubernetes/client-node';
 
-const ROLE_MASTER = 'node-role.kubernetes.io/master';
-const ROLE_NODE = 'node-role.kubernetes.io/node';
-const ROLE_ETCD = 'node-role.kubernetes.io/etcd';
+export const ROLE_MASTER = 'node-role.kubernetes.io/master';
+export const ROLE_NODE = 'node-role.kubernetes.io/node';
+export const ROLE_ETCD = 'node-role.kubernetes.io/etcd';
+export const ROLE_BOOTSTRAP = 'node-role.kubernetes.io/bootstrap';
 
 let config, coreV1, saltAPI;
 

--- a/ui/src/services/api.js
+++ b/ui/src/services/api.js
@@ -6,7 +6,7 @@ export const ROLE_NODE = 'node-role.kubernetes.io/node';
 export const ROLE_ETCD = 'node-role.kubernetes.io/etcd';
 export const ROLE_BOOTSTRAP = 'node-role.kubernetes.io/bootstrap';
 
-let config, coreV1, saltAPI;
+let config, coreV1;
 
 //Basic Auth
 export async function authenticate(token, api_server) {
@@ -28,36 +28,17 @@ export const updateApiServerConfig = (url, token) => {
   coreV1 = config.makeApiClient(Core_v1Api);
 };
 
-export async function authenticateSaltApi(token) {
-  // TODO
-
+export async function authenticateSaltApi(url, user) {
   try {
-    // const response = await axios.get(api_server.url + '/api/v1', {
-    //   headers: {
-    //     Authorization: 'Basic ' + token
-    //   }
-    // });
-    // config = new Config(api_server.url, token, 'Basic');
-    // coreV1 = config.makeApiClient(Core_v1Api);
-
-    // const url = api_server.url;
-    // const token = '';
-
-    const response = await axios.post('http://172.21.254.14:4507/login', {
-      headers: {
-        Authorization: 'Basic ' + token
-      },
+    return await axios.post(url + '/login', {
       eauth: 'kubernetes_rbac',
-      username: 'admin',
-      token: token,
+      username: user.username,
+      token: user.token,
       token_type: 'Basic'
     });
-
-    return response;
   } catch (error) {
     return { error };
   }
-  return true;
 }
 
 export async function getNodes() {
@@ -136,6 +117,24 @@ export async function createNode(payload) {
 
   try {
     return await coreV1.createNode(body);
+  } catch (error) {
+    return { error };
+  }
+}
+
+export async function deployNode(url, token, node) {
+  try {
+    return await axios.post(
+      url,
+      {
+        client: 'local',
+        tgt: node,
+        fun: 'test.ping'
+      },
+      {
+        headers: { 'X-Auth-Token': token }
+      }
+    );
   } catch (error) {
     return { error };
   }

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -25,6 +25,7 @@
   "control_plane": "Control Plane" ,
   "bootstrap": "Bootstrap",
   "roles": "Roles",
+  "role_values_error": "At least on role has to be selected!",
   "create_new_node": "Create a New Node",
   "create": "Create",
   "cancel": "Cancel",

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -31,5 +31,6 @@
   "cancel": "Cancel",
   "unknown": "Unknown",
   "ready": "Ready",
-  "not_ready": "Not Ready"
+  "not_ready": "Not Ready",
+  "deploy": "Deploy"
 }

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -23,6 +23,7 @@
   "sudo_required": "Sudo required",
   "workload_plane": "Workload Plane",
   "control_plane": "Control Plane" ,
+  "bootstrap": "Bootstrap",
   "roles": "Roles",
   "create_new_node": "Create a New Node",
   "create": "Create",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -23,6 +23,7 @@
   "sudo_required": "Sudo requis",
   "workload_plane": "Workload Plane",
   "control_plane": "Control Plane" ,
+  "bootstrap": "Bootstrap",
   "roles": "Rôles",
   "create_new_node": "Créer un nouveau node",
   "create": "Créer",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -25,6 +25,7 @@
   "control_plane": "Control Plane" ,
   "bootstrap": "Bootstrap",
   "roles": "Rôles",
+  "role_values_error": "Au moins un rôle doit être selectionné!",
   "create_new_node": "Créer un nouveau node",
   "create": "Créer",
   "cancel": "Annuler",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -31,5 +31,6 @@
   "cancel": "Annuler",
   "unknown": "Inconnu",
   "ready": "Prêt",
-  "not_ready": "Pas prêt"
+  "not_ready": "Pas prêt",
+  "deploy": "Déployer"
 }


### PR DESCRIPTION
Scope:
- Salt api login management
- Call SALT API to deploy the first step "deploy salt minion"

How to test:
- Build and Launch the UI 
- Login
- Create a new node via the form
- once created, the node is added to the list. 
- click on the "Deploy" button of the node
- a popup should display the result of the deploy