### PR TITLE
Move signing policies from salt-minion configuration to pillar

### DIFF
--- a/pillar/metalk8s/roles/ca.sls
+++ b/pillar/metalk8s/roles/ca.sls
@@ -14,3 +14,40 @@ mine_functions:
   kubernetes_sa_pub_key_b64:
     mine_function: hashutil.base64_encodefile
     fname: /etc/kubernetes/pki/sa.pub
+
+x509_signing_policies:
+  kube_apiserver_client_policy:
+    - minions: '*'
+    - signing_private_key: /etc/kubernetes/pki/ca.key
+    - signing_cert: /etc/kubernetes/pki/ca.crt
+    - keyUsage: critical digitalSignature, keyEncipherment
+    - extendedKeyUsage: clientAuth
+    - days_valid: 365
+  kube_apiserver_server_policy:
+    - minions: '*'
+    - signing_private_key: /etc/kubernetes/pki/ca.key
+    - signing_cert: /etc/kubernetes/pki/ca.crt
+    - keyUsage: critical digitalSignature, keyEncipherment
+    - extendedKeyUsage: serverAuth
+    - days_valid: 365
+  etcd_client_policy:
+    - minions: '*'
+    - signing_private_key: /etc/kubernetes/pki/etcd/ca.key
+    - signing_cert: /etc/kubernetes/pki/etcd/ca.crt
+    - keyUsage: critical digitalSignature, keyEncipherment
+    - extendedKeyUsage: clientAuth
+    - days_valid: 365
+  etcd_server_client_policy:
+    - minions: '*'
+    - signing_private_key: /etc/kubernetes/pki/etcd/ca.key
+    - signing_cert: /etc/kubernetes/pki/etcd/ca.crt
+    - keyUsage: critical digitalSignature, keyEncipherment
+    - extendedKeyUsage: serverAuth, clientAuth
+    - days_valid: 365
+  front_proxy_client_policy:
+    - minions: '*'
+    - signing_private_key: /etc/kubernetes/pki/front-proxy-ca.key
+    - signing_cert: /etc/kubernetes/pki/front-proxy-ca.crt
+    - keyUsage: critical digitalSignature, keyEncipherment
+    - extendedKeyUsage: clientAuth
+    - days_valid: 365

--- a/pillar/top.sls.in
+++ b/pillar/top.sls.in
@@ -1,5 +1,5 @@
 {%- set version = "@@VERSION" -%}
-{%- set roles = ['bootstrap', 'ca', 'etcd', 'master', 'node'] -%}
+{%- set roles = ['bootstrap', 'etcd', 'master', 'node'] -%}
 
 # The mechanics of this file are very similar to those of `salt/top.sls(.in)`.
 # Please refer to the comments in that file for more background.
@@ -25,6 +25,11 @@ metalk8s-{{ version }}:
   {{ version_match }}:
     - match: compound
     - metalk8s.roles.minion
+
+  # Specific case for ca as we need signing_policy at the very beginning
+  I@metalk8s:ca:minion:{{ grains.id }}:
+    - match: compound
+    - metalk8s.roles.ca
 
 {% for role in roles %}
   {{ version_match }} and {{ role_match(role) }}:

--- a/salt/metalk8s/kubernetes/ca/etcd/installed.sls
+++ b/salt/metalk8s/kubernetes/ca/etcd/installed.sls
@@ -2,7 +2,6 @@
 
 include:
   - metalk8s.internal.m2crypto
-  - metalk8s.salt.minion.running
 
 Create etcd CA private key:
   x509.private_key_managed:
@@ -41,31 +40,3 @@ Advertise etcd CA certificate in the mine:
       - /etc/kubernetes/pki/etcd/ca.crt
     - watch:
       - x509: Generate etcd CA certificate
-
-Create etcd CA salt signing policies:
-  file.serialize:
-    - name: /etc/salt/minion.d/30-metalk8s-etcd-ca-signing-policies.conf
-    - user: root
-    - group: root
-    - mode: 644
-    - makedirs: True
-    - dir_mode: 755
-    - formatter: yaml
-    - dataset:
-        x509_signing_policies:
-          etcd_client_policy:
-            - minions: '*'
-            - signing_private_key: /etc/kubernetes/pki/etcd/ca.key
-            - signing_cert: /etc/kubernetes/pki/etcd/ca.crt
-            - keyUsage: "critical digitalSignature, keyEncipherment"
-            - extendedKeyUsage: "clientAuth"
-            - days_valid: {{ etcd.ca.signing_policy.days_valid }}
-          etcd_server_client_policy:
-            - minions: '*'
-            - signing_private_key: /etc/kubernetes/pki/etcd/ca.key
-            - signing_cert: /etc/kubernetes/pki/etcd/ca.crt
-            - keyUsage: "critical digitalSignature, keyEncipherment"
-            - extendedKeyUsage: "serverAuth, clientAuth"
-            - days_valid: {{ etcd.ca.signing_policy.days_valid }}
-    - watch_in:
-      - cmd: Restart salt-minion

--- a/salt/metalk8s/kubernetes/ca/front-proxy/installed.sls
+++ b/salt/metalk8s/kubernetes/ca/front-proxy/installed.sls
@@ -2,7 +2,6 @@
 
 include:
   - metalk8s.internal.m2crypto
-  - metalk8s.salt.minion.running
 
 Create front proxy CA private key:
   x509.private_key_managed:
@@ -41,24 +40,3 @@ Advertise front proxy CA certificate in the mine:
       - /etc/kubernetes/pki/front-proxy-ca.crt
     - watch:
       - x509: Generate front proxy CA certificate
-
-Create front proxy CA salt signing policies:
-  file.serialize:
-    - name: /etc/salt/minion.d/30-metalk8s-front-proxy-ca-signing-policies.conf
-    - user: root
-    - group: root
-    - mode: 644
-    - makedirs: True
-    - dir_mode: 755
-    - formatter: yaml
-    - dataset:
-        x509_signing_policies:
-          front_proxy_client_policy:
-            - minions: '*'
-            - signing_private_key: /etc/kubernetes/pki/front-proxy-ca.key
-            - signing_cert: /etc/kubernetes/pki/front-proxy-ca.crt
-            - keyUsage: "critical digitalSignature, keyEncipherment"
-            - extendedKeyUsage: "clientAuth"
-            - days_valid: {{ front_proxy.ca.signing_policy.days_valid }}
-    - watch_in:
-      - cmd: Restart salt-minion

--- a/salt/metalk8s/kubernetes/ca/kubernetes/installed.sls
+++ b/salt/metalk8s/kubernetes/ca/kubernetes/installed.sls
@@ -2,7 +2,6 @@
 
 include:
   - metalk8s.internal.m2crypto
-  - metalk8s.salt.minion.running
 
 Create CA private key:
   x509.private_key_managed:
@@ -41,31 +40,3 @@ Advertise CA certificate in the mine:
       - /etc/kubernetes/pki/ca.crt
     - watch:
       - x509: Generate CA certificate
-
-Create CA salt signing_policies:
-  file.serialize:
-    - name: /etc/salt/minion.d/30-metalk8s-ca-signing-policies.conf
-    - user: root
-    - group: root
-    - mode: 644
-    - makedirs: True
-    - dir_mode: 755
-    - formatter: yaml
-    - dataset:
-        x509_signing_policies:
-          kube_apiserver_server_policy:
-            - minions: '*'
-            - signing_private_key: /etc/kubernetes/pki/ca.key
-            - signing_cert: /etc/kubernetes/pki/ca.crt
-            - keyUsage: "critical digitalSignature, keyEncipherment"
-            - extendedKeyUsage: "serverAuth"
-            - days_valid: {{ ca.signing_policy.days_valid }}
-          kube_apiserver_client_policy:
-            - minions: '*'
-            - signing_private_key: /etc/kubernetes/pki/ca.key
-            - signing_cert: /etc/kubernetes/pki/ca.crt
-            - keyUsage: "critical digitalSignature, keyEncipherment"
-            - extendedKeyUsage: "clientAuth"
-            - days_valid: {{ ca.signing_policy.days_valid }}
-    - watch_in:
-      - cmd: Restart salt-minion

--- a/salt/metalk8s/salt/minion/configured.sls
+++ b/salt/metalk8s/salt/minion/configured.sls
@@ -25,4 +25,4 @@ Remove minion local conf:
     - name: /etc/salt/minion.d/99-file-client-local.conf
     - require:
       - file: Configure salt minion
-      - service: Ensure salt-minion running
+      - module: Ensure salt-minion running

--- a/salt/metalk8s/salt/minion/running.sls
+++ b/salt/metalk8s/salt/minion/running.sls
@@ -16,3 +16,7 @@ Ensure salt-minion running:
     - enable: True
     - require:
       - module: Wait until salt-minion restarted
+  module.run:
+    - test.ping: []
+    - require:
+      - service: Ensure salt-minion running


### PR DESCRIPTION
Move signing policies to pillar to not have to restart salt-minion when we create signing_policy.

Also fix flaky about salt-minion restart

Fixes: #1059