### PR TITLE
Separate config generation from manifest for repositories

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -329,6 +329,7 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/orchestrate/upgrade/precheck.sls'),
     Path('salt/metalk8s/orchestrate/register_etcd.sls'),
 
+    Path('salt/metalk8s/products/configured.sls'),
     Path('salt/metalk8s/products/init.sls'),
     Path('salt/metalk8s/products/mounted.sls'),
 

--- a/salt/_states/metalk8s.py
+++ b/salt/_states/metalk8s.py
@@ -10,16 +10,48 @@ def __virtual__():
     return __virtualname__
 
 
-def static_pod_managed(name, source, config_files=None, context=None):
+def static_pod_managed(name,
+                       source,
+                       config_files=None,
+                       config_files_opt=None,
+                       context=None,
+                       **kwargs):
     """Simple helper to edit a static Pod manifest if configuration changes.
 
     Expects the template to use the `config_digest` variable and store it in
     the `metadata.annotations` section, with the key
     `metalk8s.scality.com/config-digest`.
+
+    name:
+        Path to the static pod manifest.
+
+    source:
+        Source file used to render the manifest.
+
+    config_files:
+        List of file to use to generate a digest store in `config_digest` in
+        the source template.
+
+    config_files_opt:
+        Same as config_files but these files are optional (ignored if the file
+        does not exists).
+
+    context:
+        Context to use to render the source template.
+
+    kwargs:
+        Any arguments supported by `file.managed` are supported.
     """
+    if not config_files:
+        config_files = []
+
+    for config_file in config_files_opt or []:
+        if __salt__["file.file_exists"](config_file):
+            config_files.append(config_file)
+
     config_file_digests = [
         __salt__["hashutil.digest_file"](config_file, checksum="sha256")
-        for config_file in config_files or []
+        for config_file in config_files
     ]
     config_digest = __salt__["hashutil.md5_digest"](
         "-".join(config_file_digests)
@@ -28,13 +60,14 @@ def static_pod_managed(name, source, config_files=None, context=None):
     return __states__["file.managed"](
         name,
         source,
-        template="jinja",
-        user="root",
-        group="root",
-        mode="0600",
-        makedirs=False,
-        backup=False,
+        template=kwargs.pop("template", "jinja"),
+        user=kwargs.pop("user", "root"),
+        group=kwargs.pop("group", "root"),
+        mode=kwargs.pop("mode", "0600"),
+        makedirs=kwargs.pop("makedirs", False),
+        backup=kwargs.pop("backup", False),
         context=dict(context or {}, config_digest=config_digest),
+        **kwargs
     )
 
 

--- a/salt/metalk8s/defaults.yaml
+++ b/salt/metalk8s/defaults.yaml
@@ -30,6 +30,11 @@ kubeadm_preflight:
       - coreutils             # provides touch
 
 repo:
+  config:
+    directory: '/var/lib/metalk8s/repositories/conf.d'
+    default: 'default.conf'
+    registry: '90-registry-config.inc'
+    common_registry: '99-registry-common.inc'
   local_mode: false
   relative_path: packages     # relative to ISO root (configured in pillar)
   port: 8080

--- a/salt/metalk8s/products/configured.sls
+++ b/salt/metalk8s/products/configured.sls
@@ -1,0 +1,3 @@
+include:
+  - metalk8s.salt.master.configured
+  - metalk8s.repo.configured

--- a/salt/metalk8s/repo/configured.sls
+++ b/salt/metalk8s/repo/configured.sls
@@ -1,2 +1,49 @@
-include:
-  - .offline
+{%- from "metalk8s/map.jinja" import repo with context %}
+
+{%- set products = salt.metalk8s.get_products() %}
+
+Generate repositories nginx configuration:
+  file.managed:
+    - name: {{ salt.file.join(repo.config.directory, repo.config.default) }}
+    - source: salt://{{ slspath }}/files/nginx.conf.j2
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: '0644'
+    - makedirs: true
+    - backup: false
+    - defaults:
+        listening_port: {{ repo.port }}
+
+Deploy common container registry nginx configuration:
+  file.managed:
+    - name: {{ salt.file.join(repo.config.directory, repo.config.common_registry) }}
+    - source: salt://{{ slspath }}/files/metalk8s-registry-common.inc
+    - user: root
+    - group: root
+    - mode: '0644'
+    - makedirs: true
+    - backup: false
+
+Deploy container registry nginx configuration:
+  file.managed:
+    - name: {{ salt.file.join(repo.config.directory, '99-' ~ saltenv ~ '-registry.inc') }}
+    - source: salt://{{ slspath }}/files/metalk8s-registry.inc
+    - user: root
+    - group: root
+    - mode: '0644'
+    - makedirs: true
+    - backup: false
+
+Generate container registry configuration:
+  file.managed:
+    - name: {{ salt.file.join(repo.config.directory, repo.config.registry) }}
+    - source: salt://{{ slspath }}/files/metalk8s-registry-config.inc.j2
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: '0644'
+    - makedirs: true
+    - backup: false
+    - defaults:
+        products: {{ products }}

--- a/salt/metalk8s/repo/init.sls
+++ b/salt/metalk8s/repo/init.sls
@@ -1,2 +1,2 @@
 include:
-  - .configured
+  - .offline


### PR DESCRIPTION
**Component**:

'salt', 'kubernetes'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

To make new iso version available we need to reconfigure repositories without upgrading the static pod, so we need to separate config generation from manifest deployment

**Summary**:

Separate config generation from manifest generation in repo states

---

Fixes: #1344 
