### PR TITLE
Generate upstream monitoring manifests according to the version we use

### DIFF
--- a/salt/metalk8s/addons/monitoring/alertmanager/upstream.sls
+++ b/salt/metalk8s/addons/monitoring/alertmanager/upstream.sls
@@ -3,44 +3,27 @@
 {%- from "metalk8s/repo/macro.sls" import build_image_name with context %}
 
 # The content below has been generated from
-# https://github.com/coreos/prometheus-operator, v0.24.0 tag,
+# https://github.com/coreos/prometheus-operator, v0.28.0 tag,
 # with the following command:
 #   hack/concat-kubernetes-manifests.sh $(find contrib/kube-prometheus/manifests/ \
-#     -name "alertmanager-*.yaml") > deployed.sls
+#     -name "alertmanager-*.yaml") > upstream.sls
 # In the following, only container image registries have been replaced.
 
 ---
 apiVersion: v1
 data:
-  alertmanager.yaml: Z2xvYmFsOgogIHJlc29sdmVfdGltZW91dDogNW0Kcm91dGU6CiAgZ3JvdXBfYnk6IFsnam9iJ10KICBncm91cF93YWl0OiAzMHMKICBncm91cF9pbnRlcnZhbDogNW0KICByZXBlYXRfaW50ZXJ2YWw6IDEyaAogIHJlY2VpdmVyOiAnbnVsbCcKICByb3V0ZXM6CiAgLSBtYXRjaDoKICAgICAgYWxlcnRuYW1lOiBEZWFkTWFuc1N3aXRjaAogICAgcmVjZWl2ZXI6ICdudWxsJwpyZWNlaXZlcnM6Ci0gbmFtZTogJ251bGwnCg==
+  alertmanager.yaml: Imdsb2JhbCI6IAogICJyZXNvbHZlX3RpbWVvdXQiOiAiNW0iCiJyZWNlaXZlcnMiOiAKLSAibmFtZSI6ICJudWxsIgoicm91dGUiOiAKICAiZ3JvdXBfYnkiOiAKICAtICJqb2IiCiAgImdyb3VwX2ludGVydmFsIjogIjVtIgogICJncm91cF93YWl0IjogIjMwcyIKICAicmVjZWl2ZXIiOiAibnVsbCIKICAicmVwZWF0X2ludGVydmFsIjogIjEyaCIKICAicm91dGVzIjogCiAgLSAibWF0Y2giOiAKICAgICAgImFsZXJ0bmFtZSI6ICJEZWFkTWFuc1N3aXRjaCIKICAgICJyZWNlaXZlciI6ICJudWxsIg==
 kind: Secret
 metadata:
   name: alertmanager-main
   namespace: monitoring
 type: Opaque
 ---
-apiVersion: monitoring.coreos.com/v1
-kind: Alertmanager
+apiVersion: v1
+kind: ServiceAccount
 metadata:
-  labels:
-    alertmanager: main
-  name: main
+  name: alertmanager-main
   namespace: monitoring
-spec:
-  baseImage: {{ build_image_name('alertmanager') }}
-  nodeSelector:
-    beta.kubernetes.io/os: linux
-    node-role.kubernetes.io/infra: ''
-  replicas: 3
-  serviceAccountName: alertmanager-main
-  version: v0.15.2
-  tolerations:
-  - key: "node-role.kubernetes.io/bootstrap"
-    operator: "Exists"
-    effect: "NoSchedule"
-  - key: "node-role.kubernetes.io/infra"
-    operator: "Exists"
-    effect: "NoSchedule"
 ---
 apiVersion: v1
 kind: Service
@@ -58,11 +41,32 @@ spec:
     alertmanager: main
     app: alertmanager
 ---
-apiVersion: v1
-kind: ServiceAccount
+apiVersion: monitoring.coreos.com/v1
+kind: Alertmanager
 metadata:
-  name: alertmanager-main
+  labels:
+    alertmanager: main
+  name: main
   namespace: monitoring
+spec:
+  baseImage: {{ build_image_name('alertmanager') }}
+  nodeSelector:
+    beta.kubernetes.io/os: linux
+    node-role.kubernetes.io/infra: ''
+  replicas: 3
+  securityContext:
+    fsGroup: 2000
+    runAsNonRoot: true
+    runAsUser: 1000
+  serviceAccountName: alertmanager-main
+  version: v0.16.0
+  tolerations:
+  - key: "node-role.kubernetes.io/bootstrap"
+    operator: "Exists"
+    effect: "NoSchedule"
+  - key: "node-role.kubernetes.io/infra"
+    operator: "Exists"
+    effect: "NoSchedule"
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/salt/metalk8s/addons/monitoring/grafana/upstream.sls
+++ b/salt/metalk8s/addons/monitoring/grafana/upstream.sls
@@ -3,10 +3,10 @@
 {%- from "metalk8s/repo/macro.sls" import build_image_name with context %}
 
 # The content below has been generated from
-# https://github.com/coreos/prometheus-operator, v0.24.0 tag,
+# https://github.com/coreos/prometheus-operator, v0.28.0 tag,
 # with the following command:
 #   hack/concat-kubernetes-manifests.sh $(find contrib/kube-prometheus/manifests/ \
-#     -name "grafana-*.yaml") > deployed.sls
+#     -name "grafana-*.yaml") > upstream.sls
 # In the following, only container image registries have been replaced.
 
 ---
@@ -20,10 +20,163 @@ metadata:
 type: Opaque
 ---
 apiVersion: v1
-kind: ServiceAccount
+data:
+  dashboards.yaml: |-
+    {
+        "apiVersion": 1,
+        "providers": [
+            {
+                "folder": "",
+                "name": "0",
+                "options": {
+                    "path": "/grafana-dashboard-definitions/0"
+                },
+                "orgId": 1,
+                "type": "file"
+            }
+        ]
+    }
+kind: ConfigMap
 metadata:
+  name: grafana-dashboards
+  namespace: monitoring
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  labels:
+    app: grafana
   name: grafana
   namespace: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+      - image: {{ build_image_name('grafana', '5.2.4') }}
+        name: grafana
+        ports:
+        - containerPort: 3000
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /api/health
+            port: http
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        volumeMounts:
+        - mountPath: /var/lib/grafana
+          name: grafana-storage
+          readOnly: false
+        - mountPath: /etc/grafana/provisioning/datasources
+          name: grafana-datasources
+          readOnly: false
+        - mountPath: /etc/grafana/provisioning/dashboards
+          name: grafana-dashboards
+          readOnly: false
+        - mountPath: /grafana-dashboard-definitions/0/k8s-cluster-rsrc-use
+          name: grafana-dashboard-k8s-cluster-rsrc-use
+          readOnly: false
+        - mountPath: /grafana-dashboard-definitions/0/k8s-node-rsrc-use
+          name: grafana-dashboard-k8s-node-rsrc-use
+          readOnly: false
+        - mountPath: /grafana-dashboard-definitions/0/k8s-resources-cluster
+          name: grafana-dashboard-k8s-resources-cluster
+          readOnly: false
+        - mountPath: /grafana-dashboard-definitions/0/k8s-resources-namespace
+          name: grafana-dashboard-k8s-resources-namespace
+          readOnly: false
+        - mountPath: /grafana-dashboard-definitions/0/k8s-resources-pod
+          name: grafana-dashboard-k8s-resources-pod
+          readOnly: false
+        - mountPath: /grafana-dashboard-definitions/0/nodes
+          name: grafana-dashboard-nodes
+          readOnly: false
+        - mountPath: /grafana-dashboard-definitions/0/persistentvolumesusage
+          name: grafana-dashboard-persistentvolumesusage
+          readOnly: false
+        - mountPath: /grafana-dashboard-definitions/0/pods
+          name: grafana-dashboard-pods
+          readOnly: false
+        - mountPath: /grafana-dashboard-definitions/0/statefulset
+          name: grafana-dashboard-statefulset
+          readOnly: false
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+        node-role.kubernetes.io/infra: ''
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      serviceAccountName: grafana
+      volumes:
+      - emptyDir: {}
+        name: grafana-storage
+      - name: grafana-datasources
+        secret:
+          secretName: grafana-datasources
+      - configMap:
+          name: grafana-dashboards
+        name: grafana-dashboards
+      - configMap:
+          name: grafana-dashboard-k8s-cluster-rsrc-use
+        name: grafana-dashboard-k8s-cluster-rsrc-use
+      - configMap:
+          name: grafana-dashboard-k8s-node-rsrc-use
+        name: grafana-dashboard-k8s-node-rsrc-use
+      - configMap:
+          name: grafana-dashboard-k8s-resources-cluster
+        name: grafana-dashboard-k8s-resources-cluster
+      - configMap:
+          name: grafana-dashboard-k8s-resources-namespace
+        name: grafana-dashboard-k8s-resources-namespace
+      - configMap:
+          name: grafana-dashboard-k8s-resources-pod
+        name: grafana-dashboard-k8s-resources-pod
+      - configMap:
+          name: grafana-dashboard-nodes
+        name: grafana-dashboard-nodes
+      - configMap:
+          name: grafana-dashboard-persistentvolumesusage
+        name: grafana-dashboard-persistentvolumesusage
+      - configMap:
+          name: grafana-dashboard-pods
+        name: grafana-dashboard-pods
+      - configMap:
+          name: grafana-dashboard-statefulset
+        name: grafana-dashboard-statefulset
+      tolerations:
+      - key: "node-role.kubernetes.io/bootstrap"
+        operator: "Exists"
+        effect: "NoSchedule"
+      - key: "node-role.kubernetes.io/infra"
+        operator: "Exists"
+        effect: "NoSchedule"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: grafana
+  name: grafana
+  namespace: monitoring
+spec:
+  ports:
+  - name: http
+    port: 3000
+    targetPort: http
+  selector:
+    app: grafana
 ---
 {%- raw %}
 apiVersion: v1
@@ -824,7 +977,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "sum(max(node_filesystem_size{fstype=\u007e\"ext[234]|btrfs|xfs|zfs\"} - node_filesystem_avail{fstype=\u007e\"ext[234]|btrfs|xfs|zfs\"}) by (device,pod,namespace)) by (pod,namespace)\n/ scalar(sum(max(node_filesystem_size{fstype=\u007e\"ext[234]|btrfs|xfs|zfs\"}) by (device,pod,namespace)))\n* on (namespace, pod) group_left (node) node_namespace_pod:kube_pod_info:\n",
+                                  "expr": "sum(max(node_filesystem_size_bytes{fstype=\u007e\"ext[234]|btrfs|xfs|zfs\"} - node_filesystem_avail_bytes{fstype=\u007e\"ext[234]|btrfs|xfs|zfs\"}) by (device,pod,namespace)) by (pod,namespace)\n/ scalar(sum(max(node_filesystem_size_bytes{fstype=\u007e\"ext[234]|btrfs|xfs|zfs\"}) by (device,pod,namespace)))\n* on (namespace, pod) group_left (node) node_namespace_pod:kube_pod_info:\n",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{node}}",
@@ -1948,7 +2101,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "1 - avg(rate(node_cpu{mode=\"idle\"}[1m]))",
+                                  "expr": "1 - avg(rate(node_cpu_seconds_total{mode=\"idle\"}[1m]))",
                                   "format": "time_series",
                                   "instant": true,
                                   "intervalFactor": 2,
@@ -2200,7 +2353,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "1 - sum(:node_memory_MemFreeCachedBuffers:sum) / sum(:node_memory_MemTotal:sum)",
+                                  "expr": "1 - sum(:node_memory_MemFreeCachedBuffers_bytes:sum) / sum(:node_memory_MemTotal_bytes:sum)",
                                   "format": "time_series",
                                   "instant": true,
                                   "intervalFactor": 2,
@@ -2284,7 +2437,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "sum(kube_pod_container_resource_requests_memory_bytes) / sum(:node_memory_MemTotal:sum)",
+                                  "expr": "sum(kube_pod_container_resource_requests_memory_bytes) / sum(:node_memory_MemTotal_bytes:sum)",
                                   "format": "time_series",
                                   "instant": true,
                                   "intervalFactor": 2,
@@ -2368,7 +2521,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "sum(kube_pod_container_resource_limits_memory_bytes) / sum(:node_memory_MemTotal:sum)",
+                                  "expr": "sum(kube_pod_container_resource_limits_memory_bytes) / sum(:node_memory_MemTotal_bytes:sum)",
                                   "format": "time_series",
                                   "instant": true,
                                   "intervalFactor": 2,
@@ -4924,6 +5077,12 @@ items:
   data:
     nodes.json: |-
       {
+          "__inputs": [
+
+          ],
+          "__requires": [
+
+          ],
           "annotations": {
               "list": [
 
@@ -5031,7 +5190,7 @@ items:
                           },
                           "yaxes": [
                               {
-                                  "format": "percentunit",
+                                  "format": "short",
                                   "label": null,
                                   "logBase": 1,
                                   "max": null,
@@ -5039,7 +5198,7 @@ items:
                                   "show": true
                               },
                               {
-                                  "format": "percentunit",
+                                  "format": "short",
                                   "label": null,
                                   "logBase": 1,
                                   "max": null,
@@ -5092,7 +5251,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "avg by (cpu) (irate(node_cpu{job=\"node-exporter\", mode!=\"idle\", instance=\"$instance\"}[5m])) * 100",
+                                  "expr": "sum by (cpu) (irate(node_cpu_seconds_total{job=\"node-exporter\", mode!=\"idle\", instance=\"$instance\"}[5m]))",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{cpu}}",
@@ -5104,7 +5263,7 @@ items:
                           ],
                           "timeFrom": null,
                           "timeShift": null,
-                          "title": "System load",
+                          "title": "Usage Per Core",
                           "tooltip": {
                               "shared": true,
                               "sort": 0,
@@ -5196,7 +5355,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "avg (sum by (cpu) (irate(node_cpu{job=\"node-exporter\", mode!=\"idle\", instance=\"$instance\"}[2m])) ) * 100\n",
+                                  "expr": "max (sum by (cpu) (irate(node_cpu_seconds_total{job=\"node-exporter\", mode!=\"idle\", instance=\"$instance\"}[2m])) ) * 100\n",
                                   "format": "time_series",
                                   "intervalFactor": 10,
                                   "legendFormat": "{{ cpu }}",
@@ -5304,10 +5463,11 @@ items:
                           "tableColumn": "",
                           "targets": [
                               {
-                                  "expr": "avg(sum by (cpu) (irate(node_cpu{job=\"node-exporter\", mode!=\"idle\", instance=\"$instance\"}[2m]))) * 100\n",
+                                  "expr": "avg(sum by (cpu) (irate(node_cpu_seconds_total{job=\"node-exporter\", mode!=\"idle\", instance=\"$instance\"}[2m]))) * 100\n",
                                   "format": "time_series",
                                   "intervalFactor": 2,
-                                  "legendFormat": ""
+                                  "legendFormat": "",
+                                  "refId": "A"
                               }
                           ],
                           "thresholds": "80, 90",
@@ -5380,28 +5540,28 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "max(\n  node_memory_MemTotal{job=\"node-exporter\", instance=\"$instance\"}\n  - node_memory_MemFree{job=\"node-exporter\", instance=\"$instance\"}\n  - node_memory_Buffers{job=\"node-exporter\", instance=\"$instance\"}\n  - node_memory_Cached{job=\"node-exporter\", instance=\"$instance\"}\n)\n",
+                                  "expr": "max(\n  node_memory_MemTotal_bytes{job=\"node-exporter\", instance=\"$instance\"}\n  - node_memory_MemFree_bytes{job=\"node-exporter\", instance=\"$instance\"}\n  - node_memory_Buffers_bytes{job=\"node-exporter\", instance=\"$instance\"}\n  - node_memory_Cached_bytes{job=\"node-exporter\", instance=\"$instance\"}\n)\n",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "memory used",
                                   "refId": "A"
                               },
                               {
-                                  "expr": "max(node_memory_Buffers{job=\"node-exporter\", instance=\"$instance\"})",
+                                  "expr": "max(node_memory_Buffers_bytes{job=\"node-exporter\", instance=\"$instance\"})",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "memory buffers",
                                   "refId": "B"
                               },
                               {
-                                  "expr": "max(node_memory_Cached{job=\"node-exporter\", instance=\"$instance\"})",
+                                  "expr": "max(node_memory_Cached_bytes{job=\"node-exporter\", instance=\"$instance\"})",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "memory cached",
                                   "refId": "C"
                               },
                               {
-                                  "expr": "max(node_memory_MemFree{job=\"node-exporter\", instance=\"$instance\"})",
+                                  "expr": "max(node_memory_MemFree_bytes{job=\"node-exporter\", instance=\"$instance\"})",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "memory free",
@@ -5509,10 +5669,11 @@ items:
                           "tableColumn": "",
                           "targets": [
                               {
-                                  "expr": "max(\n  (\n    (\n      node_memory_MemTotal{job=\"node-exporter\", instance=\"$instance\"}\n    - node_memory_MemFree{job=\"node-exporter\", instance=\"$instance\"}\n    - node_memory_Buffers{job=\"node-exporter\", instance=\"$instance\"}\n    - node_memory_Cached{job=\"node-exporter\", instance=\"$instance\"}\n    )\n    / node_memory_MemTotal{job=\"node-exporter\", instance=\"$instance\"}\n  ) * 100)\n",
+                                  "expr": "max(\n  (\n    (\n      node_memory_MemTotal_bytes{job=\"node-exporter\", instance=\"$instance\"}\n    - node_memory_MemFree_bytes{job=\"node-exporter\", instance=\"$instance\"}\n    - node_memory_Buffers_bytes{job=\"node-exporter\", instance=\"$instance\"}\n    - node_memory_Cached_bytes{job=\"node-exporter\", instance=\"$instance\"}\n    )\n    / node_memory_MemTotal_bytes{job=\"node-exporter\", instance=\"$instance\"}\n  ) * 100)\n",
                                   "format": "time_series",
                                   "intervalFactor": 2,
-                                  "legendFormat": ""
+                                  "legendFormat": "",
+                                  "refId": "A"
                               }
                           ],
                           "thresholds": "80, 90",
@@ -5592,21 +5753,21 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "max(rate(node_disk_bytes_read{job=\"node-exporter\", instance=\"$instance\"}[2m]))",
+                                  "expr": "max(rate(node_disk_read_bytes_total{job=\"node-exporter\", instance=\"$instance\"}[2m]))",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "read",
                                   "refId": "A"
                               },
                               {
-                                  "expr": "max(rate(node_disk_bytes_written{job=\"node-exporter\", instance=\"$instance\"}[2m]))",
+                                  "expr": "max(rate(node_disk_written_bytes_total{job=\"node-exporter\", instance=\"$instance\"}[2m]))",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "written",
                                   "refId": "B"
                               },
                               {
-                                  "expr": "max(rate(node_disk_io_time_ms{job=\"node-exporter\",  instance=\"$instance\"}[2m]))",
+                                  "expr": "max(rate(node_disk_io_time_seconds_total{job=\"node-exporter\",  instance=\"$instance\"}[2m]))",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "io time",
@@ -5801,7 +5962,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "max(rate(node_network_receive_bytes{job=\"node-exporter\", instance=\"$instance\", device!\u007e\"lo\"}[5m]))",
+                                  "expr": "max(rate(node_network_receive_bytes_total{job=\"node-exporter\", instance=\"$instance\", device!\u007e\"lo\"}[5m]))",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{device}}",
@@ -5892,7 +6053,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "max(rate(node_network_transmit_bytes{job=\"node-exporter\", instance=\"$instance\", device!\u007e\"lo\"}[5m]))",
+                                  "expr": "max(rate(node_network_transmit_bytes_total{job=\"node-exporter\", instance=\"$instance\", device!\u007e\"lo\"}[5m]))",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{device}}",
@@ -5947,6 +6108,198 @@ items:
                   "title": "Dashboard Row",
                   "titleSize": "h6",
                   "type": "row"
+              },
+              {
+                  "collapse": false,
+                  "collapsed": false,
+                  "panels": [
+                      {
+                          "aliasColors": {
+
+                          },
+                          "bars": false,
+                          "dashLength": 10,
+                          "dashes": false,
+                          "datasource": "$datasource",
+                          "fill": 1,
+                          "gridPos": {
+
+                          },
+                          "id": 12,
+                          "legend": {
+                              "alignAsTable": false,
+                              "avg": false,
+                              "current": false,
+                              "max": false,
+                              "min": false,
+                              "rightSide": false,
+                              "show": true,
+                              "total": false,
+                              "values": false
+                          },
+                          "lines": true,
+                          "linewidth": 1,
+                          "links": [
+
+                          ],
+                          "nullPointMode": "null",
+                          "percentage": false,
+                          "pointradius": 5,
+                          "points": false,
+                          "renderer": "flot",
+                          "repeat": null,
+                          "seriesOverrides": [
+
+                          ],
+                          "spaceLength": 10,
+                          "span": 9,
+                          "stack": false,
+                          "steppedLine": false,
+                          "targets": [
+                              {
+                                  "expr": "max(\n  node_filesystem_files{job=\"node-exporter\", instance=\"$instance\"}\n  - node_filesystem_files_free{job=\"node-exporter\", instance=\"$instance\"}\n)\n",
+                                  "format": "time_series",
+                                  "intervalFactor": 2,
+                                  "legendFormat": "inodes used",
+                                  "refId": "A"
+                              },
+                              {
+                                  "expr": "max(node_filesystem_files_free{job=\"node-exporter\", instance=\"$instance\"})",
+                                  "format": "time_series",
+                                  "intervalFactor": 2,
+                                  "legendFormat": "inodes free",
+                                  "refId": "B"
+                              }
+                          ],
+                          "thresholds": [
+
+                          ],
+                          "timeFrom": null,
+                          "timeShift": null,
+                          "title": "Inodes Usage",
+                          "tooltip": {
+                              "shared": true,
+                              "sort": 0,
+                              "value_type": "individual"
+                          },
+                          "type": "graph",
+                          "xaxis": {
+                              "buckets": null,
+                              "mode": "time",
+                              "name": null,
+                              "show": true,
+                              "values": [
+
+                              ]
+                          },
+                          "yaxes": [
+                              {
+                                  "format": "short",
+                                  "label": null,
+                                  "logBase": 1,
+                                  "max": null,
+                                  "min": null,
+                                  "show": true
+                              },
+                              {
+                                  "format": "short",
+                                  "label": null,
+                                  "logBase": 1,
+                                  "max": null,
+                                  "min": null,
+                                  "show": true
+                              }
+                          ]
+                      },
+                      {
+                          "cacheTimeout": null,
+                          "colorBackground": false,
+                          "colorValue": false,
+                          "colors": [
+                              "rgba(50, 172, 45, 0.97)",
+                              "rgba(237, 129, 40, 0.89)",
+                              "rgba(245, 54, 54, 0.9)"
+                          ],
+                          "datasource": "$datasource",
+                          "format": "percent",
+                          "gauge": {
+                              "maxValue": 100,
+                              "minValue": 0,
+                              "show": true,
+                              "thresholdLabels": false,
+                              "thresholdMarkers": true
+                          },
+                          "gridPos": {
+
+                          },
+                          "id": 13,
+                          "interval": null,
+                          "links": [
+
+                          ],
+                          "mappingType": 1,
+                          "mappingTypes": [
+                              {
+                                  "name": "value to text",
+                                  "value": 1
+                              },
+                              {
+                                  "name": "range to text",
+                                  "value": 2
+                              }
+                          ],
+                          "maxDataPoints": 100,
+                          "nullPointMode": "connected",
+                          "nullText": null,
+                          "postfix": "",
+                          "postfixFontSize": "50%",
+                          "prefix": "",
+                          "prefixFontSize": "50%",
+                          "rangeMaps": [
+                              {
+                                  "from": "null",
+                                  "text": "N/A",
+                                  "to": "null"
+                              }
+                          ],
+                          "span": 3,
+                          "sparkline": {
+                              "fillColor": "rgba(31, 118, 189, 0.18)",
+                              "full": false,
+                              "lineColor": "rgb(31, 120, 193)",
+                              "show": false
+                          },
+                          "tableColumn": "",
+                          "targets": [
+                              {
+                                  "expr": "max(\n  (\n    (\n      node_filesystem_files{job=\"node-exporter\", instance=\"$instance\"}\n    - node_filesystem_files_free{job=\"node-exporter\", instance=\"$instance\"}\n    )\n    / node_filesystem_files{job=\"node-exporter\", instance=\"$instance\"}\n  ) * 100)\n",
+                                  "format": "time_series",
+                                  "intervalFactor": 2,
+                                  "legendFormat": "",
+                                  "refId": "A"
+                              }
+                          ],
+                          "thresholds": "80, 90",
+                          "title": "Inodes Usage",
+                          "type": "singlestat",
+                          "valueFontSize": "80%",
+                          "valueMaps": [
+                              {
+                                  "op": "=",
+                                  "text": "N/A",
+                                  "value": "null"
+                              }
+                          ],
+                          "valueName": "current"
+                      }
+                  ],
+                  "repeat": null,
+                  "repeatIteration": null,
+                  "repeatRowId": null,
+                  "showTitle": false,
+                  "title": "Dashboard Row",
+                  "titleSize": "h6",
+                  "type": "row"
               }
           ],
           "schemaVersion": 14,
@@ -5986,7 +6339,7 @@ items:
                       "options": [
 
                       ],
-                      "query": "label_values(node_boot_time{job=\"node-exporter\"}, instance)",
+                      "query": "label_values(node_boot_time_seconds{job=\"node-exporter\"}, instance)",
                       "refresh": 2,
                       "regex": "",
                       "sort": 0,
@@ -6040,8 +6393,363 @@ items:
     namespace: monitoring
 - apiVersion: v1
   data:
+    persistentvolumesusage.json: |-
+      {
+          "__inputs": [
+
+          ],
+          "__requires": [
+
+          ],
+          "annotations": {
+              "list": [
+
+              ]
+          },
+          "editable": false,
+          "gnetId": null,
+          "graphTooltip": 0,
+          "hideControls": false,
+          "id": null,
+          "links": [
+
+          ],
+          "refresh": "",
+          "rows": [
+              {
+                  "collapse": false,
+                  "collapsed": false,
+                  "panels": [
+                      {
+                          "aliasColors": {
+
+                          },
+                          "bars": false,
+                          "dashLength": 10,
+                          "dashes": false,
+                          "datasource": "$datasource",
+                          "fill": 1,
+                          "gridPos": {
+
+                          },
+                          "id": 2,
+                          "legend": {
+                              "alignAsTable": false,
+                              "avg": true,
+                              "current": true,
+                              "max": true,
+                              "min": true,
+                              "rightSide": false,
+                              "show": true,
+                              "total": false,
+                              "values": true
+                          },
+                          "lines": true,
+                          "linewidth": 1,
+                          "links": [
+
+                          ],
+                          "nullPointMode": "null",
+                          "percentage": false,
+                          "pointradius": 5,
+                          "points": false,
+                          "renderer": "flot",
+                          "repeat": null,
+                          "seriesOverrides": [
+
+                          ],
+                          "spaceLength": 10,
+                          "span": 12,
+                          "stack": false,
+                          "steppedLine": false,
+                          "targets": [
+                              {
+                                  "expr": "(kubelet_volume_stats_capacity_bytes{job=\"kubelet\", persistentvolumeclaim=\"$volume\"} - kubelet_volume_stats_available_bytes{job=\"kubelet\", persistentvolumeclaim=\"$volume\"}) / kubelet_volume_stats_capacity_bytes{job=\"kubelet\", persistentvolumeclaim=\"$volume\"} * 100\n",
+                                  "format": "time_series",
+                                  "intervalFactor": 1,
+                                  "legendFormat": "{{ Usage }}",
+                                  "refId": "A"
+                              }
+                          ],
+                          "thresholds": [
+
+                          ],
+                          "timeFrom": null,
+                          "timeShift": null,
+                          "title": "Volume Space Usage",
+                          "tooltip": {
+                              "shared": true,
+                              "sort": 0,
+                              "value_type": "individual"
+                          },
+                          "type": "graph",
+                          "xaxis": {
+                              "buckets": null,
+                              "mode": "time",
+                              "name": null,
+                              "show": true,
+                              "values": [
+
+                              ]
+                          },
+                          "yaxes": [
+                              {
+                                  "format": "percent",
+                                  "label": null,
+                                  "logBase": 1,
+                                  "max": 100,
+                                  "min": 0,
+                                  "show": true
+                              },
+                              {
+                                  "format": "percent",
+                                  "label": null,
+                                  "logBase": 1,
+                                  "max": 100,
+                                  "min": 0,
+                                  "show": true
+                              }
+                          ]
+                      }
+                  ],
+                  "repeat": null,
+                  "repeatIteration": null,
+                  "repeatRowId": null,
+                  "showTitle": false,
+                  "title": "Dashboard Row",
+                  "titleSize": "h6",
+                  "type": "row"
+              },
+              {
+                  "collapse": false,
+                  "collapsed": false,
+                  "panels": [
+                      {
+                          "aliasColors": {
+
+                          },
+                          "bars": false,
+                          "dashLength": 10,
+                          "dashes": false,
+                          "datasource": "$datasource",
+                          "fill": 1,
+                          "gridPos": {
+
+                          },
+                          "id": 3,
+                          "legend": {
+                              "alignAsTable": false,
+                              "avg": true,
+                              "current": true,
+                              "max": true,
+                              "min": true,
+                              "rightSide": false,
+                              "show": true,
+                              "total": false,
+                              "values": true
+                          },
+                          "lines": true,
+                          "linewidth": 1,
+                          "links": [
+
+                          ],
+                          "nullPointMode": "null",
+                          "percentage": false,
+                          "pointradius": 5,
+                          "points": false,
+                          "renderer": "flot",
+                          "repeat": null,
+                          "seriesOverrides": [
+
+                          ],
+                          "spaceLength": 10,
+                          "span": 12,
+                          "stack": false,
+                          "steppedLine": false,
+                          "targets": [
+                              {
+                                  "expr": "kubelet_volume_stats_inodes_used{job=\"kubelet\", persistentvolumeclaim=\"$volume\"} / kubelet_volume_stats_inodes{job=\"kubelet\", persistentvolumeclaim=\"$volume\"} * 100\n",
+                                  "format": "time_series",
+                                  "intervalFactor": 1,
+                                  "legendFormat": "{{ Usage }}",
+                                  "refId": "A"
+                              }
+                          ],
+                          "thresholds": [
+
+                          ],
+                          "timeFrom": null,
+                          "timeShift": null,
+                          "title": "Volume inodes Usage",
+                          "tooltip": {
+                              "shared": true,
+                              "sort": 0,
+                              "value_type": "individual"
+                          },
+                          "type": "graph",
+                          "xaxis": {
+                              "buckets": null,
+                              "mode": "time",
+                              "name": null,
+                              "show": true,
+                              "values": [
+
+                              ]
+                          },
+                          "yaxes": [
+                              {
+                                  "format": "percent",
+                                  "label": null,
+                                  "logBase": 1,
+                                  "max": 100,
+                                  "min": 0,
+                                  "show": true
+                              },
+                              {
+                                  "format": "percent",
+                                  "label": null,
+                                  "logBase": 1,
+                                  "max": 100,
+                                  "min": 0,
+                                  "show": true
+                              }
+                          ]
+                      }
+                  ],
+                  "repeat": null,
+                  "repeatIteration": null,
+                  "repeatRowId": null,
+                  "showTitle": false,
+                  "title": "Dashboard Row",
+                  "titleSize": "h6",
+                  "type": "row"
+              }
+          ],
+          "schemaVersion": 14,
+          "style": "dark",
+          "tags": [
+
+          ],
+          "templating": {
+              "list": [
+                  {
+                      "current": {
+                          "text": "Prometheus",
+                          "value": "Prometheus"
+                      },
+                      "hide": 0,
+                      "label": null,
+                      "name": "datasource",
+                      "options": [
+
+                      ],
+                      "query": "prometheus",
+                      "refresh": 1,
+                      "regex": "",
+                      "type": "datasource"
+                  },
+                  {
+                      "allValue": null,
+                      "current": {
+
+                      },
+                      "datasource": "$datasource",
+                      "hide": 0,
+                      "includeAll": false,
+                      "label": "Namespace",
+                      "multi": false,
+                      "name": "namespace",
+                      "options": [
+
+                      ],
+                      "query": "label_values(kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}, exported_namespace)",
+                      "refresh": 2,
+                      "regex": "",
+                      "sort": 0,
+                      "tagValuesQuery": "",
+                      "tags": [
+
+                      ],
+                      "tagsQuery": "",
+                      "type": "query",
+                      "useTags": false
+                  },
+                  {
+                      "allValue": null,
+                      "current": {
+
+                      },
+                      "datasource": "$datasource",
+                      "hide": 0,
+                      "includeAll": false,
+                      "label": "PersistentVolumeClaim",
+                      "multi": false,
+                      "name": "volume",
+                      "options": [
+
+                      ],
+                      "query": "label_values(kubelet_volume_stats_capacity_bytes{job=\"kubelet\", exported_namespace=\"$namespace\"}, persistentvolumeclaim)",
+                      "refresh": 2,
+                      "regex": "",
+                      "sort": 0,
+                      "tagValuesQuery": "",
+                      "tags": [
+
+                      ],
+                      "tagsQuery": "",
+                      "type": "query",
+                      "useTags": false
+                  }
+              ]
+          },
+          "time": {
+              "from": "now-7d",
+              "to": "now"
+          },
+          "timepicker": {
+              "refresh_intervals": [
+                  "5s",
+                  "10s",
+                  "30s",
+                  "1m",
+                  "5m",
+                  "15m",
+                  "30m",
+                  "1h",
+                  "2h",
+                  "1d"
+              ],
+              "time_options": [
+                  "5m",
+                  "15m",
+                  "1h",
+                  "6h",
+                  "12h",
+                  "24h",
+                  "2d",
+                  "7d",
+                  "30d"
+              ]
+          },
+          "timezone": "",
+          "title": "Persistent Volumes",
+          "uid": "919b92a8e8041bd567af9edab12c840c",
+          "version": 0
+      }
+  kind: ConfigMap
+  metadata:
+    name: grafana-dashboard-persistentvolumesusage
+    namespace: monitoring
+- apiVersion: v1
+  data:
     pods.json: |-
       {
+          "__inputs": [
+
+          ],
+          "__requires": [
+
+          ],
           "annotations": {
               "list": [
 
@@ -6221,7 +6929,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "sum by (container_name) (rate(container_cpu_usage_seconds_total{job=\"kubelet\", image!=\"\",container_name!=\"POD\",pod_name=\"$pod\"}[1m]))",
+                                  "expr": "sum by (container_name) (rate(container_cpu_usage_seconds_total{job=\"kubelet\", namespace=\"$namespace\", image!=\"\",container_name!=\"POD\",pod_name=\"$pod\"}[1m]))",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{ container_name }}",
@@ -6324,7 +7032,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "sort_desc(sum by (pod_name) (rate(container_network_receive_bytes_total{job=\"kubelet\", pod_name=\"$pod\"}[1m])))",
+                                  "expr": "sort_desc(sum by (pod_name) (rate(container_network_receive_bytes_total{job=\"kubelet\", namespace=\"$namespace\", pod_name=\"$pod\"}[1m])))",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{ pod_name }}",
@@ -6526,6 +7234,12 @@ items:
   data:
     statefulset.json: |-
       {
+          "__inputs": [
+
+          ],
+          "__requires": [
+
+          ],
           "annotations": {
               "list": [
 
@@ -6608,7 +7322,8 @@ items:
                                   "expr": "sum(rate(container_cpu_usage_seconds_total{job=\"kubelet\", namespace=\"$namespace\", pod_name=\u007e\"$statefulset.*\"}[3m]))",
                                   "format": "time_series",
                                   "intervalFactor": 2,
-                                  "legendFormat": ""
+                                  "legendFormat": "",
+                                  "refId": "A"
                               }
                           ],
                           "thresholds": "",
@@ -6687,7 +7402,8 @@ items:
                                   "expr": "sum(container_memory_usage_bytes{job=\"kubelet\", namespace=\"$namespace\", pod_name=\u007e\"$statefulset.*\"}) / 1024^3",
                                   "format": "time_series",
                                   "intervalFactor": 2,
-                                  "legendFormat": ""
+                                  "legendFormat": "",
+                                  "refId": "A"
                               }
                           ],
                           "thresholds": "",
@@ -6766,7 +7482,8 @@ items:
                                   "expr": "sum(rate(container_network_transmit_bytes_total{job=\"kubelet\", namespace=\"$namespace\", pod_name=\u007e\"$statefulset.*\"}[3m])) + sum(rate(container_network_receive_bytes_total{namespace=\"$namespace\",pod_name=\u007e\"$statefulset.*\"}[3m]))",
                                   "format": "time_series",
                                   "intervalFactor": 2,
-                                  "legendFormat": ""
+                                  "legendFormat": "",
+                                  "refId": "A"
                               }
                           ],
                           "thresholds": "",
@@ -6860,7 +7577,8 @@ items:
                                   "expr": "max(kube_statefulset_replicas{job=\"kube-state-metrics\", namespace=\"$namespace\", statefulset=\"$statefulset\"}) without (instance, pod)",
                                   "format": "time_series",
                                   "intervalFactor": 2,
-                                  "legendFormat": ""
+                                  "legendFormat": "",
+                                  "refId": "A"
                               }
                           ],
                           "thresholds": "",
@@ -6940,7 +7658,8 @@ items:
                                   "expr": "min(kube_statefulset_status_replicas_current{job=\"kube-state-metrics\", namespace=\"$namespace\", statefulset=\"$statefulset\"}) without (instance, pod)",
                                   "format": "time_series",
                                   "intervalFactor": 2,
-                                  "legendFormat": ""
+                                  "legendFormat": "",
+                                  "refId": "A"
                               }
                           ],
                           "thresholds": "",
@@ -7020,7 +7739,8 @@ items:
                                   "expr": "max(kube_statefulset_status_observed_generation{job=\"kube-state-metrics\",  namespace=\"$namespace\", statefulset=\"$statefulset\"}) without (instance, pod)",
                                   "format": "time_series",
                                   "intervalFactor": 2,
-                                  "legendFormat": ""
+                                  "legendFormat": "",
+                                  "refId": "A"
                               }
                           ],
                           "thresholds": "",
@@ -7100,7 +7820,8 @@ items:
                                   "expr": "max(kube_statefulset_metadata_generation{job=\"kube-state-metrics\", statefulset=\"$statefulset\", namespace=\"$namespace\"}) without (instance, pod)",
                                   "format": "time_series",
                                   "intervalFactor": 2,
-                                  "legendFormat": ""
+                                  "legendFormat": "",
+                                  "refId": "A"
                               }
                           ],
                           "thresholds": "",
@@ -7375,148 +8096,21 @@ items:
 kind: ConfigMapList
 {%- endraw %}
 ---
-apiVersion: apps/v1beta2
-kind: Deployment
+apiVersion: v1
+kind: ServiceAccount
 metadata:
-  labels:
-    app: grafana
+  name: grafana
+  namespace: monitoring
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
   name: grafana
   namespace: monitoring
 spec:
-  replicas: 1
+  endpoints:
+  - interval: 15s
+    port: http
   selector:
     matchLabels:
       app: grafana
-  template:
-    metadata:
-      labels:
-        app: grafana
-    spec:
-      containers:
-      - image: {{ build_image_name('grafana', '5.2.4') }}
-        name: grafana
-        ports:
-        - containerPort: 3000
-          name: http
-        resources:
-          limits:
-            cpu: 200m
-            memory: 200Mi
-          requests:
-            cpu: 100m
-            memory: 100Mi
-        volumeMounts:
-        - mountPath: /var/lib/grafana
-          name: grafana-storage
-          readOnly: false
-        - mountPath: /etc/grafana/provisioning/datasources
-          name: grafana-datasources
-          readOnly: false
-        - mountPath: /etc/grafana/provisioning/dashboards
-          name: grafana-dashboards
-          readOnly: false
-        - mountPath: /grafana-dashboard-definitions/0/k8s-cluster-rsrc-use
-          name: grafana-dashboard-k8s-cluster-rsrc-use
-          readOnly: false
-        - mountPath: /grafana-dashboard-definitions/0/k8s-node-rsrc-use
-          name: grafana-dashboard-k8s-node-rsrc-use
-          readOnly: false
-        - mountPath: /grafana-dashboard-definitions/0/k8s-resources-cluster
-          name: grafana-dashboard-k8s-resources-cluster
-          readOnly: false
-        - mountPath: /grafana-dashboard-definitions/0/k8s-resources-namespace
-          name: grafana-dashboard-k8s-resources-namespace
-          readOnly: false
-        - mountPath: /grafana-dashboard-definitions/0/k8s-resources-pod
-          name: grafana-dashboard-k8s-resources-pod
-          readOnly: false
-        - mountPath: /grafana-dashboard-definitions/0/nodes
-          name: grafana-dashboard-nodes
-          readOnly: false
-        - mountPath: /grafana-dashboard-definitions/0/pods
-          name: grafana-dashboard-pods
-          readOnly: false
-        - mountPath: /grafana-dashboard-definitions/0/statefulset
-          name: grafana-dashboard-statefulset
-          readOnly: false
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534
-      serviceAccountName: grafana
-      volumes:
-      - emptyDir: {}
-        name: grafana-storage
-      - name: grafana-datasources
-        secret:
-          secretName: grafana-datasources
-      - configMap:
-          name: grafana-dashboards
-        name: grafana-dashboards
-      - configMap:
-          name: grafana-dashboard-k8s-cluster-rsrc-use
-        name: grafana-dashboard-k8s-cluster-rsrc-use
-      - configMap:
-          name: grafana-dashboard-k8s-node-rsrc-use
-        name: grafana-dashboard-k8s-node-rsrc-use
-      - configMap:
-          name: grafana-dashboard-k8s-resources-cluster
-        name: grafana-dashboard-k8s-resources-cluster
-      - configMap:
-          name: grafana-dashboard-k8s-resources-namespace
-        name: grafana-dashboard-k8s-resources-namespace
-      - configMap:
-          name: grafana-dashboard-k8s-resources-pod
-        name: grafana-dashboard-k8s-resources-pod
-      - configMap:
-          name: grafana-dashboard-nodes
-        name: grafana-dashboard-nodes
-      - configMap:
-          name: grafana-dashboard-pods
-        name: grafana-dashboard-pods
-      - configMap:
-          name: grafana-dashboard-statefulset
-        name: grafana-dashboard-statefulset
-      tolerations:
-      - key: "node-role.kubernetes.io/bootstrap"
-        operator: "Exists"
-        effect: "NoSchedule"
-      - key: "node-role.kubernetes.io/infra"
-        operator: "Exists"
-        effect: "NoSchedule"
-      nodeSelector:
-        node-role.kubernetes.io/infra: ''
----
-apiVersion: v1
-data:
-  dashboards.yaml: |-
-    {
-        "apiVersion": 1,
-        "providers": [
-            {
-                "folder": "",
-                "name": "0",
-                "options": {
-                    "path": "/grafana-dashboard-definitions/0"
-                },
-                "orgId": 1,
-                "type": "file"
-            }
-        ]
-    }
-kind: ConfigMap
-metadata:
-  name: grafana-dashboards
-  namespace: monitoring
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: grafana
-  namespace: monitoring
-spec:
-  ports:
-  - name: http
-    port: 3000
-    targetPort: http
-  selector:
-    app: grafana

--- a/salt/metalk8s/addons/monitoring/node-exporter/upstream.sls
+++ b/salt/metalk8s/addons/monitoring/node-exporter/upstream.sls
@@ -3,10 +3,10 @@
 {%- from "metalk8s/repo/macro.sls" import build_image_name with context %}
 
 # The content below has been generated from
-# https://github.com/coreos/prometheus-operator, v0.24.0 tag,
+# https://github.com/coreos/prometheus-operator, v0.28.0 tag,
 # with the following command:
 #   hack/concat-kubernetes-manifests.sh $(find contrib/kube-prometheus/manifests/ \
-#     -name "node-exporter-*.yaml") > deployed.sls
+#     -name "node-exporter-*.yaml") > upstream.sls
 # In the following, only container image registries have been replaced.
 
 ---
@@ -29,6 +29,22 @@ spec:
   selector:
     matchLabels:
       k8s-app: node-exporter
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: node-exporter
+  name: node-exporter
+  namespace: monitoring
+spec:
+  clusterIP: None
+  ports:
+  - name: https
+    port: 9100
+    targetPort: https
+  selector:
+    app: node-exporter
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -61,16 +77,17 @@ spec:
     spec:
       containers:
       - args:
-        - --web.listen-address=127.0.0.1:9101
+        - --web.listen-address=127.0.0.1:9100
         - --path.procfs=/host/proc
         - --path.sysfs=/host/sys
+        - --path.rootfs=/host/root
         - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
         - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
         image: {{ build_image_name('node-exporter', 'v0.17.0') }}
         name: node-exporter
         resources:
           limits:
-            cpu: 102m
+            cpu: 250m
             memory: 180Mi
           requests:
             cpu: 102m
@@ -87,9 +104,16 @@ spec:
           name: root
           readOnly: true
       - args:
-        - --secure-listen-address=:9100
-        - --upstream=http://127.0.0.1:9101/
-        image: {{ build_image_name('kube-rbac-proxy', 'v0.3.1') }}
+        - --logtostderr
+        - --secure-listen-address=$(IP):9100
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+        - --upstream=http://127.0.0.1:9100/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: {{ build_image_name('kube-rbac-proxy', 'v0.4.1') }}
         name: kube-rbac-proxy
         ports:
         - containerPort: 9100
@@ -134,6 +158,12 @@ spec:
           path: /
         name: root
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-exporter
+  namespace: monitoring
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -151,25 +181,3 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: node-exporter
-  namespace: monitoring
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    k8s-app: node-exporter
-  name: node-exporter
-  namespace: monitoring
-spec:
-  clusterIP: None
-  ports:
-  - name: https
-    port: 9100
-    targetPort: https
-  selector:
-    app: node-exporter

--- a/salt/metalk8s/addons/monitoring/prometheus-operator/upstream.sls
+++ b/salt/metalk8s/addons/monitoring/prometheus-operator/upstream.sls
@@ -3,10 +3,10 @@
 {%- from "metalk8s/repo/macro.sls" import build_image_name with context %}
 
 # The content below has been generated from
-# https://github.com/coreos/prometheus-operator, v0.24.0 tag,
+# https://github.com/coreos/prometheus-operator, v0.28.0 tag,
 # with the following command:
 #   hack/concat-kubernetes-manifests.sh $(find contrib/kube-prometheus/manifests/ \
-#     -name "0*.yaml" | sort) > deployed.sls
+#     -name "0*.yaml" | sort) > upstream.sls
 # In the following, only container image registries have been replaced.
 
 ---
@@ -43,6 +43,12 @@ spec:
           description: 'AlertmanagerSpec is a specification of the desired behavior
             of the Alertmanager cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
           properties:
+            additionalPeers:
+              description: AdditionalPeers allows injecting a set of additional Alertmanagers
+                to peer with to form a highly available cluster.
+              items:
+                type: string
+              type: array
             affinity:
               description: Affinity is a group of affinity scheduling rules.
               properties:
@@ -604,6 +610,13 @@ spec:
             baseImage:
               description: Base image that is used to deploy pods, without tag.
               type: string
+            configMaps:
+              description: ConfigMaps is a list of ConfigMaps in the same namespace
+                as the Alertmanager object, which shall be mounted into the Alertmanager
+                Pods. The ConfigMaps are mounted into /etc/alertmanager/configmaps/<configmap-name>.
+              items:
+                type: string
+              type: array
             containers:
               description: Containers allows injecting additional containers. This
                 is meant to allow adding an authentication proxy to an Alertmanager
@@ -1068,8 +1081,8 @@ spec:
                             to by services.
                           type: string
                         protocol:
-                          description: Protocol for port. Must be UDP or TCP. Defaults
-                            to "TCP".
+                          description: Protocol for port. Must be UDP, TCP, or SCTP.
+                            Defaults to "TCP".
                           type: string
                       required:
                       - containerPort
@@ -1222,6 +1235,13 @@ spec:
                           privileged containers are essentially equivalent to root
                           on the host. Defaults to false.
                         type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
                       readOnlyRootFilesystem:
                         description: Whether this container has a read-only root filesystem.
                           Default is false.
@@ -1344,8 +1364,8 @@ spec:
                         mountPropagation:
                           description: mountPropagation determines how mounts are
                             propagated from the host to container and the other way
-                            around. When not set, MountPropagationHostToContainer
-                            is used. This field is beta in 1.10.
+                            around. When not set, MountPropagationNone is used. This
+                            field is beta in 1.10.
                           type: string
                         name:
                           description: This must match the Name of a Volume.
@@ -1374,6 +1394,12 @@ spec:
               description: The external URL the Alertmanager instances will be available
                 under. This is necessary to generate correct URLs. This is necessary
                 if Alertmanager is not served from root of a DNS name.
+              type: string
+            image:
+              description: Image if specified has precedence over baseImage, tag and
+                sha combinations. Specifying the version is still necessary to ensure
+                the Prometheus Operator knows what version of Alertmanager is being
+                configured.
               type: string
             imagePullSecrets:
               description: An optional list of references to secrets in the same namespace
@@ -1580,11 +1606,12 @@ spec:
                                 the server has more data available. The value is opaque
                                 and may be used to issue another request to the endpoint
                                 that served this list to retrieve the next set of
-                                available objects. Continuing a list may not be possible
-                                if the server configuration has changed or more than
-                                a few minutes have passed. The resourceVersion field
-                                returned when using this continue value will be identical
-                                to the value in the first response.
+                                available objects. Continuing a consistent list may
+                                not be possible if the server configuration has changed
+                                or more than a few minutes have passed. The resourceVersion
+                                field returned when using this continue value will
+                                be identical to the value in the first response, unless
+                                you have received this token from an error message.
                               type: string
                             resourceVersion:
                               description: 'String that identifies the server''s internal
@@ -1685,6 +1712,9 @@ spec:
 
                     Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
                   type: string
+            priorityClassName:
+              description: Priority class assigned to the Pods
+              type: string
             replicas:
               description: Size is the expected size of the alertmanager cluster.
                 The controller will eventually make the size of the running cluster
@@ -1706,7 +1736,8 @@ spec:
                   type: object
             retention:
               description: Time duration Alertmanager shall retain data for. Default
-                is '120h'.
+                is '120h', and must match the regular expression `[0-9]+(ms|s|m|h)`
+                (milliseconds seconds minutes hours).
               type: string
             routePrefix:
               description: The route prefix Alertmanager registers HTTP handlers for.
@@ -1810,15 +1841,18 @@ spec:
               description: ServiceAccountName is the name of the ServiceAccount to
                 use to run the Prometheus Pods.
               type: string
+            sha:
+              description: SHA of Alertmanager container image to be deployed. Defaults
+                to the value of `version`. Similar to a tag, but the SHA explicitly
+                deploys an immutable container image. Version and Tag are ignored
+                if SHA is set.
+              type: string
             storage:
               description: StorageSpec defines the configured storage for a group
-                Prometheus servers.
+                Prometheus servers. If neither `emptyDir` nor `volumeClaimTemplate`
+                is specified, then by default an [EmptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir)
+                will be used.
               properties:
-                class:
-                  description: 'Name of the StorageClass to use when requesting storage
-                    provisioning. More info: https://kubernetes.io/docs/user-guide/persistent-volumes/#storageclasses
-                    DEPRECATED'
-                  type: string
                 emptyDir:
                   description: Represents an empty directory for a pod. Empty directory
                     volumes support ownership management and SELinux relabeling.
@@ -1829,63 +1863,6 @@ spec:
                         Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                       type: string
                     sizeLimit: {}
-                resources:
-                  description: ResourceRequirements describes the compute resource
-                    requirements.
-                  properties:
-                    limits:
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                selector:
-                  description: A label selector is a label query over a set of resources.
-                    The result of matchLabels and matchExpressions are ANDed. An empty
-                    label selector matches all objects. A null label selector matches
-                    no objects.
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
-                      items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies
-                              to.
-                            type: string
-                          operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
-                            type: string
-                          values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - key
-                        - operator
-                      type: array
-                    matchLabels:
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
-                      type: object
                 volumeClaimTemplate:
                   description: PersistentVolumeClaim is a user's request for and claim
                     to a persistent volume
@@ -2092,12 +2069,14 @@ spec:
                                         available. The value is opaque and may be
                                         used to issue another request to the endpoint
                                         that served this list to retrieve the next
-                                        set of available objects. Continuing a list
-                                        may not be possible if the server configuration
+                                        set of available objects. Continuing a consistent
+                                        list may not be possible if the server configuration
                                         has changed or more than a few minutes have
                                         passed. The resourceVersion field returned
                                         when using this continue value will be identical
-                                        to the value in the first response.
+                                        to the value in the first response, unless
+                                        you have received this token from an error
+                                        message.
                                       type: string
                                     resourceVersion:
                                       description: 'String that identifies the server''s
@@ -2215,6 +2194,26 @@ spec:
                           items:
                             type: string
                           type: array
+                        dataSource:
+                          description: TypedLocalObjectReference contains enough information
+                            to let you locate the typed referenced object inside the
+                            same namespace.
+                          properties:
+                            apiGroup:
+                              description: APIGroup is the group for the resource
+                                being referenced. If APIGroup is not specified, the
+                                specified Kind must be in the core API group. For
+                                any other third-party types, APIGroup is required.
+                              type: string
+                            kind:
+                              description: Kind is the type of resource being referenced
+                              type: string
+                            name:
+                              description: Name is the name of resource being referenced
+                              type: string
+                          required:
+                          - kind
+                          - name
                         resources:
                           description: ResourceRequirements describes the compute
                             resource requirements.
@@ -2348,7 +2347,7 @@ spec:
                           type: string
             tag:
               description: Tag of Alertmanager container image to be deployed. Defaults
-                to the value of `version`.
+                to the value of `version`. Version is ignored if Tag is set.
               type: string
             tolerations:
               description: If specified, the pod's tolerations.
@@ -2458,6 +2457,21 @@ spec:
             of the Prometheus cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
           properties:
             additionalAlertManagerConfigs:
+              description: SecretKeySelector selects a key of a Secret.
+              properties:
+                key:
+                  description: The key of the secret to select from.  Must be a valid
+                    secret key.
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                optional:
+                  description: Specify whether the Secret or it's key must be defined
+                  type: boolean
+              required:
+              - key
+            additionalAlertRelabelConfigs:
               description: SecretKeySelector selects a key of a Secret.
               properties:
                 key:
@@ -3175,6 +3189,13 @@ spec:
             baseImage:
               description: Base image to use for a Prometheus deployment.
               type: string
+            configMaps:
+              description: ConfigMaps is a list of ConfigMaps in the same namespace
+                as the Prometheus object, which shall be mounted into the Prometheus
+                Pods. The ConfigMaps are mounted into /etc/prometheus/configmaps/<configmap-name>.
+              items:
+                type: string
+              type: array
             containers:
               description: Containers allows injecting additional containers. This
                 is meant to allow adding an authentication proxy to a Prometheus pod.
@@ -3638,8 +3659,8 @@ spec:
                             to by services.
                           type: string
                         protocol:
-                          description: Protocol for port. Must be UDP or TCP. Defaults
-                            to "TCP".
+                          description: Protocol for port. Must be UDP, TCP, or SCTP.
+                            Defaults to "TCP".
                           type: string
                       required:
                       - containerPort
@@ -3792,6 +3813,13 @@ spec:
                           privileged containers are essentially equivalent to root
                           on the host. Defaults to false.
                         type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
                       readOnlyRootFilesystem:
                         description: Whether this container has a read-only root filesystem.
                           Default is false.
@@ -3914,8 +3942,8 @@ spec:
                         mountPropagation:
                           description: mountPropagation determines how mounts are
                             propagated from the host to container and the other way
-                            around. When not set, MountPropagationHostToContainer
-                            is used. This field is beta in 1.10.
+                            around. When not set, MountPropagationNone is used. This
+                            field is beta in 1.10.
                           type: string
                         name:
                           description: This must match the Name of a Volume.
@@ -3951,6 +3979,12 @@ spec:
               description: The external URL the Prometheus instances will be available
                 under. This is necessary to generate correct URLs. This is necessary
                 if Prometheus is not served from root of a DNS name.
+              type: string
+            image:
+              description: Image if specified has precedence over baseImage, tag and
+                sha combinations. Specifying the version is still necessary to ensure
+                the Prometheus Operator knows what version of Prometheus is being
+                configured.
               type: string
             imagePullSecrets:
               description: An optional list of references to secrets in the same namespace
@@ -4156,11 +4190,12 @@ spec:
                                 the server has more data available. The value is opaque
                                 and may be used to issue another request to the endpoint
                                 that served this list to retrieve the next set of
-                                available objects. Continuing a list may not be possible
-                                if the server configuration has changed or more than
-                                a few minutes have passed. The resourceVersion field
-                                returned when using this continue value will be identical
-                                to the value in the first response.
+                                available objects. Continuing a consistent list may
+                                not be possible if the server configuration has changed
+                                or more than a few minutes have passed. The resourceVersion
+                                field returned when using this continue value will
+                                be identical to the value in the first response, unless
+                                you have received this token from an error message.
                               type: string
                             resourceVersion:
                               description: 'String that identifies the server''s internal
@@ -4260,6 +4295,24 @@ spec:
                     UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
 
                     Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                  type: string
+            priorityClassName:
+              description: Priority class assigned to the Pods
+              type: string
+            query:
+              description: QuerySpec defines the query command line flags when starting
+                Prometheus.
+              properties:
+                lookbackDelta:
+                  description: The delta difference allowed for retrieving metrics
+                    during expression evaluations.
+                  type: string
+                maxConcurrency:
+                  description: Number of concurrent queries that can be run at once.
+                  format: int32
+                  type: integer
+                timeout:
+                  description: Maximum time a query may take before being aborted.
                   type: string
             remoteRead:
               description: If specified, the remote_read spec. This is an experimental
@@ -4526,7 +4579,8 @@ spec:
                   type: object
             retention:
               description: Time duration Prometheus shall retain data for. Default
-                is '24h'.
+                is '24h', and must match the regular expression `[0-9]+(ms|s|m|h|d|w|y)`
+                (milliseconds seconds minutes hours days weeks years).
               type: string
             routePrefix:
               description: The route prefix Prometheus registers HTTP handlers for.
@@ -4626,10 +4680,6 @@ spec:
               description: Secrets is a list of Secrets in the same namespace as the
                 Prometheus object, which shall be mounted into the Prometheus Pods.
                 The Secrets are mounted into /etc/prometheus/secrets/<secret-name>.
-                Secrets changes after initial creation of a Prometheus object are
-                not reflected in the running Pods. To change the secrets mounted into
-                the Prometheus Pods, the object must be deleted and recreated with
-                the new list of secrets.
               items:
                 type: string
               type: array
@@ -4805,15 +4855,18 @@ spec:
                     "In", and the values array contains only "value". The requirements
                     are ANDed.
                   type: object
+            sha:
+              description: SHA of Prometheus container image to be deployed. Defaults
+                to the value of `version`. Similar to a tag, but the SHA explicitly
+                deploys an immutable container image. Version and Tag are ignored
+                if SHA is set.
+              type: string
             storage:
               description: StorageSpec defines the configured storage for a group
-                Prometheus servers.
+                Prometheus servers. If neither `emptyDir` nor `volumeClaimTemplate`
+                is specified, then by default an [EmptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir)
+                will be used.
               properties:
-                class:
-                  description: 'Name of the StorageClass to use when requesting storage
-                    provisioning. More info: https://kubernetes.io/docs/user-guide/persistent-volumes/#storageclasses
-                    DEPRECATED'
-                  type: string
                 emptyDir:
                   description: Represents an empty directory for a pod. Empty directory
                     volumes support ownership management and SELinux relabeling.
@@ -4824,63 +4877,6 @@ spec:
                         Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                       type: string
                     sizeLimit: {}
-                resources:
-                  description: ResourceRequirements describes the compute resource
-                    requirements.
-                  properties:
-                    limits:
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                selector:
-                  description: A label selector is a label query over a set of resources.
-                    The result of matchLabels and matchExpressions are ANDed. An empty
-                    label selector matches all objects. A null label selector matches
-                    no objects.
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
-                      items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies
-                              to.
-                            type: string
-                          operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
-                            type: string
-                          values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - key
-                        - operator
-                      type: array
-                    matchLabels:
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
-                      type: object
                 volumeClaimTemplate:
                   description: PersistentVolumeClaim is a user's request for and claim
                     to a persistent volume
@@ -5087,12 +5083,14 @@ spec:
                                         available. The value is opaque and may be
                                         used to issue another request to the endpoint
                                         that served this list to retrieve the next
-                                        set of available objects. Continuing a list
-                                        may not be possible if the server configuration
+                                        set of available objects. Continuing a consistent
+                                        list may not be possible if the server configuration
                                         has changed or more than a few minutes have
                                         passed. The resourceVersion field returned
                                         when using this continue value will be identical
-                                        to the value in the first response.
+                                        to the value in the first response, unless
+                                        you have received this token from an error
+                                        message.
                                       type: string
                                     resourceVersion:
                                       description: 'String that identifies the server''s
@@ -5210,6 +5208,26 @@ spec:
                           items:
                             type: string
                           type: array
+                        dataSource:
+                          description: TypedLocalObjectReference contains enough information
+                            to let you locate the typed referenced object inside the
+                            same namespace.
+                          properties:
+                            apiGroup:
+                              description: APIGroup is the group for the resource
+                                being referenced. If APIGroup is not specified, the
+                                specified Kind must be in the core API group. For
+                                any other third-party types, APIGroup is required.
+                              type: string
+                            kind:
+                              description: Kind is the type of resource being referenced
+                              type: string
+                            name:
+                              description: Name is the name of resource being referenced
+                              type: string
+                          required:
+                          - kind
+                          - name
                         resources:
                           description: ResourceRequirements describes the compute
                             resource requirements.
@@ -5343,7 +5361,7 @@ spec:
                           type: string
             tag:
               description: Tag of Prometheus container image to be deployed. Defaults
-                to the value of `version`.
+                to the value of `version`. Version is ignored if Tag is set.
               type: string
             thanos:
               description: ThanosSpec defines parameters for a Prometheus server within
@@ -5376,6 +5394,12 @@ spec:
                           type: boolean
                       required:
                       - key
+                image:
+                  description: Image if specified has precedence over baseImage, tag
+                    and sha combinations. Specifying the version is still necessary
+                    to ensure the Prometheus Operator knows what version of Thanos
+                    is being configured.
+                  type: string
                 peers:
                   description: Peers is a DNS name for Thanos to discover peers through.
                   type: string
@@ -5446,9 +5470,16 @@ spec:
                       description: Whether to use S3 Signature Version 2; otherwise
                         Signature Version 4 will be used.
                       type: boolean
+                sha:
+                  description: SHA of Thanos container image to be deployed. Defaults
+                    to the value of `version`. Similar to a tag, but the SHA explicitly
+                    deploys an immutable container image. Version and Tag are ignored
+                    if SHA is set.
+                  type: string
                 tag:
                   description: Tag of Thanos sidecar container image to be deployed.
-                    Defaults to the value of `version`.
+                    Defaults to the value of `version`. Version is ignored if Tag
+                    is set.
                   type: string
                 version:
                   description: Version describes the version of Thanos to use.
@@ -5730,11 +5761,12 @@ spec:
                             server has more data available. The value is opaque and
                             may be used to issue another request to the endpoint that
                             served this list to retrieve the next set of available
-                            objects. Continuing a list may not be possible if the
-                            server configuration has changed or more than a few minutes
-                            have passed. The resourceVersion field returned when using
-                            this continue value will be identical to the value in
-                            the first response.
+                            objects. Continuing a consistent list may not be possible
+                            if the server configuration has changed or more than a
+                            few minutes have passed. The resourceVersion field returned
+                            when using this continue value will be identical to the
+                            value in the first response, unless you have received
+                            this token from an error message.
                           type: string
                         resourceVersion:
                           description: 'String that identifies the server''s internal
@@ -5856,7 +5888,9 @@ spec:
                         annotations:
                           type: object
                         expr:
-                          type: string
+                          anyOf:
+                          - type: string
+                          - type: integer
                         for:
                           type: string
                         labels:
@@ -6010,6 +6044,51 @@ spec:
                     description: ProxyURL eg http://proxyserver:2195 Directs scrapes
                       to proxy through this endpoint.
                     type: string
+                  relabelings:
+                    description: 'RelabelConfigs to apply to samples before ingestion.
+                      More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#<relabel_config>'
+                    items:
+                      description: 'RelabelConfig allows dynamic rewriting of the
+                        label set, being applied to samples before ingestion. It defines
+                        `<metric_relabel_configs>`-section of Prometheus configuration.
+                        More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                      properties:
+                        action:
+                          description: Action to perform based on regex matching.
+                            Default is 'replace'
+                          type: string
+                        modulus:
+                          description: Modulus to take of the hash of the source label
+                            values.
+                          format: int64
+                          type: integer
+                        regex:
+                          description: Regular expression against which the extracted
+                            value is matched. defailt is '(.*)'
+                          type: string
+                        replacement:
+                          description: Replacement value against which a regex replace
+                            is performed if the regular expression matches. Regex
+                            capture groups are available. Default is '$1'
+                          type: string
+                        separator:
+                          description: Separator placed between concatenated source
+                            label values. default is ';'.
+                          type: string
+                        sourceLabels:
+                          description: The source labels select values from existing
+                            labels. Their content is concatenated using the configured
+                            separator and matched against the configured regular expression
+                            for the replace, keep, and drop actions.
+                          items:
+                            type: string
+                          type: array
+                        targetLabel:
+                          description: Label to which the resulting value is written
+                            in a replace action. It is mandatory for replace actions.
+                            Regex capture groups are available.
+                          type: string
+                    type: array
                   scheme:
                     description: HTTP scheme to use for scraping.
                     type: string
@@ -6055,6 +6134,17 @@ spec:
                   items:
                     type: string
                   type: array
+            podTargetLabels:
+              description: PodTargetLabels transfers labels on the Kubernetes Pod
+                onto the target.
+              items:
+                type: string
+              type: array
+            sampleLimit:
+              description: SampleLimit defines per-scrape limit on number of scraped
+                samples that will be accepted.
+              format: int64
+              type: integer
             selector:
               description: A label selector is a label query over a set of resources.
                 The result of matchLabels and matchExpressions are ANDed. An empty
@@ -6184,6 +6274,7 @@ rules:
   resources:
   - namespaces
   verbs:
+  - get
   - list
   - watch
 ---
@@ -6209,8 +6300,8 @@ spec:
         - --kubelet-service=kube-system/kubelet
         - --logtostderr=true
         - --config-reloader-image={{ build_image_name('configmap-reload', 'v0.0.1') }}
-        - --prometheus-config-reloader={{ build_image_name('prometheus-config-reloader', 'v0.23.2') }}
-        image: {{ build_image_name('prometheus-operator', 'v0.23.2') }}
+        - --prometheus-config-reloader={{ build_image_name('prometheus-config-reloader', 'v0.27.0') }}
+        image: {{ build_image_name('prometheus-operator', 'v0.27.0') }}
         name: prometheus-operator
         ports:
         - containerPort: 8080

--- a/salt/metalk8s/addons/monitoring/prometheus/upstream.sls
+++ b/salt/metalk8s/addons/monitoring/prometheus/upstream.sls
@@ -3,191 +3,26 @@
 {%- from "metalk8s/repo/macro.sls" import build_image_name with context %}
 
 # The content below has been generated from
-# https://github.com/coreos/prometheus-operator, v0.24.0 tag,
+# https://github.com/coreos/prometheus-operator, v0.28.0 tag,
 # with the following command:
 #   hack/concat-kubernetes-manifests.sh $(find contrib/kube-prometheus/manifests/ \
-#     -name "prometheus-*.yaml") > deployed.sls
+#     -name "prometheus-*.yaml") > upstream.sls
 # In the following, only container image registries have been replaced.
 
 ---
-apiVersion: v1
-kind: ServiceAccount
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
 metadata:
-  name: prometheus-k8s
-  namespace: monitoring
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: prometheus-k8s-config
-  namespace: monitoring
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: prometheus-k8s-config
-subjects:
-- kind: ServiceAccount
-  name: prometheus-k8s
-  namespace: monitoring
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    prometheus: k8s
-  name: prometheus-k8s
-  namespace: monitoring
+  name: v1beta1.metrics.k8s.io
 spec:
-  ports:
-  - name: web
-    port: 9090
-    targetPort: web
-  selector:
-    app: prometheus
-    prometheus: k8s
----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  labels:
-    k8s-app: kube-scheduler
-  name: kube-scheduler
-  namespace: monitoring
-spec:
-  endpoints:
-  - interval: 30s
-    port: http-metrics
-  jobLabel: k8s-app
-  namespaceSelector:
-    matchNames:
-    - kube-system
-  selector:
-    matchLabels:
-      k8s-app: kube-scheduler
----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  labels:
-    k8s-app: prometheus
-  name: prometheus
-  namespace: monitoring
-spec:
-  endpoints:
-  - interval: 30s
-    port: web
-  selector:
-    matchLabels:
-      prometheus: k8s
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: prometheus-k8s
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: prometheus-k8s
-subjects:
-- kind: ServiceAccount
-  name: prometheus-k8s
-  namespace: monitoring
----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  labels:
-    k8s-app: apiserver
-  name: kube-apiserver
-  namespace: monitoring
-spec:
-  endpoints:
-  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    interval: 30s
-    metricRelabelings:
-    - action: drop
-      regex: etcd_(debugging|disk|request|server).*
-      sourceLabels:
-      - __name__
-    port: https
-    scheme: https
-    tlsConfig:
-      caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-      serverName: kubernetes
-  jobLabel: component
-  namespaceSelector:
-    matchNames:
-    - default
-  selector:
-    matchLabels:
-      component: apiserver
-      provider: kubernetes
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: prometheus-k8s-config
-  namespace: monitoring
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
----
-apiVersion: monitoring.coreos.com/v1
-kind: Prometheus
-metadata:
-  labels:
-    prometheus: k8s
-  name: k8s
-  namespace: monitoring
-spec:
-  alerting:
-    alertmanagers:
-    - name: alertmanager-main
-      namespace: monitoring
-      port: web
-  baseImage: {{ build_image_name('prometheus') }}
-  nodeSelector:
-    beta.kubernetes.io/os: linux
-    node-role.kubernetes.io/infra: ''
-  replicas: 2
-  resources:
-    requests:
-      memory: 400Mi
-  ruleSelector:
-    matchLabels:
-      prometheus: k8s
-      role: alert-rules
-  serviceAccountName: prometheus-k8s
-  serviceMonitorNamespaceSelector: {}
-  serviceMonitorSelector: {}
-  version: v2.4.3
-  tolerations:
-  - key: "node-role.kubernetes.io/bootstrap"
-    operator: "Exists"
-    effect: "NoSchedule"
-  - key: "node-role.kubernetes.io/infra"
-    operator: "Exists"
-    effect: "NoSchedule"
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: prometheus-k8s
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes/metrics
-  verbs:
-  - get
-- nonResourceURLs:
-  - /metrics
-  verbs:
-  - get
+  group: metrics.k8s.io
+  groupPriorityMinimum: 100
+  insecureSkipTLSVerify: true
+  service:
+    name: prometheus-adapter
+    namespace: monitoring
+  version: v1beta1
+  versionPriority: 100
 ---
 {%- raw %}
 apiVersion: monitoring.coreos.com/v1
@@ -314,17 +149,17 @@ spec:
       record: 'node_namespace_pod:kube_pod_info:'
     - expr: |
         count by (node) (sum by (node, cpu) (
-          node_cpu{job="node-exporter"}
+          node_cpu_seconds_total{job="node-exporter"}
         * on (namespace, pod) group_left(node)
           node_namespace_pod:kube_pod_info:
         ))
       record: node:node_num_cpu:sum
     - expr: |
-        1 - avg(rate(node_cpu{job="node-exporter",mode="idle"}[1m]))
+        1 - avg(rate(node_cpu_seconds_total{job="node-exporter",mode="idle"}[1m]))
       record: :node_cpu_utilisation:avg1m
     - expr: |
         1 - avg by (node) (
-          rate(node_cpu{job="node-exporter",mode="idle"}[1m])
+          rate(node_cpu_seconds_total{job="node-exporter",mode="idle"}[1m])
         * on (namespace, pod) group_left(node)
           node_namespace_pod:kube_pod_info:)
       record: node:node_cpu_utilisation:avg1m
@@ -344,26 +179,26 @@ spec:
       record: 'node:node_cpu_saturation_load1:'
     - expr: |
         1 -
-        sum(node_memory_MemFree{job="node-exporter"} + node_memory_Cached{job="node-exporter"} + node_memory_Buffers{job="node-exporter"})
+        sum(node_memory_MemFree_bytes{job="node-exporter"} + node_memory_Cached_bytes{job="node-exporter"} + node_memory_Buffers_bytes{job="node-exporter"})
         /
-        sum(node_memory_MemTotal{job="node-exporter"})
+        sum(node_memory_MemTotal_bytes{job="node-exporter"})
       record: ':node_memory_utilisation:'
     - expr: |
-        sum(node_memory_MemFree{job="node-exporter"} + node_memory_Cached{job="node-exporter"} + node_memory_Buffers{job="node-exporter"})
-      record: :node_memory_MemFreeCachedBuffers:sum
+        sum(node_memory_MemFree_bytes{job="node-exporter"} + node_memory_Cached_bytes{job="node-exporter"} + node_memory_Buffers_bytes{job="node-exporter"})
+      record: :node_memory_MemFreeCachedBuffers_bytes:sum
     - expr: |
-        sum(node_memory_MemTotal{job="node-exporter"})
-      record: :node_memory_MemTotal:sum
+        sum(node_memory_MemTotal_bytes{job="node-exporter"})
+      record: :node_memory_MemTotal_bytes:sum
     - expr: |
         sum by (node) (
-          (node_memory_MemFree{job="node-exporter"} + node_memory_Cached{job="node-exporter"} + node_memory_Buffers{job="node-exporter"})
+          (node_memory_MemFree_bytes{job="node-exporter"} + node_memory_Cached_bytes{job="node-exporter"} + node_memory_Buffers_bytes{job="node-exporter"})
           * on (namespace, pod) group_left(node)
             node_namespace_pod:kube_pod_info:
         )
       record: node:node_memory_bytes_available:sum
     - expr: |
         sum by (node) (
-          node_memory_MemTotal{job="node-exporter"}
+          node_memory_MemTotal_bytes{job="node-exporter"}
           * on (namespace, pod) group_left(node)
             node_namespace_pod:kube_pod_info:
         )
@@ -382,13 +217,13 @@ spec:
     - expr: |
         1 -
         sum by (node) (
-          (node_memory_MemFree{job="node-exporter"} + node_memory_Cached{job="node-exporter"} + node_memory_Buffers{job="node-exporter"})
+          (node_memory_MemFree_bytes{job="node-exporter"} + node_memory_Cached_bytes{job="node-exporter"} + node_memory_Buffers_bytes{job="node-exporter"})
         * on (namespace, pod) group_left(node)
           node_namespace_pod:kube_pod_info:
         )
         /
         sum by (node) (
-          node_memory_MemTotal{job="node-exporter"}
+          node_memory_MemTotal_bytes{job="node-exporter"}
         * on (namespace, pod) group_left(node)
           node_namespace_pod:kube_pod_info:
         )
@@ -405,270 +240,100 @@ spec:
         )
       record: node:node_memory_swap_io_bytes:sum_rate
     - expr: |
-        avg(irate(node_disk_io_time_ms{job="node-exporter",device=~"(sd|xvd|nvme).+"}[1m]) / 1e3)
+        avg(irate(node_disk_io_time_seconds_total{job="node-exporter",device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+"}[1m]))
       record: :node_disk_utilisation:avg_irate
     - expr: |
         avg by (node) (
-          irate(node_disk_io_time_ms{job="node-exporter",device=~"(sd|xvd|nvme).+"}[1m]) / 1e3
+          irate(node_disk_io_time_seconds_total{job="node-exporter",device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+"}[1m])
         * on (namespace, pod) group_left(node)
           node_namespace_pod:kube_pod_info:
         )
       record: node:node_disk_utilisation:avg_irate
     - expr: |
-        avg(irate(node_disk_io_time_weighted{job="node-exporter",device=~"(sd|xvd|nvme).+"}[1m]) / 1e3)
+        avg(irate(node_disk_io_time_weighted_seconds_total{job="node-exporter",device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+"}[1m]) / 1e3)
       record: :node_disk_saturation:avg_irate
     - expr: |
         avg by (node) (
-          irate(node_disk_io_time_weighted{job="node-exporter",device=~"(sd|xvd|nvme).+"}[1m]) / 1e3
+          irate(node_disk_io_time_weighted_seconds_total{job="node-exporter",device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+"}[1m]) / 1e3
         * on (namespace, pod) group_left(node)
           node_namespace_pod:kube_pod_info:
         )
       record: node:node_disk_saturation:avg_irate
     - expr: |
-        max by (namespace, pod, device) ((node_filesystem_size{fstype=~"ext[234]|btrfs|xfs|zfs"}
-        - node_filesystem_avail{fstype=~"ext[234]|btrfs|xfs|zfs"})
-        / node_filesystem_size{fstype=~"ext[234]|btrfs|xfs|zfs"})
+        max by (namespace, pod, device) ((node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"}
+        - node_filesystem_avail_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
+        / node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
       record: 'node:node_filesystem_usage:'
     - expr: |
-        max by (namespace, pod, device) (node_filesystem_avail{fstype=~"ext[234]|btrfs|xfs|zfs"} / node_filesystem_size{fstype=~"ext[234]|btrfs|xfs|zfs"})
+        max by (namespace, pod, device) (node_filesystem_avail_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"} / node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
       record: 'node:node_filesystem_avail:'
     - expr: |
-        sum(irate(node_network_receive_bytes{job="node-exporter",device="eth0"}[1m])) +
-        sum(irate(node_network_transmit_bytes{job="node-exporter",device="eth0"}[1m]))
+        sum(irate(node_network_receive_bytes_total{job="node-exporter",device="eth0"}[1m])) +
+        sum(irate(node_network_transmit_bytes_total{job="node-exporter",device="eth0"}[1m]))
       record: :node_net_utilisation:sum_irate
     - expr: |
         sum by (node) (
-          (irate(node_network_receive_bytes{job="node-exporter",device="eth0"}[1m]) +
-          irate(node_network_transmit_bytes{job="node-exporter",device="eth0"}[1m]))
+          (irate(node_network_receive_bytes_total{job="node-exporter",device="eth0"}[1m]) +
+          irate(node_network_transmit_bytes_total{job="node-exporter",device="eth0"}[1m]))
         * on (namespace, pod) group_left(node)
           node_namespace_pod:kube_pod_info:
         )
       record: node:node_net_utilisation:sum_irate
     - expr: |
-        sum(irate(node_network_receive_drop{job="node-exporter",device="eth0"}[1m])) +
-        sum(irate(node_network_transmit_drop{job="node-exporter",device="eth0"}[1m]))
+        sum(irate(node_network_receive_drop_total{job="node-exporter",device="eth0"}[1m])) +
+        sum(irate(node_network_transmit_drop_total{job="node-exporter",device="eth0"}[1m]))
       record: :node_net_saturation:sum_irate
     - expr: |
         sum by (node) (
-          (irate(node_network_receive_drop{job="node-exporter",device="eth0"}[1m]) +
-          irate(node_network_transmit_drop{job="node-exporter",device="eth0"}[1m]))
+          (irate(node_network_receive_drop_total{job="node-exporter",device="eth0"}[1m]) +
+          irate(node_network_transmit_drop_total{job="node-exporter",device="eth0"}[1m]))
         * on (namespace, pod) group_left(node)
           node_namespace_pod:kube_pod_info:
         )
       record: node:node_net_saturation:sum_irate
+    - expr: |
+        max(
+          max(
+            kube_pod_info{job="kube-state-metrics", host_ip!=""}
+          ) by (node, host_ip)
+          * on (host_ip) group_right (node)
+          label_replace(
+            (max(node_filesystem_files{job="node-exporter", mountpoint="/"}) by (instance)), "host_ip", "$1", "instance", "(.*):.*"
+          )
+        ) by (node)
+      record: 'node:node_inodes_total:'
+    - expr: |
+        max(
+          max(
+            kube_pod_info{job="kube-state-metrics", host_ip!=""}
+          ) by (node, host_ip)
+          * on (host_ip) group_right (node)
+          label_replace(
+            (max(node_filesystem_files_free{job="node-exporter", mountpoint="/"}) by (instance)), "host_ip", "$1", "instance", "(.*):.*"
+          )
+        ) by (node)
+      record: 'node:node_inodes_free:'
   - name: kube-prometheus-node-recording.rules
     rules:
-    - expr: sum(rate(node_cpu{mode!="idle",mode!="iowait"}[3m])) BY (instance)
+    - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait"}[3m])) BY
+        (instance)
       record: instance:node_cpu:rate:sum
-    - expr: sum((node_filesystem_size{mountpoint="/"} - node_filesystem_free{mountpoint="/"}))
+    - expr: sum((node_filesystem_size_bytes{mountpoint="/"} - node_filesystem_free_bytes{mountpoint="/"}))
         BY (instance)
       record: instance:node_filesystem_usage:sum
-    - expr: sum(rate(node_network_receive_bytes[3m])) BY (instance)
+    - expr: sum(rate(node_network_receive_bytes_total[3m])) BY (instance)
       record: instance:node_network_receive_bytes:rate:sum
-    - expr: sum(rate(node_network_transmit_bytes[3m])) BY (instance)
+    - expr: sum(rate(node_network_transmit_bytes_total[3m])) BY (instance)
       record: instance:node_network_transmit_bytes:rate:sum
-    - expr: sum(rate(node_cpu{mode!="idle",mode!="iowait"}[5m])) WITHOUT (cpu, mode)
-        / ON(instance) GROUP_LEFT() count(sum(node_cpu) BY (instance, cpu)) BY (instance)
+    - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait"}[5m])) WITHOUT
+        (cpu, mode) / ON(instance) GROUP_LEFT() count(sum(node_cpu_seconds_total)
+        BY (instance, cpu)) BY (instance)
       record: instance:node_cpu:ratio
-    - expr: sum(rate(node_cpu{mode!="idle",mode!="iowait"}[5m]))
+    - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait"}[5m]))
       record: cluster:node_cpu:sum_rate5m
-    - expr: cluster:node_cpu:rate5m / count(sum(node_cpu) BY (instance, cpu))
+    - expr: cluster:node_cpu_seconds_total:rate5m / count(sum(node_cpu_seconds_total)
+        BY (instance, cpu))
       record: cluster:node_cpu:ratio
-  - name: node_exporter-16-bcache
-    rules:
-    - expr: node_bcache_cache_read_races
-      record: node_bcache_cache_read_races_total
-  - name: node_exporter-16-buddyinfo
-    rules:
-    - expr: node_buddyinfo_blocks
-      record: node_buddyinfo_count
-  - name: node_exporter-16-stat
-    rules:
-    - expr: node_boot_time_seconds
-      record: node_boot_time
-    - expr: node_context_switches_total
-      record: node_context_switches
-    - expr: node_forks_total
-      record: node_forks
-    - expr: node_intr_total
-      record: node_intr
-  - name: node_exporter-16-cpu
-    rules:
-    - expr: label_replace(node_cpu_seconds_total, "cpu", "$1", "cpu", "cpu(.+)")
-      record: node_cpu
-  - name: node_exporter-16-diskstats
-    rules:
-    - expr: node_disk_read_bytes_total
-      record: node_disk_bytes_read
-    - expr: node_disk_written_bytes_total
-      record: node_disk_bytes_written
-    - expr: node_disk_io_time_seconds_total * 1000
-      record: node_disk_io_time_ms
-    - expr: node_disk_io_time_weighted_seconds_total
-      record: node_disk_io_time_weighted
-    - expr: node_disk_reads_completed_total
-      record: node_disk_reads_completed
-    - expr: node_disk_reads_merged_total
-      record: node_disk_reads_merged
-    - expr: node_disk_read_time_seconds_total * 1000
-      record: node_disk_read_time_ms
-    - expr: node_disk_writes_completed_total
-      record: node_disk_writes_completed
-    - expr: node_disk_writes_merged_total
-      record: node_disk_writes_merged
-    - expr: node_disk_write_time_seconds_total * 1000
-      record: node_disk_write_time_ms
-  - name: node_exporter-16-filesystem
-    rules:
-    - expr: node_filesystem_free_bytes
-      record: node_filesystem_free
-    - expr: node_filesystem_avail_bytes
-      record: node_filesystem_avail
-    - expr: node_filesystem_size_bytes
-      record: node_filesystem_size
-  - name: node_exporter-16-infiniband
-    rules:
-    - expr: node_infiniband_port_data_received_bytes_total
-      record: node_infiniband_port_data_received_bytes
-    - expr: node_infiniband_port_data_transmitted_bytes_total
-      record: node_infiniband_port_data_transmitted_bytes
-  - name: node_exporter-16-interrupts
-    rules:
-    - expr: node_interrupts_total
-      record: node_interrupts
-  - name: node_exporter-16-memory
-    rules:
-    - expr: node_memory_Active_bytes
-      record: node_memory_Active
-    - expr: node_memory_Active_anon_bytes
-      record: node_memory_Active_anon
-    - expr: node_memory_Active_file_bytes
-      record: node_memory_Active_file
-    - expr: node_memory_AnonHugePages_bytes
-      record: node_memory_AnonHugePages
-    - expr: node_memory_AnonPages_bytes
-      record: node_memory_AnonPages
-    - expr: node_memory_Bounce_bytes
-      record: node_memory_Bounce
-    - expr: node_memory_Buffers_bytes
-      record: node_memory_Buffers
-    - expr: node_memory_Cached_bytes
-      record: node_memory_Cached
-    - expr: node_memory_CommitLimit_bytes
-      record: node_memory_CommitLimit
-    - expr: node_memory_Committed_AS_bytes
-      record: node_memory_Committed_AS
-    - expr: node_memory_DirectMap2M_bytes
-      record: node_memory_DirectMap2M
-    - expr: node_memory_DirectMap4k_bytes
-      record: node_memory_DirectMap4k
-    - expr: node_memory_Dirty_bytes
-      record: node_memory_Dirty
-    - expr: node_memory_HardwareCorrupted_bytes
-      record: node_memory_HardwareCorrupted
-    - expr: node_memory_Hugepagesize_bytes
-      record: node_memory_Hugepagesize
-    - expr: node_memory_Inactive_bytes
-      record: node_memory_Inactive
-    - expr: node_memory_Inactive_anon_bytes
-      record: node_memory_Inactive_anon
-    - expr: node_memory_Inactive_file_bytes
-      record: node_memory_Inactive_file
-    - expr: node_memory_KernelStack_bytes
-      record: node_memory_KernelStack
-    - expr: node_memory_Mapped_bytes
-      record: node_memory_Mapped
-    - expr: node_memory_MemAvailable_bytes
-      record: node_memory_MemAvailable
-    - expr: node_memory_MemFree_bytes
-      record: node_memory_MemFree
-    - expr: node_memory_MemTotal_bytes
-      record: node_memory_MemTotal
-    - expr: node_memory_Mlocked_bytes
-      record: node_memory_Mlocked
-    - expr: node_memory_NFS_Unstable_bytes
-      record: node_memory_NFS_Unstable
-    - expr: node_memory_PageTables_bytes
-      record: node_memory_PageTables
-    - expr: node_memory_Shmem_bytes
-      record: node_memory_Shmem
-    - expr: node_memory_Slab_bytes
-      record: node_memory_Slab
-    - expr: node_memory_SReclaimable_bytes
-      record: node_memory_SReclaimable
-    - expr: node_memory_SUnreclaim_bytes
-      record: node_memory_SUnreclaim
-    - expr: node_memory_SwapCached_bytes
-      record: node_memory_SwapCached
-    - expr: node_memory_SwapFree_bytes
-      record: node_memory_SwapFree
-    - expr: node_memory_SwapTotal_bytes
-      record: node_memory_SwapTotal
-    - expr: node_memory_Unevictable_bytes
-      record: node_memory_Unevictable
-    - expr: node_memory_VmallocChunk_bytes
-      record: node_memory_VmallocChunk
-    - expr: node_memory_VmallocTotal_bytes
-      record: node_memory_VmallocTotal
-    - expr: node_memory_VmallocUsed_bytes
-      record: node_memory_VmallocUsed
-    - expr: node_memory_Writeback_bytes
-      record: node_memory_Writeback
-    - expr: node_memory_WritebackTmp_bytes
-      record: node_memory_WritebackTmp
-  - name: node_exporter-16-network
-    rules:
-    - expr: node_network_receive_bytes_total
-      record: node_network_receive_bytes
-    - expr: node_network_receive_compressed_total
-      record: node_network_receive_compressed
-    - expr: node_network_receive_drop_total
-      record: node_network_receive_drop
-    - expr: node_network_receive_errs_total
-      record: node_network_receive_errs
-    - expr: node_network_receive_fifo_total
-      record: node_network_receive_fifo
-    - expr: node_network_receive_frame_total
-      record: node_network_receive_frame
-    - expr: node_network_receive_multicast_total
-      record: node_network_receive_multicast
-    - expr: node_network_receive_packets_total
-      record: node_network_receive_packets
-    - expr: node_network_transmit_bytes_total
-      record: node_network_transmit_bytes
-    - expr: node_network_transmit_compressed_total
-      record: node_network_transmit_compressed
-    - expr: node_network_transmit_drop_total
-      record: node_network_transmit_drop
-    - expr: node_network_transmit_errs_total
-      record: node_network_transmit_errs
-    - expr: node_network_transmit_fifo_total
-      record: node_network_transmit_fifo
-    - expr: node_network_transmit_frame_total
-      record: node_network_transmit_frame
-    - expr: node_network_transmit_multicast_total
-      record: node_network_transmit_multicast
-    - expr: node_network_transmit_packets_total
-      record: node_network_transmit_packets
-  - name: node_exporter-16-nfs
-    rules:
-    - expr: node_nfs_connections_total
-      record: node_nfs_net_connections
-    - expr: node_nfs_packets_total
-      record: node_nfs_net_reads
-    - expr: label_replace(label_replace(node_nfs_requests_total, "proto", "$1", "version",
-        "(.+)"), "method", "$1", "procedure", "(.+)")
-      record: node_nfs_procedures
-    - expr: node_nfs_rpc_authentication_refreshes_total
-      record: node_nfs_rpc_authentication_refreshes
-    - expr: node_nfs_rpcs_total
-      record: node_nfs_rpc_operations
-    - expr: node_nfs_rpc_retransmissions_total
-      record: node_nfs_rpc_retransmissions
-  - name: node_exporter-16-textfile
-    rules:
-    - expr: node_textfile_mtime_seconds
-      record: node_textfile_mtime
   - name: kubernetes-absent
     rules:
     - alert: AlertmanagerDown
@@ -677,6 +342,15 @@ spec:
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-alertmanagerdown
       expr: |
         absent(up{job="alertmanager-main"} == 1)
+      for: 15m
+      labels:
+        severity: critical
+    - alert: CoreDNSDown
+      annotations:
+        message: CoreDNS has disappeared from Prometheus target discovery.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-corednsdown
+      expr: |
+        absent(up{job="kube-dns"} == 1)
       for: 15m
       labels:
         severity: critical
@@ -880,8 +554,8 @@ spec:
         severity: warning
     - alert: KubeCronJobRunning
       annotations:
-        message: CronJob {{ $labels.namespaces }}/{{ $labels.cronjob }} is taking
-          more than 1h to complete.
+        message: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more
+          than 1h to complete.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecronjobrunning
       expr: |
         time() - kube_cronjob_next_schedule_time{job="kube-state-metrics"} > 3600
@@ -890,8 +564,8 @@ spec:
         severity: warning
     - alert: KubeJobCompletion
       annotations:
-        message: Job {{ $labels.namespaces }}/{{ $labels.job }} is taking more than
-          one hour to complete.
+        message: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more
+          than one hour to complete.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobcompletion
       expr: |
         kube_job_spec_completions{job="kube-state-metrics"} - kube_job_status_succeeded{job="kube-state-metrics"}  > 0
@@ -900,7 +574,7 @@ spec:
         severity: warning
     - alert: KubeJobFailed
       annotations:
-        message: Job {{ $labels.namespaces }}/{{ $labels.job }} failed to complete.
+        message: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed
       expr: |
         kube_job_status_failed{job="kube-state-metrics"}  > 0
@@ -931,7 +605,7 @@ spec:
       expr: |
         sum(namespace_name:kube_pod_container_resource_requests_memory_bytes:sum)
           /
-        sum(node_memory_MemTotal)
+        sum(node_memory_MemTotal_bytes)
           >
         (count(node:node_num_cpu:sum)-1)
           /
@@ -958,7 +632,7 @@ spec:
       expr: |
         sum(kube_resourcequota{job="kube-state-metrics", type="hard", resource="requests.memory"})
           /
-        sum(node_memory_MemTotal{job="node-exporter"})
+        sum(node_memory_MemTotal_bytes{job="node-exporter"})
           > 1.5
       for: 5m
       labels:
@@ -979,10 +653,11 @@ spec:
     - alert: CPUThrottlingHigh
       annotations:
         message: '{{ printf "%0.0f" $value }}% throttling of CPU in namespace {{ $labels.namespace
-          }} for {{ $labels.container_name }}.'
+          }} for container {{ $labels.container_name }} in pod {{ $labels.pod_name
+          }}.'
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-cputhrottlinghigh
-      expr: "100 * sum(increase(container_cpu_cfs_throttled_periods_total[5m])) by
-        (container_name, pod_name, namespace) \n  / \nsum(increase(container_cpu_cfs_periods_total[5m]))
+      expr: "100 * sum(increase(container_cpu_cfs_throttled_periods_total{container_name!=\"\",
+        }[5m])) by (container_name, pod_name, namespace)\n  /\nsum(increase(container_cpu_cfs_periods_total{}[5m]))
         by (container_name, pod_name, namespace)\n  > 25 \n"
       for: 15m
       labels:
@@ -992,7 +667,7 @@ spec:
     - alert: KubePersistentVolumeUsageCritical
       annotations:
         message: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
-          }} in Namespace {{ $labels.namespace }} is only {{ printf "%0.0f" $value
+          }} in Namespace {{ $labels.namespace }} is only {{ printf "%0.2f" $value
           }}% free.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeusagecritical
       expr: |
@@ -1007,16 +682,26 @@ spec:
       annotations:
         message: Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim
           }} in Namespace {{ $labels.namespace }} is expected to fill up within four
-          days. Currently {{ $value }} bytes are available.
+          days. Currently {{ printf "%0.2f" $value }}% is available.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefullinfourdays
       expr: |
-        (
-          kubelet_volume_stats_used_bytes{job="kubelet"}
+        100 * (
+          kubelet_volume_stats_available_bytes{job="kubelet"}
             /
           kubelet_volume_stats_capacity_bytes{job="kubelet"}
-        ) > 0.85
+        ) < 15
         and
         predict_linear(kubelet_volume_stats_available_bytes{job="kubelet"}[6h], 4 * 24 * 3600) < 0
+      for: 5m
+      labels:
+        severity: critical
+    - alert: KubePersistentVolumeErrors
+      annotations:
+        message: The persistent volume {{ $labels.persistentvolume }} has status {{
+          $labels.phase }}.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeerrors
+      expr: |
+        kube_persistentvolume_status_phase{phase=~"Failed|Pending",job="kube-state-metrics"} > 0
       for: 5m
       labels:
         severity: critical
@@ -1047,7 +732,7 @@ spec:
           }}' is experiencing {{ printf "%0.0f" $value }}% errors.'
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeclienterrors
       expr: |
-        (sum(rate(rest_client_requests_total{code!~"2..|404"}[5m])) by (instance, job)
+        (sum(rate(rest_client_requests_total{code=~"5.."}[5m])) by (instance, job)
           /
         sum(rate(rest_client_requests_total[5m])) by (instance, job))
         * 100 > 1
@@ -1118,7 +803,8 @@ spec:
         severity: warning
     - alert: KubeClientCertificateExpiration
       annotations:
-        message: Kubernetes API certificate is expiring in less than 7 days.
+        message: A client certificate used to authenticate to the apiserver is expiring
+          in less than 7 days.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeclientcertificateexpiration
       expr: |
         histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 604800
@@ -1126,7 +812,8 @@ spec:
         severity: warning
     - alert: KubeClientCertificateExpiration
       annotations:
-        message: Kubernetes API certificate is expiring in less than 24 hours.
+        message: A client certificate used to authenticate to the apiserver is expiring
+          in less than 24 hours.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeclientcertificateexpiration
       expr: |
         histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 86400
@@ -1139,7 +826,7 @@ spec:
         message: The configuration of the instances of the Alertmanager cluster `{{$labels.service}}`
           are out of sync.
       expr: |
-        count_values("config_hash", alertmanager_config_hash{job="alertmanager-main"}) BY (service) / ON(service) GROUP_LEFT() label_replace(prometheus_operator_spec_replicas{job="prometheus-operator"}, "service", "alertmanager-$1", "alertmanager", "(.*)") != 1
+        count_values("config_hash", alertmanager_config_hash{job="alertmanager-main"}) BY (service) / ON(service) GROUP_LEFT() label_replace(prometheus_operator_spec_replicas{job="prometheus-operator",controller="alertmanager"}, "service", "alertmanager-$1", "name", "(.*)") != 1
       for: 5m
       labels:
         severity: critical
@@ -1152,6 +839,16 @@ spec:
       for: 10m
       labels:
         severity: warning
+    - alert: AlertmanagerMembersInconsistent
+      annotations:
+        message: Alertmanager has not found all other members of the cluster.
+      expr: |
+        alertmanager_cluster_members{job="alertmanager-main"}
+          != on (service) GROUP_LEFT()
+        count by (service) (alertmanager_cluster_members{job="alertmanager-main"})
+      for: 5m
+      labels:
+        severity: critical
   - name: general.rules
     rules:
     - alert: TargetDown
@@ -1193,7 +890,7 @@ spec:
     - alert: PrometheusConfigReloadFailed
       annotations:
         description: Reloading Prometheus' configuration has failed for {{$labels.namespace}}/{{$labels.pod}}
-        summary: Reloading Promehteus' configuration failed
+        summary: Reloading Prometheus' configuration failed
       expr: |
         prometheus_config_last_reload_successful{job="prometheus-k8s"} == 0
       for: 10m
@@ -1311,6 +1008,159 @@ spec:
 {%- endraw %}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: resource-metrics-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: prometheus-adapter
+  namespace: monitoring
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: kubelet
+  name: kubelet
+  namespace: monitoring
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    honorLabels: true
+    interval: 30s
+    port: https-metrics
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    honorLabels: true
+    interval: 30s
+    path: /metrics/cadvisor
+    port: https-metrics
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  jobLabel: k8s-app
+  namespaceSelector:
+    matchNames:
+    - kube-system
+  selector:
+    matchLabels:
+      k8s-app: kubelet
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: prometheus-adapter
+  name: prometheus-adapter
+  namespace: monitoring
+spec:
+  ports:
+  - name: https
+    port: 443
+    targetPort: 6443
+  selector:
+    name: prometheus-adapter
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s-config
+  namespace: monitoring
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: prometheus
+  name: prometheus
+  namespace: monitoring
+spec:
+  endpoints:
+  - interval: 30s
+    port: web
+  selector:
+    matchLabels:
+      prometheus: k8s
+---
+apiVersion: rbac.authorization.k8s.io/v1
+items:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: prometheus-k8s
+    namespace: default
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - services
+    - endpoints
+    - pods
+    verbs:
+    - get
+    - list
+    - watch
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: prometheus-k8s
+    namespace: kube-system
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - services
+    - endpoints
+    - pods
+    verbs:
+    - get
+    - list
+    - watch
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: prometheus-k8s
+    namespace: monitoring
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - services
+    - endpoints
+    - pods
+    verbs:
+    - get
+    - list
+    - watch
+kind: RoleList
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-k8s
+  namespace: monitoring
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-adapter
+  namespace: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
 items:
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
@@ -1353,6 +1203,67 @@ items:
     namespace: monitoring
 kind: RoleBindingList
 ---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: prometheus-adapter
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: prometheus-adapter
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        name: prometheus-adapter
+    spec:
+      containers:
+      - args:
+        - --cert-dir=/var/run/serving-cert
+        - --config=/etc/adapter/config.yaml
+        - --logtostderr=true
+        - --metrics-relist-interval=1m
+        - --prometheus-url=http://prometheus-k8s.monitoring.svc:9090/
+        - --secure-port=6443
+        image: {{ build_image_name('k8s-prometheus-adapter-amd64', 'v0.4.1') }}
+        name: prometheus-adapter
+        ports:
+        - containerPort: 6443
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmpfs
+          readOnly: false
+        - mountPath: /var/run/serving-cert
+          name: volume-serving-cert
+          readOnly: false
+        - mountPath: /etc/adapter
+          name: config
+          readOnly: false
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+        node-role.kubernetes.io/infra: ''
+      serviceAccountName: prometheus-adapter
+      volumes:
+      - emptyDir: {}
+        name: tmpfs
+      - emptyDir: {}
+        name: volume-serving-cert
+      - configMap:
+          name: adapter-config
+        name: config
+      tolerations:
+      - key: "node-role.kubernetes.io/bootstrap"
+        operator: "Exists"
+        effect: "NoSchedule"
+      - key: "node-role.kubernetes.io/infra"
+        operator: "Exists"
+        effect: "NoSchedule"
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -1364,102 +1275,172 @@ spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     interval: 15s
-    port: http-metrics
+    port: metrics
   jobLabel: k8s-app
   namespaceSelector:
     matchNames:
     - kube-system
   selector:
     matchLabels:
-      component: metrics
-      k8s-app: coredns
+      k8s-app: kube-dns
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-items:
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: Role
-  metadata:
-    name: prometheus-k8s
-    namespace: default
-  rules:
-  - apiGroups:
-    - ""
-    resources:
-    - nodes
-    - services
-    - endpoints
-    - pods
-    verbs:
-    - get
-    - list
-    - watch
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: Role
-  metadata:
-    name: prometheus-k8s
-    namespace: kube-system
-  rules:
-  - apiGroups:
-    - ""
-    resources:
-    - nodes
-    - services
-    - endpoints
-    - pods
-    verbs:
-    - get
-    - list
-    - watch
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: Role
-  metadata:
-    name: prometheus-k8s
-    namespace: monitoring
-  rules:
-  - apiGroups:
-    - ""
-    resources:
-    - nodes
-    - services
-    - endpoints
-    - pods
-    verbs:
-    - get
-    - list
-    - watch
-kind: RoleList
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  labels:
+    prometheus: k8s
+  name: k8s
+  namespace: monitoring
+spec:
+  alerting:
+    alertmanagers:
+    - name: alertmanager-main
+      namespace: monitoring
+      port: web
+  baseImage: {{ build_image_name('prometheus') }}
+  nodeSelector:
+    beta.kubernetes.io/os: linux
+    node-role.kubernetes.io/infra: ''
+  replicas: 2
+  resources:
+    requests:
+      memory: 400Mi
+  ruleSelector:
+    matchLabels:
+      prometheus: k8s
+      role: alert-rules
+  securityContext:
+    fsGroup: 2000
+    runAsNonRoot: true
+    runAsUser: 1000
+  serviceAccountName: prometheus-k8s
+  serviceMonitorNamespaceSelector: {}
+  serviceMonitorSelector: {}
+  version: v2.5.0
+  tolerations:
+  - key: "node-role.kubernetes.io/bootstrap"
+    operator: "Exists"
+    effect: "NoSchedule"
+  - key: "node-role.kubernetes.io/infra"
+    operator: "Exists"
+    effect: "NoSchedule"
+
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    k8s-app: kubelet
-  name: kubelet
+    k8s-app: apiserver
+  name: kube-apiserver
   namespace: monitoring
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    honorLabels: true
     interval: 30s
-    port: https-metrics
+    metricRelabelings:
+    - action: drop
+      regex: etcd_(debugging|disk|request|server).*
+      sourceLabels:
+      - __name__
+    port: https
     scheme: https
     tlsConfig:
-      insecureSkipVerify: true
-  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    honorLabels: true
-    interval: 30s
-    path: /metrics/cadvisor
-    port: https-metrics
-    scheme: https
-    tlsConfig:
-      insecureSkipVerify: true
-  jobLabel: k8s-app
+      caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      serverName: kubernetes
+  jobLabel: component
   namespaceSelector:
     matchNames:
-    - kube-system
+    - default
   selector:
     matchLabels:
-      k8s-app: kubelet
+      component: apiserver
+      provider: kubernetes
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-adapter
+  namespace: monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-adapter
+subjects:
+- kind: ServiceAccount
+  name: prometheus-adapter
+  namespace: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: resource-metrics:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: prometheus-adapter
+  namespace: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-adapter
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - namespaces
+  - pods
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: resource-metrics-server-resources
+rules:
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    prometheus: k8s
+  name: prometheus-k8s
+  namespace: monitoring
+spec:
+  ports:
+  - name: web
+    port: 9090
+    targetPort: web
+  selector:
+    app: prometheus
+    prometheus: k8s
+  sessionAffinity: ClientIP
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-k8s
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: monitoring
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -1485,38 +1466,85 @@ spec:
     matchLabels:
       k8s-app: kube-controller-manager
 ---
-apiVersion: v1
-kind: Service
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
 metadata:
-  namespace: kube-system
-  name: kube-scheduler-prometheus-discovery
+  name: prometheus-k8s-config
+  namespace: monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s-config
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-k8s
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes/metrics
+  verbs:
+  - get
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
   labels:
     k8s-app: kube-scheduler
+  name: kube-scheduler
+  namespace: monitoring
 spec:
+  endpoints:
+  - interval: 30s
+    port: http-metrics
+  jobLabel: k8s-app
+  namespaceSelector:
+    matchNames:
+    - kube-system
   selector:
-    component: kube-scheduler
-  type: ClusterIP
-  clusterIP: None
-  ports:
-  - name: http-metrics
-    port: 10251
-    targetPort: 10251
-    protocol: TCP
+    matchLabels:
+      k8s-app: kube-scheduler
 ---
 apiVersion: v1
-kind: Service
+data:
+  config.yaml: |
+    resourceRules:
+      cpu:
+        containerQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>}[1m])) by (<<.GroupBy>>)
+        nodeQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>, id='/'}[1m])) by (<<.GroupBy>>)
+        resources:
+          overrides:
+            node:
+              resource: node
+            namespace:
+              resource: namespace
+            pod_name:
+              resource: pod
+        containerLabel: container_name
+      memory:
+        containerQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+        nodeQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>,id='/'}) by (<<.GroupBy>>)
+        resources:
+          overrides:
+            node:
+              resource: node
+            namespace:
+              resource: namespace
+            pod_name:
+              resource: pod
+        containerLabel: container_name
+      window: 1m
+kind: ConfigMap
 metadata:
-  namespace: kube-system
-  name: kube-controller-manager-prometheus-discovery
-  labels:
-    k8s-app: kube-controller-manager
-spec:
-  selector:
-    component: kube-controller-manager
-  type: ClusterIP
-  clusterIP: None
-  ports:
-  - name: http-metrics
-    port: 10252
-    targetPort: 10252
-    protocol: TCP
+  name: adapter-config
+  namespace: monitoring


### PR DESCRIPTION

**Component**:

'salt', 'kubernetes', 'monitoring'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

Image pull in sls were not alligned with the one pulled at build time

**Summary**:

Re-generate the upstream manifests for all monitoring component corresponding to the right version

**Acceptance criteria**: 

Have a working monitoring stack for dev/2.1 and dev/2.2

---

Fixes: #1211 
