### PR TITLE
salt: disable SSH host key checking

### DIFF
--- a/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
+++ b/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
@@ -15,6 +15,9 @@ roster_defaults:
     use_superseded:
       - module.run
 
+# Globally disable SSH host key checks
+no_host_keys: true
+
 rest_cherrypy:
   port: 4507
   host: {{ salt_api_ip }}


### PR DESCRIPTION
For now, globally disable SSH host key validation. Later on, we can
implement per-node host key validation (e.g. by putting the key
fingerprint as a Node annotation).