### PR TITLE
doc: fix links to inexistent resources

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -7,7 +7,7 @@ labels: bug,moonshot
 
 <!-- Please use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks!
 
-If the matter is security related, please disclose it privately to security@scality.com
+If the matter is security related, please disclose it privately to moonshot-platform@scality.com
 -->
 
 **Component**:

--- a/README.md
+++ b/README.md
@@ -44,5 +44,5 @@ tox -e tests
 
 MetalK8s version 1 is still maintained in this repository. See the 
 `development/1.*` branches, e. g.
-[MetalK8s 1.3](github.com/scality/metalk8s/tree/development/1.3) in the same
+[MetalK8s 1.3](https://github.com/scality/metalk8s/tree/development/1.3) in the same
 repository.


### PR DESCRIPTION
**Component**: documentation

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: Broken links in readme and bug template.

**Summary**:

* correct link for Metal 1.X branches
* e-mail address for security vulnerability disclosure becomes moonshot-platform

**Acceptance criteria**: 

Working links.


---

<!-- Declare one or more issues to close once this PR gets merged -->

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
