### PR TITLE
Enable podshareprocessnamespace for kubelet 1.11

### DIFF
--- a/salt/metalk8s/salt/master/installed.sls
+++ b/salt/metalk8s/salt/master/installed.sls
@@ -19,6 +19,27 @@ Create salt master directories:
       - /var/cache/salt
       - /var/run/salt
 
+{%- if salt.pkg.version('kubelet').startswith('1.11.') %}
+{#- PodShareProcessNamespace disabled by default in 1.11, enable alpha mode
+    until upgrade of kubelet #}
+
+Enable kubelet feature gate PodShareProcessNamespace:
+  file.serialize:
+    - name: "/var/lib/kubelet/config.yaml"
+    - formatter: yaml
+    - merge_if_exists: True
+    - dataset:
+        featureGates:
+          PodShareProcessNamespace: true
+  service.running:
+    - name: kubelet
+    - watch:
+      - file: Enable kubelet feature gate PodShareProcessNamespace
+    - require_in:
+      - metalk8s: Install and start salt master manifest
+
+{%- endif %}
+
 Install and start salt master manifest:
   metalk8s.static_pod_managed:
     - name: /etc/kubernetes/manifests/salt-master.yaml


### PR DESCRIPTION
**Component**:

'salt', 'upgrade'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

In dev2.1 we use `spec.shareProcessNamespace: true` which is not enabled by default in kubelet 1.11 but only in 1.12 so when we upgrade salt-master without upgrading kubelet first we got an error

**Summary**:

In salt-master installed state enable feature gate `PodShareProcessNamespace` if we are in kubelet 1.11.

**Acceptance criteria**: 

Salt-master manifest from development/2.1 works with kubelet 1.11

---

Fixes: #1281 

