### PR TITLE
Fix-ui-crash-if-prometheus-is-not-available

### DIFF
--- a/ui/src/services/prometheus/api.js
+++ b/ui/src/services/prometheus/api.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 export async function getAlerts(api) {
   try {
-    return axios.get(api + '/api/v1/alerts');
+    return await axios.get(api + '/api/v1/alerts');
   } catch (error) {
     return { error };
   }
@@ -12,7 +12,7 @@ export async function getClusterStatus(api) {
   try {
     const query =
       'sum(up{job=~"apiserver|kube-scheduler|kube-controller-manager"} == 0)';
-    return axios.get(api + '/api/v1/query?query=' + query);
+    return await axios.get(api + '/api/v1/query?query=' + query);
   } catch (error) {
     return { error };
   }


### PR DESCRIPTION
**Component**: ui

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
When the prometheus api is not available the ui might break (it cannot create node properly for example)

**Summary**:
It's a programmation error, the promise is directly. We should return the result of a promise not the promise itself.

---

<!-- Declare one or more issues to close once this PR gets merged -->

See: #1185
