### PR TITLE
Improvement/878 use python etcd3 instead of call to etcdctl

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -250,6 +250,7 @@ SALT_FILES : Tuple[Union[Path, targets.FileTarget], ...] = (
     Path('salt/_modules/cri.py'),
     Path('salt/_modules/docker_registry.py'),
     Path('salt/_modules/metalk8s_kubernetes.py'),
+    Path('salt/_modules/metalk8s_etcd.py'),
     Path('salt/_modules/metalk8s.py'),
 
     Path('salt/_pillar/metalk8s.py'),

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -237,6 +237,8 @@ SALT_FILES : Tuple[Union[Path, targets.FileTarget], ...] = (
     Path('salt/metalk8s/salt/master/files/salt-master-manifest.yaml.j2'),
     Path('salt/metalk8s/salt/master/init.sls'),
     Path('salt/metalk8s/salt/master/installed.sls'),
+    Path('salt/metalk8s/salt/master/certs/etcd-client.sls'),
+    Path('salt/metalk8s/salt/master/certs/init.sls'),
 
     Path('salt/metalk8s/salt/minion/configured.sls'),
     Path('salt/metalk8s/salt/minion/files/minion-99-metalk8s.conf.j2'),

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -200,6 +200,7 @@ SALT_FILES : Tuple[Union[Path, targets.FileTarget], ...] = (
     Path('salt/metalk8s/orchestrate/bootstrap/accept-minion.sls'),
     Path('salt/metalk8s/orchestrate/deploy_node.sls'),
     Path('salt/metalk8s/orchestrate/upgrade/etcd.sls'),
+    Path('salt/metalk8s/orchestrate/register_etcd.sls'),
 
     Path('salt/metalk8s/registry/deployed.sls'),
     Path('salt/metalk8s/registry/files/registry-manifest.yaml.j2'),
@@ -268,6 +269,7 @@ SALT_FILES : Tuple[Union[Path, targets.FileTarget], ...] = (
     Path('salt/_states/containerd.py'),
     Path('salt/_states/kubeconfig.py'),
     Path('salt/_states/docker_registry.py'),
+    Path('salt/_states/metalk8s_etcd.py'),
     Path('salt/_states/metalk8s_kubernetes.py'),
 
     targets.RemoteImage(

--- a/images/salt-master/Dockerfile
+++ b/images/salt-master/Dockerfile
@@ -24,7 +24,9 @@ gpgkey=https://repo.saltstack.com/yum/redhat/\$releasever/\$basearch/archive/%s/
  && yum clean expire-cache \
  && yum install -y epel-release \
  && yum install -y python2-kubernetes salt-master salt-api salt-ssh openssh-clients \
+ && yum install -y python-pip \
  && yum clean all \
+ && pip install etcd3 \
  && chmod +x /tini
 
 # salt-master, salt-api

--- a/salt/_modules/metalk8s.py
+++ b/salt/_modules/metalk8s.py
@@ -33,7 +33,7 @@ def deps_missing(*args, **kwargs):
     raise CommandExecutionError("Kubernetes python client is not installed")
 
 
-@depends('KUBERNETES_PRESENT', fallback_function=deps_missing)
+@depends(KUBERNETES_PRESENT, fallback_function=deps_missing)
 def wait_apiserver(retry=10, interval=1, **kwargs):
     """Wait for kube-apiserver to respond.
 
@@ -102,7 +102,7 @@ def _execute_etcd_command(pod_name, cmd):
         raise exn
 
 
-@depends('KUBERNETES_PRESENT', fallback_function=deps_missing)
+@depends(KUBERNETES_PRESENT, fallback_function=deps_missing)
 def add_etcd_node(host, endpoint=None):
     '''Add a new `etcd` node into the `etcd` cluster.
 

--- a/salt/_modules/metalk8s.py
+++ b/salt/_modules/metalk8s.py
@@ -102,27 +102,6 @@ def _execute_etcd_command(pod_name, cmd):
         raise exn
 
 
-@depends(KUBERNETES_PRESENT, fallback_function=deps_missing)
-def add_etcd_node(host, endpoint=None):
-    '''Add a new `etcd` node into the `etcd` cluster.
-
-    This module is only runnable from the salt-master on the bootstrap node.
-
-    Arguments:
-        host (str): hostname of the new etcd node
-        endpoint (str): endpoint of the new etcd node
-    '''
-    if not endpoint:
-        # If we have no endpoint get it from mine
-        node_ip = __salt__['saltutil.runner'](
-            'mine.get', tgt=host, fun='control_plane_ip'
-        )[host]
-        endpoint = 'https://{0}:2380'.format(node_ip)
-
-    pod_name = 'etcd-{}'.format(__salt__['network.get_hostname']())
-    _execute_etcd_command(pod_name, ['member', 'add', host, endpoint])
-
-
 def check_etcd_health(hostname):
     '''Check cluster-health of the `etcd` cluster.
 

--- a/salt/_modules/metalk8s.py
+++ b/salt/_modules/metalk8s.py
@@ -82,7 +82,7 @@ def _execute_etcd_command(pod_name, cmd):
     api = kubernetes.client.CoreV1Api(api_client=client)
     etcd_command = [
         'etcdctl',
-        '--endpoints', 'https://localhost:2379',
+        '--endpoints', 'https://127.0.0.1:2379',
         '--ca-file', '/etc/kubernetes/pki/etcd/ca.crt',
         '--key-file', '/etc/kubernetes/pki/etcd/server.key',
         '--cert-file', '/etc/kubernetes/pki/etcd/server.crt',

--- a/salt/_modules/metalk8s_etcd.py
+++ b/salt/_modules/metalk8s_etcd.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+'''
+Module for handling etcd client specific calls.
+'''
+import logging
+
+from salt.exceptions import CommandExecutionError
+from salt.utils.decorators import depends
+
+PYTHON_ETCD_PRESENT = False
+try:
+    import etcd3
+    PYTHON_ETCD_PRESENT = True
+except ImportError:
+    pass
+
+# Timeout when connection to etcd server
+TIMEOUT = 30
+
+
+log = logging.getLogger(__name__)
+
+__virtualname__ = 'metalk8s_etcd'
+
+
+def __virtual__():
+    return __virtualname__
+
+
+def deps_missing(*args, **kwargs):
+    raise CommandExecutionError("python etcd client is not installed")
+
+
+def _get_endpoint_up(ca_cert, cert_key, cert_cert):
+    """Pick an answering etcd endpoint among all etcd servers."""
+    etcd_hosts = __salt__['metalk8s.minions_by_role']('etcd')
+
+    # Get host ip from etcd_hosts
+    endpoints = [
+        __salt__['saltutil.runner'](
+            'mine.get',
+            tgt=host,
+            fun='control_plane_ip'
+        )[host]
+        for host in etcd_hosts
+    ]
+
+    for endpoint in endpoints:
+        try:
+            with etcd3.client(host=endpoint,
+                              ca_cert=ca_cert,
+                              cert_key=cert_key,
+                              cert_cert=cert_cert,
+                              timeout=TIMEOUT) as etcd:
+                etcd.status()
+        except etcd3.exceptions.ConnectionFailedError:
+            pass
+        else:
+            return endpoint
+
+    raise Exception('Unable to find an available etcd member in the cluster')
+
+
+@depends(PYTHON_ETCD_PRESENT, fallback_function=deps_missing)
+def add_etcd_node(
+        peer_urls,
+        endpoint=None,
+        ca_cert='/etc/kubernetes/pki/etcd/ca.crt',
+        cert_key='/etc/kubernetes/pki/etcd/salt-master-etcd-client.key',
+        cert_cert='/etc/kubernetes/pki/etcd/salt-master-etcd-client.crt'):
+    '''Add a new `etcd` node into the `etcd` cluster.
+
+    This module is only runnable from the salt-master on the bootstrap node.
+
+    Arguments:
+        host (str): hostname of the new etcd node
+        endpoint (str): host server in the etcd cluster
+                        IP is expected, not URL
+    '''
+    if not endpoint:
+        # If we have no endpoint get it from mine
+        endpoint = _get_endpoint_up(
+            ca_cert=ca_cert,
+            cert_key=cert_key,
+            cert_cert=cert_cert
+        )
+
+    with etcd3.client(host=endpoint,
+                      ca_cert=ca_cert,
+                      cert_key=cert_key,
+                      cert_cert=cert_cert,
+                      timeout=TIMEOUT) as etcd:
+        node = etcd.add_member(peer_urls)
+
+    return node

--- a/salt/_modules/metalk8s_etcd.py
+++ b/salt/_modules/metalk8s_etcd.py
@@ -3,9 +3,9 @@
 Module for handling etcd client specific calls.
 '''
 import logging
+from urlparse import urlparse
 
 from salt.exceptions import CommandExecutionError
-from salt.utils.decorators import depends
 
 PYTHON_ETCD_PRESENT = False
 try:
@@ -24,11 +24,10 @@ __virtualname__ = 'metalk8s_etcd'
 
 
 def __virtual__():
-    return __virtualname__
-
-
-def deps_missing(*args, **kwargs):
-    raise CommandExecutionError("python etcd client is not installed")
+    if PYTHON_ETCD_PRESENT:
+        return __virtualname__
+    else:
+        return False, "python-etcd3 not available"
 
 
 def _get_endpoint_up(ca_cert, cert_key, cert_cert):
@@ -61,7 +60,6 @@ def _get_endpoint_up(ca_cert, cert_key, cert_cert):
     raise Exception('Unable to find an available etcd member in the cluster')
 
 
-@depends(PYTHON_ETCD_PRESENT, fallback_function=deps_missing)
 def add_etcd_node(
         peer_urls,
         endpoint=None,
@@ -93,3 +91,58 @@ def add_etcd_node(
         node = etcd.add_member(peer_urls)
 
     return node
+
+
+def check_etcd_health(
+        minion_id,
+        ca_cert='/etc/kubernetes/pki/etcd/ca.crt',
+        cert_key='/etc/kubernetes/pki/etcd/salt-master-etcd-client.key',
+        cert_cert='/etc/kubernetes/pki/etcd/salt-master-etcd-client.crt'):
+    '''Check cluster-health of the `etcd` cluster.
+
+    This module is only runnable from the salt-master on the bootstrap node.
+
+    Arguments:
+        minion_id (str): minion id of an etcd node
+    '''
+    # Get host ip from the minion id
+    endpoint = __salt__['saltutil.runner'](
+        'mine.get', tgt=minion_id, fun='control_plane_ip'
+    )[minion_id]
+
+    # Get all members
+    try:
+        with etcd3.client(host=endpoint,
+                          ca_cert=ca_cert,
+                          cert_key=cert_key,
+                          cert_cert=cert_cert,
+                          timeout=TIMEOUT) as etcd:
+            etcd_members = list(etcd.members)
+    except Exception:  # pylint: disable=broad-except
+        log.exception("cluster may be unhealthy: failed to list members")
+        raise
+
+    unhealthy_member = 0
+    for member in etcd_members:
+        etcd_url = urlparse(member.client_urls[0])
+        try:
+            with etcd3.client(host=etcd_url.hostname,
+                              port=etcd_url.port,
+                              ca_cert=ca_cert,
+                              cert_key=cert_key,
+                              cert_cert=cert_cert,
+                              timeout=TIMEOUT) as etcd:
+                etcd.status()
+        except Exception:  # pylint: disable=broad-except
+            log.exception(
+                "failed to check the health of member %s", member.name
+            )
+            unhealthy_member += 1
+
+    # Raise on error as this function will be called by module.run in sls file
+    if unhealthy_member == len(etcd_members):
+        raise CommandExecutionError("cluster is unavailable")
+    elif unhealthy_member > 0:
+        raise CommandExecutionError("cluster is degraded")
+    else:
+        return "cluster is healthy"

--- a/salt/_states/metalk8s_etcd.py
+++ b/salt/_states/metalk8s_etcd.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+import logging
+
+log = logging.getLogger(__name__)
+
+
+__virtualname__ = 'metalk8s_etcd'
+
+
+def __virtual__():
+    if 'metalk8s_kubernetes.ping' not in __salt__:
+        return False, '`metalk8s_kubernetes.ping` not available'
+    else:
+        return __virtualname__
+
+
+def member_present(name, peer_urls):
+    """Ensure that the etcd node is in cluster
+
+    Arguements:
+        peer_urls ([str]): List of the etcd peer urls to add
+    """
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    # Check that peer urls does not exist
+    if __salt__['metalk8s_etcd.urls_exist_in_cluster'](peer_urls):
+        ret['result'] = True
+        ret['comment'] = 'Peer URLs: {} already exists'.format(
+            ' ,'.join(peer_urls)
+        )
+        return ret
+
+    # Add node
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'Node would be added to the cluster'
+        ret['change'] = {'peer_urls': str(', '.join(peer_urls))}
+        return ret
+
+    try:
+        member = __salt__['metalk8s_etcd.add_etcd_node'](peer_urls)
+    except Exception as exc:  # pylint: disable=broad-except
+        ret['comment'] = 'Failed to add {} in the cluster: {}'.format(
+            name, exc
+        )
+    else:
+        ret['result'] = True
+        ret['changes'] = {
+            'id': member.id,
+            'name': member.name,
+            'peer_urls': str(', '.join(member.peer_urls)),
+            'client_urls': str(', '.join(member.client_urls)),
+        }
+        ret['comment'] = 'Node added in etcd cluster'
+
+    return ret

--- a/salt/metalk8s/orchestrate/bootstrap/init.sls
+++ b/salt/metalk8s/orchestrate/bootstrap/init.sls
@@ -90,6 +90,16 @@ Bring bootstrap minion to highstate:
     - salt: Sync bootstrap minion
     - salt: Deploy CA role on bootstrap minion
 
+Generate etcd client certs for salt master:
+  salt.state:
+  - sls:
+    - metalk8s.salt.master.certs
+  - tgt: {{ pillar.bootstrap_id }}
+  - pillar: {{ pillar_data | tojson }}
+  - saltenv: {{ saltenv }}
+  - require:
+    - salt: Deploy CA role on bootstrap minion
+
 Wait for API server to be available:
   http.wait_for_successful_query:
   - name: https://{{ pillar.metalk8s.api_server.host }}:6443/healthz

--- a/salt/metalk8s/orchestrate/deploy_node.sls
+++ b/salt/metalk8s/orchestrate/deploy_node.sls
@@ -86,7 +86,7 @@ Kill kube-controller-manager on all master nodes:
 
 Register the node into etcd cluster:
   module.run:
-    - metalk8s.add_etcd_node:
+    - metalk8s_etcd.add_etcd_node:
       - host: {{ node_name }}
     - require:
       - salt: Run the highstate

--- a/salt/metalk8s/orchestrate/deploy_node.sls
+++ b/salt/metalk8s/orchestrate/deploy_node.sls
@@ -85,9 +85,11 @@ Kill kube-controller-manager on all master nodes:
 {%- if 'etcd' in pillar.get('metalk8s', {}).get('nodes', {}).get(node_name, {}).get('roles', []) %}
 
 Register the node into etcd cluster:
-  module.run:
-    - metalk8s_etcd.add_etcd_node:
-      - host: {{ node_name }}
+  salt.runner:
+    - name: state.orchestrate
+    - pillar: {{ pillar | json  }}
+    - mods:
+      - metalk8s.orchestrate.register_etcd
     - require:
       - salt: Run the highstate
 

--- a/salt/metalk8s/orchestrate/register_etcd.sls
+++ b/salt/metalk8s/orchestrate/register_etcd.sls
@@ -1,0 +1,17 @@
+{# Should be run by the orchestrator runner #}
+
+{%- set nodename = pillar.orchestrate.node_name -%}
+
+{%- set node_ip = salt.saltutil.runner(
+    'mine.get',
+     tgt=nodename,
+     fun='control_plane_ip')[nodename]
+ %}
+
+{%- set peer_url = 'https://' ~ node_ip ~ ':2380' %}
+
+Register host as part of etcd cluster:
+  metalk8s_etcd.member_present:
+    - name: {{ nodename }}
+    - peer_urls:
+       - {{ peer_url }}

--- a/salt/metalk8s/orchestrate/upgrade/etcd.sls
+++ b/salt/metalk8s/orchestrate/upgrade/etcd.sls
@@ -3,7 +3,7 @@
 
 Check etcd cluster health:
   module.run:
-    - metalk8s.check_etcd_health:
+    - metalk8s_etcd.check_etcd_health:
       - hostname: {{ pillar.bootstrap_id }}
 
 {%- for node in etcd_nodes | sort %}
@@ -29,7 +29,7 @@ Upgrade etcd {{ node }} to {{ dest_version }}:
 
 Check etcd cluster health for {{ node }}:
   module.run:
-    - metalk8s.check_etcd_health:
+    - metalk8s_etcd.check_etcd_health:
       - hostname: {{ node }}
     # FIXME: Can't retry because of https://github.com/saltstack/salt/issues/44639
     # Should be ok for the moment as we check health in etcd.health state.

--- a/salt/metalk8s/salt/master/certs/etcd-client.sls
+++ b/salt/metalk8s/salt/master/certs/etcd-client.sls
@@ -1,0 +1,32 @@
+{%- from "metalk8s/map.jinja" import etcd with context %}
+
+include:
+  - metalk8s.internal.m2crypto
+
+Create salt master etcd client private key:
+  x509.private_key_managed:
+    - name: /etc/kubernetes/pki/etcd/salt-master-etcd-client.key
+    - bits: 2048
+    - verbose: False
+    - user: root
+    - group: root
+    - mode: 600
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - pkg: Install m2crypto
+
+Generate salt master etcd client certificate:
+  x509.certificate_managed:
+    - name: /etc/kubernetes/pki/etcd/salt-master-etcd-client.crt
+    - public_key: /etc/kubernetes/pki/etcd/salt-master-etcd-client.key
+    - ca_server: {{ pillar['metalk8s']['ca']['minion'] }}
+    - signing_policy: {{ etcd.cert.apiserver_client_signing_policy }}
+    - CN: etcd-salt-master-client
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - x509: Create salt master etcd client private key

--- a/salt/metalk8s/salt/master/certs/init.sls
+++ b/salt/metalk8s/salt/master/certs/init.sls
@@ -1,0 +1,10 @@
+#
+# State to manage salt master certs
+#
+# Available states
+# ================
+#
+# * etcd-client           -> generate salt master etcd client key and certificate
+#
+include:
+  - .etcd-client


### PR DESCRIPTION
**Component**:

salt, deployment

**Context**: 

When adding a new member to the cluster etcd, we used etcdctl, now we use python-etcd3.

python etcd3 is installed only on the salt master container (like python-kubernetes)

The PR includes the 4 following points:

* provision an etcd client cert for salt-master, similar to how we'll create a kubeconfig file for it
* add the python-etcd3 package in the salt-master image
* create a Salt module to manage etcd members in a cluster, given the above client cert
* use this module to add the new node as a member, on the salt-master host


Note: There is no RPM package of python etcd3 so I use pip package


**Summary**:

**Acceptance criteria**: 

Run a successful expansion