### PR TITLE
Abort bootstrap if image injection fails

### DIFF
--- a/salt/_modules/containerd.py
+++ b/salt/_modules/containerd.py
@@ -27,5 +27,5 @@ def load_cri_image(path):
     '''
     log.info('Importing image from "%s" into CRI cache', path)
     return __salt__['cmd.run_all'](
-        'ctr -n k8s.io image import "{0}"'.format(path)
+        'ctr --debug -n k8s.io image import "{0}"'.format(path)
     )

--- a/salt/_modules/cri.py
+++ b/salt/_modules/cri.py
@@ -37,6 +37,28 @@ def list_images():
     return salt.utils.json.loads(out['stdout'])['images']
 
 
+def available(name):
+    '''
+    Check if given image exists in the containerd namespace image list
+
+    name
+        Name of the container image
+    '''
+    images = list_images()
+    available = False
+    if not images:
+        return False
+
+    for image in images:
+        if name in image.get('repoTags', []):
+            available = True
+            break
+        if name in image.get('repoDigests', []):
+            available = True
+            break
+    return available
+
+
 _PULL_RES = {
     'sha256': re.compile(
         r'Image is up to date for sha256:(?P<digest>[a-fA-F0-9]{64})'),

--- a/salt/metalk8s/container-engine/containerd/configured.sls
+++ b/salt/metalk8s/container-engine/containerd/configured.sls
@@ -21,12 +21,8 @@ Inject pause image:
         ctr -n k8s.io image ls -q | grep k8s.gcr.io/pause | grep 3\\.1
     - require:
       - service: Start and enable containerd
-  cmd.run:
-    - name: >-
-        ctr -n k8s.io image import \
-            --base-name k8s.gcr.io/pause \
-            /tmp/pause-3.1.tar
-    - unless: >-
-        ctr -n k8s.io image ls -q | grep k8s.gcr.io/pause | grep 3\\.1
+  containerd.image_managed:
+    - name: k8s.gcr.io/pause:3.1
+    - archive_path: /tmp/pause-3.1.tar
     - require:
       - file: Inject pause image

--- a/salt/metalk8s/container-engine/containerd/configured.sls
+++ b/salt/metalk8s/container-engine/containerd/configured.sls
@@ -26,3 +26,4 @@ Inject pause image:
     - archive_path: /tmp/pause-3.1.tar
     - require:
       - file: Inject pause image
+      - pkg: Install and configure cri-tools

--- a/salt/metalk8s/kubernetes/kubelet/installed.sls
+++ b/salt/metalk8s/kubernetes/kubelet/installed.sls
@@ -7,21 +7,6 @@ include:
   - metalk8s.container-engine.{{ kubelet.container_engine }}
 {%- endif %}
 
-Install and configure cri-tools:
-  {{ pkg_installed('cri-tools') }}
-    - require:
-      - test: Repositories configured
-  file.serialize:
-    - name: /etc/crictl.yaml
-    - dataset:
-        runtime-endpoint: {{ kubelet.service.options.get("container-runtime-endpoint") }}
-        image-endpoint: {{ kubelet.service.options.get("container-runtime-endpoint") }}
-    - merge_if_exists: true
-    - user: root
-    - group: root
-    - mode: '0644'
-    - formatter: yaml
-
 Install kubelet:
   {{ pkg_installed('kubelet') }}
     - require:


### PR DESCRIPTION
Fixes: #942

**Component**:
bootstrap, salt
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
`ctr` command does not fail if the image is not imported , thus we need a proper check after the injection step
**Summary**:
Now we recheck image list after the injection to see if the step has been successful
**Acceptance criteria**: 
State should fails if the image is not injected

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #942 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
blocked by #1253