### PR TITLE
salt: remove node taint(node.kubernetes.io/unschedulable) before uncordon

### DIFF
--- a/salt/_states/metalk8s_cordon.py
+++ b/salt/_states/metalk8s_cordon.py
@@ -52,7 +52,6 @@ def _node_set_unschedulable(name, value, **kwargs):
     return ret
 
 
-
 def node_cordoned(name, **kwargs):
     '''
     Ensures that the named node is cordoned.


### PR DESCRIPTION
**Component**:

'salt', 'kubernetes', 'downgrade'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

During uncordon in an upgrade or downgrade procedure, we do not taint nodes which seem to pose problems.
The issue becomes even more evident when nodes are marked unschedulable during downgrade as reported here #1408.

Issue: #1408

**Summary**:

- Added  a taint removal method for the above existing taint.
- Method should only be applied during uncordon

**Acceptance criteria**: 

- Uncordon should remove taint(node.kubernetes.io/unschedulable)
- Nodes should become schedulable after a downgrade

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1408

