### PR TITLE
build/images: delete intermediate containers

### DIFF
--- a/buildchain/buildchain/docker_command.py
+++ b/buildchain/buildchain/docker_command.py
@@ -108,7 +108,8 @@ class DockerBuild:
             tag=self.tag,
             path=self.path,
             dockerfile=self.dockerfile,
-            buildargs=self.buildargs
+            buildargs=self.buildargs,
+            forcerm=True,
         )
 
 


### PR DESCRIPTION
**Component**:

buildchain

**Context**: 

When building images, we sometimes spawn intermediate containers and
because those are not cleaned up, they accumulate and waste more and
more spaces.

**Summary**:

Enable `forcerm=True` when building images, to ensure the removal of intermediate containers.

**Acceptance criteria**: 

1. Check your containers with `docker ps -a`
2. Rebuild the ISO (you may want to clean first, to be sure to actually rebuild things)
3. Check your containers with `docker ps -a`: there should be no new containers since 1.

---

Closes: #1164