### PR TITLE
build: don't pass `--broken` to `git`

### DIFF
--- a/buildchain/buildchain/constants.py
+++ b/buildchain/buildchain/constants.py
@@ -106,7 +106,7 @@ def git_ref() -> Optional[str]:
     try:
         ref : bytes = subprocess.check_output([
             config.GIT, 'describe', '--always', '--long', '--tags',
-                '--dirty', '--broken',
+                '--dirty',
         ])
 
         return ref.decode('utf-8').rstrip()


### PR DESCRIPTION
In 4979e75e3c03f the arguments passed to `git describe` to find the Git
revision of a build were somewhat changed, adding `--broken`. However,
the version of Git as shipped with CentOS 7 doesn't support this option.

Since it's not strictly required anyway, simply removing it.

See: 4979e75e3c03f2a6786b08b9d1fcc66f92f7548e