### PR TITLE
Use the superseded form of `module.wait` in kubelet installed state

### DIFF
--- a/salt/metalk8s/kubernetes/kubelet/installed.sls
+++ b/salt/metalk8s/kubernetes/kubelet/installed.sls
@@ -20,6 +20,6 @@ Install kubelet:
 # Workaround: Reload systemctl
 Reload systemctl:
   module.wait:
-    - name: service.systemctl_reload
+    - service.systemctl_reload: []
     - watch:
       - pkg: Install kubelet


### PR DESCRIPTION


**Component**:

'salt', 'kubernetes'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

In kubelet installed state we use module.wait to reload systemctl but the module syntax is the old one as we superseded it.

**Summary**:

Use the new syntax

---

Fixes: #1329
