### PR TITLE
Add Cluster Status help tips

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1765,6 +1765,14 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
       "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw=="
     },
+    "add-dom-event-listener": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/add-dom-event-listener/-/add-dom-event-listener-1.1.0.tgz",
+      "integrity": "sha512-WCxx1ixHT0GQU9hb0KI/mhgRQhnU+U3GvwY6ZvVjYq8rsihIGoaIOUbY0yMPBxLH5MDtr0kz3fisWGNcbWW7Jw==",
+      "requires": {
+        "object-assign": "4.x"
+      }
+    },
     "address": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/address/-/address-1.0.3.tgz",
@@ -4503,10 +4511,23 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
+    "component-classes": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/component-classes/-/component-classes-1.2.6.tgz",
+      "integrity": "sha1-xkI5TDYYpNiwuJGe/Mu9kw5c1pE=",
+      "requires": {
+        "component-indexof": "0.0.3"
+      }
+    },
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+    },
+    "component-indexof": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/component-indexof/-/component-indexof-0.0.3.tgz",
+      "integrity": "sha1-EdCRMSI5648yyPJa6csAL/6NPCQ="
     },
     "compressible": {
       "version": "2.0.16",
@@ -4751,6 +4772,15 @@
         "public-encrypt": "^4.0.0",
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
+      }
+    },
+    "css-animation": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/css-animation/-/css-animation-1.5.0.tgz",
+      "integrity": "sha512-hWYoWiOZ7Vr20etzLh3kpWgtC454tW5vn4I6rLANDgpzNSkO7UfOqyCEeaoBSG9CYWQpRkFWTWbWW8o3uZrNLw==",
+      "requires": {
+        "babel-runtime": "6.x",
+        "component-classes": "^1.2.5"
       }
     },
     "css-blank-pseudo": {
@@ -5808,6 +5838,11 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dom-align": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.9.0.tgz",
+      "integrity": "sha512-HvPfXISxoU7dKrbqS4vIFa1hx88wD7VdKaZ7sHWeow8y76tuzsxXkiPGbeilemLXrTd9cWbPqR4MOl4y3dkcXA=="
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -10939,6 +10974,11 @@
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.11.tgz",
       "integrity": "sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q=="
     },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+    },
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
@@ -10968,6 +11008,26 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "requires": {
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -14879,6 +14939,64 @@
         }
       }
     },
+    "rc-align": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-2.4.5.tgz",
+      "integrity": "sha512-nv9wYUYdfyfK+qskThf4BQUSIadeI/dCsfaMZfNEoxm9HwOIioQ+LyqmMK6jWHAZQgOzMLaqawhuBXlF63vgjw==",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "dom-align": "^1.7.0",
+        "prop-types": "^15.5.8",
+        "rc-util": "^4.0.4"
+      }
+    },
+    "rc-animate": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/rc-animate/-/rc-animate-2.8.3.tgz",
+      "integrity": "sha512-VPSHJF/PW9zrPVCdQ94/YOI2lFfJVlaiAeQveJN2nlPVMivgvXkuFJyfe42GbZqm+qlnRjH9B4WbY9rCZz9miw==",
+      "requires": {
+        "babel-runtime": "6.x",
+        "classnames": "^2.2.6",
+        "css-animation": "^1.3.2",
+        "prop-types": "15.x",
+        "raf": "^3.4.0",
+        "react-lifecycles-compat": "^3.0.4"
+      }
+    },
+    "rc-tooltip": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-3.7.3.tgz",
+      "integrity": "sha512-dE2ibukxxkrde7wH9W8ozHKUO4aQnPZ6qBHtrTH9LoO836PjDdiaWO73fgPB05VfJs9FbZdmGPVEbXCeOP99Ww==",
+      "requires": {
+        "babel-runtime": "6.x",
+        "prop-types": "^15.5.8",
+        "rc-trigger": "^2.2.2"
+      }
+    },
+    "rc-trigger": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-2.6.4.tgz",
+      "integrity": "sha512-dN/Iia5E+xLh33OyvIol1Gg1WfHVfL9fUdq34/ejeYENghUNkF0965PDe+GYIgypYplhUM967rjbr/UEm6ctjA==",
+      "requires": {
+        "babel-runtime": "6.x",
+        "classnames": "^2.2.6",
+        "prop-types": "15.x",
+        "rc-align": "^2.4.0",
+        "rc-animate": "2.x",
+        "rc-util": "^4.4.0"
+      }
+    },
+    "rc-util": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.6.0.tgz",
+      "integrity": "sha512-rbgrzm1/i8mgfwOI4t1CwWK7wGe+OwX+dNa7PVMgxZYPBADGh86eD4OcJO1UKGeajIMDUUKMluaZxvgraQIOmw==",
+      "requires": {
+        "add-dom-event-listener": "^1.1.0",
+        "babel-runtime": "6.x",
+        "prop-types": "^15.5.10",
+        "shallowequal": "^0.2.2"
+      }
+    },
     "react": {
       "version": "16.8.4",
       "resolved": "https://registry.npmjs.org/react/-/react-16.8.4.tgz",
@@ -16520,6 +16638,14 @@
           "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
           "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
         }
+      }
+    },
+    "shallowequal": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-0.2.2.tgz",
+      "integrity": "sha1-HjL9W8q2rWiKSBLLDMBO/HXHAU4=",
+      "requires": {
+        "lodash.keys": "^3.1.2"
       }
     },
     "shasum": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,6 +11,7 @@
     "lodash": "4.17.11",
     "memoize-one": "^4.0.2",
     "polished": "3.4.1",
+    "rc-tooltip": "^3.7.3",
     "react": "^16.8.1",
     "react-debounce-input": "3.2.0",
     "react-dom": "^16.8.1",

--- a/ui/src/components/CircleStatus.js
+++ b/ui/src/components/CircleStatus.js
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 const STATUS_WARNING = 'warning';
 const STATUS_CRITICAL = 'critical';
+const STATUS_SUCCESS = 'success';
 const STATUS_NONE = 'none';
 
 const Circle = styled.i`
@@ -11,6 +12,9 @@ const Circle = styled.i`
     let color = theme.base;
 
     switch (props.status) {
+      case STATUS_SUCCESS:
+        color = theme.success;
+        break;
       case STATUS_WARNING:
         color = theme.warning;
         break;

--- a/ui/src/components/CircleStatus.js
+++ b/ui/src/components/CircleStatus.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import styled from 'styled-components';
 
-const STATUS_WARNING = 'warning';
-const STATUS_CRITICAL = 'critical';
-const STATUS_SUCCESS = 'success';
-const STATUS_NONE = 'none';
+import {
+  STATUS_WARNING,
+  STATUS_CRITICAL,
+  STATUS_SUCCESS,
+  STATUS_NONE
+} from './constants';
 
 const Circle = styled.i`
   color: ${props => {

--- a/ui/src/components/Tooltip.js
+++ b/ui/src/components/Tooltip.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import RcTooltip from 'rc-tooltip';
+import 'rc-tooltip/assets/bootstrap.css';
+
+const Tooltip = props => {
+  return (
+    <RcTooltip
+      placement={props.placement}
+      mouseEnterDelay={props.mouseEnterDelay}
+      mouseLeaveDelay={props.mouseLeaveDelay}
+      destroyTooltipOnHide={props.destroyTooltipOnHide}
+      trigger={props.trigger}
+      overlay={props.overlay}
+    >
+      {props.children}
+    </RcTooltip>
+  );
+};
+
+Tooltip.defaultProps = {
+  placement: 'bottom',
+  mouseEnterDelay: 0,
+  mouseLeaveDelay: 0,
+  destroyTooltipOnHide: true,
+  trigger: ['hover'],
+  overlay: null
+};
+
+export default Tooltip;

--- a/ui/src/components/constants.js
+++ b/ui/src/components/constants.js
@@ -1,0 +1,4 @@
+export const STATUS_WARNING = 'warning';
+export const STATUS_CRITICAL = 'critical';
+export const STATUS_SUCCESS = 'success';
+export const STATUS_NONE = 'none';

--- a/ui/src/containers/ClusterMonitoring.js
+++ b/ui/src/containers/ClusterMonitoring.js
@@ -15,6 +15,7 @@ import {
   CLUSTER_STATUS_UP,
   CLUSTER_STATUS_DOWN
 } from '../ducks/app/monitoring';
+import { STATUS_CRITICAL, STATUS_SUCCESS } from '../components/constants';
 
 const PageContainer = styled.div`
   box-sizing: border-box;
@@ -145,7 +146,7 @@ const ClusterMonitoring = props => {
     });
 
   const checkControlPlaneStatus = jobCount =>
-    jobCount > 0 ? 'success' : 'critical';
+    jobCount > 0 ? STATUS_SUCCESS : STATUS_CRITICAL;
 
   const apiServerStatus = checkControlPlaneStatus(
     props.cluster.apiServerStatus

--- a/ui/src/containers/ClusterMonitoring.js
+++ b/ui/src/containers/ClusterMonitoring.js
@@ -64,6 +64,10 @@ const TooltipContent = styled.div`
   font-weight: ${fontWeight.bold};
 `;
 
+const ControlPlaneStatusLabel = styled.span`
+  margin-left: ${padding.smaller};
+`;
+
 const ClusterMonitoring = props => {
   useEffect(() => {
     props.refreshAlerts();
@@ -174,16 +178,22 @@ const ClusterMonitoring = props => {
           overlay={
             <TooltipContent>
               <div>
-                <CircleStatus status={apiServerStatus} />{' '}
-                {props.intl.messages.api_server}
+                <CircleStatus status={apiServerStatus} />
+                <ControlPlaneStatusLabel>
+                  {props.intl.messages.api_server}
+                </ControlPlaneStatusLabel>
               </div>
               <div>
-                <CircleStatus status={kubeSchedulerStatus} />{' '}
-                {props.intl.messages.kube_scheduler}
+                <CircleStatus status={kubeSchedulerStatus} />
+                <ControlPlaneStatusLabel>
+                  {props.intl.messages.kube_scheduler}
+                </ControlPlaneStatusLabel>
               </div>
               <div>
-                <CircleStatus status={kubeControllerManagerStatus} />{' '}
-                {props.intl.messages.kube_controller_manager}
+                <CircleStatus status={kubeControllerManagerStatus} />
+                <ControlPlaneStatusLabel>
+                  {props.intl.messages.kube_controller_manager}
+                </ControlPlaneStatusLabel>
               </div>
             </TooltipContent>
           }
@@ -214,14 +224,9 @@ const ClusterMonitoring = props => {
 
 const mapStateToProps = (state, props) => {
   return {
-<<<<<<< HEAD
     alerts: state.app.monitoring.alert,
-    clusterStatus: makeClusterStatus(state, props)
-=======
-    alerts: state.app.monitoring.alert.list,
     clusterStatus: makeClusterStatus(state, props),
     cluster: state.app.monitoring.cluster
->>>>>>> Add Cluster Status help tips
   };
 };
 

--- a/ui/src/containers/ClusterMonitoring.js
+++ b/ui/src/containers/ClusterMonitoring.js
@@ -6,8 +6,9 @@ import { injectIntl, FormattedDate, FormattedTime } from 'react-intl';
 import styled from 'styled-components';
 import { Loader as LoaderCoreUI } from '@scality/core-ui';
 import { Table } from '@scality/core-ui';
-import { padding } from '@scality/core-ui/dist/style/theme';
+import { padding, fontWeight } from '@scality/core-ui/dist/style/theme';
 import CircleStatus from '../components/CircleStatus';
+import Tooltip from '../components/Tooltip';
 import {
   refreshClusterStatusAction,
   refreshAlertsAction,
@@ -47,10 +48,19 @@ const ClusterStatusTitleContainer = styled.div`
 `;
 
 const ClusterStatusValue = styled.span`
-  margin-left: ${padding.small};
+  margin: 0 ${padding.small};
   font-weight: bold;
   color: ${props =>
     props.isUp ? props.theme.brand.success : props.theme.brand.danger};
+`;
+
+const QuestionMarkIcon = styled.i`
+  color: ${props => props.theme.brand.primary};
+`;
+
+const TooltipContent = styled.div`
+  color: ${props => props.theme.brand.secondary};
+  font-weight: ${fontWeight.bold};
 `;
 
 const ClusterMonitoring = props => {
@@ -134,6 +144,19 @@ const ClusterMonitoring = props => {
       };
     });
 
+  const checkControlPlaneStatus = jobCount =>
+    jobCount > 0 ? 'success' : 'critical';
+
+  const apiServerStatus = checkControlPlaneStatus(
+    props.cluster.apiServerStatus
+  );
+  const kubeSchedulerStatus = checkControlPlaneStatus(
+    props.cluster.kubeSchedulerStatus
+  );
+  const kubeControllerManagerStatus = checkControlPlaneStatus(
+    props.cluster.kubeControllerManagerStatus
+  );
+
   const sortedAlerts = sortAlerts(alerts, sortBy, sortDirection);
 
   return (
@@ -145,6 +168,27 @@ const ClusterMonitoring = props => {
         >
           {props.clusterStatus.label}
         </ClusterStatusValue>
+        <Tooltip
+          placement="right"
+          overlay={
+            <TooltipContent>
+              <div>
+                <CircleStatus status={apiServerStatus} />{' '}
+                {props.intl.messages.api_server}
+              </div>
+              <div>
+                <CircleStatus status={kubeSchedulerStatus} />{' '}
+                {props.intl.messages.kube_scheduler}
+              </div>
+              <div>
+                <CircleStatus status={kubeControllerManagerStatus} />{' '}
+                {props.intl.messages.kube_controller_manager}
+              </div>
+            </TooltipContent>
+          }
+        >
+          <QuestionMarkIcon className="fas fa-question-circle" />
+        </Tooltip>
         {props.clusterStatus.isLoading ? <LoaderCoreUI size="small" /> : null}
       </ClusterStatusTitleContainer>
 
@@ -169,8 +213,14 @@ const ClusterMonitoring = props => {
 
 const mapStateToProps = (state, props) => {
   return {
+<<<<<<< HEAD
     alerts: state.app.monitoring.alert,
     clusterStatus: makeClusterStatus(state, props)
+=======
+    alerts: state.app.monitoring.alert.list,
+    clusterStatus: makeClusterStatus(state, props),
+    cluster: state.app.monitoring.cluster
+>>>>>>> Add Cluster Status help tips
   };
 };
 

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -56,5 +56,8 @@
   "alerts": "Alerts",
   "node_creation": "Node creation",
   "node_creation_success": "Node {name} has been created successfully.",
-  "node_creation_failed": "Node {name} creation has failed."
+  "node_creation_failed": "Node {name} creation has failed.",
+  "api_server": "API",
+  "kube_scheduler": "Scheduler",
+  "kube_controller_manager": "Controller"
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -56,5 +56,8 @@
   "alerts": "Alertes",
   "node_creation": "Création du node",
   "node_creation_success": "Le node {name} a été créé avec succèss",
-  "node_creation_failed": "La création du node {name} a échoué."
+  "node_creation_failed": "La création du node {name} a échoué.",
+  "api_server": "API",
+  "kube_scheduler": "Ordonnanceur",
+  "kube_controller_manager": "Contrôleur"
 }


### PR DESCRIPTION
**Component**: ui

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
As a system administrator, I want to know what part of the cluster is breaking when the cluster status is down.

**Summary**:
[Screenshot](https://puu.sh/DOBOl/ad03cec027.png)

**Acceptance criteria**: 
You should see the question mark at the right of the Cluster Status.
When you hover the mouse on it, it should display some details like the screenshot.
If the cluster is down, at least one of the 3 items should be red.

**Others**:
There is some discussion about how we should rename the `Everything is up and running`, we will tackle this issue on new issue. It's out of scope or this PR.

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1341

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
