### PR TITLE
Rework compute of cluster health

### DIFF
--- a/ui/src/containers/ClusterMonitoring.js
+++ b/ui/src/containers/ClusterMonitoring.js
@@ -123,7 +123,7 @@ const ClusterMonitoring = props => {
 
   const sortedAlerts = sortAlerts(alerts, sortBy, sortDirection);
 
-  const isUp = props.clusterStatus && props.clusterStatus.length;
+  const isUp = props.cluster && props.cluster.status;
 
   return (
     <PageContainer>
@@ -155,7 +155,7 @@ const ClusterMonitoring = props => {
 const mapStateToProps = state => {
   return {
     alerts: state.app.monitoring.alertList,
-    clusterStatus: state.app.monitoring.clusterStatus
+    cluster: state.app.monitoring.cluster
   };
 };
 

--- a/ui/src/ducks/app/monitoring.js
+++ b/ui/src/ducks/app/monitoring.js
@@ -1,15 +1,26 @@
 import { put, takeEvery, select, call } from 'redux-saga/effects';
-import { getAlerts, getClusterStatus } from '../../services/prometheus/api';
+import { getAlerts, queryPrometheus } from '../../services/prometheus/api';
 
 const FETCH_ALERTS = 'FETCH_ALERTS';
 const SET_ALERTS = 'SET_ALERTS';
 
 const FETCH_CLUSTER_STATUS = 'FETCH_CLUSTER_STATUS';
 const SET_CLUSTER_STATUS = 'SET_CLUSTER_STATUS';
+const SET_APISERVER_STATUS = 'SET_APISERVER_STATUS';
+const SET_KUBESCHEDULER_STATUS = 'SET_KUBESCHEDULER_STATUS';
+const SET_KUBECONTROLLER_MANAGER_STATUS = 'SET_KUBECONTROLLER_MANAGER_STATUS';
 
 const defaultState = {
   alertList: [],
-  clusterStatus: []
+  clusterStatus: [],
+
+  cluster: {
+    // Will be change with Carlito PR
+    status: false,
+    apiServerStatus: [],
+    kubeSchedulerStatus: [],
+    kubeControllerManagerStatus: []
+  }
 };
 
 export default function(state = defaultState, action = {}) {
@@ -17,7 +28,10 @@ export default function(state = defaultState, action = {}) {
     case SET_ALERTS:
       return { ...state, alertList: action.payload };
     case SET_CLUSTER_STATUS:
-      return { ...state, clusterStatus: action.payload };
+      return {
+        ...state,
+        cluster: { ...state.cluster, status: action.payload }
+      };
     default:
       return state;
   }
@@ -39,6 +53,18 @@ export const setClusterStatusAction = payload => {
   return { type: SET_CLUSTER_STATUS, payload };
 };
 
+export const setApiServerStatusAction = payload => {
+  return { type: SET_APISERVER_STATUS, payload };
+};
+
+export const setKubeSchedulerStatusAction = payload => {
+  return { type: SET_KUBESCHEDULER_STATUS, payload };
+};
+
+export const setKubeControllerManagerStatus = payload => {
+  return { type: SET_KUBECONTROLLER_MANAGER_STATUS, payload };
+};
+
 export function* fetchAlerts() {
   const api = yield select(state => state.config.api);
   const result = yield call(getAlerts, api.url_prometheus);
@@ -49,9 +75,64 @@ export function* fetchAlerts() {
 
 export function* fetchClusterStatus() {
   const api = yield select(state => state.config.api);
-  const result = yield call(getClusterStatus, api.url_prometheus);
-  if (!result.error) {
-    yield put(setClusterStatusAction(result.data.data.result));
+
+  const apiserverQuery = 'sum(up{job="apiserver"})';
+  const kubeSchedulerQuery = 'sum(up{job="kube-scheduler"})';
+  const kubeControllerManagerQuery = 'sum(up{job="kube-controller-manager"})';
+
+  const apiserver = yield call(
+    queryPrometheus,
+    api.url_prometheus,
+    apiserverQuery
+  );
+  const apiServerValue = apiserver.data.data.result[0].value;
+
+  const kubeScheduler = yield call(
+    queryPrometheus,
+    api.url_prometheus,
+    kubeSchedulerQuery
+  );
+  const kubeSchedulerValue = kubeScheduler.data.data.result[0].value;
+
+  const kubeControllerManager = yield call(
+    queryPrometheus,
+    api.url_prometheus,
+    kubeControllerManagerQuery
+  );
+  const kubeControllerManagerValue =
+    kubeControllerManager.data.data.result[0].value;
+
+  if (apiserver && apiserver.data && apiserver.data.status === 'success') {
+    const apiServerValue = apiserver.data.data.result[0].value;
+    yield put(setApiServerStatusAction(apiServerValue));
+  }
+
+  if (
+    kubeScheduler &&
+    kubeScheduler.data &&
+    kubeScheduler.data.status === 'success'
+  ) {
+    yield put(setKubeSchedulerStatusAction(kubeSchedulerValue));
+  }
+
+  if (
+    kubeControllerManager &&
+    kubeControllerManager.data &&
+    kubeControllerManager.data.status === 'success'
+  ) {
+    yield put(setKubeControllerManagerStatus(kubeControllerManagerValue));
+  }
+
+  if (
+    apiServerValue.length > 0 &&
+    kubeSchedulerValue.length > 0 &&
+    kubeControllerManagerValue.length > 0
+  ) {
+    // There are a least one actif job for api-server, kube-scheduler and
+    // kube-controller
+    yield put(setClusterStatusAction(true));
+  } else {
+    yield put(setClusterStatusAction(false));
   }
 }
 

--- a/ui/src/ducks/app/monitoring.js
+++ b/ui/src/ducks/app/monitoring.js
@@ -5,10 +5,11 @@ const FETCH_ALERTS = 'FETCH_ALERTS';
 const SET_ALERTS = 'SET_ALERTS';
 
 const FETCH_CLUSTER_STATUS = 'FETCH_CLUSTER_STATUS';
-const SET_CLUSTER_STATUS = 'SET_CLUSTER_STATUS';
-const SET_APISERVER_STATUS = 'SET_APISERVER_STATUS';
-const SET_KUBESCHEDULER_STATUS = 'SET_KUBESCHEDULER_STATUS';
-const SET_KUBECONTROLLER_MANAGER_STATUS = 'SET_KUBECONTROLLER_MANAGER_STATUS';
+export const SET_CLUSTER_STATUS = 'SET_CLUSTER_STATUS';
+export const SET_APISERVER_STATUS = 'SET_APISERVER_STATUS';
+export const SET_KUBESCHEDULER_STATUS = 'SET_KUBESCHEDULER_STATUS';
+export const SET_KUBECONTROLLER_MANAGER_STATUS =
+  'SET_KUBECONTROLLER_MANAGER_STATUS';
 
 const defaultState = {
   alertList: [],
@@ -113,7 +114,6 @@ export function* fetchClusterStatus() {
     kubeControllerManager.data.data.result[0].value;
 
   if (apiserver && apiserver.data && apiserver.data.status === 'success') {
-    const apiServerValue = apiserver.data.data.result[0].value;
     yield put(setApiServerStatusAction(apiServerValue));
   }
 
@@ -135,11 +135,11 @@ export function* fetchClusterStatus() {
 
   if (
     apiServerValue.length > 1 &&
-    parseInt(apiServerValue[1]) > 1 &&
+    parseInt(apiServerValue[1]) > 0 &&
     kubeSchedulerValue.length > 1 &&
-    parseInt(kubeSchedulerValue[1]) > 1 &&
+    parseInt(kubeSchedulerValue[1]) > 0 &&
     kubeControllerManagerValue.length > 1 &&
-    parseInt(kubeControllerManagerValue[1]) > 1
+    parseInt(kubeControllerManagerValue[1]) > 0
   ) {
     // There are a least one actif job for api-server, kube-scheduler and
     // kube-controller

--- a/ui/src/ducks/app/monitoring.test.js
+++ b/ui/src/ducks/app/monitoring.test.js
@@ -1,0 +1,270 @@
+import { call, all, put } from 'redux-saga/effects';
+import {
+  SET_CLUSTER_STATUS,
+  SET_APISERVER_STATUS,
+  SET_KUBESCHEDULER_STATUS,
+  SET_KUBECONTROLLER_MANAGER_STATUS,
+  fetchClusterStatus
+} from './monitoring';
+import { queryPrometheus } from '../../services/prometheus/api';
+
+it('should set cluster status as UP', () => {
+  const gen = fetchClusterStatus();
+
+  expect(gen.next().value.type).toEqual('SELECT');
+
+  const result = [
+    {
+      data: {
+        status: 'success',
+        data: {
+          resultType: 'vector',
+          result: [
+            {
+              metric: {},
+              value: [1561562554.553, '1']
+            }
+          ]
+        }
+      },
+      status: 200,
+      statusText: 'OK'
+    },
+    {
+      data: {
+        status: 'success',
+        data: {
+          resultType: 'vector',
+          result: [
+            {
+              metric: {},
+              value: [1561562554.611, '1']
+            }
+          ]
+        }
+      },
+      status: 200,
+      statusText: 'OK'
+    },
+    {
+      data: {
+        status: 'success',
+        data: {
+          resultType: 'vector',
+          result: [
+            {
+              metric: {},
+              value: [1561562554.559, '1']
+            }
+          ]
+        }
+      },
+      status: 200,
+      statusText: 'OK'
+    }
+  ];
+
+  expect(gen.next({ url_prometheus: '/api' }).value).toEqual(
+    all([
+      call(queryPrometheus, '/api', 'sum(up{job="apiserver"})'),
+      call(queryPrometheus, '/api', 'sum(up{job="kube-scheduler"})'),
+      call(queryPrometheus, '/api', 'sum(up{job="kube-controller-manager"})')
+    ])
+  );
+
+  expect(gen.next(result).value).toEqual(
+    put({ type: SET_APISERVER_STATUS, payload: [1561562554.553, '1'] })
+  );
+
+  expect(gen.next(result).value).toEqual(
+    put({ type: SET_KUBESCHEDULER_STATUS, payload: [1561562554.611, '1'] })
+  );
+
+  expect(gen.next(result).value).toEqual(
+    put({
+      type: SET_KUBECONTROLLER_MANAGER_STATUS,
+      payload: [1561562554.559, '1']
+    })
+  );
+
+  expect(gen.next(result).value).toEqual(
+    put({
+      type: SET_CLUSTER_STATUS,
+      payload: true
+    })
+  );
+});
+
+it('should set cluster status as DOWN because there is no kube-controller-manager job', () => {
+  const gen = fetchClusterStatus();
+
+  expect(gen.next().value.type).toEqual('SELECT');
+
+  const result = [
+    {
+      data: {
+        status: 'success',
+        data: {
+          resultType: 'vector',
+          result: [
+            {
+              metric: {},
+              value: [1561562554.553, '1']
+            }
+          ]
+        }
+      },
+      status: 200,
+      statusText: 'OK'
+    },
+    {
+      data: {
+        status: 'success',
+        data: {
+          resultType: 'vector',
+          result: [
+            {
+              metric: {},
+              value: [1561562554.611, '1']
+            }
+          ]
+        }
+      },
+      status: 200,
+      statusText: 'OK'
+    },
+    {
+      data: {
+        status: 'success',
+        data: {
+          resultType: 'vector',
+          result: [
+            {
+              metric: {},
+              value: [1561562554.559, '0']
+            }
+          ]
+        }
+      },
+      status: 200,
+      statusText: 'OK'
+    }
+  ];
+
+  expect(gen.next({ url_prometheus: '/api' }).value).toEqual(
+    all([
+      call(queryPrometheus, '/api', 'sum(up{job="apiserver"})'),
+      call(queryPrometheus, '/api', 'sum(up{job="kube-scheduler"})'),
+      call(queryPrometheus, '/api', 'sum(up{job="kube-controller-manager"})')
+    ])
+  );
+
+  expect(gen.next(result).value).toEqual(
+    put({ type: SET_APISERVER_STATUS, payload: [1561562554.553, '1'] })
+  );
+
+  expect(gen.next(result).value).toEqual(
+    put({ type: SET_KUBESCHEDULER_STATUS, payload: [1561562554.611, '1'] })
+  );
+
+  expect(gen.next(result).value).toEqual(
+    put({
+      type: SET_KUBECONTROLLER_MANAGER_STATUS,
+      payload: [1561562554.559, '0']
+    })
+  );
+
+  expect(gen.next(result).value).toEqual(
+    put({
+      type: SET_CLUSTER_STATUS,
+      payload: false
+    })
+  );
+});
+
+it('should set cluster status as DOWN because api-server value is []', () => {
+  const gen = fetchClusterStatus();
+
+  expect(gen.next().value.type).toEqual('SELECT');
+
+  const result = [
+    {
+      data: {
+        status: 'success',
+        data: {
+          resultType: 'vector',
+          result: [
+            {
+              metric: {},
+              value: []
+            }
+          ]
+        }
+      },
+      status: 200,
+      statusText: 'OK'
+    },
+    {
+      data: {
+        status: 'success',
+        data: {
+          resultType: 'vector',
+          result: [
+            {
+              metric: {},
+              value: [1561562554.611, '1']
+            }
+          ]
+        }
+      },
+      status: 200,
+      statusText: 'OK'
+    },
+    {
+      data: {
+        status: 'success',
+        data: {
+          resultType: 'vector',
+          result: [
+            {
+              metric: {},
+              value: [1561562554.559, '1']
+            }
+          ]
+        }
+      },
+      status: 200,
+      statusText: 'OK'
+    }
+  ];
+
+  expect(gen.next({ url_prometheus: '/api' }).value).toEqual(
+    all([
+      call(queryPrometheus, '/api', 'sum(up{job="apiserver"})'),
+      call(queryPrometheus, '/api', 'sum(up{job="kube-scheduler"})'),
+      call(queryPrometheus, '/api', 'sum(up{job="kube-controller-manager"})')
+    ])
+  );
+
+  expect(gen.next(result).value).toEqual(
+    put({ type: SET_APISERVER_STATUS, payload: [] })
+  );
+
+  expect(gen.next(result).value).toEqual(
+    put({ type: SET_KUBESCHEDULER_STATUS, payload: [1561562554.611, '1'] })
+  );
+
+  expect(gen.next(result).value).toEqual(
+    put({
+      type: SET_KUBECONTROLLER_MANAGER_STATUS,
+      payload: [1561562554.559, '1']
+    })
+  );
+
+  expect(gen.next(result).value).toEqual(
+    put({
+      type: SET_CLUSTER_STATUS,
+      payload: false
+    })
+  );
+});

--- a/ui/src/services/prometheus/api.js
+++ b/ui/src/services/prometheus/api.js
@@ -17,3 +17,11 @@ export async function getClusterStatus(api) {
     return { error };
   }
 }
+
+export async function queryPrometheus(api, query) {
+  try {
+    return await axios.get(api + '/api/v1/query?query=' + query);
+  } catch (error) {
+    return { error };
+  }
+}


### PR DESCRIPTION
**Component**: ui

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
#1254 fix issue that need some changes in the compute of cluster status

**Summary**:
Cluster status will now display `Everything is up and running` when there is a least one job up for apiserver, kube-scheduler and kube-controller-manager.

**Acceptance criteria**: 

To Test this, you will need to rebase the fix from #1254 
Check that cluster status display `Everythign is up and running`.

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1248
<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
