### PR TITLE
Monitoring test - increase timeout

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -366,8 +366,8 @@ stages:
             export SSH_CONFIG_FILE=/home/centos/ssh_config &&
             export ISO_MOUNTPOINT=/var/tmp/metalk8s &&
             export TEST_HOSTS_LIST=bootstrap &&
-            tox -e tests -- -m "ci and not slow and not monitoring" &&
-            tox -e tests -- -m "ci and slow and not monitoring"'
+            tox -e tests -- -m "ci and not slow" &&
+            tox -e tests -- -m "ci and slow"'
           # yamllint enable rule:line-length
           workdir: build/eve/workers/openstack-multiple-nodes/terraform/
           haltOnFailure: true

--- a/tests/kube_utils.py
+++ b/tests/kube_utils.py
@@ -1,18 +1,24 @@
-import json
-
 from kubernetes.client.rest import ApiException
 
 from tests import utils
+
 
 def get_pods(
     k8s_client, ssh_config, label,
     node='bootstrap', namespace='default', state='Running'
 ):
     """Return the pod `component` from the specified node"""
-    nodename = utils.resolve_hostname(node, ssh_config)
-    field_selector = 'spec.nodeName={},status.phase={}'.format(nodename, state)
+
+    field_selector = ['status.phase={}'.format(state)]
+
+    if node:
+        nodename = utils.resolve_hostname(node, ssh_config)
+        field_selector.append('spec.nodeName={}'.format(nodename))
+
     return k8s_client.list_namespaced_pod(
-        namespace, field_selector=field_selector, label_selector=label
+        namespace,
+        field_selector=','.join(field_selector),
+        label_selector=label
     ).items
 
 

--- a/tests/post/features/monitoring.feature
+++ b/tests/post/features/monitoring.feature
@@ -6,11 +6,11 @@ Feature: Monitoring is up and running
 
     Scenario: Expected Pods
         Given the Kubernetes API is available
-        Then we have 1 running pod labeled 'k8s-app=prometheus-operator' in namespace 'monitoring' on node 'bootstrap'
-        And we have 2 running pod labeled 'prometheus=k8s' in namespace 'monitoring' on node 'bootstrap'
-        And we have 3 running pod labeled 'alertmanager=main' in namespace 'monitoring' on node 'bootstrap'
-        And we have 1 running pod labeled 'app=grafana' in namespace 'monitoring' on node 'bootstrap'
-        And we have 1 running pod labeled 'app=kube-state-metrics' in namespace 'monitoring' on node 'bootstrap'
+        Then we have 1 running pod labeled 'k8s-app=prometheus-operator' in namespace 'monitoring'
+        And we have 2 running pod labeled 'prometheus=k8s' in namespace 'monitoring'
+        And we have 3 running pod labeled 'alertmanager=main' in namespace 'monitoring'
+        And we have 1 running pod labeled 'app=grafana' in namespace 'monitoring'
+        And we have 1 running pod labeled 'app=kube-state-metrics' in namespace 'monitoring'
         And we have 1 running pod labeled 'app=node-exporter' in namespace 'monitoring' on node 'bootstrap'
 
     Scenario: Monitored components statuses


### PR DESCRIPTION
**Component**: tests

**Context**: flaky tests in the CI

**Summary**:
Try to reduce flakiness by raising the time between retries when checking job status through Prometheus API
Also allow to not specify a node when testing pods to avoid failure when pods are not fixed on a specific node.

**Acceptance criteria**: Green builds


---

Closes: #1303 

