### PR TITLE
Log errors in ext pillars

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -398,6 +398,8 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/_states/metalk8s_etcd.py'),
     Path('salt/_states/metalk8s_kubernetes.py'),
 
+    Path('salt/_utils/pillar_utils.py'),
+
     targets.RemoteImage(
         registry=constants.GOOGLE_REGISTRY,
         name='pause',

--- a/salt/_pillar/metalk8s.py
+++ b/salt/_pillar/metalk8s.py
@@ -3,15 +3,12 @@ import logging
 import salt.utils.files
 import salt.utils.yaml
 
-from . import utils
-
 
 log = logging.getLogger(__name__)
 
 
 DEFAULT_POD_NETWORK = '10.233.0.0/16'
 DEFAULT_SERVICE_NETWORK = '10.96.0.0/12'
-
 
 
 def _load_config(path):
@@ -27,25 +24,28 @@ def _load_config(path):
     }
 
     errors = (
-        utils._assert_equals(config, expected) +
-        utils._assert_keys(config, ['products'])
+        __utils__['pillar_utils.assert_equals'](config, expected) +
+        __utils__['pillar_utils.assert_keys'](config, ['products'])
     )
 
     if errors:
-        return utils._errors_to_dict(errors)
+        return __utils__['pillar_utils.errors_to_dict'](errors)
 
     return config
 
 
 def _load_networks(config_data):
-    errors = utils._assert_keys(config_data, ['networks'])
+    errors = __utils__['pillar_utils.assert_keys'](config_data, ['networks'])
     if errors:
-        return utils._errors_to_dict(errors)
+        return __utils__['pillar_utils.errors_to_dict'](errors)
 
     networks_data = config_data['networks']
-    errors = utils._assert_keys(config_data, ['controlPlane', 'workloadPlane'])
+    errors = __utils__['pillar_utils.assert_keys'](
+        networks_data,
+        ['controlPlane', 'workloadPlane']
+    )
     if errors:
-        return utils._errors_to_dict(errors)
+        return __utils__['pillar_utils.errors_to_dict'](errors)
 
     return {
         'control_plane': networks_data['controlPlane'],
@@ -56,14 +56,14 @@ def _load_networks(config_data):
 
 
 def _load_ca(config_data):
-    errors = utils._assert_keys(config_data, ['ca'])
+    errors = __utils__['pillar_utils.assert_keys'](config_data, ['ca'])
     if errors:
-        return utils._errors_to_dict(errors)
+        return __utils__['pillar_utils.errors_to_dict'](errors)
 
     ca_data = config_data['ca']
-    errors = utils._assert_keys(ca_data, ['minion'])
+    errors = __utils__['pillar_utils.assert_keys'](ca_data, ['minion'])
     if errors:
-        return utils._errors_to_dict(errors)
+        return __utils__['pillar_utils.errors_to_dict'](errors)
 
     return {
         'minion': ca_data['minion'],
@@ -71,9 +71,9 @@ def _load_ca(config_data):
 
 
 def _load_apiserver(config_data):
-    errors = utils._assert_keys(config_data, ['apiServer'])
+    errors = __utils__['pillar_utils.assert_keys'](config_data, ['apiServer'])
     if errors:
-        return utils._errors_to_dict(errors)
+        return __utils__['pillar_utils.errors_to_dict'](errors)
 
     as_data = config_data['apiServer']
 
@@ -86,9 +86,9 @@ def _load_apiserver(config_data):
         },
     }
 
-    errors = utils._assert_keys(as_data, ['host'])
+    errors = __utils__['pillar_utils.assert_keys'](as_data, ['host'])
     if errors:
-        return utils._errors_to_dict(errors)
+        return __utils__['pillar_utils.errors_to_dict'](errors)
 
     result['host'] = as_data['host']
 
@@ -112,11 +112,11 @@ def _load_iso_path(config_data):
         res = [res]
 
     if not isinstance(res, list):
-        return {"_errors": [
+        return __utils__['pillar_utils.errors_to_dict']([
             "Invalid products format in config file, list or string expected "
             "got {1}."
             .format(res)
-        ]}
+        ])
 
     return res
 
@@ -124,22 +124,28 @@ def _load_iso_path(config_data):
 def ext_pillar(minion_id, pillar, bootstrap_config):
     config = _load_config(bootstrap_config)
     if config.get('_errors'):
-        return utils._errors_to_dict(config['errors'])
+        metal_data = __utils__['pillar_utils.errors_to_dict'](
+            config['_errors']
+        )
 
-    result = {
-        'networks': _load_networks(config),
-        'metalk8s': {
+    else:
+        metal_data = {
             'products': _load_iso_path(config),
             'ca': _load_ca(config),
             'api_server': _load_apiserver(config)
-        },
+        }
+
+    result = {
+        'networks': _load_networks(config),
+        'metalk8s': metal_data
     }
 
-    metal = result['metalk8s']
-    for key in ['ca', 'products', 'api_server']:
-        utils._promote_errors(metal, key)
-
+    if not isinstance(metal_data['products'], list):
+        # Special case for products in pillar
+        __utils__['pillar_utils.promote_errors'](metal_data, 'products')
+    for key in ['ca', 'api_server']:
+        __utils__['pillar_utils.promote_errors'](metal_data, key)
     for key in ['networks', 'metalk8s']:
-        utils._promote_errors(result, key)
+        __utils__['pillar_utils.promote_errors'](result, key)
 
     return result

--- a/salt/_pillar/metalk8s_nodes.py
+++ b/salt/_pillar/metalk8s_nodes.py
@@ -51,9 +51,8 @@ def node_info(node, ca_minion):
 
 def ext_pillar(minion_id, pillar, kubeconfig):
     if not os.path.isfile(kubeconfig):
-        log.warning(
-            '%s: kubeconfig not found at %s', __virtualname__, kubeconfig)
-        return {}
+        error_tplt = '{}: kubeconfig not found at {}'
+        return {'_errors': error_tplt.format(__virtualname__, kubeconfig)}
 
     ca_minion = None
     if 'metalk8s' in pillar:

--- a/salt/_pillar/metalk8s_nodes.py
+++ b/salt/_pillar/metalk8s_nodes.py
@@ -8,6 +8,8 @@ try:
 except ImportError:
     HAS_DEPS = False
 
+from . import utils
+
 
 VERSION_LABEL = 'metalk8s.scality.com/version'
 ROLE_LABEL_PREFIX = 'node-role.kubernetes.io/'
@@ -52,7 +54,9 @@ def node_info(node, ca_minion):
 def ext_pillar(minion_id, pillar, kubeconfig):
     if not os.path.isfile(kubeconfig):
         error_tplt = '{}: kubeconfig not found at {}'
-        return {'_errors': error_tplt.format(__virtualname__, kubeconfig)}
+        return utils._errors_to_dict([
+            error_tplt.format(__virtualname__, kubeconfig)
+        ])
 
     ca_minion = None
     if 'metalk8s' in pillar:

--- a/salt/_pillar/metalk8s_private.py
+++ b/salt/_pillar/metalk8s_private.py
@@ -1,10 +1,8 @@
 import os.path
 import logging
 
-from . import utils
 
 SA_PRIVATE_KEY_PATH = "/etc/kubernetes/pki/sa.key"
-
 
 log = logging.getLogger(__name__)
 
@@ -31,8 +29,6 @@ def _read_sa_private_key():
 
 
 def ext_pillar(minion_id, pillar):
-    private_data = {'private': None}
-
     nodes_info = pillar.get("metalk8s", {}).get("nodes", {})
 
     if minion_id not in nodes_info:
@@ -43,15 +39,12 @@ def ext_pillar(minion_id, pillar):
 
     node_info = nodes_info[minion_id]
 
+    private_data = {'private': None}
+
     if "master" in node_info["roles"]:
-        utils._update_with_errors(
-            private_data,
-            'private',
-            _read_sa_private_key()
-        )
+        private_data['private'] = _read_sa_private_key()
+        __utils__['pillar_utils.promote_errors'](private_data, 'private')
 
-    result = {"metalk8s": None}
-
-    utils._update_with_errors(result, 'metalk8s', private_data)
+    result = {"metalk8s": private_data}
 
     return result

--- a/salt/_pillar/utils.py
+++ b/salt/_pillar/utils.py
@@ -1,0 +1,79 @@
+"""
+Utility module for external pillars.
+
+The utilities contained in this module have no external dependencies, so
+they may be imported as is in external pillar modules.
+"""
+
+def _assert_equals(source_dict, expected_dict):
+    """
+    Check equality with expected values in dictionary keys.
+
+    Args:
+     - source_dict   (dict): the dict containing the keys/values that should
+                             conform to expected values
+     - expected_dict (dict): the dict containing keys of the `source_dict`, with
+                             expected values of those keys as values
+    Returns:
+     list: empty list if all checks succeeded, list of error message str if
+           some checks failed
+    """
+    error_tplt = "Expected value '{}' for key '{}', got '{}'"
+
+    errors = [
+        error_tplt.format(value, key, source_dict.get(key))
+        for key, value in expected_dict.items()
+        if source_dict.get(key) != value
+    ]
+
+    return errors
+
+
+def _assert_keys(source_dict, keys):
+    """
+    Check key presence within a dict.
+
+    Args:
+     - source_dict (dict): the dict for which key presence should be checked
+     - keys        (list): the list of keys whose presence should be checked
+
+    Returns:
+     list: empty list if all checks succeeded, list of error message str if
+           some checks failed
+    """
+    errors = []
+    errors_tplt = "Expected presence of key '{}' in data: {}"
+
+    for key in keys:
+        if key not in source_dict:
+            errors.append(errors_tplt.format(key, source_dict))
+
+    return errors
+
+
+def _promote_errors(source, key):
+    """
+    Promote the error list of a dict's key up to toplevel
+
+    Args:
+     - source (dict): the dict that should contain the toplevel _errors
+     - key     (str): the key whose content may contain errors
+
+    Returns: None
+    """
+    patch = source[key]
+    if patch.get('_errors'):
+        source.setdefault("_errors", []).extend(patch.get("_errors"))
+
+
+def _errors_to_dict(error_list):
+    """
+    From an error list, return a dict with `_errors` key and list value.
+
+    Args:
+     - error_list (list): the error list to encapsulate
+
+    Returns:
+     dict: a dict with `_errors` key and error list value
+    """
+    return {'_errors': error_list}

--- a/salt/_utils/pillar_utils.py
+++ b/salt/_utils/pillar_utils.py
@@ -5,7 +5,7 @@ The utilities contained in this module have no external dependencies, so
 they may be imported as is in external pillar modules.
 """
 
-def _assert_equals(source_dict, expected_dict):
+def assert_equals(source_dict, expected_dict):
     """
     Check equality with expected values in dictionary keys.
 
@@ -29,7 +29,7 @@ def _assert_equals(source_dict, expected_dict):
     return errors
 
 
-def _assert_keys(source_dict, keys):
+def assert_keys(source_dict, keys):
     """
     Check key presence within a dict.
 
@@ -51,7 +51,7 @@ def _assert_keys(source_dict, keys):
     return errors
 
 
-def _promote_errors(source, key):
+def promote_errors(source, key):
     """
     Promote the error list of a dict's key up to toplevel
 
@@ -66,7 +66,7 @@ def _promote_errors(source, key):
         source.setdefault("_errors", []).extend(patch.get("_errors"))
 
 
-def _errors_to_dict(error_list):
+def errors_to_dict(error_list):
     """
     From an error list, return a dict with `_errors` key and list value.
 

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -269,6 +269,10 @@ orchestrate_bootstrap() {
 
     SALT_MASTER_CALL=(crictl exec -i "$(get_salt_container)")
 
+    run "Syncing Utility modules on Salt master" \
+        "${SALT_MASTER_CALL[@]}" salt-run --state-output=mixed saltutil.sync_utils \
+            saltenv=metalk8s-@@VERSION
+
     run "Syncing Pillar modules on Salt master" \
         "${SALT_MASTER_CALL[@]}" salt-run --state-output=mixed saltutil.sync_pillar \
             saltenv=metalk8s-@@VERSION
@@ -295,6 +299,11 @@ orchestrate_bootstrap() {
             metalk8s.orchestrate.bootstrap.accept-minion \
             saltenv=metalk8s-@@VERSION \
             pillar="${pillar[*]}"
+
+    run "Refreshing all modules and data on bootstrap minion" \
+        salt-call --state-output=mixed saltutil.sync_all \
+            refresh=True \
+            saltenv=metalk8s-@@VERSION
 
     run "Deploying bootstrap node (this may take a while)" \
         "${SALT_MASTER_CALL[@]}" salt-run --state-output=mixed state.orchestrate \


### PR DESCRIPTION
**Component**: salt pillar

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

We currently only sporadically report errors in external pillar calculations, where we should do it consistently for ease of debug.

**Summary**:

* Add `_errors` reporting to nodes external pillar
* Add `_errors` reporting to endpoints external pillar
* Add `_errors` reporting to main external pillar and remove `assert`-based control flow management.

**Acceptance criteria**:

Pillars now report errors when you `get` them.
For example, 

```
salt-call pillar.get metalk8s.endpoints._errors
```

Should yield `None` in the nominal case.

```
salt-call pillar.get metalk8s.private._errors
```
Should complain when having moved the SA private key to an unexpected path.

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1018 

<!-- If you want to refer to an issue while not closing it, use:

See: #

-->
