### PR TITLE
Feature/1116 add new check external dependency tasks

### DIFF
--- a/buildchain/buildchain/config.py
+++ b/buildchain/buildchain/config.py
@@ -47,7 +47,6 @@ VAGRANT_UP_ARGS : Tuple[str, ...] = tuple(shlex.split(
 
 # Name of the command (if in the PATH) or path to the binary.
 
-DOCKER   : str = os.getenv('DOCKER_BIN',   'docker')
 GIT      : str = os.getenv('GIT_BIN',      'git')
 HARDLINK : str = os.getenv('HARDLINK_BIN', 'hardlink')
 MKISOFS  : str = os.getenv('MKISOFS_BIN',  'mkisofs')

--- a/buildchain/buildchain/config.py
+++ b/buildchain/buildchain/config.py
@@ -9,6 +9,7 @@ Those can be edited by the user to customize/configure the build system.
 
 import os
 import shlex
+import enum
 
 from typing import Tuple
 from pathlib import Path
@@ -45,12 +46,16 @@ VAGRANT_UP_ARGS : Tuple[str, ...] = tuple(shlex.split(
 
 # External commands {{{
 
-# Name of the command (if in the PATH) or path to the binary.
+# Name of the external commands (if in the PATH) or path to the binary.
 
-GIT      : str = os.getenv('GIT_BIN',      'git')
-HARDLINK : str = os.getenv('HARDLINK_BIN', 'hardlink')
-MKISOFS  : str = os.getenv('MKISOFS_BIN',  'mkisofs')
-SKOPEO   : str = os.getenv('SKOPEO_BIN',   'skopeo')
-VAGRANT  : str = os.getenv('VAGRANT_BIN',  'vagrant')
+
+class ExtCommand(enum.Enum):
+    """External commands used by the build chain."""
+
+    GIT      = os.getenv('GIT_BIN',      'git')
+    HARDLINK = os.getenv('HARDLINK_BIN', 'hardlink')
+    MKISOFS  = os.getenv('MKISOFS_BIN',  'mkisofs')
+    SKOPEO   = os.getenv('SKOPEO_BIN',   'skopeo')
+    VAGRANT  = os.getenv('VAGRANT_BIN',  'vagrant')
 
 # }}}

--- a/buildchain/buildchain/constants.py
+++ b/buildchain/buildchain/constants.py
@@ -91,8 +91,8 @@ def git_ref() -> Optional[str]:
 
     try:
         ref : bytes = subprocess.check_output([
-            config.GIT, 'describe', '--always', '--long', '--tags',
-                '--dirty',
+            config.ExtCommand.GIT.value, 'describe', '--always', '--long',
+            '--tags', '--dirty',
         ])
 
         return ref.decode('utf-8').rstrip()

--- a/buildchain/buildchain/deps.py
+++ b/buildchain/buildchain/deps.py
@@ -1,4 +1,3 @@
-
 """Dependency checker for skopeo, vagrant, git, mkisofs and hard-link."""
 
 

--- a/buildchain/buildchain/deps.py
+++ b/buildchain/buildchain/deps.py
@@ -1,0 +1,61 @@
+
+"""Dependency checker for skopeo, vagrant, git, mkisofs and hard-link."""
+
+
+from pathlib import Path
+from typing import Optional, Iterator
+import shutil
+
+from doit.exceptions import TaskError  # type: ignore
+
+from buildchain import config
+from buildchain import constants
+from buildchain import types
+from buildchain import utils
+
+
+def task_check_for() -> Iterator[types.TaskDict]:
+    """Check the existence of the external commands."""
+    def get_command_location(
+        command_name: str, binary_path: Optional[str]
+    ) -> Optional[TaskError]:
+        """Check the existence of the given command.
+
+        If the user already specified a path for it, check for the existence
+        of the binary at the given location. Otherwise, look it up from PATH.
+
+        If the binary is not found, the task fails.
+        """
+        if binary_path:
+            path = Path(binary_path)
+            cmd_path = shutil.which(path.name, path=path.parent)
+        else:
+            cmd_path = shutil.which(command_name)
+        if cmd_path is None:
+            return TaskError(msg='command {} not found in {}'.format(
+                command_name, Path(binary_path).parent
+                if binary_path else '$PATH'
+            ))
+        return None
+
+    for ext_cmd in config.ExtCommand:
+        cmd_name = ext_cmd.name.lower()
+        cmd_path = ext_cmd.value if ext_cmd.value != cmd_name else None
+
+        def show(name: str) -> str:
+            return '{cmd: <{width}} {name}'.format(
+                cmd='CHECK CMD', width=constants.CMD_WIDTH, name=name
+            )
+
+        yield {
+            'name': cmd_name,
+            'title': lambda _, name=cmd_name: show(name),
+            'doc': 'Check the presence of the {} command.'.format(cmd_name),
+            'actions': [(get_command_location, [cmd_name, cmd_path], {})],
+            'file_dep': [],
+            'task_dep': [],
+            'uptodate': [False],
+        }
+
+
+__all__ = utils.export_only_tasks(__name__)

--- a/buildchain/buildchain/image.py
+++ b/buildchain/buildchain/image.py
@@ -80,9 +80,13 @@ def task__image_dedup_layers() -> types.TaskDict:
             path=utils.build_relpath(constants.ISO_IMAGE_ROOT)
         )
 
-    task = targets.Target(task_dep=['_image_pull', '_image_build']).basic_task
+    task = targets.Target(
+        task_dep=['check_for:hardlink', '_image_pull', '_image_build']
+    ).basic_task
     task['title']   = lambda _: show()
-    task['actions'] = [[config.HARDLINK, '-c', constants.ISO_IMAGE_ROOT]]
+    task['actions'] = [
+        [config.ExtCommand.HARDLINK.value, '-c', constants.ISO_IMAGE_ROOT]
+    ]
     return task
 
 

--- a/buildchain/buildchain/iso.py
+++ b/buildchain/buildchain/iso.py
@@ -160,7 +160,7 @@ def task__iso_generate_product_txt() -> types.TaskDict:
 def task__iso_build() -> types.TaskDict:
     """Create the ISO from the files in ISO_ROOT."""
     mkisofs = [
-        config.MKISOFS, '-output',  ISO_FILE,
+        config.ExtCommand.MKISOFS.value, '-output',  ISO_FILE,
         '-quiet',
         '-rock',
         '-joliet',
@@ -186,7 +186,7 @@ def task__iso_build() -> types.TaskDict:
         'actions': [mkisofs],
         'targets': [ISO_FILE],
         'file_dep': depends,
-        'task_dep': ['_build_root', '_iso_mkdir_root'],
+        'task_dep': ['check_for:mkisofs', '_build_root', '_iso_mkdir_root'],
         'clean': True,
     }
 

--- a/buildchain/buildchain/targets/local_image.py
+++ b/buildchain/buildchain/targets/local_image.py
@@ -107,6 +107,7 @@ class LocalImage(image.ContainerImage):
         self._save = save_on_disk
         self._build_args = build_args or {}
         kwargs.setdefault('file_dep', []).append(self.dockerfile)
+        kwargs.setdefault('task_dep', []).append('check_for:skopeo')
         super().__init__(
             name=name, version=version, destination=destination, **kwargs
         )
@@ -192,8 +193,9 @@ class LocalImage(image.ContainerImage):
         # If a destination is defined, let's save the image there.
         if self.save_on_disk:
             cmd = [
-                config.SKOPEO, '--override-os', 'linux', '--insecure-policy',
-                'copy', '--format', 'v2s2', '--dest-compress',
+                config.ExtCommand.SKOPEO.value, '--override-os', 'linux',
+                '--insecure-policy', 'copy', '--format', 'v2s2',
+                '--dest-compress',
             ]
             docker_host = os.getenv('DOCKER_HOST')
             if docker_host is not None:

--- a/buildchain/buildchain/targets/remote_image.py
+++ b/buildchain/buildchain/targets/remote_image.py
@@ -52,6 +52,7 @@ class RemoteImage(image.ContainerImage):
         self._digest = digest
         self._remote_name = remote_name or name
         self._use_tar = save_as_tar
+        kwargs.setdefault('task_dep', []).append('check_for:skopeo')
         super().__init__(
             name=name, version=version,
             destination=destination,
@@ -104,8 +105,8 @@ class RemoteImage(image.ContainerImage):
     def _skopeo_copy(self) -> List[str]:
         """Return the command line to execute skopeo copy."""
         cmd = [
-            config.SKOPEO, '--override-os', 'linux', '--insecure-policy',
-            'copy', '--format', 'v2s2'
+            config.ExtCommand.SKOPEO.value, '--override-os', 'linux',
+            '--insecure-policy', 'copy', '--format', 'v2s2'
         ]
         if not self._use_tar:
             cmd.append('--dest-compress')

--- a/buildchain/dodo.py
+++ b/buildchain/dodo.py
@@ -9,6 +9,7 @@
 import doit  # type: ignore
 
 from buildchain.build import *
+from buildchain.deps import *
 from buildchain.image import *
 from buildchain.iso import *
 from buildchain.lint import *


### PR DESCRIPTION
**Component**:

Buildchain

**Context**: 

Issue: https://github.com/scality/metalk8s/issues/1116

**Summary**:

Improve the management of external dependencies properly and become gentle with traceback printed to the user

**Acceptance criteria**: 

Generate a clean trackback if a required external dependency is missing.

E.g
`TaskError - taskid:check_for:skopeo
command skopeo not found in $PATH

########################################
check_for:skopeo <stdout>:`



---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
