### PR TITLE
SidePanel: should be expanded by default

### DIFF
--- a/ui/src/containers/App.js
+++ b/ui/src/containers/App.js
@@ -15,6 +15,7 @@ import Login from './Login';
 
 import IntlGlobalProvider from '../translations/IntlGlobalProvider';
 import { fetchConfigAction, setInitialLanguageAction } from '../ducks/config';
+import { initToggleSideBarAction } from '../ducks/app/layout';
 
 const messages = {
   en: translations_en,
@@ -28,6 +29,7 @@ class App extends Component {
     document.title = messages[this.props.config.language].product_name;
     this.props.fetchConfig();
     this.props.setInitialLanguage();
+    this.props.initToggleSideBar();
   }
 
   render() {
@@ -56,7 +58,8 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => {
   return {
     fetchConfig: () => dispatch(fetchConfigAction()),
-    setInitialLanguage: () => dispatch(setInitialLanguageAction())
+    setInitialLanguage: () => dispatch(setInitialLanguageAction()),
+    initToggleSideBar: () => dispatch(initToggleSideBarAction())
   };
 };
 

--- a/ui/src/containers/Layout.js
+++ b/ui/src/containers/Layout.js
@@ -14,7 +14,7 @@ import ClusterMonitoring from './ClusterMonitoring';
 import Welcome from '../components/Welcome';
 import PrivateRoute from './PrivateRoute';
 import { logoutAction } from '../ducks/login';
-import { toggleSidebarAction } from '../ducks/app/layout';
+import { toggleSideBarAction } from '../ducks/app/layout';
 
 import { removeNotificationAction } from '../ducks/app/notifications';
 import { updateLanguageAction } from '../ducks/config';
@@ -146,9 +146,9 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => {
   return {
     logout: () => dispatch(logoutAction()),
-    toggleSidebar: () => dispatch(toggleSidebarAction()),
     removeNotification: uid => dispatch(removeNotificationAction(uid)),
-    updateLanguage: language => dispatch(updateLanguageAction(language))
+    updateLanguage: language => dispatch(updateLanguageAction(language)),
+    toggleSidebar: () => dispatch(toggleSideBarAction())
   };
 };
 

--- a/ui/src/ducks/app/layout.js
+++ b/ui/src/ducks/app/layout.js
@@ -1,16 +1,21 @@
+import { put, takeEvery, select } from 'redux-saga/effects';
+
 // Actions
 const TOGGLE_SIDEBAR = 'TOGGLE_SIDEBAR';
+const INIT_TOGGLE_SIDEBAR = 'INIT_TOGGLE_SIDEBAR';
+export const SET_TOGGLE_SIDEBAR = 'SET_TOGGLE_SIDEBAR';
+export const SIDEBAR_EXPENDED = 'sidebar_expended';
 
 // Reducer
 const defaultState = {
   sidebar: {
-    expanded: false
+    expanded: true
   }
 };
 
 export default function reducer(state = defaultState, action = {}) {
   switch (action.type) {
-    case TOGGLE_SIDEBAR:
+    case SET_TOGGLE_SIDEBAR:
       return {
         ...state,
         sidebar: {
@@ -24,6 +29,34 @@ export default function reducer(state = defaultState, action = {}) {
 }
 
 // Action Creators
-export const toggleSidebarAction = () => {
+export const setToggleSidebarAction = () => {
+  return { type: SET_TOGGLE_SIDEBAR };
+};
+
+export const toggleSideBarAction = () => {
   return { type: TOGGLE_SIDEBAR };
 };
+
+export const initToggleSideBarAction = () => {
+  return { type: INIT_TOGGLE_SIDEBAR };
+};
+
+export function* toggleSideBar() {
+  yield put(setToggleSidebarAction());
+  const expanded = yield select(state => state.app.layout.sidebar.expanded);
+  localStorage.setItem(SIDEBAR_EXPENDED, expanded);
+}
+
+export function* initToggleSideBar() {
+  if (localStorage.getItem(SIDEBAR_EXPENDED)) {
+    const expanded = yield select(state => state.app.layout.sidebar.expanded);
+    if (expanded !== JSON.parse(localStorage.getItem(SIDEBAR_EXPENDED))) {
+      yield put(setToggleSidebarAction());
+    }
+  }
+}
+
+export function* layoutSaga() {
+  yield takeEvery(TOGGLE_SIDEBAR, toggleSideBar);
+  yield takeEvery(INIT_TOGGLE_SIDEBAR, initToggleSideBar);
+}

--- a/ui/src/ducks/app/layout.test.js
+++ b/ui/src/ducks/app/layout.test.js
@@ -1,0 +1,32 @@
+import { call, put } from 'redux-saga/effects';
+import {
+  SET_TOGGLE_SIDEBAR,
+  SIDEBAR_EXPENDED,
+  toggleSideBar,
+  initToggleSideBar
+} from './layout.js';
+
+it('should toggleSideBar', () => {
+  const gen = toggleSideBar();
+
+  expect(gen.next().value).toEqual(
+    put({
+      type: SET_TOGGLE_SIDEBAR
+    })
+  );
+  expect(gen.next().value.type).toEqual('SELECT');
+  expect(gen.next().done).toEqual(true);
+});
+
+it('should initToggleSideBar', () => {
+  localStorage.setItem(SIDEBAR_EXPENDED, 'true');
+  const gen = initToggleSideBar();
+
+  expect(gen.next().value.type).toEqual('SELECT');
+  expect(gen.next().value).toEqual(
+    put({
+      type: SET_TOGGLE_SIDEBAR
+    })
+  );
+  expect(gen.next().done).toEqual(true);
+});

--- a/ui/src/ducks/sagas.js
+++ b/ui/src/ducks/sagas.js
@@ -4,6 +4,7 @@ import { podsSaga } from './app/pods';
 import { authenticateSaga } from './login';
 import { configSaga } from './config';
 import { monitoringSaga } from './app/monitoring';
+import { layoutSaga } from './app/layout';
 
 export default function* rootSaga() {
   yield all([
@@ -11,6 +12,7 @@ export default function* rootSaga() {
     fork(podsSaga),
     fork(authenticateSaga),
     fork(configSaga),
-    fork(monitoringSaga)
+    fork(monitoringSaga),
+    fork(layoutSaga)
   ]);
 }


### PR DESCRIPTION
**Component**: UI

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
- Navigation sidebar collapsed by default, so it is confusing for users when accessing the UI for the first time

**Summary**:
- Navigation sidebar should be expanded (user preferences could be saved)

**Acceptance criteria**: 
- SidePanel should be expanded when accessing the UI for the first time.
- toggle it
- refresh the page => SidePanel should be docked

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: https://github.com/scality/metalk8s/issues/1272

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
