### PR TITLE
Add a retry logic when checking etcd cluster health

### DIFF
--- a/salt/metalk8s/orchestrate/upgrade/etcd.sls
+++ b/salt/metalk8s/orchestrate/upgrade/etcd.sls
@@ -24,17 +24,14 @@ Upgrade etcd {{ node }} to {{ dest_version }}:
       - salt: Sync {{ node }} minion
       - module: Check etcd cluster health
   {%- if previous_node is defined %}
-      - module: Check etcd cluster health for {{ previous_node }}
+      - metalk8s: Check etcd cluster health for {{ previous_node }}
   {%- endif %}
 
 Check etcd cluster health for {{ node }}:
-  module.run:
+  metalk8s.module_run:
     - metalk8s_etcd.check_etcd_health:
       - minion_id: {{ node }}
-    # FIXME: Can't retry because of https://github.com/saltstack/salt/issues/44639
-    # Should be ok for the moment as we check health in etcd.health state.
-    #- retry:
-    #    attempts: 5
+    - attemps: 5
     - require:
       - salt: Upgrade etcd {{ node }} to {{ dest_version }}
 


### PR DESCRIPTION
**Component**:

'salt', 'kubernetes', 'upgrade'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

When we upgrade etcd we check the status using python module etcd3 but when the cluster is not fully ready we got an error

Can't use the classic `retry` of salt states because we use a `module.run` https://github.com/saltstack/salt/issues/44639

**Summary**:

Add a retry logic with a custom states for `module.run` (this one could be removed in newer salt version

**Acceptance criteria**: 

Be able to upgrade the etcd cluster with only one command (no fail because etcd cluster not healthy just after the upgrade of one node)
`salt-run state.sls metalk8s.orchestrate.upgrade.etcd saltenv=metalk8s-2.1 pillar="{'orchestrate': {'dest_version': '2.1'}}"`

Fixes: #1151

