### PR TITLE
salt: Fix bug in kubernetes StatefulSet API call

### DIFF
--- a/salt/_modules/metalk8s_drain.py
+++ b/salt/_modules/metalk8s_drain.py
@@ -272,8 +272,8 @@ class Drain(object):
                 "api_operation": "list_namespaced_replica_set"
             },
             "StatefulSet": {
-                "call": "CoreV1Api->list_namespaced_stateful_set",
-                "api_source": kubernetes.client.ExtensionsV1beta1Api,
+                "call": "AppsV1Api->list_namespaced_stateful_set",
+                "api_source": kubernetes.client.AppsV1Api,
                 "api_operation": "list_namespaced_stateful_set"
             }
         }


### PR DESCRIPTION
**Component**:

'salt', 'kubernetes'

**Context**: 

Issue: #1282 

**Summary**:

List stateful set in the python kubernetes API was defined with ExtensionsV1beta1Api which should not be the case.

It should have been called with 'AppsV1Api' and the api_source being kubernetes.client.AppsV1Api.
The right StatefulSet calls are required for Node drain to work properly.

**Acceptance criteria**: 

A green build in the CI should be fine

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1282 

