### PR TITLE
ci: concurrent build

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -58,7 +58,10 @@ stages:
           name: build everything
           env:
             PYTHON_SYS: python36
-          command: ./doit.sh
+          # There are 3 CPUs available for Docker, and 1 for `doit` in the Pod.
+          # Given the network IO-bound nature of some of the build steps, and
+          # most build steps running in Docker, set concurrency to 4.
+          command: ./doit.sh -n 4
           usePTY: true
       - ShellCommand:
           name: Put the iso file in a separate folder

--- a/eve/workers/pod-builder/pod.yaml
+++ b/eve/workers/pod-builder/pod.yaml
@@ -11,10 +11,15 @@ spec:
       args: ["-c", "buildbot-worker create-worker . ${BUILDMASTER}:${BUILDMASTER_PORT} ${WORKERNAME} ${WORKERPASS} && buildbot-worker start --nodaemon"]
       resources:
         requests:
-          cpu: 500m
+          # Most of our build steps run in containers, hence to run concurrent
+          # builds, we need to allocate CPUs to the subsystem running Docker,
+          # rather than to the environment in which `doit` is merely executed.
+          # There's a limit of 4 CPUs, so we assign one to `doit`, and 3 to
+          # Docker.
+          cpu: "1"
           memory: 1Gi
         limits:
-          cpu: 500m
+          cpu: "1"
           memory: 1Gi
       env:
         - name: DOCKER_HOST
@@ -26,10 +31,10 @@ spec:
       image: docker:18.09.2-dind
       resources:
         requests:
-          cpu: "1"
+          cpu: "3"
           memory: 2Gi
         limits:
-          cpu: "2"
+          cpu: "3"
           memory: 2Gi
       securityContext:
         privileged: true


### PR DESCRIPTION
Ball-park figures: over 4 random successful recent build, average wall-clock time of the `build` step was 15:33. With this patch, on a single build, wall-clock time of the same step is reduced to 6:02.