### PR TITLE
cni: deploy a fallback `loopback` CNI configuration

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -130,6 +130,10 @@ SALT_FILES : Tuple[Union[Path, targets.FileTarget], ...] = (
     Path('salt/metalk8s/kubernetes/cni/calico/deployed.sls'),
     Path('salt/metalk8s/kubernetes/cni/calico/init.sls'),
     Path('salt/metalk8s/kubernetes/cni/calico/installed.sls'),
+    Path('salt/metalk8s/kubernetes/cni/loopback/configured.sls'),
+    Path('salt/metalk8s/kubernetes/cni/loopback/init.sls'),
+    Path('salt/metalk8s/kubernetes/cni/loopback/installed.sls'),
+
 
     Path('salt/metalk8s/kubernetes/controller-manager/init.sls'),
     Path('salt/metalk8s/kubernetes/controller-manager/installed.sls'),
@@ -214,7 +218,7 @@ SALT_FILES : Tuple[Union[Path, targets.FileTarget], ...] = (
     Path('salt/metalk8s/roles/etcd/init.sls'),
     Path('salt/metalk8s/roles/infra/init.sls'),
     Path('salt/metalk8s/roles/infra/absent.sls'),
-    Path('salt/metalk8s/roles/internal/node-without-cni.sls'),
+    Path('salt/metalk8s/roles/internal/node-without-calico.sls'),
     Path('salt/metalk8s/roles/master/absent.sls'),
     Path('salt/metalk8s/roles/master/init.sls'),
     Path('salt/metalk8s/roles/minion/init.sls'),

--- a/salt/metalk8s/kubernetes/cni/loopback/configured.sls
+++ b/salt/metalk8s/kubernetes/cni/loopback/configured.sls
@@ -1,0 +1,12 @@
+Create CNI configuration file for the 'loopback' plugin:
+  file.serialize:
+    - name: /etc/cni/net.d/99-loopback.conf
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - dir_mode: 755
+    - formatter: json
+    - dataset:
+        cniVersion: "0.3.1"
+        type: "loopback"

--- a/salt/metalk8s/kubernetes/cni/loopback/init.sls
+++ b/salt/metalk8s/kubernetes/cni/loopback/init.sls
@@ -1,0 +1,27 @@
+# When setting up a *master* and/or *etcd* node, we don't deploy Calico
+# (and its configuration) on the server, because such node is not
+# required to be part of the overlay network (it's not running any
+# non-`hostNetwork` Pods, and shouldn't connect to any other
+# non-`hostNetwork` Pods).
+#
+# However, as long as no CNI configuration is present, `kubelet`
+# complains and the Node remains in `NotReady` state.
+#
+# We can work-around this by either
+#
+# - explaining this in documentation
+# - unnecessarily deploying Calico on the node
+# - providing another valid CNI configuration, e.g. for `localhost`
+#
+# The latter seem the right approach here: it'll still require
+# documentation ('Why is my Pod not working on a non-node/infra node after
+# I removed the taints?'), but doesn't unnecessarily impact the networking
+# on a control-plane node, and doesn't keep Nodes in `NotReady` state even
+# though they kind-of are.
+#
+# Fixes: #1087
+# Fixes: https://github.com/scality/metalk8s/issues/1087
+
+include:
+  - .installed
+  - .configured

--- a/salt/metalk8s/kubernetes/cni/loopback/installed.sls
+++ b/salt/metalk8s/kubernetes/cni/loopback/installed.sls
@@ -1,0 +1,9 @@
+{%- from "metalk8s/macro.sls" import pkg_installed with context %}
+
+include:
+  - metalk8s.repo
+
+Install kubernetes-cni:
+  {{ pkg_installed('kubernetes-cni') }}
+    - require:
+      - test: Repositories configured

--- a/salt/metalk8s/roles/etcd/init.sls
+++ b/salt/metalk8s/roles/etcd/init.sls
@@ -1,3 +1,3 @@
 include:
-  - metalk8s.roles.internal.node-without-cni
+  - metalk8s.roles.internal.node-without-calico
   - metalk8s.kubernetes.etcd

--- a/salt/metalk8s/roles/internal/node-without-calico.sls
+++ b/salt/metalk8s/roles/internal/node-without-calico.sls
@@ -1,4 +1,5 @@
 include:
   - metalk8s.node.grains
+  - metalk8s.kubernetes.cni.loopback
   - metalk8s.kubernetes.kubelet
   - metalk8s.internal.preflight

--- a/salt/metalk8s/roles/master/init.sls
+++ b/salt/metalk8s/roles/master/init.sls
@@ -1,5 +1,5 @@
 include:
-  - metalk8s.roles.internal.node-without-cni
+  - metalk8s.roles.internal.node-without-calico
   - metalk8s.kubernetes.apiserver
   - metalk8s.kubernetes.controller-manager
   - metalk8s.kubernetes.scheduler

--- a/salt/metalk8s/roles/node/init.sls
+++ b/salt/metalk8s/roles/node/init.sls
@@ -1,3 +1,3 @@
 include:
-  - metalk8s.roles.internal.node-without-cni
+  - metalk8s.roles.internal.node-without-calico
   - metalk8s.kubernetes.cni.calico


### PR DESCRIPTION
When setting up a *master* and/or *etcd* node, we don't deploy Calico
(and its configuration) on the server, because such node is not
required to be part of the overlay network (it's not running any
non-`hostNetwork` Pods, and shouldn't connect to any other
non-`hostNetwork` Pods).

However, as long as no CNI configuration is present, `kubelet`
complains and the Node remains in `NotReady` state.

We can work-around this by either

- explaining this in documentation
- unnecessarily deploying Calico on the node
- providing another valid CNI configuration, e.g. for `localhost`

The latter seem the right approach here: it'll still require
documentation ('Why is my Pod not working on a non-node/infra node after
I removed the taints?'), but doesn't unnecessarily impact the networking
on a control-plane node, and doesn't keep Nodes in `NotReady` state even
though they kind-of are.

Fixes: #1087
Fixes: https://github.com/scality/metalk8s/issues/1087