### PR TITLE
NodeCreateForm: error management bug fixs

### DIFF
--- a/ui/src/containers/Login.js
+++ b/ui/src/containers/Login.js
@@ -60,7 +60,7 @@ const LoginForm = props => {
     asyncErrors
   } = props;
   //handleChange of the Formik props does not update 'values' when field value is empty
-  const handleChange = (e, field) => {
+  const handleChange = field => e => {
     const { value, checked, type } = e.target;
     setFieldValue(field, type === 'checkbox' ? checked : value, true);
   };
@@ -81,7 +81,7 @@ const LoginForm = props => {
         label={intl.messages.username}
         error={touched.username && errors.username}
         value={values.username}
-        onChange={e => handleChange(e, 'username')}
+        onChange={handleChange('username')}
         onBlur={handleOnBlur}
       />
       <Input
@@ -90,7 +90,7 @@ const LoginForm = props => {
         label={intl.messages.password}
         error={touched.password && errors.password}
         value={values.password}
-        onChange={e => handleChange(e, 'password')}
+        onChange={handleChange('password')}
         onBlur={handleOnBlur}
       />
       <Button

--- a/ui/src/containers/Login.js
+++ b/ui/src/containers/Login.js
@@ -56,7 +56,8 @@ const LoginForm = props => {
     dirty,
     intl,
     setFieldValue,
-    setFieldTouched
+    setFieldTouched,
+    asyncErrors
   } = props;
   //handleChange of the Formik props does not update 'values' when field value is empty
   const handleChange = (e, field) => {
@@ -74,8 +75,6 @@ const LoginForm = props => {
           src={process.env.PUBLIC_URL + '/brand/assets/branding.svg'}
         />
       </LogoContainer>
-
-      {errors.authentication && <Error>{errors.authentication}</Error>}
       <Input
         name="username"
         type="text"
@@ -99,6 +98,9 @@ const LoginForm = props => {
         text={intl.messages.submit}
         disabled={!dirty || !isEmpty(errors)}
       />
+      {asyncErrors && asyncErrors.authentication && (
+        <Error>{asyncErrors.authentication}</Error>
+      )}
     </Form>
   );
 };
@@ -125,7 +127,7 @@ class Login extends React.Component {
             const formikProps = {
               ...props,
               ...this.props,
-              errors: { ...props.errors, ...this.props.errors }
+              asyncErrors: this.props.asyncErrors
             };
             return <LoginForm {...formikProps} />;
           }}
@@ -136,7 +138,7 @@ class Login extends React.Component {
 }
 
 const mapStateToProps = state => ({
-  errors: state.login.errors
+  asyncErrors: state.login.errors
 });
 
 const mapDispatchToProps = dispatch => {

--- a/ui/src/containers/NodeCreateForm.js
+++ b/ui/src/containers/NodeCreateForm.js
@@ -100,7 +100,7 @@ class NodeCreateForm extends React.Component {
             } = props;
 
             //handleChange of the Formik props does not update 'values' when field value is empty
-            const handleChange = (e, field) => {
+            const handleChange = field => e => {
               const { value, checked, type } = e.target;
               setFieldValue(field, type === 'checkbox' ? checked : value, true);
             };
@@ -113,7 +113,7 @@ class NodeCreateForm extends React.Component {
                   name="name"
                   label={intl.messages.name}
                   value={values.name}
-                  onChange={e => handleChange(e, 'name')}
+                  onChange={handleChange('name')}
                   error={touched.name && errors.name}
                   onBlur={handleOnBlur}
                 />
@@ -121,7 +121,7 @@ class NodeCreateForm extends React.Component {
                   name="ssh_user"
                   label={intl.messages.ssh_user}
                   value={values.ssh_user}
-                  onChange={e => handleChange(e, 'ssh_user')}
+                  onChange={handleChange('ssh_user')}
                   error={touched.ssh_user && errors.ssh_user}
                   onBlur={handleOnBlur}
                 />
@@ -129,7 +129,7 @@ class NodeCreateForm extends React.Component {
                   name="hostName_ip"
                   label={intl.messages.hostName_ip}
                   value={values.hostName_ip}
-                  onChange={e => handleChange(e, 'hostName_ip')}
+                  onChange={handleChange('hostName_ip')}
                   error={touched.hostName_ip && errors.hostName_ip}
                   onBlur={handleOnBlur}
                 />
@@ -137,7 +137,7 @@ class NodeCreateForm extends React.Component {
                   name="ssh_port"
                   label={intl.messages.ssh_port}
                   value={values.ssh_port}
-                  onChange={e => handleChange(e, 'ssh_port')}
+                  onChange={handleChange('ssh_port')}
                   error={touched.ssh_port && errors.ssh_port}
                   onBlur={handleOnBlur}
                 />
@@ -145,7 +145,7 @@ class NodeCreateForm extends React.Component {
                   name="ssh_key_path"
                   label={intl.messages.ssh_key_path}
                   value={values.ssh_key_path}
-                  onChange={e => handleChange(e, 'ssh_key_path')}
+                  onChange={handleChange('ssh_key_path')}
                   error={touched.ssh_key_path && errors.ssh_key_path}
                   onBlur={handleOnBlur}
                 />
@@ -155,7 +155,7 @@ class NodeCreateForm extends React.Component {
                   label={intl.messages.sudo_required}
                   value={values.sudo_required}
                   checked={values.sudo_required}
-                  onChange={e => handleChange(e, 'sudo_required')}
+                  onChange={handleChange('sudo_required')}
                   onBlur={handleOnBlur}
                 />
                 <FormTitle>{intl.messages.roles}</FormTitle>
@@ -165,7 +165,7 @@ class NodeCreateForm extends React.Component {
                   label={intl.messages.workload_plane}
                   checked={values.workload_plane}
                   value={values.workload_plane}
-                  onChange={e => handleChange(e, 'workload_plane')}
+                  onChange={handleChange('workload_plane')}
                   onBlur={handleOnBlur}
                   error={
                     values.workload_plane || values.control_plane
@@ -179,7 +179,7 @@ class NodeCreateForm extends React.Component {
                   label={intl.messages.control_plane}
                   checked={values.control_plane}
                   value={values.control_plane}
-                  onChange={e => handleChange(e, 'control_plane')}
+                  onChange={handleChange('control_plane')}
                   onBlur={handleOnBlur}
                   error={
                     values.workload_plane || values.control_plane

--- a/ui/src/containers/NodeCreateForm.js
+++ b/ui/src/containers/NodeCreateForm.js
@@ -7,6 +7,7 @@ import { withRouter } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
 import { Button, Input } from 'core-ui';
 import { padding, brand } from 'core-ui/dist/style/theme';
+import { isEmpty } from 'lodash';
 import {
   createNodeAction,
   clearCreateNodeErrorAction
@@ -86,48 +87,67 @@ class NodeCreateForm extends React.Component {
         <Formik
           initialValues={initialValues}
           validationSchema={validationSchema}
-          validateOnBlur={false}
-          validateOnChange={false}
           onSubmit={this.props.createNode}
         >
           {props => {
-            const { values, handleChange, isValid, touched, errors } = props;
+            const {
+              values,
+              touched,
+              errors,
+              dirty,
+              setFieldTouched,
+              setFieldValue
+            } = props;
+
+            //handleChange of the Formik props does not update 'values' when field value is empty
+            const handleChange = (e, field) => {
+              const { value, checked, type } = e.target;
+              setFieldValue(field, type === 'checkbox' ? checked : value, true);
+            };
+            //touched is not "always" correctly set
+            const handleOnBlur = e => setFieldTouched(e.target.name, true);
+
             return (
               <Form>
                 <Input
                   name="name"
                   label={intl.messages.name}
                   value={values.name}
-                  onChange={handleChange}
+                  onChange={e => handleChange(e, 'name')}
                   error={touched.name && errors.name}
+                  onBlur={handleOnBlur}
                 />
                 <Input
                   name="ssh_user"
                   label={intl.messages.ssh_user}
                   value={values.ssh_user}
-                  onChange={handleChange}
+                  onChange={e => handleChange(e, 'ssh_user')}
                   error={touched.ssh_user && errors.ssh_user}
+                  onBlur={handleOnBlur}
                 />
                 <Input
                   name="hostName_ip"
                   label={intl.messages.hostName_ip}
                   value={values.hostName_ip}
-                  onChange={handleChange}
+                  onChange={e => handleChange(e, 'hostName_ip')}
                   error={touched.hostName_ip && errors.hostName_ip}
+                  onBlur={handleOnBlur}
                 />
                 <Input
                   name="ssh_port"
                   label={intl.messages.ssh_port}
                   value={values.ssh_port}
-                  onChange={handleChange}
+                  onChange={e => handleChange(e, 'ssh_port')}
                   error={touched.ssh_port && errors.ssh_port}
+                  onBlur={handleOnBlur}
                 />
                 <Input
                   name="ssh_key_path"
                   label={intl.messages.ssh_key_path}
                   value={values.ssh_key_path}
-                  onChange={handleChange}
+                  onChange={e => handleChange(e, 'ssh_key_path')}
                   error={touched.ssh_key_path && errors.ssh_key_path}
+                  onBlur={handleOnBlur}
                 />
                 <Input
                   name="sudo_required"
@@ -135,7 +155,8 @@ class NodeCreateForm extends React.Component {
                   label={intl.messages.sudo_required}
                   value={values.sudo_required}
                   checked={values.sudo_required}
-                  onChange={handleChange}
+                  onChange={e => handleChange(e, 'sudo_required')}
+                  onBlur={handleOnBlur}
                 />
                 <FormTitle>{intl.messages.roles}</FormTitle>
                 <Input
@@ -144,7 +165,8 @@ class NodeCreateForm extends React.Component {
                   label={intl.messages.workload_plane}
                   checked={values.workload_plane}
                   value={values.workload_plane}
-                  onChange={handleChange}
+                  onChange={e => handleChange(e, 'workload_plane')}
+                  onBlur={handleOnBlur}
                   error={
                     values.workload_plane || values.control_plane
                       ? ''
@@ -157,7 +179,8 @@ class NodeCreateForm extends React.Component {
                   label={intl.messages.control_plane}
                   checked={values.control_plane}
                   value={values.control_plane}
-                  onChange={handleChange}
+                  onChange={e => handleChange(e, 'control_plane')}
+                  onBlur={handleOnBlur}
                   error={
                     values.workload_plane || values.control_plane
                       ? ''
@@ -175,12 +198,12 @@ class NodeCreateForm extends React.Component {
                     text={intl.messages.create}
                     type="submit"
                     disabled={
-                      !isValid ||
-                      !(values.workload_plane || values.control_plane) //TODO: TO BE IMPROVED
+                      !dirty ||
+                      !isEmpty(errors) ||
+                      !(values.workload_plane || values.control_plane)
                     }
                   />
                 </ActionContainer>
-
                 {asyncErrors && asyncErrors.create_node ? (
                   <ErrorMessage>{asyncErrors.create_node}</ErrorMessage>
                 ) : null}


### PR DESCRIPTION
Fix: https://github.com/scality/metalk8s/issues/1024

How to test:
-Fill any form input then empty it, an error should appear and the input is empty ;)
-Submit button is disabled until all field are set correctly
