### PR TITLE
Salt orchestrate for etcd upgrade

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -145,6 +145,7 @@ SALT_FILES : Tuple[Union[Path, targets.FileTarget], ...] = (
     Path('salt/metalk8s/kubernetes/etcd/certs/peer.sls'),
     Path('salt/metalk8s/kubernetes/etcd/certs/server.sls'),
     Path('salt/metalk8s/kubernetes/etcd/files/manifest.yaml'),
+    Path('salt/metalk8s/kubernetes/etcd/healthy.sls'),
     Path('salt/metalk8s/kubernetes/etcd/init.sls'),
     Path('salt/metalk8s/kubernetes/etcd/installed.sls'),
 
@@ -190,6 +191,7 @@ SALT_FILES : Tuple[Union[Path, targets.FileTarget], ...] = (
     Path('salt/metalk8s/orchestrate/bootstrap/init.sls'),
     Path('salt/metalk8s/orchestrate/bootstrap/accept-minion.sls'),
     Path('salt/metalk8s/orchestrate/deploy_new_node.sls'),
+    Path('salt/metalk8s/orchestrate/upgrade/etcd.sls'),
 
     Path('salt/metalk8s/registry/deployed.sls'),
     Path('salt/metalk8s/registry/files/registry-manifest.yaml.j2'),

--- a/salt/metalk8s/kubernetes/etcd/healthy.sls
+++ b/salt/metalk8s/kubernetes/etcd/healthy.sls
@@ -1,0 +1,15 @@
+include:
+  - .installed
+
+Waiting for etcd running:
+  http.wait_for_successful_query:
+    - name: https://127.0.0.1:2379/health
+    - verify_ssl: True
+    - ca_bundle: /etc/kubernetes/pki/etcd/ca.crt
+    - cert:
+      - /etc/kubernetes/pki/etcd/server.crt
+      - /etc/kubernetes/pki/etcd/server.key
+    - status: 200
+    - match: '{"health": "true"}'
+    - require:
+      - file: Create local etcd Pod manifest

--- a/salt/metalk8s/kubernetes/etcd/init.sls
+++ b/salt/metalk8s/kubernetes/etcd/init.sls
@@ -5,6 +5,7 @@
 # ================
 #
 # * installed     -> deploy etcd manifest
+# * healthy       -> check health of etcd node
 #
 include:
   - .installed

--- a/salt/metalk8s/orchestrate/upgrade/etcd.sls
+++ b/salt/metalk8s/orchestrate/upgrade/etcd.sls
@@ -1,0 +1,44 @@
+{%- set dest_version = pillar.orchestrate.dest_version %}
+{%- set etcd_nodes = salt.metalk8s.minions_by_role('etcd') %}
+
+Check etcd cluster health:
+  module.run:
+    - metalk8s.check_etcd_health:
+      - hostname: {{ pillar.bootstrap_id }}
+
+{%- for node in etcd_nodes | sort %}
+
+Sync {{ node }} minion:
+  salt.function:
+    - name: saltutil.sync_all
+    - tgt: {{ node }}
+    - saltenv: metalk8s-{{ dest_version }}
+
+Upgrade etcd {{ node }} to {{ dest_version }}:
+  salt.state:
+    - tgt: {{ node }}
+    - sls:
+      - metalk8s.kubernetes.etcd.healthy
+    - saltenv: metalk8s-{{ dest_version }}
+    - require:
+      - salt: Sync {{ node }} minion
+      - module: Check etcd cluster health
+  {%- if previous_node is defined %}
+      - module: Check etcd cluster health for {{ previous_node }}
+  {%- endif %}
+
+Check etcd cluster health for {{ node }}:
+  module.run:
+    - metalk8s.check_etcd_health:
+      - hostname: {{ node }}
+    # FIXME: Can't retry because of https://github.com/saltstack/salt/issues/44639
+    # Should be ok for the moment as we check health in etcd.health state.
+    #- retry:
+    #    attempts: 5
+    - require:
+      - salt: Upgrade etcd {{ node }} to {{ dest_version }}
+
+  {#- Ugly but needed since we use have jinja2.7 (`loop.previtem` added in 2.10) #}
+  {%- set previous_node = node %}
+
+{%- endfor %}


### PR DESCRIPTION
Etcd upgrade and downgrade works:

Upgrade
```
salt-run state.orch metalk8s.orchestrate.upgrade.etcd saltenv=metalk8s-2.2 pillar="{'orchestrate': {'dest_version': '2.2'}, 'bootstrap_id': 'bootstrap'}"
```
Downgrade:
```
salt-run state.orch metalk8s.orchestrate.upgrade.etcd saltenv=metalk8s-2.2 pillar="{'orchestrate': {'dest_version': '2.1'}, 'bootstrap_id': 'bootstrap'}"
```

Note:
The saltenv `metalk8s-2.2` because we could maybe in the futur have action to remove thinks of this new version so we should always use the orchestrate of the newest version between dest_version and current version.

Fixes: #980