### PR TITLE
Set-up initial documentation tree and first "Integration" docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ For more information, please refer to the
 
 To build a MetalK8s ISO, simply type `./doit.sh`.
 
-For more information, please refers to developer documentation.
+For more information, please refer to the
+[Building Documentation](docs/developer/building/index.rst).
 
 ## Contributing
 
@@ -42,9 +43,10 @@ vagrant plugin install vagrant-vbguest
 
 ### End-to-End Testing
 
-To run the test-suite locally, first complete the bootstrap step as outline above
+To run the test-suite locally, first complete the bootstrap step as outlined
+above, then:
 
-```shell
+```shell 
 # Run tests with tox
 tox -e tests
 ```
@@ -68,5 +70,5 @@ tox -e docs
 
 MetalK8s version 1 is still maintained in this repository. See the
 `development/1.*` branches, e. g.
-[MetalK8s 1.3](https://github.com/scality/metalk8s/tree/development/1.3) in the same
-repository.
+[MetalK8s 1.3](https://github.com/scality/metalk8s/tree/development/1.3) in the
+same repository.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 An opinionated Kubernetes distribution with a focus on long-term on-prem deployments
 
+## Integrating
+
+MetalK8s offers a set of tools to deploy Kubernetes applications, given a set of
+standards for packaging such applications is respected.
+
+For more information, please refer to the
+[Integration Guidelines](docs/developer/solutions/index.rst).
+
 ## Building
 
 To build a MetalK8s ISO, simply type `./doit.sh`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,6 @@
+# MetalK8s documentation
+
+Please see the [documentation index](./index.rst).
+
+
+[//]: # (TODO: link to a hosted docs website, since GH doesn't render Sphinx)

--- a/docs/developer/architecture/index.rst
+++ b/docs/developer/architecture/index.rst
@@ -4,4 +4,5 @@ Architecture Documents
 .. toctree::
 
    deployment
+   monitoring
    requirements

--- a/docs/developer/architecture/monitoring.rst
+++ b/docs/developer/architecture/monitoring.rst
@@ -1,0 +1,11 @@
+Monitoring
+==========
+
+This document describes the monitoring features included in MetalK8s.
+
+.. todo::
+
+   Describe the monitoring stack (`#1075`_), include quick explanation in
+   quickstart guide.
+
+.. _`#1075`: https://github.com/scality/metalk8s/issues/1075

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -6,3 +6,4 @@ Developer Guide
    architecture/index
    building/index
    best_practices/index
+   solutions/index

--- a/docs/developer/solutions/archive.rst
+++ b/docs/developer/solutions/archive.rst
@@ -67,6 +67,7 @@ Here is the file tree expected by MetalK8s to exist in each Solution archive::
    │           ├── <layer_digest>
    │           ├── manifest.json
    │           └── version
+   ├── registry-config.inc
    ├── operator
    │   ├── crd
    │   │   └── some_crd_name.yaml
@@ -147,20 +148,30 @@ hardlinks, using the tool hardlink_::
    $ hardlink -c images
 
 A detailed procedure for generating the expected layout is available at
-`NicolasT/static-container-registry`_. You can use the script provided there
-to generate your own NGINX configuration and test this static registry for
-yourself. MetalK8s will generate its own configuration when importing the
-Solution archive.
+`NicolasT/static-container-registry`_. You can use the script provided there,
+or use the one vendored in this repository (located at
+``buildchain/buildchain/static-container-registry``) to generate the NGINX
+configuration to serve these image layers with the Docker Registry API.
+MetalK8s, when deploying the Solution, will include the ``registry-config.inc``
+file provided at the root of the archive. In order to let MetalK8s control
+the mountpoint of the ISO, the configuration **must** be generated using the
+following options::
+
+   $ ./static-container-registry.py \
+       --name-prefix '{{ repository }}' \
+       --server-root '{{ registry_root }}' \
+       /path/to/archive/images > /path/to/archive/registry-config.inc.j2
 
 Each archive will be exposed as a single repository, where the name will be
-computed as ``<NAME>-<VERSION>`` from :ref:`solution-archive-product-info`.
+computed as ``<NAME>-<VERSION>`` from :ref:`solution-archive-product-info`, and
+will be mounted at ``/srv/scality/<NAME>-<VERSION>``.
 
 .. warning::
 
-   Operator Deployments should not rely on this naming pattern for finding
-   the images for their resources. Instead, the full repository prefix will be
-   stored in a ``ConfigMap``, that Deployments will be able to expose as
-   environment variables. See :doc:`./operator` for more details.
+   Operators should not rely on this naming pattern for finding the images for
+   their resources. Instead, the full repository prefix will be exposed to
+   the Operator container as an environment variable when deployed with
+   MetalK8s. See :doc:`./operator` for more details.
 
 The images names and tags will be inferred from the directory names chosen when
 using ``skopeo copy``. Using `hardlink` is highly recommended if one wants to

--- a/docs/developer/solutions/archive.rst
+++ b/docs/developer/solutions/archive.rst
@@ -69,9 +69,13 @@ Here is the file tree expected by MetalK8s to exist in each Solution archive::
    │           └── version
    ├── registry-config.inc
    ├── operator
-   │   ├── crd
-   │   │   └── some_crd_name.yaml
-   │   └── deployment.yaml
+   |   └── deploy
+   │       ├── crds
+   │       |   └── some_crd_name.yaml
+   │       ├── operator.yaml
+   │       ├── role.yaml
+   │       ├── role_binding.yaml
+   │       └── service_account.yaml
    ├── product.txt
    └── ui
        └── deployment.yaml

--- a/docs/developer/solutions/archive.rst
+++ b/docs/developer/solutions/archive.rst
@@ -1,0 +1,157 @@
+Solution archive guidelines
+===========================
+
+To provide a predictable interface with packaged Solutions, MetalK8s expects a
+few criteria to be respected, described below.
+
+
+Archive format
+--------------
+
+Solution archives must use the `ISO-9660:1988`_ format, including `Rock Ridge`_
+and Joliet_ directory records. The character encoding must be UTF-8_. The
+conformance level is expected to be at most 3, meaning:
+
+- Directory identifiers may not exceed 31 characters (bytes) in length
+- File name + ``'.'`` + file name extension may not exceed 30 characters
+  (bytes) in length
+- Files are allowed to consist of multiple sections
+
+The generated archive should specify a volume ID, set to
+``{project_name} {version}``.
+
+.. todo::
+
+   Clarify whether Joliet/Rock Ridge records supersede the conformance level
+   w.r.t. filename lengths
+
+
+.. _`ISO-9660:1988`: https://www.iso.org/obp/ui/#iso:std:iso:9660:ed-1:v1:en
+.. _`Rock Ridge`: https://en.wikipedia.org/wiki/Rock_Ridge
+.. _Joliet: https://en.wikipedia.org/wiki/Joliet_(file_system)
+.. _UTF-8: https://tools.ietf.org/html/rfc3629
+
+Here is an example invocation of the common Unix mkisofs_ tool to generate such
+archive::
+
+   mkisofs
+       -output my_solution.iso
+       -R  # (or "-rock" if available)
+       -J  # (or "-joliet" if available)
+       -joliet-long
+       -l  # (or "-full-iso9660-filenames" if available)
+       -V 'MySolution 1.0.0'  # (or "-volid" if available)
+       -gid 0
+       -uid 0
+       -iso-level 3
+       -input-charset utf-8
+       -output-charset utf-8
+       my_solution_root/
+
+.. _mkisofs: https://linux.die.net/man/8/mkisofs
+
+.. todo::
+
+   Consider if overriding the source files UID/GID to 0 is necessary
+
+
+File hierarchy
+--------------
+
+Here is the file tree expected by MetalK8s to exist in each Solution archive::
+
+   .
+   ├── images
+   │   ├── listing.yaml
+   │   └── some_image_name.tar.gz
+   ├── operator
+   │   ├── crd
+   │   │   └── some_crd_name.yaml
+   │   └── deployment.yaml
+   ├── product.txt
+   └── ui
+       └── deployment.yaml
+
+
+Product information
+-------------------
+
+General product information about the packaged Solution must be stored in the
+``product.txt`` file, stored at the archive root.
+
+It must respect the following format (currently version 1, as specified by the
+``ARCHIVE_LAYOUT_VERSION`` value)::
+
+   NAME=Example
+   VERSION=1.0.0-dev
+   REQUIRE_METALK8S=">=2.0"
+   ARCHIVE_LAYOUT_VERSION=1
+
+It is recommended for inspection purposes to include information related to
+the build-time conditions, such as the following (where command invocations
+should be statically replaced in the generated ``product.txt``)::
+
+   GIT=$(git describe --always --long --tags --dirty)
+   BUILD_TIMESTAMP=$(date +%Y-%m-%dT%H:%M:%SZ)
+
+
+.. _solution-archive-images:
+
+OCI images
+----------
+
+.. todo::
+
+   With `#1049`_, we will have another standard way of serving OCI images with
+   a read-only registry directly exposing the ISO contents.
+   A specific process will be required to package these images, which we need
+   to document here.
+
+.. _`#1049`: https://github.com/scality/metalk8s/issues/1049
+
+MetalK8s exposes container images in the OCI_ format through a registry.
+Solutions should thus provide their container images in a compatible format,
+for example using ``docker save``.
+
+For size concerns, we expect such images to be compressed using ``gzip``.
+
+Here is an example of how to build, save and compress an image with
+``docker``::
+
+   docker build --tag my-image:1.0.0 --file my_image.dockerfile
+   docker save my-image:1.0.0 -o my_image_1_0.tar
+   gzip -9 my_image_1_0.tar
+
+.. _OCI: https://github.com/opencontainers/image-spec/blob/master/spec.md
+
+MetalK8s also defines recommended standards for container images, described in
+:ref:`req-container-images`.
+
+In order for MetalK8s to populate its registry with accurate image tags,
+Solutions must provide a ``listing.yaml`` file under ``/images``, with the
+given format::
+
+   apiVersion: metalk8s.scality.com/v1alpha1
+   kind: ImagesList
+   solution: MySolution
+   images:
+     - archive: my_image_1_0.tar.gz
+       tag: my_image:1.0.0
+
+.. note::
+
+   Each Solution ISO will be made available to Pods as a single repository.
+   Operator Deployments will then be required to accept the repository prefix,
+   stored in a ``ConfigMap``, in order to properly configure the resources they
+   manage.
+
+Operator
+--------
+
+See :doc:`./operator` for how the ``/operator`` directory should be
+populated.
+
+Web UI
+------
+
+.. todo:: Create UI guidelines and reference here

--- a/docs/developer/solutions/archive.rst
+++ b/docs/developer/solutions/archive.rst
@@ -91,6 +91,13 @@ It must respect the following format (currently version 1, as specified by the
    REQUIRE_METALK8S=">=2.0"
    ARCHIVE_LAYOUT_VERSION=1
 
+.. note::
+
+   If a Solution can require specific versions of MetalK8s on which to be
+   deployed, requiring specific services (and their respective versions) to be
+   shipped with MetalK8s (e.g. Prometheus/Grafana) is not yet feasible.
+   It will probably be handled in the Operator declaration, maybe using a CR.
+
 It is recommended for inspection purposes to include information related to
 the build-time conditions, such as the following (where command invocations
 should be statically replaced in the generated ``product.txt``)::

--- a/docs/developer/solutions/archive.rst
+++ b/docs/developer/solutions/archive.rst
@@ -91,6 +91,13 @@ It must respect the following format (currently version 1, as specified by the
    REQUIRE_METALK8S=">=2.0"
    ARCHIVE_LAYOUT_VERSION=1
 
+It is recommended for inspection purposes to include information related to
+the build-time conditions, such as the following (where command invocations
+should be statically replaced in the generated ``product.txt``)::
+
+   GIT=$(git describe --always --long --tags --dirty)
+   BUILD_TIMESTAMP=$(date +%Y-%m-%dT%H:%M:%SZ)
+
 .. note::
 
    If a Solution can require specific versions of MetalK8s on which to be

--- a/docs/developer/solutions/deployment.uml
+++ b/docs/developer/solutions/deployment.uml
@@ -1,0 +1,95 @@
+@startuml
+
+actor user as "User"
+control ui as "MetalK8s UI"
+control saltmaster as "Salt Master"
+entity bootstrap as "Bootstrap node"
+control apiserver as "Kubernetes API"
+control registry as "MetalK8s registry"
+
+== Import a new Solution (version) ==
+
+user -> bootstrap : Upload Solution ISO
+user -> bootstrap : Add ISO path to the "SolutionsConfiguration" file
+user -> saltmaster ++ : Request Solutions import
+
+saltmaster <-> apiserver : Retrieve "metalk8s-solutions" ConfigMap
+
+loop For each ISO defined in "SolutionsConfiguration"
+
+    saltmaster -> bootstrap ++ : Check ISO file (against our standards/constraints)
+    |||
+    bootstrap --> saltmaster -- : Return status (valid or not) and metadata if any
+
+    alt ISO is invalid
+        |||
+        saltmaster -> saltmaster : Fail early
+        |||
+    else ISO is valid
+        |||
+        saltmaster -> bootstrap ++ : Run "import_solution_archive" formula
+        |||
+        bootstrap -> bootstrap : Mount ISO
+        bootstrap -> registry : Configure new ISO source
+        |||
+        bootstrap -> saltmaster -- : Solution imported successfully
+    end
+
+end
+
+loop For each latest version newly imported
+
+    saltmaster <-> apiserver : Replace CRDs
+
+    saltmaster <-> apiserver : Create/Update Deployment for the Solution UI
+
+end
+
+loop For each Solution version in "metalk8s-solutions" ConfigMap not in "SolutionsConfiguration"
+    |||
+    saltmaster -> bootstrap ++ : Run "remove_solution_archive" formula
+    |||
+    bootstrap -> registry : Remove configuration for this Solution version
+    bootstrap -> bootstrap : Unmount ISO
+    |||
+    bootstrap -> saltmaster -- : Solution removed successfully
+end
+
+saltmaster <-> apiserver : Update "metalk8s-solutions" ConfigMap
+
+saltmaster -> user -- : Solutions imported successfully
+
+|||
+
+== Confirmation ==
+
+user -> ui : Request Solutions listing page
+ui <-> apiserver : Retrieve "metalk8s-solutions" ConfigMap
+
+loop For each Solution configured
+
+    ui <-> apiserver : Retrieve Solution UI Service
+
+end
+
+ui -> user : Display Solutions with the versions deployed and their UI links
+
+|||
+
+== Deployment of the Operator ==
+
+note over user
+    Deployment of a Solution Operator should
+    be managed in the Solution UI, allowing
+    the user to see multiple instances of the
+    Operator at once (different namespaces).
+end note
+
+opt If the user wants to perform manual deployment
+
+    user -> apiserver : Create new Namespace for the Operator to manage
+    user -> apiserver : Apply the example Deployment from the mounted Solution ISO
+
+end
+
+@enduml

--- a/docs/developer/solutions/index.rst
+++ b/docs/developer/solutions/index.rst
@@ -5,3 +5,4 @@ Integrating with MetalK8s
 
    introduction
    archive
+   operator

--- a/docs/developer/solutions/index.rst
+++ b/docs/developer/solutions/index.rst
@@ -1,0 +1,6 @@
+Integrating with MetalK8s
+=========================
+
+.. toctree::
+
+   introduction

--- a/docs/developer/solutions/index.rst
+++ b/docs/developer/solutions/index.rst
@@ -4,3 +4,4 @@ Integrating with MetalK8s
 .. toctree::
 
    introduction
+   archive

--- a/docs/developer/solutions/introduction.rst
+++ b/docs/developer/solutions/introduction.rst
@@ -60,6 +60,18 @@ There would be no explicit information about what an archive contains.
 Instead, we want the archive itself to contain such information (more
 details in :doc:`./archive`), and to discover it at import time.
 
+Note that Solutions will be **imported** based on this file contents, i.e.
+the images they contain will be made available in the registry and the UI
+will be deployed, however **deploying** the Operator and subsequent
+application(s) is left to the user, through manual operations or the Solution
+UI.
+
+.. note::
+
+   Removing an archive path from the ``solutions`` list will effectively
+   remove the Solution images and UI when the "import solutions" playbook is
+   run.
+
 Responsibilities of each party
 ------------------------------
 
@@ -116,3 +128,10 @@ will handle user input when deploying / upgrading Solutions.
 
 .. uml:: deployment.uml
 
+.. todo::
+
+   A detailed diagram for Operator deployment would be useful (wait for
+   `#1060`_ to land). Also, add another diagram for specific operations in an
+   upgrade scenario using two Namespaces, for staging/testing the new version.
+
+.. _`#1060`: https://github.com/scality/metalk8s/issues/1060

--- a/docs/developer/solutions/introduction.rst
+++ b/docs/developer/solutions/introduction.rst
@@ -1,0 +1,115 @@
+Introduction
+============
+
+With a focus on having minimal human actions required, both in its deployment
+and operation, MetalK8s also intends to ease deployment and operation of
+complex applications, named *Solutions*, on its cluster.
+
+This document defines what a *Solution* refers to, the responsibilities of each
+party in this integration, and will link to relevant documentation pages for
+detailed information.
+
+What is a *Solution*?
+---------------------
+
+We use the term *Solution* to describe a packaged Kubernetes application,
+archived as an ISO disk image, containing:
+
+- A set of OCI images to inject in MetalK8s image registry
+- An `Operator`_ to deploy on the cluster
+- Optionally, a UI for managing and monitoring the application, represented by
+  a standard Kubernetes ``Deployment``
+
+.. _Operator: https://coreos.com/blog/introducing-operators.html
+
+For more details, see the following documentation pages:
+
+- :doc:`./archive`
+- :doc:`./operator`
+- (TODO) Solution UI guidelines
+
+Once a Solution is deployed on MetalK8s, a user can deploy one or more versions
+of the Solution Operator, using either the Solution UI or the Kubernetes API,
+into separate namespaces. Using the Operator-defined ``CustomResource(s)``, the
+user can then effectively deploy the application packaged in the Solution.
+
+How is a *Solution* declared in MetalK8s?
+-----------------------------------------
+
+MetalK8s already uses a ``BootstrapConfiguration`` object, stored in
+``/etc/metalk8s/bootstrap.yaml``, to define how the cluster should be
+configured from the bootstrap node, and what versions of MetalK8s are available
+to the cluster.
+
+In the same vein, we want to use a ``SolutionsConfiguration`` object, stored in
+``/etc/metalk8s/solutions.yaml``, to declare which Solutions are available to
+the cluster, from the bootstrap node.
+
+.. todo:: Add specification in a future Reference guide
+
+Here is how it could look::
+
+    apiVersion: metalk8s.scality.com/v1alpha1
+    kind: SolutionsConfiguration
+    solutions:
+      - /solutions/storage_1.0.0.iso
+      - /solutions/storage_latest.iso
+      - /other_solutions/computing.iso
+
+There would be no explicit information about what an archive contains.
+Instead, we want the archive itself to contain such information (more
+details in :doc:`./archive`), and to discover it at import time.
+
+Responsibilities of each party
+------------------------------
+
+This section intends to define the boundaries between MetalK8s and the
+Solutions to integrate with, in terms of "who is doing what?".
+
+.. note:: This is still a work in progress.
+
+MetalK8s
+^^^^^^^^
+
+**MUST**:
+
+- Handle reading and mounting of the Solution ISO archive
+- Provide tooling to deploy/upgrade a Solution's CRDs and UI
+
+**MAY**:
+
+- Provide tooling to deploy/upgrade a Solution's Operator
+- Provide tooling to verify signatures in a Solution ISO
+- Expose management of Solutions in its own UI
+
+Solution
+^^^^^^^^
+
+**MUST**:
+
+- Comply with the standard archive structure defined by MetalK8s
+- If providing a UI, expose management of its Operator instances
+- Handle monitoring of its own services (both Operator and application, except
+  the UI)
+
+**MAY**:
+
+- Use MetalK8s monitoring services (Prometheus and Grafana)
+
+.. note::
+
+   Solutions can leverage the ``prometheus-operator`` CRs for setting up the
+   monitoring of their components.
+
+.. todo:: Define how Solutions can deploy Grafana dashboards.
+
+Interaction diagrams
+--------------------
+
+We include a detailed interaction sequence diagram for describing how MetalK8s
+will handle user input when deploying / upgrading Solutions.
+
+.. note:: Open the image in a new tab to see it in full resolution.
+
+.. uml:: deployment.uml
+

--- a/docs/developer/solutions/introduction.rst
+++ b/docs/developer/solutions/introduction.rst
@@ -92,16 +92,19 @@ Solution
 - Handle monitoring of its own services (both Operator and application, except
   the UI)
 
-**MAY**:
+**SHOULD**:
 
 - Use MetalK8s monitoring services (Prometheus and Grafana)
 
 .. note::
 
-   Solutions can leverage the ``prometheus-operator`` CRs for setting up the
-   monitoring of their components.
+   Solutions can leverage the `Prometheus Operator`_ CRs for setting up the
+   monitoring of their components. For more information, see
+   :doc:`/developer/architecture/monitoring` and :doc:`./operator`.
 
 .. todo:: Define how Solutions can deploy Grafana dashboards.
+
+.. _`Prometheus Operator`: https://github.com/coreos/prometheus-operator
 
 Interaction diagrams
 --------------------

--- a/docs/developer/solutions/operator.rst
+++ b/docs/developer/solutions/operator.rst
@@ -1,0 +1,86 @@
+Solution Operator guidelines
+============================
+
+..
+
+   An Operator is a method of packaging, deploying and managing a Kubernetes
+   application. A Kubernetes application is an application that is both
+   deployed on Kubernetes and managed using the Kubernetes APIs and ``kubectl``
+   tooling.
+
+   -- `coreos.com/operators <https://coreos.com/operators/>`_
+
+
+MetalK8s *Solutions* are a concept mostly centered around the Operator pattern.
+While there is no explicit requirements except the ones described below (see
+:ref:`solution-operator-requirements`), we recommend using the `Operator SDK`_
+as it will embed best practices from the Kubernetes_ community. We also include
+some :ref:`solution-operator-recommendations`.
+
+.. _`Operator SDK`: https://github.com/operator-framework/operator-sdk/
+.. _Kubernetes: https://kubernetes.io/
+
+
+.. _solution-operator-requirements:
+
+Requirements
+------------
+
+Files
+^^^^^
+
+All Operator-related files except for the container images (see
+:ref:`solution-archive-images`) should be stored under ``/operator`` in the ISO
+archive. Those files should be organized as follows::
+
+   operator
+   ├── crd
+   │   └── some_crd_name.yaml
+   └── deploy
+       ├── operator.yaml
+       ├── role.yaml
+       ├── role_binding.yaml
+       └── service_account.yaml
+
+Most of these files are generated when using the Operator SDK.
+
+.. todo::
+
+   Specify each of them, include example (after `#1060`_ is done).
+   Remember to note specificities about ``OCI_REPOSITORY_PREFIX`` / namespaces.
+   Think about using ``kustomize`` (or ``kubectl apply -k``, though only
+   available from K8s 1.14).
+
+.. _`#1060`: https://github.com/scality/metalk8s/issues/1060
+
+Monitoring
+^^^^^^^^^^
+
+MetalK8s does not handle the monitoring of a Solution application, which means:
+
+- the user, manually or through the Solution UI, should create ``Service`` and
+  ``ServiceMonitor`` objects for each Operator instance
+- Operators should create ``Service`` and ``ServiceMonitor`` objects for each
+  deployed component they own
+
+.. _solution-operator-recommendations:
+
+Recommendations
+---------------
+
+Permissions
+^^^^^^^^^^^
+
+MetalK8s does not provide tools to deploy the Operator itself, so that users
+can have better control over which version runs where.
+
+The best-practice encouraged here is to use namespace-scoped permissions for
+the Operator, instead of cluster-scoped.
+
+.. note::
+
+   Future improvements to MetalK8s may include the addition of an "Operator for
+   Operators", such as the `Operator Lifecycle Manager`_.
+
+.. _`Operator Lifecycle Manager`:
+   https://github.com/operator-framework/operator-lifecycle-manager

--- a/docs/developer/solutions/operator.rst
+++ b/docs/developer/solutions/operator.rst
@@ -83,6 +83,10 @@ can have better control over which version runs where.
 The best-practice encouraged here is to use namespace-scoped permissions for
 the Operator, instead of cluster-scoped.
 
+This allows for better isolation between different application deployments from
+a single Solution, for instance when trying out a new version before affecting
+production machines, or when managing two independent application stacks.
+
 .. note::
 
    Future improvements to MetalK8s may include the addition of an "Operator for

--- a/docs/developer/solutions/operator.rst
+++ b/docs/developer/solutions/operator.rst
@@ -63,6 +63,12 @@ MetalK8s does not handle the monitoring of a Solution application, which means:
 - Operators should create ``Service`` and ``ServiceMonitor`` objects for each
   deployed component they own
 
+The `Prometheus Operator`_ deployed by MetalK8s has cluster-scoped permissions,
+and is able to read the aforementioned ``ServiceMonitor`` objects
+to set up monitoring of your application services.
+
+.. _`Prometheus Operator`: https://github.com/coreos/prometheus-operator
+
 .. _solution-operator-recommendations:
 
 Recommendations

--- a/docs/developer/solutions/operator.rst
+++ b/docs/developer/solutions/operator.rst
@@ -34,9 +34,9 @@ All Operator-related files except for the container images (see
 archive. Those files should be organized as follows::
 
    operator
-   ├── crd
-   │   └── some_crd_name.yaml
    └── deploy
+       ├── crds
+       │   └── some_crd_name.yaml
        ├── operator.yaml
        ├── role.yaml
        ├── role_binding.yaml

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -1,6 +1,7 @@
 # Required by Sphinx on Windows
 # Added here because `pip-compile` doesn't work cross-platform.
 colorama >= 0.3.9
+plantuml >= 0.2
 Sphinx >= 1.7
 sphinx_rtd_theme >= 0.3
 sphinxcontrib_github_alt >= 1.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -35,6 +35,10 @@ docutils==0.14 \
     --hash=sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274 \
     --hash=sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6 \
     # via doc8, restructuredtext-lint, sphinx
+httplib2==0.12.3 \
+    --hash=sha256:23914b5487dfe8ef09db6656d6d63afb0cf3054ad9ebc50868ddc8e166b5f8e8 \
+    --hash=sha256:a18121c7c72a56689efbf1aef990139ad940fee1e64c6f2458831736cd593600 \
+    # via plantuml
 idna==2.8 \
     --hash=sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407 \
     --hash=sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c \
@@ -92,6 +96,8 @@ pbr==5.2.0 \
     --hash=sha256:6901995b9b686cb90cceba67a0f6d4d14ae003cd59bc12beb61549bdfbe3bc89 \
     --hash=sha256:d950c64aeea5456bbd147468382a5bb77fe692c13c9f00f0219814ce5b642755 \
     # via stevedore
+plantuml==0.2.1 \
+    --hash=sha256:a117593c4864fce120e659db44e7235c34e7b3930c0fed421d659cfebf2ddabf
 port_for==0.3.1 \
     --hash=sha256:b16a84bb29c2954db44c29be38b17c659c9c27e33918dec16b90d375cc596f1c \
     # via sphinx-autobuild


### PR DESCRIPTION
We define initial documentation for "integrating with MetalK8s", a.k.a. Solutions.

To build the docs, you can use:

```
# Will build HTML files under docs/_build
tox -e docs

# Will watch docs/ sources and serve built HTML files locally on port 8000
tox -e docs -- livehtml
```

Please make sure to read through and discuss anything feeling unclear. Details regarding the integration with Operators and their deployment will be added in the future, during the investigation work on #1060 and #1061.

**Summary**:

- [x] Define a base "integration" document for external solutions
- [x] Define Solutions archiving guidelines
- [x] Define Solutions Operator guidelines

_Note: UI guidelines are not done in this PR_

---

Fixes: #951
Fixes: #952
Fixes: #953
