### PR TITLE
1.2 Forward Port - bugfix: fix storage validation

### DIFF
--- a/roles/setup_lvm_vg/action_plugins/validate_storage.py
+++ b/roles/setup_lvm_vg/action_plugins/validate_storage.py
@@ -132,7 +132,7 @@ def is_drive_raw_device(device, ansible_devices):
     if device in ansible_devices:
         return True, ansible_devices[device]
 
-    return False
+    return False, None
 
 
 def get_drive_attributes(device, ansible_devices, unused=False):


### PR DESCRIPTION
Forward port from dev/1.0 https://github.com/scality/metalk8s/pull/1040
> This commit fixes a bug that causes the Ansible installer to fail at the
> `setup_lvm_vg` step when trying to validate any specified partition
> 
> see #1039 