### PR TITLE
NodeCreationForm: usability improvement

### DIFF
--- a/ui/src/containers/NodeCreateForm.js
+++ b/ui/src/containers/NodeCreateForm.js
@@ -98,7 +98,10 @@ const validationSchema = Yup.object().shape({
   version: Yup.string().required(),
   ssh_user: Yup.string().required(),
   hostName_ip: Yup.string().required(),
-  ssh_port: Yup.string().required(),
+  ssh_port: Yup.number()
+    .min(0)
+    .max(65535)
+    .required(),
   ssh_key_path: Yup.string().required(),
   sudo_required: Yup.boolean().required(),
   workload_plane: Yup.boolean().required(),

--- a/ui/src/containers/NodeCreateForm.js
+++ b/ui/src/containers/NodeCreateForm.js
@@ -5,8 +5,8 @@ import { Formik, Form } from 'formik';
 import * as Yup from 'yup';
 import { withRouter } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
-import { Button, Input } from '@scality/core-ui';
-import { padding } from '@scality/core-ui/dist/style/theme';
+import { Button, Input, Checkbox } from '@scality/core-ui';
+import { padding, fontSize, gray } from '@scality/core-ui/dist/style/theme';
 import { isEmpty } from 'lodash';
 import {
   createNodeAction,
@@ -17,8 +17,8 @@ const CreateNodeLayout = styled.div`
   height: 100%;
   overflow: auto;
   padding: ${padding.larger};
+  display: inline-block;
   form {
-    width: 450px;
     .sc-input {
       margin: ${padding.smaller} 0;
       .sc-input-label {
@@ -34,21 +34,50 @@ const PageHeader = styled.h2`
 
 const ActionContainer = styled.div`
   display: flex;
-  margin: ${padding.larger} 0;
+  margin: ${padding.large} 0;
   justify-content: flex-end;
 
   button {
-    margin-right: ${padding.larger};
+    margin-right: ${padding.large};
   }
 `;
 
 const ErrorMessage = styled.span`
-  margin-top: ${padding.base};
+  visibility: ${props => (props.visible ? 'visible' : 'hidden')};
   color: ${props => props.theme.brand.danger};
+  font-size: ${fontSize.small};
 `;
 
-const FormTitle = styled.h3`
-  margin: ${padding.small};
+const CheckboxGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  .sc-checkbox {
+    margin: ${padding.small} 0;
+    .text {
+      font-size: ${fontSize.base};
+    }
+  }
+`;
+
+const FormSectionTitle = styled.h3`
+  margin: 0 ${padding.small} 0;
+  color: ${gray};
+`;
+
+const FormSection = styled.div`
+  padding: 0 ${padding.larger};
+  display: flex;
+  flex-direction: column;
+`;
+
+const InputContainer = styled.div`
+  display: inline-flex;
+`;
+
+const InputLabel = styled.label`
+  padding: ${padding.small};
+  font-size: ${fontSize.base};
 `;
 
 const initialValues = {
@@ -56,7 +85,7 @@ const initialValues = {
   version: '',
   ssh_user: '',
   hostName_ip: '',
-  ssh_port: '',
+  ssh_port: '22',
   ssh_key_path: '',
   sudo_required: false,
   workload_plane: true,
@@ -112,136 +141,146 @@ class NodeCreateForm extends React.Component {
 
             return (
               <Form>
-                <Input
-                  name="name"
-                  label={intl.messages.name}
-                  value={values.name}
-                  onChange={handleChange('name')}
-                  error={touched.name && errors.name}
-                  onBlur={handleOnBlur}
-                />
-                <Input
-                  name="version"
-                  label={intl.messages.version}
-                  value={values.version}
-                  onChange={handleChange('version')}
-                  error={touched.version && errors.version}
-                  onBlur={handleOnBlur}
-                />
-                <Input
-                  name="ssh_user"
-                  label={intl.messages.ssh_user}
-                  value={values.ssh_user}
-                  onChange={handleChange('ssh_user')}
-                  error={touched.ssh_user && errors.ssh_user}
-                  onBlur={handleOnBlur}
-                />
-                <Input
-                  name="hostName_ip"
-                  label={intl.messages.hostName_ip}
-                  value={values.hostName_ip}
-                  onChange={handleChange('hostName_ip')}
-                  error={touched.hostName_ip && errors.hostName_ip}
-                  onBlur={handleOnBlur}
-                />
-                <Input
-                  name="ssh_port"
-                  label={intl.messages.ssh_port}
-                  value={values.ssh_port}
-                  onChange={handleChange('ssh_port')}
-                  error={touched.ssh_port && errors.ssh_port}
-                  onBlur={handleOnBlur}
-                />
-                <Input
-                  name="ssh_key_path"
-                  label={intl.messages.ssh_key_path}
-                  value={values.ssh_key_path}
-                  onChange={handleChange('ssh_key_path')}
-                  error={touched.ssh_key_path && errors.ssh_key_path}
-                  onBlur={handleOnBlur}
-                />
-                <Input
-                  name="sudo_required"
-                  type="checkbox"
-                  label={intl.messages.sudo_required}
-                  value={values.sudo_required}
-                  checked={values.sudo_required}
-                  onChange={handleChange('sudo_required')}
-                  onBlur={handleOnBlur}
-                />
-                <FormTitle>{intl.messages.roles}</FormTitle>
-                <Input
-                  type="checkbox"
-                  name="workload_plane"
-                  label={intl.messages.workload_plane}
-                  checked={values.workload_plane}
-                  value={values.workload_plane}
-                  onChange={handleChange('workload_plane')}
-                  onBlur={handleOnBlur}
-                  error={
-                    values.workload_plane ||
-                    values.control_plane ||
-                    values.infra
-                      ? ''
-                      : intl.messages.role_values_error
-                  }
-                />
-                <Input
-                  type="checkbox"
-                  name="control_plane"
-                  label={intl.messages.control_plane}
-                  checked={values.control_plane}
-                  value={values.control_plane}
-                  onChange={handleChange('control_plane')}
-                  onBlur={handleOnBlur}
-                  error={
-                    values.workload_plane ||
-                    values.control_plane ||
-                    values.infra
-                      ? ''
-                      : intl.messages.role_values_error
-                  }
-                />
-                <Input
-                  type="checkbox"
-                  name="infra"
-                  label={intl.messages.infra}
-                  checked={values.infra}
-                  value={values.infra}
-                  onChange={handleChange('infra')}
-                  onBlur={handleOnBlur}
-                  error={
-                    values.workload_plane ||
-                    values.control_plane ||
-                    values.infra
-                      ? ''
-                      : intl.messages.role_values_error
-                  }
-                />
+                <FormSection>
+                  <FormSectionTitle>
+                    {intl.messages.new_node_data}
+                  </FormSectionTitle>
+                  <Input
+                    name="name"
+                    label={intl.messages.name}
+                    value={values.name}
+                    onChange={handleChange('name')}
+                    error={touched.name && errors.name}
+                    onBlur={handleOnBlur}
+                  />
+                  <Input
+                    name="version"
+                    label={intl.messages.version}
+                    value={values.version}
+                    onChange={handleChange('version')}
+                    error={touched.version && errors.version}
+                    onBlur={handleOnBlur}
+                  />
+                  <InputContainer className="sc-input">
+                    <InputLabel className="sc-input-label">
+                      {intl.messages.roles}
+                    </InputLabel>
+                    <CheckboxGroup>
+                      <Checkbox
+                        name="workload_plane"
+                        label={intl.messages.workload_plane}
+                        checked={values.workload_plane}
+                        value={values.workload_plane}
+                        onChange={handleChange('workload_plane')}
+                        onBlur={handleOnBlur}
+                      />
+                      <Checkbox
+                        name="control_plane"
+                        label={intl.messages.control_plane}
+                        checked={values.control_plane}
+                        value={values.control_plane}
+                        onChange={handleChange('control_plane')}
+                        onBlur={handleOnBlur}
+                      />
+                      <Checkbox
+                        name="infra"
+                        label={intl.messages.infra}
+                        checked={values.infra}
+                        value={values.infra}
+                        onChange={handleChange('infra')}
+                        onBlur={handleOnBlur}
+                      />
+                      <ErrorMessage
+                        visible={
+                          !(
+                            values.workload_plane ||
+                            values.control_plane ||
+                            values.infra
+                          )
+                        }
+                      >
+                        {intl.messages.role_values_error}
+                      </ErrorMessage>
+                    </CheckboxGroup>
+                  </InputContainer>
+                </FormSection>
+
+                <FormSection>
+                  <FormSectionTitle>
+                    {intl.messages.new_node_access}
+                  </FormSectionTitle>
+                  <Input
+                    name="ssh_user"
+                    label={intl.messages.ssh_user}
+                    value={values.ssh_user}
+                    onChange={handleChange('ssh_user')}
+                    error={touched.ssh_user && errors.ssh_user}
+                    onBlur={handleOnBlur}
+                  />
+                  <Input
+                    name="hostName_ip"
+                    label={intl.messages.hostName_ip}
+                    value={values.hostName_ip}
+                    onChange={handleChange('hostName_ip')}
+                    error={touched.hostName_ip && errors.hostName_ip}
+                    onBlur={handleOnBlur}
+                  />
+                  <Input
+                    name="ssh_port"
+                    label={intl.messages.ssh_port}
+                    value={values.ssh_port}
+                    onChange={handleChange('ssh_port')}
+                    error={touched.ssh_port && errors.ssh_port}
+                    onBlur={handleOnBlur}
+                  />
+                  <Input
+                    name="ssh_key_path"
+                    label={intl.messages.ssh_key_path}
+                    value={values.ssh_key_path}
+                    onChange={handleChange('ssh_key_path')}
+                    error={touched.ssh_key_path && errors.ssh_key_path}
+                    onBlur={handleOnBlur}
+                  />
+                  <Input
+                    name="sudo_required"
+                    type="checkbox"
+                    label={intl.messages.sudo_required}
+                    value={values.sudo_required}
+                    checked={values.sudo_required}
+                    onChange={handleChange('sudo_required')}
+                    onBlur={handleOnBlur}
+                  />
+                </FormSection>
                 <ActionContainer>
-                  <Button
-                    text={intl.messages.cancel}
-                    type="button"
-                    outlined
-                    onClick={() => this.props.history.push('/nodes')}
-                  />
-                  <Button
-                    text={intl.messages.create}
-                    type="submit"
-                    disabled={
-                      !dirty ||
-                      !isEmpty(errors) ||
-                      !(
-                        values.workload_plane ||
-                        values.control_plane ||
-                        values.infra
-                      )
-                    }
-                  />
+                  <div>
+                    <div>
+                      <Button
+                        text={intl.messages.cancel}
+                        type="button"
+                        outlined
+                        onClick={() => this.props.history.push('/nodes')}
+                      />
+                      <Button
+                        text={intl.messages.create}
+                        type="submit"
+                        disabled={
+                          !dirty ||
+                          !isEmpty(errors) ||
+                          !(
+                            values.workload_plane ||
+                            values.control_plane ||
+                            values.infra
+                          )
+                        }
+                      />
+                    </div>
+                    <ErrorMessage
+                      visible={asyncErrors && asyncErrors.create_node}
+                    >
+                      {asyncErrors && asyncErrors.create_node}
+                    </ErrorMessage>
+                  </div>
                 </ActionContainer>
-                {asyncErrors && asyncErrors.create_node ? (
-                  <ErrorMessage>{asyncErrors.create_node}</ErrorMessage>
-                ) : null}
               </Form>
             );
           }}

--- a/ui/src/containers/NodeCreateForm.js
+++ b/ui/src/containers/NodeCreateForm.js
@@ -86,7 +86,7 @@ const initialValues = {
   ssh_user: '',
   hostName_ip: '',
   ssh_port: '22',
-  ssh_key_path: '',
+  ssh_key_path: '/etc/metalk8s/pki/salt-bootstrap',
   sudo_required: false,
   workload_plane: true,
   control_plane: false,

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -20,13 +20,13 @@
   "hostName_ip": "Hostname or IP",
   "ssh_port": "SSH Port",
   "ssh_key_path": "SSH Key Path",
-  "sudo_required": "Sudo required",
+  "sudo_required": "Sudo Required",
   "workload_plane": "Workload Plane",
   "control_plane": "Control Plane",
   "infra": "Infra" ,
   "bootstrap": "Bootstrap",
   "roles": "Roles",
-  "role_values_error": "At least on role has to be selected!",
+  "role_values_error": "At least one role has to be selected!",
   "create_new_node": "Create a New Node",
   "create": "Create",
   "cancel": "Cancel",
@@ -61,5 +61,7 @@
   "api_server": "API",
   "kube_scheduler": "Scheduler",
   "kube_controller_manager": "Controller",
-  "no_data_available": "No data available"
+  "no_data_available": "No data available",
+  "new_node_data": "New Node Data",
+  "new_node_access": "New Node Access"
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -61,5 +61,7 @@
   "api_server": "API",
   "kube_scheduler": "Ordonnanceur",
   "kube_controller_manager": "Contrôleur",
-  "no_data_available": "Pas de données disponibles"
+  "no_data_available": "Pas de données disponibles",
+  "new_node_data": "Donnée du nouveau node",
+  "new_node_access": "Accès au nouveau node"
 }


### PR DESCRIPTION
**Component**: UI

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
- Actually, the node creation form is quite confusing. We decided to split into 2 sections to make it clearer.
- SSH Port defaults to ```22```
- SSH Key Path defaults to ```/etc/metalk8s/pki/salt-bootstrap```
- Roles selection is improved
 
**Summary**:

**Acceptance criteria**: 
<img width="1440" alt="Screenshot 2019-07-16 at 15 06 35" src="https://user-images.githubusercontent.com/47394132/61297570-ccac5300-a7dc-11e9-9914-890b4b8e845d.png">

<img width="1440" alt="Screenshot 2019-07-16 at 15 06 53" src="https://user-images.githubusercontent.com/47394132/61297581-d0d87080-a7dc-11e9-9012-599d527e7288.png">

![image](https://user-images.githubusercontent.com/47394132/61301896-26188000-a7e5-11e9-9775-a5ec50fe7a35.png)


- no regression on node expansion
---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: https://github.com/scality/metalk8s/issues/1226 https://github.com/scality/metalk8s/issues/1204

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
