### PR TITLE
Kubernetes: Patch a namespace with annotations

### DIFF
--- a/salt/_modules/metalk8s_kubernetes.py
+++ b/salt/_modules/metalk8s_kubernetes.py
@@ -447,6 +447,46 @@ def namespaces(**kwargs):
         _cleanup(**cfg)
 
 
+def namespace_add_annotation(
+        name,
+        annotation_key,
+        annotation_value,
+        **kwargs):
+    '''
+    Patch a namespace as defined by the user
+        name
+            The name of the namespace
+        annotation_key
+            key of the annotation
+        annotation_value
+            value of the annotation
+    '''
+    cfg = _setup_conn(**kwargs)
+    try:
+        body = {
+            'metadata': {
+                'annotations': {
+                    annotation_key: annotation_value}
+                }
+        }
+
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.patch_namespace(name, body)
+
+        return api_response.to_dict()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                'Exception when calling '
+                'CoreV1Api->patch_namespace'
+            )
+            raise CommandExecutionError(exc)
+    finally:
+        _cleanup(**cfg)
+
+
 def deployments(namespace='default', **kwargs):
     '''
     Return a list of kubernetes deployments defined in the namespace
@@ -2155,6 +2195,19 @@ def node_annotations(name, **kwargs):
 
     if match is not None:
         return match['metadata']['annotations']
+
+    return {}
+
+
+def namespace_annotations(name, **kwargs):
+    ''' Returns the annotations of a namespace
+        name
+            The namespace name
+    '''
+    namespace_information = show_namespace(name, **kwargs)
+
+    if namespace_information is not None:
+        return namespace_information['metadata']['annotations']
 
     return {}
 

--- a/salt/metalk8s/orchestrate/bootstrap/init.sls
+++ b/salt/metalk8s/orchestrate/bootstrap/init.sls
@@ -1,5 +1,7 @@
 {# Because of the grain lookup below, the bootstrap minion *must* be available
    before invoking this SLS, otherwise rendering will fail #}
+{% set kubeconfig = "/etc/kubernetes/admin.conf" %}
+{% set context = "kubernetes-admin@kubernetes" %}
 {%- set bootstrap_control_plane_ip = salt.saltutil.cmd(
         tgt=pillar.bootstrap_id,
         fun='grains.get',
@@ -170,3 +172,13 @@ Deploy MetalK8s UI:
     - saltenv: {{ saltenv }}
     - require:
       - salt: Precheck for MetalK8s UI
+
+Store MetalK8s version in annotations:
+  metalk8s_kubernetes.namespace_annotation_present:
+    - name: "kube-system"
+    - kubeconfig: {{ kubeconfig }}
+    - context: {{ context }}
+    - annotation_key: "metalk8s.scality.com/cluster-version"
+    - annotation_value: "{{ version }}"
+    - require:
+      - http: Wait for API server to be available


### PR DESCRIPTION
**Component**:

'salt', 'kubernetes'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

Issue: #1440

**Summary**:

- Add a method to patch annotations into namespaces
- Be able to store the metalk8s version in a namespace as metadata 

**Acceptance criteria**: 

- `kubectl describe ns kube-system` should have this newly added annotation
- CI green builds obviously
---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1440

