### PR TITLE
Add Ubuntu nodes on Vagrant env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ buildchain/.venv/
 .doit.db
 
 *.pyc
+*.log

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -195,25 +195,41 @@ Vagrant.configure("2") do |config|
       inline: BOOTSTRAP
   end
 
-  (1..9).each do |i|
-    node_name = "node#{i}"
+  os_data = {
+    centos: {
+      name: 'centos/7',
+      version: '1811.02'
+    },
+    ubuntu: {
+      name: 'ubuntu/bionic64',
+      version: '20190514.0.0'
+    }
+  }
 
-    config.vm.define node_name, autostart: false do |node|
-      node.vm.hostname = node_name
+  os_data.each do |os, os_data|
+    (1..5).each do |i|
+      node_name = "#{os}#{i}"
+      config.vm.define node_name, autostart: false do |node|
 
-      node.vm.synced_folder ".", "/vagrant", disabled: true
+        node.vm.box = os_data[:name]
+        node.vm.box_version = os_data[:version]
 
-      # No need for Guest Additions since there is no synced folder
-      node.vbguest.auto_update = false
+        node.vm.hostname = node_name
 
-      node.vm.provision "copy-ssh-public-key",
-        type: "file",
-        source: ".vagrant/#{PRESHARED_SSH_KEY_NAME}.pub",
-        destination: ".ssh/#{PRESHARED_SSH_KEY_NAME}.pub"
+        node.vm.synced_folder ".", "/vagrant", disabled: true
 
-      node.vm.provision "add-ssh-public-key-to-authorized-keys",
-        type: "shell",
-        inline: DEPLOY_SSH_PUBLIC_KEY
+        # No need for Guest Additions since there is no synced folder
+        node.vbguest.auto_update = false
+
+        node.vm.provision "copy-ssh-public-key",
+          type: "file",
+          source: ".vagrant/#{PRESHARED_SSH_KEY_NAME}.pub",
+          destination: ".ssh/#{PRESHARED_SSH_KEY_NAME}.pub"
+
+        node.vm.provision "add-ssh-public-key-to-authorized-keys",
+          type: "shell",
+          inline: DEPLOY_SSH_PUBLIC_KEY
+      end
     end
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -206,6 +206,11 @@ Vagrant.configure("2") do |config|
     }
   }
 
+  INSTALL_PYTHON = <<-SCRIPT
+  #!/bin/bash
+  apt install python -y
+  SCRIPT
+
   os_data.each do |os, os_data|
     (1..5).each do |i|
       node_name = "#{os}#{i}"
@@ -229,6 +234,12 @@ Vagrant.configure("2") do |config|
         node.vm.provision "add-ssh-public-key-to-authorized-keys",
           type: "shell",
           inline: DEPLOY_SSH_PUBLIC_KEY
+
+        if os == "ubuntu"
+          node.vm.provision "install-python",
+            type: "shell",
+            inline: INSTALL_PYTHON
+        end
       end
     end
   end


### PR DESCRIPTION
**Component**: Vagrant

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: Metalk8s over Ubuntu

**Summary**: Permits to have some Ubuntu nodes on Vagrant with python 2.7 installed

**Acceptance criteria**: 
Deploy a node (with a node number > 5 ) and verify if it's a Ubuntu VM. 
Then launch the command `python` and verify the version (python 2.7.15+)


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1327 #1326 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
