### PR TITLE
Install kubectl on bootstrap node

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -104,6 +104,9 @@ SALT_FILES : Tuple[Union[Path, targets.FileTarget], ...] = (
     Path('salt/metalk8s/internal/preflight/mandatory.sls'),
     Path('salt/metalk8s/internal/preflight/recommended.sls'),
 
+    Path('salt/metalk8s/kubectl/init.sls'),
+    Path('salt/metalk8s/kubectl/installed.sls'),
+
     Path('salt/metalk8s/kubernetes/apiserver/certs/etcd-client.sls'),
     Path('salt/metalk8s/kubernetes/apiserver/certs/front-proxy-client.sls'),
     Path('salt/metalk8s/kubernetes/apiserver/certs/init.sls'),

--- a/salt/metalk8s/kubectl/init.sls
+++ b/salt/metalk8s/kubectl/init.sls
@@ -1,0 +1,11 @@
+#
+# State to manage kubectl.
+#
+# Available states
+# ================
+#
+# * installed   -> Ensure kubectl is installed
+#
+
+include:
+  - .installed

--- a/salt/metalk8s/kubectl/installed.sls
+++ b/salt/metalk8s/kubectl/installed.sls
@@ -1,0 +1,9 @@
+{%- from "metalk8s/macro.sls" import pkg_installed with context %}
+
+include :
+  - metalk8s.repo
+
+Install kubectl:
+  {{ pkg_installed('kubectl') }}
+    - require:
+      - test: Repositories configured

--- a/salt/metalk8s/roles/bootstrap/init.sls
+++ b/salt/metalk8s/roles/bootstrap/init.sls
@@ -4,3 +4,4 @@ include:
   - metalk8s.registry.populated
   - metalk8s.repo.installed
   - metalk8s.salt.master
+  - metalk8s.kubectl


### PR DESCRIPTION
Install kubectl on the bootstrap node:
* install kubectl package
* configure the default KUBECONFIG by creating a symbolic link `/root/.kube/config -> /etc/kubernetes/admin.conf`

Fixes #622