### PR TITLE
Fix SSH config file generated by Terraform

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -214,6 +214,11 @@ stages:
       - ShellCommand: *retrieve_iso_checksum
       - ShellCommand: *check_iso_checksum
       - ShellCommand:
+          name: Set-up Terraform provider plugins for v0.12
+          command: bash scripts/setup-providers.sh
+          workdir: build/eve/workers/openstack-multiple-nodes/terraform/
+          haltOnFailure: true
+      - ShellCommand:
           name: Init terraform
           command: terraform init
           workdir: build/eve/workers/openstack-multiple-nodes/terraform/

--- a/eve/workers/openstack-multiple-nodes/requirements.sh
+++ b/eve/workers/openstack-multiple-nodes/requirements.sh
@@ -5,6 +5,7 @@ yum install -y epel-release
 PACKAGES=(
     curl
     git
+    make
     python36-pip
     unzip
 )
@@ -15,7 +16,7 @@ yum clean all
 
 sudo -u eve pip3.6 install --user tox
 
-TERRAFORM_VERSION=0.11.13
+TERRAFORM_VERSION=0.12.0-rc1
 
 curl -O https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/local/sbin/

--- a/eve/workers/openstack-multiple-nodes/terraform/common.tf
+++ b/eve/workers/openstack-multiple-nodes/terraform/common.tf
@@ -1,5 +1,5 @@
 variable "worker_uuid" {
-  type    = "string"
+  type    = string
   default = ""
 }
 

--- a/eve/workers/openstack-multiple-nodes/terraform/image.tf
+++ b/eve/workers/openstack-multiple-nodes/terraform/image.tf
@@ -1,9 +1,9 @@
 variable "openstack_image_name" {
-  type    = "string"
+  type    = string
   default = "CentOS-7-x86_64-GenericCloud-1809.qcow2"
 }
 
 variable "openstack_flavour_name" {
-  type    = "string"
+  type    = string
   default = "m1.medium"
 }

--- a/eve/workers/openstack-multiple-nodes/terraform/network.tf
+++ b/eve/workers/openstack-multiple-nodes/terraform/network.tf
@@ -2,7 +2,7 @@
 
 # Default CI network
 variable "openstack_network" {
-  type = "map"
+  type = map(string)
   default = {
     name = "tenantnetwork1"
   }
@@ -10,12 +10,12 @@ variable "openstack_network" {
 
 # Default internal networks
 variable "control_plane_cidr" {
-  type    = "string"
+  type    = string
   default = "172.42.254.0/28"
 }
 
 variable "workload_plane_cidr" {
-  type    = "string"
+  type    = string
   default = "172.42.254.32/27"
 }
 
@@ -29,8 +29,8 @@ resource "openstack_networking_network_v2" "control_plane" {
 
 resource "openstack_networking_subnet_v2" "control_plane_subnet" {
   name       = "${local.prefix}-control-plane-subnet"
-  network_id = "${openstack_networking_network_v2.control_plane.id}"
-  cidr       = "${var.control_plane_cidr}"
+  network_id = openstack_networking_network_v2.control_plane.id
+  cidr       = var.control_plane_cidr
   ip_version = 4
   no_gateway = true
 }
@@ -42,18 +42,18 @@ resource "openstack_networking_network_v2" "workload_plane" {
 
 resource "openstack_networking_subnet_v2" "workload_plane_subnet" {
   name       = "${local.prefix}-workload-plane-subnet"
-  network_id = "${openstack_networking_network_v2.workload_plane.id}"
-  cidr       = "${var.workload_plane_cidr}"
+  network_id = openstack_networking_network_v2.workload_plane.id
+  cidr       = var.workload_plane_cidr
   ip_version = 4
   no_gateway = true
 }
 
 locals {
   control_plane_network = {
-    name = "${openstack_networking_network_v2.control_plane.name}"
+    name = openstack_networking_network_v2.control_plane.name
   }
   workload_plane_network = {
-    name = "${openstack_networking_network_v2.workload_plane.name}"
+    name = openstack_networking_network_v2.workload_plane.name
   }
 }
 
@@ -73,7 +73,7 @@ resource "openstack_networking_secgroup_rule_v2" "nodes_ssh" {
   port_range_min    = 22
   port_range_max    = 22
   remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = "${openstack_networking_secgroup_v2.nodes.id}"
+  security_group_id = openstack_networking_secgroup_v2.nodes.id
 }
 
 resource "openstack_networking_secgroup_rule_v2" "nodes_icmp" {
@@ -81,7 +81,7 @@ resource "openstack_networking_secgroup_rule_v2" "nodes_icmp" {
   ethertype         = "IPv4"
   protocol          = "icmp"
   remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = "${openstack_networking_secgroup_v2.nodes.id}"
+  security_group_id = openstack_networking_secgroup_v2.nodes.id
 }
 
 # Second secgroup for traffic within the control/workload plane subnets
@@ -96,8 +96,8 @@ resource "openstack_networking_secgroup_rule_v2" "nodes_internal_control" {
   protocol          = "tcp"
   port_range_min    = 1
   port_range_max    = 65535
-  remote_ip_prefix  = "${var.control_plane_cidr}"
-  security_group_id = "${openstack_networking_secgroup_v2.nodes_internal.id}"
+  remote_ip_prefix  = var.control_plane_cidr
+  security_group_id = openstack_networking_secgroup_v2.nodes_internal.id
 }
 
 resource "openstack_networking_secgroup_rule_v2" "nodes_internal_workload" {
@@ -106,6 +106,6 @@ resource "openstack_networking_secgroup_rule_v2" "nodes_internal_workload" {
   protocol          = "tcp"
   port_range_min    = 1
   port_range_max    = 65535
-  remote_ip_prefix  = "${var.workload_plane_cidr}"
-  security_group_id = "${openstack_networking_secgroup_v2.nodes_internal.id}"
+  remote_ip_prefix  = var.workload_plane_cidr
+  security_group_id = openstack_networking_secgroup_v2.nodes_internal.id
 }

--- a/eve/workers/openstack-multiple-nodes/terraform/nodes.tf
+++ b/eve/workers/openstack-multiple-nodes/terraform/nodes.tf
@@ -1,29 +1,37 @@
 resource "openstack_compute_instance_v2" "bastion" {
   name        = "${local.prefix}-bastion"
-  image_name  = "${var.openstack_image_name}"
-  flavor_name = "${var.openstack_flavour_name}"
-  key_pair    = "${openstack_compute_keypair_v2.local_ssh_key.name}"
+  image_name  = var.openstack_image_name
+  flavor_name = var.openstack_flavour_name
+  key_pair    = openstack_compute_keypair_v2.local_ssh_key.name
 
   security_groups = [
-    "${openstack_networking_secgroup_v2.nodes.name}",
-    "${openstack_networking_secgroup_v2.nodes_internal.name}"
+    openstack_networking_secgroup_v2.nodes.name,
+    openstack_networking_secgroup_v2.nodes_internal.name,
   ]
 
-  network = [
-    "${var.openstack_network}",
-    "${local.control_plane_network}",
-    "${local.workload_plane_network}",
-  ]
+  dynamic "network" {
+    for_each = [
+      var.openstack_network,
+      local.control_plane_network,
+      local.workload_plane_network
+    ]
+
+    content {
+      name = network.value.name
+    }
+  }
 
   # We need the subnets to be created before attempting to reach the DHCP server
   depends_on = [
-    "openstack_networking_subnet_v2.control_plane_subnet",
-    "openstack_networking_subnet_v2.workload_plane_subnet",
+    openstack_networking_subnet_v2.control_plane_subnet,
+    openstack_networking_subnet_v2.workload_plane_subnet,
   ]
 
   connection {
+    host        = self.access_ip_v4
+    type        = "ssh"
     user        = "centos"
-    private_key = "${file("~/.ssh/terraform")}"
+    private_key = file("~/.ssh/terraform")
   }
 
   # Provision scripts for remote-execution
@@ -40,7 +48,7 @@ resource "openstack_compute_instance_v2" "bastion" {
   # Generate Bastion SSH keypair
   provisioner "remote-exec" {
     inline = [
-      "ssh-keygen -t rsa -b 4096 -N '' -f /home/centos/.ssh/bastion"
+      "ssh-keygen -t rsa -b 4096 -N '' -f /home/centos/.ssh/bastion",
     ]
   }
 
@@ -56,30 +64,38 @@ resource "openstack_compute_instance_v2" "bastion" {
 
 resource "openstack_compute_instance_v2" "bootstrap" {
   name        = "${local.prefix}-bootstrap"
-  image_name  = "${var.openstack_image_name}"
-  flavor_name = "${var.openstack_flavour_name}"
-  key_pair    = "${openstack_compute_keypair_v2.local_ssh_key.name}"
+  image_name  = var.openstack_image_name
+  flavor_name = var.openstack_flavour_name
+  key_pair    = openstack_compute_keypair_v2.local_ssh_key.name
 
   security_groups = [
-    "${openstack_networking_secgroup_v2.nodes.name}",
-    "${openstack_networking_secgroup_v2.nodes_internal.name}"
+    openstack_networking_secgroup_v2.nodes.name,
+    openstack_networking_secgroup_v2.nodes_internal.name,
   ]
 
-  network = [
-    "${var.openstack_network}",
-    "${local.control_plane_network}",
-    "${local.workload_plane_network}",
-  ]
+  dynamic "network" {
+    for_each = [
+      var.openstack_network,
+      local.control_plane_network,
+      local.workload_plane_network
+    ]
+
+    content {
+      name = network.value.name
+    }
+  }
 
   # We need the subnets before attempting to reach their DHCP servers
   depends_on = [
-    "openstack_networking_subnet_v2.control_plane_subnet",
-    "openstack_networking_subnet_v2.workload_plane_subnet",
+    openstack_networking_subnet_v2.control_plane_subnet,
+    openstack_networking_subnet_v2.workload_plane_subnet,
   ]
 
   connection {
+    host        = self.access_ip_v4
+    type        = "ssh"
     user        = "centos"
-    private_key = "${file("~/.ssh/terraform")}"
+    private_key = file("~/.ssh/terraform")
   }
 
   # Provision scripts for remote-execution
@@ -100,36 +116,44 @@ resource "openstack_compute_instance_v2" "bootstrap" {
 }
 
 variable "nodes_count" {
-  type    = "string"
+  type    = string
   default = "1"
 }
 
 resource "openstack_compute_instance_v2" "nodes" {
-  name        = "${local.prefix}-node-${count.index+1}"
-  image_name  = "${var.openstack_image_name}"
-  flavor_name = "${var.openstack_flavour_name}"
-  key_pair    = "${openstack_compute_keypair_v2.local_ssh_key.name}"
+  name        = "${local.prefix}-node-${count.index + 1}"
+  image_name  = var.openstack_image_name
+  flavor_name = var.openstack_flavour_name
+  key_pair    = openstack_compute_keypair_v2.local_ssh_key.name
 
   security_groups = [
-    "${openstack_networking_secgroup_v2.nodes.name}",
-    "${openstack_networking_secgroup_v2.nodes_internal.name}"
+    openstack_networking_secgroup_v2.nodes.name,
+    openstack_networking_secgroup_v2.nodes_internal.name,
   ]
 
-  network = [
-    "${var.openstack_network}",
-    "${local.control_plane_network}",
-    "${local.workload_plane_network}",
-  ]
+  dynamic "network" {
+    for_each = [
+      var.openstack_network,
+      local.control_plane_network,
+      local.workload_plane_network
+    ]
+
+    content {
+      name = network.value.name
+    }
+  }
 
   # We need the subnets to be created before attempting to reach the DHCP server
   depends_on = [
-    "openstack_networking_subnet_v2.control_plane_subnet",
-    "openstack_networking_subnet_v2.workload_plane_subnet",
+    openstack_networking_subnet_v2.control_plane_subnet,
+    openstack_networking_subnet_v2.workload_plane_subnet,
   ]
 
   connection {
+    host        = self.access_ip_v4
+    type        = "ssh"
     user        = "centos"
-    private_key = "${file("~/.ssh/terraform")}"
+    private_key = file("~/.ssh/terraform")
   }
 
   # Provision scripts for remote-execution
@@ -143,31 +167,30 @@ resource "openstack_compute_instance_v2" "nodes" {
     inline = ["sudo bash scripts/get-ip-leases.sh"]
   }
 
-  count = "${var.nodes_count}"
+  count = var.nodes_count
 }
 
 locals {
-  bastion_ip   = "${openstack_compute_instance_v2.bastion.network.0.fixed_ip_v4}"
-  bootstrap_ip = "${openstack_compute_instance_v2.bootstrap.network.0.fixed_ip_v4}"
+  bastion_ip   = openstack_compute_instance_v2.bastion.network.0.fixed_ip_v4
+  bootstrap_ip = openstack_compute_instance_v2.bootstrap.network.0.fixed_ip_v4
 
   # FIXME: this syntax does not work (but will in v0.12)
   # see https://github.com/hashicorp/terraform/issues/17048
   # nodes = ["${openstack_compute_instance_v2.nodes.*.network.0.fixed_ip_v4}"]
 
-  all_instances = "${concat(
-    "${list(
-      "${openstack_compute_instance_v2.bastion.id}",
-      "${openstack_compute_instance_v2.bootstrap.id}"
-    )}",
-    "${openstack_compute_instance_v2.nodes.*.id}"
-  )}"
+  all_instances = concat(
+    [
+      openstack_compute_instance_v2.bastion.id,
+      openstack_compute_instance_v2.bootstrap.id,
+    ],
+    openstack_compute_instance_v2.nodes.*.id,
+  )
 }
-
 
 
 output "ips" {
   value = {
-    bastion   = "${local.bastion_ip}"
-    bootstrap = "${local.bootstrap_ip}"
+    bastion   = local.bastion_ip
+    bootstrap = local.bootstrap_ip
   }
 }

--- a/eve/workers/openstack-multiple-nodes/terraform/nodes.tf
+++ b/eve/workers/openstack-multiple-nodes/terraform/nodes.tf
@@ -174,9 +174,10 @@ locals {
   bastion_ip   = openstack_compute_instance_v2.bastion.network.0.fixed_ip_v4
   bootstrap_ip = openstack_compute_instance_v2.bootstrap.network.0.fixed_ip_v4
 
-  # FIXME: this syntax does not work (but will in v0.12)
-  # see https://github.com/hashicorp/terraform/issues/17048
-  # nodes = ["${openstack_compute_instance_v2.nodes.*.network.0.fixed_ip_v4}"]
+  nodes = [
+    for index, node in openstack_compute_instance_v2.nodes :
+    { name = "node${index + 1}", ip = node.network.0.fixed_ip_v4 }
+  ]
 
   all_instances = concat(
     [
@@ -192,5 +193,6 @@ output "ips" {
   value = {
     bastion   = local.bastion_ip
     bootstrap = local.bootstrap_ip
+    nodes     = [for node in local.nodes : node.ip]
   }
 }

--- a/eve/workers/openstack-multiple-nodes/terraform/nodes.tf
+++ b/eve/workers/openstack-multiple-nodes/terraform/nodes.tf
@@ -171,12 +171,12 @@ resource "openstack_compute_instance_v2" "nodes" {
 }
 
 locals {
-  bastion_ip   = openstack_compute_instance_v2.bastion.network.0.fixed_ip_v4
-  bootstrap_ip = openstack_compute_instance_v2.bootstrap.network.0.fixed_ip_v4
+  bastion_ip   = openstack_compute_instance_v2.bastion.access_ip_v4
+  bootstrap_ip = openstack_compute_instance_v2.bootstrap.access_ip_v4
 
   nodes = [
     for index, node in openstack_compute_instance_v2.nodes :
-    { name = "node${index + 1}", ip = node.network.0.fixed_ip_v4 }
+    { name = "node${index + 1}", ip = node.access_ip_v4 }
   ]
 
   all_instances = concat(

--- a/eve/workers/openstack-multiple-nodes/terraform/scripts/setup-providers.sh
+++ b/eve/workers/openstack-multiple-nodes/terraform/scripts/setup-providers.sh
@@ -1,0 +1,38 @@
+# Install development preview of Terraform providers for v0.12
+download_provider() {
+    local -r provider=$1 version=$2
+    echo "downloading provider $provider version $version"
+    curl -O "http://terraform-0.12.0-dev-snapshots.s3-website-us-west-2.amazonaws.com/terraform-provider-${provider}/${version}/terraform-provider-${provider}_${version}_linux_amd64.zip"
+    unzip "terraform-provider-${provider}_${version}_linux_amd64.zip" -d /home/eve/.terraform.d/plugins/
+    rm -f "terraform-provider-${provider}_${version}_linux_amd64.zip"
+}
+
+TERRAFORM_DIR=$(pwd)
+mkdir -p /home/eve/.terraform.d/plugins
+
+download_provider null 2.2.0-dev20190415H16-dev
+download_provider random 3.0.0-dev20190216H01-dev
+download_provider template 2.2.0-dev20190415H16-dev
+
+# Development preview of OpenStack provider is too old, we need to build it
+# from the Git repository
+
+# Install Go first
+curl -O https://dl.google.com/go/go1.12.5.linux-amd64.tar.gz
+tar -xzf go1.12.5.linux-amd64.tar.gz
+sudo mv go /usr/local
+export GOROOT=/usr/local/go
+export GOPATH=/home/eve/go
+export PATH=$PATH:$GOROOT/bin
+
+# Then build from source
+mkdir -p /home/eve/go/src/github.com/terraform-providers/
+cd /home/eve/go/src/github.com/terraform-providers/
+git clone https://github.com/terraform-providers/terraform-provider-openstack
+cd terraform-provider-openstack
+git checkout -b build-v0.12
+make build
+
+# Copy the built binary to plugins directory
+cd $TERRAFORM_DIR
+mv $GOPATH/bin/terraform-provider-openstack /home/eve/.terraform.d/plugins/

--- a/eve/workers/openstack-multiple-nodes/terraform/ssh.tf
+++ b/eve/workers/openstack-multiple-nodes/terraform/ssh.tf
@@ -8,36 +8,6 @@ resource "openstack_compute_keypair_v2" "local_ssh_key" {
   public_key = file(var.ssh_key_path)
   }
 
-
-data "template_file" "local_ssh_config" {
-  template = "${file("${path.module}/templates/ssh_config.tpl")}"
-  vars = {
-    identity_file = "~/.ssh/terraform"
-    bastion_ip = "${local.bastion_ip}"
-    bootstrap_ip = "${local.bootstrap_ip}"
-
-    # TODO: use Terraform v0.12 syntax once released
-    # nodes = [
-    #   for node in openstack_compute_instance_v2.nodes:
-    #   {
-    #     name = "node-${count.index}"  # May not work
-    #     ip   = node.network[0].fixed_ip_v4
-    #   }
-    # ]
-}
-}
-
-data "template_file" "bastion_ssh_config" {
-  template = "${file("${path.module}/templates/ssh_config.tpl")}"
-  vars = {
-    identity_file = "/home/centos/.ssh/bastion"
-    bastion_ip = "${local.bastion_ip}"
-    bootstrap_ip = "${local.bootstrap_ip}"
-
-    # nodes = []  # TODO: see above
-  }
-}
-
 resource "null_resource" "ssh_config" {
   triggers = {
     cluster_instance_ids = join(",", local.all_instances)
@@ -45,7 +15,15 @@ resource "null_resource" "ssh_config" {
 
   # Generate SSH config file for local usage
   provisioner "local-exec" {
-    command = "echo '${data.template_file.local_ssh_config.rendered}' > ssh_config"
+    command = "echo '${templatefile(
+      "${path.module}/templates/ssh_config.tpl",
+      {
+        identity_file = "~/.ssh/terraform"
+        bastion_ip    = local.bastion_ip
+        bootstrap_ip  = local.bootstrap_ip
+        nodes         = local.nodes
+      }
+    )}' > ssh_config"
   }
 
   # Generate SSH config file for the Bastion
@@ -56,7 +34,15 @@ resource "null_resource" "ssh_config" {
       private_key = file("~/.ssh/terraform")
     }
 
-    content = "${data.template_file.bastion_ssh_config.rendered}"
     destination = "/home/centos/ssh_config"
+    content = templatefile(
+      "${path.module}/templates/ssh_config.tpl",
+      {
+        identity_file = "/home/centos/.ssh/bastion"
+        bastion_ip    = local.bastion_ip
+        bootstrap_ip  = local.bootstrap_ip
+        nodes         = local.nodes
+      }
+    )
   }
 }

--- a/eve/workers/openstack-multiple-nodes/terraform/ssh.tf
+++ b/eve/workers/openstack-multiple-nodes/terraform/ssh.tf
@@ -1,12 +1,12 @@
 variable "ssh_key_path" {
-  type    = "string"
+  type    = string
   default = "~/.ssh/terraform.pub"
 }
 
 resource "openstack_compute_keypair_v2" "local_ssh_key" {
-  name       = "${local.prefix}"
-  public_key = "${file(var.ssh_key_path)}"
-}
+  name       = local.prefix
+  public_key = file(var.ssh_key_path)
+  }
 
 
 data "template_file" "local_ssh_config" {
@@ -24,7 +24,7 @@ data "template_file" "local_ssh_config" {
     #     ip   = node.network[0].fixed_ip_v4
     #   }
     # ]
-  }
+}
 }
 
 data "template_file" "bastion_ssh_config" {
@@ -39,8 +39,8 @@ data "template_file" "bastion_ssh_config" {
 }
 
 resource "null_resource" "ssh_config" {
-  triggers {
-    cluster_instance_ids = "${join(",", local.all_instances)}"
+  triggers = {
+    cluster_instance_ids = join(",", local.all_instances)
   }
 
   # Generate SSH config file for local usage
@@ -51,9 +51,9 @@ resource "null_resource" "ssh_config" {
   # Generate SSH config file for the Bastion
   provisioner "file" {
     connection {
-      host = "${local.bastion_ip}"
+      host        = local.bastion_ip
       user        = "centos"
-      private_key = "${file("~/.ssh/terraform")}"
+      private_key = file("~/.ssh/terraform")
     }
 
     content = "${data.template_file.bastion_ssh_config.rendered}"

--- a/eve/workers/openstack-multiple-nodes/terraform/templates/ssh_config.tpl
+++ b/eve/workers/openstack-multiple-nodes/terraform/templates/ssh_config.tpl
@@ -13,3 +13,14 @@ Host bootstrap
     IdentityFile ${identity_file}
     IdentitiesOnly yes
     StrictHostKeyChecking no
+
+%{ for node in nodes ~}
+Host ${node.name}
+    User centos
+    Port 22
+    Hostname ${node.ip}
+    IdentityFile ${identity_file}
+    IdentitiesOnly yes
+    StrictHostKeyChecking no
+
+%{ endfor }

--- a/eve/workers/openstack-multiple-nodes/terraform/versions.tf
+++ b/eve/workers/openstack-multiple-nodes/terraform/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
**Component**: ci, terraform

**Context**:

Tests for cluster expansion (#1031) could not run using the CI Terraform-generated SSH config file, since it did not include information about _extra_ nodes due to limitations in the Terraform syntax.

**Summary**:

- Upgrade to Terraform v0.12 (install a RC version, still no official release)
- Fix the generation of SSH config files from Terraform with the new syntax

**Acceptance criteria**: 

The SSH config files generated by Terraform should be valid and allow to connect to host `node1` from:

- the host that executed `terraform apply`
- the spawned bastion

---

Fixes: #1038