### PR TITLE
packages: use CentOS upstream `container-selinux`

### DIFF
--- a/buildchain/buildchain/packaging.py
+++ b/buildchain/buildchain/packaging.py
@@ -185,12 +185,6 @@ REPOSITORIES : Tuple[targets.Repository, ...] = (
     ),
     targets.Repository(
         basename='_build_repositories',
-        name='external',
-        builder=BUILDER,
-        task_dep=['_download_packages'],
-    ),
-    targets.Repository(
-        basename='_build_repositories',
         name='extras',
         builder=BUILDER,
         task_dep=['_download_packages'],

--- a/packages/entrypoint.sh
+++ b/packages/entrypoint.sh
@@ -89,7 +89,6 @@ download_packages() {
     local -r releasever=${RELEASEVER:-7}
     local -r basearch=${BASEARCH:-x86_64}
     local -r repo_cache_root=/install_root/var/cache/yum/$basearch/$releasever
-    local -r external_repo=$repo_cache_root/external/packages
     local -a packages=("$@")
     local -a yum_opts=(
         "--assumeyes"
@@ -102,17 +101,6 @@ download_packages() {
 
     yum groups install "${yum_opts[@]}" base core
     yum install "${yum_opts[@]}" "${packages[@]}"
-
-    local package_name
-
-    # Fetch packages from an URL and store them in the "external" repository.
-    mkdir -p "$external_repo"
-    for package in "${packages[@]}"; do
-        if [[ $package =~ ^(https?)|(ftp):// ]]; then
-            package_name=${package##*/}
-            curl -s "$package" --output "$external_repo/$package_name" --retry 3
-        fi
-    done
 
     chown -R "$TARGET_UID:$TARGET_GID" "/install_root/var"
 

--- a/packages/packages.list
+++ b/packages/packages.list
@@ -1,6 +1,6 @@
 containerd
 cri-tools
-ftp://ftp.scientificlinux.org/linux/scientific/7x/external_products/extras/x86_64/container-selinux-2.77-1.el7_6.noarch.rpm
+container-selinux
 genisoimage
 kubectl-1.11.10
 kubelet-1.11.10

--- a/salt/metalk8s/defaults.yaml
+++ b/salt/metalk8s/defaults.yaml
@@ -55,13 +55,6 @@ repo:
       repo_gpg_check: 0
       enabled: 0
 
-    metalk8s-external:
-      humanname: Scality - External resources
-      gpgcheck: 0
-      gpgkeys: []
-      repo_gpg_check: 0
-      enabled: 0
-
     metalk8s-extras:
       humanname: CentOS - Extras
       gpgcheck: 1
@@ -108,7 +101,7 @@ repo:
       repository: metalk8s-scality
     container-selinux:
       version: latest
-      repository: metalk8s-external
+      repository: metalk8s-extras
     containerd:
       version: latest
       repository: metalk8s-epel

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -56,7 +56,6 @@ SALT_CALL=${SALT_CALL:-salt-call}
 declare -A GPGCHECK_REPOSITORIES=(
     [metalk8s-base]=1
     [metalk8s-epel]=1
-    [metalk8s-external]=0
     [metalk8s-extras]=1
     [metalk8s-updates]=1
     [metalk8s-kubernetes]=1


### PR DESCRIPTION
The upstream CentOS 'extras' repository now ships
`container-selinux-2.99-1.el7_6.noarch` which is sufficiently new enough
(i.e., >= 2.77) for `containerd` to work properly. As a result, we no
longer need the version from ScientificLinux.

Since this was the only package in the `metalk8s-external` repository,
this whole repository and the build infrastructure coming with it is now
gone.

Fixes: #575
See: https://github.com/scality/metalk8s/issues/575
See: https://github.com/scality/metalk8s/issues/573
See: https://github.com/scality/metalk8s/pull/574