### PR TITLE
Escape backslashes in `parsed-literal` blocks

### DIFF
--- a/docs/quickstart/expansion.rst
+++ b/docs/quickstart/expansion.rst
@@ -212,8 +212,8 @@ Start the node deployment.
 
 .. parsed-literal::
 
-   root@salt-master-bootstrap $ salt-run state.orchestrate metalk8s.orchestrate.deploy_node \
-                                saltenv=metalk8s-|release| \
+   root@salt-master-bootstrap $ salt-run state.orchestrate metalk8s.orchestrate.deploy_node \\
+                                saltenv=metalk8s-|release| \\
                                 pillar='{"orchestrate": {"node_name": "<node-name>"}}'
 
    ... lots of output ...


### PR DESCRIPTION
**Component**: docs

**Context**: In the Quickstart/Expansion guide, for the Deploy node orchestration command, backslashes were interpreted, effectively "unbreaking" the command line, and
leaving spaces, which confused users.

**Summary**: Escape backslashes.

**Acceptance criteria**: The relevant doc section should look like:

```
root@salt-master-bootstrap $ salt-run state.orchestrate metalk8s.orchestrate.deploy_node \
                             saltenv=metalk8s-2.0.0-dev \
                             pillar='{"orchestrate": {"node_name": "<node-name>"}}'
```
