### PR TITLE
ClusterMonitoring: exclude pending alerts

### DIFF
--- a/ui/src/containers/ClusterMonitoring.js
+++ b/ui/src/containers/ClusterMonitoring.js
@@ -117,14 +117,16 @@ const ClusterMonitoring = props => {
     }
   ];
 
-  const alerts = props.alerts.map(alert => {
-    return {
-      name: alert.labels.alertname,
-      severity: alert.labels.severity,
-      message: alert.annotations.message,
-      activeAt: alert.activeAt
-    };
-  });
+  const alerts = props.alerts
+    .filter(alert => alert.state !== 'pending')
+    .map(alert => {
+      return {
+        name: alert.labels.alertname,
+        severity: alert.labels.severity,
+        message: alert.annotations.message,
+        activeAt: alert.activeAt
+      };
+    });
 
   const sortedAlerts = sortAlerts(alerts, sortBy, sortDirection);
 


### PR DESCRIPTION
**Component**:UI

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
- the UI currently lists all Prometheus alerts, including 'pending' ones

**Summary**:

**Acceptance criteria**: 
- UI doesn't display 'pending' ones

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: https://github.com/scality/metalk8s/issues/1242

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
