### PR TITLE
Mount all iso listed in bootstrap config file

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -132,6 +132,9 @@ apiServer:
   host: #{IPAddr.new(CONTROL_PLANE_IP).mask(CONTROL_PLANE_NETMASK).to_range.last(2).first.to_s}
   keepalived:
     enabled: true
+products:
+  metalk8s:
+  - /srv/scality/metalk8s-$SHORT_VERSION
 EOF
 
 echo "Launching bootstrap"

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -278,6 +278,9 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/orchestrate/upgrade/precheck.sls'),
     Path('salt/metalk8s/orchestrate/register_etcd.sls'),
 
+    Path('salt/metalk8s/products/init.sls'),
+    Path('salt/metalk8s/products/mounted.sls'),
+
     Path('salt/metalk8s/repo/configured.sls'),
     Path('salt/metalk8s/repo/deployed.sls'),
     Path('salt/metalk8s/repo/files/nginx.conf.j2'),

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -112,18 +112,11 @@ class StaticContainerRegistry(targets.AtomicTarget):
 
 
 PILLAR_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
-    Path('pillar/metalk8s/roles/minion.sls'),
-    targets.TemplateFile(
-        task_name='bootstrap.sls',
-        source=constants.ROOT/'pillar'/'metalk8s'/'roles'/'bootstrap.sls.in',
-        destination=
-            constants.ISO_ROOT/'pillar'/'metalk8s'/'roles'/'bootstrap.sls',
-        context={'VERSION': constants.SHORT_VERSION},
-        file_dep=[constants.VERSION_FILE],
-    ),
+    Path('pillar/metalk8s/roles/bootstrap.sls'),
     Path('pillar/metalk8s/roles/ca.sls'),
     Path('pillar/metalk8s/roles/etcd.sls'),
     Path('pillar/metalk8s/roles/master.sls'),
+    Path('pillar/metalk8s/roles/minion.sls'),
     Path('pillar/metalk8s/roles/node.sls'),
     targets.TemplateFile(
         task_name='top.sls',

--- a/docs/quickstart/bootstrap.rst
+++ b/docs/quickstart/bootstrap.rst
@@ -40,11 +40,15 @@ Configuration
         minion: <hostname-of-the-bootstrap-node>
       apiServer:
         host: <IP-of-the-bootstrap-node>
+      products:
+        metalk8s:
+          - <path-to-extracted-directory-or-iso>
 
 .. todo::
 
    - Explain the role of this config file and its values
    - Add a note about setting HA for ``apiServer``
+   - Explain the ``products`` list
 
 
 .. _quickstart-bootstrap-ssh:

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -163,6 +163,9 @@ stages:
               minion: $(hostname)
             apiServer:
               host: $(ip route get 10.100.0.0 | awk '/10.100.0.0/{ print $6 }')
+            products:
+              metalk8s:
+                - /srv/scality/metalk8s-%(prop:metalk8s_short_version)s
             END
             EOF
       - ShellCommand:
@@ -274,15 +277,14 @@ stages:
           name: Create mountpoint in bootstrap node
           command: >
             ssh -F ssh_config bootstrap
-            sudo mkdir -p /srv/scality/metalk8s-%(prop:metalk8s_short_version)s
+            sudo mkdir -p /var/tmp/metalk8s
           workdir: build/eve/workers/openstack-multiple-nodes/terraform/
           haltOnFailure: true
       - ShellCommand:
           name: Mount ISO image in bootstrap node
           command: >
             ssh -F ssh_config bootstrap
-            sudo mount -o loop metalk8s.iso
-            /srv/scality/metalk8s-%(prop:metalk8s_short_version)s
+            sudo mount -o loop metalk8s.iso /var/tmp/metalk8s
           workdir: build/eve/workers/openstack-multiple-nodes/terraform/
           haltOnFailure: true
       - ShellCommand:
@@ -290,8 +292,7 @@ stages:
           command: >
             ssh -F ssh_config bootstrap
             sudo bash
-            /srv/scality/metalk8s-%(prop:metalk8s_short_version)s/bootstrap.sh
-            --verbose
+            /var/tmp/metalk8s/bootstrap.sh --verbose
           workdir: build/eve/workers/openstack-multiple-nodes/terraform/
           haltOnFailure: true
       - ShellCommand:
@@ -320,7 +321,7 @@ stages:
             ssh -F ssh_config bastion --
             'cd metalk8s &&
             export SSH_CONFIG_FILE=/home/centos/ssh_config &&
-            export ISO_MOUNTPOINT=/srv/scality/metalk8s-%(prop:metalk8s_short_version)s &&
+            export ISO_MOUNTPOINT=/var/tmp/metalk8s &&
             export TEST_HOSTS_LIST=bootstrap &&
             tox -e tests -- -m "ci and not slow" &&
             tox -e tests -- -m "ci and slow"'

--- a/eve/workers/openstack-multiple-nodes/terraform/scripts/bootstrap-config.sh
+++ b/eve/workers/openstack-multiple-nodes/terraform/scripts/bootstrap-config.sh
@@ -19,6 +19,9 @@ ca:
   minion: $(cat /etc/salt/minion_id)
 apiServer:
   host: $(ip route get 172.42.254.0 | awk '/172.42.254.0/{ print $6 }')
+products:
+  metalk8s:
+    - /var/tmp/metalk8s
 EOF
 
 ls "$(dirname $OUTPUT_FILE)"

--- a/packages/packages.list
+++ b/packages/packages.list
@@ -1,6 +1,7 @@
 containerd
 cri-tools
 ftp://ftp.scientificlinux.org/linux/scientific/7x/external_products/extras/x86_64/container-selinux-2.77-1.el7_6.noarch.rpm
+genisoimage
 kubectl-1.11.7-0
 kubelet-1.11.7-0
 m2crypto

--- a/pillar/metalk8s/roles/bootstrap.sls.in
+++ b/pillar/metalk8s/roles/bootstrap.sls.in
@@ -1,4 +1,0 @@
-metalk8s:
-  # The mountpoint used for this environment's ISO
-  iso_root_path:
-    metalk8s-@@VERSION: /srv/scality/metalk8s-@@VERSION

--- a/pillar/top.sls.in
+++ b/pillar/top.sls.in
@@ -11,17 +11,6 @@ I@metalk8s:nodes:{{ grains.id }}:roles:{{ name }}
 {%- endmacro %}
 
 metalk8s-{{ version }}:
-  # The 'bootstrap' node requires the value of `metalk8s.iso_root_path`, which
-  # is only set in the `metalk8s.roles.bootstrap` Pillar. However, the
-  # compound-match below which assigns that Pillar to a node based on its role
-  # only works when the roles are available, i.e. late in the deployment (when
-  # the API server and associated `ext_pillar`s are in place).
-  # To work-around this, we assign the 'bootstrap' role Pillar data to all nodes
-  # for now, until either a better solution is found, or we get rid of
-  # `iso_root_path` and instead use what comes out of #924.
-  '*':
-    - metalk8s.roles.bootstrap
-
   {{ version_match }}:
     - match: compound
     - metalk8s.roles.minion

--- a/salt/_pillar/metalk8s.py
+++ b/salt/_pillar/metalk8s.py
@@ -20,6 +20,7 @@ def _load_config(path):
 
     assert config.get('apiVersion') == 'metalk8s.scality.com/v1alpha2'
     assert config.get('kind') == 'BootstrapConfiguration'
+    assert 'products' in config
 
     return config
 
@@ -78,12 +79,32 @@ def _load_apiserver(config_data):
     return result
 
 
+def _load_iso_path(config_data):
+    """Load iso path from BootstrapConfiguration
+
+    """
+    res = config_data['products']['metalk8s']
+
+    if isinstance(res, str):
+        res = [res]
+
+    if not isinstance(res, list):
+        return {"_errors": [
+            "Invalid products format in config file, list or string expected "
+            "got {1}."
+            .format(res)
+        ]}
+
+    return res
+
+
 def ext_pillar(minion_id, pillar, bootstrap_config):
     config = _load_config(bootstrap_config)
 
     return {
         'networks': _load_networks(config),
         'metalk8s': {
+            'products': _load_iso_path(config),
             'ca': _load_ca(config),
             'api_server': _load_apiserver(config),
         },

--- a/salt/metalk8s/orchestrate/bootstrap/init.sls
+++ b/salt/metalk8s/orchestrate/bootstrap/init.sls
@@ -32,7 +32,7 @@
         'metalk8s': {
             'nodes': {
                 pillar.bootstrap_id: {
-                    'roles': ['bootstrap', 'master', 'etcd','ca', 'infra'],
+                    'roles': ['bootstrap', 'master', 'etcd', 'ca', 'infra'],
                     'version': version,
                 },
             },

--- a/salt/metalk8s/products/init.sls
+++ b/salt/metalk8s/products/init.sls
@@ -1,0 +1,4 @@
+include:
+  - .mounted
+  - metalk8s.repo.installed
+  - metalk8s.salt.master

--- a/salt/metalk8s/products/mounted.sls
+++ b/salt/metalk8s/products/mounted.sls
@@ -1,0 +1,49 @@
+{%- for _, product in salt.metalk8s.get_products().items() %}
+  {%- if product.iso %}
+    {%- if not product.version %}
+
+Product {{ product.iso }} available:
+  test.configurable_test_state:
+  - changes: false
+  - result: false
+  - comment: >
+      Unable to retrieve product version from given product file 
+      {{ product.iso }}, assumed to be an ISO archive containing a 
+      "product.txt" file.
+
+    {%- else %}
+
+Product path {{ product.path }} exists:
+  file.directory:
+  - name: {{ product.path }}
+  - makedirs: true
+
+Product {{ product.iso }} available at {{ product.path }}:
+  mount.mounted:
+  - name: {{ product.path }}
+  - device: {{ product.iso }}
+  - fstype: iso9660
+  - mkmnt: false
+  - opts: ro
+  - persist: true
+  - require:
+    - file: Product path {{ product.path }} exists
+  - require_in:
+    - file: Assert '{{ product.path }}/product.txt' exists
+
+    {%- endif %}
+
+  {%- endif %}
+
+Assert '{{ product.path }}/product.txt' exists:
+  file.exists:
+  - name: {{ product.path }}/product.txt
+
+Assert product '{{ product.path }}' is MetalK8s:
+  cmd.run:
+  - name: grep '^NAME=MetalK8s$' {{ product.path }}/product.txt > /dev/null
+  - stateful: true
+  - require:
+    - file: Assert '{{ product.path }}/product.txt' exists
+
+{%- endfor %}

--- a/salt/metalk8s/repo/files/90-metalk8s-registry-config.inc.j2
+++ b/salt/metalk8s/repo/files/90-metalk8s-registry-config.inc.j2
@@ -1,1 +1,3 @@
-set ${{ var_prefix }}_images "{{ images_path }}";
+{%- for env in products.keys() %}
+set ${{ env | replace('.', '_') | replace('-', '_') }}_images "/srv/scality/{{ env }}/images/";
+{%- endfor %}

--- a/salt/metalk8s/repo/files/repositories-manifest.yaml.j2
+++ b/salt/metalk8s/repo/files/repositories-manifest.yaml.j2
@@ -41,22 +41,26 @@ spec:
           port: http
           path: /
       volumeMounts:
-        - name: repositories
-          mountPath: /var/www/repositories
         - name: nginx-configuration
           mountPath: /etc/nginx/conf.d
-        - name: registry
-          mountPath: {{ images_path }}
+        {%- for env, product in products.items() | sort(attribute='0') %}
+        - name: repositories-{{ env | replace('.', '-') }}
+          mountPath: /var/www/repositories/{{ env }}/
+        - name: registry-{{ env | replace('.', '-') }}
+          mountPath: /srv/scality/{{ env }}/images/
+        {%- endfor %}
   volumes:
-    - name: repositories
-      hostPath:
-        path: {{ packages_path }}
-        type: Directory
     - name: nginx-configuration
       hostPath:
         path: {{ nginx_confd_path }}
         type: Directory
-    - name: registry
+    {%- for env, product in products.items() | sort(attribute='0') %}
+    - name: repositories-{{ env | replace('.', '-') }}
       hostPath:
-        path: {{ images_path }}
+        path: {{ product.path ~ package_path }}
         type: Directory
+    - name: registry-{{ env | replace('.', '-') }}
+      hostPath:
+        path: {{ product.path ~ image_path }}
+        type: Directory
+    {%- endfor %}

--- a/salt/metalk8s/repo/offline.sls
+++ b/salt/metalk8s/repo/offline.sls
@@ -13,10 +13,12 @@ Install yum-plugin-versionlock:
 
 {%- for repo_name, repo_config in repo.repositories.items() %}
   {%- if repo.local_mode %}
-    {%- set iso_root = metalk8s.iso_root_path[saltenv] %}
-    {%- set repo_base_url = "file://" ~ iso_root ~ "/" ~ repo.relative_path %}
+    {%- set repo_base_url = "file://" ~ 
+                            salt.metalk8s.get_products()[saltenv].path ~ "/" ~
+                            repo.relative_path %}
   {%- else %}
-    {%- set repo_base_url = "http://" ~ repo_host ~ ':' ~ repo_port %}
+    {%- set repo_base_url = "http://" ~ repo_host ~ ':' ~ repo_port ~ 
+                            "/" ~ saltenv %}
   {%- endif %}
   {%- set repo_url = repo_base_url ~ "/" ~ repo_name ~ "-el$releasever" %}
   {%- set gpg_keys = [] %}

--- a/salt/metalk8s/roles/bootstrap/init.sls
+++ b/salt/metalk8s/roles/bootstrap/init.sls
@@ -1,4 +1,5 @@
 include:
+  - metalk8s.products.mounted
   - metalk8s.kubernetes.kubelet.standalone
   - metalk8s.internal.preflight
   - metalk8s.repo.installed

--- a/salt/metalk8s/salt/master/configured.sls
+++ b/salt/metalk8s/salt/master/configured.sls
@@ -1,6 +1,7 @@
 {%- from "metalk8s/map.jinja" import metalk8s with context %}
 
 {%- set salt_ip = grains['metalk8s']['control_plane_ip'] -%}
+{%- set products = salt.metalk8s.get_products() %}
 
 Configure salt master:
   file.managed:
@@ -27,12 +28,12 @@ Configure salt master roots paths:
     - backup: false
     - dataset:
         file_roots:
-        {%- for version, path in metalk8s.iso_root_path.items() | sort(attribute='0') %}
-          {{ version }}:
-            - {{ path }}/salt
+        {%- for env in products.keys() | sort(attribute='0') %}
+          {{ env }}:
+            - /srv/scality/{{ env }}/salt
         {%- endfor %}
         pillar_roots:
-        {%- for version, path in metalk8s.iso_root_path.items() | sort(attribute='0') %}
-          {{ version }}:
-            - {{ path }}/pillar
+        {%- for env in products.keys() | sort(attribute='0') %}
+          {{ env }}:
+            - /srv/scality/{{ env }}/pillar
         {%- endfor %}

--- a/salt/metalk8s/salt/master/files/salt-master-manifest.yaml.j2
+++ b/salt/metalk8s/salt/master/files/salt-master-manifest.yaml.j2
@@ -60,12 +60,12 @@ spec:
           mountPath: '/var/cache/salt'
         - name: run
           mountPath: '/var/run/salt'
-        {%- for version, path in iso_root_path.items() | sort(attribute='0') %}
-        - name: states-{{ version | replace('.', '-') }}
-          mountPath: '{{ path }}/salt'
+        {%- for env, product in products.items() | sort(attribute='0') %}
+        - name: states-{{ env | replace('.', '-') }}
+          mountPath: '/srv/scality/{{ env }}/salt'
           readOnly: true
-        - name: pillar-{{ version | replace('.', '-') }}
-          mountPath: '{{ path }}/pillar'
+        - name: pillar-{{ env | replace('.', '-') }}
+          mountPath: '/srv/scality/{{ env }}/pillar'
           readOnly: true
         {%- endfor %}
         - name: metalk8s-config
@@ -111,14 +111,14 @@ spec:
       hostPath:
         path: '/var/run/salt'
         type: Directory
-    {%- for version, path in iso_root_path.items() | sort(attribute='0') %}
-    - name: states-{{ version | replace('.', '-') }}
+    {%- for env, product in products.items() | sort(attribute='0') %}
+    - name: states-{{ env | replace('.', '-') }}
       hostPath:
-        path: '{{ path }}/salt'
+        path: '{{ product.path }}/salt'
         type: Directory
-    - name: pillar-{{ version | replace('.', '-') }}
+    - name: pillar-{{ env | replace('.', '-') }}
       hostPath:
-        path: '{{ path }}/pillar'
+        path: '{{ product.path }}/pillar'
         type: Directory
     {%- endfor %}
     - name: metalk8s-config

--- a/salt/metalk8s/salt/master/installed.sls
+++ b/salt/metalk8s/salt/master/installed.sls
@@ -29,7 +29,7 @@ Install and start salt master manifest:
     - context:
         salt_master_image: {{ salt_master_image }}
         salt_master_version: {{ salt_master_version }}
-        iso_root_path: {{ metalk8s.iso_root_path }}
+        products: {{ salt.metalk8s.get_products() }}
         salt_ip: "{{ salt_ip }}"
     - require:
       - file: Create salt master directories

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -297,6 +297,9 @@ orchestrate_bootstrap() {
     run "Syncing Runner modules on Salt master" \
         "${SALT_MASTER_CALL[@]}" salt-run --state-output=mixed saltutil.sync_runners \
             saltenv=metalk8s-@@VERSION
+    run "Syncing Execution modules on Salt master" \
+        "${SALT_MASTER_CALL[@]}" salt-run --state-output=mixed saltutil.sync_modules \
+            saltenv=metalk8s-@@VERSION
 
     local -r bootstrap_id=$(
         ${SALT_CALL} --local --out txt grains.get id \

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -284,7 +284,7 @@ orchestrate_bootstrap() {
 
     run "Deploying early-stage bootstrap node in local mode (this may take a while)" \
         "${SALT_CALL}" --local --state-output=mixed --retcode-passthrough state.sls \
-            '["metalk8s.roles.minion", "metalk8s.roles.bootstrap"]' \
+            '["metalk8s.roles.bootstrap", "metalk8s.roles.minion"]' \
             saltenv=metalk8s-@@VERSION \
             pillarenv=metalk8s-@@VERSION \
             pillar="${pillar[*]}"

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -195,6 +195,16 @@ install_salt_minion() {
     "$YUM" install "${yum_opts[@]}" salt-minion
 }
 
+install_genisoimage() {
+    local -a yum_opts=(
+        '--assumeyes'
+        '--disablerepo=*'
+        '--enablerepo=metalk8s-*'
+    )
+
+    "$YUM" install "${yum_opts[@]}" genisoimage
+}
+
 configure_salt_minion_local_mode() {
     "$SALT_CALL" --file-root=/srv/scality/metalk8s-@@VERSION/salt \
         --local --retcode-passthrough saltutil.sync_all
@@ -321,6 +331,7 @@ main() {
     run "Stopping Salt minion service" stop_salt_minion_service
     run "Configuring local YUM repositories" configure_yum_repositories
     run "Installing Salt minion" install_salt_minion
+    run "Installing genisoimage" install_genisoimage
     run "Configuring Salt minion to run in local mode" configure_salt_minion_local_mode
 
     orchestrate_bootstrap

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -167,7 +167,7 @@ configure_yum_local_repositories() {
 
 configure_yum_local_repository() {
     local -r repo_name=$1 gpgcheck=${2:-0}
-    local -r repo_path=/srv/scality/metalk8s-@@VERSION/packages/$repo_name-el7
+    local -r repo_path=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/packages/$repo_name-el7
     local gpg_keys
 
     gpg_keys=$(
@@ -206,16 +206,19 @@ install_genisoimage() {
 }
 
 configure_salt_minion_local_mode() {
-    "$SALT_CALL" --file-root=/srv/scality/metalk8s-@@VERSION/salt \
+    local -r file_root=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/salt
+    local -r pillar_root=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/pillar
+
+    "$SALT_CALL" --file-root="$file_root" \
         --local --retcode-passthrough saltutil.sync_all
 
     cat > "${SALT_MINION_FILE_CLIENT_LOCAL_CONF}" << EOF
 file_roots:
   metalk8s-@@VERSION:
-    - /srv/scality/metalk8s-@@VERSION/salt
+    - $file_root
 pillar_roots:
   metalk8s-@@VERSION:
-    - /srv/scality/metalk8s-@@VERSION/pillar
+    - $pillar_root
 
 # use new module.run format
 use_superseded:


### PR DESCRIPTION



WIP from Nicolas's stash: https://github.com/scality/metalk8s/commit/c2aa4c538a0f2b8f3912887873e05899375a85a2
cf context for description

Mount all iso listed in /etc/metalk8s/bootstrap.yaml and configure salt-master

**Component**:

deployment

**Context**: 

Add a products entry in /etc/metalk8s/bootstrap.yaml which will contain
the product path or the product iso. If product path is provided,
expose saltstack file_roots and pillar_roots
into salt master configuration. If a iso image is provided, mount the iso
first before performing the same operation.

As set of assertion is also made to verify the product version. In this
case, if the products:metalk8s field contains an iso, isoinfo binary is
required to extract the product version

Change in the bootstrap config:

```
apiVersion: metalk8s.scality.com/v1alpha2
kind: BootstrapConfiguration
networks:
  controlPlane: 172.21.254.0/28
  workloadPlane: 172.21.254.32/27
ca:
  minion: bootstrap
apiServer:
  host: 172.21.254.14
  keepalived:
    enabled: true
products:
  metalk8s:
  - /srv/scality/metalk8s-2.0.0-dev/
```

**Note**
The PR is not fully functional right now. In fact, the `iso_root_path` pillar is moved to ext_pillar and generated by the salt master. The issue is that is the iso path provided by the user is not accessible from the salt master container, the ext_pillar will fail

**Summary**:

**Acceptance criteria**: 


---

See: #924


