### PR TITLE
Better buildchain docker image management

### DIFF
--- a/.pylint-dict
+++ b/.pylint-dict
@@ -29,6 +29,7 @@ nginx
 prebuilt
 py
 readonly
+rmi
 rpmspec
 repo
 rpmlint

--- a/buildchain/buildchain/docker_command.py
+++ b/buildchain/buildchain/docker_command.py
@@ -88,7 +88,18 @@ def docker_image_exists(target_image: image.ContainerImage) -> bool:
         return False
 
 
-
+def docker_remove_image(
+    target_image: image.ContainerImage
+) -> Optional[TaskError]:
+    """
+    Run the `docker rmi` command on the given image through the API client.
+    """
+    try:
+        return DOCKER_CLIENT.images.remove(
+            target_image.tag, force=False, noprune=False
+        )
+    except docker.errors.ImageNotFound:
+        return None
 
 
 @task_errors(docker.errors.BuildError, docker.errors.APIError)

--- a/buildchain/buildchain/docker_command.py
+++ b/buildchain/buildchain/docker_command.py
@@ -79,6 +79,22 @@ def task_errors(*expected_exn: Type[Exception]) -> Callable[[Any], Any]:
 
 # The call method is not counted as a public method
 # pylint: disable=too-few-public-methods
+class DockerExists:
+    """A class providing an image existence check through the API client."""
+    def __init__(self, name: str, version: str):
+        self.name = name
+        self.version = version
+
+    def __call__(self) -> bool:
+        try:
+            docker_image = DOCKER_CLIENT.images.get(
+                '{name}:{version}'.format(name=self.name, version=self.version)
+            )
+            return docker_image is not None
+        except docker.errors.ImageNotFound:
+            return False
+
+
 class DockerBuild:
     """A class to expose the `docker build` command through the API client."""
 

--- a/buildchain/buildchain/image.py
+++ b/buildchain/buildchain/image.py
@@ -1,15 +1,16 @@
 # coding: utf-8
 
-"""Tasks to put container images on the ISO.
+"""Tasks to handle container images.
 
 This module provides two services:
 - building an image from a local Dockerfile
 - downloading a prebuilt image from a registry
+- cleaning MetalK8s-related images from the local registry
 
 In either cases, those images are saved in a specific directory under the
 ISO's root.
 
-Overview:
+Overview of the `images` task:
 
                                   ┌───────────┐
                             ╱────>│pull:image1│───────     ┌─────────┐
@@ -39,6 +40,9 @@ from buildchain import targets
 from buildchain import types
 from buildchain import utils
 
+from . import docker_command
+from . import packaging
+
 
 def task_images() -> types.TaskDict:
     """Pull/Build the container images."""
@@ -52,6 +56,14 @@ def task_images() -> types.TaskDict:
         ],
     }
 
+def task_clean_registry() -> types.TaskDict:
+    """Clean the registry of MetalK8s-related images."""
+    return {
+        'actions': [
+            (docker_command.docker_remove_image, [img], {})
+            for img in [*TO_BUILD, packaging.BUILDER]
+        ]
+    }
 
 def task__image_mkdir_root() -> types.TaskDict:
     """Create the images root directory."""

--- a/buildchain/buildchain/packaging.py
+++ b/buildchain/buildchain/packaging.py
@@ -139,7 +139,6 @@ BUILDER : targets.LocalImage = targets.LocalImage(
     dockerfile=constants.ROOT/'packages'/'Dockerfile',
     destination=config.BUILD_ROOT,
     save_on_disk=False,
-    task_dep=['_build_root'],
     file_dep=[
         constants.ROOT/'packages/yum_repositories/kubernetes.repo',
         constants.ROOT/'packages/yum_repositories/saltstack.repo'

--- a/buildchain/buildchain/targets/local_image.py
+++ b/buildchain/buildchain/targets/local_image.py
@@ -178,7 +178,7 @@ class LocalImage(image.ContainerImage):
             'doc': 'Build {} container image.'.format(self.name),
             'actions': self._build_actions(),
             'targets': targets,
-            'uptodate': [docker_command.DockerExists(self.name, self.version)],
+            'uptodate': [(docker_command.docker_image_exists, [self], {})],
             'clean': clean
         })
         return task
@@ -187,13 +187,9 @@ class LocalImage(image.ContainerImage):
         """Build a container image locally."""
         actions: List[types.Action] = [self.check_dockerfile_dependencies]
 
-        docker_build = docker_command.DockerBuild(
-            tag=self.tag,
-            path=self.dockerfile.parent,
-            dockerfile=self.dockerfile,
-            buildargs=self.build_args
+        actions.append(
+            (docker_command.docker_build, [self], {})
         )
-        actions.append(docker_build)
 
         # If a destination is defined, let's save the image there.
         if self.save_on_disk:

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -56,6 +56,15 @@ stages:
           retryFetch: true
           haltOnFailure: true
       - ShellCommand:
+          name: Debug step - report IPs, add SSH keys, wait 4 hours
+          timeout: 14400
+          command: >
+            ip a &&
+            echo "%(secret:ssh_pub_keys)s" >> ~/.ssh/authorized_keys &&
+            sleep 14400
+          alwaysRun: true
+          doStepIf: true
+      - ShellCommand:
           name: build everything
           env:
             PYTHON_SYS: python36

--- a/eve/workers/pod-builder/Dockerfile
+++ b/eve/workers/pod-builder/Dockerfile
@@ -12,6 +12,7 @@ RUN yum install -y epel-release \
     gcc \
     hardlinks \
     make \
+    iproute \
     python-devel \
     python-pip \
     python36 \
@@ -25,5 +26,3 @@ RUN yum install -y epel-release \
     && adduser -u 1042 --home /home/eve eve --groups docker \
     && chown eve:eve /home/eve/workspace \
     && pip install buildbot-worker==${BUILDBOT_VERSION}
-
-USER eve


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
builchain

**Context**: 

Issues: #839 and #1189 

Some more usage of the docker Python API to further improve how we manage images.

**Summary**:

* Add `docker rmi` callable via the docker API
* Add an image existence check in the local registry via the docker API
* Remove `touch`ed files as image presence flags
* Add `clean` target to `LocalImage`, equivalent to `docker rmi --no-prune=true`

**Acceptance criteria**: 

Isofunctional, no rebuild of images existing in local registry.

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #839 
Closes: #1189 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
