### PR TITLE
salt: fix string interpolation format in metalk8s_endpoints

### DIFF
--- a/salt/_pillar/metalk8s_endpoints.py
+++ b/salt/_pillar/metalk8s_endpoints.py
@@ -90,7 +90,7 @@ def service_endpoints(service, namespace, kubeconfig):
     except Exception as exc:  # pylint: disable=broad-except
         error_tplt = (
             'Unable to get kubernetes endpoints'
-            'for %s in namespace %s:\n%s'
+            ' for {} in namespace {}:\n{}'
         )
         return __utils__['pillar_utils.errors_to_dict']([
             error_tplt.format(service, namespace, exc)


### PR DESCRIPTION
Closes: #1396

**Component**: salt

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: `metalk8s_endpoints` external pillar error generation had the wrong string interpolation format.

**Summary**: Fix the string interpolation format.

**Acceptance criteria**: 

Errors are correctly formatted when getting endpoint-related data from the pillar.


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1396 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
