### PR TITLE
build: fix concurrent build on MacOS

### DIFF
--- a/buildchain/dodo.py
+++ b/buildchain/dodo.py
@@ -5,6 +5,7 @@
 
 """Build entry point."""
 
+import sys
 
 import doit  # type: ignore
 
@@ -44,3 +45,12 @@ DOIT_CONFIG = {
     'cleandep': True,
     'cleanforget': True,
 }
+
+# Because some code (in `doit` or even below) seems to be using a dangerous mix
+# of threads and fork, the workers processes are killed by macOS (search for
+# OBJC_DISABLE_INITIALIZE_FORK_SAFETY for the details).
+#
+# Until the guilty code is properly fixed (if ever), let's force the use of
+# threads instead of forks on macOS to sidestep the issue.
+if sys.platform == 'darwin':
+    DOIT_CONFIG['par_type'] = 'thread'


### PR DESCRIPTION
**Component**:

buildchain

**Context**: 

When trying to use the parallel execution feature of `doit` on Mac, we observe that the worker processes are killed by the OS and only the main one survives.

**Summary**:

The issues seems related to the fact that:
- by default `doit` uses `fork` (through `multiprocessing`) to spawn its workers
- since macOS 10.13 (High Sierra), Apple added [a new security measure](http://sealiesoftware.com/blog/archive/2017/6/5/Objective-C_and_fork_in_macOS_1013.html) that kill processes that are using [a dangerous mix of threads and forks](https://blog.phusion.nl/2017/10/13/why-ruby-app-servers-break-on-macos-high-sierra-and-what-can-be-done-about-it/))

As a consequence, now instead of working most of the time (and failing in a hard way to debug) , the processes are directly killed.

There are three ways to solve this problems:
1. set the environment variable `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES.`
2. don't use `fork`
3. fix the code that uses a dangerous mix of thread and forks

① is not good as it doesn't fix the underlying issue: it only disable the security and we're back to "works most of the time, sometimes does weird things"
② is easy to do because we can tell to `doit` to uses only threads instead of forks.
③ is probably the best, but requires more troubleshooting/time/…

In conclusion, this commit implements ② until ③ is done (if ever…) by detecting macOS and forcing the use of thread in that case.

**Acceptance criteria**: 

Build with multiple workers (e.g.: `./doit.sh -n 4`) are working on macOS.

---

Closes: #1354