### PR TITLE
Increase sizing of VMs for CI deployments

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -235,7 +235,7 @@ stages:
     worker:
       type: openstack
       image: CentOS 7 (PVHVM)
-      flavor: m1.medium
+      flavor: m1.large
       path: eve/workers/openstack-multiple-nodes
     steps:
       - Git: *git_pull

--- a/eve/workers/openstack-multiple-nodes/terraform/image.tf
+++ b/eve/workers/openstack-multiple-nodes/terraform/image.tf
@@ -5,5 +5,5 @@ variable "openstack_image_name" {
 
 variable "openstack_flavour_name" {
   type    = string
-  default = "m1.medium"
+  default = "m1.large"
 }


### PR DESCRIPTION
**Component**: ci

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: Multiple occurences of deployment failures were seen due to `etcd`
timing out. Using larger VM flavours might help.

**Summary**: Bump flavour from `m1.medium` to `m1.large` in both `single-node` and `multiple-nodes` deployments.