### PR TITLE
Ubuntu workload plane node deployment online

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ If you'd like to contribute, please review the
 - [tox](https://pypi.org/project/tox)
 - [Vagrant](https://www.vagrantup.com/)
 - [VirtualBox](https://www.virtualbox.org)
-- [Plantuml](http://plantuml.com/starting)
 
 ### Bootstrapping a local environment
 
@@ -43,8 +42,12 @@ tox -e tests
 ```
 
 ### Documentation
+### Requirements
+- [Python3.6+](https://www.python.org/)
+- [tox](https://pypi.org/project/tox)
+- [Plantuml](http://plantuml.com/starting)
 
-To generate html documentation locally in `docs/_build/html`, run the following command
+To generate HTML documentation locally in `docs/_build/html`, run the following command:
 
 ```shell
 # Generate doc with tox

--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ If you'd like to contribute, please review the
 - [tox](https://pypi.org/project/tox)
 - [Vagrant](https://www.vagrantup.com/)
 - [VirtualBox](https://www.virtualbox.org)
+- [Plantuml](http://plantuml.com/starting)
 
 ### Bootstrapping a local environment
 
-```shell 
+```shell
 # Install virtualbox guest addition plugin
 vagrant plugin install vagrant-vbguest
 # Bootstrap a platform on a vagrant environment using
@@ -35,22 +36,24 @@ vagrant plugin install vagrant-vbguest
 ### End-to-End Testing
 
 To run the test-suite locally, first complete the bootstrap step as outline above
-```shell 
+
+```shell
 # Run tests with tox
 tox -e tests
 ```
 
 ### Documentation
 
-To generate html documentation locally in docs/_build/html, run the following command
-```shell 
+To generate html documentation locally in `docs/_build/html`, run the following command
+
+```shell
 # Generate doc with tox
 tox -e docs
 ```
 
 ---
 
-MetalK8s version 1 is still maintained in this repository. See the 
+MetalK8s version 1 is still maintained in this repository. See the
 `development/1.*` branches, e. g.
 [MetalK8s 1.3](https://github.com/scality/metalk8s/tree/development/1.3) in the same
 repository.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ To run the test-suite locally, first complete the bootstrap step as outline abov
 tox -e tests
 ```
 
+### Documentation
+
+To generate html documentation locally in docs/_build/html, run the following command
+```shell 
+# Generate doc with tox
+tox -e docs
+```
+
 ---
 
 MetalK8s version 1 is still maintained in this repository. See the 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,13 @@ To run the test-suite locally, first complete the bootstrap step as outline abov
 tox -e tests
 ```
 
-### Documentation
+## Documentation
 ### Requirements
 - [Python3.6+](https://www.python.org/)
 - [tox](https://pypi.org/project/tox)
 - [Plantuml](http://plantuml.com/starting)
+
+### Building
 
 To generate HTML documentation locally in `docs/_build/html`, run the following command:
 

--- a/salt/_pillar/metalk8s_endpoints.py
+++ b/salt/_pillar/metalk8s_endpoints.py
@@ -90,7 +90,7 @@ def service_endpoints(service, namespace, kubeconfig):
     except Exception as exc:  # pylint: disable=broad-except
         error_tplt = (
             'Unable to get kubernetes endpoints'
-            'for %s in namespace %s:\n%s'
+            ' for {} in namespace {}:\n{}'
         )
         return __utils__['pillar_utils.errors_to_dict']([
             error_tplt.format(service, namespace, exc)


### PR DESCRIPTION
**Component**: formula, packages, salt

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: Metalk8s over Ubuntu

**Summary**:  Modify salt formula to permits workload plane Ubuntu nodes deployment.

**Acceptance criteria**: 
- Deploy a Ubuntu Workload plane node
- Verify every pods are scheduled and working well

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1353 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
