### PR TITLE
salt: don't calculate Pillar top based on cluster

### DIFF
--- a/pillar/mine_functions.sls
+++ b/pillar/mine_functions.sls
@@ -1,9 +1,0 @@
-mine_functions:
-  control_plane_ip:
-    mine_function: grains.get
-    key: metalk8s:control_plane_ip
-  workload_plane_ip:
-    mine_function: grains.get
-    key: metalk8s:workload_plane_ip
-  etcd_endpoints:
-    mine_function: metalk8s.get_etcd_endpoint

--- a/pillar/top.sls.in
+++ b/pillar/top.sls.in
@@ -4,10 +4,10 @@
 # The mechanics of this file are very similar to those of `salt/top.sls(.in)`.
 # Please refer to the comments in that file for more background.
 
-{%- set version_match = "I@metalk8s:nodes:*:version:" ~ version -%}
+{%- set version_match = "I@metalk8s:nodes:" ~ grains.id ~ ":version:" ~ version -%}
 
 {%- macro role_match(name) -%}
-I@metalk8s:nodes:*:roles:{{ name }}
+I@metalk8s:nodes:{{ grains.id }}:roles:{{ name }}
 {%- endmacro %}
 
 metalk8s-{{ version }}:


### PR DESCRIPTION
In 13485d2, changes were made to the way Pillar data is calculated, in an attempt to base this on the 'role' of a minion.

However, this implementation is flawed: instead of matching on the minion ID in the `metalk8s.nodes` structure, it matches on the existence of *any* minion in a specific role in the whole cluster, so de-facto all minions get the same computed Pillar data.

The fix is trivial: instead of matching on `*` in the Pillar glob match, only match on `grains.id` in `metalk8s.nodes`.

See: #1010
See: 13485d2