### PR TITLE
Include issue reference in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,3 +7,16 @@
 **Summary**:
 
 **Acceptance criteria**: 
+
+
+---
+
+<!-- Declare one or more issues to close once this PR gets merged -->
+
+Closes: #ISSUE_NUMBER
+
+<!-- If you want to refer to an issue while not closing it, use:
+
+See: #ISSUE_NUMBER
+
+-->


### PR DESCRIPTION
**Component**: github

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

We want to encourage developers in referencing issues in their PR descriptions.
It will allow us to leverage the automatic issue closing feature from GH, and also to facilitate linking PRs with issues in GH API.

**Summary**:

- Include `Fixes: #ISSUE_NUMBER` in pull request template
- Suggest using `See: #ISSUE_NUMBER` for other issue references

**Acceptance criteria**: Not applicable

---

No issue was created for this task :sweat_smile:.