### PR TITLE
Improvement/950 add sosreport collecting

### DIFF
--- a/buildchain/buildchain/packaging.py
+++ b/buildchain/buildchain/packaging.py
@@ -151,6 +151,19 @@ CALICO_CNI_PLUGIN_VERSION : str = '3.8.0'
 # Packages per repository.
 PACKAGES : Dict[str, Tuple[targets.Package, ...]] = {
     'scality': (
+        # SOS report custom plugins.
+        targets.Package(
+            basename='_build_packages',
+            name='metalk8s-sosreport',
+            version=constants.SHORT_VERSION,
+            build_id=1,
+            sources=[
+                Path('metalk8s.py'),
+                Path('containerd.py'),
+            ],
+            builder=BUILDER,
+            task_dep=['_package_mkdir_root', '_build_container'],
+        ),
         # Calico Container Network Interface Plugin.
         targets.Package(
             basename='_build_packages',

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -229,6 +229,9 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/internal/preflight/mandatory.sls'),
     Path('salt/metalk8s/internal/preflight/recommended.sls'),
 
+    Path('salt/metalk8s/sreport/init.sls'),
+    Path('salt/metalk8s/sreport/installed.sls'),
+
     Path('salt/metalk8s/kubectl/init.sls'),
     Path('salt/metalk8s/kubectl/installed.sls'),
 

--- a/buildchain/buildchain/targets/package.py
+++ b/buildchain/buildchain/targets/package.py
@@ -27,6 +27,7 @@ Overview;
 import os
 import operator
 import re
+import shutil
 import urllib.parse
 import urllib.request
 from pathlib import Path
@@ -188,7 +189,7 @@ class Package(base.CompositeTarget):
         targets = [self.srcdir]
         targets.extend(self.sources)
         actions = directory.Mkdir(directory=self.srcdir).task['actions']
-        actions.append(self._download_sources)
+        actions.append(self._get_sources)
         task = self.basic_task
         task.update({
             'name': 'pkg_get_source',
@@ -235,12 +236,16 @@ class Package(base.CompositeTarget):
                                                self.MKDIR_TASK_NAME))
         return task
 
-    def _download_sources(self) -> None:
-        """Return a list of actions to download the source files."""
+    def _get_sources(self) -> None:
+        """Gather the package resources."""
         for srcfile, url in self._get_source_files_urls().items():
-            with urllib.request.urlopen(url) as conn:
-                with open(srcfile, 'wb') as fp:
-                    fp.write(conn.read())
+            if urllib.parse.urlparse(url).scheme:
+                with urllib.request.urlopen(url) as conn:
+                    with open(srcfile, 'wb') as fp:
+                        fp.write(conn.read())
+            else:
+                url = os.path.join(constants.ROOT/'packages', url)
+                shutil.copyfile(url, srcfile)
 
     def _get_source_files_urls(self) -> Dict[Path, str]:
         """Extract source file URLs from .meta file."""

--- a/buildchain/buildchain/targets/package.py
+++ b/buildchain/buildchain/targets/package.py
@@ -209,6 +209,7 @@ class Package(base.CompositeTarget):
             'SPEC': self.spec.name,
             'SRPM': self.srpm.name,
             'SOURCES': ' '.join(source.name for source in self.sources),
+            'VERSION': self.version,
         }
 
         buildsrpm_callable = docker_command.DockerRun(

--- a/packages/entrypoint.sh
+++ b/packages/entrypoint.sh
@@ -25,6 +25,8 @@ buildsrpm() {
     done
     cp "/rpmbuild/SPECS/${SPEC}" "/home/build/rpmbuild/SPECS/${SPEC}"
     chown build:build "/home/build/rpmbuild/SPECS/${SPEC}"
+    # Overwrite version if supported
+    sed -i 's/_VERSION_/'"${VERSION}"'/g' "/home/build/rpmbuild/SPECS/${SPEC}"
     su -l build -c "rpmbuild -bs /home/build/rpmbuild/SPECS/${SPEC}"
     su -l build -c \
        "rpmlint -f /rpmbuild/rpmlintrc /home/build/rpmbuild/SRPMS/${SRPM}"

--- a/packages/metalk8s-sosreport.spec
+++ b/packages/metalk8s-sosreport.spec
@@ -1,0 +1,38 @@
+Name:		metalk8s-sosreport
+Version:	_VERSION_
+Release:	1%{?dist}
+Summary: 	Metalk8s SOS report custom plugins
+
+
+Requires: python >= 2.6, python < 2.8
+Requires: sos >= 3.1
+# NameError on FileNotFoundError in sos 3.5 python2.7
+Conflicts: sos = 3.5
+
+ExclusiveArch:  x86_64
+ExclusiveOS:    Linux
+
+License:        GPL+
+Source0:        metalk8s-sosreport/src/metalk8s.py
+Source1:        metalk8s-sosreport/src/containerd.py
+
+%description
+%{Summary}
+
+%install
+install -m 755 -d %{buildroot}/%{python_sitelib}/sos/plugins
+install -p -m 755 %{_topdir}/SOURCES/metalk8s.py %{buildroot}/%{python_sitelib}/sos/plugins/metalk8s.py
+install -p -m 755 %{_topdir}/SOURCES/containerd.py %{buildroot}/%{python_sitelib}/sos/plugins/containerd.py
+
+%files
+%defattr(-,root,root)
+%{python_sitelib}/sos/plugins/metalk8s.py
+%{python_sitelib}/sos/plugins/containerd.py
+%{python_sitelib}/sos/plugins/metalk8s.pyc
+%{python_sitelib}/sos/plugins/containerd.pyc
+%{python_sitelib}/sos/plugins/metalk8s.pyo
+%{python_sitelib}/sos/plugins/containerd.pyo
+
+%changelog
+* Fri Jul 05 2019 SayfEddine Hammemi <sayf-eddine.hammemi@scality.com> - 1.0.0-1
+- Initial build

--- a/packages/metalk8s-sosreport/src/containerd.py
+++ b/packages/metalk8s-sosreport/src/containerd.py
@@ -1,0 +1,73 @@
+#! /bin/env python
+
+from sos.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+
+
+class containerd(Plugin, RedHatPlugin, UbuntuPlugin):
+
+    """containerd engine"""
+
+    plugin_name = 'containerd'
+    profiles = ('container',)
+    packages = ('cri-tools')
+
+    option_list = [
+        ('all', 'enable capture for all containers, even containers '
+            'that have terminated', 'fast', False),
+        ('logs', 'capture logs for running containers', 'fast', False),
+    ]
+
+    def setup(self):
+        self.add_copy_spec([
+            '/etc/containerd',
+            '/etc/crictl.yaml'
+        ])
+        self.add_copy_spec('/var/log/containers')
+
+        subcmds = [
+            'info',
+            'images',
+            'pods',
+            'ps',
+            'ps -a',
+            'ps -v',
+            'stats',
+            'version',
+        ]
+
+        self.add_journal(units='containerd')
+        self.add_cmd_output(['crictl {}'.format(s) for s in subcmds])
+        self.add_cmd_output('ls -alhR /etc/cni')
+
+        ps_cmd = 'crictl ps --quiet'
+        if self.get_option('all'):
+            ps_cmd = '{} -a'.format(ps_cmd)
+
+        img_cmd = 'crictl images --quiet'
+        pod_cmd = 'crictl pods --quiet'
+
+        containers = self._get_crio_list(ps_cmd)
+        images = self._get_crio_list(img_cmd)
+        pods = self._get_crio_list(pod_cmd)
+
+        for container in containers:
+            self.add_cmd_output('crictl inspect {}'.format(container))
+            if self.get_option('logs'):
+                self.add_cmd_output('crictl logs -t {}'.format(container))
+
+        for image in images:
+            self.add_cmd_output('crictl inspecti {}'.format(image))
+
+        for pod in pods:
+            self.add_cmd_output('crictl inspectp {}'.format(pod))
+
+    def _get_crio_list(self, cmd):
+        ret = []
+        result = self.get_command_output(cmd)
+        if result['status'] == 0:
+            for entry in result['output'].splitlines():
+                if 'deprecated' not in entry[0]:
+                    # Prevent the socket deprecation warning
+                    # from being iterated over
+                    ret.append(entry)
+        return ret

--- a/packages/metalk8s-sosreport/src/metalk8s.py
+++ b/packages/metalk8s-sosreport/src/metalk8s.py
@@ -1,0 +1,119 @@
+#! /bin/env python
+
+from sos.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+from os import path
+
+
+class metalk8s(Plugin, RedHatPlugin, UbuntuPlugin):
+
+    """Metalk8s plugin"""
+
+    plugin_name = 'metalk8s'
+    packages = ('kubernetes', 'kubernetes-master')
+    profiles = ('container',)
+    files = ('/etc/kubernetes/admin.conf',)
+
+    option_list = [
+        ('all', 'also collect all namespaces output separately',
+            'slow', False),
+        ('describe', 'capture descriptions of all kube resources',
+            'fast', False),
+        ('podlogs', 'capture logs for pods', 'slow', False),
+    ]
+
+    def check_is_master(self):
+        return any([path.exists("/etc/kubernetes/admin.conf")])
+
+    def setup(self):
+        self.add_copy_spec('/etc/kubernetes/manifests')
+        self.add_copy_spec('/var/log/pods')
+        self.add_copy_spec('/var/log/metalk8s-bootstrap.log')
+
+        services = [
+            'kubelet',
+        ]
+
+        for service in services:
+            self.add_journal(units=service)
+
+        # We can only grab kubectl output from the master
+        if self.check_is_master():
+            kube_cmd = 'kubectl '
+            if path.exists('/etc/kubernetes/admin.conf'):
+                kube_cmd += '--kubeconfig=/etc/kubernetes/admin.conf'
+
+            kube_get_cmd = 'get -o json '
+            for subcmd in ['version', 'config view']:
+                self.add_cmd_output('{0} {1}'.format(kube_cmd, subcmd))
+
+            # get all namespaces in use
+            namespaces_result = self.get_command_output('{0} get namespaces'.format(kube_cmd))
+            kube_namespaces = [n.split()[0] for n in namespaces_result['output'].splitlines()[1:] if n]
+
+            resources = [
+                'pods',
+                'deploy',
+                'rc',
+                'services',
+                'ds',
+                'cm',
+            ]
+
+            # nodes and pvs are not namespaced, must pull separately.
+            # Also collect master metrics
+            self.add_cmd_output([
+                '{} get -o json nodes'.format(kube_cmd),
+                '{} get -o json pv'.format(kube_cmd),
+                '{} get --raw /metrics'.format(kube_cmd)
+            ])
+
+            for n in kube_namespaces:
+                kube_namespace = '--namespace={}'.format(n)
+                if self.get_option('all'):
+                    kube_namespaced_cmd = '{0} {1} {2}'.format(kube_cmd, kube_get_cmd, kube_namespace)
+
+                    self.add_cmd_output('{} events'.format(kube_namespaced_cmd))
+
+                    for res in resources:
+                        self.add_cmd_output('{0} {1}'.format(kube_namespaced_cmd, res))
+
+                    if self.get_option('describe'):
+                        # need to drop json formatting for this
+                        kube_namespaced_cmd = '{0} get {1}'.format(kube_cmd, kube_namespace)
+                        for res in resources:
+                            r = self.get_command_output(
+                                '{0} {1}'.format(kube_namespaced_cmd, res))
+                            if r['status'] == 0:
+                                kube_cmd_result = [k.split()[0] for k in
+                                          r['output'].splitlines()[1:]]
+                                for k in kube_cmd_result:
+                                    kube_namespaced_cmd = '{0} {1}'.format(kube_cmd, kube_namespace)
+                                    self.add_cmd_output(
+                                        '{0} describe {1} {2}'.format(kube_namespaced_cmd, res, k))
+
+                if self.get_option('podlogs'):
+                    kube_namespaced_cmd = '{0} {1}'.format(kube_cmd, kube_namespace)
+                    r = self.get_command_output('{} get pods'.format(kube_namespaced_cmd))
+                    if r['status'] == 0:
+                        pods = [p.split()[0] for p in
+                                r['output'].splitlines()[1:]]
+                        for pod in pods:
+                            self.add_cmd_output('{0} logs {1}'.format(kube_namespaced_cmd, pod))
+
+            if not self.get_option('all'):
+                kube_namespaced_cmd = '{} get --all-namespaces=true'.format(kube_cmd)
+                for res in resources:
+                    self.add_cmd_output('{0} {1}'.format(kube_namespaced_cmd, res))
+
+    def postproc(self):
+        # First, clear sensitive data from the json output collected.
+        # This will mask values when the 'name' looks susceptible of
+        # values worth obfuscating, i.e. if the name contains strings
+        # like 'pass', 'pwd', 'key' or 'token'
+        env_regexp = r'(?P<var>{\s*"name":\s*[^,]*' \
+            r'(pass|pwd|key|token|cred|PASS|PWD|KEY)[^,]*,\s*"value":)[^}]*'
+        self.do_cmd_output_sub('kubectl', env_regexp,
+                               r'\g<var> "********"')
+        # Next, we need to handle the private keys and certs in some
+        # output that is not hit by the previous iteration.
+        self.do_cmd_private_sub('kubectl')

--- a/packages/packages.list
+++ b/packages/packages.list
@@ -10,3 +10,4 @@ runc
 salt-minion-2018.3.4-1.el7
 skopeo
 yum-plugin-versionlock
+sos

--- a/packages/rpmlintrc
+++ b/packages/rpmlintrc
@@ -4,3 +4,7 @@ addFilter("calico-cni-plugin.x86_64: E: statically-linked-binary /opt/cni/bin/ca
 addFilter("calico-cni-plugin.x86_64: E: statically-linked-binary /opt/cni/bin/calico-ipam")
 addFilter("calico-cni-plugin.x86_64: E: dir-or-file-in-opt /opt/cni/bin/calico")
 addFilter("calico-cni-plugin.x86_64: E: dir-or-file-in-opt /opt/cni/bin/calico-ipam")
+
+addFilter("metalk8s-sosreport.x86_64: W: no-url-tag")
+addFilter("metalk8s-sosreport.x86_64: E: no-binary")
+addFilter("metalk8s-sosreport.x86_64: W: no-documentation")

--- a/salt/metalk8s/roles/minion/init.sls
+++ b/salt/metalk8s/roles/minion/init.sls
@@ -1,2 +1,3 @@
 include:
   - metalk8s.salt.minion.configured
+  - metalk8s.sreport.installed

--- a/salt/metalk8s/sreport/init.sls
+++ b/salt/metalk8s/sreport/init.sls
@@ -1,0 +1,2 @@
+include:
+  - .installed

--- a/salt/metalk8s/sreport/installed.sls
+++ b/salt/metalk8s/sreport/installed.sls
@@ -1,0 +1,9 @@
+{%- from "metalk8s/macro.sls" import pkg_installed with context %}
+
+include:
+  - metalk8s.repo
+
+Install sos report and custom plugins:
+  {{ pkg_installed('metalk8s-sosreport') }}
+    - require:
+      - test: Repositories configured


### PR DESCRIPTION
**Component**: salt, tests

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**:  We need to collect logs and config files to ease debugging and reproducing all kind of issues

**Summary**:
Sosreport can now be installed with two plugins that help recover all trace of logs from the platform
**Acceptance criteria**: 
running `salt-call state.sls metalk8s.internal.sreport saltenv=metalk8s-2.0.0-dev` shoud install both sosreport and our custom plugins then you need to run
`sosreport --all-logs -o metalk8s -o containerd -kmetalk8s.podlogs=True -kcontainerd.all=True -kcontainerd.logs=True --batch --tmp-dir <chose a dir>` to generate the report

---

<!-- Declare one or more issues to close once this PR gets merged -->


<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
