### PR TITLE
salt: Add a yum package dependency manager

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -387,6 +387,8 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/_modules/metalk8s_etcd.py'),
     Path('salt/_modules/metalk8s_kubernetes_utils.py'),
     Path('salt/_modules/metalk8s.py'),
+    Path('salt/_modules/metalk8s_package_manager.py'),
+
 
     Path('salt/_pillar/metalk8s.py'),
     Path('salt/_pillar/metalk8s_endpoints.py'),
@@ -406,6 +408,7 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/_states/metalk8s_drain.py'),
     Path('salt/_states/metalk8s_etcd.py'),
     Path('salt/_states/metalk8s_kubernetes.py'),
+    Path('salt/_states/metalk8s_package_manager.py'),
 
     Path('salt/_utils/pillar_utils.py'),
 

--- a/salt/_modules/metalk8s_package_manager.py
+++ b/salt/_modules/metalk8s_package_manager.py
@@ -1,0 +1,78 @@
+'''
+Describes our custom way to deal with yum packages
+so that we can support downgrade in metalk8s
+'''
+
+import logging
+
+log = logging.getLogger(__name__)
+
+
+__virtualname__ = 'metalk8s_package_manager'
+
+
+def __virtual__():
+    return __virtualname__
+
+
+def list_pkg_deps(pkg_name, version=None, fromrepo=None):
+    '''
+    Check dependencies related to the packages installed so that we can pass
+    this information to pkg.installed
+
+    name
+        Name of the package installed
+
+    version
+        Version number of the package
+
+        Use : salt '*' metalk8s_package_manager.list_pkg_deps kubelet 1.11.9
+    '''
+    log.info(
+        'Listing deps for "%s" with version "%s"',
+        str(pkg_name),
+        str(version)
+    )
+    pkgs_dict = {pkg_name: version}
+
+    if not version:
+        return pkgs_dict
+
+    command_all = [
+        'repoquery', '--whatrequires', '--recursive', '--qf',
+        '%{NAME} %{VERSION}-%{RELEASE}',
+        '{}-{}'.format(str(pkg_name), str(version))
+    ]
+
+    if fromrepo:
+        command_all.extend(['--disablerepo', '*', '--enablerepo', fromrepo])
+
+    deps_list = __salt__['cmd.run_all'](command_all)
+
+    if deps_list['retcode'] != 0:
+        log.error(
+            'Failed to list package dependencies: %s',
+            deps_list['stderr'] or deps_list['stdout']
+        )
+        return None
+
+    out = deps_list['stdout'].splitlines()
+    for line in out:
+        name, version = line.strip().split()
+        pkgs_dict[name] = version
+
+    for key in pkgs_dict.keys():
+        package_query = __salt__['cmd.run_all'](
+            ['rpm', '-qa', key]
+        )
+
+        if package_query['retcode'] == 1:
+            pkgs_dict.pop(key)
+        elif package_query['retcode'] != 0:
+            log.error(
+                'Failed to check if package is installed: %s',
+                deps_list['stderr'] or deps_list['stdout']
+            )
+            return None
+
+    return pkgs_dict

--- a/salt/_states/metalk8s_package_manager.py
+++ b/salt/_states/metalk8s_package_manager.py
@@ -1,0 +1,33 @@
+"""Custom state for managing yum packages and dependencies"""
+
+from __future__ import absolute_import
+
+import logging
+
+
+log = logging.getLogger(__name__)
+
+
+__virtualname__ = "metalk8s_package_manager"
+
+
+def __virtualname__():
+    if __grains__['os_family'].lower() == 'redhat':
+        return __virtualname__
+    return (False, "metalk8s_package_manager: no RPM-based system detected")
+
+
+def installed(name, version=None, fromrepo=None, **kwargs):
+    """Simple helper to manage package downgrade including dependencies."""
+    if version is None or kwargs.get('pkgs'):
+        return __states__["pkg.installed"](
+            name=name, version=version, fromrepo=fromrepo, **kwargs
+        )
+
+    dep_list = __salt__['metalk8s_package_manager.list_pkg_deps'](
+        name, version, fromrepo
+    )
+    pkgs = [{k: v} for k, v in dep_list.items()]
+    return __states__["pkg.installed"](
+        name=name, pkgs=pkgs, fromrepo=fromrepo, **kwargs
+    )

--- a/salt/metalk8s/addons/monitoring/kube-controller-manager/exposed.sls
+++ b/salt/metalk8s/addons/monitoring/kube-controller-manager/exposed.sls
@@ -21,4 +21,4 @@ Expose Kubernetes Controller Manager to Prometheus:
         type: ClusterIP
         clusterIP: None
   require:
-    - pkg: Install Python Kubernetes client
+    - metalk8s_package_manager: Install Python Kubernetes client

--- a/salt/metalk8s/addons/monitoring/kube-scheduler/exposed.sls
+++ b/salt/metalk8s/addons/monitoring/kube-scheduler/exposed.sls
@@ -21,4 +21,4 @@ Expose Kubernetes Scheduler to Prometheus:
         type: ClusterIP
         clusterIP: None
   require:
-    - pkg: Install Python Kubernetes client
+    - metalk8s_package_manager: Install Python Kubernetes client

--- a/salt/metalk8s/container-engine/containerd/configured.sls
+++ b/salt/metalk8s/container-engine/containerd/configured.sls
@@ -8,7 +8,7 @@ Start and enable containerd:
     - name: containerd
     - enable: True
     - require:
-      - pkg: Install containerd
+      - metalk8s_package_manager: Install containerd
     - watch:
       - file: Configure registry IP in containerd conf
 
@@ -26,4 +26,4 @@ Inject pause image:
     - archive_path: /tmp/pause-3.1.tar
     - require:
       - file: Inject pause image
-      - pkg: Install and configure cri-tools
+      - metalk8s_package_manager: Install and configure cri-tools

--- a/salt/metalk8s/container-engine/containerd/installed.sls
+++ b/salt/metalk8s/container-engine/containerd/installed.sls
@@ -17,14 +17,14 @@ Install runc:
   {{ pkg_installed('runc') }}
     - require:
       - test: Repositories configured
-      - pkg: Install container-selinux
+      - metalk8s_package_manager: Install container-selinux
 
 Install containerd:
   {{ pkg_installed('containerd') }}
     - require:
       - test: Repositories configured
-      - pkg: Install runc
-      - pkg: Install container-selinux
+      - metalk8s_package_manager: Install runc
+      - metalk8s_package_manager: Install container-selinux
  
 Install and configure cri-tools:
   {{ pkg_installed('cri-tools') }}
@@ -49,4 +49,4 @@ Configure registry IP in containerd conf:
         [plugins.cri.registry.mirrors."{{ registry_ip }}:{{ registry_port }}"]
           endpoint = ["http://{{ registry_ip }}:{{ registry_port }}"]
     - require:
-      - pkg: Install containerd
+      - metalk8s_package_manager: Install containerd

--- a/salt/metalk8s/kubernetes/apiserver/certs/etcd-client.sls
+++ b/salt/metalk8s/kubernetes/apiserver/certs/etcd-client.sls
@@ -14,7 +14,7 @@ Create apiserver etcd client private key:
     - makedirs: True
     - dir_mode: 755
     - require:
-      - pkg: Install m2crypto
+      - metalk8s_package_manager: Install m2crypto
 
 Generate apiserver etcd client certificate:
   x509.certificate_managed:

--- a/salt/metalk8s/kubernetes/apiserver/certs/front-proxy-client.sls
+++ b/salt/metalk8s/kubernetes/apiserver/certs/front-proxy-client.sls
@@ -14,7 +14,7 @@ Create front proxy client private key:
     - makedirs: True
     - dir_mode: 755
     - require:
-      - pkg: Install m2crypto
+      - metalk8s_package_manager: Install m2crypto
 
 Generate front proxy client certificate:
   x509.certificate_managed:

--- a/salt/metalk8s/kubernetes/apiserver/certs/kubelet-client.sls
+++ b/salt/metalk8s/kubernetes/apiserver/certs/kubelet-client.sls
@@ -14,7 +14,7 @@ Create kube-apiserver kubelet client private key:
     - makedirs: True
     - dir_mode: 755
     - require:
-      - pkg: Install m2crypto
+      - metalk8s_package_manager: Install m2crypto
 
 Generate kube-apiserver kubelet client certificate:
   x509.certificate_managed:

--- a/salt/metalk8s/kubernetes/apiserver/certs/server.sls
+++ b/salt/metalk8s/kubernetes/apiserver/certs/server.sls
@@ -14,7 +14,7 @@ Create kube-apiserver private key:
     - makedirs: True
     - dir_mode: 755
     - require:
-      - pkg: Install m2crypto
+      - metalk8s_package_manager: Install m2crypto
 
 {% set certSANs = [
     grains['fqdn'],

--- a/salt/metalk8s/kubernetes/apiserver/kubeconfig.sls
+++ b/salt/metalk8s/kubernetes/apiserver/kubeconfig.sls
@@ -14,4 +14,4 @@ Create kubeconfig file for admin:
     - apiserver: {{ apiserver }}
     - cluster: {{ kubernetes.cluster }}
     - require:
-      - pkg: Install m2crypto
+      - metalk8s_package_manager: Install m2crypto

--- a/salt/metalk8s/kubernetes/ca/etcd/installed.sls
+++ b/salt/metalk8s/kubernetes/ca/etcd/installed.sls
@@ -14,7 +14,7 @@ Create etcd CA private key:
     - makedirs: True
     - dir_mode: 755
     - require:
-      - pkg: Install m2crypto
+      - metalk8s_package_manager: Install m2crypto
 
 Generate etcd CA certificate:
   x509.certificate_managed:

--- a/salt/metalk8s/kubernetes/ca/front-proxy/installed.sls
+++ b/salt/metalk8s/kubernetes/ca/front-proxy/installed.sls
@@ -14,7 +14,7 @@ Create front proxy CA private key:
     - makedirs: True
     - dir_mode: 755
     - require:
-      - pkg: Install m2crypto
+      - metalk8s_package_manager: Install m2crypto
 
 Generate front proxy CA certificate:
   x509.certificate_managed:

--- a/salt/metalk8s/kubernetes/ca/kubernetes/installed.sls
+++ b/salt/metalk8s/kubernetes/ca/kubernetes/installed.sls
@@ -14,7 +14,7 @@ Create CA private key:
     - makedirs: True
     - dir_mode: 755
     - require:
-      - pkg: Install m2crypto
+      - metalk8s_package_manager: Install m2crypto
 
 Generate CA certificate:
   x509.certificate_managed:

--- a/salt/metalk8s/kubernetes/cni/calico/configured.sls
+++ b/salt/metalk8s/kubernetes/cni/calico/configured.sls
@@ -15,7 +15,7 @@ Create kubeconf file for calico:
     - apiserver: https://{{ kube_api.service_ip }}:443
     - cluster: {{ kubernetes.cluster }}
     - require:
-      - pkg: Install m2crypto
+      - metalk8s_package_manager: Install m2crypto
 
 Create CNI calico configuration file:
   file.serialize:

--- a/salt/metalk8s/kubernetes/cni/calico/upgraded.sls
+++ b/salt/metalk8s/kubernetes/cni/calico/upgraded.sls
@@ -10,6 +10,6 @@ Upgrade Calico IPAM data:
         - CALICO_NETWORKING_BACKEND: 'bird'
         - KUBECONFIG: '/etc/kubernetes/calico.conf'
     - require:
-        - pkg: Install calico-cni-plugin
+        - metalk8s_package_manager: Install calico-cni-plugin
         - metalk8s_kubeconfig: Create kubeconf file for calico
         - file: Create CNI calico configuration file

--- a/salt/metalk8s/kubernetes/controller-manager/kubeconfig.sls
+++ b/salt/metalk8s/kubernetes/controller-manager/kubeconfig.sls
@@ -16,4 +16,4 @@ Create kubeconfig file for controller-manager:
     - apiserver: {{ apiserver }}
     - cluster: {{ kubernetes.cluster }}
     - require:
-      - pkg: Install m2crypto
+      - metalk8s_package_manager: Install m2crypto

--- a/salt/metalk8s/kubernetes/etcd/certs/healthcheck-client.sls
+++ b/salt/metalk8s/kubernetes/etcd/certs/healthcheck-client.sls
@@ -14,7 +14,7 @@ Create etcd healthcheck client private key:
     - makedirs: True
     - dir_mode: 755
     - require:
-      - pkg: Install m2crypto
+      - metalk8s_package_manager: Install m2crypto
 
 Generate etcd healthcheck client certificate:
   x509.certificate_managed:

--- a/salt/metalk8s/kubernetes/etcd/certs/peer.sls
+++ b/salt/metalk8s/kubernetes/etcd/certs/peer.sls
@@ -14,7 +14,7 @@ Create etcd peer private key:
     - makedirs: True
     - dir_mode: 755
     - require:
-      - pkg: Install m2crypto
+      - metalk8s_package_manager: Install m2crypto
 
 Generate etcd peer certificate:
   x509.certificate_managed:

--- a/salt/metalk8s/kubernetes/etcd/certs/server.sls
+++ b/salt/metalk8s/kubernetes/etcd/certs/server.sls
@@ -14,7 +14,7 @@ Create etcd server private key:
     - makedirs: True
     - dir_mode: 755
     - require:
-      - pkg: Install m2crypto
+      - metalk8s_package_manager: Install m2crypto
 
 Generate etcd server certificate:
   x509.certificate_managed:

--- a/salt/metalk8s/kubernetes/kubelet/configured.sls
+++ b/salt/metalk8s/kubernetes/kubelet/configured.sls
@@ -19,7 +19,7 @@ Create kubeconfig file for kubelet:
     - apiserver: {{ apiserver }}
     - cluster: {{ kubernetes.cluster }}
     - require:
-      - pkg: Install m2crypto
+      - metalk8s_package_manager: Install m2crypto
     - watch_in:
       - service: Ensure kubelet running
 
@@ -37,7 +37,7 @@ Configure kubelet service:
         env_file: "/var/lib/kubelet/kubeadm-flags.env"
         config_file: "/var/lib/kubelet/config.yaml"
     - require:
-      - pkg: Install kubelet
+      - metalk8s_package_manager: Install kubelet
       - metalk8s_kubeconfig: Create kubeconfig file for kubelet
     - watch_in:
       - service: Ensure kubelet running

--- a/salt/metalk8s/kubernetes/kubelet/installed.sls
+++ b/salt/metalk8s/kubernetes/kubelet/installed.sls
@@ -22,4 +22,4 @@ Reload systemctl:
   module.wait:
     - service.systemctl_reload: []
     - watch:
-      - pkg: Install kubelet
+      - metalk8s_package_manager: Install kubelet

--- a/salt/metalk8s/kubernetes/kubelet/running.sls
+++ b/salt/metalk8s/kubernetes/kubelet/running.sls
@@ -6,6 +6,6 @@ Ensure kubelet running:
     - name: kubelet
     - enable: True
     - watch:
-      - pkg: Install kubelet
+      - metalk8s_package_manager: Install kubelet
     - require:
       - module: Reload systemctl

--- a/salt/metalk8s/kubernetes/kubelet/standalone.sls
+++ b/salt/metalk8s/kubernetes/kubelet/standalone.sls
@@ -17,7 +17,7 @@ Create kubelet service environment file:
         options: {{ kubelet.service.options }}
         node_ip: {{ grains['metalk8s']['control_plane_ip'] }}
     - require:
-      - pkg: Install kubelet
+      - metalk8s_package_manager: Install kubelet
     - watch_in:
       - service: Ensure kubelet running
 
@@ -105,7 +105,7 @@ Create kubelet config file:
         syncFrequency: 1m0s
         volumeStatsAggPeriod: 1m0s
     - require:
-      - pkg: Install kubelet
+      - metalk8s_package_manager: Install kubelet
     - watch_in:
       - service: Ensure kubelet running
 

--- a/salt/metalk8s/kubernetes/sa/installed.sls
+++ b/salt/metalk8s/kubernetes/sa/installed.sls
@@ -12,7 +12,7 @@ Create SA private key:
     - makedirs: True
     - dir_mode: 755
     - require:
-      - pkg: Install m2crypto
+      - metalk8s_package_manager: Install m2crypto
 
 Store SA public key:
   file.managed:

--- a/salt/metalk8s/kubernetes/scheduler/kubeconfig.sls
+++ b/salt/metalk8s/kubernetes/scheduler/kubeconfig.sls
@@ -16,4 +16,4 @@ Create kubeconfig file for scheduler:
     - apiserver: {{ apiserver }}
     - cluster: {{ kubernetes.cluster }}
     - require:
-      - pkg: Install m2crypto
+      - metalk8s_package_manager: Install m2crypto

--- a/salt/metalk8s/macro.sls
+++ b/salt/metalk8s/macro.sls
@@ -2,7 +2,7 @@
 
 {%- macro pkg_installed(name='') -%}
   {%- set package = repo.packages[name] | default({}) %}
-  pkg.installed:
+  metalk8s_package_manager.installed:
     - name: {{ name }}
     - fromrepo: {{ repo.repositories.keys() | join(',') }}
     {%- if package.version | default(None) %}
@@ -10,4 +10,5 @@
     - hold: True
     - update_holds: True
     {%- endif %}
+    - reload_modules: True
 {%- endmacro -%}

--- a/salt/metalk8s/orchestrate/bootstrap/init.sls
+++ b/salt/metalk8s/orchestrate/bootstrap/init.sls
@@ -73,7 +73,8 @@ Sync bootstrap minion:
   salt.function:
   - name: saltutil.sync_all
   - tgt: {{ pillar.bootstrap_id }}
-  - saltenv: metalk8s-{{ version }}
+  - kwarg:
+      saltenv: metalk8s-{{ version }}
 
 Deploy CA role on bootstrap minion:
   salt.state:

--- a/salt/metalk8s/salt/master/certs/etcd-client.sls
+++ b/salt/metalk8s/salt/master/certs/etcd-client.sls
@@ -14,7 +14,7 @@ Create salt master etcd client private key:
     - makedirs: True
     - dir_mode: 755
     - require:
-      - pkg: Install m2crypto
+      - metalk8s_package_manager: Install m2crypto
 
 Generate salt master etcd client certificate:
   x509.certificate_managed:


### PR DESCRIPTION

**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
'salt', 'downgrade'

**Context**: 

Issue: #1143

**Summary**:

We would like to support package downgrade plus their corresponding dependencies. 
So what have we done?
- Introducing a way to find packages + dependencies (supported on redhat only for now) using salt module.
- Adapting pkg.installed to work with our custom module.

**Acceptance criteria**: 

- Be able to downgrade a package like Kubelet successfully
- Used in  parallel with Downgrade orchestrate, we should be able downgrade metalk8s to a previous minor version.
- used to test : #1343


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1143

<!-- If you want to refer to an issue while not closing it, use:



-->
