### PR TITLE
Revert "Enable PodShareProcessNamespace when installing salt-master

### DIFF
--- a/salt/metalk8s/salt/master/installed.sls
+++ b/salt/metalk8s/salt/master/installed.sls
@@ -19,27 +19,6 @@ Create salt master directories:
       - /var/cache/salt
       - /var/run/salt
 
-{%- if salt.pkg.version('kubelet').startswith('1.11.') %}
-{#- PodShareProcessNamespace disabled by default in 1.11, enable alpha mode
-    until upgrade of kubelet #}
-
-Enable kubelet feature gate PodShareProcessNamespace:
-  file.serialize:
-    - name: "/var/lib/kubelet/config.yaml"
-    - formatter: yaml
-    - merge_if_exists: True
-    - dataset:
-        featureGates:
-          PodShareProcessNamespace: true
-  service.running:
-    - name: kubelet
-    - watch:
-      - file: Enable kubelet feature gate PodShareProcessNamespace
-    - require_in:
-      - metalk8s: Install and start salt master manifest
-
-{%- endif %}
-
 Install and start salt master manifest:
   metalk8s.static_pod_managed:
     - name: /etc/kubernetes/manifests/salt-master.yaml


### PR DESCRIPTION

**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
'salt', 'kubernetes'

**Context**: 

Issue: #1349

**Summary**:

This reverts commit f8064e786908a29dd6b93bce38a9bf2b9a3b0143.

This commit was introduced to resolve https://github.com/scality/metalk8s/issues/1281. These changes are no longer necessary hence clean-up.

**Acceptance criteria**: 


---

Closes: #1349

