### PR TITLE
Set kube-state-metrics limits and requests to cpu 102m and memory 180Mi

### DIFF
--- a/salt/metalk8s/addons/monitoring/kube-state-metrics/deployed.sls
+++ b/salt/metalk8s/addons/monitoring/kube-state-metrics/deployed.sls
@@ -219,11 +219,11 @@ spec:
         name: kube-state-metrics
         resources:
           limits:
-            cpu: 100m
-            memory: 150Mi
+            cpu: 102m
+            memory: 180Mi
           requests:
-            cpu: 100m
-            memory: 150Mi
+            cpu: 102m
+            memory: 180Mi
       - command:
         - /pod_nanny
         - --container=kube-state-metrics


### PR DESCRIPTION

**Component**:

'salt', 'deployment'

**Context**: 

`pod_nanny` seems to require the exact ressource he has in command and fail if not

**Summary**:

Set the requests and limits cpu to the right value corresponding to pod_nanny values.
cpu = 102m (100m + 2m extra)
memory= 180Mi (150Mi + 30Mi extra) 

**Acceptance criteria**: 

Have a working kube-state-metrics

---
Fixes: #1176

