### PR TITLE
Store digests of config files in static Pods annotations

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -269,6 +269,7 @@ SALT_FILES : Tuple[Union[Path, targets.FileTarget], ...] = (
     Path('salt/_states/containerd.py'),
     Path('salt/_states/kubeconfig.py'),
     Path('salt/_states/docker_registry.py'),
+    Path('salt/_states/metalk8s.py'),
     Path('salt/_states/metalk8s_etcd.py'),
     Path('salt/_states/metalk8s_kubernetes.py'),
 

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -182,7 +182,9 @@ stages:
           env:
             ISO_MOUNTPOINT: >
               /srv/scality/metalk8s-%(prop:metalk8s_short_version)s
-          command: tox -e tests-local
+          command: >
+            tox -e tests-local -- -m "ci and not slow" &&
+            tox -e tests-local -- -m "ci and slow"
           haltOnFailure: true
       - ShellCommand:
           name: Cypress test
@@ -308,13 +310,16 @@ stages:
             scp -F $SSH_CONFIG -r tests bastion:metalk8s/
       - ShellCommand:
           name: Run tests on the bastion
+          # yamllint disable rule:line-length
           command: >
-            ssh -F ssh_config bastion
-            "cd metalk8s &&
-            SSH_CONFIG_FILE=/home/centos/ssh_config
-            ISO_MOUNTPOINT=/srv/scality/metalk8s-%(prop:metalk8s_short_version)s
-            TEST_HOSTS_LIST=bootstrap
-            tox -e tests"
+            ssh -F ssh_config bastion --
+            'cd metalk8s &&
+            export SSH_CONFIG_FILE=/home/centos/ssh_config &&
+            export ISO_MOUNTPOINT=/srv/scality/metalk8s-%(prop:metalk8s_short_version)s &&
+            export TEST_HOSTS_LIST=bootstrap &&
+            tox -e tests -- -m "ci and not slow" &&
+            tox -e tests -- -m "ci and slow"'
+          # yamllint enable rule:line-length
           workdir: build/eve/workers/openstack-multiple-nodes/terraform/
           haltOnFailure: true
       - ShellCommand:

--- a/salt/_states/metalk8s.py
+++ b/salt/_states/metalk8s.py
@@ -1,0 +1,35 @@
+"""Custom states for MetalK8s."""
+
+__virtualname__ = "metalk8s"
+
+
+def __virtual__():
+    return __virtualname__
+
+
+def static_pod_managed(name, source, config_files=None, context=None):
+    """Simple helper to edit a static Pod manifest if configuration changes.
+
+    Expects the template to use the `config_digest` variable and store it in
+    the `metadata.annotations` section, with the key
+    `metalk8s.scality.com/config-digest`.
+    """
+    config_file_digests = [
+        __salt__["hashutil.digest_file"](config_file, checksum="sha256")
+        for config_file in config_files or []
+    ]
+    config_digest = __salt__["hashutil.md5_digest"](
+        "-".join(config_file_digests)
+    )
+
+    return __states__["file.managed"](
+        name,
+        source,
+        template="jinja",
+        user="root",
+        group="root",
+        mode="0600",
+        makedirs=False,
+        backup=False,
+        context=dict(context or {}, config_digest=config_digest),
+    )

--- a/salt/metalk8s/kubernetes/controller-manager/installed.sls
+++ b/salt/metalk8s/kubernetes/controller-manager/installed.sls
@@ -5,15 +5,13 @@ include:
   - .kubeconfig
 
 Create kube-controller-manager Pod manifest:
-  file.managed:
+  metalk8s.static_pod_managed:
     - name: /etc/kubernetes/manifests/kube-controller-manager.yaml
     - source: salt://metalk8s/kubernetes/files/control-plane-manifest.yaml
-    - template: jinja
-    - user: root
-    - group: root
-    - mode: 644
-    - makedirs: True
-    - dir_mode: 750
+    - config_files:
+        - /etc/kubernetes/controller-manager.conf
+        - /etc/kubernetes/pki/ca.crt
+        - /etc/kubernetes/pki/sa.key
     - context:
         name: kube-controller-manager
         image_name: {{ kubernetes_image("kube-controller-manager") }}
@@ -45,5 +43,5 @@ Create kube-controller-manager Pod manifest:
           - path: /etc/kubernetes/controller-manager.conf
             name: kubeconfig
             type: File
-    - require:
+    - onchanges:
       - metalk8s_kubeconfig: Create kubeconfig file for controller-manager

--- a/salt/metalk8s/kubernetes/etcd/installed.sls
+++ b/salt/metalk8s/kubernetes/etcd/installed.sls
@@ -29,15 +29,15 @@ Create etcd database directory:
     - makedirs: True
 
 Create local etcd Pod manifest:
-  file.managed:
+  metalk8s.static_pod_managed:
     - name: /etc/kubernetes/manifests/etcd.yaml
     - source: salt://{{ slspath }}/files/manifest.yaml
-    - template: jinja
-    - user: root
-    - group: root
-    - mode: 644
-    - makedirs: True
-    - dir_mode: 750
+    - config_files:
+        - /etc/kubernetes/pki/etcd/ca.crt
+        - /etc/kubernetes/pki/etcd/peer.crt
+        - /etc/kubernetes/pki/etcd/peer.key
+        - /etc/kubernetes/pki/etcd/server.crt
+        - /etc/kubernetes/pki/etcd/server.key
     - context:
         name: etcd
         image_name: {{ image_name }}
@@ -76,4 +76,4 @@ Advertise etcd node in the mine:
       - func: 'etcd_endpoints'
       - mine_function: metalk8s.get_etcd_endpoint
     - watch:
-      - file: Create local etcd Pod manifest
+      - metalk8s: Create local etcd Pod manifest

--- a/salt/metalk8s/kubernetes/files/control-plane-manifest.yaml
+++ b/salt/metalk8s/kubernetes/files/control-plane-manifest.yaml
@@ -3,6 +3,7 @@ kind: Pod
 metadata:
   annotations:
     scheduler.alpha.kubernetes.io/critical-pod: ""
+    metalk8s.scality.com/config-digest: "{{ config_digest }}"
   creationTimestamp: null
   name: {{ name }}
   namespace: "kube-system"

--- a/salt/metalk8s/kubernetes/scheduler/installed.sls
+++ b/salt/metalk8s/kubernetes/scheduler/installed.sls
@@ -4,15 +4,11 @@ include:
   - .kubeconfig
 
 Create kube-scheduler Pod manifest:
-  file.managed:
+  metalk8s.static_pod_managed:
     - name: /etc/kubernetes/manifests/kube-scheduler.yaml
     - source: salt://metalk8s/kubernetes/files/control-plane-manifest.yaml
-    - template: jinja
-    - user: root
-    - group: root
-    - mode: 644
-    - makedirs: True
-    - dir_mode: 750
+    - config_files:
+      - /etc/kubernetes/scheduler.conf
     - context:
         name: kube-scheduler
         image_name: {{ kubernetes_image("kube-scheduler") }}
@@ -29,5 +25,5 @@ Create kube-scheduler Pod manifest:
           - path: /etc/kubernetes/scheduler.conf
             name: kubeconfig
             type: File
-    - require:
+    - onchanges:
       - metalk8s_kubeconfig: Create kubeconfig file for scheduler

--- a/salt/metalk8s/registry/files/registry-manifest.yaml.j2
+++ b/salt/metalk8s/registry/files/registry-manifest.yaml.j2
@@ -11,6 +11,8 @@ metadata:
     heritage: metalk8s
     app.kubernetes.io/part-of: metalk8s
     app.kubernetes.io/managed-by: salt
+  annotations:
+    metalk8s.scality.com/config-digest: '{{ config_digest }}'
 spec:
   hostNetwork: true
   priorityClassName: system-cluster-critical

--- a/salt/metalk8s/registry/installed.sls
+++ b/salt/metalk8s/registry/installed.sls
@@ -31,22 +31,16 @@ Create OCI registry user:
     - mode: '0700'
 
 Install OCI registry manifest:
-  file.managed:
+  metalk8s.static_pod_managed:
     - name: /etc/kubernetes/manifests/registry.yaml
     - source: salt://{{ slspath }}/files/registry-manifest.yaml.j2
-    - template: jinja
-    - user: root
-    - group: root
-    - mode: '0644'
-    - makedirs: false
-    - backup: false
-    - require:
-      - group: Create OCI registry user
-      - user: Create OCI registry user
-      - file: Create OCI registry user
-    - defaults:
+    - context:
         registry_image: {{ registry_image }}
         registry_version: {{ registry_version }}
         registry_ip: {{ grains.metalk8s.control_plane_ip }}
         registry_user: {{ registry_user }}
         registry_group: {{ registry_group }}
+    - require:
+      - group: Create OCI registry user
+      - user: Create OCI registry user
+      - file: Create OCI registry user

--- a/salt/metalk8s/registry/populated.sls
+++ b/salt/metalk8s/registry/populated.sls
@@ -71,5 +71,5 @@ Import {{ image.name }} image:
     - tls_verify: false
     - require:
       - pkg: Install skopeo
-      - file: Install OCI registry manifest
+      - metalk8s: Install OCI registry manifest
 {% endfor %}

--- a/salt/metalk8s/repo/files/package-repositories-manifest.yaml.j2
+++ b/salt/metalk8s/repo/files/package-repositories-manifest.yaml.j2
@@ -10,6 +10,8 @@ metadata:
     heritage: metalk8s
     app.kubernetes.io/part-of: metalk8s
     app.kubernetes.io/managed-by: salt
+  annotations:
+    metalk8s.scality.com/config-digest: "{{ config_digest }}"
 spec:
   hostNetwork: true
   priorityClassName: system-cluster-critical

--- a/salt/metalk8s/repo/installed.sls
+++ b/salt/metalk8s/repo/installed.sls
@@ -21,23 +21,19 @@ Generate package repositories nginx configuration:
         listening_port: {{ repo.port }}
 
 Install package repositories manifest:
-  file.managed:
+  metalk8s.static_pod_managed:
     - name: /etc/kubernetes/manifests/package-repositories.yaml
     - source: salt://{{ slspath }}/files/package-repositories-manifest.yaml.j2
-    - template: jinja
-    - user: root
-    - group: root
-    - mode: '0644'
-    - makedirs: false
-    - backup: false
-    - defaults:
+    - config_files:
+      - {{ nginx_configuration_path }}
+    - context:
         container_port: {{ repo.port }}
         image: {{ package_repositories_image }}
         name: {{ package_repositories_name }}
         version: {{ package_repositories_version }}
         packages_path: {{ metalk8s.iso_root_path }}/{{ repo.relative_path }}
         nginx_configuration_path: {{ nginx_configuration_path }}
-    - require:
+    - onchanges:
       - file: Generate package repositories nginx configuration
 
 Ensure package repositories container is up:
@@ -46,4 +42,4 @@ Ensure package repositories container is up:
       - name: {{ package_repositories_name }}
       - state: running
     - require:
-      - file: Install package repositories manifest
+      - metalk8s: Install package repositories manifest

--- a/salt/metalk8s/salt/master/files/salt-master-manifest.yaml.j2
+++ b/salt/metalk8s/salt/master/files/salt-master-manifest.yaml.j2
@@ -13,6 +13,8 @@ metadata:
     heritage: metalk8s
     app.kubernetes.io/part-of: metalk8s
     app.kubernetes.io/managed-by: salt
+  annotations:
+    metalk8s.scality.com/config-digest: '{{ config_digest }}'
 spec:
   hostNetwork: true
   priorityClassName: system-cluster-critical

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,8 +58,39 @@ def kubeconfig(kubeconfig_data, tmp_path):
 
 
 @pytest.fixture
-def k8s_client(kubeconfig):
-    kubernetes.config.load_kube_config(config_file=kubeconfig)
-    return kubernetes.client.CoreV1Api()
+def k8s_apiclient(kubeconfig):
+    """Return an ApiClient to use for interacting with all K8s APIs."""
+    return kubernetes.config.new_client_from_config(
+        config_file=kubeconfig, persist_config=False
+    )
+
+
+@pytest.fixture
+def k8s_client(request, k8s_apiclient):
+    """Parametrized fixture to instantiate a client for a single K8s API.
+
+    By default, this will return a CoreV1Api client.
+    One can decorate a test function to use another API, like so:
+
+    ```
+    @pytest.mark.parametrize(
+        'k8s_client', ['AppsV1Api'], indirect=True
+    )
+    def test_something(k8s_client):
+        assert k8s_client.list_namespaced_deployment(namespace="default")
+    ```
+    """
+    api_name = getattr(request, "param", "CoreV1Api")
+    api_cls = getattr(kubernetes.client, api_name, None)
+
+    if api_cls is None:
+        pytest.fail(
+            "Unknown K8s API '{}' to use with `k8s_client` fixture.".format(
+                api_name
+            )
+        )
+
+    return api_cls(api_client=k8s_apiclient)
+
 
 # }}}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,9 @@
 import pathlib
 
+import kubernetes
+import pytest
+import yaml
+
 
 # Pytest command-line options
 def pytest_addoption(parser):
@@ -10,3 +14,52 @@ def pytest_addoption(parser):
         type=pathlib.Path,
         help="Root of the ISO file tree."
     )
+
+# Fixtures {{{
+
+
+@pytest.fixture(scope="module")
+def version(request, host):
+    iso_root = request.config.getoption("--iso-root")
+    product_path = iso_root / "product.txt"
+    with host.sudo():
+        return host.check_output(
+            'source %s && echo $SHORT_VERSION', str(product_path)
+        )
+
+@pytest.fixture(scope="module")
+def hostname(host):
+    """Return the result of `hostname` on the `host` fixture.
+
+    The hostname registered in the SSH config file may not match the one known
+    by the server, especially if running tests locally.
+    """
+    return host.check_output('hostname')
+
+
+@pytest.fixture(scope="module")
+def kubeconfig_data(request, host):
+    """Fixture to generate a kubeconfig file for remote usage."""
+    with host.sudo():
+        kubeconfig_file = host.file('/etc/kubernetes/admin.conf')
+        if not kubeconfig_file.exists:
+            pytest.skip(
+                "Must be run on bootstrap node, or have an existing file at "
+                "/etc/kubernetes/admin.conf"
+            )
+        return yaml.safe_load(kubeconfig_file.content_string)
+
+
+@pytest.fixture
+def kubeconfig(kubeconfig_data, tmp_path):
+    kubeconfig_path = tmp_path / "admin.conf"
+    kubeconfig_path.write_text(yaml.dump(kubeconfig_data), encoding='utf-8')
+    return str(kubeconfig_path)  # Need Python 3.6 to open() a Path object
+
+
+@pytest.fixture
+def k8s_client(kubeconfig):
+    kubernetes.config.load_kube_config(config_file=kubeconfig)
+    return kubernetes.client.CoreV1Api()
+
+# }}}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture(scope="module")
-def version(request, host):
+def short_version(request, host):
     iso_root = request.config.getoption("--iso-root")
     product_path = iso_root / "product.txt"
     with host.sudo():

--- a/tests/kube_utils.py
+++ b/tests/kube_utils.py
@@ -1,16 +1,41 @@
 import json
 
+from kubernetes.client.rest import ApiException
 
-def get_pods(host, label, namespace='default', status_phase='Running'):
+
+def get_pods(host, label, namespace="default", status_phase="Running"):
     with host.sudo():
         result = host.run(
-            'kubectl --kubeconfig=/etc/kubernetes/admin.conf '
+            "kubectl --kubeconfig=/etc/kubernetes/admin.conf "
             'get pods -l "%s" --field-selector=status.phase=%s '
-            '--namespace %s -o json',
+            "--namespace %s -o json",
             label,
             status_phase,
             namespace,
         )
         assert result.rc == 0, result.stdout
 
-        return json.loads(result.stdout)['items']
+        return json.loads(result.stdout)["items"]
+
+
+def wait_for_pod(k8s_client, name, namespace="default", state="Running"):
+    """Helper to generate a simple assertion method to check a Pod state.
+
+    It is designed to be used with `tests.utils.retry`, and handles 404
+    exceptions as transient (i.e. raises an `AssertionError` for a later
+    `retry`).
+    """
+
+    def _wait_for_pod():
+        try:
+            pod = k8s_client.read_namespaced_pod(
+                name=name, namespace=namespace
+            )
+        except ApiException as err:
+            if err.status == 404:
+                raise AssertionError("Pod not yet created")
+            raise
+
+        assert pod.status.phase == state, "Pod not yet '{}'".format(state)
+
+    return _wait_for_pod

--- a/tests/post/features/bootstrap.feature
+++ b/tests/post/features/bootstrap.feature
@@ -1,6 +1,6 @@
 @post @ci @local
 Feature: Bootstrap
     Scenario: Re-run bootstrap
-        Given bootstrap was run once
+        Given the Kubernetes API is available
         When we run bootstrap a second time
         Then the Kubernetes API is available

--- a/tests/post/features/bootstrap.feature
+++ b/tests/post/features/bootstrap.feature
@@ -1,4 +1,4 @@
-@post @ci @local
+@post @ci @local @slow
 Feature: Bootstrap
     Scenario: Re-run bootstrap
         Given the Kubernetes API is available

--- a/tests/post/features/salt_api.feature
+++ b/tests/post/features/salt_api.feature
@@ -1,4 +1,4 @@
-@popst @ci @local @salt
+@post @ci @local @salt
 Feature: SaltAPI
     Scenario: Login to SaltAPI
         Given the Kubernetes API is available

--- a/tests/post/features/static_pods.feature
+++ b/tests/post/features/static_pods.feature
@@ -1,0 +1,8 @@
+@ci @local @post
+Feature: Static Pods management
+    Scenario: Static Pods restart on configuration change
+        Given the Kubernetes API is available
+        And I have set up a static pod
+        When I edit the configuration of the static pod
+        And I use Salt to manage the static pod
+        Then the static pod was changed

--- a/tests/post/features/static_pods.feature
+++ b/tests/post/features/static_pods.feature
@@ -1,4 +1,4 @@
-@ci @local @post
+@ci @local @post @salt
 Feature: Static Pods management
     Scenario: Static Pods restart on configuration change
         Given the Kubernetes API is available

--- a/tests/post/features/ui_alive.feature
+++ b/tests/post/features/ui_alive.feature
@@ -1,4 +1,4 @@
-@post @ui
+@post @local @ci @ui
 Feature: The UI should be reachable
     Scenario: Reach the UI
         Given the Kubernetes API is available

--- a/tests/post/steps/conftest.py
+++ b/tests/post/steps/conftest.py
@@ -2,7 +2,6 @@
 from pytest_bdd import (
     given,
     then,
-    when,
     parsers,
 )
 
@@ -18,24 +17,9 @@ def _verify_kubeapi_service(host):
         assert retcode == 0
 
 
-def _run_bootstrap(request, host):
-    # FIXME: this can only run on the bootstrap node, we'd need to skip such
-    #        test if the host fixture is not adapted
-    iso_root = request.config.getoption("--iso-root")
-    cmd = str(iso_root / "bootstrap.sh")
-    with host.sudo():
-        res = host.run(cmd)
-        assert res.rc == 0, res.stdout
-
-
 # Pytest-bdd steps
 
 # Given
-@given('bootstrap was run once')
-def run_bootstrap(request, host):
-    _run_bootstrap(request, host)
-
-
 @given("the Kubernetes API is available")
 def check_service(host):
     _verify_kubeapi_service(host)
@@ -50,12 +34,6 @@ def check_pod_state(host, label, state):
     assert len(pods) > 0, "No {} pod with label '{}' found".format(
         state.lower(), label
     )
-
-
-# When
-@when('we run bootstrap a second time')
-def rerun_bootstrap(request, host):
-    _run_bootstrap(request, host)
 
 
 # Then

--- a/tests/post/steps/conftest.py
+++ b/tests/post/steps/conftest.py
@@ -1,47 +1,15 @@
 # -*- coding: utf-8 -*-
-import pytest
 from pytest_bdd import (
     given,
     then,
     when,
     parsers,
 )
-import yaml
 
 from tests import kube_utils
 
 
-# Pytest fixtures
-@pytest.fixture(scope="module")
-def kubeconfig_data(request, host):
-    """Fixture to generate a kubeconfig file for remote usage."""
-    with host.sudo():
-        kubeconfig_file = host.file('/etc/kubernetes/admin.conf')
-        if not kubeconfig_file.exists:
-            pytest.skip(
-                "Must be run on bootstrap node, or have an existing file at "
-                "/etc/kubernetes/admin.conf"
-            )
-        return yaml.safe_load(kubeconfig_file.content_string)
-
-
-@pytest.fixture
-def kubeconfig(kubeconfig_data, tmp_path):
-    kubeconfig_path = tmp_path / "admin.conf"
-    kubeconfig_path.write_text(yaml.dump(kubeconfig_data), encoding='utf-8')
-    return str(kubeconfig_path)  # Need Python 3.6 to open() a Path object
-
-
-@pytest.fixture
-def version(request, host):
-    iso_root = request.config.getoption("--iso-root")
-    product_path = iso_root / "product.txt"
-    with host.sudo():
-        return host.check_output(
-            'source %s && echo $SHORT_VERSION', str(product_path)
-        )
-
-
+# Helpers
 def _verify_kubeapi_service(host):
     """Verify that the kubeapi service answer"""
     with host.sudo():

--- a/tests/post/steps/files/static-pod.yaml.tpl
+++ b/tests/post/steps/files/static-pod.yaml.tpl
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $name
+  namespace: default
+  labels:
+    app: $name
+    app.kubernetes.io/name: $name
+  annotations:
+    metalk8s.scality.com/config-digest: {{ config_digest }}
+spec:
+  tolerations:
+  - key: "node-role.kubernetes.io/bootstrap"
+    operator: "Equal"
+    effect: "NoSchedule"
+  - key: "node-role.kubernetes.io/infra"
+    operator: "Equal"
+    effect: "NoSchedule"
+  containers:
+    - name: $name
+      image: $image
+      command:
+      - sleep
+      - "3600"
+      volumeMounts:
+        - name: config-file
+          mountPath: $config_path
+  volumes:
+    - name: config-file
+      hostPath:
+        path: $config_path
+        type: File
+  restartPolicy: Always

--- a/tests/post/steps/test_bootstrap.py
+++ b/tests/post/steps/test_bootstrap.py
@@ -1,7 +1,17 @@
-from pytest_bdd import scenario
+from pytest_bdd import scenario, when
 
 
 # Scenarios
 @scenario('../features/bootstrap.feature', 'Re-run bootstrap')
 def test_bootstrap(host):
     pass
+
+
+# When
+@when('we run bootstrap a second time')
+def rerun_bootstrap(request, host):
+    iso_root = request.config.getoption("--iso-root")
+    cmd = str(iso_root / "bootstrap.sh")
+    with host.sudo():
+        res = host.run(cmd)
+        assert res.rc == 0, res.stdout

--- a/tests/post/steps/test_dns.py
+++ b/tests/post/steps/test_dns.py
@@ -10,10 +10,7 @@ from tests import utils
 
 
 @pytest.fixture
-def busybox_pod(kubeconfig):
-    config.load_kube_config(config_file=kubeconfig)
-    k8s_client = client.CoreV1Api()
-
+def busybox_pod(k8s_client):
     # Create the busybox pod
     pod_manifest = os.path.join(
         os.path.realpath(os.path.dirname(__file__)),

--- a/tests/post/steps/test_dns.py
+++ b/tests/post/steps/test_dns.py
@@ -33,6 +33,7 @@ def busybox_pod(kubeconfig):
             k8s_client, name="busybox", namespace="default", state="Running"
         ),
         times=10,
+        wait=5,
         name="wait for Pod 'busybox'",
     )
 

--- a/tests/post/steps/test_dns.py
+++ b/tests/post/steps/test_dns.py
@@ -5,6 +5,7 @@ import pytest
 from pytest_bdd import scenario, then, parsers
 import yaml
 
+from tests import kube_utils
 from tests import utils
 
 
@@ -27,16 +28,13 @@ def busybox_pod(kubeconfig):
     )
 
     # Wait for the busybox to be ready
-    def _check_status():
-        pod_info = k8s_client.read_namespaced_pod(
-            name="busybox",
-            namespace="default",
-        )
-        assert pod_info.status.phase == "Running", (
-            "Wrong status for 'busybox' Pod - found {status}"
-        ).format(status=pod_info.status.phase)
-
-    utils.retry(_check_status, times=10)
+    utils.retry(
+        kube_utils.wait_for_pod(
+            k8s_client, name="busybox", namespace="default", state="Running"
+        ),
+        times=10,
+        name="wait for Pod 'busybox'",
+    )
 
     yield "busybox"
 

--- a/tests/post/steps/test_salt_api.py
+++ b/tests/post/steps/test_salt_api.py
@@ -29,11 +29,11 @@ def context():
 
 @when(parsers.parse(
     "we login to SaltAPI as '{username}' using password '{password}'"))
-def login_salt_api(host, username, password, version, context, request):
+def login_salt_api(host, username, password, short_version, context, request):
     cmd_cidr = ' '.join([
         'salt-call pillar.get',
         'networks:control_plane',
-        'saltenv=metalk8s-{version}'.format(version=version),
+        'saltenv=metalk8s-{version}'.format(version=short_version),
         '--out json',
     ])
     with host.sudo():

--- a/tests/post/steps/test_static_pods.py
+++ b/tests/post/steps/test_static_pods.py
@@ -104,7 +104,7 @@ def set_up_static_pod(host, hostname, k8s_client, transient_files):
 
     utils.retry(
         kube_utils.wait_for_pod(k8s_client, fullname),
-        times=3,
+        times=10,
         wait=5,
         name="wait for Pod '{}'".format(fullname),
     )
@@ -139,7 +139,7 @@ def check_static_pod_changed(host, hostname, k8s_client, static_pod_id):
     fullname = "{}-{}".format(DEFAULT_POD_NAME, hostname)
     utils.retry(
         kube_utils.wait_for_pod(k8s_client, fullname),
-        times=3,
+        times=10,
         wait=5,
         name="wait for Pod '{}'".format(fullname),
     )

--- a/tests/post/steps/test_static_pods.py
+++ b/tests/post/steps/test_static_pods.py
@@ -1,0 +1,170 @@
+import pathlib
+import string
+import time
+
+from kubernetes.client.rest import ApiException
+import pytest
+from pytest_bdd import given, scenario, then, when
+
+from tests import utils
+
+# Constants {{{
+
+MANIFESTS_PATH = pathlib.Path("/etc/kubernetes/manifests/")
+TEMPLATES_PATH = pathlib.Path("/srv/scality/_templates/")
+SOURCE_TEMPLATE = (
+    pathlib.Path(__file__) / ".." / "files" / "static-pod.yaml.tpl"
+).resolve()
+DEFAULT_POD_NAME = "sample-static-pod"
+
+# }}}
+# Fixtures {{{
+
+
+@pytest.fixture(scope="function")
+def transient_files(host):
+    """A fixture to store a list of filenames to remove after a test."""
+    filenames = []
+
+    yield filenames
+
+    with host.sudo():
+        for file in filenames:
+            cmd = host.run("rm -f %s", file)
+            assert cmd.rc == 0, "Failed to remove file '{}': {}".format(
+                file, cmd.stderr
+            )
+
+
+# }}}
+
+
+@scenario(
+    "../features/static_pods.feature",
+    "Static Pods restart on configuration change",
+)
+def test_static_pods_restart(host, transient_files):
+    pass
+
+
+@given("I have set up a static pod", target_fixture="static_pod_id")
+def set_up_static_pod(host, hostname, k8s_client, transient_files):
+    manifest_path = str(MANIFESTS_PATH / "{}.yaml".format(DEFAULT_POD_NAME))
+
+    with host.sudo():
+        if host.file(manifest_path).exists:
+            pytest.fail(
+                "Cannot set up static Pod with manifest at path '{}': "
+                "already exists".format(manifest_path)
+            )
+
+    # A sample config file for the static Pod
+    config_path = "/tmp/{}.conf".format(DEFAULT_POD_NAME)
+    write_config = utils.write_string(host, config_path, '{"hello": "world"}')
+    assert write_config.rc == 0, (
+        "Failed to write static Pod config file at '{}': {}"
+    ).format(config_path, write_config.stderr)
+
+    transient_files.append(config_path)
+
+    # The manifest template to use with Salt
+    manifest_template = SOURCE_TEMPLATE.read_text(encoding="utf-8")
+    manifest = string.Template(manifest_template).substitute(
+        name=DEFAULT_POD_NAME,
+        image="busybox",  # TODO: use base image from #1093
+        config_path=config_path,
+    )
+
+    with host.sudo():
+        host.run_test("mkdir -p %s", str(TEMPLATES_PATH))
+
+        template_path = str(
+            TEMPLATES_PATH / "{}.yaml.j2".format(DEFAULT_POD_NAME)
+        )
+        write_template = utils.write_string(host, template_path, manifest)
+        assert write_template.rc == 0, (
+            "Failed to create static Pod manifest template '{}': {}"
+        ).format(template_path, write_template.stderr)
+
+    transient_files.append(template_path)
+
+    # Use Salt to generate the effective static Pod manifest
+    _manage_static_pod(host, manifest_path, template_path, config_path)
+
+    assert host.file(manifest_path).exists, (
+        "Something went wrong: "
+        "static Pod manifest could not be found after set-up"
+    )
+
+    # We want to remove the manifest before the config file, since kubelet
+    # may try to mount it and, when not found, create a directory (bug).
+    # See: https://github.com/kubernetes/kubernetes/issues/65825
+    transient_files.insert(0, manifest_path)
+
+    fullname = "{}-{}".format(DEFAULT_POD_NAME, hostname)
+
+    def _wait_for_pod():
+        try:
+            pod = k8s_client.read_namespaced_pod(
+                name=fullname, namespace="default"
+            )
+        except ApiException as err:
+            if err.status == 404:
+                raise AssertionError("Pod not yet created")
+            raise
+
+        assert pod.status.phase == "Running", "Pod not yet running"
+
+    utils.retry(_wait_for_pod, times=3, wait=5)
+
+    pod = k8s_client.read_namespaced_pod(name=fullname, namespace="default")
+    return pod.metadata.uid
+
+
+@when("I edit the configuration of the static pod")
+def edit_static_pod_config(host):
+    config_path = "/tmp/{}.conf".format(DEFAULT_POD_NAME)
+
+    with host.sudo():
+        edit_config = utils.write_string(
+            host, config_path, '{"goodbye": "world"}'
+        )
+        assert edit_config.rc == 0, (
+            "Failed to edit config file at '{}': {}"
+        ).format(config_path, edit_config.stderr)
+
+
+@when("I use Salt to manage the static pod")
+def manage_static_pod(host):
+    manifest_path = str(MANIFESTS_PATH / "{}.yaml".format(DEFAULT_POD_NAME))
+    template_path = str(TEMPLATES_PATH / "{}.yaml.j2".format(DEFAULT_POD_NAME))
+    config_path = "/tmp/{}.conf".format(DEFAULT_POD_NAME)
+    _manage_static_pod(host, manifest_path, template_path, config_path)
+
+
+@then("the static pod was changed")
+def check_static_pod_changed(host, hostname, k8s_client, static_pod_id):
+    fullname = "{}-{}".format(DEFAULT_POD_NAME, hostname)
+    pod = k8s_client.read_namespaced_pod(name=fullname, namespace="default")
+
+    assert pod.metadata.uid != static_pod_id
+
+
+# Helpers {{{
+
+
+def _manage_static_pod(host, manifest_path, template_path, config_path):
+    with host.sudo():
+        manage_static_pod = host.run(
+            "salt-call state.single metalk8s.static_pod_managed "
+            'name=%s source=%s config_files=["%s"]',
+            manifest_path,
+            template_path,
+            config_path,
+        )
+        assert manage_static_pod.rc == 0, (
+            "Failed to manage static Pod with Salt: {}"
+        ).format(manage_static_pod.stderr)
+
+
+# }}}

--- a/tests/post/steps/test_ui.py
+++ b/tests/post/steps/test_ui.py
@@ -12,7 +12,7 @@ def test_ui(host):
 
 
 @then("we can reach the UI")
-def reach_UI(host, version, request):
+def reach_UI(host):
     with host.sudo():
         output = host.check_output(' '.join([
             'salt-call', '--local', '--out=json',

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from typing import Optional, Dict
 
 import pytest
 
@@ -27,3 +28,7 @@ def retry(operation, times=1, wait=1, error_msg=None, name="default"):
             ).format(name=name, attempts=times, total=times * wait)
 
         pytest.fail(error_msg)
+
+
+def write_string(host, dest, contents):
+    return host.run("cat > {} << EOF\n{}\nEOF".format(dest, contents))

--- a/tox.ini
+++ b/tox.ini
@@ -103,7 +103,7 @@ commands =
          --ssh-config={env:SSH_CONFIG_FILE:{envdir}/vagrant_ssh_config} \
          --hosts={env:TEST_HOSTS_LIST:bootstrap} \
          --iso-root={env:ISO_MOUNTPOINT:/vagrant/_build/root} \
-         {posargs} tests
+         {posargs:-m local} tests
 
 [testenv:tests-local]
 description =
@@ -111,9 +111,19 @@ description =
 deps = {[testenv:tests]deps}
 passenv =
     ISO_MOUNTPOINT
-commands = pytest --iso-root={env:ISO_MOUNTPOINT:_build/root} {posargs} tests
+commands =
+    pytest \
+        --iso-root={env:ISO_MOUNTPOINT:_build/root} \
+        {posargs:-m local} tests
 
 [pytest]
+markers =
+    ci: tag a BDD feature as part of CI test suite
+    local: tag a BDD feature as part of local test suite
+    post: tag a BDD feature as a post-installation test
+    slow: tag a BDD feature as a long running test
+    ui: tag a BDD feature as related to MetalK8s UI
+    salt: tag a BDD feature as related to Salt operations
 filterwarnings =
     ignore:encode_point has been deprecated on EllipticCurvePublicNumbers and will be removed in a future version. Please use EllipticCurvePublicKey.public_bytes to obtain both compressed and uncompressed point encoding.:UserWarning
     ignore:Support for unsafe construction of public numbers from encoded data will be removed in a future version. Please use EllipticCurvePublicKey.from_encoded_point:UserWarning


### PR DESCRIPTION
**Component**: salt, kubernetes
**Type**: bugfix

**Context**:

- In order to have `kubelet` restart static Pod containers on configuration changes, we need to actually change the static Pod manifest

**Summary**:

- Introduce a basic `metalk8s.static_pod_managed` helper state to compute config files digests at runtime (so we can still rely on Salt `require`/`watch` ordering to lazily evaluate the hashes)
    - Hashing algorithm is basically: `md5 ( '-'.join( sha256(file for file in config_files) )`

- Use it for Salt master
- Use it for K8s control plane components (`k-a`, `k-s`, `k-c-m`) and `etcd`
- Use it for the package repositories and OCI registry

- Each static pod includes **every** single file that it wants to read (certificates, private keys, kubeconfig, etc.)

**Acceptance criteria**:

- On changes to the Salt master configuration files (**made using Salt**), `salt-master` Pod should be "restarted" by `kubelet` (actually replaced)
- On changes to other config files (e.g. certificates, kubeconfigs), related Pods should be "restarted"

**Notes**:

When trying to make this PR get a green build, I ran into many CI issues linked to "not waiting long enough" in tests. In the process of fixing this, a few modifications around tests were made:

- Pytest markers are now documented and used by default: see a4f1f09ae0ff04e78c6c59fe0becfe23f4ddf679
- The "bootstrap idempotent" test only runs the bootstrap once, since it's a `@post` test, and is now marked as `@slow`, which runs after the other tests in the CI (and can be filtered out easily with `tox -e tests -- -m "not slow"`)
- A number of tests now wait (through multiple retries) much longer than they used to before attempting operations on `Running` Pods

---

Fixes: GH-937
Fixes: GH-881