### PR TITLE
UI- I18n: translation in redux sagas management

### DIFF
--- a/ui/src/containers/App.js
+++ b/ui/src/containers/App.js
@@ -13,6 +13,7 @@ import translations_fr from '../translations/fr';
 import Layout from './Layout';
 import Login from './Login';
 
+import IntlGlobalProvider from '../translations/IntlGlobalProvider';
 import { fetchConfigAction } from '../ducks/config';
 
 const messages = {
@@ -33,10 +34,12 @@ class App extends Component {
 
     return api && theme && this.props.isUserInfoLoaded ? (
       <IntlProvider locale={language} messages={messages[language]}>
-        <Switch>
-          <Route path="/login" component={Login} />
-          <Route component={Layout} />
-        </Switch>
+        <IntlGlobalProvider>
+          <Switch>
+            <Route path="/login" component={Login} />
+            <Route component={Layout} />
+          </Switch>
+        </IntlGlobalProvider>
       </IntlProvider>
     ) : (
       <Loader />

--- a/ui/src/containers/NodeList.js
+++ b/ui/src/containers/NodeList.js
@@ -178,16 +178,6 @@ class NodeList extends React.Component {
         roles.push(intl.messages.workload_plane);
       }
       node.roles = roles.join(' / ');
-
-      let statusType = node.statusType;
-      let status = intl.messages.unknown;
-
-      if (statusType && statusType.status === 'True') {
-        status = intl.messages.ready;
-      } else if (statusType && statusType.status === 'False') {
-        status = intl.messages.not_ready;
-      }
-      node.status = status;
       return node;
     });
 

--- a/ui/src/ducks/app/nodes.js
+++ b/ui/src/ducks/app/nodes.js
@@ -11,7 +11,6 @@ import { eventChannel, END } from 'redux-saga';
 
 import * as ApiK8s from '../../services/k8s/api';
 import * as ApiSalt from '../../services/salt/api';
-import { convertK8sMemoryToBytes, prettifyBytes } from '../../services/utils';
 import history from '../../history';
 import {
   addNotificationSuccessAction,

--- a/ui/src/ducks/app/nodes.js
+++ b/ui/src/ducks/app/nodes.js
@@ -18,6 +18,7 @@ import {
   addNotificationErrorAction
 } from './notifications';
 
+import { intl } from '../../translations/IntlGlobalProvider';
 import { addJobAction, removeJobAction } from './salt.js';
 
 import {
@@ -177,17 +178,19 @@ export function* getJobStatus(name) {
       if (status.success) {
         yield put(
           addNotificationSuccessAction({
-            title: 'Node Deployment',
-            message: `Node ${name} has been deployed successfully.`
+            title: intl.translate('node_deployment'),
+            message: intl.translate('node_deployment_success', { name })
           })
         );
       } else {
         yield put(
           addNotificationErrorAction({
-            title: 'Node Deployment',
-            message: `Node ${name} deployment has failed. ${status.step_id} - ${
-              status.comment
-            }`
+            title: intl.translate('node_deployment'),
+            message: intl.translate('node_deployment_failed', {
+              name,
+              step: status.step_id,
+              reason: status.comment
+            })
           })
         );
       }
@@ -203,8 +206,8 @@ export function* createNode({ payload }) {
     yield call(history.push, '/nodes');
     yield put(
       addNotificationSuccessAction({
-        title: 'Node Creation',
-        message: `Node ${payload.name} has been created successfully.`
+        title: intl.translate('node_creation'),
+        message: intl.translate('node_creation_success', { name: payload.name })
       })
     );
   } else {
@@ -214,8 +217,8 @@ export function* createNode({ payload }) {
     });
     yield put(
       addNotificationErrorAction({
-        title: 'Node Creation',
-        message: `Node ${payload.name} creation has failed.`
+        title: intl.translate('node_creation'),
+        message: intl.translate('node_creation_failed', { name: payload.name })
       })
     );
   }
@@ -234,7 +237,7 @@ export function* deployNode({ payload }) {
   if (result.error) {
     yield put(
       addNotificationErrorAction({
-        title: 'Node Deployment',
+        title: intl.translate('node_deployment'),
         message: result.error
       })
     );
@@ -295,17 +298,19 @@ export function* updateDeployEvents(jid, msg) {
       if (status.success) {
         yield put(
           addNotificationSuccessAction({
-            title: 'Node Deployment',
-            message: `Node ${name} has been deployed successfully.`
+            title: intl.translate('node_deployment'),
+            message: intl.translate('node_deployment_success', { name })
           })
         );
       } else {
         yield put(
           addNotificationErrorAction({
-            title: 'Node Deployment',
-            message: `Node ${name} deployment has failed. ${status.step_id} - ${
-              status.comment
-            }`
+            title: intl.translate('node_deployment'),
+            message: intl.translate('node_deployment_failed', {
+              name,
+              step: status.step_id,
+              reason: status.comment
+            })
           })
         );
       }

--- a/ui/src/ducks/app/nodes.js
+++ b/ui/src/ducks/app/nodes.js
@@ -127,22 +127,23 @@ export function* fetchNodes() {
           const statusType =
             node.status.conditions &&
             node.status.conditions.find(conditon => conditon.type === 'Ready');
+          let status;
+          if (statusType && statusType.status === 'True') {
+            status = intl.translate('ready');
+          } else if (statusType && statusType.status === 'False') {
+            status = intl.translate('not_ready');
+          } else {
+            status = intl.translate('unknown');
+          }
+
           return {
             name: node.metadata.name,
             metalk8s_version:
               node.metadata.labels['metalk8s.scality.com/version'],
-            statusType: statusType,
-            cpu: node.status.capacity && node.status.capacity.cpu,
+            status: status,
             control_plane: isRolePresentInLabels(node, ApiK8s.ROLE_MASTER),
             workload_plane: isRolePresentInLabels(node, ApiK8s.ROLE_NODE),
             bootstrap: isRolePresentInLabels(node, ApiK8s.ROLE_BOOTSTRAP),
-            memory:
-              node.status.capacity &&
-              prettifyBytes(
-                convertK8sMemoryToBytes(node.status.capacity.memory),
-                2
-              ).value,
-            creationDate: node.metadata.creationTimestamp,
             jid: getJidFromNameLocalStorage(node.metadata.name)
           };
         })

--- a/ui/src/ducks/app/nodes.test.js
+++ b/ui/src/ducks/app/nodes.test.js
@@ -25,7 +25,8 @@ it('update the control plane nodes state when fetchNodes', () => {
             },
             labels: {
               'node-role.kubernetes.io/etcd': '',
-              'node-role.kubernetes.io/master': ''
+              'node-role.kubernetes.io/master': '',
+              'metalk8s.scality.com/version': '2.0'
             }
           },
           status: {
@@ -60,16 +61,12 @@ it('update the control plane nodes state when fetchNodes', () => {
   const nodes = [
     {
       name: 'boostrap',
-      cpu: '2',
-      memory: '1000 KiB',
-      creationDate: '2019-29-03',
       workload_plane: false,
       control_plane: true,
       bootstrap: false,
-      statusType: {
-        status: 'True',
-        type: 'Ready'
-      }
+      status: 'Ready',
+      jid: undefined,
+      metalk8s_version: '2.0'
     }
   ];
 
@@ -102,7 +99,8 @@ it('update the bootstrap nodes state when fetchNodes', () => {
             labels: {
               'node-role.kubernetes.io/bootstrap': '',
               'node-role.kubernetes.io/etcd': '',
-              'node-role.kubernetes.io/master': ''
+              'node-role.kubernetes.io/master': '',
+              'metalk8s.scality.com/version': '2.0'
             }
           },
           status: {
@@ -125,16 +123,12 @@ it('update the bootstrap nodes state when fetchNodes', () => {
   const nodes = [
     {
       name: 'boostrap',
-      cpu: '2',
-      memory: '1000 KiB',
-      creationDate: '2019-29-03',
       workload_plane: false,
       control_plane: true,
       bootstrap: true,
-      statusType: {
-        status: 'True',
-        type: 'Ready'
-      }
+      status: 'Ready',
+      jid: undefined,
+      metalk8s_version: '2.0'
     }
   ];
 
@@ -166,7 +160,8 @@ it('update the workload plane nodes state when fetchNodes', () => {
               'metalk8s.scality.com/ssh-sudo': 'true'
             },
             labels: {
-              'node-role.kubernetes.io/node': ''
+              'node-role.kubernetes.io/node': '',
+              'metalk8s.scality.com/version': '2.0'
             }
           },
           status: {
@@ -189,16 +184,12 @@ it('update the workload plane nodes state when fetchNodes', () => {
   const nodes = [
     {
       name: 'boostrap',
-      cpu: '2',
-      memory: '1000 KiB',
-      creationDate: '2019-29-03',
       workload_plane: true,
       control_plane: false,
       bootstrap: false,
-      statusType: {
-        status: 'True',
-        type: 'Ready'
-      }
+      status: 'Ready',
+      jid: undefined,
+      metalk8s_version: '2.0'
     }
   ];
 
@@ -231,7 +222,8 @@ it('update the control plane/workload plane nodes state when fetchNodes', () => 
             labels: {
               'node-role.kubernetes.io/node': '',
               'node-role.kubernetes.io/etcd': '',
-              'node-role.kubernetes.io/master': ''
+              'node-role.kubernetes.io/master': '',
+              'metalk8s.scality.com/version': '2.0'
             }
           },
           status: {
@@ -254,16 +246,12 @@ it('update the control plane/workload plane nodes state when fetchNodes', () => 
   const nodes = [
     {
       name: 'boostrap',
-      cpu: '2',
-      memory: '1000 KiB',
-      creationDate: '2019-29-03',
       workload_plane: true,
       control_plane: true,
       bootstrap: false,
-      statusType: {
-        status: 'True',
-        type: 'Ready'
-      }
+      status: 'Ready',
+      jid: undefined,
+      metalk8s_version: '2.0'
     }
   ];
   expect(gen.next(result).value).toEqual(

--- a/ui/src/setupTests.js
+++ b/ui/src/setupTests.js
@@ -1,0 +1,12 @@
+import { IntlProvider, addLocaleData } from 'react-intl';
+import IntlGlobalProvider from './translations/IntlGlobalProvider';
+import translations_en from './translations/en';
+
+const intlProvider = new IntlProvider({
+  locale: 'en',
+  messages: translations_en
+});
+const { intl } = intlProvider.getChildContext();
+
+//init to test i18n in sagas
+IntlGlobalProvider({}, { intl });

--- a/ui/src/translations/IntlGlobalProvider.js
+++ b/ui/src/translations/IntlGlobalProvider.js
@@ -1,0 +1,49 @@
+// NPM Modules
+import { intlShape, defineMessages } from 'react-intl';
+
+// ======================================================
+// React intl passes the messages and format functions down the component
+// tree using the 'context' scope. the injectIntl HOC basically takes these out
+// of the context and injects them into the props of the component. To be able to
+// import this translation functionality as a module anywhere (and not just inside react components),
+// this function inherits props & context from its parent and exports a singleton that'll
+// expose all that shizzle.
+// ======================================================
+var INTL;
+const IntlGlobalProvider = (props, context) => {
+  INTL = context.intl;
+  return props.children;
+};
+
+IntlGlobalProvider.contextTypes = {
+  intl: intlShape.isRequired
+};
+
+// ======================================================
+// Class that exposes translations
+// ======================================================
+var instance;
+class IntlTranslator {
+  // Singleton
+  constructor() {
+    if (!instance) {
+      instance = this;
+    }
+    return instance;
+  }
+
+  // ------------------------------------
+  // Formatting Functions
+  // ------------------------------------
+  translate(key, values) {
+    const description = defineMessages({
+      message: {
+        id: key
+      }
+    });
+    return INTL.formatMessage(description.message, values);
+  }
+}
+
+export const intl = new IntlTranslator();
+export default IntlGlobalProvider;

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -37,6 +37,8 @@
   "deployment": "Deployment",
   "version": "MetalK8s Version",
   "node_deployment": "Node Deployment",
+  "node_deployment_success": "Node {name} has been deployed successfully.",
+  "node_deployment_failed": "Node {name} deployment has failed. {step} - {reason}",
   "back_to_node_list": "Back to nodes list",
   "success": "Success",
   "error": "Error",
@@ -50,5 +52,8 @@
   "active_at": "Active Since",
   "cluster_up_and_running": "Everything is up and running",
   "down": "Down",
-  "alerts": "Alerts"
+  "alerts": "Alerts",
+  "node_creation": "Node creation",
+  "node_creation_success": "Node {name} has been created successfully.",
+  "node_creation_failed": "Node {name} creation has failed."
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -37,12 +37,14 @@
   "deployment": "Déploiement",
   "version": "MetalK8s Version",
   "node_deployment": "Déploiement du node",
+  "node_deployment_success": "Déploiement du node {name} a terminé avec succèss",
+  "node_deployment_failed": "Déploiement du node {name} a échoué. {step} - {reason}",
   "back_to_node_list": "Retour à la liste des nodes",
   "success": "Succès",
   "error": "Erreur",
   "completed": "Terminé",
   "node_registered": "Node enregistré",
-  "deployment_started": "Deploiement commencé",
+  "deployment_started": "Déploiement commencé",
   "cluster_status": "Status de la grappe de serveurs",
   "cluster_monitoring": "Surveillance de la grappe de serveurs",
   "severity": "Sévérité",
@@ -50,5 +52,8 @@
   "active_at": "Actif depuis",
   "cluster_up_and_running": "Grappe de serveurs opérationnelle",
   "down": "H.S",
-  "alerts": "Alertes"
+  "alerts": "Alertes",
+  "node_creation": "Création du node",
+  "node_creation_success": "Le node {name} a été créé avec succèss",
+  "node_creation_failed": "La création du node {name} a échoué."
 }


### PR DESCRIPTION
**Component**: UI

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
Actually, there is no way to translate "text" in saga (for ex: notification title and message => hardcoded). So far, all translations are executed by injectIntl HOC in react containers.

**Summary**:
-Add IntlGlobalProvider which wraps a Singleton to expose ```translate``` function
**Acceptance criteria**: 
All labels in sagas (notifications for example) have to be translated
<!-- Declare one or more issues to close once this PR gets merged -->

Closes: https://github.com/scality/metalk8s/issues/1154

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
