### PR TITLE
Salt daemon not bound to control-plane IP

### DIFF
--- a/salt/metalk8s/salt/master/configured.sls
+++ b/salt/metalk8s/salt/master/configured.sls
@@ -1,12 +1,6 @@
 {%- from "metalk8s/map.jinja" import metalk8s with context %}
-{%- from "metalk8s/map.jinja" import networks with context %}
 
-{%- set ip_candidates = salt.network.ip_addrs(cidr=networks.control_plane) %}
-{%- if ip_candidates %}
-    {%- set salt_api_ip = ip_candidates[0] %}
-{%- else %}
-    {%- set salt_api_ip = '127.0.0.1' %}
-{%- endif %}
+{%- set salt_ip = grains['metalk8s']['control_plane_ip'] -%}
 
 Configure salt master:
   file.managed:
@@ -19,7 +13,7 @@ Configure salt master:
     - backup: false
     - template: jinja
     - defaults:
-        salt_api_ip: "{{ salt_api_ip }}"
+        salt_ip: "{{ salt_ip }}"
 
 Configure salt master roots paths:
   file.serialize:

--- a/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
+++ b/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
@@ -1,3 +1,5 @@
+interface: {{ salt_ip }}
+
 peer:
   .*:
     - x509.sign_remote_certificate
@@ -20,7 +22,7 @@ no_host_keys: true
 
 rest_cherrypy:
   port: 4507
-  host: {{ salt_api_ip }}
+  host: {{ salt_ip }}
   disable_ssl: true
 
 external_auth:

--- a/salt/metalk8s/salt/master/files/salt-master-manifest.yaml.j2
+++ b/salt/metalk8s/salt/master/files/salt-master-manifest.yaml.j2
@@ -84,12 +84,12 @@ spec:
         httpGet:
           path: /
           port: api
-          host: {{ salt_api_ip }}
+          host: {{ salt_ip }}
       readinessProbe:
         httpGet:
           path: /
           port: api
-          host: {{ salt_api_ip }}
+          host: {{ salt_ip }}
       volumeMounts:
         - name: config
           mountPath: '/etc/salt'

--- a/salt/metalk8s/salt/master/installed.sls
+++ b/salt/metalk8s/salt/master/installed.sls
@@ -3,14 +3,7 @@
 {% set salt_master_image = 'salt-master' %}
 {% set salt_master_version = '2018.3.4-1' %}
 
-{%- from "metalk8s/map.jinja" import networks with context %}
-
-{%- set ip_candidates = salt.network.ip_addrs(cidr=networks.control_plane) %}
-{%- if ip_candidates %}
-    {%- set salt_api_ip = ip_candidates[0] %}
-{%- else %}
-    {%- set salt_api_ip = '127.0.0.1' %}
-{%- endif %}
+{%- set salt_ip = grains['metalk8s']['control_plane_ip'] -%}
 
 include:
   - .configured
@@ -37,7 +30,7 @@ Install and start salt master manifest:
         salt_master_image: {{ salt_master_image }}
         salt_master_version: {{ salt_master_version }}
         iso_root_path: {{ metalk8s.iso_root_path }}
-        salt_api_ip: "{{ salt_api_ip }}"
+        salt_ip: "{{ salt_ip }}"
     - require:
       - file: Create salt master directories
     - onchanges:
@@ -54,5 +47,5 @@ Make sure salt master container is up:
 
 Wait for Salt API to answer:
   http.wait_for_successful_query:
-    - name: http://{{ salt_api_ip }}:4507/
+    - name: http://{{ salt_ip }}:4507/
     - status: 200


### PR DESCRIPTION
The Salt master daemon binds to 0.0.0.0, set it to the control-plane
IP only.

Fixes #766

**Component**:

salt master

**Context**: 

Update salt master listening addr

**Summary**:

**Acceptance criteria**: 

Salt master should listen on control plane IP instead of `0.0.0.0`