### PR TITLE
bootstrap: be more and less verbose during script execution

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -146,6 +146,7 @@ stages:
           command: >
             sudo bash
             /srv/scality/metalk8s-%(prop:metalk8s_short_version)s/bootstrap.sh
+            --verbose
           haltOnFailure: true
       - ShellCommand:
           name: Install kubectl for running tests
@@ -254,6 +255,7 @@ stages:
             ssh -F ssh_config bootstrap
             sudo bash
             /srv/scality/metalk8s-%(prop:metalk8s_short_version)s/bootstrap.sh
+            --verbose
           workdir: build/eve/workers/openstack-multiple-nodes/terraform/
           haltOnFailure: true
       - ShellCommand:

--- a/salt/metalk8s/salt/minion/files/minion-99-metalk8s.conf.j2
+++ b/salt/metalk8s/salt/minion/files/minion-99-metalk8s.conf.j2
@@ -6,3 +6,5 @@ retry_dns_count: 5
 # use new module.run format
 use_superseded:
   - module.run
+
+log_level_logfile: info

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -7,6 +7,14 @@ set -u
 # support `-o pipefail` (though must support `-e` and `-u` per POSIX).
 if test -z "$(type -p)"; then set -o pipefail; fi
 
+TMPFILES=$(mktemp -d)
+
+cleanup() {
+    rm -rf "${TMPFILES}" || true
+}
+
+trap cleanup EXIT
+
 RPM=${RPM:-$(command -v rpm)}
 SYSTEMCTL=${SYSTEMCTL:-$(command -v systemctl)}
 YUM=${YUM:-$(command -v yum)}
@@ -29,9 +37,53 @@ declare -A GPGCHECK_REPOSITORIES=(
     [metalk8s-scality]=0
 )
 
+run() {
+    local name=$1
+    shift 1
+
+    echo -n "> ${name}..."
+    local start
+    start=$(date +%s)
+    set +e
+    "$@" > "${TMPFILES}/out" 2>&1
+    local RC=$?
+    set -e
+    local end
+    end=$(date +%s)
+
+    local duration=$(( end - start ))
+
+    if [ $RC -eq 0 ]; then
+        echo " done [${duration}s]"
+    else
+        echo " fail [${duration}s]"
+        cat >/dev/stderr << EOM
+
+Failure while running step '${name}'
+
+Command: $@
+
+Output:
+
+<< BEGIN >>
+EOM
+        cat "${TMPFILES}/out" > /dev/stderr
+
+        cat >/dev/stderr << EOM
+<< END >>
+
+This script will now exit
+
+EOM
+
+        exit 1
+    fi
+}
+
+
 die() {
     echo 1>&2 "$@"
-    exit 1
+    return 1
 }
 
 pre_minion_checks() {
@@ -143,10 +195,11 @@ orchestrate_bootstrap() {
     # Grains must be set (in `/etc/salt/grains`) *before* invoking `salt-call`,
     # otherwise grains set during execution won't be taken into account
     # properly.
-    ${SALT_CALL} --local --state-output=mixed --retcode-passthrough state.sls \
-        metalk8s.node.grains \
-        saltenv=metalk8s-@@VERSION \
-        pillarenv=metalk8s-@@VERSION
+    run "Calculating Salt grains in local mode" \
+        "${SALT_CALL}" --local --state-output=mixed --retcode-passthrough state.sls \
+            metalk8s.node.grains \
+            saltenv=metalk8s-@@VERSION \
+            pillarenv=metalk8s-@@VERSION
 
     local -r control_plane_ip=$(
         ${SALT_CALL} --local grains.get metalk8s:control_plane_ip --out txt \
@@ -165,18 +218,21 @@ orchestrate_bootstrap() {
       "}"
     )
 
-    ${SALT_CALL} --local --state-output=mixed --retcode-passthrough state.sls \
-        '["metalk8s.roles.minion", "metalk8s.roles.bootstrap"]' \
-        saltenv=metalk8s-@@VERSION \
-        pillarenv=metalk8s-@@VERSION \
-        pillar="${pillar[*]}"
+    run "Deploying early-stage bootstrap node in local mode (this may take a while)" \
+        "${SALT_CALL}" --local --state-output=mixed --retcode-passthrough state.sls \
+            '["metalk8s.roles.minion", "metalk8s.roles.bootstrap"]' \
+            saltenv=metalk8s-@@VERSION \
+            pillarenv=metalk8s-@@VERSION \
+            pillar="${pillar[*]}"
 
-    SALT_MASTER_CALL="crictl exec -i $(get_salt_container)"
+    SALT_MASTER_CALL=(crictl exec -i "$(get_salt_container)")
 
-    ${SALT_MASTER_CALL} salt-run --state-output=mixed saltutil.sync_pillar \
-        saltenv=metalk8s-@@VERSION
-    ${SALT_MASTER_CALL} salt-run --state-output=mixed saltutil.sync_runners \
-        saltenv=metalk8s-@@VERSION
+    run "Syncing Pillar modules on Salt master" \
+        "${SALT_MASTER_CALL[@]}" salt-run --state-output=mixed saltutil.sync_pillar \
+            saltenv=metalk8s-@@VERSION
+    run "Syncing Runner modules on Salt master" \
+        "${SALT_MASTER_CALL[@]}" salt-run --state-output=mixed saltutil.sync_runners \
+            saltenv=metalk8s-@@VERSION
 
     local -r bootstrap_id=$(
         ${SALT_CALL} --local --out txt grains.get id \
@@ -189,24 +245,26 @@ orchestrate_bootstrap() {
       "}"
     )
 
-    ${SALT_MASTER_CALL} salt-run --state-output=mixed state.orchestrate \
-        metalk8s.orchestrate.bootstrap.accept-minion \
-        saltenv=metalk8s-@@VERSION \
-        pillar="${pillar[*]}"
+    run "Accepting bootstrap minion key on Salt master" \
+        "${SALT_MASTER_CALL[@]}" salt-run --state-output=mixed state.orchestrate \
+            metalk8s.orchestrate.bootstrap.accept-minion \
+            saltenv=metalk8s-@@VERSION \
+            pillar="${pillar[*]}"
 
-    ${SALT_MASTER_CALL} salt-run --state-output=mixed state.orchestrate \
-        metalk8s.orchestrate.bootstrap \
-        saltenv=metalk8s-@@VERSION \
-        pillar="${pillar[*]}"
+    run "Deploying bootstrap node (this may take a while)" \
+        "${SALT_MASTER_CALL[@]}" salt-run --state-output=mixed state.orchestrate \
+            metalk8s.orchestrate.bootstrap \
+            saltenv=metalk8s-@@VERSION \
+            pillar="${pillar[*]}"
 }
 
 main() {
-    pre_minion_checks
-    disable_salt_minion_service
-    stop_salt_minion_service
-    configure_yum_repositories
-    install_salt_minion
-    configure_salt_minion_local_mode
+    run "Pre-minion system tests" pre_minion_checks
+    run "Disabling Salt minion service" disable_salt_minion_service
+    run "Stopping Salt minion service" stop_salt_minion_service
+    run "Configuring local YUM repositories" configure_yum_repositories
+    run "Installing Salt minion" install_salt_minion
+    run "Configuring Salt minion to run in local mode" configure_salt_minion_local_mode
 
     orchestrate_bootstrap
 }

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -8,8 +8,9 @@ set -u
 if test -z "$(type -p)"; then set -o pipefail; fi
 
 VERBOSE=${VERBOSE:-0}
+LOGFILE=/var/log/metalk8s-bootstrap.log
 
-if ! options=$(getopt --options v --long verbose -- "$@"); then
+if ! options=$(getopt --options v --long verbose,log-file: -- "$@"); then
     echo 1>&2 "Incorrect arguments provided"
     exit 1
 fi
@@ -19,6 +20,10 @@ while true; do
     case "$1" in
         -v|--verbose)
             VERBOSE=1;
+            shift;;
+        --log-file)
+            shift;
+            LOGFILE="$1";
             shift;;
         --)
             shift;
@@ -30,6 +35,12 @@ while true; do
 done
 
 TMPFILES=$(mktemp -d)
+
+cat << EOF >> "${LOGFILE}"
+--- Bootstrap started on $(date -u -R) ---
+EOF
+
+exec > >(tee -ia "${LOGFILE}") 2>&1
 
 cleanup() {
     rm -rf "${TMPFILES}" || true
@@ -67,7 +78,7 @@ run_quiet() {
     local start
     start=$(date +%s)
     set +e
-    "$@" > "${TMPFILES}/out" 2>&1
+    "$@" 2>&1 | tee -ia "${LOGFILE}" > "${TMPFILES}/out"
     local RC=$?
     set -e
     local end

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -7,6 +7,28 @@ set -u
 # support `-o pipefail` (though must support `-e` and `-u` per POSIX).
 if test -z "$(type -p)"; then set -o pipefail; fi
 
+VERBOSE=${VERBOSE:-0}
+
+if ! options=$(getopt --options v --long verbose -- "$@"); then
+    echo 1>&2 "Incorrect arguments provided"
+    exit 1
+fi
+eval set -- "$options"
+
+while true; do
+    case "$1" in
+        -v|--verbose)
+            VERBOSE=1;
+            shift;;
+        --)
+            shift;
+            break;;
+        *)
+            echo 1>&2 "Option parsing failure";
+            exit 1;;
+    esac
+done
+
 TMPFILES=$(mktemp -d)
 
 cleanup() {
@@ -37,7 +59,7 @@ declare -A GPGCHECK_REPOSITORIES=(
     [metalk8s-scality]=0
 )
 
-run() {
+run_quiet() {
     local name=$1
     shift 1
 
@@ -80,6 +102,21 @@ EOM
     fi
 }
 
+run_verbose() {
+    local name=$1
+    shift 1
+
+    echo "> ${name}..."
+    "$@"
+}
+
+run() {
+    if [ "$VERBOSE" -eq 1 ]; then
+        run_verbose "${@}"
+    else
+        run_quiet "${@}"
+    fi
+}
 
 die() {
     echo 1>&2 "$@"


### PR DESCRIPTION
Successful execution (on, admittedly, a previously-deployed bootstrap node, hence the timings):

```
$ ./bootstrap.sh
> Pre-minion system tests... done [0s]
> Disabling Salt minion service... done [0s]
> Stopping Salt minion service... done [1s]
> Configuring local YUM repositories... done [0s]
> Installing Salt minion... done [0s]
> Configuring Salt minion to run in local mode... done [4s]
> Calculating Salt grains in local mode... done [2s]
> Deploying early-stage bootstrap node in local mode (this may take a while)... done [14s]
> Syncing Pillar modules on Salt master... done [1s]
> Syncing Runner modules on Salt master... done [2s]
> Accepting bootstrap minion key on Salt master... done [3s]
> Deploying bootstrap node (this may take a while)... done [48s]
```

When failing:

```
$ SALT_CALL=not-salt-call ./bootstrap.sh
> Pre-minion system tests... done [0s]
> Disabling Salt minion service... done [0s]
> Stopping Salt minion service... done [0s]
> Configuring local YUM repositories... done [1s]
> Installing Salt minion... done [0s]
> Configuring Salt minion to run in local mode... done [0s]
> Calculating Salt grains in local mode... fail [0s]

Failure while running step 'Calculating Salt grains in local mode'

Command: not-salt-call --local --state-output=mixed --retcode-passthrough state.sls metalk8s.node.grains saltenv=metalk8s-2.0 pillarenv=metalk8s-2.0

Output:

<< BEGIN >>
./bootstrap.sh: line 48: not-salt-call: command not found
<< END >>

This script will now exit

```

Fixes: #1029
Fixes: https://github.com/scality/metalk8s/issues/1029