### PR TITLE
Pin busybox version to v1.28

### DIFF
--- a/tests/post/steps/files/busybox.yaml
+++ b/tests/post/steps/files/busybox.yaml
@@ -12,7 +12,7 @@ spec:
     operator: "Equal"
     effect: "NoSchedule"
   containers:
-  - image: busybox
+  - image: busybox:1.28
     command:
       - sleep
       - "3600"


### PR DESCRIPTION
There was a bug during the test with CoreDNS.

Issue: GH-1146

**Component**:
tests

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
Fail during the CoreDNS test

**Summary**:
Pin the busybox version because the latest cause issues

**Acceptance criteria**: 
test do not failed anymore
