### PR TITLE
Update buildchain and CI for operator

### DIFF
--- a/.pylint-dict
+++ b/.pylint-dict
@@ -20,6 +20,7 @@ epel
 filename
 init
 io
+Kubernetes
 linter
 metadata
 mkdir
@@ -33,6 +34,7 @@ rpmspec
 repo
 rpmlint
 scality
+sdk
 skopeo
 sls
 timestamp

--- a/.pylint-dict
+++ b/.pylint-dict
@@ -17,6 +17,7 @@ doit
 dedup
 env
 epel
+gofmt
 filename
 init
 io

--- a/buildchain/buildchain/codegen.py
+++ b/buildchain/buildchain/codegen.py
@@ -1,0 +1,49 @@
+# coding: utf-8
+
+
+"""Tasks for code generation."""
+
+
+import shlex
+from typing import Callable, Iterator, Tuple
+
+import doit  # type: ignore
+
+from buildchain import config
+from buildchain import constants
+from buildchain import types
+from buildchain import utils
+
+def task_codegen() -> Iterator[types.TaskDict]:
+    """Run the code generation tools."""
+    for create_codegen_task in CODEGEN:
+        yield create_codegen_task()
+
+
+def codegen_go() -> types.TaskDict:
+    """Generate Go code using operator-sdk."""
+    cwd  = constants.STORAGE_OPERATOR_ROOT
+    actions = []
+    for target in ('k8s', 'openapi'):
+        cmd = ' '.join(map(shlex.quote, [
+            config.ExtCommand.OPERATOR_SDK.value, 'generate', target
+        ]))
+        actions.append(doit.action.CmdAction(cmd, cwd=cwd))
+
+    return {
+        'name': 'go',
+        'title': lambda task: utils.title_with_subtask_name('CODEGEN', task),
+        'doc': codegen_go.__doc__,
+        'actions': actions,
+        'task_dep': ['check_for:operator-sdk'],
+        'file_dep': list(constants.STORAGE_OPERATOR_SOURCES),
+    }
+
+
+# List of available code generation tasks.
+CODEGEN : Tuple[Callable[[], types.TaskDict], ...] = (
+    codegen_go,
+)
+
+
+__all__ = utils.export_only_tasks(__name__)

--- a/buildchain/buildchain/codegen.py
+++ b/buildchain/buildchain/codegen.py
@@ -32,7 +32,7 @@ def codegen_go() -> types.TaskDict:
 
     return {
         'name': 'go',
-        'title': lambda task: utils.title_with_subtask_name('CODEGEN', task),
+        'title': utils.title_with_subtask_name('CODEGEN'),
         'doc': codegen_go.__doc__,
         'actions': actions,
         'task_dep': ['check_for:operator-sdk'],

--- a/buildchain/buildchain/config.py
+++ b/buildchain/buildchain/config.py
@@ -52,11 +52,12 @@ VAGRANT_UP_ARGS : Tuple[str, ...] = tuple(shlex.split(
 class ExtCommand(enum.Enum):
     """External commands used by the build chain."""
 
-    GIT      = os.getenv('GIT_BIN',      'git')
-    HARDLINK = os.getenv('HARDLINK_BIN', 'hardlink')
-    MKISOFS  = os.getenv('MKISOFS_BIN',  'mkisofs')
-    SKOPEO   = os.getenv('SKOPEO_BIN',   'skopeo')
-    VAGRANT  = os.getenv('VAGRANT_BIN',  'vagrant')
+    GIT          = os.getenv('GIT_BIN',          'git')
+    HARDLINK     = os.getenv('HARDLINK_BIN',     'hardlink')
+    MKISOFS      = os.getenv('MKISOFS_BIN',      'mkisofs')
+    SKOPEO       = os.getenv('SKOPEO_BIN',       'skopeo')
+    VAGRANT      = os.getenv('VAGRANT_BIN',      'vagrant')
+    OPERATOR_SDK = os.getenv('OPERATOR_SDK_BIN', 'operator-sdk')
 
     @property
     def command_name(self) -> str:

--- a/buildchain/buildchain/config.py
+++ b/buildchain/buildchain/config.py
@@ -58,6 +58,7 @@ class ExtCommand(enum.Enum):
     SKOPEO       = os.getenv('SKOPEO_BIN',       'skopeo')
     VAGRANT      = os.getenv('VAGRANT_BIN',      'vagrant')
     OPERATOR_SDK = os.getenv('OPERATOR_SDK_BIN', 'operator-sdk')
+    GOFMT        = os.getenv('GOFMT_BIN',        'gofmt')
 
     @property
     def command_name(self) -> str:

--- a/buildchain/buildchain/config.py
+++ b/buildchain/buildchain/config.py
@@ -63,6 +63,8 @@ class ExtCommand(enum.Enum):
         """Return the name of the command."""
         if self is self.OPERATOR_SDK:
             return 'operator-sdk'
+        # See https://github.com/PyCQA/pylint/issues/2062
+        # pylint: disable=no-member
         return self.name.lower()
 
 # }}}

--- a/buildchain/buildchain/config.py
+++ b/buildchain/buildchain/config.py
@@ -58,4 +58,11 @@ class ExtCommand(enum.Enum):
     SKOPEO   = os.getenv('SKOPEO_BIN',   'skopeo')
     VAGRANT  = os.getenv('VAGRANT_BIN',  'vagrant')
 
+    @property
+    def command_name(self) -> str:
+        """Return the name of the command."""
+        if self is self.OPERATOR_SDK:
+            return 'operator-sdk'
+        return self.name.lower()
+
 # }}}

--- a/buildchain/buildchain/constants.py
+++ b/buildchain/buildchain/constants.py
@@ -106,12 +106,11 @@ GIT_REF = git_ref()
 
 # }}}
 
-# Only keep directories (except `vendor`) and top-level Go source files.
+# Only keep directories and top-level Go source files.
 STORAGE_OPERATOR_FMT_ARGS : FrozenSet[str] = frozenset([
     path.name for path in STORAGE_OPERATOR_ROOT.glob('*')
-    if (path.is_dir() and path.name != 'vendor') or path.suffix == '.go'
+    if path.is_dir() or path.suffix == '.go'
 ])
 STORAGE_OPERATOR_SOURCES : FrozenSet[Path] = frozenset([
     filepath for filepath in STORAGE_OPERATOR_ROOT.rglob('*.go')
-    if 'vendor' not in str(filepath.parent)
 ])

--- a/buildchain/buildchain/constants.py
+++ b/buildchain/buildchain/constants.py
@@ -106,6 +106,11 @@ GIT_REF = git_ref()
 
 # }}}
 
+# Only keep directories (except `vendor`) and top-level Go source files.
+STORAGE_OPERATOR_FMT_ARGS : FrozenSet[str] = frozenset([
+    path.name for path in STORAGE_OPERATOR_ROOT.glob('*')
+    if (path.is_dir() and path.name != 'vendor') or path.suffix == '.go'
+])
 STORAGE_OPERATOR_SOURCES : FrozenSet[Path] = frozenset([
     filepath for filepath in STORAGE_OPERATOR_ROOT.rglob('*.go')
     if 'vendor' not in str(filepath.parent)

--- a/buildchain/buildchain/constants.py
+++ b/buildchain/buildchain/constants.py
@@ -6,7 +6,7 @@
 
 from pathlib import Path
 import subprocess
-from typing import Optional
+from typing import Optional, FrozenSet
 
 from buildchain import ROOT  # Re-export ROOT through this module.
 from buildchain import config
@@ -39,6 +39,8 @@ VAGRANT_ROOT : Path = ROOT/'.vagrant'
 STATIC_CONTAINER_REGISTRY : Path = Path(
     ROOT, 'buildchain/static-container-registry'
 )
+# Path to the storage-operator source directory.
+STORAGE_OPERATOR_ROOT : Path = ROOT/'storage-operator'
 
 # }}}
 # Vagrant parameters {{{
@@ -103,3 +105,8 @@ def git_ref() -> Optional[str]:
 GIT_REF = git_ref()
 
 # }}}
+
+STORAGE_OPERATOR_SOURCES : FrozenSet[Path] = frozenset([
+    filepath for filepath in STORAGE_OPERATOR_ROOT.rglob('*.go')
+    if 'vendor' not in str(filepath.parent)
+])

--- a/buildchain/buildchain/deps.py
+++ b/buildchain/buildchain/deps.py
@@ -38,7 +38,7 @@ def task_check_for() -> Iterator[types.TaskDict]:
         return None
 
     for ext_cmd in config.ExtCommand:
-        cmd_name = ext_cmd.name.lower()
+        cmd_name = ext_cmd.command_name
         cmd_path = ext_cmd.value if ext_cmd.value != cmd_name else None
 
         def show(name: str) -> str:

--- a/buildchain/buildchain/format.py
+++ b/buildchain/buildchain/format.py
@@ -31,7 +31,7 @@ def format_go() -> types.TaskDict:
 
     return {
         'name': 'go',
-        'title': lambda task: utils.title_with_subtask_name('FORMAT', task),
+        'title': utils.title_with_subtask_name('FORMAT'),
         'doc': format_go.__doc__,
         'actions': [doit.action.CmdAction(cmd, cwd=cwd)],
         'task_dep': ['check_for:gofmt'],

--- a/buildchain/buildchain/format.py
+++ b/buildchain/buildchain/format.py
@@ -23,14 +23,10 @@ def task_format() -> Iterator[types.TaskDict]:
 
 def format_go() -> types.TaskDict:
     """Format Go code using gofmt."""
-    # Only keep directories (except `vendor`) and top-level Go source files.
-    targets = [
-        path.name for path in constants.STORAGE_OPERATOR_ROOT.glob('*')
-        if (path.is_dir() and path.name != 'vendor') or path.suffix == '.go'
-    ]
     cwd  = constants.STORAGE_OPERATOR_ROOT
     cmd = ' '.join(map(shlex.quote, [
-        config.ExtCommand.GOFMT.value, '-s', '-w', *targets
+        config.ExtCommand.GOFMT.value, '-s', '-w',
+        *tuple(constants.STORAGE_OPERATOR_FMT_ARGS)
     ]))
 
     return {

--- a/buildchain/buildchain/format.py
+++ b/buildchain/buildchain/format.py
@@ -1,0 +1,60 @@
+# coding: utf-8
+
+
+"""Tasks for code auto-formatting."""
+
+
+import shlex
+from typing import Callable, Iterator, Tuple
+
+import doit  # type: ignore
+
+from buildchain import config
+from buildchain import constants
+from buildchain import types
+from buildchain import utils
+
+
+def task_format() -> Iterator[types.TaskDict]:
+    """Run the code auto-formatting tools."""
+    for create_format_task in FORMATTERS:
+        yield create_format_task()
+
+
+def format_go() -> types.TaskDict:
+    """Format Go code using gofmt."""
+    # Only keep directories (except `vendor`) and top-level Go source files.
+    targets = [
+        path.name for path in constants.STORAGE_OPERATOR_ROOT.glob('*')
+        if (path.is_dir() and path.name != 'vendor') or path.suffix == '.go'
+    ]
+    cwd  = constants.STORAGE_OPERATOR_ROOT
+    cmd = ' '.join(map(shlex.quote, [
+        config.ExtCommand.GOFMT.value, '-s', '-w', *targets
+    ]))
+
+    return {
+        'name': 'go',
+        'title': format_task_title,
+        'doc': format_go.__doc__,
+        'actions': [doit.action.CmdAction(cmd, cwd=cwd)],
+        'task_dep': ['check_for:gofmt'],
+        'file_dep': list(constants.STORAGE_OPERATOR_SOURCES),
+    }
+
+
+def format_task_title(task: types.Task) -> str:
+    """Display a nice title for format tasks."""
+    # Since format tasks are sub-tasks, we extract the sub-task name (after `:`)
+    return '{cmd: <{width}} {name}'.format(
+        cmd='FORMAT', width=constants.CMD_WIDTH, name=task.name.split(':')[1]
+    )
+
+
+# List of available formatting tasks.
+FORMATTERS: Tuple[Callable[[], types.TaskDict], ...] = (
+    format_go,
+)
+
+
+__all__ = utils.export_only_tasks(__name__)

--- a/buildchain/buildchain/format.py
+++ b/buildchain/buildchain/format.py
@@ -31,20 +31,12 @@ def format_go() -> types.TaskDict:
 
     return {
         'name': 'go',
-        'title': format_task_title,
+        'title': lambda task: utils.title_with_subtask_name('FORMAT', task),
         'doc': format_go.__doc__,
         'actions': [doit.action.CmdAction(cmd, cwd=cwd)],
         'task_dep': ['check_for:gofmt'],
         'file_dep': list(constants.STORAGE_OPERATOR_SOURCES),
     }
-
-
-def format_task_title(task: types.Task) -> str:
-    """Display a nice title for format tasks."""
-    # Since format tasks are sub-tasks, we extract the sub-task name (after `:`)
-    return '{cmd: <{width}} {name}'.format(
-        cmd='FORMAT', width=constants.CMD_WIDTH, name=task.name.split(':')[1]
-    )
 
 
 # List of available formatting tasks.

--- a/buildchain/buildchain/image.py
+++ b/buildchain/buildchain/image.py
@@ -344,6 +344,13 @@ TO_BUILD : Tuple[targets.LocalImage, ...] = (
         },
         task_dep=['_image_mkdir_root'],
     ),
+    targets.OperatorImage(
+        name='storage-operator',
+        version='latest',
+        destination=constants.ISO_IMAGE_ROOT,
+        task_dep=['_image_mkdir_root'],
+        file_dep=list(constants.STORAGE_OPERATOR_SOURCES)
+    ),
 )
 
 

--- a/buildchain/buildchain/iso.py
+++ b/buildchain/buildchain/iso.py
@@ -104,7 +104,7 @@ def task__iso_add_node_manifest() -> types.TaskDict:
     dest_vagrant = constants.ISO_ROOT/'examples'/'new-node_vagrant.yaml'
     new_node_vagrant = [src_vagrant, dest_vagrant]
     return {
-         'title': lambda task: utils.title_with_target1('COPY', task),
+         'title': utils.title_with_target1('COPY'),
          'actions': [
              (coreutils.cp_file, new_node_generic),
              (coreutils.cp_file, new_node_vagrant)
@@ -122,7 +122,7 @@ def task__iso_add_iso_manager() -> types.TaskDict:
     dest = constants.ISO_ROOT/'iso-manager.sh'
     iso_manager = [src, dest]
     return {
-            'title': lambda task: utils.title_with_target1('COPY', task),
+            'title': utils.title_with_target1('COPY'),
             'actions': [(coreutils.cp_file, iso_manager)],
             'targets': [dest],
             'task_dep': ['_iso_mkdir_root'],
@@ -162,7 +162,7 @@ def task__iso_generate_product_txt() -> types.TaskDict:
             fp.write('\n')
 
     return {
-        'title': lambda task: utils.title_with_target1('GENERATE', task),
+        'title': utils.title_with_target1('GENERATE'),
         'actions': [action],
         'targets': [constants.ISO_ROOT/'product.txt'],
         'file_dep': [constants.VERSION_FILE],
@@ -197,7 +197,7 @@ def task__iso_build() -> types.TaskDict:
     depends = list(coreutils.ls_files_rec(constants.ISO_ROOT))
     depends.append(constants.VERSION_FILE)
     return {
-        'title': lambda task: utils.title_with_target1('MKISOFS', task),
+        'title': utils.title_with_target1('MKISOFS'),
         'doc': doc,
         'actions': [mkisofs],
         'targets': [ISO_FILE],

--- a/buildchain/buildchain/lint.py
+++ b/buildchain/buildchain/lint.py
@@ -59,7 +59,7 @@ def lint_python() -> types.TaskDict:
     env = {'PATH': os.environ['PATH'], 'OSTYPE': os.uname().sysname}
     return {
         'name': 'python',
-        'title': _title,
+        'title': utils.title_with_subtask_name('LINT'),
         'doc': lint_python.__doc__,
         'actions': [doit.action.CmdAction(cmd, env=env)],
         'file_dep': python_sources,
@@ -75,7 +75,7 @@ def lint_shell() -> types.TaskDict:
         shell_scripts.extend(constants.ROOT.glob('*/*{}'.format(ext)))
     return {
         'name': 'shell',
-        'title': _title,
+        'title': utils.title_with_subtask_name('LINT'),
         'doc': lint_shell.__doc__,
         'actions': [['tox', '-e', 'lint-shell']],
         'file_dep': shell_scripts,
@@ -88,7 +88,7 @@ def lint_yaml() -> types.TaskDict:
     """Run YAML linting."""
     return {
         'name': 'yaml',
-        'title': _title,
+        'title': utils.title_with_subtask_name('LINT'),
         'doc': lint_yaml.__doc__,
         'actions': [['tox', '-e', 'lint-yaml']],
         'file_dep': list(constants.ROOT.glob('salt/**/*.yaml')),
@@ -134,7 +134,7 @@ def lint_go() -> types.TaskDict:
     """Run Go linting."""
     return {
         'name': 'go',
-        'title': _title,
+        'title': utils.title_with_subtask_name('LINT'),
         'doc': lint_go.__doc__,
         'actions': [check_go_fmt, check_go_codegen],
         'task_dep': [
@@ -144,10 +144,6 @@ def lint_go() -> types.TaskDict:
     }
 
 # }}}
-
-def _title(task: types.Task) -> str:
-    return utils.title_with_subtask_name('LINT', task)
-
 
 # List of available linter task.
 LINTERS : Tuple[Callable[[], types.TaskDict], ...] = (

--- a/buildchain/buildchain/lint.py
+++ b/buildchain/buildchain/lint.py
@@ -58,7 +58,7 @@ def lint_python() -> types.TaskDict:
     env = {'PATH': os.environ['PATH'], 'OSTYPE': os.uname().sysname}
     return {
         'name': 'python',
-        'title': lint_task_title,
+        'title': _title,
         'doc': lint_python.__doc__,
         'actions': [doit.action.CmdAction(cmd, env=env)],
         'file_dep': python_sources,
@@ -72,7 +72,7 @@ def lint_shell() -> types.TaskDict:
         shell_scripts.extend(constants.ROOT.glob('*/*{}'.format(ext)))
     return {
         'name': 'shell',
-        'title': lint_task_title,
+        'title': _title,
         'doc': lint_shell.__doc__,
         'actions': [['tox', '-e', 'lint-shell']],
         'file_dep': shell_scripts,
@@ -83,7 +83,7 @@ def lint_yaml() -> types.TaskDict:
     """Run YAML linting."""
     return {
         'name': 'yaml',
-        'title': lint_task_title,
+        'title': _title,
         'doc': lint_yaml.__doc__,
         'actions': [['tox', '-e', 'lint-yaml']],
         'file_dep': list(constants.ROOT.glob('salt/**/*.yaml')),
@@ -106,7 +106,7 @@ def lint_go() -> types.TaskDict:
 
     return {
         'name': 'go',
-        'title': lint_task_title,
+        'title': _title,
         'doc': lint_go.__doc__,
         'actions': [check_go_fmt],
         'task_dep': ['check_for:gofmt'],
@@ -114,12 +114,8 @@ def lint_go() -> types.TaskDict:
     }
 
 
-def lint_task_title(task: types.Task) -> str:
-    """Display a nice title for lint tasks."""
-    # Since lint tasks are sub-tasks, we extract the sub-task name (after `:`).
-    return '{cmd: <{width}} {name}'.format(
-        cmd='LINT', width=constants.CMD_WIDTH, name=task.name.split(':')[1]
-    )
+def _title(task: types.Task) -> str:
+    return utils.title_with_subtask_name('LINT', task)
 
 
 # List of available linter task.

--- a/buildchain/buildchain/lint.py
+++ b/buildchain/buildchain/lint.py
@@ -58,6 +58,7 @@ def lint_python() -> types.TaskDict:
     env = {'PATH': os.environ['PATH'], 'OSTYPE': os.uname().sysname}
     return {
         'name': 'python',
+        'title': lint_task_title,
         'doc': lint_python.__doc__,
         'actions': [doit.action.CmdAction(cmd, env=env)],
         'file_dep': python_sources,
@@ -71,6 +72,7 @@ def lint_shell() -> types.TaskDict:
         shell_scripts.extend(constants.ROOT.glob('*/*{}'.format(ext)))
     return {
         'name': 'shell',
+        'title': lint_task_title,
         'doc': lint_shell.__doc__,
         'actions': [['tox', '-e', 'lint-shell']],
         'file_dep': shell_scripts,
@@ -81,6 +83,7 @@ def lint_yaml() -> types.TaskDict:
     """Run YAML linting."""
     return {
         'name': 'yaml',
+        'title': lint_task_title,
         'doc': lint_yaml.__doc__,
         'actions': [['tox', '-e', 'lint-yaml']],
         'file_dep': list(constants.ROOT.glob('salt/**/*.yaml')),
@@ -106,11 +109,20 @@ def lint_go() -> types.TaskDict:
 
     return {
         'name': 'go',
+        'title': lint_task_title,
         'doc': lint_go.__doc__,
         'actions': [check_go_fmt],
         'task_dep': ['check_for:gofmt'],
         'file_dep': list(constants.STORAGE_OPERATOR_SOURCES),
     }
+
+
+def lint_task_title(task: types.Task) -> str:
+    """Display a nice title for lint tasks."""
+    # Since lint tasks are sub-tasks, we extract the sub-task name (after `:`).
+    return '{cmd: <{width}} {name}'.format(
+        cmd='LINT', width=constants.CMD_WIDTH, name=task.name.split(':')[1]
+    )
 
 
 # List of available linter task.

--- a/buildchain/buildchain/lint.py
+++ b/buildchain/buildchain/lint.py
@@ -10,14 +10,19 @@ is run in its own sub-task (so that you can run a single one and/or run several
 linting tools in parallel).
 
 Overview:
-
-                ┌────────────┐
-            ───>│ lint:yaml  │
-┌────────┐╱     └────────────┘
+                ┌──────────────┐
+           ╱───>│ lint:python  │
+          ╱     └──────────────┘
+         ╱      ┌──────────────┐
+        ╱   ───>│ lint:yaml    │
+┌────────┐╱     └──────────────┘
 │  lint  │
-└────────┘╲     ┌────────────┐
-            ───>│ lint:shell │
-                └────────────┘
+└────────┘╲     ┌──────────────┐
+        ╲   ───>│ lint:shell   │
+         ╲      └──────────────┘
+          ╲     ┌──────────────┐
+           ╲───>│ lint:go      │
+                └──────────────┘
 """
 
 

--- a/buildchain/buildchain/lint.py
+++ b/buildchain/buildchain/lint.py
@@ -91,15 +91,12 @@ def lint_yaml() -> types.TaskDict:
 
 def lint_go() -> types.TaskDict:
     """Run Go linting."""
-    # Only keep directories (except `vendor`) and top-level Go source files.
-    targets = [
-        path.name for path in constants.STORAGE_OPERATOR_ROOT.glob('*')
-        if (path.is_dir() and path.name != 'vendor') or path.suffix == '.go'
-    ]
-
     def check_go_fmt() -> Optional[doit.exceptions.TaskError]:
         cwd  = constants.STORAGE_OPERATOR_ROOT
-        cmd  = [config.ExtCommand.GOFMT.value, '-s', '-d', *targets]
+        cmd  = [
+            config.ExtCommand.GOFMT.value, '-s', '-d',
+            *tuple(constants.STORAGE_OPERATOR_FMT_ARGS)
+        ]
         diff = subprocess.check_output(cmd, cwd=cwd)
         if diff:
             return doit.exceptions.TaskError(

--- a/buildchain/buildchain/packaging.py
+++ b/buildchain/buildchain/packaging.py
@@ -105,7 +105,7 @@ def task__download_packages() -> types.TaskDict:
         environment={'RELEASEVER': 7}
     )
     return {
-        'title': lambda task: utils.title_with_target1('GET PKGS', task),
+        'title': utils.title_with_target1('GET PKGS'),
         'actions': [dl_packages_callable],
         'targets': [constants.PKG_ROOT/'var'],
         'file_dep': [pkg_list],

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -82,17 +82,12 @@ class CommonStaticContainerRegistry(targets.AtomicTarget):
     def task(self) -> types.TaskDict:
         task = self.basic_task
         task.update({
-            'title': self._show,
+            'title': utils.title_with_target1('NGINX_CFG'),
             'doc': 'Generate the nginx config to serve a common static '
                    'container registry.',
             'actions': [self._run],
         })
         return task
-
-    @staticmethod
-    def _show(task: types.Task) -> str:
-        """Return a description of the task."""
-        return utils.title_with_target1('NGINX_CFG', task)
 
     def _run(self) -> None:
         """Generate the nginx configuration."""
@@ -131,16 +126,11 @@ class StaticContainerRegistry(targets.AtomicTarget):
     def task(self) -> types.TaskDict:
         task = self.basic_task
         task.update({
-            'title': self._show,
+            'title': utils.title_with_target1('NGINX_CFG'),
             'doc': 'Generate the nginx config to serve a container registry.',
             'actions': [self._run],
         })
         return task
-
-    @staticmethod
-    def _show(task: types.Task) -> str:
-        """Return a description of the task."""
-        return utils.title_with_target1('NGINX_CFG', task)
 
     def _run(self) -> None:
         """Generate the nginx configuration."""

--- a/buildchain/buildchain/targets/__init__.py
+++ b/buildchain/buildchain/targets/__init__.py
@@ -9,6 +9,7 @@ from buildchain.targets.checksum import Sha256Sum
 from buildchain.targets.directory import Mkdir
 from buildchain.targets.file_tree import FileTree
 from buildchain.targets.local_image import LocalImage
+from buildchain.targets.operator_image import OperatorImage
 from buildchain.targets.package import Package
 from buildchain.targets.remote_image import RemoteImage
 from buildchain.targets.repository import Repository

--- a/buildchain/buildchain/targets/directory.py
+++ b/buildchain/buildchain/targets/directory.py
@@ -32,7 +32,7 @@ class Mkdir(base.AtomicTarget):
     def task(self) -> types.TaskDict:
         task = self.basic_task
         task.update({
-            'title': lambda task: utils.title_with_target1('MKDIR', task),
+            'title': utils.title_with_target1('MKDIR'),
             'actions': [(self._run, [task['targets'][0]])],
             'uptodate': [True],
         })

--- a/buildchain/buildchain/targets/file_tree.py
+++ b/buildchain/buildchain/targets/file_tree.py
@@ -116,7 +116,7 @@ class FileTree(base.CompositeTarget):
         task.update({
             'name': MAKE_TASK_NAME,
             'doc': 'Create directory hierarchy for {}.'.format(self._root),
-            'title': lambda task: utils.title_with_target1('MKTREE', task),
+            'title': utils.title_with_target1('MKTREE'),
             'actions': [mkdirs],
             'targets': self.directories,
             'uptodate': [True],

--- a/buildchain/buildchain/targets/operator_image.py
+++ b/buildchain/buildchain/targets/operator_image.py
@@ -1,0 +1,54 @@
+# coding: utf-8
+
+
+"""Provides container image construction for Kubernetes Operator.
+
+Those are very similar to the locally built images, except that they are build
+by the `operator-sdk` command (which also takes care of compiling the Go code)
+instead of calling Docker directly.
+"""
+
+
+from pathlib import Path
+import shlex
+from typing import Any, List
+
+import doit # type: ignore
+
+from buildchain import config
+from buildchain import constants
+from buildchain import types
+
+from . import local_image
+
+
+class OperatorImage(local_image.LocalImage):
+    """A locally built container image for a Kubernetes Operator."""
+    def __init__(
+        self, name: str, version: str, destination: Path, **kwargs: Any
+    ):
+        """Initialize an operator container image.
+
+        Arguments:
+            name:         image name
+            version:      image version
+            destination:  where to save the result
+
+        Keyword Arguments:
+            They are passed to `Target` init method.
+        """
+        dockerfile = constants.ROOT/name/'build'/'Dockerfile'
+        kwargs.setdefault('task_dep', []).append('check_for:operator-sdk')
+        super().__init__(
+            name=name, version=version, dockerfile=dockerfile,
+            destination=destination, save_on_disk=True, build_args=None,
+            **kwargs
+        )
+
+    def _do_build(self) -> List[types.Action]:
+        """Return the actions used to build the image."""
+        cwd = constants.ROOT/self.name
+        cmd = ' '.join(map(shlex.quote, [
+            config.ExtCommand.OPERATOR_SDK.value, 'build', self.tag
+        ]))
+        return [doit.action.CmdAction(cmd, cwd=cwd)]

--- a/buildchain/buildchain/targets/package.py
+++ b/buildchain/buildchain/targets/package.py
@@ -176,7 +176,7 @@ class Package(base.CompositeTarget):
             'name': 'pkg_rpmspec',
             'actions': [buildmeta_callable],
             'doc': 'Generate {}.meta'.format(self.name),
-            'title': lambda task: utils.title_with_target1('RPMSPEC', task),
+            'title': utils.title_with_target1('RPMSPEC'),
             'targets': [self.meta],
         })
         task['file_dep'].extend([self.spec])
@@ -195,7 +195,7 @@ class Package(base.CompositeTarget):
             'name': 'pkg_get_source',
             'actions': actions,
             'doc': 'Download source files for {}.'.format(self.name),
-            'title': lambda task: utils.title_with_target1('GET_SRC', task),
+            'title': utils.title_with_target1('GET_SRC'),
             'targets': targets,
         })
         task['file_dep'].append(self.meta)
@@ -226,7 +226,7 @@ class Package(base.CompositeTarget):
             'name': 'pkg_srpm',
             'actions': [buildsrpm_callable],
             'doc': 'Build {}'.format(self.srpm.name),
-            'title': lambda task: utils.title_with_target1('BUILD SRPM', task),
+            'title': utils.title_with_target1('BUILD SRPM'),
             'targets': [self.srpm],
             # Prevent Docker from polluting our output.
             'verbosity': 0,

--- a/buildchain/buildchain/targets/repository.py
+++ b/buildchain/buildchain/targets/repository.py
@@ -131,7 +131,7 @@ class Repository(base.CompositeTarget):
             'name': 'build_repodata',
             'actions': actions,
             'doc': 'Build the {} repository metadata.'.format(self.name),
-            'title': lambda task: utils.title_with_target1('BUILD REPO', task),
+            'title': utils.title_with_target1('BUILD REPO'),
             'targets': targets,
             'uptodate': [True],
             'clean': [clean],
@@ -172,9 +172,7 @@ class Repository(base.CompositeTarget):
                 'doc': 'Build {pkg} RPM for the {repo} repository.'.format(
                     pkg=pkg.name, repo=self.name
                 ),
-                'title': lambda task: utils.title_with_target1(
-                    'BUILD RPM', task
-                ),
+                'title': utils.title_with_target1('BUILD RPM'),
                 'targets': [self._get_rpm_path(pkg)],
                 # Prevent Docker from polluting our output.
                 'verbosity': 0,

--- a/buildchain/buildchain/targets/template.py
+++ b/buildchain/buildchain/targets/template.py
@@ -55,16 +55,11 @@ class TemplateFile(base.AtomicTarget):
     def task(self) -> types.TaskDict:
         task = self.basic_task
         task.update({
-            'title': self._show,
+            'title': utils.title_with_target1('RENDER'),
             'doc': 'Render template {}.'.format(self._src.name),
             'actions': [self._run],
         })
         return task
-
-    @staticmethod
-    def _show(task: types.Task) -> str:
-        """Return a description of the task."""
-        return utils.title_with_target1('RENDER', task)
 
     def _run(self) -> None:
         """Render the template."""

--- a/buildchain/buildchain/utils.py
+++ b/buildchain/buildchain/utils.py
@@ -61,3 +61,19 @@ def title_with_target1(command: str, task: types.Task) -> str:
         cmd=command, width=constants.CMD_WIDTH,
         path=build_relpath(Path(task.targets[0])),
     )
+
+
+def title_with_subtask_name(command: str, task: types.Task) -> str:
+    """Return a title with the command suffixed with the sub-task name.
+
+    Arguments:
+        command: name of the command
+        task: a doit task
+
+    Returns:
+        A string describing the task, with the command name properly padded.
+    """
+    # Extract the sub-task name (the part after `:`) from the task name.
+    return '{cmd: <{width}} {name}'.format(
+        cmd=command, width=constants.CMD_WIDTH, name=task.name.split(':')[1]
+    )

--- a/buildchain/buildchain/utils.py
+++ b/buildchain/buildchain/utils.py
@@ -7,7 +7,7 @@
 import inspect
 import sys
 from pathlib import Path
-from typing import List
+from typing import Callable, List
 
 from buildchain import config
 from buildchain import constants
@@ -47,7 +47,7 @@ def build_relpath(path: Path) -> Path:
     return path.relative_to(config.BUILD_ROOT.parent)
 
 
-def title_with_target1(command: str, task: types.Task) -> str:
+def title_with_target1(command: str) -> Callable[[types.Task], str]:
     """Return a title with the command suffixed with the first target.
 
     Arguments:
@@ -55,15 +55,17 @@ def title_with_target1(command: str, task: types.Task) -> str:
         task: a doit task
 
     Returns:
-        A string describing the task, with the command name properly padded.
+        A function that returns the title
     """
-    return '{cmd: <{width}} {path}'.format(
-        cmd=command, width=constants.CMD_WIDTH,
-        path=build_relpath(Path(task.targets[0])),
-    )
+    def title(task: types.Task) -> str:
+        return '{cmd: <{width}} {path}'.format(
+            cmd=command, width=constants.CMD_WIDTH,
+            path=build_relpath(Path(task.targets[0])),
+        )
+    return title
 
 
-def title_with_subtask_name(command: str, task: types.Task) -> str:
+def title_with_subtask_name(command: str) -> Callable[[types.Task], str]:
     """Return a title with the command suffixed with the sub-task name.
 
     Arguments:
@@ -71,9 +73,11 @@ def title_with_subtask_name(command: str, task: types.Task) -> str:
         task: a doit task
 
     Returns:
-        A string describing the task, with the command name properly padded.
+        A function that returns the title
     """
-    # Extract the sub-task name (the part after `:`) from the task name.
-    return '{cmd: <{width}} {name}'.format(
-        cmd=command, width=constants.CMD_WIDTH, name=task.name.split(':')[1]
-    )
+    def title(task: types.Task) -> str:
+        # Extract the sub-task name (the part after `:`) from the task name.
+        return '{cmd: <{width}} {name}'.format(
+            cmd=command, width=constants.CMD_WIDTH, name=task.name.split(':')[1]
+        )
+    return title

--- a/buildchain/buildchain/utils.py
+++ b/buildchain/buildchain/utils.py
@@ -48,7 +48,7 @@ def build_relpath(path: Path) -> Path:
 
 
 def title_with_target1(command: str, task: types.Task) -> str:
-    """Return a title with the command prefixed with the first target.
+    """Return a title with the command suffixed with the first target.
 
     Arguments:
         command: name of the command

--- a/buildchain/dodo.py
+++ b/buildchain/dodo.py
@@ -13,6 +13,7 @@ from buildchain.build import *
 from buildchain.deps import *
 from buildchain.image import *
 from buildchain.iso import *
+from buildchain.format import *
 from buildchain.lint import *
 from buildchain.packaging import *
 from buildchain.salt_tree import *

--- a/buildchain/dodo.py
+++ b/buildchain/dodo.py
@@ -10,6 +10,7 @@ import sys
 import doit  # type: ignore
 
 from buildchain.build import *
+from buildchain.codegen import *
 from buildchain.deps import *
 from buildchain.image import *
 from buildchain.iso import *

--- a/docs/developer/building/configuration.rst
+++ b/docs/developer/building/configuration.rst
@@ -18,6 +18,8 @@ Available options are:
 - ``MKISOFS_BIN``: mkisofs binary (name or path to the binary)
 - ``SKOPEO_BIN``: skopeo binary (name or path to the binary)
 - ``VAGRANT_BIN``: Vagrant binary (name or path to the binary)
+- ``GOFMT_BIN``: gofmt binary (name or path to the binary)
+- ``OPERATOR_SDK_BIN``: the Operator SDK binary (name or path to the binary)
 
 Default settings are equivalent to the following ``.env``:
 
@@ -33,3 +35,5 @@ Default settings are equivalent to the following ``.env``:
    export MKISOFS_BIN=mkisofs
    export SKOPEO_BIN=skopeo
    export VAGRANT_BIN=vagrant
+   export GOFMT_BIN=gofmt
+   export OPERATOR_SDK_BIN=operator-sdk

--- a/docs/developer/building/requirements.rst
+++ b/docs/developer/building/requirements.rst
@@ -9,11 +9,15 @@ Mandatory
 
 - `Python <https://www.python.org/>`_ 3.6 or higher: our buildchain is
   Python-based
-- `docker <https://www.docker.com/>`_: to build some images locally
+- `docker <https://www.docker.com/>`_ 17.03 or higher: to build some images
+  locally
 - `skopeo <https://github.com/containers/skopeo>`_, 0.1.19 or higher: to save
   local and remote images
 - `hardlink <https://jak-linux.org/projects/hardlink/>`_: to de-duplicate images
   layers
+- `Go <https://golang.org/>`_ (1.12 or higher) and
+  `operator-sdk <https://github.com/operator-framework/operator-sdk>`_ (0.9 or
+  higher): to build the Kubernetes Operators
 - mkisofs: to create the MetalK8s ISO
 
 Optional

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -36,7 +36,9 @@ stages:
       type: kube_pod
       path: eve/workers/pod-builder/pod.yaml
       images:
-        docker-builder: eve/workers/pod-builder
+        docker-builder:
+          context: 'storage-operator'
+          dockerfile: eve/workers/pod-builder/Dockerfile
     steps:
       - ShellCommand:
           name: Wait for Docker daemon to be ready
@@ -106,7 +108,9 @@ stages:
       type: kube_pod
       path: eve/workers/pod-linter/pod.yaml
       images:
-        docker-linter: eve/workers/pod-linter
+        docker-linter:
+          context: 'storage-operator'
+          dockerfile: eve/workers/pod-linter/Dockerfile
     steps:
       - Git: *git_pull
       - ShellCommand:

--- a/eve/workers/pod-builder/Dockerfile
+++ b/eve/workers/pod-builder/Dockerfile
@@ -1,6 +1,8 @@
 FROM centos:7
 
 ARG BUILDBOT_VERSION=0.9.12
+ARG GO_VERSION=1.12.7
+ARG OPERATOR_SDK_VERSION=v0.9.0
 
 WORKDIR /home/eve/workspace
 
@@ -23,7 +25,21 @@ RUN yum install -y epel-release \
     yum-utils \
     docker-ce-cli-18.09.6 \
     && adduser -u 1042 --home /home/eve eve --groups docker \
-    && chown eve:eve /home/eve/workspace \
+    && chown -R eve:eve /home/eve \
     && pip install buildbot-worker==${BUILDBOT_VERSION}
+
+# Install Go tooling to build the Kubernetes Operators.
+ENV GOROOT /usr/local/go
+ENV GOPATH /home/eve/.golang
+ENV GOCACHE /home/eve/.cache
+ENV PATH $GOPATH/bin:$GOROOT/bin:$PATH
+
+RUN curl -ORL https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz      \
+    && tar xzvf go${GO_VERSION}.linux-amd64.tar.gz                             \
+    && rm go${GO_VERSION}.linux-amd64.tar.gz                                   \
+    && mv go /usr/local                                                        \
+    && curl -RLo /usr/bin/operator-sdk                                         \
+        https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu \
+    && chmod +x /usr/bin/operator-sdk
 
 USER eve

--- a/eve/workers/pod-builder/Dockerfile
+++ b/eve/workers/pod-builder/Dockerfile
@@ -21,6 +21,7 @@ RUN yum install -y epel-release \
     python36-pip \
     genisoimage \
     git \
+    hg \
     skopeo \
     yum-utils \
     docker-ce-cli-18.09.6 \
@@ -43,3 +44,7 @@ RUN curl -ORL https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz      \
     && chmod +x /usr/bin/operator-sdk
 
 USER eve
+
+# Pre-download the Go dependencies.
+COPY go.mod go.sum ./
+RUN go mod download

--- a/eve/workers/pod-linter/Dockerfile
+++ b/eve/workers/pod-linter/Dockerfile
@@ -13,6 +13,7 @@ RUN dnf install -y git \
   gcc \
   make \
   enchant \
+  hg \
   python2-twisted \
   python \
   python-devel \
@@ -41,3 +42,7 @@ RUN curl -ORL https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz      \
     && chmod +x /usr/bin/operator-sdk
 
 USER eve
+
+# Pre-download the Go dependencies.
+COPY go.mod go.sum ./
+RUN go mod download

--- a/eve/workers/pod-linter/Dockerfile
+++ b/eve/workers/pod-linter/Dockerfile
@@ -2,6 +2,8 @@
 FROM fedora:29
 
 ARG BUILDBOT_VERSION=0.9.12
+ARG GO_VERSION=1.12.7
+ARG OPERATOR_SDK_VERSION=v0.9.0
 
 ENV LANG=en_US.utf8
 
@@ -20,8 +22,22 @@ RUN dnf install -y git \
   ShellCheck \
   && dnf clean all \
   && adduser -u 1042 --home /home/eve eve \
-  && chown eve:eve /home/eve/workspace \
+  && chown -R eve:eve /home/eve \
   && pip install tox \
   && pip install buildbot-worker==${BUILDBOT_VERSION}
+
+# Install Go tooling to lint the Kubernetes Operators.
+ENV GOROOT /usr/local/go
+ENV GOPATH /home/eve/.golang
+ENV GOCACHE /home/eve/.cache
+ENV PATH $GOPATH/bin:$GOROOT/bin:$PATH
+
+RUN curl -ORL https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz      \
+    && tar xzvf go${GO_VERSION}.linux-amd64.tar.gz                             \
+    && rm go${GO_VERSION}.linux-amd64.tar.gz                                   \
+    && mv go /usr/local                                                        \
+    && curl -RLo /usr/bin/operator-sdk                                         \
+        https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu \
+    && chmod +x /usr/bin/operator-sdk
 
 USER eve

--- a/storage-operator/.dockerignore
+++ b/storage-operator/.dockerignore
@@ -1,0 +1,5 @@
+cmd/
+deploy/
+pkg/
+tools.go
+version/


### PR DESCRIPTION
**Component**:

ci, buildchain

**Context**: 

In order to deploy the operator, we need to be able to build it and add it in the ISO.

**Summary**:

Add new dependencies in the CI to build the operator (`go`, `operator-sdk` and `dep`).
Update the buildchain with new tasks:
- to build the operator image and add it to the ISO
- to lint the Go code (and check that the generated files are up-to-date)
- to help formatting Go code (using `gofmt`) and generating boilerplate code (using `operator-sdk generate`).

**Acceptance criteria**: 

When building the ISO, you should have the operator image in the build tree (check with `ls _build/root/images/storage-operator/*`)
If you're familiar with Go, you can also edit `storage-operator/pkg/apis/storage/v1alpha1/volume_types.go` to test the new tasks:
- `./doit.sh format` should reformat the code according to `gofmt`
- `./doit.sh codegen` should re-generate the boilerplate code
- `./doit.sh lint:go` should complains if either the formatting is not good or the generated files are outdated.

---

Closes: #1410 
