### PR TITLE
Improvement/doc in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ If you'd like to contribute, please review the
 - [tox](https://pypi.org/project/tox)
 - [Vagrant](https://www.vagrantup.com/)
 - [VirtualBox](https://www.virtualbox.org)
-- [Plantuml](http://plantuml.com/starting)
 
 ### Bootstrapping a local environment
 
@@ -43,8 +42,12 @@ tox -e tests
 ```
 
 ### Documentation
+### Requirements
+- [Python3.6+](https://www.python.org/)
+- [tox](https://pypi.org/project/tox)
+- [Plantuml](http://plantuml.com/starting)
 
-To generate html documentation locally in `docs/_build/html`, run the following command
+To generate HTML documentation locally in `docs/_build/html`, run the following command:
 
 ```shell
 # Generate doc with tox

--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ If you'd like to contribute, please review the
 - [tox](https://pypi.org/project/tox)
 - [Vagrant](https://www.vagrantup.com/)
 - [VirtualBox](https://www.virtualbox.org)
+- [Plantuml](http://plantuml.com/starting)
 
 ### Bootstrapping a local environment
 
-```shell 
+```shell
 # Install virtualbox guest addition plugin
 vagrant plugin install vagrant-vbguest
 # Bootstrap a platform on a vagrant environment using
@@ -35,22 +36,24 @@ vagrant plugin install vagrant-vbguest
 ### End-to-End Testing
 
 To run the test-suite locally, first complete the bootstrap step as outline above
-```shell 
+
+```shell
 # Run tests with tox
 tox -e tests
 ```
 
 ### Documentation
 
-To generate html documentation locally in docs/_build/html, run the following command
-```shell 
+To generate html documentation locally in `docs/_build/html`, run the following command
+
+```shell
 # Generate doc with tox
 tox -e docs
 ```
 
 ---
 
-MetalK8s version 1 is still maintained in this repository. See the 
+MetalK8s version 1 is still maintained in this repository. See the
 `development/1.*` branches, e. g.
 [MetalK8s 1.3](https://github.com/scality/metalk8s/tree/development/1.3) in the same
 repository.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ To run the test-suite locally, first complete the bootstrap step as outline abov
 tox -e tests
 ```
 
+### Documentation
+
+To generate html documentation locally in docs/_build/html, run the following command
+```shell 
+# Generate doc with tox
+tox -e docs
+```
+
 ---
 
 MetalK8s version 1 is still maintained in this repository. See the 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,13 @@ To run the test-suite locally, first complete the bootstrap step as outline abov
 tox -e tests
 ```
 
-### Documentation
+## Documentation
 ### Requirements
 - [Python3.6+](https://www.python.org/)
 - [tox](https://pypi.org/project/tox)
 - [Plantuml](http://plantuml.com/starting)
+
+### Building
 
 To generate HTML documentation locally in `docs/_build/html`, run the following command:
 


### PR DESCRIPTION
Add how to generate doc in README

**Component**:

build

**Context**: 

Someone recently built metal on his laptop and went to the metalk8s doc hosted on Scality site and as a result was not able to deploy metal because doc and iso were not in sync.
Actually, the guys didn't know we could generate doc from his laptop (because it is missing in README)

**Summary**:

Just add the command to run in README and also maybe extra dependencies

**Acceptance criteria**: 

Anyone following the README can build the doc

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
