### PR TITLE
Separate `common location` in registry nginx configuration from version specific

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -59,6 +59,47 @@ def task__deploy_salt_tree() -> Iterator[types.TaskDict]:
         yield from file_tree.execution_plan
 
 
+class CommonStaticContainerRegistry(targets.AtomicTarget):
+    """Generate a nginx configuration to serve common static container
+    registry."""
+    def __init__(
+        self,
+        destination: Path,
+        **kwargs: Any
+    ):
+        """Set target destination.
+
+        Arguments:
+            destination: path to the nginx configuration file to write
+
+        Keyword Arguments:
+            They are passed to `Target` init method.
+        """
+        kwargs['targets'] = [destination]
+        super().__init__(task_name=destination.name, **kwargs)
+
+    @property
+    def task(self) -> types.TaskDict:
+        task = self.basic_task
+        task.update({
+            'title': self._show,
+            'doc': 'Generate the nginx config to serve a common static '
+                   'container registry.',
+            'actions': [self._run],
+        })
+        return task
+
+    @staticmethod
+    def _show(task: types.Task) -> str:
+        """Return a description of the task."""
+        return utils.title_with_target1('NGINX_CFG', task)
+
+    def _run(self) -> None:
+        """Generate the nginx configuration."""
+        with Path(self.targets[0]).open('w', encoding='utf-8') as fp:
+            fp.write(container_registry.CONSTANTS)
+
+
 class StaticContainerRegistry(targets.AtomicTarget):
     """Generate a nginx configuration to serve a static container registry."""
     def __init__(
@@ -105,7 +146,7 @@ class StaticContainerRegistry(targets.AtomicTarget):
         """Generate the nginx configuration."""
         with Path(self.targets[0]).open('w', encoding='utf-8') as fp:
             parts = container_registry.create_config(
-                self._img_root, self._srv_root, self._name_pfx
+                self._img_root, self._srv_root, self._name_pfx, False
             )
             for part in parts:
                 fp.write(part)
@@ -367,6 +408,13 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
         save_as_tar=True,
     ),
 
+    CommonStaticContainerRegistry(
+        destination=Path(
+            constants.ISO_ROOT,
+            'salt/metalk8s/repo/files',
+            '{}-registry-common.inc'.format(config.PROJECT_NAME.lower())
+        )
+    ),
     StaticContainerRegistry(
         root=constants.ISO_IMAGE_ROOT,
         server_root='${}_{}_images'.format(

--- a/buildchain/static-container-registry/static-container-registry.py
+++ b/buildchain/static-container-registry/static-container-registry.py
@@ -88,8 +88,9 @@ def find_images(root):
             yield (name, tag)
 
 
-def create_config(root, server_root, name_prefix):
-    yield CONSTANTS
+def create_config(root, server_root, name_prefix, with_constants=True):
+    if with_constants:
+        yield CONSTANTS
 
     images = {}
     for (name, tag) in find_images(root):

--- a/salt/metalk8s/repo/installed.sls
+++ b/salt/metalk8s/repo/installed.sls
@@ -8,6 +8,7 @@
 
 {%- set nginx_confd  = '/var/lib/metalk8s/repositories/conf.d/' %}
 {%- set nginx_default_conf = nginx_confd ~ 'default.conf' %}
+{%- set nginx_common_conf = nginx_confd ~ '99-registry-common.inc' %}
 {%- set nginx_registry        = '99-' ~ saltenv ~ '-registry.inc' %}
 {%- set nginx_registry_config = '90-' ~ saltenv ~ '-registry-config.inc' %}
 {%- set nginx_registry_path        = nginx_confd ~ nginx_registry %}
@@ -25,6 +26,16 @@ Generate repositories nginx configuration:
     - backup: false
     - defaults:
         listening_port: {{ repo.port }}
+
+Deploy common container registry nginx configuration:
+  file.managed:
+    - name: {{ nginx_common_conf}}
+    - source: salt://{{ slspath }}/files/metalk8s-registry-common.inc
+    - user: root
+    - group: root
+    - mode: '0644'
+    - makedirs: true
+    - backup: false
 
 Deploy container registry nginx configuration:
   file.managed:


### PR DESCRIPTION


**Component**:

'salt', 'registry', 'upgrade'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

We generate one nginx config file per version to serve container images.
But the config file conflict.

**Summary**:

Generate 2 separate file, one with constants location registry nginx configuration and one with version specific location registry nginx configuration

**Acceptance criteria**: 

Have 2 version of metalk8s registry served at the same time

---

Fixes: #1150

