### PR TITLE
build/deps: fix the type of `path` for `which`

### DIFF
--- a/buildchain/buildchain/deps.py
+++ b/buildchain/buildchain/deps.py
@@ -27,7 +27,7 @@ def task_check_for() -> Iterator[types.TaskDict]:
         """
         if binary_path:
             path = Path(binary_path)
-            cmd_path = shutil.which(path.name, path=path.parent)
+            cmd_path = shutil.which(path.name, path=str(path.parent))
         else:
             cmd_path = shutil.which(command_name)
         if cmd_path is None:


### PR DESCRIPTION
**Component**:

buildchain

**Context**: 

The buildchain can be configured to use binaries in location out of `PATH`, but currently this cause the code to die with an exception.
This bug stems from the fact that `shutil.which` doesn't work with `Path` object.

**Summary**:

We convert the `path` argument to `str` before passing it to `shutil.which`.

**Acceptance criteria**: 

You can build MetalK8s with binaries in custom location (i.e. defined in `.env`).

---

Closes: #1335