### PR TITLE
ClusterHealth: Refresh

### DIFF
--- a/ui/src/constants.js
+++ b/ui/src/constants.js
@@ -1,0 +1,1 @@
+export const REFRESH_TIMEOUT = 15000;

--- a/ui/src/containers/NodeList.js
+++ b/ui/src/containers/NodeList.js
@@ -9,6 +9,7 @@ import { Table, Button, Loader } from '@scality/core-ui';
 import { padding } from '@scality/core-ui/dist/style/theme';
 
 import { fetchNodesAction, deployNodeAction } from '../ducks/app/nodes';
+import { REFRESH_TIMEOUT } from '../constants';
 
 const PageContainer = styled.div`
   box-sizing: border-box;
@@ -125,7 +126,7 @@ class NodeList extends React.Component {
 
   componentDidMount() {
     this.props.fetchNodes();
-    this.interval = setInterval(() => this.props.fetchNodes(), 10000);
+    this.interval = setInterval(() => this.props.fetchNodes(), REFRESH_TIMEOUT);
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
**Component**: UI

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
- we need to refresh the cluster status page to display the updated information

**Summary**:

**Acceptance criteria**: 
- the page is update every 15s.
<img width="1427" alt="Screenshot 2019-07-03 at 13 50 45" src="https://user-images.githubusercontent.com/47394132/60589431-ce682680-9d99-11e9-9196-b14c8d96c413.png">
---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: https://github.com/scality/metalk8s/issues/1340

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
