### PR TITLE
salt: add `kubernetes` renderer

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -246,6 +246,8 @@ SALT_FILES : Tuple[Union[Path, targets.FileTarget], ...] = (
     Path('salt/_pillar/metalk8s_endpoints.py'),
     Path('salt/_pillar/metalk8s_nodes.py'),
 
+    Path('salt/_renderers/metalk8s_kubernetes.py'),
+
     Path('salt/_roster/kubernetes_nodes.py'),
 
     Path('salt/_runners/metalk8s_saltutil.py'),

--- a/salt/_renderers/metalk8s_kubernetes.py
+++ b/salt/_renderers/metalk8s_kubernetes.py
@@ -1,0 +1,99 @@
+'''
+A renderer for Kubernetes YAML manifests
+
+Given a Kubernetes YAML file (which may be a stream of objects, i.e. YAML
+snippets separated by `---` lines), this will render an SLS which calls Salt
+`*_present` states for every such object.
+
+To use it, add a shebang like `#!kubernetes` as the first line of your manifests
+SLS file. Optionally, you can use rendering pipelines (if templating is
+required), e.g. `#!jinja | kubernetes`.
+'''
+
+import yaml
+
+import salt.utils.yaml
+from salt.utils.odict import OrderedDict
+
+from salt.ext import six
+
+__virtualname__ = 'kubernetes'
+
+
+def __virtual__():
+    return __virtualname__
+
+
+def _step_name(obj):
+    namespace = obj['metadata'].get('namespace')
+
+    if namespace:
+        name = '{}/{}'.format(
+            namespace,
+            obj['metadata']['name'],
+        )
+    else:
+        name = obj['metadata']['name']
+
+    return "Apply {}/{} '{}'".format(
+        obj['apiVersion'],
+        obj['kind'],
+        name,
+    )
+
+
+_HANDLERS = {}
+
+def handle(api_version, kind):
+    '''
+    Register a 'handler' (object -> state mapping) for `apiVersion` and `kind`
+    '''
+    tag = (api_version, kind)
+
+    def register(f):
+        assert tag not in _HANDLERS
+
+        _HANDLERS[tag] = f
+
+        return f
+
+    return register
+
+
+@handle('v1', 'ServiceAccount')
+def _handle_v1_serviceaccount(obj):
+    return {
+        'metalk8s_kubernetes.serviceaccount_present': [
+            {'name': obj['metadata']['name']},
+            {'namespace': obj['metadata']['namespace']},
+        ],
+    }
+
+
+del handle
+
+
+def _step(obj):
+    '''
+    Handle a single Kubernetes object, rendering it into a state 'step'
+    '''
+    name = _step_name(obj)
+    api_version = obj['apiVersion']
+    kind = obj['kind']
+
+    handler = _HANDLERS.get((api_version, kind))
+    if not handler:
+        raise ValueError('No handler for {}/{}'.format(api_version, kind))
+
+    state = handler(obj)
+
+    return (name, state)
+
+
+def render(yaml_data, saltenv='', sls='', **kwargs):
+    if not isinstance(yaml_data, six.string_types):
+        yaml_data = yaml_data.read()
+
+    data = yaml.load_all(yaml_data, Loader=salt.utils.yaml.SaltYamlSafeLoader)
+
+    return OrderedDict(_step(obj) for obj in data if obj)


### PR DESCRIPTION
Add a (very incomplete) `renderer` for Kubernetes YAML manifests.

The intent is to take a standard Kubernetes YAML manifest (or a pipeline generating such manifest, e.g. after Jinja templating), and output a Salt SLS using the `metalk8s_kubernetes` states to realize the various objects contained in said manifest.

It's 'incomplete' because currently, only `v1/ServiceAccount` objects are handled properly. Handlers for other object kinds are to be added gradually.

As an example (and to test), first deploy the renderer:

```
$ salt-call saltutil.sync_renderers saltenv=metalk8s-2.0
```

Then, assuming the following file exists in your Salt tree:

```
$ cat /srv/scality/metalk8s-2.0/salt/metalk8s/k8s-demo.sls
#!jinja | kubernetes

---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: calico-node
  namespace: kube-system

---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: calico-node2
  namespace: kube-system
```
(note: in the above, the `jinja` part of the rendering pipeline is not necessary since we're not doing any templating anyway)

Then, let's try to render (without validating) the result:

```
$ salt-call slsutil.renderer /srv/scality/metalk8s-2.0/salt/metalk8s/k8s-demo.sls --out=yaml

local:
  Apply v1/ServiceAccount 'kube-system/calico-node':
    metalk8s_kubernetes.serviceaccount_present:
    - name: calico-node
    - namespace: kube-system
  Apply v1/ServiceAccount 'kube-system/calico-node2':
    metalk8s_kubernetes.serviceaccount_present:
    - name: calico-node2
    - namespace: kube-system
```

Finally, rendering and validating the whole SLS:

```
$ salt-call state.show_sls metalk8s.k8s-demo saltenv=metalk8s-2.0
local:
    ----------
    Apply v1/ServiceAccount 'kube-system/calico-node':
        ----------
        __env__:
            metalk8s-2.0
        __sls__:
            metalk8s.k8s-demo
        metalk8s_kubernetes:
            |_
              ----------
              name:
                  calico-node
            |_
              ----------
              namespace:
                  kube-system
            - serviceaccount_present
            |_
              ----------
              order:
                  10000
    Apply v1/ServiceAccount 'kube-system/calico-node2':
        ----------
        __env__:
            metalk8s-2.0
        __sls__:
            metalk8s.k8s-demo
        metalk8s_kubernetes:
            |_
              ----------
              name:
                  calico-node2
            |_
              ----------
              namespace:
                  kube-system
            - serviceaccount_present
            |_
              ----------
              order:
                  10001
```