### PR TITLE
Correction of the vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -235,7 +235,7 @@ Vagrant.configure("2") do |config|
           type: "shell",
           inline: DEPLOY_SSH_PUBLIC_KEY
 
-        if os == "ubuntu"
+        if os == :ubuntu
           node.vm.provision "install-python",
             type: "shell",
             inline: INSTALL_PYTHON


### PR DESCRIPTION
Permit to install Python2.7 on Ubuntu node
during the VM deployment.

Issue: GH-1413

**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: Need python2.7 on Ubuntu nodes for salt minion installation

**Summary**: Permits to have some Ubuntu nodes on Vagrant with python 2.7 installed

**Acceptance criteria**: Have python 2.7 already installed on Ubuntu nodes.


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1413 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
