### PR TITLE
Add github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,23 @@
+---
+name: Bug Report
+about: Report a bug encountered while operating MetalK8s
+labels: bug,moonshot
+
+---
+
+<!-- Please use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks!
+
+If the matter is security related, please disclose it privately to security@scality.com
+-->
+
+**Component**:
+
+<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
+
+**What happened**:
+
+**What was expected**:
+
+**Steps to reproduce**
+
+**Resolution proposal** (optional):

--- a/.github/ISSUE_TEMPLATE/improvement.md
+++ b/.github/ISSUE_TEMPLATE/improvement.md
@@ -1,0 +1,19 @@
+---
+name: Improvement
+about: Suggest an improvement to the MetalK8s project
+labels: moonshot
+
+---
+<!-- Please only use this template for submitting improvement requests, and make sure it is linked to the relevant GitHub Project. -->
+
+**Component**:
+
+<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
+
+**Why this is needed**:
+
+**What should be done**:
+
+**Implementation proposal** (strongly recommended):
+
+**Test plan**:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+**Component**:
+
+<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
+
+**Context**: 
+
+**Summary**:
+
+**Acceptance criteria**: 

--- a/README.md
+++ b/README.md
@@ -35,3 +35,10 @@ vagrant ssh-config >bootstrap.ssh.config
 # The test command should be in that case
 SSH_CONFIG_FILE=bootstrap.ssh.config SSH_HOSTS_LIST=bootstrap tox -e tests
 ```
+
+---
+
+MetalK8s version 1 is still maintained in this repository. See the 
+`development/1.*` branches, e. g.
+[MetalK8s 1.3](github.com/scality/metalk8s/tree/development/1.3) in the same
+repository.


### PR DESCRIPTION
**Component**: Project

**Type**: bugfix/improvement/feature

**Context**: 
* Part of our drive to improve traceability and ease of understanding of outstanding issues for any contributor unaware of an issue's context.
* As a side-effect of making templates, we need to switch the main branch from Github's perspective to `2.0` and document that change.
* As a bonus, we include a PR template

**Summary**:

* add issue templates in `.github`
* add pull request template in `.github`
* add mention of MetalK8s 1.X in `README`

**Acceptance criteria**: 
* Issue templates to be visible as soon as the main branch switches to `2.0`
* Pull request template to be visible as soon as the main branch switches to `2.0`
* Main README reflects the fact that MetalK8s-1.X is unrelated to MetalK8s-2.X.