### PR TITLE
add missing plugin install+update doit subtask

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -21,7 +21,7 @@ The most important ones are:
 - `iso`:  build the MetalK8s ISO
 - `lint`: run the linting tools on the codebase
 - `populate_iso`: populate the ISO file tree
-- `vagrantup`: spawn a development environment using Vagrant
+- `vagrant_up`: spawn a development environment using Vagrant
 
 By default, i.e. if you only type `./doit.sh` with no arguments, the `iso` task is
 executed.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For more information, please refers to [BUILDING.md](BUILDING.md).
 If you'd like to contribute, please review the
 [Contributing Guidelines](CONTRIBUTING.md).
 
-## End-to-End Testing
+## Testing
 ### Requirements
 
 - [Python3.6+](https://www.python.org/)
@@ -23,12 +23,19 @@ If you'd like to contribute, please review the
 - [Vagrant](https://www.vagrantup.com/)
 - [VirtualBox](https://www.virtualbox.org)
 
-### Usage
+### Bootstrapping local environment
 
-To run tests locally:
-```shell
+```shell 
+# Install virtualbox guest addition plugin
+vagrant plugin install vagrant-vbguest
 # Bootstrap a platform on a vagrant environment using
-./doit.sh vagrantup
+./doit.sh vagrant_up
+```
+
+### End-to-End Testing
+
+To run tests locally: Complete the bootstrapping step above
+```shell 
 # Generate an ssh-config file from vagrant
 vagrant ssh-config >bootstrap.ssh.config
 # Run tox with two environment variables

--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ To run the test-suite locally, first complete the bootstrap step as outline abov
 ```shell 
 # Run tests with tox
 tox -e tests
-# The test command should be in that case
-SSH_CONFIG_FILE=bootstrap.ssh.config SSH_HOSTS_LIST=bootstrap tox -e tests
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -36,9 +36,8 @@ vagrant plugin install vagrant-vbguest
 
 To run the test-suite locally, first complete the bootstrap step as outline above
 ```shell 
-# Generate an ssh-config file from vagrant
-vagrant ssh-config >bootstrap.ssh.config
-# Run tox with two environment variables
+# Run tests with tox
+tox -e tests
 # The test command should be in that case
 SSH_CONFIG_FILE=bootstrap.ssh.config SSH_HOSTS_LIST=bootstrap tox -e tests
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you'd like to contribute, please review the
 - [Vagrant](https://www.vagrantup.com/)
 - [VirtualBox](https://www.virtualbox.org)
 
-### Bootstrapping local environment
+### Bootstrapping a local environment
 
 ```shell 
 # Install virtualbox guest addition plugin
@@ -34,7 +34,7 @@ vagrant plugin install vagrant-vbguest
 
 ### End-to-End Testing
 
-To run tests locally: Complete the bootstrapping step above
+To run the test-suite locally, first complete the bootstrap step as outline above
 ```shell 
 # Generate an ssh-config file from vagrant
 vagrant ssh-config >bootstrap.ssh.config


### PR DESCRIPTION
**Component**: Documentation

**Context**: Updating documentation from Local Dev Standpoint

**Summary**:
Proposes a few new changes to how the Readme documentation is outlined while including a missing & mandatory bootstrapping step.

- The missing step happens to be the VirtualBox guest addition which is required for bootstrapping a local dev environment.


Also, a few changes have been made to the Build doc relating to `doit` sub-commands ie vagrant_up
