### PR TITLE
calico: disable usage reporting

### DIFF
--- a/salt/metalk8s/kubernetes/cni/calico/deployed.sls
+++ b/salt/metalk8s/kubernetes/cni/calico/deployed.sls
@@ -651,6 +651,8 @@ spec:
               value: "info"
             - name: FELIX_HEALTHENABLED
               value: "true"
+            - name: FELIX_USAGEREPORTINGENABLED
+              value: "false"
           securityContext:
             privileged: true
           resources:


### PR DESCRIPTION
We can't have this in our customer environments.

See: https://docs.projectcalico.org/v3.8/reference/felix/configuration