### PR TITLE
Improvement/1423 redesign volume list page

### DIFF
--- a/ui/src/components/Volumes.js
+++ b/ui/src/components/Volumes.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Button, Table } from '@scality/core-ui';
+import { padding } from '@scality/core-ui/dist/style/theme';
+
+const VolumePageContainer = styled.div`
+  margin-top: ${padding.small};
+`;
+
+const VolumeTable = styled.div`
+  flex-grow: 1;
+  margin-top: ${padding.small};
+`;
+
+const Volumes = () => {
+  const volumes = [];
+
+  const columns = [
+    {
+      label: 'Name',
+      dataKey: 'name',
+      flexGrow: 1
+    },
+    {
+      label: 'Status',
+      dataKey: 'status'
+    },
+    {
+      label: 'Size',
+      dataKey: 'namespace'
+    },
+    {
+      label: 'StorageClass',
+      dataKey: 'startTime'
+    },
+    {
+      label: 'Creation Time',
+      dataKey: 'namespace'
+    }
+  ];
+
+  return (
+    <VolumePageContainer>
+      <Button text={'Create New Volume'} type="button" />
+      <VolumeTable>
+        <Table
+          list={volumes}
+          columns={columns}
+          disableHeader={false}
+          headerHeight={40}
+          rowHeight={40}
+          // sortBy={this.state.sortBy}
+          // sortDirection={this.state.sortDirection}
+          // onSort={this.onSort}
+          onRowClick={() => {}}
+        />
+      </VolumeTable>
+    </VolumePageContainer>
+  );
+};
+
+export default Volumes;

--- a/ui/src/components/Volumes.js
+++ b/ui/src/components/Volumes.js
@@ -4,6 +4,9 @@ import { Button, Table } from '@scality/core-ui';
 import { padding } from '@scality/core-ui/dist/style/theme';
 
 const VolumePageContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
   margin-top: ${padding.small};
 `;
 
@@ -12,9 +15,7 @@ const VolumeTable = styled.div`
   margin-top: ${padding.small};
 `;
 
-const Volumes = () => {
-  const volumes = [];
-
+const Volumes = props => {
   const columns = [
     {
       label: 'Name',
@@ -27,24 +28,26 @@ const Volumes = () => {
     },
     {
       label: 'Size',
-      dataKey: 'namespace'
+      dataKey: 'size'
     },
     {
       label: 'StorageClass',
-      dataKey: 'startTime'
+      dataKey: 'storageClass'
     },
     {
       label: 'Creation Time',
-      dataKey: 'namespace'
+      dataKey: 'creationTime'
     }
   ];
 
   return (
     <VolumePageContainer>
-      {/* <Button text={'Create New Volume'} type="button" /> */}
+      <div>
+        <Button text={'Create New Volume'} type="button" />
+      </div>
       <VolumeTable>
         <Table
-          list={volumes}
+          list={props.data}
           columns={columns}
           disableHeader={false}
           headerHeight={40}

--- a/ui/src/components/Volumes.js
+++ b/ui/src/components/Volumes.js
@@ -14,6 +14,7 @@ const VolumeTable = styled.div`
 `;
 
 const Volumes = props => {
+  // FIXME Add translation
   const columns = [
     {
       label: 'Name',

--- a/ui/src/components/Volumes.js
+++ b/ui/src/components/Volumes.js
@@ -1,12 +1,10 @@
 import React from 'react';
 import styled from 'styled-components';
+import { FormattedDate, FormattedTime } from 'react-intl';
 import { Button, Table } from '@scality/core-ui';
 import { padding } from '@scality/core-ui/dist/style/theme';
 
-const VolumePageContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  height: 100%;
+const ButtonContainer = styled.div`
   margin-top: ${padding.small};
 `;
 
@@ -36,15 +34,26 @@ const Volumes = props => {
     },
     {
       label: 'Creation Time',
-      dataKey: 'creationTime'
+      dataKey: 'creationTime',
+      renderer: data => (
+        <span>
+          <FormattedDate value={data} />{' '}
+          <FormattedTime
+            hour="2-digit"
+            minute="2-digit"
+            second="2-digit"
+            value={data}
+          />
+        </span>
+      )
     }
   ];
 
   return (
-    <VolumePageContainer>
-      <div>
+    <>
+      <ButtonContainer>
         <Button text={'Create New Volume'} type="button" />
-      </div>
+      </ButtonContainer>
       <VolumeTable>
         <Table
           list={props.data}
@@ -58,7 +67,7 @@ const Volumes = props => {
           onRowClick={() => {}}
         />
       </VolumeTable>
-    </VolumePageContainer>
+    </>
   );
 };
 

--- a/ui/src/components/Volumes.js
+++ b/ui/src/components/Volumes.js
@@ -41,7 +41,7 @@ const Volumes = () => {
 
   return (
     <VolumePageContainer>
-      <Button text={'Create New Volume'} type="button" />
+      {/* <Button text={'Create New Volume'} type="button" /> */}
       <VolumeTable>
         <Table
           list={volumes}

--- a/ui/src/containers/Layout.js
+++ b/ui/src/containers/Layout.js
@@ -126,7 +126,7 @@ class Layout extends Component {
               path="/nodes/deploy/:id"
               component={NodeDeployment}
             />
-            <PrivateRoute exact path="/nodes/:id" component={NodeInformation} />
+            <PrivateRoute path="/nodes/:id" component={NodeInformation} />
             <PrivateRoute exact path="/nodes" component={NodeList} />
             <PrivateRoute exact path="/about" component={Welcome} />
             <PrivateRoute exact path="/" component={ClusterMonitoring} />

--- a/ui/src/containers/Layout.js
+++ b/ui/src/containers/Layout.js
@@ -44,7 +44,7 @@ class Layout extends Component {
       expanded: this.props.sidebar.expanded,
       actions: [
         {
-          label: this.props.intl.messages.cluster_monitoring,
+          label: this.props.intl.messages.monitoring,
           icon: <i className="fas fa-desktop" />,
           onClick: () => {
             this.props.history.push('/');

--- a/ui/src/containers/NodeInformation.js
+++ b/ui/src/containers/NodeInformation.js
@@ -220,6 +220,42 @@ class NodeInformation extends React.Component {
   }
 }
 
+const getNodeNameFromUrl = (state, props) => {
+  if (props && props.match && props.match.params && props.match.params.id) {
+    return props.match.params.id;
+  } else {
+    return '';
+  }
+};
+
+const getNodes = state =>
+  (state && state.app && state.app.nodes && state.app.nodes.list) || [];
+
+const getPods = state =>
+  (state && state.app && state.app.pods && state.app.pods.list) || [];
+
+const getVolumes = state =>
+  (state && state.app && state.app.volumes && state.app.volumes.list) || [];
+
+const makeGetNodeFromUrl = createSelector(
+  getNodeNameFromUrl,
+  getNodes,
+  (nodeName, nodes) => nodes.find(node => node.name === nodeName) || {}
+);
+
+const makeGetPodsFromUrl = createSelector(
+  getNodeNameFromUrl,
+  getPods,
+  (nodeName, pods) => pods.filter(pod => pod.nodeName === nodeName) || []
+);
+
+const makeGetVolumesFromUrl = createSelector(
+  getNodeNameFromUrl,
+  getVolumes,
+  (nodeName, volumes) =>
+    volumes.filter(v => v && v.spec && v.spec.nodeName === nodeName)
+);
+
 const mapStateToProps = (state, ownProps) => ({
   node: makeGetNodeFromUrl(state, ownProps),
   pods: makeGetPodsFromUrl(state, ownProps),
@@ -233,58 +269,6 @@ const mapDispatchToProps = dispatch => {
     fetchVolumes: () => dispatch(fetchVolumesAction())
   };
 };
-
-const getNodeFromUrl = (state, props) => {
-  const nodes = state.app.nodes.list || [];
-  if (props && props.match && props.match.params && props.match.params.id) {
-    return nodes.find(node => node.name === props.match.params.id) || {};
-  } else {
-    return {};
-  }
-};
-
-const getPodsFromUrl = (state, props) => {
-  const pods = state.app.pods.list || [];
-  if (props && props.match && props.match.params && props.match.params.id) {
-    return pods.filter(pod => pod.nodeName === props.match.params.id) || [];
-  } else {
-    return [];
-  }
-};
-
-const getNodeNameFromUrl = (state, props) => {
-  if (props && props.match && props.match.params && props.match.params.id) {
-    return props.match.params.id;
-  } else {
-    return '';
-  }
-};
-
-const getVolumes = state => {
-  if (state && state.app && state.app.volumes && state.app.volumes.list) {
-    return state.app.volumes.list;
-  } else {
-    return [];
-  }
-};
-
-const makeGetNodeFromUrl = createSelector(
-  getNodeFromUrl,
-  node => node
-);
-
-const makeGetPodsFromUrl = createSelector(
-  getPodsFromUrl,
-  pods => pods
-);
-
-const makeGetVolumesFromUrl = createSelector(
-  getNodeNameFromUrl,
-  getVolumes,
-  (nodeName, volumes) => {
-    return volumes.filter(v => v && v.spec && v.spec.nodeName === nodeName);
-  }
-);
 
 export default injectIntl(
   withRouter(

--- a/ui/src/containers/NodeInformation.js
+++ b/ui/src/containers/NodeInformation.js
@@ -29,25 +29,28 @@ const NodeInformationContainer = styled.div`
 
 const PodsContainer = styled.div`
   flex-grow: 1;
+  margin-top: ${padding.base};
 `;
 
-const PageTitle = styled.h2``;
-
-const InformationTitle = styled.h3``;
+const DetailsContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-top: ${padding.base};
+`;
 
 const InformationSpan = styled.span`
-  padding: 0 ${padding.larger} ${padding.small} ${padding.larger};
+  padding: 0 ${padding.larger} ${padding.small} 0;
 `;
 
 const InformationLabel = styled.span`
-  font-size: ${fontSize.small};
-  padding: 0 ${padding.base};
-  min-width: 120px;
+  font-size: ${fontSize.large};
+  padding-right: ${padding.base}
+  min-width: 150px;
   display: inline-block;
 `;
 
 const InformationValue = styled.span`
-  font-size: ${fontSize.base};
+  font-size: ${fontSize.large};
 `;
 
 const InformationMainValue = styled(InformationValue)`
@@ -112,7 +115,7 @@ class NodeInformation extends React.Component {
   }
 
   render() {
-    const { match, volumes, history, intl, node } = this.props;
+    const { match, history, location, volumes, intl, node } = this.props;
     const podsSortedList = sortSelector(
       this.props.pods,
       this.state.sortBy,
@@ -120,8 +123,7 @@ class NodeInformation extends React.Component {
     );
 
     const NodeDetails = () => (
-      <>
-        <PageTitle>{intl.messages.information}</PageTitle>
+      <DetailsContainer>
         <InformationSpan>
           <InformationLabel>{intl.messages.name}</InformationLabel>
           <InformationMainValue>{node.name}</InformationMainValue>
@@ -138,12 +140,11 @@ class NodeInformation extends React.Component {
           <InformationLabel>{intl.messages.version}</InformationLabel>
           <InformationValue>{node.metalk8s_version}</InformationValue>
         </InformationSpan>
-      </>
+      </DetailsContainer>
     );
 
     const NodePods = () => (
       <>
-        <InformationTitle>{intl.messages.pods}</InformationTitle>
         <PodsContainer>
           <Table
             list={podsSortedList}
@@ -177,6 +178,9 @@ class NodeInformation extends React.Component {
       };
     });
 
+    const isVolumesPage = location.pathname.endsWith('/volumes');
+    const isPodsPage = location.pathname.endsWith('/pods');
+
     return (
       <NodeInformationContainer>
         <div>
@@ -189,20 +193,27 @@ class NodeInformation extends React.Component {
           />
         </div>
 
+        {/**
+         * FIXME This is a temporary solution.
+         * We will replace this with a real tab soon
+         */}
         <ButtonTabContainer>
           <TabButton
             text="Details"
             type="button"
+            outlined={!isVolumesPage && !isPodsPage}
             onClick={() => history.push(match.url)}
           />
           <TabButton
             text="Volumes"
             type="button"
+            outlined={isVolumesPage}
             onClick={() => history.push(`${match.url}/volumes`)}
           />
           <TabButton
             text="Pods"
             type="button"
+            outlined={isPodsPage}
             onClick={() => history.push(`${match.url}/pods`)}
           />
         </ButtonTabContainer>

--- a/ui/src/containers/NodeInformation.js
+++ b/ui/src/containers/NodeInformation.js
@@ -264,7 +264,9 @@ const makeGetVolumesFromUrl = createSelector(
   getNodeNameFromUrl,
   getVolumes,
   (nodeName, volumes) =>
-    volumes.filter(v => v && v.spec && v.spec.nodeName === nodeName)
+    volumes.filter(
+      volume => volume && volume.spec && volume.spec.nodeName === nodeName
+    )
 );
 
 const mapStateToProps = (state, ownProps) => ({

--- a/ui/src/containers/NodeInformation.js
+++ b/ui/src/containers/NodeInformation.js
@@ -2,18 +2,21 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { injectIntl, FormattedDate, FormattedTime } from 'react-intl';
 import { createSelector } from 'reselect';
-import { Table, Button } from '@scality/core-ui';
 import styled from 'styled-components';
 import { withRouter, Switch, Route } from 'react-router-dom';
-import { fetchPodsAction } from '../ducks/app/pods';
-import { fetchNodesAction } from '../ducks/app/nodes';
-import { sortSelector } from '../services/utils';
+import { Table, Button } from '@scality/core-ui';
 import {
   fontWeight,
   fontSize,
   padding
 } from '@scality/core-ui/dist/style/theme';
 import NoRowsRenderer from '../components/NoRowsRenderer';
+
+import { fetchPodsAction } from '../ducks/app/pods';
+import { fetchNodesAction } from '../ducks/app/nodes';
+import { sortSelector } from '../services/utils';
+
+import Volumes from '../components/Volumes';
 
 const NodeInformationContainer = styled.div`
   box-sizing: border-box;
@@ -50,11 +53,11 @@ const InformationMainValue = styled(InformationValue)`
   font-weight: ${fontWeight.bold};
 `;
 const ButtonTabContainer = styled.div`
-  margin-top: 10px;
+  margin-top: ${padding.small};
 `;
 
 const TabButton = styled(Button)`
-  margin-right: 10px;
+  margin-right: ${padding.small};
 `;
 
 class NodeInformation extends React.Component {
@@ -196,6 +199,7 @@ class NodeInformation extends React.Component {
 
         <Switch>
           <Route path={`${match.url}/pods`} component={NodePods} />
+          <Route path={`${match.url}/volumes`} component={Volumes} />
           <Route path="/" component={NodeDetails} />
         </Switch>
       </NodeInformationContainer>

--- a/ui/src/containers/NodeInformation.js
+++ b/ui/src/containers/NodeInformation.js
@@ -17,7 +17,7 @@ import { fetchNodesAction } from '../ducks/app/nodes';
 import { fetchVolumesAction } from '../ducks/app/volumes';
 import { sortSelector } from '../services/utils';
 
-import Volumes from '../components/Volumes';
+import NodeVolumes from './NodeVolumes';
 
 const NodeInformationContainer = styled.div`
   box-sizing: border-box;
@@ -172,7 +172,7 @@ class NodeInformation extends React.Component {
         status:
           (volume && volume.status && volume.status.phase) ||
           intl.messages.unknown,
-        size: volume.spec.sparseLoopDevice.size,
+        storageCapacity: volume.spec.sparseLoopDevice.size,
         storageClass: volume.spec.storageClassName,
         creationTime: volume.metadata.creationTimestamp
       };
@@ -222,7 +222,7 @@ class NodeInformation extends React.Component {
           <Route path={`${match.url}/pods`} component={NodePods} />
           <Route
             path={`${match.url}/volumes`}
-            component={() => <Volumes data={volumeData} />}
+            component={() => <NodeVolumes data={volumeData} />}
           />
           <Route path="/" component={NodeDetails} />
         </Switch>

--- a/ui/src/containers/NodeInformation.js
+++ b/ui/src/containers/NodeInformation.js
@@ -14,6 +14,7 @@ import NoRowsRenderer from '../components/NoRowsRenderer';
 
 import { fetchPodsAction } from '../ducks/app/pods';
 import { fetchNodesAction } from '../ducks/app/nodes';
+import { fetchVolumesAction } from '../ducks/app/volumes';
 import { sortSelector } from '../services/utils';
 
 import Volumes from '../components/Volumes';
@@ -103,6 +104,7 @@ class NodeInformation extends React.Component {
   componentDidMount() {
     this.props.fetchNodes();
     this.props.fetchPods();
+    this.props.fetchVolumes();
   }
 
   onSort({ sortBy, sortDirection }) {
@@ -215,7 +217,8 @@ const mapStateToProps = (state, ownProps) => ({
 const mapDispatchToProps = dispatch => {
   return {
     fetchPods: () => dispatch(fetchPodsAction()),
-    fetchNodes: () => dispatch(fetchNodesAction())
+    fetchNodes: () => dispatch(fetchNodesAction()),
+    fetchVolumes: () => dispatch(fetchVolumesAction())
   };
 };
 

--- a/ui/src/containers/NodeInformation.js
+++ b/ui/src/containers/NodeInformation.js
@@ -223,7 +223,7 @@ class NodeInformation extends React.Component {
 const mapStateToProps = (state, ownProps) => ({
   node: makeGetNodeFromUrl(state, ownProps),
   pods: makeGetPodsFromUrl(state, ownProps),
-  volumes: state.app.volumes.list
+  volumes: makeGetVolumesFromUrl(state, ownProps)
 });
 
 const mapDispatchToProps = dispatch => {
@@ -252,6 +252,22 @@ const getPodsFromUrl = (state, props) => {
   }
 };
 
+const getNodeNameFromUrl = (state, props) => {
+  if (props && props.match && props.match.params && props.match.params.id) {
+    return props.match.params.id;
+  } else {
+    return '';
+  }
+};
+
+const getVolumes = state => {
+  if (state && state.app && state.app.volumes && state.app.volumes.list) {
+    return state.app.volumes.list;
+  } else {
+    return [];
+  }
+};
+
 const makeGetNodeFromUrl = createSelector(
   getNodeFromUrl,
   node => node
@@ -260,6 +276,14 @@ const makeGetNodeFromUrl = createSelector(
 const makeGetPodsFromUrl = createSelector(
   getPodsFromUrl,
   pods => pods
+);
+
+const makeGetVolumesFromUrl = createSelector(
+  getNodeNameFromUrl,
+  getVolumes,
+  (nodeName, volumes) => {
+    return volumes.filter(v => v && v.spec && v.spec.nodeName === nodeName);
+  }
 );
 
 export default injectIntl(

--- a/ui/src/containers/NodeInformation.js
+++ b/ui/src/containers/NodeInformation.js
@@ -4,7 +4,7 @@ import { injectIntl, FormattedDate, FormattedTime } from 'react-intl';
 import { createSelector } from 'reselect';
 import { Table, Button } from '@scality/core-ui';
 import styled from 'styled-components';
-
+import { withRouter, Switch, Route } from 'react-router-dom';
 import { fetchPodsAction } from '../ducks/app/pods';
 import { fetchNodesAction } from '../ducks/app/nodes';
 import { sortSelector } from '../services/utils';
@@ -48,6 +48,13 @@ const InformationValue = styled.span`
 
 const InformationMainValue = styled(InformationValue)`
   font-weight: ${fontWeight.bold};
+`;
+const ButtonTabContainer = styled.div`
+  margin-top: 10px;
+`;
+
+const TabButton = styled(Button)`
+  margin-right: 10px;
 `;
 
 class NodeInformation extends React.Component {
@@ -100,23 +107,15 @@ class NodeInformation extends React.Component {
   }
 
   render() {
+    const { match } = this.props;
     const podsSortedList = sortSelector(
       this.props.pods,
       this.state.sortBy,
       this.state.sortDirection
     );
 
-    return (
-      <NodeInformationContainer>
-        <div>
-          <Button
-            text={this.props.intl.messages.back_to_node_list}
-            type="button"
-            outlined
-            onClick={() => this.props.history.push('/nodes')}
-            icon={<i className="fas fa-arrow-left" />}
-          />
-        </div>
+    const NodeDetails = () => (
+      <>
         <PageTitle>{this.props.intl.messages.information}</PageTitle>
         <InformationSpan>
           <InformationLabel>{this.props.intl.messages.name}</InformationLabel>
@@ -138,7 +137,11 @@ class NodeInformation extends React.Component {
             {this.props.node.metalk8s_version}
           </InformationValue>
         </InformationSpan>
+      </>
+    );
 
+    const NodePods = () => (
+      <>
         <InformationTitle>{this.props.intl.messages.pods}</InformationTitle>
         <PodsContainer>
           <Table
@@ -158,6 +161,43 @@ class NodeInformation extends React.Component {
             )}
           />
         </PodsContainer>
+      </>
+    );
+
+    return (
+      <NodeInformationContainer>
+        <div>
+          <Button
+            text={this.props.intl.messages.back_to_node_list}
+            type="button"
+            outlined
+            onClick={() => this.props.history.push('/nodes')}
+            icon={<i className="fas fa-arrow-left" />}
+          />
+        </div>
+
+        <ButtonTabContainer>
+          <TabButton
+            text="Details"
+            type="button"
+            onClick={() => this.props.history.push(match.url)}
+          />
+          <TabButton
+            text="Volumes"
+            type="button"
+            onClick={() => this.props.history.push(`${match.url}/volumes`)}
+          />
+          <TabButton
+            text="Pods"
+            type="button"
+            onClick={() => this.props.history.push(`${match.url}/pods`)}
+          />
+        </ButtonTabContainer>
+
+        <Switch>
+          <Route path={`${match.url}/pods`} component={NodePods} />
+          <Route path="/" component={NodeDetails} />
+        </Switch>
       </NodeInformationContainer>
     );
   }
@@ -204,8 +244,10 @@ const makeGetPodsFromUrl = createSelector(
 );
 
 export default injectIntl(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  )(NodeInformation)
+  withRouter(
+    connect(
+      mapStateToProps,
+      mapDispatchToProps
+    )(NodeInformation)
+  )
 );

--- a/ui/src/containers/NodeInformation.js
+++ b/ui/src/containers/NodeInformation.js
@@ -112,7 +112,7 @@ class NodeInformation extends React.Component {
   }
 
   render() {
-    const { match } = this.props;
+    const { match, volumes, history, intl, node } = this.props;
     const podsSortedList = sortSelector(
       this.props.pods,
       this.state.sortBy,
@@ -121,33 +121,29 @@ class NodeInformation extends React.Component {
 
     const NodeDetails = () => (
       <>
-        <PageTitle>{this.props.intl.messages.information}</PageTitle>
+        <PageTitle>{intl.messages.information}</PageTitle>
         <InformationSpan>
-          <InformationLabel>{this.props.intl.messages.name}</InformationLabel>
-          <InformationMainValue>{this.props.node.name}</InformationMainValue>
+          <InformationLabel>{intl.messages.name}</InformationLabel>
+          <InformationMainValue>{node.name}</InformationMainValue>
         </InformationSpan>
         <InformationSpan>
-          <InformationLabel>{this.props.intl.messages.status}</InformationLabel>
-          <InformationValue>{this.props.node.status}</InformationValue>
+          <InformationLabel>{intl.messages.status}</InformationLabel>
+          <InformationValue>{node.status}</InformationValue>
         </InformationSpan>
         <InformationSpan>
-          <InformationLabel>{this.props.intl.messages.roles}</InformationLabel>
-          <InformationValue>{this.props.node.roles}</InformationValue>
+          <InformationLabel>{intl.messages.roles}</InformationLabel>
+          <InformationValue>{node.roles}</InformationValue>
         </InformationSpan>
         <InformationSpan>
-          <InformationLabel>
-            {this.props.intl.messages.version}
-          </InformationLabel>
-          <InformationValue>
-            {this.props.node.metalk8s_version}
-          </InformationValue>
+          <InformationLabel>{intl.messages.version}</InformationLabel>
+          <InformationValue>{node.metalk8s_version}</InformationValue>
         </InformationSpan>
       </>
     );
 
     const NodePods = () => (
       <>
-        <InformationTitle>{this.props.intl.messages.pods}</InformationTitle>
+        <InformationTitle>{intl.messages.pods}</InformationTitle>
         <PodsContainer>
           <Table
             list={podsSortedList}
@@ -169,14 +165,26 @@ class NodeInformation extends React.Component {
       </>
     );
 
+    const volumeData = volumes.map(volume => {
+      return {
+        name: volume.metadata.name,
+        status:
+          (volume && volume.status && volume.status.phase) ||
+          intl.messages.unknown,
+        size: volume.spec.sparseLoopDevice.size,
+        storageClass: volume.spec.storageClassName,
+        creationTime: volume.metadata.creationTimestamp
+      };
+    });
+
     return (
       <NodeInformationContainer>
         <div>
           <Button
-            text={this.props.intl.messages.back_to_node_list}
+            text={intl.messages.back_to_node_list}
             type="button"
             outlined
-            onClick={() => this.props.history.push('/nodes')}
+            onClick={() => history.push('/nodes')}
             icon={<i className="fas fa-arrow-left" />}
           />
         </div>
@@ -185,23 +193,26 @@ class NodeInformation extends React.Component {
           <TabButton
             text="Details"
             type="button"
-            onClick={() => this.props.history.push(match.url)}
+            onClick={() => history.push(match.url)}
           />
           <TabButton
             text="Volumes"
             type="button"
-            onClick={() => this.props.history.push(`${match.url}/volumes`)}
+            onClick={() => history.push(`${match.url}/volumes`)}
           />
           <TabButton
             text="Pods"
             type="button"
-            onClick={() => this.props.history.push(`${match.url}/pods`)}
+            onClick={() => history.push(`${match.url}/pods`)}
           />
         </ButtonTabContainer>
 
         <Switch>
           <Route path={`${match.url}/pods`} component={NodePods} />
-          <Route path={`${match.url}/volumes`} component={Volumes} />
+          <Route
+            path={`${match.url}/volumes`}
+            component={() => <Volumes data={volumeData} />}
+          />
           <Route path="/" component={NodeDetails} />
         </Switch>
       </NodeInformationContainer>
@@ -211,7 +222,8 @@ class NodeInformation extends React.Component {
 
 const mapStateToProps = (state, ownProps) => ({
   node: makeGetNodeFromUrl(state, ownProps),
-  pods: makeGetPodsFromUrl(state, ownProps)
+  pods: makeGetPodsFromUrl(state, ownProps),
+  volumes: state.app.volumes.list
 });
 
 const mapDispatchToProps = dispatch => {

--- a/ui/src/containers/NodeVolumes.js
+++ b/ui/src/containers/NodeVolumes.js
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { FormattedDate, FormattedTime } from 'react-intl';
 import { Button, Table } from '@scality/core-ui';
 import { padding } from '@scality/core-ui/dist/style/theme';
+import NoRowsRenderer from '../components/NoRowsRenderer';
 
 const ButtonContainer = styled.div`
   margin-top: ${padding.small};
@@ -14,7 +15,7 @@ const VolumeTable = styled.div`
   margin-top: ${padding.small};
 `;
 
-const Volumes = props => {
+const NodeVolumes = props => {
   const [sortBy, setSortBy] = useState('name');
   const [sortDirection, setSortDirection] = useState('ASC');
 
@@ -61,7 +62,7 @@ const Volumes = props => {
   return (
     <>
       <ButtonContainer>
-        <Button text={'Create New Volume'} type="button" />
+        <Button text={props.intl.messages.create_new_volume} type="button" />
       </ButtonContainer>
       <VolumeTable>
         <Table
@@ -74,10 +75,13 @@ const Volumes = props => {
           sortDirection={sortDirection}
           onSort={onSort}
           onRowClick={() => {}}
+          noRowsRenderer={() => (
+            <NoRowsRenderer content={props.intl.messages.no_volume_found} />
+          )}
         />
       </VolumeTable>
     </>
   );
 };
 
-export default injectIntl(Volumes);
+export default injectIntl(NodeVolumes);

--- a/ui/src/containers/NodeVolumes.js
+++ b/ui/src/containers/NodeVolumes.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { injectIntl } from 'react-intl';
 import styled from 'styled-components';
 import { FormattedDate, FormattedTime } from 'react-intl';
 import { Button, Table } from '@scality/core-ui';
@@ -14,27 +15,34 @@ const VolumeTable = styled.div`
 `;
 
 const Volumes = props => {
-  // FIXME Add translation
+  const [sortBy, setSortBy] = useState('name');
+  const [sortDirection, setSortDirection] = useState('ASC');
+
+  const onSort = ({ sortBy, sortDirection }) => {
+    setSortBy(sortBy);
+    setSortDirection(sortDirection);
+  };
+
   const columns = [
     {
-      label: 'Name',
+      label: props.intl.messages.name,
       dataKey: 'name',
       flexGrow: 1
     },
     {
-      label: 'Status',
+      label: props.intl.messages.status,
       dataKey: 'status'
     },
     {
-      label: 'Size',
-      dataKey: 'size'
+      label: props.intl.messages.storageCapacity,
+      dataKey: 'storageCapacity'
     },
     {
-      label: 'StorageClass',
+      label: props.intl.messages.storageClass,
       dataKey: 'storageClass'
     },
     {
-      label: 'Creation Time',
+      label: props.intl.messages.creationTime,
       dataKey: 'creationTime',
       renderer: data => (
         <span>
@@ -62,9 +70,9 @@ const Volumes = props => {
           disableHeader={false}
           headerHeight={40}
           rowHeight={40}
-          // sortBy={this.state.sortBy}
-          // sortDirection={this.state.sortDirection}
-          // onSort={this.onSort}
+          sortBy={sortBy}
+          sortDirection={sortDirection}
+          onSort={onSort}
           onRowClick={() => {}}
         />
       </VolumeTable>
@@ -72,4 +80,4 @@ const Volumes = props => {
   );
 };
 
-export default Volumes;
+export default injectIntl(Volumes);

--- a/ui/src/ducks/app/volumes.js
+++ b/ui/src/ducks/app/volumes.js
@@ -1,0 +1,36 @@
+import { takeLatest, call, put } from 'redux-saga/effects';
+import * as ApiK8s from '../../services/k8s/api';
+// Actions
+const FETCH_VOLUMES = 'FETCH_VOLUMES';
+const SET_VOLUMES = 'SET_VOLUMES';
+
+// Reducer
+const defaultState = { volumes: [] };
+
+export default function reducer(state = defaultState, action = {}) {
+  switch (action.type) {
+    case SET_VOLUMES:
+      return { ...state, volumes: action.payload };
+    default:
+      return state;
+  }
+}
+// Action Creators
+export const fetchVolumesAction = () => {
+  return { type: FETCH_VOLUMES };
+};
+
+export const setVolumesAction = payload => {
+  return { type: SET_VOLUMES, payload };
+};
+
+// Sagas
+export function* fetchVolumes() {
+  // Call the API
+  const result = yield call(ApiK8s.getVolumes);
+  yield put(setVolumesAction(result.body.items));
+}
+
+export function* volumesSaga() {
+  yield takeLatest(FETCH_VOLUMES, fetchVolumes);
+}

--- a/ui/src/ducks/app/volumes.js
+++ b/ui/src/ducks/app/volumes.js
@@ -5,12 +5,12 @@ const FETCH_VOLUMES = 'FETCH_VOLUMES';
 const SET_VOLUMES = 'SET_VOLUMES';
 
 // Reducer
-const defaultState = { volumes: [] };
+const defaultState = { list: [] };
 
 export default function reducer(state = defaultState, action = {}) {
   switch (action.type) {
     case SET_VOLUMES:
-      return { ...state, volumes: action.payload };
+      return { ...state, list: action.payload };
     default:
       return state;
   }

--- a/ui/src/ducks/reducer.js
+++ b/ui/src/ducks/reducer.js
@@ -3,6 +3,7 @@ import { combineReducers } from 'redux';
 import config from './config';
 import nodes from './app/nodes';
 import pods from './app/pods';
+import volumes from './app/volumes';
 import login from './login';
 import layout from './app/layout';
 import notifications from './app/notifications';
@@ -18,7 +19,8 @@ const rootReducer = combineReducers({
     pods,
     notifications,
     salt,
-    monitoring
+    monitoring,
+    volumes
   })
 });
 

--- a/ui/src/ducks/sagas.js
+++ b/ui/src/ducks/sagas.js
@@ -1,6 +1,7 @@
 import { all, fork } from 'redux-saga/effects';
 import { nodesSaga } from './app/nodes';
 import { podsSaga } from './app/pods';
+import { volumesSaga } from './app/volumes';
 import { authenticateSaga } from './login';
 import { configSaga } from './config';
 import { monitoringSaga } from './app/monitoring';
@@ -13,6 +14,7 @@ export default function* rootSaga() {
     fork(authenticateSaga),
     fork(configSaga),
     fork(monitoringSaga),
-    fork(layoutSaga)
+    fork(layoutSaga),
+    fork(volumesSaga)
   ]);
 }

--- a/ui/src/services/k8s/api.js
+++ b/ui/src/services/k8s/api.js
@@ -1,7 +1,9 @@
 import ApiClient from '../ApiClient';
-import { Config, Core_v1Api } from '@kubernetes/client-node';
+import { Config, Core_v1Api, Custom_objectsApi } from '@kubernetes/client-node';
 
-let config, coreV1;
+let config;
+let coreV1;
+let customObjects;
 let k8sApiClient = null;
 
 export function initialize(apiUrl) {
@@ -20,6 +22,7 @@ export function authenticate(token) {
 export const updateApiServerConfig = (url, token) => {
   config = new Config(url, token, 'Basic');
   coreV1 = config.makeApiClient(Core_v1Api);
+  customObjects = config.makeApiClient(Custom_objectsApi);
 };
 
 export async function getNodes() {
@@ -41,6 +44,19 @@ export async function getPods() {
 export async function createNode(payload) {
   try {
     return await coreV1.createNode(payload);
+  } catch (error) {
+    return { error };
+  }
+}
+
+export async function getVolumes() {
+  try {
+    // We want to change this hardcoded data later
+    return await customObjects.listClusterCustomObject(
+      'storage.metalk8s.scality.com',
+      'v1alpha1',
+      'volumes'
+    );
   } catch (error) {
     return { error };
   }

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -66,5 +66,7 @@
   "new_node_access": "New Node Access",
   "storageCapacity": "Storage Capacity",
   "storageClass": "Storage Class",
-  "creationTime": "Created"
+  "creationTime": "Created",
+  "create_new_volume": "Create a New Volume",
+  "no_volume_found": "No volumes on this node"
 }

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -63,5 +63,8 @@
   "kube_controller_manager": "Controller",
   "no_data_available": "No data available",
   "new_node_data": "New Node Data",
-  "new_node_access": "New Node Access"
+  "new_node_access": "New Node Access",
+  "storageCapacity": "Storage Capacity",
+  "storageClass": "Storage Class",
+  "creationTime": "Created"
 }

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -47,7 +47,7 @@
   "node_registered": "Node registered",
   "deployment_started": "Deployment started",
   "cluster_status": "Cluster Status",
-  "cluster_monitoring": "Cluster Monitoring",
+  "monitoring": "Monitoring",
   "severity": "Severity",
   "message": "Message",
   "active_at": "Active Since",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -63,5 +63,8 @@
   "kube_controller_manager": "Contrôleur",
   "no_data_available": "Pas de données disponibles",
   "new_node_data": "Donnée du nouveau node",
-  "new_node_access": "Accès au nouveau node"
+  "new_node_access": "Accès au nouveau node",
+  "storageCapacity": "Capacité",
+  "storageClass": "Storage Class",
+  "creationTime": "Créer à"
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -47,7 +47,7 @@
   "node_registered": "Node enregistré",
   "deployment_started": "Déploiement commencé",
   "cluster_status": "Status de la grappe de serveurs",
-  "cluster_monitoring": "Surveillance de la grappe de serveurs",
+  "monitoring": "Monitoring",
   "severity": "Sévérité",
   "message": "Message",
   "active_at": "Actif depuis",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -66,5 +66,7 @@
   "new_node_access": "Accès au nouveau node",
   "storageCapacity": "Capacité",
   "storageClass": "Storage Class",
-  "creationTime": "Créer à"
+  "creationTime": "Créer à",
+  "create_new_volume": "Créer un nouveau volume",
+  "no_volume_found": "Aucun volume sur ce node"
 }


### PR DESCRIPTION
**Component**: ui

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
As a system admin, I want to be able to see the volumes of each node.

**Summary**:
This PR add :
- Volume list on each node
- A introduction of tab (very basic one)

**Acceptance criteria**: 
- The UI should look something like [that](https://puu.sh/DUm7a/7e52af3bd9.png).
- When there are no volumes you should see `No volumes on this node` or `Aucun volume sur ce node`

**Node**: 
- Create Volume button does not do anything right now.

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1423

See: #1421
