### PR TITLE
INTEGRATION [PR#1265 > development/2.1] upgrade: Bump kubernetes version (v1.11.10)

### DIFF
--- a/buildchain/buildchain/constants.py
+++ b/buildchain/buildchain/constants.py
@@ -48,7 +48,7 @@ VAGRANT_SSH_KEY_PAIR : Path = VAGRANT_ROOT/'preshared_key_for_k8s_nodes'
 # }}}
 # Versions {{{
 
-K8S_VERSION  : str = '1.11.7'
+K8S_VERSION  : str = '1.11.10'
 SALT_VERSION : str = '2018.3.4'
 KEEPALIVED_VERSION : str = '1.3.5-8.el7_6'
 KEEPALIVED_BUILD_ID : int = 1


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1265.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/2.1/improvement/902-bump-k8s_version-fixing-path-traversal-vulnerability`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/2.1/improvement/902-bump-k8s_version-fixing-path-traversal-vulnerability
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/2.1/improvement/902-bump-k8s_version-fixing-path-traversal-vulnerability
```

Please always comment pull request #1265 instead of this one.