### PR TITLE
Add a script to automate product addition and configuration

### DIFF
--- a/buildchain/buildchain/iso.py
+++ b/buildchain/buildchain/iso.py
@@ -79,6 +79,7 @@ def task_populate_iso() -> types.TaskDict:
             '_iso_render_bootstrap',
             '_iso_add_node_manifest',
             '_iso_generate_product_txt',
+            '_iso_add_iso_manager',
             'images',
             'salt_tree',
             'packaging',
@@ -113,6 +114,21 @@ def task__iso_add_node_manifest() -> types.TaskDict:
          'uptodate': [True],
          'clean': True,
      }
+
+
+def task__iso_add_iso_manager() -> types.TaskDict:
+    """Copy the ISO manager script to scripts."""
+    src = constants.ROOT/'scripts'/'iso-manager.sh'
+    dest = constants.ISO_ROOT/'iso-manager.sh'
+    iso_manager = [src, dest]
+    return {
+            'title': lambda task: utils.title_with_target1('COPY', task),
+            'actions': [(coreutils.cp_file, iso_manager)],
+            'targets': [dest],
+            'task_dep': ['_iso_mkdir_root'],
+            'file_dep': [src],
+            'clean': True,
+            }
 
 
 def task__iso_render_bootstrap() -> types.TaskDict:

--- a/buildchain/buildchain/iso.py
+++ b/buildchain/buildchain/iso.py
@@ -95,23 +95,23 @@ def task__iso_mkdir_examples() -> types.TaskDict:
 
 def task__iso_add_node_manifest() -> types.TaskDict:
     """Copy the node announcement manifest to examples."""
+    # generic node manifest
+    src_generic = constants.ROOT/'examples'/'new-node.yaml'
     dest_generic = constants.ISO_ROOT/'examples'/'new-node.yaml'
+    new_node_generic = [src_generic, dest_generic]
+    # vagrant node manifest
+    src_vagrant = constants.ROOT/'examples'/'new-node_vagrant.yaml'
     dest_vagrant = constants.ISO_ROOT/'examples'/'new-node_vagrant.yaml'
-    new_node_generic = [
-        constants.ROOT/'examples'/'new-node.yaml', dest_generic
-    ]
-    new_node_vagrant = [
-        constants.ROOT/'examples'/'new-node_vagrant.yaml', dest_vagrant
-    ]
+    new_node_vagrant = [src_vagrant, dest_vagrant]
     return {
-         'title': lambda task: utils.title_with_target1('GENERATE', task),
+         'title': lambda task: utils.title_with_target1('COPY', task),
          'actions': [
              (coreutils.cp_file, new_node_generic),
              (coreutils.cp_file, new_node_vagrant)
          ],
          'targets': [dest_generic, dest_vagrant],
          'task_dep': ['_iso_mkdir_examples'],
-         'uptodate': [True],
+         'file_dep': [src_generic, src_vagrant],
          'clean': True,
      }
 

--- a/docs/operation/preparation.rst
+++ b/docs/operation/preparation.rst
@@ -3,43 +3,10 @@ ISO Preparation
 This section describes a reliable way for provisioning a new **MetalK8s** ISO
 for upgrade or downgrade.
 
-.. important::
-
-    - **<destination_version>**
-      is a suffix which must be replaced with appropriate version number.
-
-Make new ISO available
-~~~~~~~~~~~~~~~~~~~~~~
-
-#. Upload the MetalK8s `.ISO` file to the :term:`Bootstrap node`.
-
-#. Connect to the :term:`Bootstrap node`.
-
-#. Edit the :file:`bootstrap.yaml` file located in
-   :file:`/etc/metalk8s/bootstrap.yaml` then add the new MetalK8s ISO path.
+To provision a new **Metalk8s** ISO you need to run the utility script shipped
+with the current installation:
 
    .. code::
 
-      products:
-        metalk8s:
-        - /home/scality/metalk8s-2.0.0.iso
-        - <path_to_the_new_iso>                        <=== New line to add
+     /srv/scality/metalk8s-X.X.X/iso-manager.sh -p <path_to_iso>
 
-#. Mount the ISO file.
-
-   .. code::
-
-      salt-call state.sls metalk8s.products.mounted saltenv=metalk8s-$(salt-call --out txt slsutil.renderer string="{{ pillar.metalk8s.nodes[grains.id].version }}" | cut -c 8-)
-
-#. Configure the new repositories and salt-master.
-   Replace **<destination_version>** with the appropriate version number.
-
-   .. code::
-
-      salt-call --local state.sls metalk8s.products.configured saltenv=metalk8s-<destination_version> pillar="{'metalk8s': {'endpoints': $(salt-call --out txt pillar.get metalk8s:endpoints | cut -c 8-)}}"
-
-#. Make the new version available.
-
-   .. code::
-
-      salt-call state.sls metalk8s.products saltenv=metalk8s-$(salt-call --out txt slsutil.renderer string="{{ pillar.metalk8s.nodes[grains.id].version }}" | cut -c 8-)

--- a/scripts/iso-manager.sh
+++ b/scripts/iso-manager.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+
+BOOTSTRAP_CONFIG="/etc/metalk8s/bootstrap.yaml"
+DEBUG="on"
+LOGFILE="/tmp/iso.log"
+DRY_RUN="False"
+
+# Helpers
+_usage() {
+    echo "iso-manager.sh [options]"
+    echo "Options:"
+    echo "-p/--product <product path>:     Path to product folder or ISO"
+    echo "-l/--log-file <logfile_path>:    path to log file"
+    echo "-v/--verbose:                    Run in verbose mode"
+    echo "-d/--dry-run:                    Run actions in dry run mode"
+}
+
+# Exit with error code and message
+die() {
+    echo "$*" 1>&2 ;
+    exit 1;
+}
+
+# Run commands and log their output
+_log() {
+    if [ -n "$LOGFILE" ]; then
+        "$@" >> "$LOGFILE" 2>&1
+    else
+        "$@" >&2
+    fi
+}
+
+# Run commands and display/write the output to stdout/logfile
+_info() {
+    if [ "$DEBUG" == "info" ]; then
+        _log "$@"
+    else
+        "$@" >&/dev/null
+    fi
+}
+
+# helper function to set the current saltenv
+_set_env() {
+    if [ -z "$SALTENV" ]; then
+        SALTENV="metalk8s-$(salt-call --out txt slsutil.renderer \
+            string="{{ pillar.metalk8s.nodes[grains.id].version }}" \
+            | cut -c 8-)"
+    fi
+}
+
+# helper function to check for element in array
+containsElement () {
+  local element match="$1"
+  shift
+  for element in "$@"; do
+      [[ "$element" == "$match" ]] && return 0;
+  done
+  return 1
+}
+
+_add_products() {
+    # Skip adding product if None passed
+    [ $# -lt 1 ] && return 0
+    # Use salt file.serialize merge require having full list
+    # salt-call output example:
+    # local: ["/srv/scality/metalk8s-2.0.0/", "/tmp/metalk8s-2.1.0.iso"]
+    # parsed products:
+    # ("/srv/scality/metalk8s-2.0.0/" "/tmp/metalk8s-2.1.0.iso")
+    products=("$(salt-call pillar.get metalk8s:products \
+        --out txt | cut -d' ' -f2- | tr -d '[],')")
+    for product in "$@"; do
+        if ! containsElement "$product" "$@"; then
+            products+=("$product")
+        fi
+    done
+    _log echo "Collecting products..."
+    _info echo "${products[@]}"
+    # build product list
+    product_list=${products[0]}
+    for i in "${products[@]:1}"; do
+        product_list+=,$i
+    done
+    _log echo "Updating bootstrap.yaml"
+    _info salt-call state.single file.serialize "$BOOTSTRAP_CONFIG" \
+        dataset="{'products': {'metalk8s': [$product_list]}}" \
+        merge_if_exists=True \
+        formatter=yaml \
+        show_changes=True \
+        test=$DRY_RUN
+    return $?
+}
+
+_configure_products() {
+    # Mount products
+    _log echo "Mount products..."
+    _info salt-call state.sls metalk8s.products.mounted \
+        saltenv="$SALTENV" test=$DRY_RUN
+    # Configure repos
+    salt_envs=$(salt-call --out txt slsutil.renderer \
+        string="{{ salt.metalk8s.get_products().keys() | join(' ') }}" \
+        | cut -d' ' -f2-)
+    [[ -z $salt_envs ]] && die "Cannot detect products envs"
+    for salt_env in $salt_envs; do
+        _log echo "Configuring product $salt_env..."
+        _info salt-call --local state.sls metalk8s.products.configured \
+            saltenv="$salt_env" \
+            pillar="{'metalk8s': {'endpoints': \
+            $(salt-call --out txt pillar.get metalk8s:endpoints | cut -c 8-)}}" \
+            test=$DRY_RUN
+    done
+    # Make the new version available
+    _log echo "Making new versions available"
+    _info salt-call state.sls metalk8s.products saltenv="$SALTENV" test="$DRY_RUN"
+}
+
+# Main
+
+PRODUCTS=()
+
+while (( "$#" )); do
+  case "$1" in
+    -p|--product)
+      PRODUCTS+=("$2")
+      shift 2
+      ;;
+    -d|--dry-run)
+      DRY_RUN=True
+      shift
+      ;;
+    -v|--verbose)
+      DEBUG="info"
+      shift
+      ;;
+    -l|--log-file)
+      LOGFILE="$2"
+      [ -z "$DEBUG" ] && DEBUG="on"
+      shift 2
+      ;;
+    *) # unsupported flags
+      echo "Error: Unsupported flag $1" >&2
+      _usage
+      exit 1
+      ;;
+  esac
+done
+
+_set_env
+[ -z "$SALTENV" ] && die "saltenv not set"
+
+_add_products "${PRODUCTS[@]}"
+_configure_products


### PR DESCRIPTION
Fixes: #1401

**Component**: salt, upgrade, downgrade

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
The steps to add a product and configure it is very manual, we need a script to automate it
**Summary**:
A script has been added that automate product configurations
**Acceptance criteria**: 
Check the script help and use it to configure a new metalk8s iso

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1401 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
