### PR TITLE
Bugfix/1305 expansion test flakiness

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -397,7 +397,7 @@ stages:
             SSH_CONFIG: >-
               eve/workers/openstack-multiple-nodes/terraform/ssh_config
           command: >
-            for host in bootstrap; do
+            for host in bootstrap node1; do
               ssh -F $SSH_CONFIG $host \
               "sudo sosreport --all-logs -o metalk8s -kmetalk8s.podlogs=True\
               -o containerd -kcontainerd.all=True -kcontainerd.logs=True\
@@ -411,7 +411,7 @@ stages:
             SSH_CONFIG: >-
               eve/workers/openstack-multiple-nodes/terraform/ssh_config
           command: >
-            for host in bootstrap; do
+            for host in bootstrap node1; do
               scp -F $SSH_CONFIG \
               $host:/var/tmp/sosreport-* \
               sosreport/sosreport/multi-node/$host-sosreport.tar.xz

--- a/tests/install/steps/test_expansion.py
+++ b/tests/install/steps/test_expansion.py
@@ -11,7 +11,6 @@ import yaml
 from tests import utils
 
 # Scenarios
-@pytest.mark.skip(reason="Flaky test, needs to be fixed (#1305)")
 @scenario('../features/expansion.feature',
           'Add one node to the cluster',
           strict_gherkin=False)

--- a/tests/install/steps/test_expansion.py
+++ b/tests/install/steps/test_expansion.py
@@ -40,7 +40,7 @@ def declare_node(
 
 
 @when(parsers.parse('we deploy the node "{name}"'))
-def deploy_node(ssh_config, version, k8s_client, name):
+def deploy_node(host, ssh_config, version, name):
     node_name = utils.resolve_hostname(name, ssh_config)
     accept_ssh_key = [
         'salt-ssh', '-i', node_name, 'test.ping', '--roster=kubernetes'
@@ -49,10 +49,10 @@ def deploy_node(ssh_config, version, k8s_client, name):
     deploy = [
         'salt-run', 'state.orchestrate', 'metalk8s.orchestrate.deploy_node',
         'saltenv=metalk8s-{}'.format(version),
-        'pillar={}'.format(json.dumps(pillar))
+        "pillar='{}'".format(json.dumps(pillar))
     ]
-    run_salt_command(k8s_client, accept_ssh_key, ssh_config)
-    run_salt_command(k8s_client, deploy, ssh_config)
+    run_salt_command(host, accept_ssh_key, ssh_config)
+    run_salt_command(host, deploy, ssh_config)
 
 
 # }}}
@@ -100,6 +100,33 @@ def check_etcd_role(ssh_config, k8s_client, node_name):
 # }}}
 # Helpers {{{
 
+def kubectl_exec(
+    host,
+    command,
+    pod,
+    kubeconfig='/etc/kubernetes/admin.conf',
+    **kwargs
+):
+    """Grab the return code from a `kubectl exec`"""
+    kube_args = ['--kubeconfig', kubeconfig]
+
+    if kwargs.get('container'):
+        kube_args.extend(['-c', kwargs.get('container')])
+    if kwargs.get('namespace'):
+        kube_args.extend(['-n', kwargs.get('namespace')])
+
+    kubectl_cmd_tplt = 'kubectl exec {} {} -- {}'
+
+    with host.sudo():
+        output = host.run(
+            kubectl_cmd_tplt.format(
+                pod,
+                ' '.join(kube_args),
+                ' '.join(command)
+            )
+        )
+        return output
+
 def get_node_ip(hostname, ssh_config, bootstrap_config):
     """Return the IP of the node `hostname`.
     We have to jump through hoops because `testinfra` does not provide a simple
@@ -124,18 +151,26 @@ def node_from_manifest(manifest):
     manifest['api_version'] = manifest.pop('apiVersion')
     return k8s.client.V1Node(**manifest)
 
-def run_salt_command(k8s_client, command, ssh_config):
+def run_salt_command(host, command, ssh_config):
     """Run a command inside the salt-master container."""
-    name = 'salt-master-{}'.format(
+
+    pod = 'salt-master-{}'.format(
         utils.resolve_hostname('bootstrap', ssh_config)
     )
-    stderr = k8s.stream.stream(
-        k8s_client.connect_get_namespaced_pod_exec,
-        name=name, namespace='kube-system', container='salt-master',
-        command=command,
-        stderr=True, stdin=False, stdout=False, tty=False
+
+    output = kubectl_exec(
+        host,
+        command,
+        pod,
+        container='salt-master',
+        namespace='kube-system'
     )
-    assert not stderr, 'deploy failed with {}'.format(stderr)
+
+    assert output.exit_status == 0, \
+        'deploy failed with: \nout: {}\nerr:'.format(
+            output.stdout,
+            output.stderr
+        )
 
 def etcdctl(k8s_client, command, ssh_config):
     """Run an etcdctl command inside the etcd container."""

--- a/tests/post/steps/test_static_pods.py
+++ b/tests/post/steps/test_static_pods.py
@@ -38,7 +38,6 @@ def transient_files(host):
 # }}}
 
 
-@pytest.mark.skip(reason="Flaky test, needs to be fixed (#1304)")
 @scenario(
     "../features/static_pods.feature",
     "Static Pods restart on configuration change",


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

Flaky test management time!

* Some pods fail to start even after 90s (30 x 3s wait).
Example build: https://eve.devsca.com/github/scality/metalk8s/#/builders/1/builds/6895

* More stuff...

**Summary**:

* Revert expansion test disable
* Change approach for command execution in salt-master
* Enable log collection on `node1`, since we now do expansion

**Acceptance criteria**: 

* No more flakies due warning logs going into `stderr` in salt output of `deploy_node`.
* Actual formula execution errors still report failures (see https://eve.devsca.com/github/scality/metalk8s/#/builders/10/builds/2300 for example, where a syntax error inserted in the `deploy_node` Jinja file caused the build to fail with comprehensive error output).


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1305 
<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
