### PR TITLE
Upgrade addon-resizer to 1.8.3

### DIFF
--- a/buildchain/buildchain/image.py
+++ b/buildchain/buildchain/image.py
@@ -95,10 +95,10 @@ NODE_IMAGE_VERSION : str = '10.16.0'
 # pylint:disable=line-too-long
 TO_PULL : Tuple[targets.RemoteImage, ...] = (
     targets.RemoteImage(
-        registry=constants.COREOS_REGISTRY,
+        registry=constants.GOOGLE_REGISTRY,
         name='addon-resizer',
-        version='1.0',
-        digest='sha256:f84cebb37aa907e3b34ca165d6258730fa8d15fa00d490c300bd04222a29e708',
+        version='1.8.3',
+        digest='sha256:07353f7b26327f0d933515a22b1de587b040d3d85c464ea299c1b9f242529326',
         destination=constants.ISO_IMAGE_ROOT,
         task_dep=['_image_mkdir_root'],
     ),

--- a/salt/metalk8s/addons/monitoring/kube-state-metrics/upstream.sls
+++ b/salt/metalk8s/addons/monitoring/kube-state-metrics/upstream.sls
@@ -219,11 +219,11 @@ spec:
         name: kube-state-metrics
         resources:
           limits:
-            cpu: 102m
-            memory: 180Mi
+            cpu: 100m
+            memory: 150Mi
           requests:
-            cpu: 102m
-            memory: 180Mi
+            cpu: 100m
+            memory: 150Mi
       - command:
         - /pod_nanny
         - --container=kube-state-metrics
@@ -244,7 +244,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: {{ build_image_name('addon-resizer', '1.0') }}
+        image: {{ build_image_name('addon-resizer', '1.8.3') }}
         name: addon-resizer
         resources:
           limits:


### PR DESCRIPTION
**Component**:

'salt', 'deployment', 'monitoring'

**Context**: 

addon_resizer update `kube-state-metrics` deployment to resize the `kube-state-metrics` container according to the size fo the cluster, in version 1.0 due to a bug (https://github.com/kubernetes/autoscaler/issues/188) tolerations get removed.

**Summary**:

Upgrade addon_resizer to 1.8.3 to fix this issue

**Acceptance criteria**: 

Deployment `kube-state-metrics` tolerations not get removed

---

Fixes: #1201