### PR TITLE
salt: Remove retry output from etcd status check

### DIFF
--- a/salt/_modules/metalk8s_etcd.py
+++ b/salt/_modules/metalk8s_etcd.py
@@ -138,16 +138,12 @@ def check_etcd_health(
     )[minion_id]
 
     # Get all members
-    try:
-        with etcd3.client(host=endpoint,
-                          ca_cert=ca_cert,
-                          cert_key=cert_key,
-                          cert_cert=cert_cert,
-                          timeout=TIMEOUT) as etcd:
-            etcd_members = list(etcd.members)
-    except Exception:  # pylint: disable=broad-except
-        log.exception("cluster may be unhealthy: failed to list members")
-        raise
+    with etcd3.client(host=endpoint,
+                      ca_cert=ca_cert,
+                      cert_key=cert_key,
+                      cert_cert=cert_cert,
+                      timeout=TIMEOUT) as etcd:
+        etcd_members = list(etcd.members)
 
     unhealthy_member = 0
     for member in etcd_members:
@@ -161,7 +157,7 @@ def check_etcd_health(
                               timeout=TIMEOUT) as etcd:
                 etcd.status()
         except Exception:  # pylint: disable=broad-except
-            log.exception(
+            log.debug(
                 "failed to check the health of member %s", member.name
             )
             unhealthy_member += 1


### PR DESCRIPTION
**Component**:

'salt', 'kubernetes', 'upgrade'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

Issue: #1363 

**Summary**:

During an upgrade, we perform an etcd status health check which prints a messy stack trace.

We do not want to see this mess, so we have decided to hide it.

**Acceptance criteria**: 

- No stacktrace when etcd performs status check during upgrade

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1363 


