### PR TITLE
Supply workload plane IP for prometheus node in `config.json`

### DIFF
--- a/salt/metalk8s/orchestrate/bootstrap/init.sls
+++ b/salt/metalk8s/orchestrate/bootstrap/init.sls
@@ -9,6 +9,16 @@
     )[pillar.bootstrap_id]['ret']
 %}
 
+{%- set bootstrap_workload_plane_ip = salt.saltutil.cmd(
+        tgt=pillar.bootstrap_id,
+        fun='grains.get',
+        kwarg={
+            'key': 'metalk8s:workload_plane_ip',
+        },
+    )[pillar.bootstrap_id]['ret']
+%}
+
+
 {%- if 'metalk8s' in pillar
         and 'nodes' in pillar.metalk8s
         and pillar.bootstrap_id in pillar.metalk8s.nodes
@@ -40,7 +50,7 @@
                     },
                 },
                 'prometheus': {
-                    'ip': bootstrap_control_plane_ip,
+                    'ip': bootstrap_workload_plane_ip,
                     'ports': {
                         'node_port': 30222
                     }


### PR DESCRIPTION
Issue: #1296

**Component**: monitoring

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

We supply the control-plane IP to the bootstrap state, which has the effect of creating a `config.json` with the wrong IP for the UI (we want workload plane).

**Summary**:

* Get workload plane IP from the pillar just like we get the control plane IP. 
* Pass this one to the `pillar_data`

**Acceptance criteria**: 

After a deployment, the UI has an alert list (so its Prometheus URL is correctly passed).


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1206 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
