### PR TITLE
Share SA private key with `master` Nodes

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -264,6 +264,7 @@ SALT_FILES : Tuple[Union[Path, targets.FileTarget], ...] = (
     Path('salt/_pillar/metalk8s.py'),
     Path('salt/_pillar/metalk8s_endpoints.py'),
     Path('salt/_pillar/metalk8s_nodes.py'),
+    Path('salt/_pillar/metalk8s_private.py'),
 
     Path('salt/_renderers/metalk8s_kubernetes.py'),
 

--- a/salt/_pillar/metalk8s_private.py
+++ b/salt/_pillar/metalk8s_private.py
@@ -1,0 +1,49 @@
+import os.path
+import logging
+
+
+SA_PRIVATE_KEY_PATH = "/etc/kubernetes/pki/sa.key"
+
+
+log = logging.getLogger(__name__)
+
+__virtualname__ = "metalk8s_private"
+
+
+def __virtual__():
+    return __virtualname__
+
+
+def _read_sa_private_key():
+    # FIXME: we only have access to this file because:
+    #   1- Salt master Pod mounts all of /etc/kubernetes
+    #   2- Salt master Pod runs on the 'bootstrap' minion, which is, by chance,
+    #      also the 'ca' minion, the owner of this key
+    # Suggestion: read through https://github.com/saltstack/salt/issues/45882
+    if not os.path.isfile(SA_PRIVATE_KEY_PATH):
+        log.warn("Missing SA key to share with master node.")
+        return {}
+
+    with open(SA_PRIVATE_KEY_PATH, "r") as key_file:
+        key_data = key_file.read()
+
+    return {"sa_private_key": key_data}
+
+
+def ext_pillar(minion_id, pillar):
+    private_data = {}
+
+    nodes_info = pillar.get("metalk8s", {}).get("nodes", {})
+
+    if minion_id not in nodes_info:
+        log.debug(
+            "No information about minion '%s' in K8s API, skipping.", minion_id
+            )
+        return {}
+
+    node_info = nodes_info[minion_id]
+
+    if "master" in node_info["roles"]:
+        private_data.update(_read_sa_private_key())
+
+    return {"metalk8s": {"private": private_data}}

--- a/salt/_pillar/metalk8s_private.py
+++ b/salt/_pillar/metalk8s_private.py
@@ -21,10 +21,9 @@ def _read_sa_private_key():
     #      also the 'ca' minion, the owner of this key
     # Suggestion: read through https://github.com/saltstack/salt/issues/45882
     if not os.path.isfile(SA_PRIVATE_KEY_PATH):
-        log.warn("Missing SA key to share with master node.")
-        return {}
+        return {"_errors": ["Missing SA key to share with master node."]}
 
-    with open(SA_PRIVATE_KEY_PATH, "r") as key_file:
+    with open(SA_PRIVATE_KEY_PATH, 'r') as key_file:
         key_data = key_file.read()
 
     return {"sa_private_key": key_data}
@@ -38,12 +37,21 @@ def ext_pillar(minion_id, pillar):
     if minion_id not in nodes_info:
         log.debug(
             "No information about minion '%s' in K8s API, skipping.", minion_id
-            )
+        )
         return {}
 
     node_info = nodes_info[minion_id]
 
     if "master" in node_info["roles"]:
-        private_data.update(_read_sa_private_key())
+        _update_with_errors(private_data, _read_sa_private_key())
 
     return {"metalk8s": {"private": private_data}}
+
+
+# Helpers
+
+def _update_with_errors(source, patch):
+    if "_errors" in patch:
+        source.setdefault("_errors", []).extend(patch.pop("_errors"))
+
+    source.update(patch)

--- a/salt/metalk8s/kubernetes/controller-manager/installed.sls
+++ b/salt/metalk8s/kubernetes/controller-manager/installed.sls
@@ -3,6 +3,8 @@
 
 include:
   - .kubeconfig
+  - metalk8s.kubernetes.ca.kubernetes.advertised
+  - metalk8s.kubernetes.sa.advertised
 
 Create kube-controller-manager Pod manifest:
   metalk8s.static_pod_managed:
@@ -23,8 +25,6 @@ Create kube-controller-manager Pod manifest:
           - --address=127.0.0.1
           - --allocate-node-cidrs=true
           - --cluster-cidr={{ networks.pod }}
-          - --cluster-signing-cert-file=/etc/kubernetes/pki/ca.crt
-          - --cluster-signing-key-file=/etc/kubernetes/pki/ca.key
           - --controllers=*,bootstrapsigner,tokencleaner
           - --kubeconfig=/etc/kubernetes/controller-manager.conf
           - --leader-elect=true

--- a/salt/metalk8s/kubernetes/sa/advertised.sls
+++ b/salt/metalk8s/kubernetes/sa/advertised.sls
@@ -21,3 +21,31 @@ Unable to get SA pub key, no kubernetes_sa_pub_key_b64 in mine:
   test.fail_without_changes: []
 
 {%- endif %}
+
+{%- set nodes = pillar['metalk8s']['nodes'] %}
+{%- set roles = nodes.get(grains['id'], {}).get('roles', []) %}
+
+{%- if 'master' in roles %}
+
+{%- set sa_priv_key = pillar['metalk8s'].get('private', {}).get('sa_private_key') %}
+
+{%- if sa_priv_key %}
+
+Ensure SA private key is present:
+  file.managed:
+    - name: /etc/kubernetes/pki/sa.key
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - dir_mode: 755
+    - contents: {{ sa_priv_key.splitlines() }}
+
+{%- else %}
+
+Unable to get SA private key, missing 'metalk8s:certs:sa_private_key' in pillar:
+  test.fail_without_changes: []
+
+{%- endif %}
+
+{%- endif %}

--- a/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
+++ b/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
@@ -11,6 +11,7 @@ ext_pillar:
   - metalk8s: /etc/metalk8s/bootstrap.yaml
   - metalk8s_endpoints: /etc/kubernetes/admin.conf
   - metalk8s_nodes: /etc/kubernetes/admin.conf
+  - metalk8s_private: {}
 
 roster_defaults:
   minion_opts:


### PR DESCRIPTION
**Component**: salt

**Context**: Control-plane expansion is broken since #1080, because we require the SA private key to be available where we deploy `k-c-m` static Pods.

**Summary**:

- Introduce an `ext_pillar` for passing secure data to a subset of minions (filtering is done using the Node roles)
- Use this information in `metalk8s.kubernetes.sa.advertised` to write the `sa.key` file if on a `master` Node
- Include `...sa.advertised` in `metalk8s.kubernetes.controller-manager.installed`

**Acceptance criteria**: 

- Control-plane expansion (follow the steps outlined in #1135) should work

---

Fixes: #1135 