### PR TITLE
Fix alertmanager manifest

### DIFF
--- a/salt/metalk8s/addons/monitoring/grafana/upstream.sls
+++ b/salt/metalk8s/addons/monitoring/grafana/upstream.sls
@@ -12,25 +12,12 @@
 ---
 apiVersion: v1
 data:
-  prometheus.yaml: |-
-    {
-        "apiVersion": 1,
-        "datasources": [
-            {
-                "access": "proxy",
-                "editable": false,
-                "name": "prometheus",
-                "orgId": 1,
-                "type": "prometheus",
-                "url": "http://prometheus-k8s.monitoring.svc:9090",
-                "version": 1
-            }
-        ]
-    }
-kind: ConfigMap
+  prometheus.yaml: ewogICAgImFwaVZlcnNpb24iOiAxLAogICAgImRhdGFzb3VyY2VzIjogWwogICAgICAgIHsKICAgICAgICAgICAgImFjY2VzcyI6ICJwcm94eSIsCiAgICAgICAgICAgICJlZGl0YWJsZSI6IGZhbHNlLAogICAgICAgICAgICAibmFtZSI6ICJwcm9tZXRoZXVzIiwKICAgICAgICAgICAgIm9yZ0lkIjogMSwKICAgICAgICAgICAgInR5cGUiOiAicHJvbWV0aGV1cyIsCiAgICAgICAgICAgICJ1cmwiOiAiaHR0cDovL3Byb21ldGhldXMtazhzLm1vbml0b3Jpbmcuc3ZjOjkwOTAiLAogICAgICAgICAgICAidmVyc2lvbiI6IDEKICAgICAgICB9CiAgICBdCn0=
+kind: Secret
 metadata:
   name: grafana-datasources
   namespace: monitoring
+type: Opaque
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -7459,9 +7446,9 @@ spec:
       volumes:
       - emptyDir: {}
         name: grafana-storage
-      - configMap:
-          name: grafana-datasources
-        name: grafana-datasources
+      - name: grafana-datasources
+        secret:
+          secretName: grafana-datasources
       - configMap:
           name: grafana-dashboards
         name: grafana-dashboards


### PR DESCRIPTION
**Component**: salt, monitoring

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**:

The `alertmanager` manifest, like the `grafana` manifest, used a `Secret` with some base64 data, and crashed on an attempt to marshal that data into YAML like `grafana` (see #1170).

The root cause (thanks @gdemonet) is the kubernetes salt module, which expects the data we pass it to be plain text, and does the encoding itself, so we had a double-encoded value passed to K8s, which only decoded it once.

**Summary**:

We fix this in the renderer for now, by decoding the data before passing it to the salt state, since: 

* Reusing the workaround wouldn't work in this case since the `Secret` for `alertmanager` seems to be not directly mounted in the upstream manifest but used by the CR. 
* Rewriting some *more* of the vendored version of the kubernetes salt module means more "magic" and divergence with the upstream of that module.

Commits:

* Handle secret data correctly in the renderer for the saltified upstream manifests
* Revert the `grafana` workaround, since it's no longer needed

**Acceptance criteria**: 

All pods in the `monitoring` namespace should be in Running state upon completion of a bootstrap. All pods in the `monitoring` namespace should eventually be in Running state upon reload of their `deployed` state.

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1175 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
