### PR TITLE
UI: remove imagePullPolicy: Always

### DIFF
--- a/salt/metalk8s/addons/ui/files/metalk8s-ui-deployment.yaml
+++ b/salt/metalk8s/addons/ui/files/metalk8s-ui-deployment.yaml
@@ -27,7 +27,6 @@ spec:
       containers:
         - name: metalk8s-ui
           image: {{ build_image_name('metalk8s-ui', '0.2') }}
-          imagePullPolicy: Always
           resources:
             limits:
               memory: 170Mi

--- a/salt/metalk8s/addons/ui/files/metalk8s-ui-deployment.yaml
+++ b/salt/metalk8s/addons/ui/files/metalk8s-ui-deployment.yaml
@@ -27,6 +27,7 @@ spec:
       containers:
         - name: metalk8s-ui
           image: {{ build_image_name('metalk8s-ui', '0.2') }}
+          imagePullPolicy: IfNotPresent
           resources:
             limits:
               memory: 170Mi


### PR DESCRIPTION
**Component**:UI

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
- Actually we do not need  ``` imagePullPolicy: Always ``` for development anymore since we can launch the UI on locals. Let's put ``` imagePullPolicy: IfNotPresent ``` to be more explicit.
**Summary**:

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: https://github.com/scality/metalk8s/issues/1238

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
