### PR TITLE
bugfix: fix storage validation

### DIFF
--- a/eve/images/pep8-checker/Dockerfile
+++ b/eve/images/pep8-checker/Dockerfile
@@ -5,9 +5,17 @@
 
 FROM alpine:3.8
 
-RUN apk add --no-cache git python python3 py2-pip py-twisted && \
+RUN apk add --no-cache \
+        gcc \
+        git \
+        musl-dev \
+        python \
+        python2-dev \
+        python3 \
+        py2-pip \
+        && \
     pip install tox && \
-    pip install buildbot-worker
+    pip install buildbot-worker==1.8.0
 
 WORKDIR /usr/src/metalk8s
 ARG USER_ID=1000

--- a/roles/setup_lvm_vg/action_plugins/validate_storage.py
+++ b/roles/setup_lvm_vg/action_plugins/validate_storage.py
@@ -132,7 +132,7 @@ def is_drive_raw_device(device, ansible_devices):
     if device in ansible_devices:
         return True, ansible_devices[device]
 
-    return False
+    return False, None
 
 
 def get_drive_attributes(device, ansible_devices, unused=False):


### PR DESCRIPTION
This commit fixes a bug that causes the Ansible installer to fail at the
`setup_lvm_vg` step when trying to validate any specified partition.

See https://github.com/scality/metalk8s/issues/1039