### PR TITLE
UI: improve Dockerfile for faster build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,6 @@ buildchain/.venv/
 .doit.db
 
 *.pyc
+
+node_modules
+npm-debug.log

--- a/buildchain/buildchain/image.py
+++ b/buildchain/buildchain/image.py
@@ -87,7 +87,7 @@ def task__image_dedup_layers() -> types.TaskDict:
 
 
 NGINX_IMAGE_VERSION : str = '1.15.8'
-
+NODE_IMAGE_VERSION : str = '10.16.0'
 
 # List of container images to pull.
 #
@@ -301,9 +301,20 @@ TO_BUILD : Tuple[targets.LocalImage, ...] = (
         dockerfile=constants.ROOT/'ui'/'Dockerfile',
         destination=constants.ISO_IMAGE_ROOT,
         save_on_disk=True,
-        build_args={'NGINX_IMAGE_VERSION': NGINX_IMAGE_VERSION},
+        build_args={
+            'NGINX_IMAGE_VERSION': NGINX_IMAGE_VERSION,
+            'NODE_IMAGE_VERSION': NODE_IMAGE_VERSION
+        },
         task_dep=['_image_mkdir_root'],
-        file_dep=list(coreutils.ls_files_rec(constants.ROOT/'ui')),
+        file_dep=(
+            list(coreutils.ls_files_rec(constants.ROOT/'ui'/'public')) +
+            list(coreutils.ls_files_rec(constants.ROOT/'ui'/'src')) +
+            [
+                constants.ROOT/'ui'/'package.json',
+                constants.ROOT/'ui'/'package-lock.json',
+                constants.ROOT/'ui'/'conf'/'nginx.conf'
+            ]
+        )
     ),
 )
 

--- a/salt/metalk8s/addons/ui/files/metalk8s-ui-deployment.yaml
+++ b/salt/metalk8s/addons/ui/files/metalk8s-ui-deployment.yaml
@@ -27,6 +27,7 @@ spec:
       containers:
         - name: metalk8s-ui
           image: {{ build_image_name('metalk8s-ui', '0.2') }}
+          imagePullPolicy: Always
           resources:
             limits:
               memory: 170Mi

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -3,8 +3,11 @@ ARG NGINX_IMAGE_VERSION=1.15.8
 FROM node AS build-step
 
 WORKDIR /home/node
-COPY . /home/node/
+COPY package*.json /home/node/
 RUN npm install
+
+COPY public /home/node/public
+COPY src /home/node/src
 RUN npm run build
 
 FROM nginx:${NGINX_IMAGE_VERSION}

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,6 +1,7 @@
 ARG NGINX_IMAGE_VERSION=1.15.8
+ARG NODE_IMAGE_VERSION=10.16.0
 
-FROM node AS build-step
+FROM node:${NODE_IMAGE_VERSION} AS build-step
 
 WORKDIR /home/node
 COPY package*.json /home/node/

--- a/ui/src/containers/Layout.js
+++ b/ui/src/containers/Layout.js
@@ -99,7 +99,6 @@ class Layout extends Component {
             <PrivateRoute exact path="/about" component={Welcome} />
             <PrivateRoute exact path="/" component={NodeList} />
           </Switch>
-          )}
         </CoreUILayout>
       </ThemeProvider>
     );


### PR DESCRIPTION
**Component**: UI

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
The UI is extremely slow to build (~15 minutes). This should be remedied now rather than later.

**Summary**:
Some docker layers could be cached.

**Acceptance criteria**: 
The UI build is faster after the first build since some docker layers are cached.
Limitations: when rebuilding UI, we have to restart the pods manually to pull the new UI image (correctly generated) since the UI version does not change every times. Otherwise, the new image will be not correctly deployed.
``` kubectl delete pods metalk8s-ui-xxx-xxx -n kube-system ```

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: https://github.com/scality/metalk8s/issues/1139

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
