### PR TITLE
buildchain: provide more error output in container run/build crashes

### DIFF
--- a/buildchain/buildchain/docker_command.py
+++ b/buildchain/buildchain/docker_command.py
@@ -56,7 +56,31 @@ def bind_ro_mount(source: Path, target: Path) -> Mount:
     )
 
 
-def task_errors(*expected_exn: Type[Exception]) -> Callable[[Any], Any]:
+def default_error_handler(exc: Exception) -> str:
+    """Default string formatting exception handler."""
+    return str(exc)
+
+
+def build_error_handler(build_error: BuildError) -> str:
+    """String formatting exception handler for Docker API BuildError."""
+    output_lines = [
+        item['stream']
+        if 'stream' in item else item['error']
+        for item in build_error.build_log
+    ]
+    log = ''.join(output_lines)
+    return '{}:\n{}'.format(str(build_error), log)
+
+
+def container_error_handler(container_error: ContainerError) -> str:
+    """String formatting exception handler for Docker API ContainerError."""
+    return '{}:\n{}'.format(str(container_error), container_error.stderr)
+
+
+def task_error(
+    expected_exn: Type[Exception],
+    handler: Callable[[Exception], str] = default_error_handler
+) -> Callable[[Any], Any]:
     """Wrap a callable to create a resilient `doit` task
 
     This decorator wraps action functions in a try…except block that abstracts
@@ -72,21 +96,7 @@ def task_errors(*expected_exn: Type[Exception]) -> Callable[[Any], Any]:
             try:
                 task_func(*args, **kwargs)
             except expected_exn as err:
-                # Output container build log on BuildError
-                if isinstance(err, BuildError):
-                    output_lines = [
-                        item['stream']
-                        if 'stream' in item else item['error']
-                        for item in err.build_log
-                    ]
-                    log = ''.join(output_lines)
-                    err_msg = '{}. Build log:\n{}'.format(str(err), log)
-                # Output stderr on ContainerError (docker CMD error)
-                elif isinstance(err, ContainerError):
-                    err_msg = '{}:\n{}'.format(str(err), err.stderr)
-                else:
-                    err_msg = str(err)
-                return TaskError(err_msg)
+                return TaskError(handler(err))
             return None
         return decorated_task
     return wrapped_task
@@ -117,7 +127,8 @@ class DockerBuild:
         self.dockerfile = str(dockerfile)
         self.buildargs = buildargs
 
-    @task_errors(docker.errors.BuildError, docker.errors.APIError)
+    @task_error(docker.errors.BuildError, handler=build_error_handler)
+    @task_error(docker.errors.APIError)
     def __call__(self) -> Optional[TaskError]:
         return DOCKER_CLIENT.images.build(
             tag=self.tag,
@@ -240,11 +251,9 @@ class DockerRun:
 
         return run_config
 
-    @task_errors(
-        docker.errors.ContainerError,
-        docker.errors.ImageNotFound,
-        docker.errors.APIError
-    )
+    @task_error(docker.errors.ContainerError, handler=container_error_handler)
+    @task_error(docker.errors.ImageNotFound)
+    @task_error(docker.errors.APIError)
     def __call__(self) -> Optional[TaskError]:
         run_config = self.expand_config()
         return DOCKER_CLIENT.containers.run(
@@ -270,7 +279,8 @@ class DockerTag:
         self.full_name = full_name
         self.version = version
 
-    @task_errors(docker.errors.BuildError, docker.errors.APIError)
+    @task_error(docker.errors.BuildError, handler=build_error_handler)
+    @task_error(docker.errors.APIError)
     def __call__(self) -> Optional[TaskError]:
         to_tag = DOCKER_CLIENT.images.get(self.full_name)
         return to_tag.tag(self.repository, tag=self.version)
@@ -290,7 +300,8 @@ class DockerPull:
         self.repository = repository
         self.digest = digest
 
-    @task_errors(docker.errors.BuildError, docker.errors.APIError)
+    @task_error(docker.errors.BuildError, handler=build_error_handler)
+    @task_error(docker.errors.APIError)
     def __call__(self) -> Optional[TaskError]:
         return DOCKER_CLIENT.images.pull(self.repository, tag=self.digest)
 
@@ -309,7 +320,8 @@ class DockerSave:
         self.tag = tag
         self.save_path = save_path
 
-    @task_errors(docker.errors.APIError, OSError)
+    @task_error(docker.errors.APIError)
+    @task_error(OSError)
     def __call__(self) -> Optional[TaskError]:
         to_save = DOCKER_CLIENT.images.get(self.tag)
         image_stream = to_save.save(named=True)


### PR DESCRIPTION
**Component**:

buildchain
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

More verbose docker errors.

**Summary**:

* More verbose `ContainerError` (`docker run`)
* More verbose `BuildError` (`docker build`)

**Acceptance criteria**: 

More verbose errors.

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1263 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
