### PR TITLE
eve: handle Dependabot branches

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -2,7 +2,7 @@
 version: "0.2"
 
 branches:
-  user/*, feature/*, improvement/*, bugfix/*, w/*, q/*, hotfix/*:
+  user/*, feature/*, improvement/*, bugfix/*, w/*, q/*, hotfix/*, dependabot/*:
     stage: pre-merge
 
 stages:


### PR DESCRIPTION
Dependabot creates PRs prefixed with `dependabot/`. If we let Eve handle
these, then overriding author approval with BertE would get branches
merged properly.

See: https://github.com/scality/metalk8s/pull/1425
See: https://github.com/apps/dependabot