### PR TITLE
buildchain: better log "parsing" for `BuildError` handler

### DIFF
--- a/buildchain/buildchain/docker_command.py
+++ b/buildchain/buildchain/docker_command.py
@@ -63,11 +63,22 @@ def default_error_handler(exc: Exception) -> str:
 
 def build_error_handler(build_error: BuildError) -> str:
     """String formatting exception handler for Docker API BuildError."""
-    output_lines = [
-        item['stream']
-        if 'stream' in item else item['error']
-        for item in build_error.build_log
-    ]
+    output_lines = []
+    for item in build_error.build_log:
+        if 'stream' in item:
+            line = item['stream']
+        elif 'status' in item:
+            line = '{}: {}/{}'.format(
+                item['status'],
+                item['progressDetail']['current'],
+                item['progressDetail']['total']
+            )
+        elif 'error' in item:
+            line = item['error']
+        else:
+            line = 'buildchain: Unknown build log entry {}'.format(str(item))
+        output_lines.append(line)
+
     log = ''.join(output_lines)
     return '{}:\n{}'.format(str(build_error), log)
 


### PR DESCRIPTION
The `BuildError` build_log field may contain items that have neither
`stream` nor `error` dicts - this was spotted with `status` dicts.
We should be more resilient to new fields, and ugly-print them if they
are not known.

Closes: #1370

**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: Bad log item handling in  #1264 for #1263.

**Summary**: More resilient log item handling

**Acceptance criteria**: 

A crashing `docker build` reads out its build log without the handler itself crashing.

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1370 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
