### PR TITLE
ClusterHealthStatus: stop refresh

### DIFF
--- a/ui/src/containers/ClusterMonitoring.js
+++ b/ui/src/containers/ClusterMonitoring.js
@@ -12,6 +12,8 @@ import Tooltip from '../components/Tooltip';
 import {
   refreshClusterStatusAction,
   refreshAlertsAction,
+  stopRefreshAlertsAction,
+  stopRefreshClusterStatusAction,
   CLUSTER_STATUS_UP,
   CLUSTER_STATUS_DOWN
 } from '../ducks/app/monitoring';
@@ -71,10 +73,12 @@ const ControlPlaneStatusLabel = styled.span`
 const ClusterMonitoring = props => {
   useEffect(() => {
     props.refreshAlerts();
+    return () => props.stopRefreshAlerts();
   }, []);
 
   useEffect(() => {
     props.refreshClusterStatus();
+    return () => props.stopRefreshClusterStatus();
   }, []);
 
   const [sortBy, setSortBy] = useState('name');
@@ -255,7 +259,9 @@ const makeClusterStatus = (state, props) => {
 const mapDispatchToProps = dispatch => {
   return {
     refreshClusterStatus: () => dispatch(refreshClusterStatusAction()),
-    refreshAlerts: () => dispatch(refreshAlertsAction())
+    refreshAlerts: () => dispatch(refreshAlertsAction()),
+    stopRefreshAlerts: () => dispatch(stopRefreshAlertsAction()),
+    stopRefreshClusterStatus: () => dispatch(stopRefreshClusterStatusAction())
   };
 };
 

--- a/ui/src/ducks/app/monitoring.test.js
+++ b/ui/src/ducks/app/monitoring.test.js
@@ -393,26 +393,80 @@ it('should handleClusterError when prometheus is down', () => {
 
 it('should refresh Alerts if no error', () => {
   const gen = refreshAlerts();
+  expect(gen.next().value).toEqual(
+    put({
+      type: UPDATE_ALERTS,
+      payload: { isRefreshing: true }
+    })
+  );
   expect(gen.next().value).toEqual(call(fetchAlerts));
   expect(gen.next({}).value).toEqual(delay(REFRESH_TIMEOUT));
-  expect(gen.next().value).toEqual(call(refreshAlerts));
+  expect(gen.next().value.type).toEqual('SELECT');
+  expect(gen.next(true).value).toEqual(call(refreshAlerts));
+});
+
+it('should stop refresh Alerts', () => {
+  const gen = refreshAlerts();
+  expect(gen.next().value).toEqual(
+    put({
+      type: UPDATE_ALERTS,
+      payload: { isRefreshing: true }
+    })
+  );
+  expect(gen.next().value).toEqual(call(fetchAlerts));
+  expect(gen.next({}).value).toEqual(delay(REFRESH_TIMEOUT));
+  expect(gen.next().value.type).toEqual('SELECT');
+  expect(gen.next(false).done).toEqual(true);
 });
 
 it('should not refresh Alerts if error', () => {
   const gen = refreshAlerts();
+  expect(gen.next().value).toEqual(
+    put({
+      type: UPDATE_ALERTS,
+      payload: { isRefreshing: true }
+    })
+  );
   expect(gen.next().value).toEqual(call(fetchAlerts));
   expect(gen.next({ error: '404' }).done).toEqual(true);
 });
 
 it('should refresh ClusterStatus if no error', () => {
   const gen = refreshClusterStatus();
+  expect(gen.next().value).toEqual(
+    put({
+      type: UPDATE_CLUSTER_STATUS,
+      payload: { isRefreshing: true }
+    })
+  );
   expect(gen.next().value).toEqual(call(fetchClusterStatus));
   expect(gen.next().value).toEqual(delay(REFRESH_TIMEOUT));
-  expect(gen.next().value).toEqual(call(refreshClusterStatus));
+  expect(gen.next().value.type).toEqual('SELECT');
+  expect(gen.next(true).value).toEqual(call(refreshClusterStatus));
+});
+
+it('should stop refresh ClusterStatus', () => {
+  const gen = refreshClusterStatus();
+  expect(gen.next().value).toEqual(
+    put({
+      type: UPDATE_CLUSTER_STATUS,
+      payload: { isRefreshing: true }
+    })
+  );
+  expect(gen.next().value).toEqual(call(fetchClusterStatus));
+  expect(gen.next().value).toEqual(delay(REFRESH_TIMEOUT));
+  expect(gen.next().value.type).toEqual('SELECT');
+  expect(gen.next(false).done).toEqual(true);
 });
 
 it('should not refresh ClusterStatus if error', () => {
   const gen = refreshClusterStatus();
+  expect(gen.next().value).toEqual(
+    put({
+      type: UPDATE_CLUSTER_STATUS,
+      payload: { isRefreshing: true }
+    })
+  );
   expect(gen.next().value).toEqual(call(fetchClusterStatus));
   expect(gen.next({ error: '404' }).done).toEqual(true);
 });


### PR DESCRIPTION

**Component**:UI

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
- Actually, the cluster status refresh is not stopped when leaving the Cluster Monitoring page

**Summary**:

**Acceptance criteria**: 
- the cluster status refresh is stopped when leaving the Cluster Monitoring page

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: https://github.com/scality/metalk8s/issues/1340

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
