### PR TITLE
Run multi-nodes CI stage offline

### DIFF
--- a/buildchain/buildchain/image.py
+++ b/buildchain/buildchain/image.py
@@ -320,6 +320,23 @@ TO_BUILD : Tuple[targets.LocalImage, ...] = (
             ]
         )
     ),
+    targets.LocalImage(
+        name='metalk8s-utils',
+        version=constants.VERSION,
+        dockerfile=constants.ROOT/'images'/'metalk8s-utils'/'Dockerfile',
+        destination=constants.ISO_IMAGE_ROOT,
+        save_on_disk=True,
+        build_args={
+            'BASE_IMAGE': constants.CENTOS_BASE_IMAGE,
+            'BASE_IMAGE_SHA256': constants.CENTOS_BASE_IMAGE_SHA256,
+            'BUILD_DATE': datetime.datetime.now(datetime.timezone.utc)
+                            .astimezone()
+                            .isoformat(),
+            'VCS_REF': constants.GIT_REF or '<unknown>',
+            'METALK8S_VERSION': constants.VERSION,
+        },
+        task_dep=['_image_mkdir_root'],
+    ),
 )
 
 

--- a/eve/workers/openstack-multiple-nodes/terraform/network.tf
+++ b/eve/workers/openstack-multiple-nodes/terraform/network.tf
@@ -1,5 +1,3 @@
-# Variables
-
 # Default CI network
 variable "openstack_network" {
   type = map(string)
@@ -8,12 +6,33 @@ variable "openstack_network" {
   }
 }
 
-# Security groups
+data "openstack_networking_network_v2" "default_network" {
+  name = var.openstack_network.name
+}
 
-# First secgroup for SSH or ping from the outside
+data "openstack_networking_subnet_v2" "default_subnet" {
+  network_id = data.openstack_networking_network_v2.default_network.id
+}
+
+locals {
+  dns_servers = tolist(
+    data.openstack_networking_subnet_v2.default_subnet.dns_nameservers
+  )
+}
+
+# Metadata service used by cloud-init
+# https://docs.openstack.org/nova/latest/user/metadata-service.html
+variable "openstack_link_local_ip" {
+  type    = string
+  default = "169.254.169.254"
+}
+
+
+# Security groups
 resource "openstack_networking_secgroup_v2" "nodes" {
-  name        = "${local.prefix}-nodes"
-  description = "Security group for reaching MetalK8s nodes from outside"
+  name                 = "${local.prefix}-nodes"
+  description          = "Security group for MetalK8s nodes"
+  delete_default_rules = true # Removes default (open) egress rules
 }
 
 resource "openstack_networking_secgroup_rule_v2" "nodes_ssh" {
@@ -39,4 +58,39 @@ resource "openstack_networking_secgroup_rule_v2" "nodes_ingress" {
   ethertype         = "IPv4"
   remote_group_id   = openstack_networking_secgroup_v2.nodes.id
   security_group_id = openstack_networking_secgroup_v2.nodes.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "nodes_egress" {
+  direction         = "egress"
+  ethertype         = "IPv4"
+  remote_group_id   = openstack_networking_secgroup_v2.nodes.id
+  security_group_id = openstack_networking_secgroup_v2.nodes.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "link_local_egress" {
+  direction         = "egress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 80
+  port_range_max    = 80
+  remote_ip_prefix  = "${var.openstack_link_local_ip}/32"
+  security_group_id = openstack_networking_secgroup_v2.nodes.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "dns_egress" {
+  direction         = "egress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 53
+  port_range_max    = 53
+  remote_ip_prefix  = "${element(local.dns_servers, count.index)}/32"
+  security_group_id = openstack_networking_secgroup_v2.nodes.id
+
+  count = length(local.dns_servers)
+}
+
+# Use the default rules for the Bastion so it remains online
+resource "openstack_networking_secgroup_v2" "bastion" {
+  name        = "${local.prefix}-bastion"
+  description = "Security group for the Bastion VM"
 }

--- a/eve/workers/openstack-multiple-nodes/terraform/nodes.tf
+++ b/eve/workers/openstack-multiple-nodes/terraform/nodes.tf
@@ -6,6 +6,7 @@ resource "openstack_compute_instance_v2" "bastion" {
 
   security_groups = [
     openstack_networking_secgroup_v2.nodes.name,
+    openstack_networking_secgroup_v2.bastion.name,
   ]
 
   dynamic "network" {

--- a/eve/workers/openstack-multiple-nodes/terraform/nodes.tf
+++ b/eve/workers/openstack-multiple-nodes/terraform/nodes.tf
@@ -1,8 +1,17 @@
+resource "openstack_compute_servergroup_v2" "all" {
+  name     = "${local.prefix}-servergroup"
+  policies = []
+}
+
 resource "openstack_compute_instance_v2" "bastion" {
   name        = "${local.prefix}-bastion"
   image_name  = var.openstack_image_name
   flavor_name = var.openstack_flavour_name
   key_pair    = openstack_compute_keypair_v2.local_ssh_key.name
+
+  scheduler_hints {
+    group = openstack_compute_servergroup_v2.all.id
+  }
 
   security_groups = [
     openstack_networking_secgroup_v2.nodes.name,
@@ -59,6 +68,10 @@ resource "openstack_compute_instance_v2" "bootstrap" {
   flavor_name = var.openstack_flavour_name
   key_pair    = openstack_compute_keypair_v2.local_ssh_key.name
 
+  scheduler_hints {
+    group = openstack_compute_servergroup_v2.all.id
+  }
+
   security_groups = [
     openstack_networking_secgroup_v2.nodes.name,
   ]
@@ -106,6 +119,10 @@ resource "openstack_compute_instance_v2" "nodes" {
   image_name  = var.openstack_image_name
   flavor_name = var.openstack_flavour_name
   key_pair    = openstack_compute_keypair_v2.local_ssh_key.name
+
+  scheduler_hints {
+    group = openstack_compute_servergroup_v2.all.id
+  }
 
   security_groups = [
     openstack_networking_secgroup_v2.nodes.name,

--- a/eve/workers/openstack-multiple-nodes/terraform/ssh.tf
+++ b/eve/workers/openstack-multiple-nodes/terraform/ssh.tf
@@ -6,7 +6,7 @@ variable "ssh_key_path" {
 resource "openstack_compute_keypair_v2" "local_ssh_key" {
   name       = local.prefix
   public_key = file(var.ssh_key_path)
-  }
+}
 
 resource "null_resource" "ssh_config" {
   triggers = {

--- a/images/metalk8s-utils/Dockerfile
+++ b/images/metalk8s-utils/Dockerfile
@@ -1,0 +1,58 @@
+# SHA256 digest of the base image
+ARG BASE_IMAGE_SHA256
+ARG BASE_IMAGE=docker.io/centos
+
+FROM $BASE_IMAGE@sha256:$BASE_IMAGE_SHA256
+
+# Timestamp of the build, formatted as RFC3339
+ARG BUILD_DATE
+# Git revision o the tree at build time
+ARG VCS_REF
+# Version of the image
+ARG VERSION
+# Version of the project, e.g. `git describe --always --long --dirty --broken`
+ARG METALK8S_VERSION
+
+ENTRYPOINT ["/bin/sh"]
+
+# These contain BUILD_DATE so should come 'late' for layer caching
+LABEL maintainer="moonshot-platform@scality.com" \
+      # http://label-schema.org/rc1/
+      org.label-schema.build-date="$BUILD_DATE" \
+      org.label-schema.name="metalk8s-utils" \
+      org.label-schema.description="Utilities container for MetalK8s" \
+      org.label-schema.url="https://github.com/scality/metalk8s/" \
+      org.label-schema.vcs-url="https://github.com/scality/metalk8s.git" \
+      org.label-schema.vcs-ref="$VCS_REF" \
+      org.label-schema.vendor="Scality" \
+      org.label-schema.version="$VERSION" \
+      org.label-schema.schema-version="1.0" \
+      # https://github.com/opencontainers/image-spec/blob/master/annotations.md
+      org.opencontainers.image.created="$BUILD_DATE" \
+      org.opencontainers.image.authors="moonshot-platform@scality.com" \
+      org.opencontainers.image.url="https://github.com/scality/metalk8s/" \
+      org.opencontainers.image.source="https://github.com/scality/metalk8s.git" \
+      org.opencontainers.image.version="$VERSION" \
+      org.opencontainers.image.revision="$VCS_REF" \
+      org.opencontainers.image.vendor="Scality" \
+      org.opencontainers.image.title="metalk8s-utils" \
+      org.opencontainers.image.description="Utilities container for MetalK8s" \
+      # https://docs.openshift.org/latest/creating_images/metadata.html
+      io.openshift.tags="metalk8s,utils" \
+      io.k8s.description="Utilities container for MetalK8s" \
+      io.openshift.non-scalable="true" \
+      # Various
+      com.scality.metalk8s.version="$METALK8S_VERSION"
+
+# Final layers, installing tooling
+RUN yum install -y epel-release && \
+    yum install -y \
+        bind-utils \
+        curl \
+        httpie \
+        iperf \
+        iproute \
+        socat \
+        telnet \
+        && \
+    yum clean all

--- a/tests/post/steps/files/utils.yaml
+++ b/tests/post/steps/files/utils.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: busybox
+  name: utils
   namespace: default
 spec:
   tolerations:
@@ -12,10 +12,10 @@ spec:
     operator: "Equal"
     effect: "NoSchedule"
   containers:
-  - image: busybox:1.28
+  - image: ""
     command:
       - sleep
       - "3600"
     imagePullPolicy: IfNotPresent
-    name: busybox
+    name: utils
   restartPolicy: Always

--- a/tests/post/steps/test_static_pods.py
+++ b/tests/post/steps/test_static_pods.py
@@ -48,7 +48,9 @@ def test_static_pods_restart(host, transient_files):
 
 
 @given("I have set up a static pod", target_fixture="static_pod_id")
-def set_up_static_pod(host, hostname, k8s_client, transient_files):
+def set_up_static_pod(
+    host, hostname, k8s_client, utils_image, transient_files
+):
     manifest_path = str(MANIFESTS_PATH / "{}.yaml".format(DEFAULT_POD_NAME))
 
     with host.sudo():
@@ -71,7 +73,7 @@ def set_up_static_pod(host, hostname, k8s_client, transient_files):
     manifest_template = SOURCE_TEMPLATE.read_text(encoding="utf-8")
     manifest = string.Template(manifest_template).substitute(
         name=DEFAULT_POD_NAME,
-        image="busybox",  # TODO: use base image from #1093
+        image=utils_image,
         config_path=config_path,
     )
 


### PR DESCRIPTION
**Component**: ci, tests

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: We need to catch undesired behaviours of the product w.r.t. online connectivity.

**Summary**:

- run the multi-nodes deployment stage offline (using Openstack security groups)
- ship a simple `metalk8s-utils` container image to replace previous use of `busybox` in tests
    - NB: the ISO only increases in size for around 15MB, thanks to the same base image as other containers and the use of `hardlink`

**Acceptance criteria**:

- tests in CI should pass
- one should be able to install an offline platform, and run a container using the utils container image `{bootstrap_control_plane_ip}:8080/metalk8s-{version}/metalk8s-utils:{version}`

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #713 
Closes: #1093

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
