### PR TITLE
Deploy MetalLB and nginx-ingress

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,8 +5,8 @@ cat << EOF
 EOF
 
 helm template \
-        --name metallb \
-        --namespace metallb-system \
-        --values salt/metalk8s/addons/metallb/values.yaml \
-        charts/metallb | \
+        --name nginx-ingress \
+        --namespace nginx-ingress-system \
+        --values salt/metalk8s/addons/nginx-ingress/values.yaml \
+        charts/nginx-ingress | \
         python fix-chart.py metallb-system

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,12 @@
+cat << EOF
+#!jinja | kubernetes kubeconfig=/etc/kubernetes/admin.conf&context=kubernetes-admin@kubernetes
+
+{%- from "metalk8s/repo/macro.sls" import build_image_repo with context %}
+EOF
+
+helm template \
+        --name metallb \
+        --namespace metallb-system \
+        --values salt/metalk8s/addons/metallb/values.yaml \
+        charts/metallb | \
+        python fix-chart.py metallb-system

--- a/buildchain/buildchain/constants.py
+++ b/buildchain/buildchain/constants.py
@@ -22,6 +22,7 @@ DOCKER_REGISTRY : str = 'docker.io/library'
 COREOS_REGISTRY : str = 'quay.io/coreos'
 PROMETHEUS_REGISTRY : str = 'quay.io/prometheus'
 GRAFANA_REGISTRY : str = 'docker.io/grafana'
+METALLB_REGISTRY : str = 'docker.io/metallb'
 
 # Paths {{{
 

--- a/buildchain/buildchain/image.py
+++ b/buildchain/buildchain/image.py
@@ -249,6 +249,41 @@ TO_PULL : Tuple[targets.RemoteImage, ...] = (
         destination=constants.ISO_IMAGE_ROOT,
         task_dep=['_image_mkdir_root'],
     ),
+    targets.RemoteImage(
+        registry=constants.METALLB_REGISTRY,
+        remote_name='controller',
+        name='metallb-controller',
+        version='v0.7.3',
+        digest='sha256:642e212a6e503609e69ac1728c9199b9833c3216b7ea0dcb0d78e7679b65b703',
+        destination=constants.ISO_IMAGE_ROOT,
+        task_dep=['_image_mkdir_root'],
+    ),
+    targets.RemoteImage(
+        registry=constants.METALLB_REGISTRY,
+        remote_name='speaker',
+        name='metallb-speaker',
+        version='v0.7.3',
+        digest='sha256:dc13f9c56ca0282d7ea545d71a89fd98c2fa76a1e297d08fd2958821508435ed',
+        destination=constants.ISO_IMAGE_ROOT,
+        task_dep=['_image_mkdir_root'],
+    ),
+    targets.RemoteImage(
+        registry='quay.io/kubernetes-ingress-controller',
+        name='nginx-ingress-controller',
+        version='0.24.1',
+        digest='sha256:76861d167e4e3db18f2672fd3435396aaa898ddf4d1128375d7c93b91c59f87f',
+        destination=constants.ISO_IMAGE_ROOT,
+        task_dep=['_image_mkdir_root'],
+    ),
+    targets.RemoteImage(
+        registry=constants.GOOGLE_REGISTRY,
+        remote_name='defaultbackend-amd64',
+        name='nginx-ingress-defaultbackend-amd64',
+        version='1.5',
+        digest='sha256:4dc5e07c8ca4e23bddb3153737d7b8c556e5fb2f29c4558b7cd6e6df99c512c7',
+        destination=constants.ISO_IMAGE_ROOT,
+        task_dep=['_image_mkdir_root'],
+    ),
 )
 
 

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -151,6 +151,11 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/addons/monitoring/prometheus/deployed.sls'),
     Path('salt/metalk8s/addons/monitoring/prometheus-operator/deployed.sls'),
 
+    Path('salt/metalk8s/addons/metallb/deployed/init.sls'),
+    Path('salt/metalk8s/addons/metallb/deployed/configured.sls'),
+    Path('salt/metalk8s/addons/metallb/deployed/chart.sls'),
+    Path('salt/metalk8s/addons/metallb/deployed/namespace.sls'),
+
     Path('salt/metalk8s/addons/ui/deployed.sls'),
     Path('salt/metalk8s/addons/ui/files/metalk8s-ui-deployment.yaml'),
 

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -156,6 +156,10 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/addons/metallb/deployed/chart.sls'),
     Path('salt/metalk8s/addons/metallb/deployed/namespace.sls'),
 
+    Path('salt/metalk8s/addons/nginx-ingress/deployed/init.sls'),
+    Path('salt/metalk8s/addons/nginx-ingress/deployed/chart.sls'),
+    Path('salt/metalk8s/addons/nginx-ingress/deployed/namespace.sls'),
+
     Path('salt/metalk8s/addons/ui/deployed.sls'),
     Path('salt/metalk8s/addons/ui/files/metalk8s-ui-deployment.yaml'),
 

--- a/charts/metallb/.helmignore
+++ b/charts/metallb/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/metallb/Chart.yaml
+++ b/charts/metallb/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+appVersion: 0.7.3
+description: MetalLB is a load-balancer implementation for bare metal Kubernetes clusters
+home: https://metallb.universe.tf
+icon: https://metallb.universe.tf/images/logo.png
+keywords:
+- load-balancer
+- balancer
+- lb
+- bgp
+- arp
+- vrrp
+- vip
+maintainers:
+- email: dave@natulte.net
+  name: danderson
+name: metallb
+version: 0.9.5

--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -1,0 +1,115 @@
+MetalLB
+-------
+
+MetalLB is a load-balancer implementation for bare metal [Kubernetes][k8s-home]
+clusters, using standard routing protocols.
+
+TL;DR;
+------
+
+```console
+$ helm install --name metallb stable/metallb
+```
+
+Introduction
+------------
+
+This chart bootstraps a [MetalLB][metallb-home] installation on
+a [Kubernetes][k8s-home] cluster using the [Helm][helm-home] package manager.
+This chart provides an implementation for LoadBalancer Service objects.
+
+MetalLB is a cluster service, and as such can only be deployed as a
+cluster singleton. Running multiple installations of MetalLB in a
+single cluster is not supported.
+
+Prerequisites
+-------------
+
+-  Kubernetes 1.9+
+
+Installing the Chart
+--------------------
+
+The chart can be installed as follows:
+
+```console
+$ helm install --name metallb stable/metallb
+```
+
+The command deploys MetalLB on the Kubernetes cluster. This chart does
+not provide a default configuration; MetalLB will not act on your
+Kubernetes Services until you provide
+one. The [configuration](#configuration) section lists various ways to
+provide this configuration.
+
+Uninstalling the Chart
+----------------------
+
+To uninstall/delete the `metallb` deployment:
+
+```console
+$ helm delete metallb
+```
+
+The command removes all the Kubernetes components associated with the
+chart, but will not remove the release metadata from `helm` — this will prevent
+you, for example, if you later try to create a release also named `metallb`). To
+fully delete the release and release history, simply [include the `--purge`
+flag][helm-usage]:
+
+```console
+$ helm delete --purge metallb
+```
+
+Configuration
+-------------
+
+See `values.yaml` for configuration notes. Specify each parameter
+using the `--set key=value[,key=value]` argument to `helm
+install`. For example,
+
+```console
+$ helm install --name metallb \
+  --set rbac.create=false \
+    stable/metallb
+```
+
+The above command disables the use of RBAC rules.
+
+Alternatively, a YAML file that specifies the values for the above
+parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install --name metallb -f values.yaml stable/metallb
+```
+
+By default, this chart does not install a configuration for MetalLB, and simply
+warns you that you must follow [the configuration instructions on MetalLB's
+website][metallb-config] to create an appropriate ConfigMap.
+
+If you have a more complex configuration and want Helm to manage it for you, you
+can provide it in the `config` parameter. The configuration format is
+[documented on MetalLB's website][metallb-config].
+
+```console
+$ cat values.yaml
+configInline:
+  peers:
+  - peer-address: 10.0.0.1
+    peer-asn: 64512
+    my-asn: 64512
+  address-pools:
+  - name: default
+    protocol: bgp
+    addresses:
+    - 198.51.100.0/24
+
+$ helm install --name metallb -f values.yaml stable/metallb
+```
+
+[helm-home]: https://helm.sh
+[helm-usage]: https://docs.helm.sh/using_helm/
+[k8s-home]: https://kubernetes.io
+[metallb-arpndp-concepts]: https://metallb.universe.tf/concepts/arp-ndp/
+[metallb-config]: https://metallb.universe.tf/configuration/
+[metallb-home]: https://metallb.universe.tf

--- a/charts/metallb/templates/NOTES.txt
+++ b/charts/metallb/templates/NOTES.txt
@@ -1,0 +1,11 @@
+
+MetalLB is now running in the cluster.
+{{- if .Values.configInline }}
+LoadBalancer Services in your cluster are now available on the IPs you
+defined in MetalLB's configuration. To see IP assignments,
+try `kubectl get services`.
+{{- else }}
+WARNING: you specified a ConfigMap that isn't managed by
+Helm. LoadBalancer services will not function until you add that
+ConfigMap to your cluster yourself.
+{{- end }}

--- a/charts/metallb/templates/_helpers.tpl
+++ b/charts/metallb/templates/_helpers.tpl
@@ -1,0 +1,65 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "metallb.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "metallb.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "metallb.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the controller service account to use
+*/}}
+{{- define "metallb.controllerServiceAccountName" -}}
+{{- if .Values.serviceAccounts.controller.create -}}
+    {{ default (printf "%s-controller" (include "metallb.fullname" .)) .Values.serviceAccounts.controller.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccounts.controller.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the speaker service account to use
+*/}}
+{{- define "metallb.speakerServiceAccountName" -}}
+{{- if .Values.serviceAccounts.speaker.create -}}
+    {{ default (printf "%s-speaker" (include "metallb.fullname" .)) .Values.serviceAccounts.speaker.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccounts.speaker.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the settings ConfigMap to use.
+*/}}
+{{- define "metallb.configMapName" -}}
+{{- if .Values.configInline -}}
+    {{ include "metallb.fullname" . }}
+{{- else -}}
+    {{ .Values.existingConfigMap }}
+{{- end -}}
+{{- end -}}

--- a/charts/metallb/templates/config.yaml
+++ b/charts/metallb/templates/config.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.configInline }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "metallb.fullname" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+data:
+  config: |
+{{ toYaml .Values.configInline | indent 4 }}
+{{- end }}

--- a/charts/metallb/templates/controller.yaml
+++ b/charts/metallb/templates/controller.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "metallb.fullname" . }}-controller
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+    component: controller
+spec:
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: {{ template "metallb.name" . }}
+      component: controller
+      release: {{ .Release.Name | quote }}
+  template:
+    metadata:
+      labels:
+        heritage: {{ .Release.Service | quote }}
+        release: {{ .Release.Name | quote }}
+        chart: {{ template "metallb.chart" . }}
+        app: {{ template "metallb.name" . }}
+        component: controller
+{{- if .Values.prometheus.scrapeAnnotations }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "7472"
+{{- end }}
+    spec:
+      serviceAccountName: {{ template "metallb.controllerServiceAccountName" . }}
+      terminationGracePeriodSeconds: 0
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534 # nobody
+    {{- with .Values.controller.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.controller.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.controller.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      containers:
+      - name: controller
+        image: {{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}
+        imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
+        args:
+        - --port=7472
+        - --config={{ template "metallb.configMapName" . }}
+        ports:
+        - name: monitoring
+          containerPort: 7472
+        resources:
+{{ toYaml .Values.controller.resources | indent 10 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true

--- a/charts/metallb/templates/controller.yaml
+++ b/charts/metallb/templates/controller.yaml
@@ -48,7 +48,7 @@ spec:
     {{- end }}
       containers:
       - name: controller
-        image: {{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}
+        image: '{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}'
         imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
         args:
         - --port=7472

--- a/charts/metallb/templates/psp.yaml
+++ b/charts/metallb/templates/psp.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.psp.create -}}
+
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "metallb.fullname" . }}-speaker
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+spec:
+  hostNetwork: true
+  hostPorts:
+  - min: 7472
+    max: 7472
+  privileged: true
+  allowPrivilegeEscalation: false
+  allowedCapabilities:
+  - 'NET_ADMIN'
+  - 'NET_RAW'
+  - 'SYS_ADMIN'
+  volumes:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+{{- end -}}

--- a/charts/metallb/templates/rbac.yaml
+++ b/charts/metallb/templates/rbac.yaml
@@ -1,0 +1,117 @@
+{{- if .Values.rbac.create -}}
+
+# Roles
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "metallb.fullname" . }}:controller
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list", "watch", "update"]
+- apiGroups: [""]
+  resources: ["services/status"]
+  verbs: ["update"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "metallb.fullname" . }}:speaker
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+rules:
+- apiGroups: [""]
+  resources: ["services", "endpoints", "nodes"]
+  verbs: ["get", "list", "watch"]
+{{- if .Values.psp.create }}
+- apiGroups: ["extensions"]
+  resources: ["podsecuritypolicies"]
+  resourceNames: [{{ printf "%s-speaker" (include "metallb.fullname" .) | quote}}]
+  verbs: ["use"]
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "metallb.fullname" . }}-config-watcher
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create"]
+---
+
+## Role bindings
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "metallb.fullname" . }}:controller
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "metallb.controllerServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "metallb.fullname" . }}:controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "metallb.fullname" . }}:speaker
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "metallb.speakerServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "metallb.fullname" . }}:speaker
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "metallb.fullname" . }}-config-watcher
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "metallb.controllerServiceAccountName" . }}
+- kind: ServiceAccount
+  name: {{ template "metallb.speakerServiceAccountName" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "metallb.fullname" . }}-config-watcher
+{{- end -}}

--- a/charts/metallb/templates/service-accounts.yaml
+++ b/charts/metallb/templates/service-accounts.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.serviceAccounts.controller.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "metallb.controllerServiceAccountName" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+{{- end }}
+---
+{{- if .Values.serviceAccounts.speaker.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "metallb.speakerServiceAccountName" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+{{- end }}

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1beta2
+kind: DaemonSet
+metadata:
+  name: {{ template "metallb.fullname" . }}-speaker
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+    component: speaker
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "metallb.name" . }}
+      component: speaker
+      release: {{ .Release.Name | quote }}
+  template:
+    metadata:
+      labels:
+        heritage: {{ .Release.Service | quote }}
+        release: {{ .Release.Name | quote }}
+        chart: {{ template "metallb.chart" . }}
+        app: {{ template "metallb.name" . }}
+        component: speaker
+{{- if .Values.prometheus.scrapeAnnotations }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "7472"
+{{- end }}
+    spec:
+      serviceAccountName: {{ template "metallb.speakerServiceAccountName" . }}
+      terminationGracePeriodSeconds: 0
+      hostNetwork: true
+      containers:
+      - name: speaker
+        image: {{ .Values.speaker.image.repository }}:{{ .Values.speaker.image.tag }}
+        imagePullPolicy: {{ .Values.speaker.image.pullPolicy }}
+        args:
+        - --port=7472
+        - --config={{ template "metallb.configMapName" . }}
+        env:
+        - name: METALLB_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        ports:
+        - name: monitoring
+          containerPort: 7472
+        resources:
+{{ toYaml .Values.speaker.resources | indent 10 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+            add:
+            - NET_RAW
+    {{- with .Values.speaker.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.speaker.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.speaker.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       containers:
       - name: speaker
-        image: {{ .Values.speaker.image.repository }}:{{ .Values.speaker.image.tag }}
+        image: '{{ .Values.speaker.image.repository }}:{{ .Values.speaker.image.tag }}'
         imagePullPolicy: {{ .Values.speaker.image.pullPolicy }}
         args:
         - --port=7472

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -1,0 +1,100 @@
+# Default values for metallb.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# To configure MetalLB, you must specify ONE of the following two
+# options.
+
+# existingConfigMap specifies the name of an externally-defined
+# ConfigMap to use as the configuration. Helm will not manage the
+# contents of this ConfigMap, it is your responsibility to create it.
+existingConfigMap: metallb-config
+
+# configInline specifies MetalLB's configuration directly, in yaml
+# format. When configInline is used, Helm manages MetalLB's
+# configuration ConfigMap as part of the release, and
+# existingConfigMap is ignored.
+#
+# Refer to https://metallb.universe.tf/configuration/ for
+# available options.
+configInline:
+    # Example ARP Configuration
+    # address-pools:
+    # - name: default
+    #  protocol: layer2
+    #  addresses:
+    #  - 192.168.1.240-192.168.1.250
+    #
+    # Example BGP Configuration
+    # peers:
+    # - peer-address: 10.0.0.1
+    #   peer-asn: 64501
+    #   my-asn: 64500
+    # address-pools:
+    # - name: default
+    #   protocol: bgp
+    #   addresses:
+    #   - 192.168.10.0/24
+
+rbac:
+  # create specifies whether to install and use RBAC rules.
+  create: true
+
+psp:
+  # create specifies whether to install and use Pod Security Policies.
+  create: true
+
+prometheus:
+  # scrape annotations specifies whether to add Prometheus metric
+  # auto-collection annotations to pods. See
+  # https://github.com/prometheus/prometheus/blob/release-2.1/documentation/examples/prometheus-kubernetes.yml
+  # for a corresponding Prometheus configuration. Alternatively, you
+  # may want to use the Prometheus Operator
+  # (https://github.com/coreos/prometheus-operator) for more powerful
+  # monitoring configuration. If you use the Prometheus operator, this
+  # can be left at false.
+  scrapeAnnotations: false
+
+serviceAccounts:
+  controller:
+    # Specifies whether a ServiceAccount should be created
+    create: true
+    # The name of the ServiceAccount to use.  If not set and create is
+    # true, a name is generated using the fullname template
+    name: ""
+  speaker:
+    # Specifies whether a ServiceAccount should be created
+    create: true
+    # The name of the ServiceAccount to use.  If not set and create is
+    # true, a name is generated using the fullname template
+    name: ""
+
+# controller contains configuration specific to the MetalLB cluster
+# controller.
+controller:
+  image:
+    repository: metallb/controller
+    tag: v0.7.3
+    pullPolicy: IfNotPresent
+  resources: {}
+    # limits:
+      # cpu: 100m
+      # memory: 100Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# speaker contains configuration specific to the MetalLB speaker
+# daemonset.
+speaker:
+  image:
+    repository: metallb/speaker
+    tag: v0.7.3
+    pullPolicy: IfNotPresent
+  resources: {}
+    # limits:
+      # cpu: 100m
+      # memory: 100Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}

--- a/charts/nginx-ingress/.helmignore
+++ b/charts/nginx-ingress/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/nginx-ingress/Chart.yaml
+++ b/charts/nginx-ingress/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+appVersion: 0.24.1
+description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
+engine: gotpl
+home: https://github.com/kubernetes/ingress-nginx
+icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
+keywords:
+- ingress
+- nginx
+maintainers:
+- email: jack.zampolin@gmail.com
+  name: jackzampolin
+- email: mgoodness@gmail.com
+  name: mgoodness
+- name: ChiefAlexander
+name: nginx-ingress
+sources:
+- https://github.com/kubernetes/ingress-nginx
+version: 1.6.13

--- a/charts/nginx-ingress/OWNERS
+++ b/charts/nginx-ingress/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- jackzampolin
+- mgoodness
+- ChiefAlexander
+reviewers:
+- jackzampolin
+- mgoodness
+- ChiefAlexander

--- a/charts/nginx-ingress/README.md
+++ b/charts/nginx-ingress/README.md
@@ -1,0 +1,258 @@
+# nginx-ingress
+
+[nginx-ingress](https://github.com/kubernetes/ingress-nginx) is an Ingress controller that uses ConfigMap to store the nginx configuration.
+
+To use, add the `kubernetes.io/ingress.class: nginx` annotation to your Ingress resources.
+
+## TL;DR;
+
+```console
+$ helm install stable/nginx-ingress
+```
+
+## Introduction
+
+This chart bootstraps an nginx-ingress deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+  - Kubernetes 1.6+
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install --name my-release stable/nginx-ingress
+```
+
+The command deploys nginx-ingress on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the nginx-ingress chart and their default values.
+
+Parameter | Description | Default
+--- | --- | ---
+`controller.name` | name of the controller component | `controller`
+`controller.image.repository` | controller container image repository | `quay.io/kubernetes-ingress-controller/nginx-ingress-controller`
+`controller.image.tag` | controller container image tag | `0.24.1`
+`controller.image.pullPolicy` | controller container image pull policy | `IfNotPresent`
+`controller.image.runAsUser` | User ID of the controller process. Value depends on the Linux distribution used inside of the container image. By default uses debian one. | `33`
+`controller.containerPort.http` | The port that the controller container listens on for http connections. | `80`
+`controller.containerPort.https` | The port that the controller container listens on for https connections. | `443`
+`controller.config` | nginx [ConfigMap](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md) entries | none
+`controller.hostNetwork` | If the nginx deployment / daemonset should run on the host's network namespace. Do not set this when `controller.service.externalIPs` is set and `kube-proxy` is used as there will be a port-conflict for port `80` | false
+`controller.defaultBackendService` | default 404 backend service; required only if `defaultBackend.enabled = false` | `""`
+`controller.dnsPolicy` | If using `hostNetwork=true`, change to `ClusterFirstWithHostNet`. See [pod's dns policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy) for details | `ClusterFirst`
+`controller.electionID` | election ID to use for the status update | `ingress-controller-leader`
+`controller.extraEnvs` | any additional environment variables to set in the pods | `{}`
+`controller.extraContainers` | Sidecar containers to add to the controller pod. See [LemonLDAP::NG controller](https://github.com/lemonldap-ng-controller/lemonldap-ng-controller) as example | `{}`
+`controller.extraVolumeMounts` | Additional volumeMounts to the controller main container | `{}`
+`controller.extraVolumes` | Additional volumes to the controller pod | `{}`
+`controller.extraInitContainers` | Containers, which are run before the app containers are started | `[]`
+`controller.ingressClass` | name of the ingress class to route through this controller | `nginx`
+`controller.scope.enabled` | limit the scope of the ingress controller | `false` (watch all namespaces)
+`controller.scope.namespace` | namespace to watch for ingress | `""` (use the release namespace)
+`controller.extraArgs` | Additional controller container arguments | `{}`
+`controller.kind` | install as Deployment or DaemonSet | `Deployment`
+`controller.daemonset.useHostPort` | If `controller.kind` is `DaemonSet`, this will enable `hostPort` for TCP/80 and TCP/443 | false
+`controller.daemonset.hostPorts.http` | If `controller.daemonset.useHostPort` is `true` and this is non-empty, it sets the hostPort | `"80"`
+`controller.daemonset.hostPorts.https` | If `controller.daemonset.useHostPort` is `true` and this is non-empty, it sets the hostPort | `"443"`
+`controller.daemonset.hostPorts.stats` | If `controller.daemonset.useHostPort` is `true` and this is non-empty, it sets the hostPort | `"18080"`
+`controller.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
+`controller.affinity` | node/pod affinities (requires Kubernetes >=1.6) | `{}`
+`controller.minReadySeconds` | how many seconds a pod needs to be ready before killing the next, during update | `0`
+`controller.nodeSelector` | node labels for pod assignment | `{}`
+`controller.podAnnotations` | annotations to be added to pods | `{}`
+`controller.podLabels` | labels to add to the pod container metadata | `{}`
+`controller.podSecurityContext` | Security context policies to add to the controller pod | `{}`
+`controller.replicaCount` | desired number of controller pods | `1`
+`controller.minAvailable` | minimum number of available controller pods for PodDisruptionBudget | `1`
+`controller.resources` | controller pod resource requests & limits | `{}`
+`controller.priorityClassName` | controller priorityClassName | `nil`
+`controller.lifecycle` | controller pod lifecycle hooks | `{}`
+`controller.service.annotations` | annotations for controller service | `{}`
+`controller.service.labels` | labels for controller service | `{}`
+`controller.publishService.enabled` | if true, the controller will set the endpoint records on the ingress objects to reflect those on the service | `false`
+`controller.publishService.pathOverride` | override of the default publish-service name | `""`
+`controller.service.clusterIP` | internal controller cluster service IP | `""`
+`controller.service.omitClusterIP` | To omit the `clusterIP` from the controller service | `false`
+`controller.service.externalIPs` | controller service external IP addresses. Do not set this when `controller.hostNetwork` is set to `true` and `kube-proxy` is used as there will be a port-conflict for port `80` | `[]`
+`controller.service.externalTrafficPolicy` | If `controller.service.type` is `NodePort` or `LoadBalancer`, set this to `Local` to enable [source IP preservation](https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typenodeport) | `"Cluster"`
+`controller.service.healthCheckNodePort` | If `controller.service.type` is `NodePort` or `LoadBalancer` and `controller.service.externalTrafficPolicy` is set to `Local`, set this to [the managed health-check port the kube-proxy will expose](https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typenodeport). If blank, a random port in the `NodePort` range will be assigned | `""`
+`controller.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
+`controller.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
+`controller.service.enableHttp` | if port 80 should be opened for service | `true`
+`controller.service.enableHttps` | if port 443 should be opened for service | `true`
+`controller.service.targetPorts.http` | Sets the targetPort that maps to the Ingress' port 80 | `80`
+`controller.service.targetPorts.https` | Sets the targetPort that maps to the Ingress' port 443 | `443`
+`controller.service.type` | type of controller service to create | `LoadBalancer`
+`controller.service.nodePorts.http` | If `controller.service.type` is either `NodePort` or `LoadBalancer` and this is non-empty, it sets the nodePort that maps to the Ingress' port 80 | `""`
+`controller.service.nodePorts.https` | If `controller.service.type` is either `NodePort` or `LoadBalancer` and this is non-empty, it sets the nodePort that maps to the Ingress' port 443 | `""`
+`controller.livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated | 10
+`controller.livenessProbe.periodSeconds` | How often to perform the probe | 10
+`controller.livenessProbe.timeoutSeconds` | When the probe times out | 5
+`controller.livenessProbe.successThreshold` | Minimum consecutive successes for the probe to be considered successful after having failed. | 1
+`controller.livenessProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded. | 3
+`controller.livenessProbe.port` | The port number that the liveness probe will listen on. | 10254
+`controller.readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated | 10
+`controller.readinessProbe.periodSeconds` | How often to perform the probe | 10
+`controller.readinessProbe.timeoutSeconds` | When the probe times out | 1
+`controller.readinessProbe.successThreshold` | Minimum consecutive successes for the probe to be considered successful after having failed. | 1
+`controller.readinessProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded. | 3
+`controller.readinessProbe.port` | The port number that the readiness probe will listen on. | 10254
+`controller.stats.enabled` | if `true`, enable "vts-status" page | `false`
+`controller.stats.service.annotations` | annotations for controller stats service | `{}`
+`controller.stats.service.clusterIP` | internal controller stats cluster service IP | `""`
+`controller.stats.service.omitClusterIP` | To omit the `clusterIP` from the stats service | `false`
+`controller.stats.service.externalIPs` | controller service stats external IP addresses | `[]`
+`controller.stats.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
+`controller.stats.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
+`controller.stats.service.type` | type of controller stats service to create | `ClusterIP`
+`controller.metrics.enabled` | if `true`, enable Prometheus metrics (`controller.stats.enabled` must be `true` as well) | `false`
+`controller.metrics.service.annotations` | annotations for Prometheus metrics service | `{}`
+`controller.metrics.service.clusterIP` | cluster IP address to assign to service | `""`
+`controller.metrics.service.omitClusterIP` | To omit the `clusterIP` from the metrics service | `false`
+`controller.metrics.service.externalIPs` | Prometheus metrics service external IP addresses | `[]`
+`controller.metrics.service.labels` | labels for metrics service | `{}`
+`controller.metrics.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
+`controller.metrics.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
+`controller.metrics.service.servicePort` | Prometheus metrics service port | `9913`
+`controller.metrics.service.type` | type of Prometheus metrics service to create | `ClusterIP`
+`controller.metrics.serviceMonitor.enabled` | Set this to `true` to create ServiceMonitor for Prometheus operator | `false`
+`controller.metrics.serviceMonitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`
+`controller.metrics.serviceMonitor.namespace` | namespace where servicemonitor resource should be created | `the same namespace as nginx ingress`
+`controller.metrics.serviceMonitor.honorLabels` | honorLabels chooses the metric's labels on collisions with target labels. | `false`
+`controller.customTemplate.configMapName` | configMap containing a custom nginx template | `""`
+`controller.customTemplate.configMapKey` | configMap key containing the nginx template | `""`
+`controller.headers` | configMap key:value pairs containing the [custom headers](https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers) for Nginx | `{}`
+`controller.updateStrategy` | allows setting of RollingUpdate strategy | `{}`
+`defaultBackend.enabled` | If false, controller.defaultBackendService must be provided | `true`
+`defaultBackend.name` | name of the default backend component | `default-backend`
+`defaultBackend.image.repository` | default backend container image repository | `k8s.gcr.io/defaultbackend-amd64`
+`defaultBackend.image.tag` | default backend container image tag | `1.5`
+`defaultBackend.image.pullPolicy` | default backend container image pull policy | `IfNotPresent`
+`defaultBackend.extraArgs` | Additional default backend container arguments | `{}`
+`defaultBackend.port` | Http port number | `8080`
+`defaultBackend.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
+`defaultBackend.affinity` | node/pod affinities (requires Kubernetes >=1.6) | `{}`
+`defaultBackend.nodeSelector` | node labels for pod assignment | `{}`
+`defaultBackend.podAnnotations` | annotations to be added to pods | `{}`
+`defaultBackend.podLabels` | labels to add to the pod container metadata | `{}`
+`defaultBackend.replicaCount` | desired number of default backend pods | `1`
+`defaultBackend.minAvailable` | minimum number of available default backend pods for PodDisruptionBudget | `1`
+`defaultBackend.resources` | default backend pod resource requests & limits | `{}`
+`defaultBackend.priorityClassName` | default backend  priorityClassName | `nil`
+`defaultBackend.service.annotations` | annotations for default backend service | `{}`
+`defaultBackend.service.clusterIP` | internal default backend cluster service IP | `""`
+`defaultBackend.service.omitClusterIP` | To omit the `clusterIP` from the default backend service | `false`
+`defaultBackend.service.externalIPs` | default backend service external IP addresses | `[]`
+`defaultBackend.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
+`defaultBackend.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
+`defaultBackend.service.type` | type of default backend service to create | `ClusterIP`
+`imagePullSecrets` | name of Secret resource containing private registry credentials | `nil`
+`rbac.create` | if `true`, create & use RBAC resources | `true`
+`podSecurityPolicy.enabled` | if `true`, create & use Pod Security Policy resources | `false`
+`serviceAccount.create` | if `true`, create a service account | ``
+`serviceAccount.name` | The name of the service account to use. If not set and `create` is `true`, a name is generated using the fullname template. | ``
+`revisionHistoryLimit` | The number of old history to retain to allow rollback. | `10`
+`tcp` | TCP service key:value pairs. The value is evaluated as a template. | `{}`
+`udp` | UDP service key:value pairs The value is evaluated as a template. | `{}`
+
+```console
+$ helm install stable/nginx-ingress --name my-release \
+    --set controller.stats.enabled=true
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install stable/nginx-ingress --name my-release -f values.yaml
+```
+
+A useful trick to debug issues with ingress is to increase the logLevel
+as described [here](https://github.com/kubernetes/ingress-nginx/blob/master/docs/troubleshooting.md#debug)
+
+```console
+$ helm install stable/nginx-ingress --set controller.extraArgs.v=2
+```
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## PodDisruptionBudget
+Note that the PodDisruptionBudget resource will only be defined if the replicaCount is greater than one,
+else it would make it impossible to evacuate a node. See [gh issue #7127](https://github.com/helm/charts/issues/7127) for more info.
+
+## Prometheus Metrics
+
+The Nginx ingress controller can export Prometheus metrics. In order for this to work, the VTS dashboard must be enabled as well.
+
+```console
+$ helm install stable/nginx-ingress --name my-release \
+    --set controller.stats.enabled=true \
+    --set controller.metrics.enabled=true
+```
+
+You can add Prometheus annotations to the metrics service using `controller.metrics.service.annotations`. Alternatively, if you use the Prometheus Operator, you can enable ServiceMonitor creation using `controller.metrics.serviceMonitor.enabled`.
+
+## ExternalDNS Service configuration
+
+Add an [ExternalDNS](https://github.com/kubernetes-incubator/external-dns) annotation to the LoadBalancer service:
+
+```yaml
+controller:
+  service:
+    annotations:
+      external-dns.alpha.kubernetes.io/hostname: kubernetes-example.com.
+```
+
+## AWS L7 ELB with SSL Termination
+
+Annotate the controller as shown in the [nginx-ingress l7 patch](https://github.com/kubernetes/ingress-nginx/blob/master/deploy/provider/aws/service-l7.yaml):
+
+```yaml
+controller:
+  service:
+    targetPorts:
+      http: http
+      https: http
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:XX-XXXX-X:XXXXXXXXX:certificate/XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXX
+      service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
+      service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "https"
+      service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '3600'
+```
+
+## AWS route53-mapper
+
+To configure the LoadBalancer service with the [route53-mapper addon](https://github.com/kubernetes/kops/tree/master/addons/route53-mapper), add the `domainName` annotation and `dns` label:
+
+```yaml
+controller:
+  service:
+    labels:
+      dns: "route53"
+    annotations:
+      domainName: "kubernetes-example.com"
+```
+
+## Helm error when upgrading: spec.clusterIP: Invalid value: ""
+
+If you are upgrading this chart from a version between 0.31.0 and 1.2.2 then you may get an error like this:
+
+```
+Error: UPGRADE FAILED: Service "?????-controller" is invalid: spec.clusterIP: Invalid value: "": field is immutable
+```
+
+Detail of how and why are in [this issue](https://github.com/helm/charts/pull/13646) but to resolve this you can set `xxxx.service.omitClusterIP` to `true` where `xxxx` is the service referenced in the error.

--- a/charts/nginx-ingress/ci/psp-values.yaml
+++ b/charts/nginx-ingress/ci/psp-values.yaml
@@ -1,0 +1,2 @@
+podSecurityPolicy:
+  enabled: true

--- a/charts/nginx-ingress/templates/NOTES.txt
+++ b/charts/nginx-ingress/templates/NOTES.txt
@@ -1,0 +1,64 @@
+The nginx-ingress controller has been installed.
+
+{{- if contains "NodePort" .Values.controller.service.type }}
+Get the application URL by running these commands:
+
+{{- if (not (empty .Values.controller.service.nodePorts.http)) }}
+  export HTTP_NODE_PORT={{ .Values.controller.service.nodePorts.http }}
+{{- else }}
+  export HTTP_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[0].nodePort}" {{ template "nginx-ingress.controller.fullname" . }})
+{{- end }}
+{{- if (not (empty .Values.controller.service.nodePorts.https)) }}
+  export HTTPS_NODE_PORT={{ .Values.controller.service.nodePorts.https }}
+{{- else }}
+  export HTTPS_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[1].nodePort}" {{ template "nginx-ingress.controller.fullname" . }})
+{{- end }}
+  export NODE_IP=$(kubectl --namespace {{ .Release.Namespace }} get nodes -o jsonpath="{.items[0].status.addresses[1].address}")
+
+  echo "Visit http://$NODE_IP:$HTTP_NODE_PORT to access your application via HTTP."
+  echo "Visit https://$NODE_IP:$HTTPS_NODE_PORT to access your application via HTTPS."
+{{- else if contains "LoadBalancer" .Values.controller.service.type }}
+It may take a few minutes for the LoadBalancer IP to be available.
+You can watch the status by running 'kubectl --namespace {{ .Release.Namespace }} get services -o wide -w {{ template "nginx-ingress.controller.fullname" . }}'
+{{- else if contains "ClusterIP"  .Values.controller.service.type }}
+Get the application URL by running these commands:
+  export POD_NAME=$(kubectl --namespace {{ .Release.Namespace }} get pods -o jsonpath="{.items[0].metadata.name}" -l "app={{ template "nginx-ingress.name" . }},component={{ .Values.controller.name }},release={{ .Release.Name }}")
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+  echo "Visit http://127.0.0.1:8080 to access your application."
+{{- end }}
+
+An example Ingress that makes use of the controller:
+
+  apiVersion: extensions/v1beta1
+  kind: Ingress
+  metadata:
+    annotations:
+      kubernetes.io/ingress.class: {{ .Values.controller.ingressClass }}
+    name: example
+    namespace: foo
+  spec:
+    rules:
+      - host: www.example.com
+        http:
+          paths:
+            - backend:
+                serviceName: exampleService
+                servicePort: 80
+              path: /
+    # This section is only required if TLS is to be enabled for the Ingress
+    tls:
+        - hosts:
+            - www.example.com
+          secretName: example-tls
+
+If TLS is enabled for the Ingress, a Secret containing the certificate and key must also be provided:
+
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: example-tls
+    namespace: foo
+  data:
+    tls.crt: <base64 encoded cert>
+    tls.key: <base64 encoded key>
+  type: kubernetes.io/tls

--- a/charts/nginx-ingress/templates/_helpers.tpl
+++ b/charts/nginx-ingress/templates/_helpers.tpl
@@ -1,0 +1,66 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nginx-ingress.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "nginx-ingress.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified controller name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "nginx-ingress.controller.fullname" -}}
+{{- printf "%s-%s" (include "nginx-ingress.fullname" .) .Values.controller.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Construct the path for the publish-service.
+
+By convention this will simply use the <namespace>/<controller-name> to match the name of the
+service generated.
+
+Users can provide an override for an explicit service they want bound via `.Values.controller.publishService.pathOverride`
+
+*/}}
+{{- define "nginx-ingress.controller.publishServicePath" -}}
+{{- $defServiceName := printf "%s/%s" .Release.Namespace (include "nginx-ingress.controller.fullname" .) -}}
+{{- $servicePath := default $defServiceName .Values.controller.publishService.pathOverride }}
+{{- print $servicePath | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified default backend name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "nginx-ingress.defaultBackend.fullname" -}}
+{{- printf "%s-%s" (include "nginx-ingress.fullname" .) .Values.defaultBackend.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "nginx-ingress.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "nginx-ingress.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/nginx-ingress/templates/clusterrole.yaml
+++ b/charts/nginx-ingress/templates/clusterrole.yaml
@@ -1,0 +1,69 @@
+{{- if and .Values.rbac.create (not .Values.controller.scope.enabled) -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.fullname" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - nodes
+      - pods
+      - secrets
+    verbs:
+      - list
+      - watch
+{{- if and .Values.controller.scope.enabled .Values.controller.scope.namespace }}
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    resourceNames:
+      - "{{ .Values.controller.scope.namespace }}"
+    verbs:
+      - get
+{{- end }}
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+{{- end -}}

--- a/charts/nginx-ingress/templates/clusterrolebinding.yaml
+++ b/charts/nginx-ingress/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.rbac.create (not .Values.controller.scope.enabled) -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "nginx-ingress.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "nginx-ingress.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/nginx-ingress/templates/controller-configmap.yaml
+++ b/charts/nginx-ingress/templates/controller-configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.controller.fullname" . }}
+data:
+  enable-vts-status: "{{ .Values.controller.stats.enabled }}"
+{{- if .Values.controller.headers }}
+  proxy-set-headers: {{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-custom-headers
+{{- end }}
+{{- if .Values.controller.config }}
+{{ toYaml .Values.controller.config | indent 2 }}
+{{- end }}

--- a/charts/nginx-ingress/templates/controller-daemonset.yaml
+++ b/charts/nginx-ingress/templates/controller-daemonset.yaml
@@ -1,0 +1,212 @@
+{{- if eq .Values.controller.kind "DaemonSet" }}
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.controller.fullname" . }}
+spec:
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  updateStrategy:
+{{ toYaml .Values.controller.updateStrategy | indent 4 }}
+  minReadySeconds: {{ .Values.controller.minReadySeconds }}
+  template:
+    metadata:
+      {{- if .Values.controller.podAnnotations }}
+      annotations:
+      {{- range $key, $value := .Values.controller.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
+      labels:
+        app: {{ template "nginx-ingress.name" . }}
+        component: "{{ .Values.controller.name }}"
+        release: {{ .Release.Name }}
+        {{- if .Values.controller.podLabels }}
+{{ toYaml .Values.controller.podLabels | indent 8}}
+        {{- end }}
+    spec:
+      dnsPolicy: {{ .Values.controller.dnsPolicy }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
+{{- if .Values.controller.priorityClassName }}
+      priorityClassName: "{{ .Values.controller.priorityClassName }}"
+{{- end }}
+      {{- if .Values.controller.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.controller.podSecurityContext | indent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ template "nginx-ingress.name" . }}-{{ .Values.controller.name }}
+          image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
+          imagePullPolicy: "{{ .Values.controller.image.pullPolicy }}"
+          {{- if .Values.controller.lifecycle }}
+          lifecycle:
+{{ toYaml .Values.controller.lifecycle | indent 12 }}
+          {{- end }}
+          args:
+            - /nginx-ingress-controller
+            - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ .Release.Namespace }}/{{ template "nginx-ingress.defaultBackend.fullname" . }}{{ else }}{{ .Values.controller.defaultBackendService }}{{ end }}
+          {{- if and (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
+            - --publish-service={{ template "nginx-ingress.controller.publishServicePath" . }}
+          {{- end }}
+          {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
+            - --election-id={{ .Values.controller.electionID }}
+          {{- end }}
+          {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
+            - --ingress-class={{ .Values.controller.ingressClass }}
+          {{- end }}
+          {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
+            - --configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}
+          {{- else }}
+            - --nginx-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}
+          {{- end }}
+          {{- if .Values.tcp }}
+            - --tcp-services-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-tcp
+          {{- end }}
+          {{- if .Values.udp }}
+            - --udp-services-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-udp
+          {{- end }}
+          {{- if .Values.controller.scope.enabled }}
+            - --watch-namespace={{ default .Release.Namespace .Values.controller.scope.namespace }}
+          {{- end }}
+          {{- range $key, $value := .Values.controller.extraArgs }}
+            {{- if $value }}
+            - --{{ $key }}={{ $value }}
+            {{- else }}
+            - --{{ $key }}
+            {{- end }}
+          {{- end }}
+          {{- if (semverCompare ">=0.16.0" .Values.controller.image.tag) }}
+          securityContext:
+            capabilities:
+                drop:
+                - ALL
+                add:
+                - NET_BIND_SERVICE
+            runAsUser: {{ .Values.controller.image.runAsUser }}
+          {{- end }}
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          {{- if .Values.controller.extraEnvs }}
+{{ toYaml .Values.controller.extraEnvs | indent 12 }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.controller.livenessProbe.port }}
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.controller.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.controller.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.controller.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.controller.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.controller.livenessProbe.failureThreshold }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.controller.containerPort.http }}
+              protocol: TCP
+              {{- if .Values.controller.daemonset.useHostPort }}
+              hostPort: {{ .Values.controller.daemonset.hostPorts.http }}
+              {{- end }}
+            - name: https
+              containerPort: {{ .Values.controller.containerPort.https }}
+              protocol: TCP
+              {{- if .Values.controller.daemonset.useHostPort }}
+              hostPort: {{ .Values.controller.daemonset.hostPorts.https }}
+              {{- end }}
+          {{- if .Values.controller.stats.enabled }}
+            - name: stats
+              containerPort: 18080
+              protocol: TCP
+              {{- if .Values.controller.daemonset.useHostPort }}
+              hostPort: {{ .Values.controller.daemonset.hostPorts.stats }}
+              {{- end }}
+            {{- if .Values.controller.metrics.enabled }}
+            - name: metrics
+              containerPort: 10254
+              protocol: TCP
+            {{- end }}
+          {{- end }}
+          {{- range $key, $value := .Values.tcp }}
+            - name: "{{ $key }}-tcp"
+              containerPort: {{ $key }}
+              protocol: TCP
+          {{- end }}
+          {{- range $key, $value := .Values.udp }}
+            - name: "{{ $key }}-udp"
+              containerPort: {{ $key }}
+              protocol: UDP
+          {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.controller.readinessProbe.port }}
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.controller.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.controller.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.controller.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.controller.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.controller.readinessProbe.failureThreshold }}
+{{- if (or .Values.controller.customTemplate.configMapName .Values.controller.extraVolumeMounts) }}
+          volumeMounts:
+{{- end }}
+{{- if .Values.controller.customTemplate.configMapName }}
+            - mountPath: /etc/nginx/template
+              name: nginx-template-volume
+              readOnly: true
+{{- end }}
+{{- if .Values.controller.extraVolumeMounts }}
+{{ toYaml .Values.controller.extraVolumeMounts | indent 12}}
+{{- end }}
+          resources:
+{{ toYaml .Values.controller.resources | indent 12 }}
+{{- if .Values.controller.extraContainers }}
+{{ toYaml .Values.controller.extraContainers | indent 8}}
+{{- end }}
+{{- if .Values.controller.extraInitContainers }}
+      initContainers:
+{{ toYaml .Values.controller.extraInitContainers | indent 8}}
+{{- end }}
+      hostNetwork: {{ .Values.controller.hostNetwork }}
+    {{- if .Values.controller.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.controller.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.controller.tolerations }}
+      tolerations:
+{{ toYaml .Values.controller.tolerations | indent 8 }}
+    {{- end }}
+    {{- if .Values.controller.affinity }}
+      affinity:
+{{ toYaml .Values.controller.affinity | indent 8 }}
+    {{- end }}
+      serviceAccountName: {{ template "nginx-ingress.serviceAccountName" . }}
+      terminationGracePeriodSeconds: 60
+{{- if (or .Values.controller.customTemplate.configMapName .Values.controller.extraVolumes) }}
+      volumes:
+{{- end }}
+{{- if .Values.controller.customTemplate.configMapName }}
+        - name: nginx-template-volume
+          configMap:
+            name: {{ .Values.controller.customTemplate.configMapName }}
+            items:
+            - key: {{ .Values.controller.customTemplate.configMapKey }}
+              path: nginx.tmpl
+{{- end }}
+{{- if .Values.controller.extraVolumes }}
+{{ toYaml .Values.controller.extraVolumes | indent 8}}
+{{- end }}
+{{- end }}

--- a/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -1,0 +1,204 @@
+{{- if eq .Values.controller.kind "Deployment" }}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.controller.fullname" . }}
+spec:
+  replicas: {{ .Values.controller.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+{{ toYaml .Values.controller.updateStrategy | indent 4 }}
+  minReadySeconds: {{ .Values.controller.minReadySeconds }}
+  template:
+    metadata:
+      {{- if .Values.controller.podAnnotations }}
+      annotations:
+      {{- range $key, $value := .Values.controller.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
+      labels:
+        app: {{ template "nginx-ingress.name" . }}
+        component: "{{ .Values.controller.name }}"
+        release: {{ .Release.Name }}
+        {{- if .Values.controller.podLabels }}
+{{ toYaml .Values.controller.podLabels | indent 8 }}
+        {{- end }}
+    spec:
+      dnsPolicy: {{ .Values.controller.dnsPolicy }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
+{{- if .Values.controller.priorityClassName }}
+      priorityClassName: "{{ .Values.controller.priorityClassName }}"
+{{- end }}
+      {{- if .Values.controller.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.controller.podSecurityContext | indent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ template "nginx-ingress.name" . }}-{{ .Values.controller.name }}
+          image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
+          imagePullPolicy: "{{ .Values.controller.image.pullPolicy }}"
+          {{- if .Values.controller.lifecycle }}
+          lifecycle:
+{{ toYaml .Values.controller.lifecycle | indent 12 }}
+          {{- end }}
+          args:
+            - /nginx-ingress-controller
+            - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ .Release.Namespace }}/{{ template "nginx-ingress.defaultBackend.fullname" . }}{{ else }}{{ .Values.controller.defaultBackendService }}{{ end }}
+          {{- if and (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
+            - --publish-service={{ template "nginx-ingress.controller.publishServicePath" . }}
+          {{- end }}
+          {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
+            - --election-id={{ .Values.controller.electionID }}
+          {{- end }}
+          {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
+            - --ingress-class={{ .Values.controller.ingressClass }}
+          {{- end }}
+          {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
+            - --configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}
+          {{- else }}
+            - --nginx-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}
+          {{- end }}
+          {{- if .Values.tcp }}
+            - --tcp-services-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-tcp
+          {{- end }}
+          {{- if .Values.udp }}
+            - --udp-services-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-udp
+          {{- end }}
+          {{- if .Values.controller.scope.enabled }}
+            - --watch-namespace={{ default .Release.Namespace .Values.controller.scope.namespace }}
+          {{- end }}
+          {{- range $key, $value := .Values.controller.extraArgs }}
+            {{- if $value }}
+            - --{{ $key }}={{ $value }}
+            {{- else }}
+            - --{{ $key }}
+            {{- end }}
+          {{- end }}
+          {{- if (semverCompare ">=0.16.0" .Values.controller.image.tag) }}
+          securityContext:
+            capabilities:
+                drop:
+                - ALL
+                add:
+                - NET_BIND_SERVICE
+            runAsUser: {{ .Values.controller.image.runAsUser }}
+          {{- end }}
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          {{- if .Values.controller.extraEnvs }}
+{{ toYaml .Values.controller.extraEnvs | indent 12 }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.controller.livenessProbe.port }}
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.controller.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.controller.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.controller.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.controller.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.controller.livenessProbe.failureThreshold }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.controller.containerPort.http }}
+              protocol: TCP
+            - name: https
+              containerPort: {{ .Values.controller.containerPort.https }}
+              protocol: TCP
+          {{- if .Values.controller.stats.enabled }}
+            - name: stats
+              containerPort: 18080
+              protocol: TCP
+            {{- if .Values.controller.metrics.enabled }}
+            - name: metrics
+              containerPort: 10254
+              protocol: TCP
+            {{- end }}
+          {{- end }}
+          {{- range $key, $value := .Values.tcp }}
+            - name: "{{ $key }}-tcp"
+              containerPort: {{ $key }}
+              protocol: TCP
+          {{- end }}
+          {{- range $key, $value := .Values.udp }}
+            - name: "{{ $key }}-udp"
+              containerPort: {{ $key }}
+              protocol: UDP
+          {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.controller.readinessProbe.port }}
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.controller.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.controller.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.controller.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.controller.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.controller.readinessProbe.failureThreshold }}
+{{- if (or .Values.controller.customTemplate.configMapName .Values.controller.extraVolumeMounts) }}
+          volumeMounts:
+{{- end }}
+{{- if .Values.controller.customTemplate.configMapName }}
+            - mountPath: /etc/nginx/template
+              name: nginx-template-volume
+              readOnly: true
+{{- end }}
+{{- if .Values.controller.extraVolumeMounts }}
+{{ toYaml .Values.controller.extraVolumeMounts | indent 12}}
+{{- end }}
+          resources:
+{{ toYaml .Values.controller.resources | indent 12 }}
+{{- if .Values.controller.extraContainers }}
+{{ toYaml .Values.controller.extraContainers | indent 8}}
+{{- end }}
+{{- if .Values.controller.extraInitContainers }}
+      initContainers:
+{{ toYaml .Values.controller.extraInitContainers | indent 8}}
+{{- end }}
+      hostNetwork: {{ .Values.controller.hostNetwork }}
+    {{- if .Values.controller.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.controller.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.controller.tolerations }}
+      tolerations:
+{{ toYaml .Values.controller.tolerations | indent 8 }}
+    {{- end }}
+    {{- if .Values.controller.affinity }}
+      affinity:
+{{ toYaml .Values.controller.affinity | indent 8 }}
+    {{- end }}
+      serviceAccountName: {{ template "nginx-ingress.serviceAccountName" . }}
+      terminationGracePeriodSeconds: 60
+{{- if (or .Values.controller.customTemplate.configMapName .Values.controller.extraVolumes) }}
+      volumes:
+{{- end }}
+{{- if .Values.controller.customTemplate.configMapName }}
+        - name: nginx-template-volume
+          configMap:
+            name: {{ .Values.controller.customTemplate.configMapName }}
+            items:
+            - key: {{ .Values.controller.customTemplate.configMapKey }}
+              path: nginx.tmpl
+{{- end }}
+{{- if .Values.controller.extraVolumes }}
+{{ toYaml .Values.controller.extraVolumes | indent 8}}
+{{- end }}
+{{- end }}

--- a/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -45,7 +45,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ template "nginx-ingress.name" . }}-{{ .Values.controller.name }}
-          image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
+          image: '{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}'
           imagePullPolicy: "{{ .Values.controller.image.pullPolicy }}"
           {{- if .Values.controller.lifecycle }}
           lifecycle:

--- a/charts/nginx-ingress/templates/controller-hpa.yaml
+++ b/charts/nginx-ingress/templates/controller-hpa.yaml
@@ -1,0 +1,30 @@
+{{- if eq .Values.controller.kind "Deployment" }}
+{{- if .Values.controller.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.controller.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1beta1
+    kind: Deployment
+    name: {{ template "nginx-ingress.controller.fullname" . }}
+  minReplicas: {{ .Values.controller.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.controller.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.controller.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.controller.autoscaling.targetMemoryUtilizationPercentage }}
+{{- end }}
+{{- end }}

--- a/charts/nginx-ingress/templates/controller-metrics-service.yaml
+++ b/charts/nginx-ingress/templates/controller-metrics-service.yaml
@@ -1,0 +1,45 @@
+{{- if and .Values.controller.stats.enabled .Values.controller.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.controller.metrics.service.annotations }}
+  annotations:
+  {{- range $key, $value := .Values.controller.metrics.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
+  labels:
+{{- if .Values.controller.metrics.service.labels }}
+{{ toYaml .Values.controller.metrics.service.labels | indent 4 }}
+{{- end }}
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.controller.fullname" . }}-metrics
+spec:
+{{- if not .Values.controller.metrics.service.omitClusterIP }}
+  clusterIP: "{{ .Values.controller.metrics.service.clusterIP }}"
+{{- end }}
+{{- if .Values.controller.metrics.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.controller.metrics.service.externalIPs | indent 4 }}
+{{- end }}
+{{- if .Values.controller.metrics.service.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.controller.metrics.service.loadBalancerIP }}"
+{{- end }}
+{{- if .Values.controller.metrics.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.controller.metrics.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
+  ports:
+    - name: metrics
+      port: {{ .Values.controller.metrics.service.servicePort }}
+      targetPort: metrics
+  selector:
+    app: {{ template "nginx-ingress.name" . }}
+    component: "{{ .Values.controller.name }}"
+    release: {{ .Release.Name }}
+  type: "{{ .Values.controller.metrics.service.type }}"
+{{- end }}

--- a/charts/nginx-ingress/templates/controller-poddisruptionbudget.yaml
+++ b/charts/nginx-ingress/templates/controller-poddisruptionbudget.yaml
@@ -1,0 +1,19 @@
+{{- if gt .Values.controller.replicaCount 1.0 }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.controller.fullname" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "nginx-ingress.name" . }}
+      release: {{ .Release.Name }}
+      component: "{{ .Values.controller.name }}"
+  minAvailable: {{ .Values.controller.minAvailable }}
+{{- end }}

--- a/charts/nginx-ingress/templates/controller-service.yaml
+++ b/charts/nginx-ingress/templates/controller-service.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.controller.service.annotations }}
+  annotations:
+  {{- range $key, $value := .Values.controller.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
+  labels:
+{{- if .Values.controller.service.labels }}
+{{ toYaml .Values.controller.service.labels | indent 4 }}
+{{- end }}
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.controller.fullname" . }}
+spec:
+{{- if not .Values.controller.service.omitClusterIP }}
+  clusterIP: "{{ .Values.controller.service.clusterIP }}"
+{{- end }}
+{{- if .Values.controller.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.controller.service.externalIPs | indent 4 }}
+{{- end }}
+{{- if .Values.controller.service.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.controller.service.loadBalancerIP }}"
+{{- end }}
+{{- if .Values.controller.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.controller.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
+{{- if and (semverCompare ">=1.7-0" .Capabilities.KubeVersion.GitVersion) (.Values.controller.service.externalTrafficPolicy) }}
+  externalTrafficPolicy: "{{ .Values.controller.service.externalTrafficPolicy }}"
+{{- end }}
+{{- if and (semverCompare ">=1.7-0" .Capabilities.KubeVersion.GitVersion) (.Values.controller.service.healthCheckNodePort) }}
+  healthCheckNodePort: {{ .Values.controller.service.healthCheckNodePort }}
+{{- end }}
+  ports:
+    {{- $setNodePorts := (or (eq .Values.controller.service.type "NodePort") (eq .Values.controller.service.type "LoadBalancer")) }}
+    {{- if .Values.controller.service.enableHttp }}
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: {{ .Values.controller.service.targetPorts.http }}
+      {{- if (and $setNodePorts (not (empty .Values.controller.service.nodePorts.http))) }}
+      nodePort: {{ .Values.controller.service.nodePorts.http }}
+      {{- end }}
+    {{- end }}
+    {{- if .Values.controller.service.enableHttps }}
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: {{ .Values.controller.service.targetPorts.https }}
+      {{- if (and $setNodePorts (not (empty .Values.controller.service.nodePorts.https))) }}
+      nodePort: {{ .Values.controller.service.nodePorts.https }}
+      {{- end }}
+    {{- end }}
+  {{- range $key, $value := .Values.tcp }}
+    - name: "{{ $key }}-tcp"
+      port: {{ $key }}
+      protocol: TCP
+      targetPort: "{{ $key }}-tcp"
+  {{- end }}
+  {{- range $key, $value := .Values.udp }}
+    - name: "{{ $key }}-udp"
+      port: {{ $key }}
+      protocol: UDP
+      targetPort: "{{ $key }}-udp"
+  {{- end }}
+  selector:
+    app: {{ template "nginx-ingress.name" . }}
+    component: "{{ .Values.controller.name }}"
+    release: {{ .Release.Name }}
+  type: "{{ .Values.controller.service.type }}"

--- a/charts/nginx-ingress/templates/controller-servicemonitor.yaml
+++ b/charts/nginx-ingress/templates/controller-servicemonitor.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.controller.stats.enabled .Values.controller.metrics.enabled .Values.controller.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "nginx-ingress.controller.fullname" . }}
+  {{- if .Values.controller.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.controller.metrics.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    {{- if .Values.controller.metrics.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.controller.metrics.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+      interval: 30s
+      {{- if .Values.controller.metrics.serviceMonitor.honorLabels }}
+      honorLabels: true
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ template "nginx-ingress.name" . }}
+      component: "{{ .Values.controller.name }}"
+      release: {{ .Release.Name }}
+{{- end }}

--- a/charts/nginx-ingress/templates/controller-stats-service.yaml
+++ b/charts/nginx-ingress/templates/controller-stats-service.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.controller.stats.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.controller.stats.service.annotations }}
+  annotations:
+  {{- range $key, $value := .Values.controller.stats.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.controller.fullname" . }}-stats
+spec:
+{{- if not .Values.controller.stats.service.omitClusterIP }}
+  clusterIP: "{{ .Values.controller.stats.service.clusterIP }}"
+{{- end }}
+{{- if .Values.controller.stats.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.controller.stats.service.externalIPs | indent 4 }}
+{{- end }}
+{{- if .Values.controller.stats.service.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.controller.stats.service.loadBalancerIP }}"
+{{- end }}
+{{- if .Values.controller.stats.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.controller.stats.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
+  ports:
+    - name: stats
+      port: {{ .Values.controller.stats.service.servicePort }}
+      targetPort: stats
+  selector:
+    app: {{ template "nginx-ingress.name" . }}
+    component: "{{ .Values.controller.name }}"
+    release: {{ .Release.Name }}
+  type: "{{ .Values.controller.stats.service.type }}"
+{{- end }}

--- a/charts/nginx-ingress/templates/default-backend-deployment.yaml
+++ b/charts/nginx-ingress/templates/default-backend-deployment.yaml
@@ -1,0 +1,77 @@
+{{- if .Values.defaultBackend.enabled }}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.defaultBackend.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.defaultBackend.fullname" . }}
+spec:
+  replicas: {{ .Values.defaultBackend.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  template:
+    metadata:
+    {{- if .Values.defaultBackend.podAnnotations }}
+      annotations:
+      {{- range $key, $value := .Values.defaultBackend.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+    {{- end }}
+      labels:
+        app: {{ template "nginx-ingress.name" . }}
+        component: "{{ .Values.defaultBackend.name }}"
+        release: {{ .Release.Name }}
+        {{- if .Values.defaultBackend.podLabels }}
+{{ toYaml .Values.defaultBackend.podLabels | indent 8 }}
+        {{- end }}
+    spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
+{{- if .Values.defaultBackend.priorityClassName }}
+      priorityClassName: "{{ .Values.defaultBackend.priorityClassName }}"
+{{- end }}
+      containers:
+        - name: {{ template "nginx-ingress.name" . }}-{{ .Values.defaultBackend.name }}
+          image: "{{ .Values.defaultBackend.image.repository }}:{{ .Values.defaultBackend.image.tag }}"
+          imagePullPolicy: "{{ .Values.defaultBackend.image.pullPolicy }}"
+          args:
+          {{- range $key, $value := .Values.defaultBackend.extraArgs }}
+            {{- if $value }}
+            - --{{ $key }}={{ $value }}
+            {{- else }}
+            - --{{ $key }}
+            {{- end }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.defaultBackend.port }}
+              scheme: HTTP
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+          ports:
+            - name: http
+              containerPort: {{ .Values.defaultBackend.port }}
+              protocol: TCP
+          resources:
+{{ toYaml .Values.defaultBackend.resources | indent 12 }}
+      serviceAccountName: {{ template "nginx-ingress.serviceAccountName" . }}
+    {{- if .Values.defaultBackend.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.defaultBackend.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.defaultBackend.tolerations }}
+      tolerations:
+{{ toYaml .Values.defaultBackend.tolerations | indent 8 }}
+    {{- end }}
+    {{- if .Values.defaultBackend.affinity }}
+      affinity:
+{{ toYaml .Values.defaultBackend.affinity | indent 8 }}
+    {{- end }}
+      terminationGracePeriodSeconds: 60
+{{- end }}

--- a/charts/nginx-ingress/templates/default-backend-deployment.yaml
+++ b/charts/nginx-ingress/templates/default-backend-deployment.yaml
@@ -37,7 +37,7 @@ spec:
 {{- end }}
       containers:
         - name: {{ template "nginx-ingress.name" . }}-{{ .Values.defaultBackend.name }}
-          image: "{{ .Values.defaultBackend.image.repository }}:{{ .Values.defaultBackend.image.tag }}"
+          image: '{{ .Values.defaultBackend.image.repository }}:{{ .Values.defaultBackend.image.tag }}'
           imagePullPolicy: "{{ .Values.defaultBackend.image.pullPolicy }}"
           args:
           {{- range $key, $value := .Values.defaultBackend.extraArgs }}

--- a/charts/nginx-ingress/templates/default-backend-poddisruptionbudget.yaml
+++ b/charts/nginx-ingress/templates/default-backend-poddisruptionbudget.yaml
@@ -1,0 +1,19 @@
+{{- if gt .Values.defaultBackend.replicaCount 1.0 }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.defaultBackend.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.defaultBackend.fullname" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "nginx-ingress.name" . }}
+      release: {{ .Release.Name }}
+      component: "{{ .Values.defaultBackend.name }}"
+  minAvailable: {{ .Values.defaultBackend.minAvailable }}
+{{- end }}

--- a/charts/nginx-ingress/templates/default-backend-service.yaml
+++ b/charts/nginx-ingress/templates/default-backend-service.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.defaultBackend.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.defaultBackend.service.annotations }}
+  annotations:
+  {{- range $key, $value := .Values.defaultBackend.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.defaultBackend.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.defaultBackend.fullname" . }}
+spec:
+{{- if not .Values.defaultBackend.service.omitClusterIP }}
+  clusterIP: "{{ .Values.defaultBackend.service.clusterIP }}"
+{{- end }}
+{{- if .Values.defaultBackend.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.defaultBackend.service.externalIPs | indent 4 }}
+{{- end }}
+{{- if .Values.defaultBackend.service.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.defaultBackend.service.loadBalancerIP }}"
+{{- end }}
+{{- if .Values.defaultBackend.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.defaultBackend.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.defaultBackend.service.servicePort }}
+      protocol: TCP
+      targetPort: http
+  selector:
+    app: {{ template "nginx-ingress.name" . }}
+    component: "{{ .Values.defaultBackend.name }}"
+    release: {{ .Release.Name }}
+  type: "{{ .Values.defaultBackend.service.type }}"
+{{- end }}

--- a/charts/nginx-ingress/templates/headers-configmap.yaml
+++ b/charts/nginx-ingress/templates/headers-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.controller.headers }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.fullname" . }}-custom-headers
+data:
+{{ toYaml .Values.controller.headers | indent 2 }}
+{{- end }}

--- a/charts/nginx-ingress/templates/podsecuritypolicy.yaml
+++ b/charts/nginx-ingress/templates/podsecuritypolicy.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.podSecurityPolicy.enabled}}
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "nginx-ingress.fullname" . }} 
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  allowedCapabilities:
+    - NET_BIND_SERVICE
+  privileged: false
+  allowPrivilegeEscalation: true
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    #- 'emptyDir'
+    #- 'projected'
+    - 'secret'
+    #- 'downwardAPI'
+  hostNetwork: {{ .Values.controller.hostNetwork }}
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    # Require the container to run without root privileges.
+    rule: 'MustRunAsNonRoot'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+  seLinux:
+    rule: 'RunAsAny'
+  hostPorts:
+    - max: 65535
+      min: 1
+{{- end }}

--- a/charts/nginx-ingress/templates/role.yaml
+++ b/charts/nginx-ingress/templates/role.yaml
@@ -1,0 +1,89 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.fullname" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - {{ .Values.controller.electionID }}-{{ .Values.controller.ingressClass }}
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - create
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+{{- if .Values.podSecurityPolicy.enabled }}
+  - apiGroups:      ['extensions']
+    resources:      ['podsecuritypolicies']
+    verbs:          ['use']
+    resourceNames:  [{{ template "nginx-ingress.fullname" . }}]
+{{- end }}
+
+{{- end -}}

--- a/charts/nginx-ingress/templates/rolebinding.yaml
+++ b/charts/nginx-ingress/templates/rolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "nginx-ingress.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "nginx-ingress.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/nginx-ingress/templates/serviceaccount.yaml
+++ b/charts/nginx-ingress/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if or .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.serviceAccountName" . }}
+{{- end -}}

--- a/charts/nginx-ingress/templates/tcp-configmap.yaml
+++ b/charts/nginx-ingress/templates/tcp-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.tcp }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.fullname" . }}-tcp
+data:
+{{ tpl (toYaml .Values.tcp) . | indent 2 }}
+{{- end }}

--- a/charts/nginx-ingress/templates/udp-configmap.yaml
+++ b/charts/nginx-ingress/templates/udp-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.udp }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.fullname" . }}-udp
+data:
+{{ tpl (toYaml .Values.udp) . | indent 2 }}
+{{- end }}

--- a/charts/nginx-ingress/values.yaml
+++ b/charts/nginx-ingress/values.yaml
@@ -1,0 +1,406 @@
+## nginx configuration
+## Ref: https://github.com/kubernetes/ingress/blob/master/controllers/nginx/configuration.md
+##
+controller:
+  name: controller
+  image:
+    repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
+    tag: "0.24.1"
+    pullPolicy: IfNotPresent
+    # www-data -> uid 33
+    runAsUser: 33
+
+  # Configures the ports the nginx-controller listens on
+  containerPort:
+    http: 80
+    https: 443
+
+  config: {}
+  # Will add custom header to Nginx https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers
+  headers: {}
+
+  # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
+  # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920
+  # is merged
+  hostNetwork: false
+
+  # Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true'.
+  # By default, while using host network, name resolution uses the host's DNS. If you wish nginx-controller
+  # to keep resolving names inside the k8s network, use ClusterFirstWithHostNet.
+  dnsPolicy: ClusterFirst
+
+  ## Use host ports 80 and 443
+  daemonset:
+    useHostPort: false
+
+    hostPorts:
+      http: 80
+      https: 443
+      ## healthz endpoint
+      stats: 18080
+
+  ## Required only if defaultBackend.enabled = false
+  ## Must be <namespace>/<service_name>
+  ##
+  defaultBackendService: ""
+
+  ## Election ID to use for status update
+  ##
+  electionID: ingress-controller-leader
+
+  ## Name of the ingress class to route through this controller
+  ##
+  ingressClass: nginx
+
+  # labels to add to the pod container metadata
+  podLabels: {}
+  #  key: value
+
+  ## Security Context policies for controller pods
+  ## See https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/ for
+  ## notes on enabling and using sysctls
+  ##
+  podSecurityContext: {}
+
+  ## Allows customization of the external service
+  ## the ingress will be bound to via DNS
+  publishService:
+    enabled: false
+    ## Allows overriding of the publish service to bind to
+    ## Must be <namespace>/<service_name>
+    ##
+    pathOverride: ""
+
+  ## Limit the scope of the controller
+  ##
+  scope:
+    enabled: false
+    namespace: ""   # defaults to .Release.Namespace
+
+  ## Additional command line arguments to pass to nginx-ingress-controller
+  ## E.g. to specify the default SSL certificate you can use
+  ## extraArgs:
+  ##   default-ssl-certificate: "<namespace>/<secret_name>"
+  extraArgs: {}
+
+  ## Additional environment variables to set
+  extraEnvs: []
+  # extraEnvs:
+  #   - name: FOO
+  #     valueFrom:
+  #       secretKeyRef:
+  #         key: FOO
+  #         name: secret-resource
+
+  ## DaemonSet or Deployment
+  ##
+  kind: Deployment
+
+  # The update strategy to apply to the Deployment or DaemonSet
+  ##
+  updateStrategy: {}
+  #  rollingUpdate:
+  #    maxUnavailable: 1
+  #  type: RollingUpdate
+
+  # minReadySeconds to avoid killing pods before we are ready
+  ##
+  minReadySeconds: 0
+
+
+  ## Node tolerations for server scheduling to nodes with taints
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  tolerations: []
+  #  - key: "key"
+  #    operator: "Equal|Exists"
+  #    value: "value"
+  #    effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+
+  affinity: {}
+
+  ## Node labels for controller pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Liveness and readiness probe values
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ##
+  livenessProbe:
+    failureThreshold: 3
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 1
+    port: 10254
+  readinessProbe:
+    failureThreshold: 3
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 1
+    port: 10254
+
+  ## Annotations to be added to controller pods
+  ##
+  podAnnotations: {}
+
+  replicaCount: 1
+
+  minAvailable: 1
+
+  resources: {}
+  #  limits:
+  #    cpu: 100m
+  #    memory: 64Mi
+  #  requests:
+  #    cpu: 100m
+  #    memory: 64Mi
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 11
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 50
+
+  ## Override NGINX template
+  customTemplate:
+    configMapName: ""
+    configMapKey: ""
+
+  service:
+    annotations: {}
+    labels: {}
+    omitClusterIP: false
+    clusterIP: ""
+
+    ## List of IP addresses at which the controller services are available
+    ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+    ##
+    externalIPs: []
+
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+
+    enableHttp: true
+    enableHttps: true
+
+    ## Set external traffic policy to: "Local" to preserve source IP on
+    ## providers supporting it
+    ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
+    externalTrafficPolicy: ""
+
+    healthCheckNodePort: 0
+
+    targetPorts:
+      http: http
+      https: https
+
+    type: LoadBalancer
+
+    # type: NodePort
+    # nodePorts:
+    #   http: 32080
+    #   https: 32443
+    nodePorts:
+      http: ""
+      https: ""
+
+  extraContainers: []
+  ## Additional containers to be added to the controller pod.
+  ## See https://github.com/lemonldap-ng-controller/lemonldap-ng-controller as example.
+  #  - name: my-sidecar
+  #    image: nginx:latest
+  #  - name: lemonldap-ng-controller
+  #    image: lemonldapng/lemonldap-ng-controller:0.2.0
+  #    args:
+  #      - /lemonldap-ng-controller
+  #      - --alsologtostderr
+  #      - --configmap=$(POD_NAMESPACE)/lemonldap-ng-configuration
+  #    env:
+  #      - name: POD_NAME
+  #        valueFrom:
+  #          fieldRef:
+  #            fieldPath: metadata.name
+  #      - name: POD_NAMESPACE
+  #        valueFrom:
+  #          fieldRef:
+  #            fieldPath: metadata.namespace
+  #    volumeMounts:
+  #    - name: copy-portal-skins
+  #      mountPath: /srv/var/lib/lemonldap-ng/portal/skins
+
+  extraVolumeMounts: []
+  ## Additional volumeMounts to the controller main container.
+  #  - name: copy-portal-skins
+  #   mountPath: /var/lib/lemonldap-ng/portal/skins
+
+  extraVolumes: []
+  ## Additional volumes to the controller pod.
+  #  - name: copy-portal-skins
+  #    emptyDir: {}
+
+  extraInitContainers: []
+  ## Containers, which are run before the app containers are started.
+  # - name: init-myservice
+  #   image: busybox
+  #   command: ['sh', '-c', 'until nslookup myservice; do echo waiting for myservice; sleep 2; done;']
+
+
+  stats:
+    enabled: false
+
+    service:
+      annotations: {}
+      omitClusterIP: false
+      clusterIP: ""
+
+      ## List of IP addresses at which the stats service is available
+      ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+      ##
+      externalIPs: []
+
+      loadBalancerIP: ""
+      loadBalancerSourceRanges: []
+      servicePort: 18080
+      type: ClusterIP
+
+  ## If controller.stats.enabled = true and controller.metrics.enabled = true, Prometheus metrics will be exported
+  ##
+  metrics:
+    enabled: false
+
+    service:
+      annotations: {}
+      # prometheus.io/scrape: "true"
+      # prometheus.io/port: "10254"
+
+      omitClusterIP: false
+      clusterIP: ""
+
+      ## List of IP addresses at which the stats-exporter service is available
+      ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+      ##
+      externalIPs: []
+
+      loadBalancerIP: ""
+      loadBalancerSourceRanges: []
+      servicePort: 9913
+      type: ClusterIP
+
+    serviceMonitor:
+      enabled: false
+      additionalLabels: {}
+      namespace: ""
+      # honorLabels: true
+
+  lifecycle: {}
+
+  priorityClassName: ""
+
+## Rollback limit
+##
+revisionHistoryLimit: 10
+
+## Default 404 backend
+##
+defaultBackend:
+
+  ## If false, controller.defaultBackendService must be provided
+  ##
+  enabled: true
+
+  name: default-backend
+  image:
+    repository: k8s.gcr.io/defaultbackend-amd64
+    tag: "1.5"
+    pullPolicy: IfNotPresent
+
+  extraArgs: {}
+
+  port: 8080
+
+  ## Node tolerations for server scheduling to nodes with taints
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  tolerations: []
+  #  - key: "key"
+  #    operator: "Equal|Exists"
+  #    value: "value"
+  #    effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+
+  affinity: {}
+
+  # labels to add to the pod container metadata
+  podLabels: {}
+  #  key: value
+
+  ## Node labels for default backend pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Annotations to be added to default backend pods
+  ##
+  podAnnotations: {}
+
+  replicaCount: 1
+
+  minAvailable: 1
+
+  resources: {}
+  # limits:
+  #   cpu: 10m
+  #   memory: 20Mi
+  # requests:
+  #   cpu: 10m
+  #   memory: 20Mi
+
+  service:
+    annotations: {}
+    omitClusterIP: false
+    clusterIP: ""
+
+    ## List of IP addresses at which the default backend service is available
+    ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+    ##
+    externalIPs: []
+
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+    servicePort: 80
+    type: ClusterIP
+
+  priorityClassName: ""
+
+## Enable RBAC as per https://github.com/kubernetes/ingress/tree/master/examples/rbac/nginx and https://github.com/kubernetes/ingress/issues/266
+rbac:
+  create: true
+
+# If true, create & use Pod Security Policy resources
+# https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+podSecurityPolicy:
+  enabled: false
+
+serviceAccount:
+  create: true
+  name:
+
+## Optional array of imagePullSecrets containing private registry credentials
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# - name: secretName
+
+# TCP service key:value pairs
+# Ref: https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/tcp
+##
+tcp: {}
+#  8080: "default/example-tcp-svc:9000"
+
+# UDP service key:value pairs
+# Ref: https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/udp
+##
+udp: {}
+#  53: "kube-system/kube-dns:53"

--- a/fix-chart.py
+++ b/fix-chart.py
@@ -1,0 +1,49 @@
+import sys
+
+import yaml
+
+
+def maybe_copy(doc, src, dest):
+    obj = object()
+    value = doc.get(src, obj)
+    if value is not obj:
+        doc[dest] = value
+
+
+def fixup_dict(doc):
+    if doc.get('heritage') == 'Tiller':
+        maybe_copy(doc, 'app', 'app.kubernetes.io/name')
+        maybe_copy(doc, 'component', 'app.kubernetes.io/component')
+
+        doc['heritage'] = 'metalk8s'
+        doc['app.kubernetes.io/part-of'] = 'metalk8s'
+        doc['app.kubernetes.io/managed-by'] = 'metalk8s'
+
+    return dict((key, fixup_doc(value)) for (key, value) in doc.items())
+
+
+def fixup_doc(doc):
+    if isinstance(doc, dict):
+        return fixup_dict(doc)
+    elif isinstance(doc, list):
+        return map(fixup_doc, doc)
+    else:
+        return doc
+
+
+def fixup_metadata(doc):
+    if 'metadata' in doc and 'namespace' not in doc['metadata']:
+        doc['metadata']['namespace'] = 'metallb-system'
+
+    return doc
+
+
+def main(fd_in, fd_out):
+    yaml.safe_dump_all(
+        (fixup_metadata(fixup_doc(doc)) for doc in yaml.safe_load_all(fd_in) if doc),
+        fd_out,
+    )
+
+
+if __name__ == '__main__':
+    main(sys.stdin, sys.stdout)

--- a/fix-chart.py
+++ b/fix-chart.py
@@ -33,7 +33,7 @@ def fixup_doc(doc):
 
 def fixup_metadata(doc):
     if 'metadata' in doc and 'namespace' not in doc['metadata']:
-        doc['metadata']['namespace'] = 'metallb-system'
+        doc['metadata']['namespace'] = 'nginx-ingress-system'
 
     return doc
 

--- a/packages/packages.list
+++ b/packages/packages.list
@@ -1,4 +1,4 @@
-containerd
+http://rpmfind.net/linux/fedora/linux/releases/30/Everything/x86_64/os/Packages/c/containerd-1.2.4-1.fc30.x86_64.rpm
 cri-tools
 ftp://ftp.scientificlinux.org/linux/scientific/7x/external_products/extras/x86_64/container-selinux-2.77-1.el7_6.noarch.rpm
 kubectl-1.11.7-0

--- a/salt/_modules/metalk8s_kubernetes.py
+++ b/salt/_modules/metalk8s_kubernetes.py
@@ -2679,3 +2679,100 @@ def show_api_service(name, **kwargs):
             raise CommandExecutionError(exc)
     finally:
         _cleanup(**cfg)
+
+
+def show_ingress(name, namespace='default', **kwargs):
+    '''
+    Return the kubernetes ingress defined by name and namespace
+
+    CLI Examples::
+
+        salt '*' kubernetes.show_ingress kube-proxy kube-system
+        salt '*' kubernetes.show_ingress name=kube-proxy namespace=kube-system
+    '''
+    cfg = _setup_conn(**kwargs)
+    try:
+        api_instance = kubernetes.client.ExtensionsV1beta1Api()
+        api_response = api_instance.read_namespaced_ingress(name, namespace)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'ExtensionsV1beta1Api->read_namespaced_ingress'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def create_ingress(
+        name,
+        namespace,
+        metadata,
+        spec,
+        **kwargs):
+    if not metadata:
+        metadata = {}
+    metadata['name'] = name
+    metadata['namespace'] = namespace
+    meta_obj = kubernetes.client.V1ObjectMeta(**metadata)
+    body = kubernetes.client.V1beta1Ingress(
+        metadata=meta_obj, spec=spec)
+
+    cfg = _setup_conn(**kwargs)
+
+    try:
+        api_instance = kubernetes.client.ExtensionsV1beta1Api()
+        api_response = api_instance.create_namespaced_ingress(
+            namespace=namespace, body=body)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'ExtensionsV1beta1Api->create_namespaced_ingress'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
+def replace_ingress(
+        name,
+        namespace,
+        metadata,
+        spec,
+        **kwargs):
+    if not metadata:
+        metadata = {}
+    metadata['name'] = name
+    metadata['namespace'] = namespace
+    meta_obj = kubernetes.client.V1ObjectMeta(**metadata)
+    body = kubernetes.client.V1beta1Ingress(
+        metadata=meta_obj, spec=spec)
+
+    cfg = _setup_conn(**kwargs)
+
+    try:
+        api_instance = kubernetes.client.ExtensionsV1beta1Api()
+        api_response = api_instance.replace_namespaced_ingress(name, namespace, body)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'ExtensionsV1beta1Api->replace_namespaced_ingress'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)

--- a/salt/_modules/metalk8s_kubernetes.py
+++ b/salt/_modules/metalk8s_kubernetes.py
@@ -1623,6 +1623,10 @@ def __dict_to_service_spec(spec):
                     for port_key, port_value in iteritems(port):
                         if port_key in ("name", "port", "protocol", "node_port", "target_port"):
                             port_kwargs[port_key] = port_value
+                        elif port_key == 'targetPort':
+                            port_kwargs['target_port'] = port_value
+                        elif port_key == 'nodePort':
+                            port_kwargs['node_port'] = port_value
                 else:
                     port_kwargs = {"port": port}
                 kube_port = kubernetes.client.V1ServicePort(**port_kwargs)

--- a/salt/_renderers/metalk8s_kubernetes.py
+++ b/salt/_renderers/metalk8s_kubernetes.py
@@ -140,6 +140,7 @@ def _handle_rbac_v1beta1_clusterrolebinding(obj, kubeconfig, context):
 
 
 @handle('rbac.authorization.k8s.io/v1', 'Role')
+@handle('rbac.authorization.k8s.io/v1beta1', 'Role')
 def _handle_rbac_v1beta1_role(obj, kubeconfig, context):
     return {
         'metalk8s_kubernetes.role_present': [
@@ -153,6 +154,7 @@ def _handle_rbac_v1beta1_role(obj, kubeconfig, context):
 
 
 @handle('rbac.authorization.k8s.io/v1', 'RoleBinding')
+@handle('rbac.authorization.k8s.io/v1beta1', 'RoleBinding')
 def _handle_rbac_v1beta1_rolebinding(obj, kubeconfig, context):
     return {
         'metalk8s_kubernetes.rolebinding_present': [

--- a/salt/_renderers/metalk8s_kubernetes.py
+++ b/salt/_renderers/metalk8s_kubernetes.py
@@ -167,6 +167,7 @@ def _handle_rbac_v1beta1_rolebinding(obj, kubeconfig, context):
 
 
 @handle('extensions/v1beta1', 'DaemonSet')
+@handle('apps/v1beta2', 'DaemonSet')
 def _handle_extensions_v1beta1_daemonset(obj, kubeconfig, context):
     return {
         'metalk8s_kubernetes.daemonset_present': [

--- a/salt/metalk8s/addons/metallb/deployed/chart.sls
+++ b/salt/metalk8s/addons/metallb/deployed/chart.sls
@@ -1,0 +1,332 @@
+#!jinja | kubernetes kubeconfig=/etc/kubernetes/admin.conf&context=kubernetes-admin@kubernetes
+
+{%- from "metalk8s/repo/macro.sls" import build_image_repo with context %}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: metallb
+    app.kubernetes.io/managed-by: metalk8s
+    app.kubernetes.io/name: metallb
+    app.kubernetes.io/part-of: metalk8s
+    chart: metallb-0.9.5
+    heritage: metalk8s
+    release: metallb
+  name: metallb-controller
+  namespace: metallb-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: metallb
+    app.kubernetes.io/managed-by: metalk8s
+    app.kubernetes.io/name: metallb
+    app.kubernetes.io/part-of: metalk8s
+    chart: metallb-0.9.5
+    heritage: metalk8s
+    release: metallb
+  name: metallb-speaker
+  namespace: metallb-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: metallb
+    app.kubernetes.io/managed-by: metalk8s
+    app.kubernetes.io/name: metallb
+    app.kubernetes.io/part-of: metalk8s
+    chart: metallb-0.9.5
+    heritage: metalk8s
+    release: metallb
+  name: metallb:controller
+  namespace: metallb-system
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - services/status
+  verbs:
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: metallb
+    app.kubernetes.io/managed-by: metalk8s
+    app.kubernetes.io/name: metallb
+    app.kubernetes.io/part-of: metalk8s
+    chart: metallb-0.9.5
+    heritage: metalk8s
+    release: metallb
+  name: metallb:speaker
+  namespace: metallb-system
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - services
+  - endpoints
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: metallb
+    app.kubernetes.io/managed-by: metalk8s
+    app.kubernetes.io/name: metallb
+    app.kubernetes.io/part-of: metalk8s
+    chart: metallb-0.9.5
+    heritage: metalk8s
+    release: metallb
+  name: metallb-config-watcher
+  namespace: metallb-system
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: metallb
+    app.kubernetes.io/managed-by: metalk8s
+    app.kubernetes.io/name: metallb
+    app.kubernetes.io/part-of: metalk8s
+    chart: metallb-0.9.5
+    heritage: metalk8s
+    release: metallb
+  name: metallb:controller
+  namespace: metallb-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metallb:controller
+subjects:
+- kind: ServiceAccount
+  name: metallb-controller
+  namespace: metallb-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: metallb
+    app.kubernetes.io/managed-by: metalk8s
+    app.kubernetes.io/name: metallb
+    app.kubernetes.io/part-of: metalk8s
+    chart: metallb-0.9.5
+    heritage: metalk8s
+    release: metallb
+  name: metallb:speaker
+  namespace: metallb-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metallb:speaker
+subjects:
+- kind: ServiceAccount
+  name: metallb-speaker
+  namespace: metallb-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: metallb
+    app.kubernetes.io/managed-by: metalk8s
+    app.kubernetes.io/name: metallb
+    app.kubernetes.io/part-of: metalk8s
+    chart: metallb-0.9.5
+    heritage: metalk8s
+    release: metallb
+  name: metallb-config-watcher
+  namespace: metallb-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: metallb-config-watcher
+subjects:
+- kind: ServiceAccount
+  name: metallb-controller
+- kind: ServiceAccount
+  name: metallb-speaker
+---
+apiVersion: apps/v1beta2
+kind: DaemonSet
+metadata:
+  labels:
+    app: metallb
+    app.kubernetes.io/component: speaker
+    app.kubernetes.io/managed-by: metalk8s
+    app.kubernetes.io/name: metallb
+    app.kubernetes.io/part-of: metalk8s
+    chart: metallb-0.9.5
+    component: speaker
+    heritage: metalk8s
+    release: metallb
+  name: metallb-speaker
+  namespace: metallb-system
+spec:
+  selector:
+    matchLabels:
+      app: metallb
+      component: speaker
+      release: metallb
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: '7472'
+        prometheus.io/scrape: 'true'
+      labels:
+        app: metallb
+        app.kubernetes.io/component: speaker
+        app.kubernetes.io/managed-by: metalk8s
+        app.kubernetes.io/name: metallb
+        app.kubernetes.io/part-of: metalk8s
+        chart: metallb-0.9.5
+        component: speaker
+        heritage: metalk8s
+        release: metallb
+    spec:
+      containers:
+      - args:
+        - --port=7472
+        - --config=metallb-config
+        env:
+        - name: METALLB_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: '{{ build_image_repo("metallb-speaker") }}:v0.7.3'
+        imagePullPolicy: IfNotPresent
+        name: speaker
+        ports:
+        - containerPort: 7472
+          name: monitoring
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_RAW
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+      hostNetwork: true
+      serviceAccountName: metallb-speaker
+      terminationGracePeriodSeconds: 0
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/bootstrap
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  labels:
+    app: metallb
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/managed-by: metalk8s
+    app.kubernetes.io/name: metallb
+    app.kubernetes.io/part-of: metalk8s
+    chart: metallb-0.9.5
+    component: controller
+    heritage: metalk8s
+    release: metallb
+  name: metallb-controller
+  namespace: metallb-system
+spec:
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: metallb
+      component: controller
+      release: metallb
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: '7472'
+        prometheus.io/scrape: 'true'
+      labels:
+        app: metallb
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/managed-by: metalk8s
+        app.kubernetes.io/name: metallb
+        app.kubernetes.io/part-of: metalk8s
+        chart: metallb-0.9.5
+        component: controller
+        heritage: metalk8s
+        release: metallb
+    spec:
+      containers:
+      - args:
+        - --port=7472
+        - --config=metallb-config
+        image: '{{ build_image_repo("metallb-controller") }}:v0.7.3'
+        imagePullPolicy: IfNotPresent
+        name: controller
+        ports:
+        - containerPort: 7472
+          name: monitoring
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      serviceAccountName: metallb-controller
+      terminationGracePeriodSeconds: 0
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/bootstrap
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra

--- a/salt/metalk8s/addons/metallb/deployed/configured.sls
+++ b/salt/metalk8s/addons/metallb/deployed/configured.sls
@@ -1,0 +1,14 @@
+#!jinja | kubernetes kubeconfig=/etc/kubernetes/admin.conf&context=kubernetes-admin@kubernetes
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: metallb-config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - 172.21.254.47-172.21.254.62

--- a/salt/metalk8s/addons/metallb/deployed/init.sls
+++ b/salt/metalk8s/addons/metallb/deployed/init.sls
@@ -1,0 +1,4 @@
+include:
+  - .namespace
+  - .chart
+  - .configured

--- a/salt/metalk8s/addons/metallb/deployed/namespace.sls
+++ b/salt/metalk8s/addons/metallb/deployed/namespace.sls
@@ -1,0 +1,8 @@
+#! kubernetes kubeconfig=/etc/kubernetes/admin.conf&context=kubernetes-admin@kubernetes
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metallb-system
+  labels:
+    app: metallb

--- a/salt/metalk8s/addons/metallb/values.yaml
+++ b/salt/metalk8s/addons/metallb/values.yaml
@@ -1,0 +1,33 @@
+psp:
+  create: false
+
+prometheus:
+  scrapeAnnotations: true
+
+controller:
+  image:
+    repository: '{{ build_image_repo("metallb-controller") }}'
+  nodeSelector:
+    node-role.kubernetes.io/infra: ''
+  tolerations:
+    - key: node-role.kubernetes.io/bootstrap
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/infra
+      effect: NoSchedule
+  resources:
+    limits:
+      cpu: 100m
+      memory: 100Mi
+
+speaker:
+  image:
+    repository: '{{ build_image_repo("metallb-speaker") }}'
+  tolerations:
+    - key: node-role.kubernetes.io/bootstrap
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/infra
+      effect: NoSchedule
+  resources:
+    limits:
+      cpu: 100m
+      memory: 100Mi

--- a/salt/metalk8s/addons/nginx-ingress/deployed/chart.sls
+++ b/salt/metalk8s/addons/nginx-ingress/deployed/chart.sls
@@ -1,0 +1,431 @@
+#!jinja | kubernetes kubeconfig=/etc/kubernetes/admin.conf&context=kubernetes-admin@kubernetes
+
+{%- from "metalk8s/repo/macro.sls" import build_image_repo with context %}
+apiVersion: v1
+data:
+  enable-vts-status: 'false'
+kind: ConfigMap
+metadata:
+  labels:
+    app: nginx-ingress
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/managed-by: metalk8s
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/part-of: metalk8s
+    chart: nginx-ingress-1.6.13
+    component: controller
+    heritage: metalk8s
+    release: nginx-ingress
+  name: nginx-ingress-controller
+  namespace: nginx-ingress-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: nginx-ingress
+    app.kubernetes.io/managed-by: metalk8s
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/part-of: metalk8s
+    chart: nginx-ingress-1.6.13
+    heritage: metalk8s
+    release: nginx-ingress
+  name: nginx-ingress
+  namespace: nginx-ingress-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: nginx-ingress
+    app.kubernetes.io/managed-by: metalk8s
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/part-of: metalk8s
+    chart: nginx-ingress-1.6.13
+    heritage: metalk8s
+    release: nginx-ingress
+  name: nginx-ingress
+  namespace: nginx-ingress-system
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  - endpoints
+  - nodes
+  - pods
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ''
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: nginx-ingress
+    app.kubernetes.io/managed-by: metalk8s
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/part-of: metalk8s
+    chart: nginx-ingress-1.6.13
+    heritage: metalk8s
+    release: nginx-ingress
+  name: nginx-ingress
+  namespace: nginx-ingress-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nginx-ingress
+subjects:
+- kind: ServiceAccount
+  name: nginx-ingress
+  namespace: nginx-ingress-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  labels:
+    app: nginx-ingress
+    app.kubernetes.io/managed-by: metalk8s
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/part-of: metalk8s
+    chart: nginx-ingress-1.6.13
+    heritage: metalk8s
+    release: nginx-ingress
+  name: nginx-ingress
+  namespace: nginx-ingress-system
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  - pods
+  - secrets
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - ''
+  resourceNames:
+  - ingress-controller-leader-nginx
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - create
+- apiGroups:
+  - ''
+  resources:
+  - endpoints
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  labels:
+    app: nginx-ingress
+    app.kubernetes.io/managed-by: metalk8s
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/part-of: metalk8s
+    chart: nginx-ingress-1.6.13
+    heritage: metalk8s
+    release: nginx-ingress
+  name: nginx-ingress
+  namespace: nginx-ingress-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nginx-ingress
+subjects:
+- kind: ServiceAccount
+  name: nginx-ingress
+  namespace: nginx-ingress-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nginx-ingress
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/managed-by: metalk8s
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/part-of: metalk8s
+    chart: nginx-ingress-1.6.13
+    component: controller
+    heritage: metalk8s
+    release: nginx-ingress
+  name: nginx-ingress-controller
+  namespace: nginx-ingress-system
+spec:
+  clusterIP: ''
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: http
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: https
+  selector:
+    app: nginx-ingress
+    component: controller
+    release: nginx-ingress
+  type: LoadBalancer
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nginx-ingress
+    app.kubernetes.io/component: default-backend
+    app.kubernetes.io/managed-by: metalk8s
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/part-of: metalk8s
+    chart: nginx-ingress-1.6.13
+    component: default-backend
+    heritage: metalk8s
+    release: nginx-ingress
+  name: nginx-ingress-default-backend
+  namespace: nginx-ingress-system
+spec:
+  clusterIP: ''
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: http
+  selector:
+    app: nginx-ingress
+    component: default-backend
+    release: nginx-ingress
+  type: ClusterIP
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: nginx-ingress
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/managed-by: metalk8s
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/part-of: metalk8s
+    chart: nginx-ingress-1.6.13
+    component: controller
+    heritage: metalk8s
+    release: nginx-ingress
+  name: nginx-ingress-controller
+  namespace: nginx-ingress-system
+spec:
+  minReadySeconds: 0
+  replicas: 1
+  revisionHistoryLimit: 10
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: nginx-ingress
+        component: controller
+        release: nginx-ingress
+    spec:
+      containers:
+      - args:
+        - /nginx-ingress-controller
+        - --default-backend-service=nginx-ingress-system/nginx-ingress-default-backend
+        - --publish-service=nginx-ingress-system/nginx-ingress-controller
+        - --election-id=ingress-controller-leader
+        - --ingress-class=nginx
+        - --configmap=nginx-ingress-system/nginx-ingress-controller
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: '{{ build_image_repo("nginx-ingress-controller") }}:0.24.1'
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: nginx-ingress-controller
+        ports:
+        - containerPort: 80
+          name: http
+          protocol: TCP
+        - containerPort: 443
+          name: https
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - ALL
+          runAsUser: 33
+      dnsPolicy: ClusterFirst
+      hostNetwork: false
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      serviceAccountName: nginx-ingress
+      terminationGracePeriodSeconds: 60
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/bootstrap
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: nginx-ingress
+    app.kubernetes.io/component: default-backend
+    app.kubernetes.io/managed-by: metalk8s
+    app.kubernetes.io/name: nginx-ingress
+    app.kubernetes.io/part-of: metalk8s
+    chart: nginx-ingress-1.6.13
+    component: default-backend
+    heritage: metalk8s
+    release: nginx-ingress
+  name: nginx-ingress-default-backend
+  namespace: nginx-ingress-system
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  template:
+    metadata:
+      labels:
+        app: nginx-ingress
+        component: default-backend
+        release: nginx-ingress
+    spec:
+      containers:
+      - args: null
+        image: '{{ build_image_repo("nginx-ingress-defaultbackend-amd64") }}:1.5'
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        name: nginx-ingress-default-backend
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        resources: {}
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      serviceAccountName: nginx-ingress
+      terminationGracePeriodSeconds: 60
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/bootstrap

--- a/salt/metalk8s/addons/nginx-ingress/deployed/init.sls
+++ b/salt/metalk8s/addons/nginx-ingress/deployed/init.sls
@@ -1,0 +1,3 @@
+include:
+  - .namespace
+  - .chart

--- a/salt/metalk8s/addons/nginx-ingress/deployed/namespace.sls
+++ b/salt/metalk8s/addons/nginx-ingress/deployed/namespace.sls
@@ -1,0 +1,8 @@
+#! kubernetes kubeconfig=/etc/kubernetes/admin.conf&context=kubernetes-admin@kubernetes
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nginx-ingress-system
+  labels:
+    app: nginx-ingress

--- a/salt/metalk8s/addons/nginx-ingress/values.yaml
+++ b/salt/metalk8s/addons/nginx-ingress/values.yaml
@@ -1,0 +1,28 @@
+controller:
+  image:
+    repository: '{{ build_image_repo("nginx-ingress-controller") }}'
+
+  publishService:
+    enabled: true
+
+  tolerations:
+    - key: node-role.kubernetes.io/infra
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/bootstrap
+      effect: NoSchedule
+
+  nodeSelector:
+    node-role.kubernetes.io/infra: ''
+
+defaultBackend:
+  image:
+    repository: '{{ build_image_repo("nginx-ingress-defaultbackend-amd64") }}'
+
+  tolerations:
+    - key: node-role.kubernetes.io/infra
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/bootstrap
+      effect: NoSchedule
+
+  nodeSelector:
+    node-role.kubernetes.io/infra: ''

--- a/salt/metalk8s/addons/ui/deployed.sls
+++ b/salt/metalk8s/addons/ui/deployed.sls
@@ -32,9 +32,36 @@ Create metalk8s-ui service:
           targetPort: 80
         selector:
           k8s-app: ui
-        type: NodePort
+        type: ClusterIP
   require:
     - pkg: Install Python Kubernetes client
+
+Create metalk8s-ui Ingress:
+  metalk8s_kubernetes.ingress_present:
+    - name: metalk8s-ui
+    - namespace: kube-system
+    - kubeconfig: {{ kubeconfig }}
+    - context: {{ context }}
+    - metadata:
+        name: metalk8s-ui
+        labels:
+          k8s-app: ui
+        annotations:
+          kubernetes.io/ingress.class: nginx
+          nginx.ingress.kubernetes.io/rewrite-target: /
+    - spec:
+        rules:
+          - host: metalk8s
+            http:
+              paths:
+                - path: /
+                  backend:
+                    serviceName: metalk8s-ui
+                    servicePort: 80
+
+  require:
+    - pkg: Install Python Kubernetes client
+    - metalk8s_kubernetes: Create metalk8s-ui service
 
 Create metalk8s-ui ConfigMap:
   metalk8s_kubernetes.configmap_present:

--- a/salt/metalk8s/deployed.sls
+++ b/salt/metalk8s/deployed.sls
@@ -10,3 +10,5 @@ include:
   - metalk8s.addons.monitoring.prometheus.deployed
   - metalk8s.addons.monitoring.kube-state-metrics.deployed
   - metalk8s.addons.monitoring.grafana.deployed
+  - metalk8s.addons.metallb.deployed
+  - metalk8s.addons.nginx-ingress.deployed

--- a/salt/metalk8s/repo/macro.sls
+++ b/salt/metalk8s/repo/macro.sls
@@ -5,6 +5,10 @@
 "{{ metalk8s.endpoints['repositories'].ip }}:{{ metalk8s.endpoints['repositories'].ports.http }}/{{ saltenv }}/{{ name }}:{{ tag }}"
 {%- endmacro -%}
 
+{%- macro build_image_repo(name) -%}
+{{ metalk8s.endpoints['repositories'].ip }}:{{ metalk8s.endpoints['repositories'].ports.http }}/{{ saltenv }}/{{ name }}
+{%- endmacro -%}
+
 {%- macro kubernetes_image(component) -%}
 {{ build_image_name(component, kubernetes.version) }}
 {%- endmacro -%}


### PR DESCRIPTION
**Component**: salt, kubernetes, metallb, ingress, nginx-ingress

**Summary**: deploy MetalLB and `nginx-ingress` as part of the cluster.

**Acceptance criteria**: 
- Deploy the cluster
- Find the `nginx-ingress-controller` `LoadBalancer` service (now managed by MetalLB):

```
$ kubectl -n nginx-ingress-system get svc
...
nginx-ingress-system   nginx-ingress-controller        LoadBalancer   10.101.134.174   172.21.254.47   80:30107/TCP,443:31177/TCP   6m
...
```

- Ensure the `metalk8s-ui` `Ingress` exists:

```
$  kubectl -n kube-system get ingress metalk8s-ui
NAME          HOSTS      ADDRESS   PORTS     AGE
metalk8s-ui   metalk8s             80        3h
```

- Either set up `/etc/hosts` for `metalk8s` to point to the LB address, or use `curl` and name resolution override to validate access to the admin UI service through the LB address using

```
$  curl http://metalk8s --resolve 'metalk8s:80:172.21.254.47'
...
```

Closes: #779
Closes: #791