### PR TITLE
ft: add nfs-utils package to enable out of the box NFS PV usage

### DIFF
--- a/roles/prepare_os/tasks/main.yml
+++ b/roles/prepare_os/tasks/main.yml
@@ -5,6 +5,7 @@
   with_items:
     - ipvsadm
     - libselinux-python
+    - nfs-utils
   when: ansible_os_family == 'RedHat'
 
 - import_tasks: persistent_logs.yml


### PR DESCRIPTION
Adds the `nfs-utils` into the `prepare_os` role to enable out of the box NFS PV usage.

Resolves #1052
