### PR TITLE
build: fix skopeo usage on MacOS

### DIFF
--- a/buildchain/buildchain/targets/remote_image.py
+++ b/buildchain/buildchain/targets/remote_image.py
@@ -103,7 +103,10 @@ class RemoteImage(image.ContainerImage):
 
     def _skopeo_copy(self) -> List[str]:
         """Return the command line to execute skopeo copy."""
-        cmd = [config.SKOPEO, 'copy', '--format', 'v2s2']
+        cmd = [
+            config.SKOPEO, '--override-os', 'linux', '--insecure-policy',
+            'copy', '--format', 'v2s2'
+        ]
         if not self._use_tar:
             cmd.append('--dest-compress')
         cmd.append('docker://{}'.format(self.fullname))


### PR DESCRIPTION
**Component**:

buildchain

**Context**: 

Since the implementation of #1049, the buildchain uses `skopeo` and this breaks the build on MacOS.

**Summary**:

This fix two issues related to skopeo on MacOS:
- first, the policy file is, for some reason (missing? need root?), not readable => this is fixed by passing the `--insecure-policy` flags (which should be OK: IIUC the default conf allows insecure)
- then, being on MacOS `skopeo` tried to fetch images for MacOS (which may not exists), since we target Linux we specify `--override-os linux` to enforce the download of images for Linux.

**Acceptance criteria**: 

The build should work on MacOS.

Closes: #1152