### PR TITLE
Archive containerd-supported images tarballs

### DIFF
--- a/buildchain/buildchain/targets/remote_image.py
+++ b/buildchain/buildchain/targets/remote_image.py
@@ -11,9 +11,11 @@ All of these actions are done by a single task.
 
 
 import operator
+import os
 from pathlib import Path
 from typing import Any, Optional, List
 
+from buildchain import docker_command
 from buildchain import config
 from buildchain import types
 
@@ -73,6 +75,28 @@ class RemoteImage(image.ContainerImage):
         )
 
     @property
+    def basicname(self) -> str:
+        """Base image name (no digest).
+
+        Usable by `docker` commands.
+        """
+        return '{obj.registry}/{obj._remote_name}:{obj.version}'.format(
+            obj=self
+        )
+
+
+    @property
+    def repository(self) -> str:
+        """Base image name (no digest).
+
+        Usable by `docker` commands.
+        """
+        return '{obj.registry}/{obj._remote_name}'.format(
+            obj=self
+        )
+
+
+    @property
     def filepath(self) -> Path:
         """Path to the file tracked on disk."""
         if self._use_tar:
@@ -90,9 +114,25 @@ class RemoteImage(image.ContainerImage):
             'doc': 'Download {} container image.'.format(self.name),
             'uptodate': [True],
         })
+        docker_pull = docker_command.DockerPull(
+            self.repository,
+            self.digest
+        )
+        docker_tag = docker_command.DockerTag(
+                self.repository,
+                self.fullname,
+                self.version
+        )
+        docker_save = docker_command.DockerSave(
+            self.basicname,
+            Path(os.path.join(
+                self.dest_dir,
+                '{}-{}.tar'.format(self.name, self.version)
+            ))
+        )
         if self._use_tar:
             task.update({
-                'actions': [self._skopeo_copy()],
+                'actions': [docker_pull,  docker_tag, docker_save],
             })
         else:
             task.update({


### PR DESCRIPTION


Fixes: #1250

**Component**:
build

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
container image build
**Summary**:
Skopeo produces incompatible tarballs with containerd thus we re
replacing it with docker in that step, the normal image (no tarballs
should stay the same)
**Acceptance criteria**: 
containerd should be able to import the produced images (nginx and pause)

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1250 

<!-- If you want to refer to an issue while not closing it, use:
-->
See: #942

