### PR TITLE
Remove VERSION_SUFFIX  from Eve "product_version"

### DIFF
--- a/eve/get_product_version.sh
+++ b/eve/get_product_version.sh
@@ -4,5 +4,4 @@ script_full_path=$(readlink -f "$0")
 file_dir=$(dirname "$script_full_path")/..
 # shellcheck disable=SC1090
 source "$file_dir/VERSION" && \
-    echo "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${VERSION_SUFFIX}"
-
+    echo "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}"


### PR DESCRIPTION
**Component**: build

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1166

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
