### PR TITLE
containers: Ensure that salt-master container is up during upgrade

### DIFF
--- a/salt/metalk8s/salt/master/installed.sls
+++ b/salt/metalk8s/salt/master/installed.sls
@@ -36,6 +36,13 @@ Install and start salt master manifest:
       - file: /etc/salt/master.d/99-metalk8s.conf
       - file: /etc/salt/master.d/99-metalk8s-roots.conf
 
+Delay after new pod deployment:
+  module.wait:
+    - test.sleep:
+      - length: 10
+    - watch:
+      - metalk8s: Install and start salt master manifest
+
 Make sure salt master container is up:
   module.wait:
     - cri.wait_container:
@@ -43,8 +50,12 @@ Make sure salt master container is up:
       - state: running
     - watch:
       - metalk8s: Install and start salt master manifest
+    - require:
+      - module: Delay after new pod deployment
 
 Wait for Salt API to answer:
   http.wait_for_successful_query:
     - name: http://{{ salt_ip }}:4507/
     - status: 200
+    - require:
+      - module: Make sure salt master container is up


### PR DESCRIPTION

**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
'salt', 'containers'

**Context**: 

Issue : #1333 

**Summary**:

- We have added a `module.wait` to check that the salt-master container is up and running correctly during an upgrade.
 Initially, we do not make this quick check and as a result, the next  upgrade step which happens to be connecting to the salt-master container fails randomly.

**Acceptance criteria**: 

- During upgrade; after running `metalk8s.products` salt-state, we should be able to connect to the salt-master container and run orchestrate.

- Perform a successful test upgrade
---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1333 


