### PR TITLE
monitoring: add relevant tolerations to monitoring components

### DIFF
--- a/salt/metalk8s/addons/monitoring/alertmanager/deployed.sls
+++ b/salt/metalk8s/addons/monitoring/alertmanager/deployed.sls
@@ -33,6 +33,13 @@ spec:
   replicas: 3
   serviceAccountName: alertmanager-main
   version: v0.15.2
+  tolerations:
+  - key: "node-role.kubernetes.io/bootstrap"
+    operator: "Exists"
+    effect: "NoSchedule"
+  - key: "node-role.kubernetes.io/infra"
+    operator: "Exists"
+    effect: "NoSchedule"
 ---
 apiVersion: v1
 kind: Service

--- a/salt/metalk8s/addons/monitoring/grafana/deployed.sls
+++ b/salt/metalk8s/addons/monitoring/grafana/deployed.sls
@@ -7476,6 +7476,13 @@ spec:
       - configMap:
           name: grafana-dashboard-statefulset
         name: grafana-dashboard-statefulset
+      tolerations:
+      - key: "node-role.kubernetes.io/bootstrap"
+        operator: "Exists"
+        effect: "NoSchedule"
+      - key: "node-role.kubernetes.io/infra"
+        operator: "Exists"
+        effect: "NoSchedule"
 ---
 apiVersion: v1
 data:

--- a/salt/metalk8s/addons/monitoring/kube-state-metrics/deployed.sls
+++ b/salt/metalk8s/addons/monitoring/kube-state-metrics/deployed.sls
@@ -259,6 +259,13 @@ spec:
         runAsNonRoot: true
         runAsUser: 65534
       serviceAccountName: kube-state-metrics
+      tolerations:
+      - key: "node-role.kubernetes.io/bootstrap"
+        operator: "Exists"
+        effect: "NoSchedule"
+      - key: "node-role.kubernetes.io/infra"
+        operator: "Exists"
+        effect: "NoSchedule"
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/salt/metalk8s/addons/monitoring/prometheus-operator/deployed.sls
+++ b/salt/metalk8s/addons/monitoring/prometheus-operator/deployed.sls
@@ -6231,6 +6231,13 @@ spec:
         runAsNonRoot: true
         runAsUser: 65534
       serviceAccountName: prometheus-operator
+      tolerations:
+      - key: "node-role.kubernetes.io/bootstrap"
+        operator: "Exists"
+        effect: "NoSchedule"
+      - key: "node-role.kubernetes.io/infra"
+        operator: "Exists"
+        effect: "NoSchedule"
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/salt/metalk8s/addons/monitoring/prometheus/deployed.sls
+++ b/salt/metalk8s/addons/monitoring/prometheus/deployed.sls
@@ -164,6 +164,13 @@ spec:
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector: {}
   version: v2.4.3
+  tolerations:
+  - key: "node-role.kubernetes.io/bootstrap"
+    operator: "Exists"
+    effect: "NoSchedule"
+  - key: "node-role.kubernetes.io/infra"
+    operator: "Exists"
+    effect: "NoSchedule"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
The monitoring components need to be able to run on `infra`-tainted
nodes, as well as the `bootstrap`-tainted node.

Issue: #1171

**Component**: monitoring

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: monitoring pods do not start

**Summary**: add toleration to every monitoring node

**Acceptance criteria**: after bootstrap, all nodes have the expected infra and bootstrap tolerations


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1171 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
