### PR TITLE
Wait for pillar value available before deploying metalk8s UI

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -206,6 +206,7 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
         context={'VERSION': constants.VERSION},
         file_dep=[constants.VERSION_FILE],
     ),
+    Path('salt/metalk8s/addons/ui/precheck.sls'),
 
     Path('salt/metalk8s/container-engine/containerd/configured.sls'),
     Path('salt/metalk8s/container-engine/containerd/init.sls'),

--- a/salt/metalk8s/addons/ui/deployed.sls
+++ b/salt/metalk8s/addons/ui/deployed.sls
@@ -1,3 +1,6 @@
+include:
+  - .precheck
+
 {%- set kubeconfig = "/etc/kubernetes/admin.conf" %}
 {%- set context = "kubernetes-admin@kubernetes" %}
 

--- a/salt/metalk8s/addons/ui/precheck.sls
+++ b/salt/metalk8s/addons/ui/precheck.sls
@@ -1,0 +1,9 @@
+Check pillar for MetalK8s UI:
+  test.check_pillar:
+    - string:
+      - metalk8s:api_server:host
+      - metalk8s:endpoints:salt-master:ip
+      - metalk8s:endpoints:prometheus:ip
+    - integer:
+      - metalk8s:endpoints:salt-master:ports:api
+      - metalk8s:endpoints:prometheus:ports:api:node_port

--- a/salt/metalk8s/deployed.sls
+++ b/salt/metalk8s/deployed.sls
@@ -4,7 +4,6 @@ include:
   - metalk8s.kubernetes.coredns.deployed
   - metalk8s.repo.deployed
   - metalk8s.salt.master.deployed
-  - metalk8s.addons.ui.deployed
   - metalk8s.addons.monitoring.prometheus-operator.deployed
   - metalk8s.addons.monitoring.alertmanager.deployed
   - metalk8s.addons.monitoring.prometheus.deployed

--- a/salt/metalk8s/orchestrate/bootstrap/init.sls
+++ b/salt/metalk8s/orchestrate/bootstrap/init.sls
@@ -49,14 +49,6 @@
                         'http': 8080,
                     },
                 },
-                'prometheus': {
-                    'ip': bootstrap_workload_plane_ip,
-                    'ports': {
-                        'api': {
-                            'node_port': 30222
-                        }
-                    }
-                }
             },
         },
     }
@@ -157,3 +149,23 @@ Deploy Kubernetes objects:
   - pillar: {{ pillar_data | tojson }}
   - require:
     - http: Wait for API server to be available
+
+Precheck for MetalK8s UI:
+  salt.runner:
+    - name: state.orchestrate
+    - mods:
+      - metalk8s.addons.ui.precheck
+    - saltenv: {{ saltenv }}
+    - retry:
+        attempts: 5
+    - require:
+      - salt: Deploy Kubernetes objects
+
+Deploy MetalK8s UI:
+  salt.runner:
+    - name: state.orchestrate
+    - mods:
+      - metalk8s.addons.ui.deployed
+    - saltenv: {{ saltenv }}
+    - require:
+      - salt: Precheck for MetalK8s UI

--- a/salt/metalk8s/orchestrate/deploy_node.sls
+++ b/salt/metalk8s/orchestrate/deploy_node.sls
@@ -52,7 +52,7 @@ Cordon the node:
     - kubeconfig: {{ kubeconfig }}
     - context: {{ context }}
 
-{%- if not pillar.orchestrate.get('skip_draining', True) %}
+{%- if not pillar.orchestrate.get('skip_draining', False) %}
 
 Drain the node:
   metalk8s_drain.node_drained:

--- a/salt/metalk8s/orchestrate/upgrade/init.sls
+++ b/salt/metalk8s/orchestrate/upgrade/init.sls
@@ -74,3 +74,23 @@ Deploy Kubernetes objects:
     - saltenv: {{ saltenv }}
     - require:
       - salt: Upgrade etcd cluster
+
+Precheck for MetalK8s UI:
+  salt.runner:
+    - name: state.orchestrate
+    - mods:
+      - metalk8s.addons.ui.precheck
+    - saltenv: {{ saltenv }}
+    - retry:
+        attempts: 5
+    - require:
+      - salt: Deploy Kubernetes objects
+
+Deploy MetalK8s UI:
+  salt.runner:
+    - name: state.orchestrate
+    - mods:
+      - metalk8s.addons.ui.deployed
+    - saltenv: {{ saltenv }}
+    - require:
+      - salt: Precheck for MetalK8s UI


### PR DESCRIPTION
**Component**:

'salt', 'upgrade'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

During upgrade we drain each node including the infra one hosting prometheus so prometheus endpoint no longer available and ui deployed need it

**Summary**:

Separate MetalK8s UI deployment from others kubernetes objects and retry until pillar value available

---

Fixes: #1300 
