### PR TITLE
fix cleanup condition for local images

### DIFF
--- a/buildchain/buildchain/targets/local_image.py
+++ b/buildchain/buildchain/targets/local_image.py
@@ -174,7 +174,7 @@ class LocalImage(image.ContainerImage):
                 self.dirname/'manifest.json' if self.save_on_disk
                 else self.dest_dir/self.tag
             ],
-            'clean': True if self.save_on_disk else [self.clean]
+            'clean': [self.clean] if self.save_on_disk else True
         })
         return task
 


### PR DESCRIPTION
**Component**:

buildchain

**Context**: 

`doit.sh clean` doesn't remove the locally built images from the build tree.

**Summary**:

When we save on disk, we use `skopeo` and it creates a file tree that should be cleaned up with a recursive `rm`
Otherwise, we simply touch a file and using `True` is enough to let `doit` do the cleanup.

We simply have to  swap the branches to fix the issue.

**Acceptance criteria**: 

From a clean build tree, run:
- build the images: `./doit.sh -n 4 _image_build`
- clean them up: `./doit.sh clean`
- eveything should be removed (i.e. `_build` no longer exists)

---

Closes: #1373