### PR TITLE
Configure salt minion for local mode when mounting iso

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -324,6 +324,7 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/salt/minion/files/minion-99-metalk8s.conf.j2'),
     Path('salt/metalk8s/salt/minion/init.sls'),
     Path('salt/metalk8s/salt/minion/installed.sls'),
+    Path('salt/metalk8s/salt/minion/local.sls'),
     Path('salt/metalk8s/salt/minion/running.sls'),
 
     Path('salt/_auth/kubernetes_rbac.py'),

--- a/salt/_modules/metalk8s.py
+++ b/salt/_modules/metalk8s.py
@@ -194,6 +194,8 @@ def get_products(products=None):
     if not products:
         products = __pillar__.get('metalk8s', {}).get('products', [])
 
+    if isinstance(products, unicode):
+        products = str(products)
     if isinstance(products, str):
         products = [products]
     if not isinstance(products, list):

--- a/salt/metalk8s/products/mounted.sls
+++ b/salt/metalk8s/products/mounted.sls
@@ -1,3 +1,6 @@
+include:
+  - metalk8s.salt.minion.local
+
 {%- for _, product in salt.metalk8s.get_products().items() %}
   {%- if product.iso %}
     {%- if not product.version %}

--- a/salt/metalk8s/salt/minion/configured.sls
+++ b/salt/metalk8s/salt/minion/configured.sls
@@ -19,10 +19,3 @@ Configure salt minion:
       minion_id: {{ grains.id }}
     - watch_in:
       - cmd: Restart salt-minion
-
-Remove minion local conf:
-  file.absent:
-    - name: /etc/salt/minion.d/99-file-client-local.conf
-    - require:
-      - file: Configure salt minion
-      - module: Ensure salt-minion running

--- a/salt/metalk8s/salt/minion/local.sls
+++ b/salt/metalk8s/salt/minion/local.sls
@@ -1,0 +1,28 @@
+{%- set products = salt.metalk8s.get_products() %}
+
+Configure salt minion for local mode:
+  file.serialize:
+    - name: /etc/salt/minion.d/99-metalk8s-local.conf
+    - user: root
+    - group: root
+    - mode: '0644'
+    - formatter: yaml
+    - makedirs: true
+    - backup: false
+    - dataset:
+        file_roots:
+        {%- for env, info in products.items() | sort(attribute='0') %}
+          {{ env }}:
+            - {{ salt.file.join(info.path, 'salt') }}
+        {%- endfor %}
+        pillar_roots:
+        {%- for env, info in products.items() | sort(attribute='0') %}
+          {{ env }}:
+            - {{ salt.file.join(info.path, 'pillar') }}
+        {%- endfor %}
+        use_superseded:
+          - module.run
+        ext_pillar_first: true
+        ext_pillar:
+          - metalk8s: /etc/metalk8s/bootstrap.yaml
+        retry_dns_count: 3

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -53,7 +53,6 @@ SYSTEMCTL=${SYSTEMCTL:-$(command -v systemctl)}
 YUM=${YUM:-$(command -v yum)}
 SALT_CALL=${SALT_CALL:-salt-call}
 
-SALT_MINION_FILE_CLIENT_LOCAL_CONF=/etc/salt/minion.d/99-file-client-local.conf
 # shellcheck disable=SC2034
 SALT_MASTER_FILE_CONF=/etc/salt/master.d/99-metalk8s.conf
 # shellcheck disable=SC2034
@@ -206,30 +205,14 @@ install_genisoimage() {
 }
 
 configure_salt_minion_local_mode() {
-    local -r file_root=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/salt
-    local -r pillar_root=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/pillar
+    local -r base_dir=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
+    local -r file_root="$base_dir/salt"
 
     "$SALT_CALL" --file-root="$file_root" \
         --local --retcode-passthrough saltutil.sync_all
-
-    cat > "${SALT_MINION_FILE_CLIENT_LOCAL_CONF}" << EOF
-file_roots:
-  metalk8s-@@VERSION:
-    - $file_root
-pillar_roots:
-  metalk8s-@@VERSION:
-    - $pillar_root
-
-# use new module.run format
-use_superseded:
-  - module.run
-
-ext_pillar_first: true
-ext_pillar:
-  - metalk8s: /etc/metalk8s/bootstrap.yaml
-
-retry_dns_count: 3
-EOF
+    "$SALT_CALL" --file-root="$file_root" \
+        --local --retcode-passthrough state.sls metalk8s.salt.minion.local \
+        pillar="{'metalk8s': {'products': '$base_dir'}}"
 }
 
 get_salt_container() {

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -53,11 +53,6 @@ SYSTEMCTL=${SYSTEMCTL:-$(command -v systemctl)}
 YUM=${YUM:-$(command -v yum)}
 SALT_CALL=${SALT_CALL:-salt-call}
 
-# shellcheck disable=SC2034
-SALT_MASTER_FILE_CONF=/etc/salt/master.d/99-metalk8s.conf
-# shellcheck disable=SC2034
-SALT_MINION_FILE_CONF=/etc/salt/minion.d/99-metalk8s.conf
-
 declare -A GPGCHECK_REPOSITORIES=(
     [metalk8s-base]=1
     [metalk8s-epel]=1


### PR DESCRIPTION
**Component**:

'salt'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

For upgrade process we will need to use salt-minion in local mode to configure the new salt-master and repositories (+registry).

**Summary**:

Adding a state to configure salt-minion to be able to use local mode after deployment and use this states in the bootstrap script and when mounting/configuring new ISOs

**Acceptance criteria**: 

Be able to use some states with `salt-call --local`
(not all available as the external pillar that need k8s not working in local mode)

---

Fixes: #1256 
