### PR TITLE
Pin tox version in docs/Dockerfile

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -27,7 +27,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 # NOTE: the tox package available is too old; we want tox >= 3.4, for the
 # `commands_pre` syntax
-RUN python3.6 -m pip install tox && \
+RUN python3.6 -m pip install tox==3.9.0 && \
     rm -rf ~/.cache/pip
 
 WORKDIR /usr/src/metalk8s


### PR DESCRIPTION
**Component**:

doc, ci

**Context**: 

The latest version raises issues due to our basepython being set to
`python3`, which does not match the `python3.6` we use for the `docs`
environment.

More details on this behaviour:
https://github.com/tox-dev/tox/issues/425

**Summary**:

Pin the tox version

**Acceptance criteria**: 

The build is green