### PR TITLE
salt: check kube-apiserver healthz before uncordon node

### DIFF
--- a/salt/metalk8s/orchestrate/deploy_node.sls
+++ b/salt/metalk8s/orchestrate/deploy_node.sls
@@ -78,6 +78,13 @@ Run the highstate:
       - salt: Refresh the mine
       - metalk8s_cordon: Cordon the node
 
+Wait for API server to be available:
+  http.wait_for_successful_query:
+  - name: https://{{ pillar.metalk8s.api_server.host }}:6443/healthz
+  - match: 'ok'
+  - status: 200
+  - verify_ssl: false
+
 Uncordon the node:
   metalk8s_cordon.node_uncordoned:
     - name: {{ node_name }}
@@ -85,6 +92,7 @@ Uncordon the node:
     - context: {{ context }}
     - require:
       - salt: Run the highstate
+      - http: Wait for API server to be available
 
 {%- set master_minions = salt['metalk8s.minions_by_role']('master') %}
 


### PR DESCRIPTION
**Component**:

'salt', 'kubernetes'

**Context**: 

Issue: #1297 

**Summary**:

During orchestrate when we apply the highstate for deploy_node, we make changes to the Kube-apiserver manifest file. This renders Kube-apiserver unavailable for a very short period of time.

While Kube-apiserver is still in an unready state, we try to uncordon node which results in failures. 

**Acceptance criteria**:
 
- During orchestrate, applying salt state for deploy node should work normally


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1297 
