### PR TITLE
Do a `yum clean all` when configuring the repositories

### DIFF
--- a/salt/metalk8s/orchestrate/upgrade/init.sls
+++ b/salt/metalk8s/orchestrate/upgrade/init.sls
@@ -30,11 +30,6 @@ Upgrade etcd cluster:
   {%- set kubeconfig = "/etc/kubernetes/admin.conf" %}
   {%- set context = "kubernetes-admin@kubernetes" %}
 
-Refresh the package repository for {{ node }}:
-  salt.function:
-    - tgt: {{ node }}
-    - name: pkg.refresh_db
-
 Set node {{ node }} version to {{ dest_version }}:
   metalk8s_kubernetes.node_label_present:
     - name: metalk8s.scality.com/version
@@ -44,7 +39,6 @@ Set node {{ node }} version to {{ dest_version }}:
     - context: {{ context }}
     - require:
       - salt: Upgrade etcd cluster
-      - salt: Refresh the package repository for {{ node }}
   {%- if previous_node is defined %}
       - salt: Deploy node {{ previous_node }}
   {%- endif %}

--- a/salt/metalk8s/repo/offline.sls
+++ b/salt/metalk8s/repo/offline.sls
@@ -36,7 +36,23 @@ Configure {{ repo_name }} repository:
   {%- endif %}
     - repo_gpg_check: {{ repo_config.repo_gpg_check }}
     - enabled: {{ repo_config.enabled }}
+    - refresh: false
+    - onchanges_in:
+      - cmd: Refresh yum cache
 {%- endfor %}
+
+# Refresh cache manually as we use the same repo name for all versions
+Refresh yum cache:
+  # Refresh_db not enough as it's only expire-cache
+  cmd.run:
+  - name: "yum clean all --disablerepo='*'
+           --enablerepo='{{ repo.repositories.keys() | join(',') }}'"
+  module.run:
+    - pkg.refresh_db:
+      - disablerepo: '*'
+      - enablerepo: {{ repo.repositories.keys() | tojson }}
+    - onchanges:
+      - cmd: Refresh yum cache
 
 Repositories configured:
   test.succeed_without_changes:


### PR DESCRIPTION
**Component**:

'salt'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

We use the same repositories name for all MetalK8s versions so we need to clean all the yum cache to be able to have the right list of packages

**Summary**:

When one of the repositories changes do a `yum clean all` + refresh_db

---

Fixes: #1298 
