### PR TITLE
Add orchestrate for Upgrade MetalK8s cluster

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -155,6 +155,7 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/container-engine/containerd/installed.sls'),
 
     Path('salt/metalk8s/defaults.yaml'),
+    Path('salt/metalk8s/deployed.sls'),
 
     Path('salt/metalk8s/internal/init.sls'),
 
@@ -262,6 +263,8 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/orchestrate/bootstrap/accept-minion.sls'),
     Path('salt/metalk8s/orchestrate/deploy_node.sls'),
     Path('salt/metalk8s/orchestrate/upgrade/etcd.sls'),
+    Path('salt/metalk8s/orchestrate/upgrade/init.sls'),
+    Path('salt/metalk8s/orchestrate/upgrade/precheck.sls'),
     Path('salt/metalk8s/orchestrate/register_etcd.sls'),
 
     Path('salt/metalk8s/repo/configured.sls'),

--- a/pillar/metalk8s/roles/bootstrap.sls.in
+++ b/pillar/metalk8s/roles/bootstrap.sls.in
@@ -1,3 +1,4 @@
 metalk8s:
   # The mountpoint used for this environment's ISO
-  iso_root_path: /srv/scality/metalk8s-@@VERSION
+  iso_root_path:
+    metalk8s-@@VERSION: /srv/scality/metalk8s-@@VERSION

--- a/salt/_modules/metalk8s_drain.py
+++ b/salt/_modules/metalk8s_drain.py
@@ -579,9 +579,11 @@ def node_drain(node_name,
     )
     __salt__['metalk8s_kubernetes.node_cordon'](node_name, **kwargs)
     try:
-        result = drainer.run_drain(dry_run=dry_run, **kwargs)
+        result = drainer.run_drain(dry_run=dry_run)
     # CommandExecutionError should fall through, but we want cleanup regardless
     except CommandExecutionError:
         raise
     finally:
         __salt__['metalk8s_kubernetes.cleanup'](**cfg)
+
+    return result

--- a/salt/_states/metalk8s_drain.py
+++ b/salt/_states/metalk8s_drain.py
@@ -24,9 +24,11 @@ def node_drained(
 
     res = __salt__['metalk8s_kubernetes.node_drain'](name, **kwargs)
 
+    ret['result'] = True
+    ret['comment'] = res
+
     ret['changes'][name] = {
-        'old': [],
-        'new': []
+        name: 'drained'
     }
 
     return ret

--- a/salt/metalk8s/deployed.sls
+++ b/salt/metalk8s/deployed.sls
@@ -1,0 +1,8 @@
+include:
+  - metalk8s.kubernetes.kube-proxy.deployed
+  - metalk8s.kubernetes.cni.calico.deployed
+  - metalk8s.kubernetes.coredns.deployed
+  - metalk8s.repo.deployed
+  - metalk8s.salt.master.deployed
+  - metalk8s.addons.ui.deployed
+  - metalk8s.addons.prometheus-operator.deployed

--- a/salt/metalk8s/kubernetes/apiserver/installed.sls
+++ b/salt/metalk8s/kubernetes/apiserver/installed.sls
@@ -204,7 +204,7 @@ Create kube-apiserver Pod manifest:
             emptyDir:
               medium: Memory
 {%- endif %}
-    - onchanges:
+    - require:
       - file: Ensure kubernetes CA cert is present
       - file: Ensure etcd CA cert is present
       - file: Ensure front-proxy CA cert is present

--- a/salt/metalk8s/kubernetes/controller-manager/installed.sls
+++ b/salt/metalk8s/kubernetes/controller-manager/installed.sls
@@ -43,5 +43,5 @@ Create kube-controller-manager Pod manifest:
           - path: /etc/kubernetes/controller-manager.conf
             name: kubeconfig
             type: File
-    - onchanges:
+    - require:
       - metalk8s_kubeconfig: Create kubeconfig file for controller-manager

--- a/salt/metalk8s/kubernetes/etcd/healthy.sls
+++ b/salt/metalk8s/kubernetes/etcd/healthy.sls
@@ -12,4 +12,4 @@ Waiting for etcd running:
     - status: 200
     - match: '{"health": "true"}'
     - require:
-      - file: Create local etcd Pod manifest
+      - metalk8s: Create local etcd Pod manifest

--- a/salt/metalk8s/kubernetes/kubelet/installed.sls
+++ b/salt/metalk8s/kubernetes/kubelet/installed.sls
@@ -26,3 +26,15 @@ Install kubelet:
   {{ pkg_installed('kubelet') }}
     - require:
       - test: Repositories configured
+
+# When upgrading kubelet on centos7 we have error when trying to restart or get
+# status of the kubelet service
+# $ systemctl status kubelet
+# Failed to get properties: Access denied
+# 
+# Workaround: Reload systemctl
+Reload systemctl:
+  module.wait:
+    - name: service.systemctl_reload
+    - watch:
+      - pkg: Install kubelet

--- a/salt/metalk8s/kubernetes/kubelet/running.sls
+++ b/salt/metalk8s/kubernetes/kubelet/running.sls
@@ -5,5 +5,7 @@ Ensure kubelet running:
   service.running:
     - name: kubelet
     - enable: True
-    - require:
+    - watch:
       - pkg: Install kubelet
+    - require:
+      - module: Reload systemctl

--- a/salt/metalk8s/kubernetes/scheduler/installed.sls
+++ b/salt/metalk8s/kubernetes/scheduler/installed.sls
@@ -25,5 +25,5 @@ Create kube-scheduler Pod manifest:
           - path: /etc/kubernetes/scheduler.conf
             name: kubeconfig
             type: File
-    - onchanges:
+    - require:
       - metalk8s_kubeconfig: Create kubeconfig file for scheduler

--- a/salt/metalk8s/orchestrate/bootstrap/init.sls
+++ b/salt/metalk8s/orchestrate/bootstrap/init.sls
@@ -134,13 +134,7 @@ Deploy Kubernetes objects:
   salt.runner:
   - name: state.orchestrate
   - mods:
-    - metalk8s.kubernetes.kube-proxy.deployed
-    - metalk8s.kubernetes.cni.calico.deployed
-    - metalk8s.kubernetes.coredns.deployed
-    - metalk8s.repo.deployed
-    - metalk8s.salt.master.deployed
-    - metalk8s.addons.ui.deployed
-    - metalk8s.addons.prometheus-operator.deployed
+    - metalk8s.deployed
   - saltenv: {{ saltenv }}
   - pillar: {{ pillar_data | tojson }}
   - require:

--- a/salt/metalk8s/orchestrate/deploy_node.sls
+++ b/salt/metalk8s/orchestrate/deploy_node.sls
@@ -47,7 +47,7 @@ Refresh the mine:
     - tgt: '*'
 
 Cordon the node:
-  metalk8s_kubernetes.node_cordoned:
+  metalk8s_cordon.node_cordoned:
     - name: {{ node_name }}
     - kubeconfig: {{ kubeconfig }}
     - context: {{ context }}
@@ -60,6 +60,8 @@ Drain the node:
     - force: True
     - kubeconfig: {{ kubeconfig }}
     - context: {{ context }}
+    - require:
+      - metalk8s_cordon: Cordon the node
 
 Run the highstate:
   salt.state:
@@ -68,10 +70,10 @@ Run the highstate:
     - require:
       - salt: Set grains
       - salt: Refresh the mine
-      - metalk8s_kubernetes: Cordon the node
+      - metalk8s_drain: Drain the node
 
 Uncordon the node:
-  metalk8s_kubernetes.node_uncordoned:
+  metalk8s_cordon.node_uncordoned:
     - name: {{ node_name }}
     - kubeconfig: {{ kubeconfig }}
     - context: {{ context }}

--- a/salt/metalk8s/orchestrate/upgrade/etcd.sls
+++ b/salt/metalk8s/orchestrate/upgrade/etcd.sls
@@ -4,7 +4,7 @@
 Check etcd cluster health:
   module.run:
     - metalk8s_etcd.check_etcd_health:
-      - hostname: {{ pillar.bootstrap_id }}
+      - minion_id: {{ salt.network.get_hostname() }}
 
 {%- for node in etcd_nodes | sort %}
 
@@ -30,7 +30,7 @@ Upgrade etcd {{ node }} to {{ dest_version }}:
 Check etcd cluster health for {{ node }}:
   module.run:
     - metalk8s_etcd.check_etcd_health:
-      - hostname: {{ node }}
+      - minion_id: {{ node }}
     # FIXME: Can't retry because of https://github.com/saltstack/salt/issues/44639
     # Should be ok for the moment as we check health in etcd.health state.
     #- retry:
@@ -38,7 +38,7 @@ Check etcd cluster health for {{ node }}:
     - require:
       - salt: Upgrade etcd {{ node }} to {{ dest_version }}
 
-  {#- Ugly but needed since we use have jinja2.7 (`loop.previtem` added in 2.10) #}
+  {#- Ugly but needed since we have jinja2.7 (`loop.previtem` added in 2.10) #}
   {%- set previous_node = node %}
 
 {%- endfor %}

--- a/salt/metalk8s/orchestrate/upgrade/init.sls
+++ b/salt/metalk8s/orchestrate/upgrade/init.sls
@@ -1,0 +1,72 @@
+{%- set dest_version = pillar.orchestrate.dest_version %}
+
+Execute the upgrade prechecks:
+  salt.runner:
+    - name: state.orchestrate
+    - mods:
+      - metalk8s.orchestrate.upgrade.precheck
+    - saltenv: {{ saltenv }}
+    - pillar:
+        orchestrate:
+          dest_version: {{ dest_version }}
+
+Upgrade etcd cluster:
+  salt.runner:
+    - name: state.orchestrate
+    - mods:
+      - metalk8s.orchestrate.upgrade.etcd
+    - saltenv: {{ saltenv }}
+    - pillar:
+        orchestrate:
+          dest_version: {{ dest_version }}
+    - require:
+      - salt: Execute the upgrade prechecks
+
+{%- set cp_nodes = salt.metalk8s.minions_by_role('master') | sort %}
+{%- set other_nodes = pillar.metalk8s.nodes.keys() | difference(cp_nodes) | sort %}
+
+{%- for node in cp_nodes + other_nodes %}
+
+  {%- set kubeconfig = "/etc/kubernetes/admin.conf" %}
+  {%- set context = "kubernetes-admin@kubernetes" %}
+
+Set node {{ node }} version to {{ dest_version }}:
+  metalk8s_kubernetes.node_label_present:
+    - name: metalk8s.scality.com/version
+    - node: {{ node }}
+    - value: "{{ dest_version }}"
+    - kubeconfig: {{ kubeconfig }}
+    - context: {{ context }}
+    - require:
+      - salt: Upgrade etcd cluster
+  {%- if previous_node is defined %}
+      - salt: Deploy node {{ previous_node }}
+  {%- endif %}
+
+Deploy node {{ node }}:
+  salt.runner:
+    - name: state.orchestrate
+    - mods:
+      - metalk8s.orchestrate.deploy_node
+    - saltenv: {{ saltenv }}
+    - pillar:
+        orchestrate:
+          node_name: {{ node }}
+    - require:
+      - metalk8s_kubernetes: Set node {{ node }} version to {{ dest_version }}
+    - require_in:
+      - salt: Deploy Kubernetes objects
+
+  {#- Ugly but needed since we have jinja2.7 (`loop.previtem` added in 2.10) #}
+  {%- set previous_node = node %}
+
+{%- endfor %}
+
+Deploy Kubernetes objects:
+  salt.runner:
+    - name: state.orchestrate
+    - mods:
+      - metalk8s.deployed
+    - saltenv: {{ saltenv }}
+    - require:
+      - salt: Upgrade etcd cluster

--- a/salt/metalk8s/orchestrate/upgrade/precheck.sls
+++ b/salt/metalk8s/orchestrate/upgrade/precheck.sls
@@ -1,0 +1,49 @@
+{%- set dest_version = pillar.orchestrate.dest_version %}
+{%- set saltenv_ver = {'current': saltenv.split('-')[1], 'expected': dest_version} %}
+
+{%- set dest = (dest_version|string).split('.') %}
+{%- for node, values in pillar.metalk8s.nodes.items() %}
+
+  {#- 1 = Upgrade, -1 = Downgrade, 0 = Correct version #}
+  {%- set upgrade = salt.pkg.version_cmp(dest_version, values['version']) %}
+
+  {%- if upgrade == 1 %}
+    {%- set action = "upgrade" %}
+  {%- elif upgrade == -1 %}
+    {%- set action = "downgrade" %}
+  {%- endif %}
+
+  {%- if salt.pkg.version_cmp(saltenv_ver['expected'], values['version']) == -1 %}
+    {%- do saltenv_ver.update({'expected': values['version']}) %}
+  {%- endif %}
+
+  {#- As we don't know how many minor version we do before a new major,
+      never block upgrade between major version #}
+  {%- set current = (values['version']|string).split('.') %}
+  {%- if dest[0]|int == current[0]|int
+     and (dest[1]|int - current[1]|int)|abs > 1 %}
+
+Unable to {{ action }} from more than 1 version, Node {{ node }} from {{ values['version'] }} to {{ dest_version }}:
+  test.fail_without_changes
+
+  {%- elif upgrade != 0 %}
+
+Node {{ node }} will be {{ action }}d from {{ values['version'] }} to {{ dest_version }}:
+  test.succeed_without_changes
+
+  {%- else %}
+
+Node {{ node }} already in version {{ dest_version }}:
+  test.succeed_without_changes
+
+  {%- endif %}
+
+{%- endfor %}
+
+{#- We need to use the newest saltenv available #}
+{%- if salt.pkg.version_cmp(saltenv_ver['current'], saltenv_ver['expected']) != 0 %}
+
+Invalid saltenv "{{ saltenv }}" consider using "metalk8s-{{ saltenv_ver['expected'] }}":
+  test.fail_without_changes
+
+{%- endif %}

--- a/salt/metalk8s/repo/installed.sls
+++ b/salt/metalk8s/repo/installed.sls
@@ -6,7 +6,7 @@
 {%- set repositories_version = '1.0.0' %}
 {%- set repositories_image = build_image_name('nginx', '1.15.8') %}
 
-{%- set images_path = metalk8s.iso_root_path ~ '/images/' %}
+{%- set images_path = metalk8s.iso_root_path[saltenv] ~ '/images/' %}
 
 {%- set nginx_confd  = '/var/lib/metalk8s/repositories/conf.d/' %}
 {%- set nginx_default_conf = nginx_confd ~ 'default.conf' %}
@@ -57,7 +57,7 @@ Generate container registry configuration:
 Inject nginx image:
   containerd.image_managed:
     - name: docker.io/library/nginx:1.15.8
-    - archive_path: {{ metalk8s.iso_root_path }}/images/nginx-1.15.8.tar
+    - archive_path: {{ metalk8s.iso_root_path[saltenv] }}/images/nginx-1.15.8.tar
 
 Install repositories manifest:
   metalk8s.static_pod_managed:
@@ -72,10 +72,10 @@ Install repositories manifest:
         image: docker.io/library/nginx:1.15.8
         name: {{ repositories_name }}
         version: {{ repositories_version }}
-        packages_path: {{ metalk8s.iso_root_path }}/{{ repo.relative_path }}
+        packages_path: {{ metalk8s.iso_root_path[saltenv] }}/{{ repo.relative_path }}
         nginx_confd_path: {{ nginx_confd }}
         images_path: {{ images_path }}
-    - onchanges:
+    - require:
       - containerd: Inject nginx image
       - file: Generate repositories nginx configuration
       - file: Deploy container registry nginx configuration

--- a/salt/metalk8s/repo/offline.sls
+++ b/salt/metalk8s/repo/offline.sls
@@ -13,7 +13,7 @@ Install yum-plugin-versionlock:
 
 {%- for repo_name, repo_config in repo.repositories.items() %}
   {%- if repo.local_mode %}
-    {%- set iso_root = metalk8s.iso_root_path %}
+    {%- set iso_root = metalk8s.iso_root_path[saltenv] %}
     {%- set repo_base_url = "file://" ~ iso_root ~ "/" ~ repo.relative_path %}
   {%- else %}
     {%- set repo_base_url = "http://" ~ repo_host ~ ':' ~ repo_port %}

--- a/salt/metalk8s/salt/master/configured.sls
+++ b/salt/metalk8s/salt/master/configured.sls
@@ -27,8 +27,12 @@ Configure salt master roots paths:
     - backup: false
     - dataset:
         file_roots:
-          {{ saltenv }}:
-            - {{ metalk8s.iso_root_path }}/salt
+        {%- for version, path in metalk8s.iso_root_path.items() | sort(attribute='0') %}
+          {{ version }}:
+            - {{ path }}/salt
+        {%- endfor %}
         pillar_roots:
-          {{ saltenv }}:
-            - {{ metalk8s.iso_root_path }}/pillar
+        {%- for version, path in metalk8s.iso_root_path.items() | sort(attribute='0') %}
+          {{ version }}:
+            - {{ path }}/pillar
+        {%- endfor %}

--- a/salt/metalk8s/salt/master/files/salt-master-manifest.yaml.j2
+++ b/salt/metalk8s/salt/master/files/salt-master-manifest.yaml.j2
@@ -60,12 +60,14 @@ spec:
           mountPath: '/var/cache/salt'
         - name: run
           mountPath: '/var/run/salt'
-        - name: states
-          mountPath: '{{ iso_root_path }}/salt'
+        {%- for version, path in iso_root_path.items() | sort(attribute='0') %}
+        - name: states-{{ version | replace('.', '-') }}
+          mountPath: '{{ path }}/salt'
           readOnly: true
-        - name: pillar
-          mountPath: '{{ iso_root_path }}/pillar'
+        - name: pillar-{{ version | replace('.', '-') }}
+          mountPath: '{{ path }}/pillar'
           readOnly: true
+        {%- endfor %}
         - name: metalk8s-config
           mountPath: '/etc/metalk8s'
           readOnly: true
@@ -109,14 +111,16 @@ spec:
       hostPath:
         path: '/var/run/salt'
         type: Directory
-    - name: states
+    {%- for version, path in iso_root_path.items() | sort(attribute='0') %}
+    - name: states-{{ version | replace('.', '-') }}
       hostPath:
-        path: '{{ iso_root_path }}/salt'
+        path: '{{ path }}/salt'
         type: Directory
-    - name: pillar
+    - name: pillar-{{ version | replace('.', '-') }}
       hostPath:
-        path: '{{ iso_root_path }}/pillar'
+        path: '{{ path }}/pillar'
         type: Directory
+    {%- endfor %}
     - name: metalk8s-config
       hostPath:
         path: '/etc/metalk8s'

--- a/salt/metalk8s/salt/master/installed.sls
+++ b/salt/metalk8s/salt/master/installed.sls
@@ -33,7 +33,6 @@ Install and start salt master manifest:
         salt_ip: "{{ salt_ip }}"
     - require:
       - file: Create salt master directories
-    - onchanges:
       - file: /etc/salt/master.d/99-metalk8s.conf
       - file: /etc/salt/master.d/99-metalk8s-roots.conf
 


### PR DESCRIPTION
**Component**:

salt, deployment, upgrade

**Context**: 

We want to be able to upgrade a MetalK8s clusters just by running one orchestrate state.

**Summary**:

This PR include:
- A `precheck` state (to check if we can start an upgrade of the cluster)
- A `init` state (to orchestrate all the upgrade process)

**Full upgrade from <old_version> to <new_version>**

To make a new iso available:
```
# Mount the iso in `/srv/scality/metalk8s-<new_version>`
mount -o loop <new_iso> /srv/scality/metalk8s-<new_version>
# Reconfigure salt master
salt-call state.sls metalk8s.salt.master saltenv=metalk8s-<old_version> pillar="{'metalk8s': {'iso_root_path': {'metalk8s-<new_version>': '/srv/scality/metalk8s-<new_version>'}}}"
# Reconfigure repos
salt-call state.sls metalk8s.repo.installed saltenv=metalk8s-<new_version>
```

To run an upgrade:
```
salt-run state.orchestrate metalk8s.orchestrate.upgrade saltenv=metalk8s-<new_version> pillar="{'orchestrate': {'dest_version': '<new_version>'}}"
```

Downgrade not supported will be done in #1143 

**Acceptance criteria**: 

Fixes: #981