### PR TITLE
salt: Refresh yum cache during upgrade

### DIFF
--- a/salt/metalk8s/orchestrate/upgrade/init.sls
+++ b/salt/metalk8s/orchestrate/upgrade/init.sls
@@ -30,6 +30,11 @@ Upgrade etcd cluster:
   {%- set kubeconfig = "/etc/kubernetes/admin.conf" %}
   {%- set context = "kubernetes-admin@kubernetes" %}
 
+Refresh the package repository for {{ node }}:
+  salt.function:
+    - tgt: {{ node }}
+    - name: pkg.refresh_db
+
 Set node {{ node }} version to {{ dest_version }}:
   metalk8s_kubernetes.node_label_present:
     - name: metalk8s.scality.com/version
@@ -39,6 +44,7 @@ Set node {{ node }} version to {{ dest_version }}:
     - context: {{ context }}
     - require:
       - salt: Upgrade etcd cluster
+      - salt: Refresh the package repository for {{ node }}
   {%- if previous_node is defined %}
       - salt: Deploy node {{ previous_node }}
   {%- endif %}


### PR DESCRIPTION

**Component**:

'salt', 'upgrade'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

Issue: #1298 

**Summary**:

Yum package repository is not up-to-date during an upgrade. For example, if we try to update Kubelet, it results in errors since the new package is not available.

Now, we refresh the yum package repository as a precheck step for upgrades. 

**Acceptance criteria**: 

- A successful upgrade of Kubelet during upgrade attempt.


---

Closes: #1298

