### PR TITLE
Reduce flakiness in bootstrap execution

### DIFF
--- a/salt/_runners/metalk8s_saltutil.py
+++ b/salt/_runners/metalk8s_saltutil.py
@@ -1,6 +1,11 @@
 from __future__ import absolute_import, print_function, unicode_literals
+import logging
 
+import salt.client
 import salt.utils.extmods
+
+log = logging.getLogger(__name__)
+
 
 def sync_auth(saltenv='base', extmod_whitelist=None, extmod_blacklist=None):
     return salt.utils.extmods.sync(
@@ -10,3 +15,45 @@ def sync_auth(saltenv='base', extmod_whitelist=None, extmod_blacklist=None):
         extmod_whitelist=extmod_whitelist,
         extmod_blacklist=extmod_blacklist,
     )[0]
+
+
+def wait_minions(tgt='*', retry=10):
+    client = salt.client.get_local_client(__opts__['conf_file'])
+
+    minions = client.cmd(tgt, 'test.ping', timeout=2)
+    attempts = 1
+
+    while not all(status for status in minions.values()) and attempts < retry:
+        log.info(
+            "[Attempt %d/%d] Waiting for minions to respond: %s",
+            attempts,
+            retry,
+            ', '.join(
+                minion for minion, status in minions.items() if not status
+            )
+        )
+        minions = client.cmd(tgt, 'test.ping', timeout=2)
+        attempts += 1
+
+    if not all(status for status in minions.values()):
+        error_message = (
+            'Minion{plural} failed to respond after {retry} retries: {minions}'
+        ).format(
+            plural='s' if len(minions) > 1 else '',
+            retry=retry,
+            minions=', '.join(
+                minion for minion, status in minions.items() if not status
+            )
+        )
+        log.error(error_message)
+        return {
+            'result': False,
+            'error': error_message
+        }
+
+    return {
+        'result': True,
+        'comment': 'All minions matching "{}" responded: {}'.format(
+            tgt, ', '.join(minions)
+        )
+    }

--- a/salt/metalk8s/orchestrate/bootstrap_with_master.sls
+++ b/salt/metalk8s/orchestrate/bootstrap_with_master.sls
@@ -27,6 +27,14 @@ Bootstrap control plane:
     - pillar:
         registry_ip: {{ pillar.get('registry_ip') }}
 
+Wait for kube-apiserver to be ready:
+  salt.runner:
+    - name: salt.cmd
+    - arg:
+      - fun: metalk8s.wait_apiserver
+    - require:
+      - salt: Bootstrap control plane
+
 Bootstrap services:
   salt.state:
     - tgt: {{ pillar['bootstrap_id'] }}
@@ -34,7 +42,7 @@ Bootstrap services:
     - sls:
       - metalk8s.bootstrap.services
     - require:
-      - salt: Bootstrap control plane
+      - salt: Wait for kube-apiserver to be ready
 
 Bootstrap node:
   salt.state:
@@ -45,6 +53,6 @@ Bootstrap node:
       - metalk8s.bootstrap.addons
       - metalk8s.bootstrap.calico
     - require:
-      - salt: Bootstrap control plane
+      - salt: Wait for kube-apiserver to be ready
     - pillar:
         registry_ip: {{ pillar.get('registry_ip') }}

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -144,28 +144,38 @@ retry_dns_count: 3
 EOF
 }
 
-set_salt_command() {
-    echo "Setting salt master command"
-    # shellcheck disable=SC2046
-    SALT_MASTER_CALL="crictl exec -i $(crictl ps -q --label io.kubernetes.container.name=salt-master --label io.kubernetes.pod.namespace=kube-system)"
-}
+get_salt_container() {
+    local -r max_retries=10
+    local salt_container='' attempts=0
 
-sync_salt() {
-    $SALT_MASTER_CALL salt '*' saltutil.sync_all refresh=True \
-        saltenv=metalk8s-@@VERSION
-    $SALT_MASTER_CALL salt '*' mine.update
-    local SALT_CONTAINER
-    SALT_CONTAINER="$(crictl ps -q \
+    while [ -z "$salt_container" ] && [ $attempts -lt $max_retries ]; do
+        salt_container="$(crictl ps -q \
             --label io.kubernetes.pod.namespace=kube-system \
             --label io.kubernetes.container.name=salt-master \
             --state Running)"
-    test -n "$SALT_CONTAINER"
-    crictl exec -i "$SALT_CONTAINER" \
-        salt-run saltutil.sync_all saltenv=metalk8s-@@VERSION
-    crictl exec -i "$SALT_CONTAINER" \
-        salt-run saltutil.sync_roster saltenv=metalk8s-@@VERSION
-    crictl exec -i "$SALT_CONTAINER" \
-        salt-run metalk8s_saltutil.sync_auth saltenv=metalk8s-@@VERSION
+        (( attempts++ ))
+    done
+
+    if [ -z "$salt_container" ]; then
+        echo "Failed to find a running 'salt-master' container" >&2
+        exit 1
+    fi
+
+    echo "$salt_container"
+}
+
+sync_salt() {
+    local -r salt_master_call="crictl exec -i $(get_salt_container)"
+
+    $salt_master_call salt '*' saltutil.sync_all refresh=True \
+        saltenv=metalk8s-@@VERSION
+
+    $salt_master_call salt '*' mine.update
+
+    $salt_master_call salt-run saltutil.sync_all saltenv=metalk8s-@@VERSION
+    $salt_master_call salt-run saltutil.sync_roster saltenv=metalk8s-@@VERSION
+    $salt_master_call salt-run metalk8s_saltutil.sync_auth \
+        saltenv=metalk8s-@@VERSION
 }
 
 orchestrate_bootstrap() {
@@ -177,34 +187,46 @@ orchestrate_bootstrap() {
         saltenv=metalk8s-@@VERSION \
         pillarenv=metalk8s-@@VERSION
 
-    # TODO: FIX register IP
-    local registry_ip
-    registry_ip=$(salt-call --local grains.get metalk8s:control_plane_ip --out txt | awk '/^local\: /{ print $2 }')
+    # TODO: Registry IP should not need a pillar override here
+    local -r registry_ip=$(
+        ${SALT_CALL} --local grains.get metalk8s:control_plane_ip --out txt \
+        | awk '/^local\: /{ print $2 }'
+    )
+
     ${SALT_CALL} --local --retcode-passthrough state.orchestrate \
         metalk8s.orchestrate.bootstrap_without_master \
         saltenv=metalk8s-@@VERSION \
         pillarenv=metalk8s-@@VERSION \
-        pillar="{'registry_ip': $registry_ip}"
+        pillar="{'registry_ip': '$registry_ip'}"
 
-    set_salt_command
     sync_salt
 
-    # shellcheck disable=SC2086
-    ${SALT_MASTER_CALL} salt-run state.orchestrate \
+    local -r salt_master_call="crictl exec -i $(get_salt_container)"
+
+    $salt_master_call salt-run state.orchestrate \
         metalk8s.orchestrate.bootstrap_with_master \
         saltenv=metalk8s-@@VERSION \
         pillarenv=metalk8s-@@VERSION \
-        pillar="{'bootstrap_id': '$(cat /etc/salt/minion_id)', 'registry_ip': $registry_ip}"
+        pillar="{ \
+            'bootstrap_id': '$(cat /etc/salt/minion_id)', \
+            'registry_ip': '$registry_ip' \
+        }"
 }
 
 deploy_metalk8s_ui() {
-    bootstrap_id=$(cat /etc/salt/minion_id)
-    registry_ip=$(salt-call --local grains.get metalk8s:control_plane_ip --out txt | awk '/^local\: /{ print $2 }')
+    local -r bootstrap_id=$(cat /etc/salt/minion_id)
+    local -r registry_ip=$(
+        ${SALT_CALL} --local grains.get metalk8s:control_plane_ip --out txt \
+        | awk '/^local\: /{ print $2 }'
+    )
 
     "$SALT_CALL" --retcode-passthrough state.apply \
         metalk8s.ui saltenv=metalk8s-@@VERSION \
         pillarenv=metalk8s-@@VERSION \
-        pillar="{'bootstrap_id': $bootstrap_id, 'registry_ip': $registry_ip}"
+        pillar="{ \
+            'bootstrap_id': '$bootstrap_id', \
+            'registry_ip': '$registry_ip' \
+        }"
 }
 
 

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -164,18 +164,18 @@ get_salt_container() {
     echo "$salt_container"
 }
 
-sync_salt() {
+sync_salt_master() {
     local -r salt_master_call="crictl exec -i $(get_salt_container)"
-
-    $salt_master_call salt '*' saltutil.sync_all refresh=True \
-        saltenv=metalk8s-@@VERSION
-
-    $salt_master_call salt '*' mine.update
 
     $salt_master_call salt-run saltutil.sync_all saltenv=metalk8s-@@VERSION
     $salt_master_call salt-run saltutil.sync_roster saltenv=metalk8s-@@VERSION
     $salt_master_call salt-run metalk8s_saltutil.sync_auth \
         saltenv=metalk8s-@@VERSION
+}
+
+sync_salt_minion() {
+    ${SALT_CALL} saltutil.sync_all refresh=True saltenv=metalk8s-@@VERSION
+    ${SALT_CALL} mine.update
 }
 
 orchestrate_bootstrap() {
@@ -199,16 +199,24 @@ orchestrate_bootstrap() {
         pillarenv=metalk8s-@@VERSION \
         pillar="{'registry_ip': '$registry_ip'}"
 
-    sync_salt
+    sync_salt_master
 
     local -r salt_master_call="crictl exec -i $(get_salt_container)"
+    local -r bootstrap_id=$(cat /etc/salt/minion_id)
+
+    # Wait for Salt minion to respond before proceeding (may not have completed
+    # handshake with the master yet)
+    $salt_master_call salt-run metalk8s_saltutil.wait_minions \
+        tgt="$bootstrap_id"
+
+    sync_salt_minion "$bootstrap_id"
 
     $salt_master_call salt-run state.orchestrate \
         metalk8s.orchestrate.bootstrap_with_master \
         saltenv=metalk8s-@@VERSION \
         pillarenv=metalk8s-@@VERSION \
         pillar="{ \
-            'bootstrap_id': '$(cat /etc/salt/minion_id)', \
+            'bootstrap_id': '$bootstrap_id', \
             'registry_ip': '$registry_ip' \
         }"
 }

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -30,26 +30,26 @@ declare -A GPGCHECK_REPOSITORIES=(
 )
 
 die() {
-        echo 1>&2 "$@"
-        exit 1
+    echo 1>&2 "$@"
+    exit 1
 }
 
 pre_minion_checks() {
-        test "x$(whoami)" = "xroot" || die "Script must run as root"
-        test -n "${RPM}" || die "rpm not found"
-        test -x "${RPM}" || die "rpm at '${RPM}' is not executable"
-        test -n "${SYSTEMCTL}" || die "systemctl not found"
-        test -x "${SYSTEMCTL}" || die "systemctl at '${SYSTEMCTL}' is not executable"
-        test -n "${YUM}" || die "yum not found"
-        test -x "${YUM}" || die "yum at '${YUM}' is not executable"
+    test "x$(whoami)" = "xroot" || die "Script must run as root"
+    test -n "${RPM}" || die "rpm not found"
+    test -x "${RPM}" || die "rpm at '${RPM}' is not executable"
+    test -n "${SYSTEMCTL}" || die "systemctl not found"
+    test -x "${SYSTEMCTL}" || die "systemctl at '${SYSTEMCTL}' is not executable"
+    test -n "${YUM}" || die "yum not found"
+    test -x "${YUM}" || die "yum at '${YUM}' is not executable"
 }
 
 disable_salt_minion_service() {
-        ${SYSTEMCTL} disable salt-minion.service 2>/dev/null || true
+    ${SYSTEMCTL} disable salt-minion.service 2>/dev/null || true
 }
 
 stop_salt_minion_service() {
-        ${SYSTEMCTL} stop salt-minion.service 2>/dev/null || true
+    ${SYSTEMCTL} stop salt-minion.service 2>/dev/null || true
 }
 
 configure_yum_repositories() {
@@ -93,7 +93,7 @@ configure_yum_local_repository() {
 
     gpg_keys=$(
         find "$repo_path" -maxdepth 1 -name "RPM-GPG-KEY-*" \
-	    -printf "file://%p "
+            -printf "file://%p "
     )
 
     cat > /etc/yum.repos.d/"$repo_name".repo << EOF
@@ -113,9 +113,9 @@ install_salt_minion() {
 
     if [[ ${online_mode,,} = false ]]; then
         yum_opts+=(
-	          '--disablerepo=*'
-	          '--enablerepo=metalk8s-*'
-	      )
+            '--disablerepo=*'
+            '--enablerepo=metalk8s-*'
+        )
     fi
 
     "$YUM" install "${yum_opts[@]}" salt-minion


### PR DESCRIPTION
## What

We introduce two main "waiting" methods where we already encountered failures:


#### Waiting for Salt minion to respond to the master once its keys were accepted

This was implemented as a custom runner function, `metalk8s_saltutil.wait_minions`, which takes as arguments:
- `tgt`, defaults to `'*'`, for reducing the scope of the wait (in the bootstrap script, we only wait for the bootstrap minion)
- `retry`, defaults to 10, for the amount of `test.ping` attempts before bailing out if some minion still fails to respond

#### Waiting for Kube API Server to respond after being deployed/restarted

This was implemented as a custom execution function, `metalk8s.wait_apiserver`, which takes as arguments:
- `retry`, defaults to 10, for the amount of `metalk8s_kubernetes.ping` attempts
- `interval`, defaults to 1, for the number of seconds to wait between two attempts

---

Fixes: GH-994