### PR TITLE
Job Events Parser

### DIFF
--- a/ui/src/containers/NodeDeployment.js
+++ b/ui/src/containers/NodeDeployment.js
@@ -47,27 +47,13 @@ const NodeDeploymentStatus = styled.div`
 
 const SuccessLabel = styled.span`
   color: ${brand.success};
+  padding: 0 ${padding.base};
 `;
 
 const ErrorLabel = styled.span`
   color: ${brand.danger};
+  padding: 0 ${padding.base};
 `;
-
-function NodeDeploymentResult(props) {
-  return (
-    <span>
-      {props.intl.messages.status} :
-      {props.status.success ? (
-        <SuccessLabel>{props.intl.messages.success}</SuccessLabel>
-      ) : (
-        <ErrorLabel>
-          `{props.intl.messages.error}: ${props.status.step_id} - $
-          {props.status.comment}`
-        </ErrorLabel>
-      )}
-    </span>
-  );
-}
 
 function NodeDeployment(props) {
   useEffect(() => {
@@ -76,13 +62,11 @@ function NodeDeployment(props) {
     }
   });
 
-  const getJobResult = () => {
-    const result = props.events.find(event => event.tag.includes('/ret'));
-    if (result) {
-      return getJobStatusFromEventRet(result.data);
-    }
-    return null;
-  };
+  const result = props.events.find(event => event.tag.includes('/ret'));
+  let status = null;
+  if (result) {
+    status = getJobStatusFromEventRet(result.data);
+  }
 
   return (
     <NodeDeploymentContainer>
@@ -100,8 +84,19 @@ function NodeDeployment(props) {
           {props.intl.messages.node_deployment}
         </NodeDeploymentTitle>
         <NodeDeploymentStatus>
-          {getJobResult() ? (
-            <NodeDeploymentResult status={getJobResult()} />
+          {status ? (
+            <span>
+              {props.intl.messages.status}
+              {status.success ? (
+                <SuccessLabel>{props.intl.messages.success}</SuccessLabel>
+              ) : (
+                <ErrorLabel>
+                  {`${props.intl.messages.error}: ${status.step_id} - ${
+                    status.comment
+                  }`}
+                </ErrorLabel>
+              )}
+            </span>
           ) : (
             <Loader>{props.intl.messages.deploying}</Loader>
           )}

--- a/ui/src/containers/NodeList.js
+++ b/ui/src/containers/NodeList.js
@@ -128,6 +128,11 @@ class NodeList extends React.Component {
 
   componentDidMount() {
     this.props.fetchNodes();
+    this.interval = setInterval(() => this.props.fetchNodes(), 10000);
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.interval);
   }
 
   onSort({ sortBy, sortDirection }) {

--- a/ui/src/containers/NodeList.js
+++ b/ui/src/containers/NodeList.js
@@ -4,7 +4,7 @@ import { withRouter } from 'react-router-dom';
 import memoizeOne from 'memoize-one';
 import styled from 'styled-components';
 import { sortBy as sortByArray } from 'lodash';
-import { injectIntl, FormattedDate, FormattedTime } from 'react-intl';
+import { injectIntl } from 'react-intl';
 import { Table, Button, Loader } from 'core-ui';
 import { padding } from 'core-ui/dist/style/theme';
 
@@ -64,12 +64,19 @@ class NodeList extends React.Component {
         },
         {
           label: props.intl.messages.status,
-          dataKey: 'status',
+          dataKey: 'status'
+        },
+        {
+          label: props.intl.messages.deployment,
+          dataKey: 'deployment',
+          flexGrow: 1,
           renderer: (data, rowData) => {
-            if ((!data || data === 'Unknown') && !rowData.jid) {
+            if (
+              (!rowData.status || rowData.status === 'Unknown') &&
+              !rowData.jid
+            ) {
               return (
                 <span className="status">
-                  {data}
                   <Button
                     text={this.props.intl.messages.deploy}
                     onClick={event => {
@@ -78,13 +85,19 @@ class NodeList extends React.Component {
                     }}
                     size="smaller"
                   />
+                  {data && (
+                    <span>
+                      {data.success
+                        ? props.intl.messages.success
+                        : `${data.step_id} : ${data.comment}`}
+                    </span>
+                  )}
                 </span>
               );
             }
             if (rowData.jid) {
               return (
                 <span className="status">
-                  {data}
                   <Button
                     text={this.props.intl.messages.deploying}
                     onClick={event => {
@@ -102,24 +115,13 @@ class NodeList extends React.Component {
         },
         {
           label: props.intl.messages.roles,
-          dataKey: 'roles'
+          dataKey: 'roles',
+          flexGrow: 1
         },
         {
-          label: props.intl.messages.cpu_capacity,
-          dataKey: 'cpu'
-        },
-        {
-          label: props.intl.messages.memory,
-          dataKey: 'memory'
-        },
-        {
-          label: props.intl.messages.creationDate,
-          dataKey: 'creationDate',
-          renderer: data => (
-            <span>
-              <FormattedDate value={data} /> <FormattedTime value={data} />
-            </span>
-          )
+          label: props.intl.messages.version,
+          dataKey: 'metalk8s_version',
+          width: 200
         }
       ]
     };

--- a/ui/src/containers/NodeList.js
+++ b/ui/src/containers/NodeList.js
@@ -85,13 +85,6 @@ class NodeList extends React.Component {
                     }}
                     size="smaller"
                   />
-                  {data && (
-                    <span>
-                      {data.success
-                        ? props.intl.messages.success
-                        : `${data.step_id} : ${data.comment}`}
-                    </span>
-                  )}
                 </span>
               );
             }

--- a/ui/src/ducks/app/nodes.js
+++ b/ui/src/ducks/app/nodes.js
@@ -18,6 +18,8 @@ import {
   addNotificationErrorAction
 } from './notifications';
 
+import { addJobAction, removeJobAction } from './salt.js';
+
 import {
   isJobCompleted,
   getJidFromNameLocalStorage,
@@ -35,8 +37,6 @@ const DEPLOY_NODE = 'DEPLOY_NODE';
 const CONNECT_SALT_API = 'CONNECT_SALT_API';
 const UPDATE_EVENTS = 'UPDATE_EVENTS';
 const SUBSCRIBE_DEPLOY_EVENTS = 'SUBSCRIBE_DEPLOY_EVENTS';
-
-let eventSrc, channel;
 
 // Reducer
 const defaultState = {
@@ -165,6 +165,7 @@ export function* removeCompletedJobFromLocalStorage(name) {
       jid
     );
     if (isJobCompleted(result.data, jid)) {
+      yield put(removeJobAction(jid));
       removeJobLocalStorage(jid);
     }
   }
@@ -214,6 +215,7 @@ export function* deployNode({ payload }) {
       })
     );
   } else {
+    yield call(subscribeDeployEvents, { jid: result.data.return[0].jid });
     updateJobLocalStorage(result.data.return[0].jid, payload.name);
     yield call(fetchNodes);
   }
@@ -235,24 +237,40 @@ export function subSSE(eventSrc) {
 }
 
 export function* sseSagas({ payload }) {
-  eventSrc = new EventSource(`${payload.url}/events?token=${payload.token}`);
-  channel = yield call(subSSE, eventSrc);
-}
-
-export function* subscribeDeployEvents({ jid }) {
+  const eventSrc = new EventSource(
+    `${payload.url}/events?token=${payload.token}`
+  );
+  const channel = yield call(subSSE, eventSrc);
   while (true) {
     const msg = yield take(channel);
     const data = JSON.parse(msg.data);
-    if (data.tag.includes(jid)) {
-      yield put(updateDeployEventsAction({ jid, msg: data }));
-    }
+    const jobs = yield select(state => state.app.salt.jobs);
+
+    yield all(
+      jobs.map(jid => {
+        if (data.tag.includes(jid)) {
+          return call(updateDeployEvents, jid, data);
+        }
+      })
+    );
+  }
+}
+
+export function* updateDeployEvents(jid, msg) {
+  yield put(updateDeployEventsAction({ jid, msg }));
+}
+
+export function* subscribeDeployEvents({ jid }) {
+  const jobs = yield select(state => state.app.salt.jobs);
+  if (!jobs.includes(jid)) {
+    yield put(addJobAction(jid));
   }
 }
 
 export function* nodesSaga() {
   yield takeLatest(FETCH_NODES, fetchNodes);
   yield takeEvery(CREATE_NODE, createNode);
-  yield takeEvery(DEPLOY_NODE, deployNode);
+  yield takeLatest(DEPLOY_NODE, deployNode);
   yield takeEvery(CONNECT_SALT_API, sseSagas);
   yield takeEvery(SUBSCRIBE_DEPLOY_EVENTS, subscribeDeployEvents);
 }

--- a/ui/src/ducks/app/nodes.js
+++ b/ui/src/ducks/app/nodes.js
@@ -21,7 +21,7 @@ import {
 import { addJobAction, removeJobAction } from './salt.js';
 
 import {
-  isJobCompleted,
+  getJobStatusFromPrintJob,
   getJidFromNameLocalStorage,
   updateJobLocalStorage,
   removeJobLocalStorage
@@ -164,7 +164,7 @@ export function* removeCompletedJobFromLocalStorage(name) {
       salt.data.return[0].token,
       jid
     );
-    if (isJobCompleted(result.data, jid)) {
+    if (getJobStatusFromPrintJob(result.data, jid).completed) {
       yield put(removeJobAction(jid));
       removeJobLocalStorage(jid);
     }
@@ -251,6 +251,7 @@ export function* sseSagas({ payload }) {
         if (data.tag.includes(jid)) {
           return call(updateDeployEvents, jid, data);
         }
+        return data;
       })
     );
   }

--- a/ui/src/ducks/app/nodes.test.js
+++ b/ui/src/ducks/app/nodes.test.js
@@ -2,7 +2,7 @@ import { call, put, all } from 'redux-saga/effects';
 import { fetchNodes, createNode, SET_NODES, CREATE_NODE_FAILED } from './nodes';
 import * as ApiK8s from '../../services/k8s/api';
 import history from '../../history';
-import { removeCompletedJobFromLocalStorage } from './nodes.js';
+import { getJobStatus } from './nodes.js';
 
 it('update the control plane nodes state when fetchNodes', () => {
   const gen = fetchNodes();
@@ -74,12 +74,9 @@ it('update the control plane nodes state when fetchNodes', () => {
   ];
 
   expect(gen.next(result).value).toEqual(
-    all([call(removeCompletedJobFromLocalStorage, 'boostrap')])
-  );
-
-  expect(gen.next(result).value).toEqual(
     put({ type: SET_NODES, payload: nodes })
   );
+  expect(gen.next(result).value).toEqual(all([call(getJobStatus, 'boostrap')]));
 });
 
 it('update the bootstrap nodes state when fetchNodes', () => {
@@ -142,12 +139,10 @@ it('update the bootstrap nodes state when fetchNodes', () => {
   ];
 
   expect(gen.next(result).value).toEqual(
-    all([call(removeCompletedJobFromLocalStorage, 'boostrap')])
-  );
-
-  expect(gen.next(result).value).toEqual(
     put({ type: SET_NODES, payload: nodes })
   );
+
+  expect(gen.next(result).value).toEqual(all([call(getJobStatus, 'boostrap')]));
 });
 
 it('update the workload plane nodes state when fetchNodes', () => {
@@ -208,12 +203,9 @@ it('update the workload plane nodes state when fetchNodes', () => {
   ];
 
   expect(gen.next(result).value).toEqual(
-    all([call(removeCompletedJobFromLocalStorage, 'boostrap')])
-  );
-
-  expect(gen.next(result).value).toEqual(
     put({ type: SET_NODES, payload: nodes })
   );
+  expect(gen.next(result).value).toEqual(all([call(getJobStatus, 'boostrap')]));
 });
 
 it('update the control plane/workload plane nodes state when fetchNodes', () => {
@@ -274,14 +266,11 @@ it('update the control plane/workload plane nodes state when fetchNodes', () => 
       }
     }
   ];
-
-  expect(gen.next(result).value).toEqual(
-    all([call(removeCompletedJobFromLocalStorage, 'boostrap')])
-  );
-
   expect(gen.next(result).value).toEqual(
     put({ type: SET_NODES, payload: nodes })
   );
+
+  expect(gen.next(result).value).toEqual(all([call(getJobStatus, 'boostrap')]));
 });
 
 it('create Node success', () => {

--- a/ui/src/ducks/app/salt.js
+++ b/ui/src/ducks/app/salt.js
@@ -1,0 +1,31 @@
+// Actions
+const ADD_JOB = 'REMOVE_JOB';
+const REMOVE_JOB = 'UPDATE_JOBS';
+
+// Reducer
+const defaultState = {
+  jobs: []
+};
+
+export default function reducer(state = defaultState, action = {}) {
+  switch (action.type) {
+    case ADD_JOB:
+      return { ...state, jobs: [...state.jobs, action.payload] };
+    case REMOVE_JOB:
+      return {
+        ...state,
+        jobs: state.jobs.filter(job => job !== action.payload)
+      };
+    default:
+      return state;
+  }
+}
+
+// Action Creators
+export function addJobAction(job) {
+  return { type: ADD_JOB, payload: job };
+}
+
+export function removeJobAction(job) {
+  return { type: REMOVE_JOB, payload: job };
+}

--- a/ui/src/ducks/reducer.js
+++ b/ui/src/ducks/reducer.js
@@ -6,6 +6,7 @@ import pods from './app/pods';
 import login from './login';
 import layout from './app/layout';
 import notifications from './app/notifications';
+import salt from './app/salt';
 
 const rootReducer = combineReducers({
   config,
@@ -14,7 +15,8 @@ const rootReducer = combineReducers({
     nodes,
     layout,
     pods,
-    notifications
+    notifications,
+    salt
   })
 });
 

--- a/ui/src/services/salt/mockDataEventRet.js
+++ b/ui/src/services/salt/mockDataEventRet.js
@@ -1,0 +1,174 @@
+export const data = {
+  fun_args: [
+    'metalk8s.orchestrate.deploy_node',
+    {
+      saltenv: 'metalk8s-2.0',
+      pillar: {
+        orchestrate: {
+          node_name: 'node1'
+        }
+      }
+    }
+  ],
+  jid: '20190527152722429535',
+  return: {
+    outputter: 'highstate',
+    data: {
+      bootstrap_master: {
+        'salt_|-Set grains_|-Set grains_|-state': {
+          comment: 'States ran successfully. Updating node1.',
+          name: 'Set grains',
+          start_time: '15:28:25.541001',
+          result: true,
+          duration: 1318.444,
+          __run_num__: 3,
+          __jid__: '20190527152825671379'
+        },
+        'metalk8s_drain_|-Drain the node_|-node1_|-node_drained': {
+          comment: 'Eviction complete.',
+          name: 'node1',
+          start_time: '15:28:28.923923',
+          result: true,
+          duration: 244.721,
+          __run_num__: 6,
+          __sls__: 'metalk8s.orchestrate.deploy_node',
+          changes: {
+            node1: {
+              node1: 'drained'
+            }
+          },
+          __id__: 'Drain the node'
+        },
+        'salt_|-Kill kube-controller-manager on all master nodes_|-ps.pkill_|-function': {
+          comment:
+            'Function ran successfully. Function ps.pkill ran on node1, bootstrap.',
+          name: 'ps.pkill',
+          start_time: '15:30:29.425156',
+          result: true,
+          duration: 347.902,
+          __run_num__: 9,
+          __jid__: '20190527153029554041',
+          __sls__: 'metalk8s.orchestrate.deploy_node',
+          changes: {
+            ret: {
+              node1: null,
+              bootstrap: {
+                killed: [14909]
+              }
+            },
+            out: 'highstate'
+          },
+          __id__: 'Kill kube-controller-manager on all master nodes'
+        },
+        'salt_|-Deploy salt-minion on a new node_|-Deploy salt-minion on a new node_|-state': {
+          comment: 'States ran successfully. Updating node1.',
+          name: 'Deploy salt-minion on a new node',
+          start_time: '15:27:25.134589',
+          result: true,
+          duration: 47344.676,
+          __run_num__: 0,
+          __jid__: '20190527152731311813',
+          __sls__: 'metalk8s.orchestrate.deploy_node'
+        },
+        'module_|-Accept key_|-Accept key_|-run': {
+          comment: 'saltutil.wheel: Success',
+          name: ['saltutil.wheel'],
+          start_time: '15:28:12.482345',
+          result: true,
+          duration: 357.834,
+          __run_num__: 1
+        },
+        'salt_|-Run the highstate_|-Run the highstate_|-state': {
+          comment: 'States ran successfully. Updating node1.',
+          name: 'Run the highstate',
+          start_time: '15:28:29.169805',
+          result: true,
+          duration: 120024.083,
+          __run_num__: 7,
+          __jid__: '20190527152829304045'
+        },
+        'metalk8s_cordon_|-Uncordon the node_|-node1_|-node_uncordoned': {
+          comment: 'Node node1 uncordoned',
+          name: 'node1',
+          start_time: '15:30:29.194902',
+          result: true,
+          duration: 229.821,
+          __run_num__: 8,
+          __sls__: 'metalk8s.orchestrate.deploy_node'
+        },
+        'metalk8s_cordon_|-Cordon the node_|-node1_|-node_cordoned': {
+          comment: 'Node node1 cordoned',
+          name: 'node1',
+          start_time: '15:28:28.688465',
+          result: true,
+          duration: 232.145,
+          __run_num__: 5,
+          __sls__: 'metalk8s.orchestrate.deploy_node'
+        },
+        'salt_|-Refresh the mine_|-mine.update_|-function': {
+          comment:
+            'Function ran successfully. Function mine.update ran on node1, bootstrap.',
+          name: 'mine.update',
+          start_time: '15:28:26.859849',
+          result: true,
+          duration: 1824.89,
+          __run_num__: 4,
+          __jid__: '20190527152826991322'
+        },
+        'salt_|-Register the node into etcd cluster_|-state.orchestrate_|-runner': {
+          comment: "Runner function 'state.orchestrate' executed.",
+          name: 'state.orchestrate',
+          __orchestration__: true,
+          start_time: '15:30:29.775013',
+          result: false,
+          duration: 4972.308,
+          __run_num__: 10,
+          __jid__: '20190527153030131303',
+          __sls__: 'metalk8s.orchestrate.deploy_node',
+          changes: {
+            return: {
+              outputter: 'highstate',
+              data: {
+                bootstrap_master: {
+                  'metalk8s_etcd_|-Register host as part of etcd cluster_|-node1_|-member_present': {
+                    comment: 'Node added in etcd cluster',
+                    name: 'node1',
+                    start_time: '15:30:32.771762',
+                    result: false,
+                    duration: 1965.116,
+                    __run_num__: 0,
+                    __sls__: 'metalk8s.orchestrate.register_etcd',
+                    changes: {
+                      peer_urls: 'https://172.21.254.13:2380',
+                      client_urls: '',
+                      id: 860341623853584300,
+                      name: ''
+                    },
+                    __id__: 'Register host as part of etcd cluster'
+                  }
+                }
+              },
+              retcode: 0
+            }
+          },
+          __id__: 'Register the node into etcd cluster'
+        },
+        'salt_|-Wait minion available_|-metalk8s_saltutil.wait_minions_|-runner': {
+          comment: "Runner function 'metalk8s_saltutil.wait_minions' executed.",
+          name: 'metalk8s_saltutil.wait_minions',
+          __orchestration__: true,
+          start_time: '15:28:12.840829',
+          result: true,
+          duration: 12699.302,
+          __run_num__: 2,
+          __jid__: '20190527152813179108'
+        }
+      }
+    },
+    retcode: 0
+  },
+  success: false,
+  _stamp: '2019-05-27T15:30:34.778305',
+  user: 'admin',
+  fun: 'runner.state.orchestrate'
+};

--- a/ui/src/services/salt/mockDataPrintJob.js
+++ b/ui/src/services/salt/mockDataPrintJob.js
@@ -1,0 +1,195 @@
+export const data = {
+  return: [
+    {
+      '20190527213228970129': {
+        Result: {
+          bootstrap_master: {
+            return: {
+              fun_args: [],
+              jid: '20190527213228970129',
+              return: {
+                outputter: 'highstate',
+                data: {
+                  bootstrap_master: {
+                    'salt_|-Set grains_|-Set grains_|-state': {
+                      comment: 'Updating node1 failed',
+                      name: 'Set grains',
+                      start_time: '21:33:33.408716',
+                      result: false,
+                      duration: 1478.199,
+                      __run_num__: 3,
+                      __jid__: '20190527213333559560',
+                      __sls__: 'metalk8s.orchestrate.deploy_node',
+                      changes: {
+                        ret: {
+                          node1: {
+                            'grains_|-Set control_plane_ip grain_|-metalk8s:control_plane_ip_|-present': {
+                              comment:
+                                'Set grain metalk8s:control_plane_ip to 172.21.254.12',
+                              name: 'metalk8s:control_plane_ip',
+                              start_time: '21:33:34.750189',
+                              result: false,
+                              duration: 11.342,
+                              __run_num__: 0
+                            },
+                            'grains_|-Set workload_plane_ip grain_|-metalk8s:workload_plane_ip_|-present': {
+                              comment:
+                                'Set grain metalk8s:workload_plane_ip to 172.21.254.45',
+                              name: 'metalk8s:workload_plane_ip',
+                              start_time: '21:33:34.761797',
+                              result: false,
+                              duration: 4.798,
+                              __run_num__: 1
+                            }
+                          }
+                        },
+                        out: 'highstate'
+                      },
+                      __id__: 'Set grains'
+                    },
+                    'metalk8s_drain_|-Drain the node_|-node1_|-node_drained': {
+                      comment: 'Eviction complete.',
+                      name: 'node1',
+                      start_time: '21:33:36.057387',
+                      result: true,
+                      duration: 259.239,
+                      __run_num__: 6
+                    },
+                    'salt_|-Kill kube-controller-manager on all master nodes_|-ps.pkill_|-function': {
+                      comment:
+                        'Function ran successfully. Function ps.pkill ran on bootstrap.',
+                      name: 'ps.pkill',
+                      start_time: '21:34:56.906105',
+                      result: true,
+                      duration: 350.539,
+                      __run_num__: 9,
+                      __jid__: '20190527213457035999',
+                      __sls__: 'metalk8s.orchestrate.deploy_node',
+                      changes: {
+                        ret: {
+                          bootstrap: {
+                            killed: [14939]
+                          }
+                        },
+                        out: 'highstate'
+                      },
+                      __id__: 'Kill kube-controller-manager on all master nodes'
+                    },
+                    'salt_|-Deploy salt-minion on a new node_|-Deploy salt-minion on a new node_|-state': {
+                      comment: 'States ran successfully. Updating node1.',
+                      name: 'Deploy salt-minion on a new node',
+                      start_time: '21:32:31.403702',
+                      result: true,
+                      duration: 48700.922,
+                      __run_num__: 0,
+                      __jid__: '20190527213237875376'
+                    },
+                    'module_|-Accept key_|-Accept key_|-run': {
+                      comment: 'saltutil.wheel: Success',
+                      name: ['saltutil.wheel'],
+                      start_time: '21:33:20.106366',
+                      result: true,
+                      duration: 350.636,
+                      __run_num__: 1
+                    },
+                    'salt_|-Run the highstate_|-Run the highstate_|-state': {
+                      comment: 'States ran successfully. Updating node1.',
+                      name: 'Run the highstate',
+                      start_time: '21:33:36.318055',
+                      result: true,
+                      duration: 80352.861,
+                      __run_num__: 7,
+                      __jid__: '20190527213336504932'
+                    },
+                    'metalk8s_cordon_|-Uncordon the node_|-node1_|-node_uncordoned': {
+                      comment: 'Node node1 uncordoned',
+                      name: 'node1',
+                      start_time: '21:34:56.671443',
+                      result: true,
+                      duration: 234.004,
+                      __run_num__: 8,
+                      __sls__: 'metalk8s.orchestrate.deploy_node',
+                      changes: {
+                        new: {
+                          unschedulable: null
+                        },
+                        old: {
+                          unschedulable: true
+                        }
+                      },
+                      __id__: 'Uncordon the node'
+                    },
+                    'metalk8s_cordon_|-Cordon the node_|-node1_|-node_cordoned': {
+                      comment: 'Node node1 cordoned',
+                      name: 'node1',
+                      start_time: '21:33:35.818960',
+                      result: true,
+                      duration: 236.41,
+                      __run_num__: 5,
+                      __sls__: 'metalk8s.orchestrate.deploy_node',
+                      changes: {
+                        new: {
+                          unschedulable: true
+                        },
+                        old: {
+                          unschedulable: false
+                        }
+                      },
+                      __id__: 'Cordon the node'
+                    },
+                    'salt_|-Refresh the mine_|-mine.update_|-function': {
+                      comment:
+                        'Function ran successfully. Function mine.update ran on node1, bootstrap.',
+                      name: 'mine.update',
+                      start_time: '21:33:34.887400',
+                      result: true,
+                      duration: 927.167,
+                      __run_num__: 4,
+                      __jid__: '20190527213335026675',
+                      __sls__: 'metalk8s.orchestrate.deploy_node',
+                      changes: {
+                        ret: {
+                          node1: true,
+                          bootstrap: true
+                        },
+                        out: 'highstate'
+                      },
+                      __id__: 'Refresh the mine'
+                    },
+                    'salt_|-Wait minion available_|-metalk8s_saltutil.wait_minions_|-runner': {
+                      comment:
+                        "Runner function 'metalk8s_saltutil.wait_minions' executed.",
+                      name: 'metalk8s_saltutil.wait_minions',
+                      __orchestration__: true,
+                      start_time: '21:33:20.457775',
+                      result: true,
+                      duration: 12949.553,
+                      __run_num__: 2,
+                      __jid__: '20190527213320824803',
+                      __sls__: 'metalk8s.orchestrate.deploy_node',
+                      changes: {
+                        return: {
+                          comment:
+                            'All minions matching "node1" responded: node1',
+                          result: true
+                        }
+                      },
+                      __id__: 'Wait minion available'
+                    }
+                  }
+                },
+                retcode: 0
+              },
+              success: false,
+              _stamp: '2019-05-27T21:32:29.351849',
+              user: 'admin',
+              fun: 'runner.state.orchestrate'
+            }
+          }
+        },
+        StartTime: '2019, May 27 21:32:28.970129',
+        Error: 'Cannot contact returner or no job with this jid'
+      }
+    }
+  ]
+};

--- a/ui/src/services/salt/utils.js
+++ b/ui/src/services/salt/utils.js
@@ -1,11 +1,6 @@
 const JOBS = 'JOBS';
 
-export function isJobCompleted(result, jid) {
-  return (
-    result.return[0][jid] && Object.keys(result.return[0][jid]['Result']).length
-  );
-}
-
+//Parse only first error level
 export function getJobErrorStatus(returner, status) {
   const steps = Object.values(returner.return.data)[0];
   let firstFailedStepIndex = Infinity;

--- a/ui/src/services/salt/utils.js
+++ b/ui/src/services/salt/utils.js
@@ -62,7 +62,7 @@ export function getNameFromJidLocalStorage(jid) {
   return job && job.name;
 }
 
-export function updateJobLocalStorage(jid, name) {
+export function addJobLocalStorage(jid, name) {
   const jobs = JSON.parse(localStorage.getItem(JOBS)) || [];
   jobs.push({ jid, name });
   localStorage.setItem(JOBS, JSON.stringify(jobs));

--- a/ui/src/services/salt/utils.js
+++ b/ui/src/services/salt/utils.js
@@ -6,6 +6,55 @@ export function isJobCompleted(result, jid) {
   );
 }
 
+export function getJobErrorStatus(returner, status) {
+  const steps = Object.values(returner.return.data)[0];
+  let firstFailedStepIndex = Infinity;
+  let firstFailedStepKey;
+  Object.keys(steps).forEach(key => {
+    if (!steps[key].result && steps[key].__run_num__ < firstFailedStepIndex) {
+      firstFailedStepIndex = steps[key].__run_num__;
+      firstFailedStepKey = key;
+    }
+  });
+
+  if (firstFailedStepKey) {
+    const failedStep = steps[firstFailedStepKey];
+    const step_id = firstFailedStepKey.split('_|-')[1];
+    status.step_id = step_id;
+    status.comment = failedStep.comment;
+  }
+}
+export function getJobStatusFromPrintJob(result, jid) {
+  const status = {
+    completed: false
+  };
+
+  const job = result.return[0][jid];
+
+  if (job && Object.keys(job['Result']).length) {
+    status.completed = true;
+    const returner = Object.values(job['Result'])[0].return;
+    const success = returner.success;
+    status.success = success;
+    if (!success) {
+      getJobErrorStatus(returner, status);
+    }
+  }
+  return status;
+}
+
+export function getJobStatusFromEventRet(result) {
+  const status = {
+    completed: true
+  };
+  const success = result.success;
+  status.success = success;
+  if (!success) {
+    getJobErrorStatus(result, status);
+  }
+  return status;
+}
+
 export function getJidFromNameLocalStorage(name) {
   const jobs = JSON.parse(localStorage.getItem(JOBS)) || [];
   const job = jobs.find(job => job.name === name);

--- a/ui/src/services/salt/utils.js
+++ b/ui/src/services/salt/utils.js
@@ -64,7 +64,12 @@ export function getNameFromJidLocalStorage(jid) {
 
 export function addJobLocalStorage(jid, name) {
   const jobs = JSON.parse(localStorage.getItem(JOBS)) || [];
-  jobs.push({ jid, name });
+  const job = jobs.find(item => item.name === name);
+  if (job) {
+    job.jid = jid;
+  } else {
+    jobs.push({ jid, name });
+  }
   localStorage.setItem(JOBS, JSON.stringify(jobs));
 }
 

--- a/ui/src/services/salt/utils.test.js
+++ b/ui/src/services/salt/utils.test.js
@@ -1,0 +1,84 @@
+import { data as dataPrintJob } from './mockDataPrintJob';
+import { data as dataEventRet } from './mockDataEventRet';
+import { getJobStatusFromPrintJob, getJobStatusFromEventRet } from './utils';
+
+test('getJobStatusFromPrintJob not completed', () => {
+  const data = {
+    return: [
+      {
+        '20190527213228970129': {
+          Result: {}
+        }
+      }
+    ]
+  };
+
+  const expectedResult = {
+    completed: false
+  };
+  expect(getJobStatusFromPrintJob(data, '20190527213228970129')).toEqual(
+    expectedResult
+  );
+});
+
+test('getJobStatusFromPrintJob completed success', () => {
+  const data = {
+    return: [
+      {
+        '20190527213228970129': {
+          Result: {
+            bootstrap_master: {
+              return: {
+                success: true
+              }
+            }
+          }
+        }
+      }
+    ]
+  };
+
+  const expectedResult = {
+    completed: true,
+    success: true
+  };
+  expect(getJobStatusFromPrintJob(data, '20190527213228970129')).toEqual(
+    expectedResult
+  );
+});
+
+test('getJobStatusFromPrintJob completed failed', () => {
+  const expectedResult = {
+    completed: true,
+    success: false,
+    step_id: 'Set grains',
+    comment: 'Updating node1 failed'
+  };
+  expect(
+    getJobStatusFromPrintJob(dataPrintJob, '20190527213228970129')
+  ).toEqual(expectedResult);
+});
+
+test('getJobStatusFromEventRet completed success', () => {
+  const data = {
+    success: true
+  };
+
+  const expectedResult = {
+    completed: true,
+    success: true
+  };
+  expect(getJobStatusFromEventRet(data, '20190527213228970129')).toEqual(
+    expectedResult
+  );
+});
+
+test('getJobStatusFromEventRet completed failed', () => {
+  const expectedResult = {
+    completed: true,
+    success: false,
+    step_id: 'Register the node into etcd cluster',
+    comment: "Runner function 'state.orchestrate' executed."
+  };
+  expect(getJobStatusFromEventRet(dataEventRet)).toEqual(expectedResult);
+});

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -34,7 +34,10 @@
   "not_ready": "Not Ready",
   "deploy": "Deploy",
   "deploying": "Deploying",
+  "deployment": "Deployment",
   "version": "MetalK8s Version",
   "node_deployment": "Node Deployment",
-  "back_to_node_list": "Back to nodes list"
+  "back_to_node_list": "Back to nodes list",
+  "success": "Success",
+  "error": "Error"
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -34,7 +34,10 @@
   "not_ready": "Pas prêt",
   "deploy": "Déployer",
   "deploying": "Déploiement en cours",
+  "deployment": "Déploiement",
   "version": "MetalK8s Version",
   "node_deployment": "Déploiement du node",
-  "back_to_node_list": "Retour à la liste des nodes"
+  "back_to_node_list": "Retour à la liste des nodes",
+  "success": "Succès",
+  "error": "Erreur"
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -30,7 +30,7 @@
   "create": "Créer",
   "cancel": "Annuler",
   "unknown": "Inconnu",
-  "ready": "Prêt",
+  "ready": "Prêt", 
   "not_ready": "Pas prêt",
   "deploy": "Déployer",
   "deploying": "Déploiement en cours",


### PR DESCRIPTION
**Component**: UI

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: When a runner (deploy_node in particular) fails, the orchestrate sends a large JSON payload with all states return information (whether they failed or not). A non-technical user would find it difficult to understand.

**Summary**:
The UI should provide a simple parsing logic to extract the "first" failing state in case of orchestrate failure to display in the node list and the node deploy page

**Acceptance criteria**: 
Have a clear deployment status in the node list and the node deploy page when the deployment  failed.

![image](https://user-images.githubusercontent.com/47394132/58548138-0911f880-8209-11e9-9829-b590b1a6ec69.png)

<img width="1440" alt="Screenshot 2019-05-29 at 11 14 10" src="https://user-images.githubusercontent.com/47394132/58548168-162ee780-8209-11e9-9c2b-57ff1d4849b5.png">

Workaround: As the nodes list is refreshed every 10s, so the error message is only available during max 10s since there is no way to persist it... => We display notifications instead

![image](https://user-images.githubusercontent.com/47394132/58549275-6e66e900-820b-11e9-94f0-94f59b8c4817.png)


<!-- Declare one or more issues to close once this PR gets merged -->

Closes: https://github.com/scality/metalk8s/issues/1145

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
