### PR TITLE
salt: no need for `metalk8s.node` in pillar

### DIFF
--- a/salt/_pillar/metalk8s_nodes.py
+++ b/salt/_pillar/metalk8s_nodes.py
@@ -75,6 +75,5 @@ def ext_pillar(minion_id, pillar, kubeconfig):
     return {
         'metalk8s': {
             'nodes': pillar_nodes,
-            'node': pillar_nodes.get(minion_id, None),
         },
     }

--- a/salt/top.sls.in
+++ b/salt/top.sls.in
@@ -1,22 +1,51 @@
-metalk8s-@@VERSION:
-  'metalk8s:node:version:@@VERSION':
-    - match: pillar
-    - metalk8s.roles.minion
-  'I@metalk8s:node:version:@@VERSION and I@metalk8s:node:roles:bootstrap':
-    - match: compound
-    - metalk8s.roles.bootstrap
-    - metalk8s.roles.salt-master
-    - metalk8s.roles.registry
-    - metalk8s.roles.repository
-  'I@metalk8s:node:version:@@VERSION and I@metalk8s:node:roles:ca':
-    - match: compound
-    - metalk8s.roles.ca
-  'I@metalk8s:node:version:@@VERSION and I@metalk8s:node:roles:etcd':
-    - match: compound
-    - metalk8s.roles.etcd
-  'I@metalk8s:node:version:@@VERSION and I@metalk8s:node:roles:master':
-    - match: compound
-    - metalk8s.roles.master
-  'I@metalk8s:node:version:@@VERSION and I@metalk8s:node:roles:node':
-    - match: compound
-    - metalk8s.roles.node
+{%- set version = "@@VERSION" %}
+
+{%- set version_match = "metalk8s:nodes:" ~ grains['id'] ~ ":version:" ~ version %}
+
+{% macro role_match(name) -%}
+metalk8s:nodes:{{ grains['id'] }}:roles:{{ name }}
+{%- endmacro %}
+
+{% macro role(name='', states=[]) -%}
+{%- if name %}
+  'I@{{ version_match }} and I@{{ role_match(name) }}':
+{%- else %}
+  'I@{{ version_match }}':
+{%- endif %}
+    {{ ([{ "match": "compound" }] + states) | yaml }}
+{%- endmacro %}
+
+metalk8s-{{ version }}:
+  # 'Default' role applicable to all nodes
+  {{ role(states=[
+       'metalk8s.roles.minion',
+     ])
+  }}
+
+  {{ role('bootstrap', [
+       'metalk8s.roles.bootstrap',
+       'metalk8s.roles.salt-master',
+       'metalk8s.roles.registry',
+       'metalk8s.roles.repository',
+     ])
+  }}
+
+  {{ role('ca', [
+       'metalk8s.roles.ca',
+     ])
+  }}
+
+  {{ role('etcd', [
+       'metalk8s.roles.etcd',
+     ])
+  }}
+
+  {{ role('master', [
+       'metalk8s.roles.master',
+     ])
+  }}
+
+  {{ role('node', [
+       'metalk8s.roles.node',
+     ])
+  }}


### PR DESCRIPTION
Since the `top.sls` is calculated on the minion, we can use a minion's
grains in it. These grains contain the minion ID, which we can then use
to further dispatch on values in `metalk8s.nodes` as found in the
environment Pillar (populated from Kubernetes API information), instead
of special-casing a per-node `metalk8s.node` Pillar value.

See: 7ca23367ae15c33e9f186c89f5a9615df541cba5