### PR TITLE
Fix ui deployed salt state

### DIFF
--- a/salt/metalk8s/addons/monitoring/prometheus/deployed.sls
+++ b/salt/metalk8s/addons/monitoring/prometheus/deployed.sls
@@ -32,5 +32,3 @@ Expose Prometheus:
           app: prometheus
           prometheus: k8s
         type: NodePort
-  require:
-    - pkg: Install Python Kubernetes client

--- a/salt/metalk8s/addons/ui/deployed.sls
+++ b/salt/metalk8s/addons/ui/deployed.sls
@@ -3,7 +3,7 @@
 
 {%- set apiserver = 'https://' ~ pillar.metalk8s.api_server.host ~ ':6443' %}
 {%- set saltapi = 'http://' ~ pillar.metalk8s.endpoints['salt-master'].ip ~ ':' ~ pillar.metalk8s.endpoints['salt-master'].ports.api %}
-{%- set prometheus = 'http://' ~ pillar.metalk8s.endpoints.prometheus.ip ~ ':' ~ pillar.metalk8s.endpoints.prometheus.ports.node_port  %}
+{%- set prometheus = 'http://' ~ pillar.metalk8s.endpoints.prometheus.ip ~ ':' ~ pillar.metalk8s.endpoints.prometheus.ports.api.node_port  %}
 
 Create metalk8s-ui deployment:
   metalk8s_kubernetes.deployment_present:

--- a/salt/metalk8s/addons/ui/deployed.sls
+++ b/salt/metalk8s/addons/ui/deployed.sls
@@ -13,8 +13,6 @@ Create metalk8s-ui deployment:
     - context: {{ context }}
     - source: salt://{{ slspath }}/files/metalk8s-ui-deployment.yaml
     - template: jinja
-  require:
-    - pkg: Install Python Kubernetes client
 
 Create metalk8s-ui service:
   metalk8s_kubernetes.service_present:
@@ -34,8 +32,6 @@ Create metalk8s-ui service:
         selector:
           k8s-app: ui
         type: NodePort
-  require:
-    - pkg: Install Python Kubernetes client
 
 Create metalk8s-ui ConfigMap:
   metalk8s_kubernetes.configmap_present:
@@ -52,5 +48,3 @@ Create metalk8s-ui ConfigMap:
           }
         theme.json: |
           {"brand": {"primary": "#403e40", "secondary": "#e99121"}}
-  require:
-    - pkg: Install Python Kubernetes client

--- a/salt/metalk8s/kubernetes/coredns/deployed.sls
+++ b/salt/metalk8s/kubernetes/coredns/deployed.sls
@@ -35,8 +35,8 @@ Create coredns deployment:
     - context: {{ context }}
     - source: salt://{{ slspath }}/files/coredns-deployment.yaml.j2
     - template: jinja
-  require:
-    - metalk8s_kubernetes: Create coredns ConfigMap
+    - require:
+      - metalk8s_kubernetes: Create coredns ConfigMap
 
 Create coredns service:
   metalk8s_kubernetes.service_present:
@@ -66,8 +66,8 @@ Create coredns service:
         - name: metrics
           port: 9153
           protocol: TCP
-  require:
-    - metalk8s_kubernetes: Create coredns deployment
+    - require:
+      - metalk8s_kubernetes: Create coredns deployment
 
 Create coredns service account:
   metalk8s_kubernetes.serviceaccount_present:

--- a/salt/metalk8s/orchestrate/bootstrap/init.sls
+++ b/salt/metalk8s/orchestrate/bootstrap/init.sls
@@ -52,7 +52,9 @@
                 'prometheus': {
                     'ip': bootstrap_workload_plane_ip,
                     'ports': {
-                        'node_port': 30222
+                        'api': {
+                            'node_port': 30222
+                        }
                     }
                 }
             },


### PR DESCRIPTION
**Component**:

'salt'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

In `salt/metalk8s/addons/ui/deployed.sls` we use pillar key `pillar.metalk8s.endpoints.prometheus.ports.node_port` instead of `pillar.metalk8s.endpoints.prometheus.ports.api.node_port`.

**Summary**:

Use the right pillar key and remove/changes some useless/invalid require in salt states.

---

Fixes: #1294 
