### PR TITLE
Node-Management: configure metal k8s version

### DIFF
--- a/ui/src/containers/NodeCreateForm.js
+++ b/ui/src/containers/NodeCreateForm.js
@@ -54,6 +54,7 @@ const FormTitle = styled.h3`
 
 const initialValues = {
   name: '',
+  version: '',
   ssh_user: '',
   hostName_ip: '',
   ssh_port: '',
@@ -65,6 +66,7 @@ const initialValues = {
 
 const validationSchema = Yup.object().shape({
   name: Yup.string().required(),
+  version: Yup.string().required(),
   ssh_user: Yup.string().required(),
   hostName_ip: Yup.string().required(),
   ssh_port: Yup.string().required(),
@@ -115,6 +117,14 @@ class NodeCreateForm extends React.Component {
                   value={values.name}
                   onChange={handleChange('name')}
                   error={touched.name && errors.name}
+                  onBlur={handleOnBlur}
+                />
+                <Input
+                  name="version"
+                  label={intl.messages.version}
+                  value={values.version}
+                  onChange={handleChange('version')}
+                  error={touched.version && errors.version}
                   onBlur={handleOnBlur}
                 />
                 <Input

--- a/ui/src/ducks/app/nodes.js
+++ b/ui/src/ducks/app/nodes.js
@@ -77,6 +77,8 @@ export function* fetchNodes() {
 
           return {
             name: node.metadata.name,
+            metalk8s_version:
+              node.metadata.labels['metalk8s.scality.com/version'],
             statusType: statusType,
             cpu: node.status.capacity && node.status.capacity.cpu,
             control_plane: isRolePresentInLabels(node, Api.ROLE_MASTER),
@@ -118,7 +120,8 @@ export function* deployNode({ payload }) {
     Api.deployNode,
     api.url_salt,
     salt.data.return[0].token,
-    payload.name
+    payload.name,
+    payload.metalk8s_version
   );
   yield put(layoutLoadingAction(false));
   if (result.error) {

--- a/ui/src/services/api.js
+++ b/ui/src/services/api.js
@@ -78,7 +78,7 @@ export async function createNode(payload) {
     metadata: {
       name: payload.name,
       labels: {
-        'metalk8s.scality.com/version': '2.0'
+        'metalk8s.scality.com/version': payload.version
       },
       annotations: {
         'metalk8s.scality.com/ssh-user': payload.ssh_user,
@@ -122,7 +122,7 @@ export async function createNode(payload) {
   }
 }
 
-export async function deployNode(url, token, node) {
+export async function deployNode(url, token, node, version) {
   try {
     return await axios.post(
       url,
@@ -131,8 +131,8 @@ export async function deployNode(url, token, node) {
         fun: 'state.orchestrate',
         arg: ['metalk8s.orchestrate.deploy_node'],
         kwarg: {
-          saltenv: 'metalk8s-2.0',
-          pillar: { orchestrate: { node_name: node }}
+          saltenv: `metalk8s-${version}`,
+          pillar: { orchestrate: { node_name: node } }
         }
       },
       {

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -33,5 +33,5 @@
   "ready": "Ready",
   "not_ready": "Not Ready",
   "deploy": "Deploy",
-  "version": "Metalk8s Version"
+  "version": "MetalK8s Version"
 }

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -32,5 +32,6 @@
   "unknown": "Unknown",
   "ready": "Ready",
   "not_ready": "Not Ready",
-  "deploy": "Deploy"
+  "deploy": "Deploy",
+  "version": "Metalk8s Version"
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -32,5 +32,6 @@
   "unknown": "Inconnu",
   "ready": "Prêt",
   "not_ready": "Pas prêt",
-  "deploy": "Déployer"
+  "deploy": "Déployer",
+  "version": "Metalk8s Version"
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -33,5 +33,5 @@
   "ready": "Prêt",
   "not_ready": "Pas prêt",
   "deploy": "Déployer",
-  "version": "Metalk8s Version"
+  "version": "MetalK8s Version"
 }


### PR DESCRIPTION
**Component**: UI (duplicate https://github.com/scality/metalk8s/pull/1114 but change the branch name)

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
Actually, the metalk8s version is hardcoded in the UI when creating and deploying a node
**Summary**:
The idea is to add a "version" field into the creation node form the use its value for deployement
**Acceptance criteria**: 
-No regression when creating and deploying a node
-Check if the metalk8s version is correct.
