### PR TITLE
deployment: kill kube-controller-manager when adding a new node

### DIFF
--- a/salt/_modules/metalk8s.py
+++ b/salt/_modules/metalk8s.py
@@ -153,3 +153,20 @@ def format_san(names):
         return result
 
     return ', '.join(sorted(format_name(name) for name in names))
+
+
+def minions_by_role(role, nodes=None):
+    '''Return a list of minion IDs in a specific role from Pillar data.
+
+    Arguments:
+        role (str): Role to match on
+        nodes (dict(str, dict)): Nodes to inspect
+            Defaults to `pillar.metalk8s.nodes`.
+    '''
+    nodes = nodes or __pillar__['metalk8s']['nodes']
+
+    return [
+        node
+        for (node, node_info) in nodes.items()
+        if role in node_info.get('roles', [])
+    ]

--- a/salt/_runners/metalk8s_saltutil.py
+++ b/salt/_runners/metalk8s_saltutil.py
@@ -57,3 +57,42 @@ def wait_minions(tgt='*', retry=10):
             tgt, ', '.join(minions)
         )
     }
+
+
+def orchestrate_show_sls(mods,
+                         saltenv='base',
+                         test=None,
+                         queue=False,
+                         pillar=None,
+                         pillarenv=None,
+                         pillar_enc=None):
+    '''
+    Display the state data from a specific sls, or list of sls files, after
+    being render using the master minion.
+
+    Note, the master minion adds a "_master" suffix to it's minion id.
+
+    .. seealso:: The state.show_sls module function
+
+    CLI Example:
+    .. code-block:: bash
+
+        salt-run state.orch_show_sls my-orch-formula.my-orch-state 'pillar={ nodegroup: ng1 }'
+    '''
+    if pillar is not None and not isinstance(pillar, dict):
+        raise SaltInvocationError(
+            'Pillar data must be formatted as a dictionary')
+
+    __opts__['file_client'] = 'local'
+    minion = salt.minion.MasterMinion(__opts__)
+    running = minion.functions['state.show_sls'](
+        mods,
+        test,
+        queue,
+        pillar=pillar,
+        pillarenv=pillarenv,
+        pillar_enc=pillar_enc,
+        saltenv=saltenv)
+
+    ret = {minion.opts['id']: running}
+    return ret

--- a/salt/metalk8s/orchestrate/deploy_new_node.sls
+++ b/salt/metalk8s/orchestrate/deploy_new_node.sls
@@ -63,6 +63,17 @@ Run the highstate:
       - salt: Set grains
       - salt: Refresh the mine
 
+# Work-around for https://github.com/scality/metalk8s/pull/1028
+Kill kube-controller-manager on all master nodes:
+  salt.function:
+    - name: ps.pkill
+    - tgt: "{{ salt['metalk8s.minions_by_role']('master') | join(',') }}"
+    - tgt_type: list
+    - kwarg:
+        pattern: kube-controller-manager
+    - require:
+      - salt: Run the highstate
+
 {%- if 'etcd' in pillar.get('metalk8s', {}).get('nodes', {}).get(pillar['node_name'], {}).get('roles', []) %}
 
 Register the node into etcd cluster:


### PR DESCRIPTION
~We had a long-standing issue with cluster expansion, where after
creating and deploying a new node, no `kube-proxy` Pod got scheduled on
it, rendering the node unusable.~

~When investigating, one could observe an event on the `DaemonSet` where
the `DaemonSetController` from `kube-controller-manager` reported the
Pod was not schedulable, since the Node had not enough resources: 1 Pod
needed, 0 available.~

~This is indeed the case when we create a new Node object without
provisioning the node (yet), though once `kubelet` is running on the new
node, the available resources are properly propagated to the Node
object. However, DSC didn't reschedule a Pod.~

~At this point, it did however schedule a new Pod for the `calico-node`
`DaemonSet` :-/~

~After spending some time reading the `DaemonSetController` source-code,
and pondering the differences between the `calico-node` and `kube-proxy`
`DaemonSet`s, as well as running `kube-controller-manager` with a
slightly higher log-level, made one thing clear: where the `kube-proxy`
scheduling failed because of missing resources, the scheduling of
`calico-node` initially failed because of missing resources, as well as
a non-matching `nodeSelector` (for `beta.kubernetes.io/os: linux`).
Given the source-code of the controller, it turns out that, indeed, this
second reason (as it's called in said code) causes a different code-path
to be taken in the controller implementation.~

~Trying to emulate this 'fix' by simply adding a `nodeSelector` to the
`kube-proxy` `DaemonSet` indeed causes the issue to be solved, and a Pod
to be scheduled once the new node is properly provisioned.~

~A patch that went into Kubernetes 1.12.0 could've fixed this as well,
however in testing this seems not to be the case.~

~See: https://github.com/kubernetes/kubernetes/commit/c42439c6765589b03fd4f79b75e8f30b1ec8fcfc#diff-3af9d435092399b4bf3ef61e0387eb36
See: https://github.com/kubernetes/kubernetes/pull/67337~

Previous approach didn't work in the end. Now resorting to killing/restarting `kube-controller-manager` when deploying a new node.