### PR TITLE
Deploy node exporter daemonset on all nodes (not only infra)

### DIFF
--- a/salt/metalk8s/addons/monitoring/node-exporter/upstream.sls
+++ b/salt/metalk8s/addons/monitoring/node-exporter/upstream.sls
@@ -106,7 +106,6 @@ spec:
       hostPID: true
       nodeSelector:
         beta.kubernetes.io/os: linux
-        node-role.kubernetes.io/infra: ''
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
@@ -116,6 +115,12 @@ spec:
         operator: "Exists"
         effect: "NoSchedule"
       - key: "node-role.kubernetes.io/infra"
+        operator: "Exists"
+        effect: "NoSchedule"
+      - key: "node-role.kubernetes.io/etcd"
+        operator: "Exists"
+        effect: "NoSchedule"
+      - key: "node-role.kubernetes.io/master"
         operator: "Exists"
         effect: "NoSchedule"
       volumes:


### PR DESCRIPTION
**Component**:

'salt', 'kubernetes', 'monitoring'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

Node exporter daemonset not scheduled on all nodes.

**Summary**:

A node selector is in the deployment to only select "infra" nodes. Remove this node selector

**Acceptance criteria**: 

Have all nodes in grafana dashboard

---

Fixes: #1203
