### PR TITLE
Does not drain when upgrading a single node cluster

### DIFF
--- a/salt/metalk8s/orchestrate/deploy_node.sls
+++ b/salt/metalk8s/orchestrate/deploy_node.sls
@@ -52,6 +52,8 @@ Cordon the node:
     - kubeconfig: {{ kubeconfig }}
     - context: {{ context }}
 
+{%- if not pillar.orchestrate.get('skip_draining', True) %}
+
 Drain the node:
   metalk8s_drain.node_drained:
     - name: {{ node_name }}
@@ -62,6 +64,10 @@ Drain the node:
     - context: {{ context }}
     - require:
       - metalk8s_cordon: Cordon the node
+    - require_in:
+      - salt: Run the highstate
+
+{%- endif %}
 
 Run the highstate:
   salt.state:
@@ -70,7 +76,7 @@ Run the highstate:
     - require:
       - salt: Set grains
       - salt: Refresh the mine
-      - metalk8s_drain: Drain the node
+      - metalk8s_cordon: Cordon the node
 
 Uncordon the node:
   metalk8s_cordon.node_uncordoned:

--- a/salt/metalk8s/orchestrate/upgrade/init.sls
+++ b/salt/metalk8s/orchestrate/upgrade/init.sls
@@ -52,6 +52,10 @@ Deploy node {{ node }}:
     - pillar:
         orchestrate:
           node_name: {{ node }}
+          {%- if pillar.metalk8s.nodes|length == 1 %}
+          {#- Do not drain if we are in single node cluster #}
+          skip_draining: True
+          {%- endif %}
     - require:
       - metalk8s_kubernetes: Set node {{ node }} version to {{ dest_version }}
     - require_in:


### PR DESCRIPTION
**Component**:

'salt', 'upgrade'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

When upgrading we drain node one by one, When we have only one node we will stop pods like alertmanager and prometheus and then prometheus IP needed by UI no longer available so ui deployed state will fail.

**Summary**:

Skip draining when we have only one node as the pods will not be scheduled somewhere else.

---

Fixes: #1291
