### PR TITLE
ci: split IP reporting and debug `sleep` command

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -144,6 +144,12 @@ stages:
       path: eve/workers/openstack-single-node
     steps:
       - Git: *git_pull
+      - ShellCommand: &ssh_ip_setup
+          name: Report IP and install SSH keys
+          command: >
+            ip a &&
+            mkdir -p ~/.ssh &&
+            echo "%(secret:ssh_pub_keys)s" >> ~/.ssh/authorized_keys
       - ShellCommand: &retrieve_iso
           name: Retrieve ISO image
           command: >
@@ -219,13 +225,9 @@ stages:
           workdir: build/ui
           haltOnFailure: true
       - ShellCommand:
-          name: Debug step - report IPs, add SSH keys, wait 1 hour
+          name: Debug step - wait 1 hour before allowing resource destruction
           timeout: 3600
-          command: >
-            ip a &&
-            mkdir -p ~/.ssh &&
-            echo "%(secret:ssh_pub_keys)s" >> ~/.ssh/authorized_keys &&
-            sleep 3600
+          command: sleep 3600
           doStepIf: false
           alwaysRun: true
 
@@ -237,6 +239,7 @@ stages:
       path: eve/workers/openstack-multiple-nodes
     steps:
       - Git: *git_pull
+      - ShellCommand: *ssh_ip_setup
       - ShellCommand: *retrieve_iso
       - ShellCommand: *retrieve_iso_checksum
       - ShellCommand: *check_iso_checksum
@@ -367,6 +370,12 @@ stages:
           workdir: build/eve/workers/openstack-multiple-nodes/terraform/
           haltOnFailure: true
       - ShellCommand:
+          name: Debug step - wait 4 hours before allowing resource destruction
+          timeout: 14400
+          command: sleep 14400
+          alwaysRun: true
+          doStepIf: false
+      - ShellCommand:
           name: Destroy openstack virtual infra
           command: |-
             for _ in $(seq 1 3); do
@@ -376,13 +385,3 @@ stages:
           env: *terraform_spawn_multiple_nodes
           alwaysRun: true
           sigtermTime: 600
-      - ShellCommand:
-          name: Debug step - report IPs, add SSH keys, wait 4 hours
-          timeout: 14400
-          command: >
-            ip a &&
-            mkdir -p ~/.ssh &&
-            echo "%(secret:ssh_pub_keys)s" >> ~/.ssh/authorized_keys &&
-            sleep 14400
-          alwaysRun: true
-          doStepIf: false


### PR DESCRIPTION
Issue: #1308

**Component**: CI

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

The SSH key deployment step/IP reporting can be useful to always have, in case the build hangs.

**Summary**:

* Split debug step into SSH key installation/IP report and actual debug sleep step.
* Make SSH/IP step referenceable.

**Acceptance criteria**: 

Single- and multi-node deployments both report the IP of their Openstack worker at the beginning of their stage.

Debug steps are positioned __before__ any resource destruction.


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1308 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
