### PR TITLE
Setup operator authentication

### DIFF
--- a/docs/developer/building/requirements.rst
+++ b/docs/developer/building/requirements.rst
@@ -19,6 +19,8 @@ Mandatory
   `operator-sdk <https://github.com/operator-framework/operator-sdk>`_ (0.9 or
   higher): to build the Kubernetes Operators
 - mkisofs: to create the MetalK8s ISO
+- `Mercurial <https://www.mercurial-scm.org/>`_: some Go dependencies are
+  downloaded from Mercurial repositories.
 
 Optional
 --------

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -141,6 +141,11 @@ stages:
             --no-update-notifier &&
             npm run test:nowatch --no-update-notifier
           haltOnFailure: false
+      - ShellCommand:
+          name: Run all storage-operator unit tests
+          workdir: build/storage-operator
+          command: go test -cover -v ./...
+          haltOnFailure: false
 
   single-node:
     worker:

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -124,7 +124,9 @@ stages:
       type: kube_pod
       path: eve/workers/pod-unit-tests/pod.yaml
       images:
-        docker-unit-tests: eve/workers/pod-unit-tests
+        docker-unit-tests:
+          context: 'storage-operator'
+          dockerfile: eve/workers/pod-unit-tests/Dockerfile
     steps:
       - Git: *git_pull
       - ShellCommand:

--- a/eve/workers/pod-unit-tests/Dockerfile
+++ b/eve/workers/pod-unit-tests/Dockerfile
@@ -1,6 +1,8 @@
 FROM centos:7
 
 ARG BUILDBOT_VERSION=0.9.12
+ARG GO_VERSION=1.12.7
+ARG OPERATOR_SDK_VERSION=v0.9.0
 
 ENV LANG=en_US.utf8
 
@@ -15,10 +17,29 @@ RUN yum install -y epel-release \
     python36 \
     python36-devel \
     python36-pip \
+    hg \
     git \
     nodejs \
     && adduser -u 1042 --home /home/eve eve \
-    && chown eve:eve /home/eve/workspace \
+    && chown -R eve:eve /home/eve \
     && pip install buildbot-worker==${BUILDBOT_VERSION}
 
+# Install Go tooling to build the Kubernetes Operators.
+ENV GOROOT /usr/local/go
+ENV GOPATH /home/eve/.golang
+ENV GOCACHE /home/eve/.cache
+ENV PATH $GOPATH/bin:$GOROOT/bin:$PATH
+
+RUN curl -ORL https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz      \
+    && tar xzvf go${GO_VERSION}.linux-amd64.tar.gz                             \
+    && rm go${GO_VERSION}.linux-amd64.tar.gz                                   \
+    && mv go /usr/local                                                        \
+    && curl -RLo /usr/bin/operator-sdk                                         \
+        https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu \
+    && chmod +x /usr/bin/operator-sdk
+
 USER eve
+
+# Pre-download the Go dependencies.
+COPY go.mod go.sum ./
+RUN go mod download

--- a/salt/_auth/kubernetes_rbac.py
+++ b/salt/_auth/kubernetes_rbac.py
@@ -120,6 +120,30 @@ AUTH_HANDLERS['basic'] = {
     'groups': _groups_basic,
 }
 
+@_log_exceptions
+def _auth_bearer(kubeconfig, username, token):
+    # Using the '/version/' endpoint which is unauthenticated by default but,
+    # when presented authentication data, will process this information and fail
+    # accordingly.
+    url = '{}/version/'.format(kubeconfig.host)
+    verify = kubeconfig.ssl_ca_cert if kubeconfig.verify_ssl else False
+    try:
+        response = requests.get(
+            url,
+            headers={
+                'Authorization': 'Basic {}'.format(token),
+            },
+            verify=verify,
+        )
+        return 200 <= response.status_code < 300:
+    except:
+        log.exception('Error during request')
+        raise
+    return False
+
+AUTH_HANDLERS['bearer'] = {
+    'auth': _auth_bearer,
+}
 
 @_log_exceptions
 def _load_kubeconfig(opts):

--- a/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
+++ b/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
@@ -35,3 +35,6 @@ external_auth:
       - '@wheel'
       - '@runner'
       - '@jobs'
+    storage-operator:
+      - '*':
+        - 'test.ping'

--- a/storage-operator/deploy/role.yaml
+++ b/storage-operator/deploy/role.yaml
@@ -10,6 +10,7 @@ rules:
   - pods
   - services
   - endpoints
+  - persistentvolumes
   - persistentvolumeclaims
   - events
   - configmaps

--- a/storage-operator/go.mod
+++ b/storage-operator/go.mod
@@ -2,6 +2,7 @@ module github.com/scality/metalk8s/storage-operator
 
 require (
 	github.com/NYTimes/gziphandler v1.0.1 // indirect
+	github.com/go-logr/logr v0.1.0
 	github.com/operator-framework/operator-sdk v0.9.1-0.20190712203509-e1d904fa80a4
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/pflag v1.0.3

--- a/storage-operator/go.mod
+++ b/storage-operator/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/operator-framework/operator-sdk v0.9.1-0.20190712203509-e1d904fa80a4
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/pflag v1.0.3
+	github.com/stretchr/testify v1.3.0
 	k8s.io/api v0.0.0-20190612125737-db0771252981
 	k8s.io/apimachinery v0.0.0-20190612125636-6a5db36e93ad
 	k8s.io/client-go v11.0.0+incompatible

--- a/storage-operator/go.mod
+++ b/storage-operator/go.mod
@@ -3,6 +3,7 @@ module github.com/scality/metalk8s/storage-operator
 require (
 	github.com/NYTimes/gziphandler v1.0.1 // indirect
 	github.com/operator-framework/operator-sdk v0.9.1-0.20190712203509-e1d904fa80a4
+	github.com/pkg/errors v0.8.1
 	github.com/spf13/pflag v1.0.3
 	k8s.io/api v0.0.0-20190612125737-db0771252981
 	k8s.io/apimachinery v0.0.0-20190612125636-6a5db36e93ad

--- a/storage-operator/pkg/controller/volume/volume_controller.go
+++ b/storage-operator/pkg/controller/volume/volume_controller.go
@@ -102,6 +102,11 @@ func (r *ReconcileVolume) Reconcile(request reconcile.Request) (reconcile.Result
 		return reconcile.Result{}, err
 	}
 
+	if err = r.salt.Authenticate(); err != nil {
+		reqLogger.Error(err, "Salt API authentication failed")
+		return reconcile.Result{}, err
+	}
+
 	pv := newPersistentVolumeForCR(instance)
 
 	// Set Volume instance as the owner and controller

--- a/storage-operator/pkg/controller/volume/volume_controller.go
+++ b/storage-operator/pkg/controller/volume/volume_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	storagev1alpha1 "github.com/scality/metalk8s/storage-operator/pkg/apis/storage/v1alpha1"
+	"github.com/scality/metalk8s/storage-operator/pkg/salt"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -30,7 +31,11 @@ func Add(mgr manager.Manager) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &ReconcileVolume{client: mgr.GetClient(), scheme: mgr.GetScheme()}
+	return &ReconcileVolume{
+		client: mgr.GetClient(),
+		scheme: mgr.GetScheme(),
+		salt:   salt.NewClient(),
+	}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
@@ -68,6 +73,7 @@ type ReconcileVolume struct {
 	// that reads objects from the cache and writes to the apiserver
 	client client.Client
 	scheme *runtime.Scheme
+	salt   *salt.Client
 }
 
 // Reconcile reads that state of the cluster for a Volume object and makes changes based on the state read

--- a/storage-operator/pkg/controller/volume/volume_controller.go
+++ b/storage-operator/pkg/controller/volume/volume_controller.go
@@ -106,6 +106,16 @@ func (r *ReconcileVolume) Reconcile(request reconcile.Request) (reconcile.Result
 		reqLogger.Error(err, "Salt API authentication failed")
 		return reconcile.Result{}, err
 	}
+	result, err := r.salt.TestPing()
+	if err != nil {
+		reqLogger.Error(err, "test.ping failed")
+		return reconcile.Result{}, err
+	}
+	for hostname := range result {
+		reqLogger.Info(
+			"ping", "hostname", hostname, "result", result[hostname].(bool),
+		)
+	}
 
 	pv := newPersistentVolumeForCR(instance)
 

--- a/storage-operator/pkg/controller/volume/volume_controller.go
+++ b/storage-operator/pkg/controller/volume/volume_controller.go
@@ -102,10 +102,6 @@ func (r *ReconcileVolume) Reconcile(request reconcile.Request) (reconcile.Result
 		return reconcile.Result{}, err
 	}
 
-	if err = r.salt.Authenticate(); err != nil {
-		reqLogger.Error(err, "Salt API authentication failed")
-		return reconcile.Result{}, err
-	}
 	result, err := r.salt.TestPing()
 	if err != nil {
 		reqLogger.Error(err, "test.ping failed")

--- a/storage-operator/pkg/controller/volume/volume_controller_test.go
+++ b/storage-operator/pkg/controller/volume/volume_controller_test.go
@@ -1,0 +1,43 @@
+package volume
+
+import (
+	"testing"
+
+	"github.com/scality/metalk8s/storage-operator/pkg/salt"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/rest"
+)
+
+func TestGetAuthCredential(t *testing.T) {
+	tests := map[string]struct {
+		token    string
+		username string
+		password string
+		expected *salt.Credential
+	}{
+		"ServiceAccount": {
+			token: "foo", username: "", password: "",
+			expected: salt.NewCredential("storage-operator", "foo", "Bearer"),
+		},
+		"BasicAuth": {
+			token: "", username: "foo", password: "bar",
+			expected: salt.NewCredential("foo", "Zm9vOmJhcg==", "Basic"),
+		},
+		"DefaultCreds": {
+			token: "", username: "", password: "",
+			expected: salt.NewCredential("admin", "YWRtaW46YWRtaW4=", "Basic"),
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			config := rest.Config{
+				BearerToken: tc.token,
+				Username:    tc.username,
+				Password:    tc.password,
+			}
+			creds := getAuthCredential(&config)
+
+			assert.Equal(t, tc.expected, creds)
+		})
+	}
+}

--- a/storage-operator/pkg/salt/client.go
+++ b/storage-operator/pkg/salt/client.go
@@ -1,13 +1,20 @@
 package salt
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"os"
+
+	"github.com/pkg/errors"
 )
 
 // A Salt API client.
 type Client struct {
-	address string // Address of the Salt API server.
+	address string       // Address of the Salt API server.
+	client  *http.Client // HTTP client to query Salt API.
 }
 
 // Create a new Salt API client.
@@ -21,5 +28,64 @@ func NewClient() *Client {
 
 	return &Client{
 		address: fmt.Sprintf("%s:%d", address, SALT_API_PORT),
+		client:  &http.Client{},
 	}
+}
+
+// Send POST request to Salt API.
+//
+// Arguments
+//     endpoint: API endpoint.
+//     payload:  POST JSON payload.
+//     headers:  HTTP headers to add to the POST request.
+//
+// Returns
+//     The decoded response body.
+func (self *Client) post(
+	endpoint string, payload map[string]string, headers map[string]string,
+) (map[string]interface{}, error) {
+	// Build target URL.
+	url := fmt.Sprintf("%s%s", self.address, endpoint)
+	// Encode the payload into JSON.
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot serialize POST body")
+	}
+	// Prepare the POST request.
+	request, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot prepare POST query for Salt API")
+	}
+	// Set the HTTP headers.
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Content-Type", "application/json")
+	for hdr, value := range headers {
+		request.Header.Set(hdr, value)
+	}
+	// Send the POST request.
+	response, err := self.client.Do(request)
+	if err != nil {
+		return nil, errors.Wrap(err, "POST failed on Salt API")
+	}
+	defer response.Body.Close()
+	// Check the return code before trying to decode the body.
+	if response.StatusCode != 200 {
+		errmsg := fmt.Sprintf(
+			"Salt API failed with code %d", response.StatusCode,
+		)
+		// No decode: Salt API may returns HTML even when you asked for JSON…
+		buf, err := ioutil.ReadAll(response.Body)
+		if err == nil {
+			errmsg = fmt.Sprintf("%s: %s", errmsg, string(buf))
+		}
+		return nil, errors.New(errmsg)
+	}
+	// Decode the response body.
+	var result map[string]interface{}
+	if err = json.NewDecoder(response.Body).Decode(&result); err != nil {
+		return nil, errors.Wrap(err, "cannot decode Salt API response")
+	}
+
+	// The real result is in a single-item list stored in the `return` field.
+	return result["return"].([]interface{})[0].(map[string]interface{}), nil
 }

--- a/storage-operator/pkg/salt/client.go
+++ b/storage-operator/pkg/salt/client.go
@@ -1,0 +1,25 @@
+package salt
+
+import (
+	"fmt"
+	"os"
+)
+
+// A Salt API client.
+type Client struct {
+	address string // Address of the Salt API server.
+}
+
+// Create a new Salt API client.
+func NewClient() *Client {
+	const SALT_API_PORT int = 4507 // As defined in master-99-metalk8s.conf
+
+	address := os.Getenv("METALK8S_SALT_MASTER_ADDRESS")
+	if address == "" {
+		address = "http://salt-master"
+	}
+
+	return &Client{
+		address: fmt.Sprintf("%s:%d", address, SALT_API_PORT),
+	}
+}

--- a/storage-operator/pkg/salt/client.go
+++ b/storage-operator/pkg/salt/client.go
@@ -127,6 +127,7 @@ func (self *Client) authenticate() error {
 		return errors.Wrap(err, "Salt API authentication failed")
 	}
 
+	// TODO(#1461): make this more robust.
 	self.token = newToken(
 		output["token"].(string), output["expire"].(float64),
 	)
@@ -247,5 +248,6 @@ func decodeApiResponse(response *http.Response) (map[string]interface{}, error) 
 		return nil, errors.Wrap(err, "cannot decode Salt API response")
 	}
 	// The real result is in a single-item list stored in the `return` field.
+	// TODO(#1461): make this more robust.
 	return result["return"].([]interface{})[0].(map[string]interface{}), nil
 }

--- a/storage-operator/pkg/salt/client.go
+++ b/storage-operator/pkg/salt/client.go
@@ -62,6 +62,26 @@ func (self *Client) Authenticate() error {
 	return nil
 }
 
+// Test function, will be removed later…
+func (self *Client) TestPing() (map[string]interface{}, error) {
+	payload := map[string]string{
+		"client": "local",
+		"tgt":    "*",
+		"fun":    "test.ping",
+	}
+	headers := map[string]string{
+		"X-Auth-Token": self.token,
+	}
+
+	self.logger.Info("test.ping")
+
+	ans, err := self.post("/", payload, headers)
+	if err != nil {
+		return nil, errors.Wrap(err, "test.ping failed")
+	}
+	return ans, nil
+}
+
 // Send POST request to Salt API.
 //
 // Arguments

--- a/storage-operator/pkg/salt/client_test.go
+++ b/storage-operator/pkg/salt/client_test.go
@@ -1,0 +1,97 @@
+package salt
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewClientDefault(t *testing.T) {
+	tests := map[string]struct {
+		value    string
+		expected string
+	}{
+		"default": {value: "", expected: "http://salt-master:4507"},
+		"env_var": {value: "http://foo", expected: "http://foo:4507"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			os.Setenv("METALK8S_SALT_MASTER_ADDRESS", tc.value)
+
+			client := NewClient(nil)
+
+			assert.Equal(t, tc.expected, client.address)
+		})
+	}
+}
+
+func TestNewPostRequest(t *testing.T) {
+	tests := map[string]struct {
+		is_auth  bool
+		expected string
+	}{
+		"no_auth":   {is_auth: false, expected: ""},
+		"with_auth": {is_auth: true, expected: "foo"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			client := NewClient(nil)
+			client.token = newToken("foo", 0)
+
+			request, _ := client.newPostRequest("/", nil, tc.is_auth)
+			token := request.Header.Get("X-Auth-Token")
+
+			assert.Equal(t, tc.expected, token)
+		})
+	}
+}
+
+func TestDecodeApiResponse(t *testing.T) {
+	tests := map[string]struct {
+		status int
+		body   io.ReadCloser
+		result map[string]interface{}
+		error  string
+	}{
+		"httpError": {
+			status: 401, body: httpBody("error"),
+			result: nil, error: "Salt API failed with code 401: error",
+		},
+		"formatError": {
+			status: 200, body: httpBody("<html></html>"),
+			result: nil, error: "cannot decode Salt API response",
+		},
+		"ok": {
+			status: 200, body: httpBody(`{"return": [{"token": "foo"}]}`),
+			result: map[string]interface{}{"token": "foo"}, error: "",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			response := http.Response{StatusCode: tc.status, Body: tc.body}
+
+			result, err := decodeApiResponse(&response)
+
+			if tc.error != "" {
+				assert.Error(t, err)
+				assert.Regexp(t, regexp.MustCompile(tc.error), err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.result, result)
+			}
+		})
+	}
+}
+
+func httpBody(body string) io.ReadCloser {
+	return ioutil.NopCloser(strings.NewReader(body))
+}

--- a/storage-operator/pkg/salt/creds.go
+++ b/storage-operator/pkg/salt/creds.go
@@ -1,0 +1,23 @@
+package salt
+
+import "fmt"
+
+// Credentials for Salt API.
+type Credential struct {
+	username string // User name.
+	token    string // User token.
+	kind     string // Token type: Basic or Bearer.
+}
+
+// Create a new Salt API client.
+//
+// Arguments
+//     username: user name
+//     token:    user token
+//     kind:     token type (must be either Basic or Bearer)
+func NewCredential(username string, token string, kind string) *Credential {
+	if kind != "Basic" && kind != "Bearer" {
+		panic(fmt.Sprintf("invalid token type: %s", kind))
+	}
+	return &Credential{username: username, token: token, kind: kind}
+}

--- a/storage-operator/pkg/salt/creds_test.go
+++ b/storage-operator/pkg/salt/creds_test.go
@@ -1,0 +1,33 @@
+package salt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCredential(t *testing.T) {
+	tests := map[string]struct {
+		username string
+		token    string
+	}{
+		"Basic":  {username: "foo", token: "bar"},
+		"Bearer": {username: "baz", token: "qux"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			creds := NewCredential(tc.username, tc.token, name)
+
+			assert.Equal(t, tc.username, creds.username)
+			assert.Equal(t, tc.token, creds.token)
+			assert.Equal(t, name, creds.kind)
+		})
+	}
+}
+
+func TestNewCredentialBadToken(t *testing.T) {
+	assert.Panics(t, func() {
+		NewCredential("foo", "*****", "Secret")
+	})
+}

--- a/storage-operator/pkg/salt/token.go
+++ b/storage-operator/pkg/salt/token.go
@@ -1,0 +1,31 @@
+package salt
+
+import (
+	"time"
+)
+
+// A Salt API authentication token.
+type authToken struct {
+	value  string    // Authentication token.
+	expire time.Time // Expiration date of the token.
+}
+
+// Create a new Salt API authentication token.
+//
+// Arguments
+//     token:  the token.
+//     expire: the token expiration date, as an UNIX timestamp.
+//
+// Returns
+//     An authentication token.
+func newToken(token string, expire float64) *authToken {
+	return &authToken{
+		value:  token,
+		expire: time.Unix(int64(expire), 0).UTC(),
+	}
+}
+
+// Check if the token is expired.
+func (self *authToken) isExpired() bool {
+	return time.Now().UTC().After(self.expire)
+}

--- a/storage-operator/pkg/salt/token_test.go
+++ b/storage-operator/pkg/salt/token_test.go
@@ -1,0 +1,27 @@
+package salt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsExpired(t *testing.T) {
+	tests := map[string]struct {
+		expire   float64
+		expected bool
+	}{
+		"valid":   {expire: 2147472000, expected: false},
+		"expired": {expire: 0, expected: true},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			token := newToken("value", tc.expire)
+
+			is_expired := token.isExpired()
+
+			assert.Equal(t, tc.expected, is_expired)
+		})
+	}
+}


### PR DESCRIPTION
**Component**:

operator, salt

**Context**: 

The operator will need to interact with salt-api, and thus it should be able to authenticate.

**Summary**:

In the PR we:
- update the `kubernetes_rbac` Salt authentication module to support `Bearer` authorization
- add a Salt API client in the storage operator such as we can authenticate against the Salt API server and run a dummy command (`test.ping`) for now

**Acceptance criteria**: 

You can test either with the operator running locally (will use HTTP Basic Authentication with default hardcoded creds) or inside the cluster (will use the ServiceAccount token, which is the expected behavior in production).

#### Local deployment

##### Setup

1. Connect to the bootstrap node: `vagrant ssh bootstrap`
2. Become root: `sudo su`
3. Register the new CRD: `kubectl --kubeconfig /etc/kubernetes/admin.conf apply -f /vagrant/storage-operator/deploy/crds/storage_v1alpha1_volume_crd.yaml`
4. Get the "public" IP of the Salt API server (the one that use the port `4507`): `kubectl --kubeconfig /etc/kubernetes/admin.conf  -n kube-system describe svc salt-master | grep 'Endpoints'`
5. Copy the `/etc/kubernetes/admin.conf` from the bootstrap node to your local machine.

##### Testing

1. Start the operator locally:

```
cd storage-operator
export KUBECONFIG=<path-to-the-admin.cong-you-copied-locally>
export METALK8S_SALT_MASTER_ADDRESS=http://<IP-OF-SALT-API-WITHOUT-PORT>
operator-sdk up local 
```

2. Create a new volume: `kubectl --kubeconfig /etc/kubernetes/admin.conf apply -f /vagrant/storage-operator/deploy/crds/storage_v1alpha1_volume_cr.yaml`

3. Check that in the Operator log you see a lines like:

```json
{"level":"info","ts":1563867500.5190809,"logger":"controller_volume","msg":"Reconciling Volume","Request.Name":"example-volume"}
{"level":"info","ts":1563867500.5191145,"logger":"salt_api","msg":"test.ping"}
{"level":"info","ts":1563867500.5191262,"logger":"salt_api","msg":"Auth","username":"admin","type":"Basic"}
{"level":"info","ts":1563867500.7507794,"logger":"salt_api","msg":"POST","url":"http://172.21.254.13:4507/login","StatusCode":200,"duration":231}
{"level":"info","ts":1563867501.0259755,"logger":"salt_api","msg":"POST","url":"http://172.21.254.13:4507/","StatusCode":200,"duration":275}
{"level":"info","ts":1563867501.0272095,"logger":"controller_volume","msg":"ping","Request.Name":"example-volume","hostname":"bootstrap","result":true}
```

e.g.: Basic Auth with `admin` (`"msg":"Auth","username":"admin","type":"Basic"`) and `test.ping` result (`"hostname":"bootstrap","result":true`)

#### In-cluster deployment

##### Setup

1. Connect to the bootstrap node: `vagrant ssh bootstrap`
2. Become root: `sudo su`
3. Register the new CRD: `kubectl --kubeconfig /etc/kubernetes/admin.conf apply -f /vagrant/storage-operator/deploy/crds/storage_v1alpha1_volume_crd.yaml`
4. Copy the deployment file: `mkdir deploy && cp /vagrant/storage-operator/deploy/*.yaml deploy`
5. Get the IP of the image repository: `kubectl --kubeconfig /etc/kubernetes/admin.conf -n kube-system get deployment metalk8s-ui -o yaml | grep 'image:'`
6. Edit the `deploy/operator.yaml`:
- replace `REPLACE_IMAGE` by `<IP-OF-THE-REPOSITORY>/metalk8s-2.4.0-dev/storage-operator:latest`
- add toleration so that the operator can be scheduled on the boostrap node.

Example:
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: storage-operator
  namespace: kube-system
spec:
  replicas: 1
  selector:
    matchLabels:
      name: storage-operator
  template:
    metadata:
      labels:
        name: storage-operator
    spec:
      serviceAccountName: storage-operator
      tolerations:
      - key: "node-role.kubernetes.io/bootstrap"
        operator: "Exists"
        effect: "NoSchedule"
      - key: "node-role.kubernetes.io/infra"
        operator: "Exists"
        effect: "NoSchedule"
      containers:
        - name: storage-operator
          image: 172.21.254.13:8080/metalk8s-2.4.0-dev/storage-operator:latest
          command:
          - storage-operator
          imagePullPolicy: Always
          env:
            - name: WATCH_NAMESPACE
              value: ''
            - name: POD_NAME
              valueFrom:
                fieldRef:
                  fieldPath: metadata.name
            - name: OPERATOR_NAME
              value: "storage-operator"
```

7. Deploy the operaror: `kubectl --kubeconfig /etc/kubernetes/admin.conf -n kube-system apply -f deploy`

##### Testing

1. Get the name of the pod: `kubectl --kubeconfig /etc/kubernetes/admin.conf -n kube-system get pod | grep operator`
2. Monitor the log of the operator: `kubectl --kubeconfig /etc/kubernetes/admin.conf -n kube-system log -f <OPERATOR-POD-NAME>`

3. Create a new volume: `kubectl --kubeconfig /etc/kubernetes/admin.conf apply -f /vagrant/storage-operator/deploy/crds/storage_v1alpha1_volume_cr.yaml`

4. Check that in the Operator log you see a lines like:

```json
{"level":"info","ts":1563868271.6474633,"logger":"controller_volume","msg":"Reconciling Volume","Request.Name":"example-volume"}
{"level":"info","ts":1563868271.6475801,"logger":"salt_api","msg":"test.ping"}
{"level":"info","ts":1563868271.647586,"logger":"salt_api","msg":"Auth","username":"storage-operator","type":"Bearer"}
{"level":"info","ts":1563868271.7349274,"logger":"salt_api","msg":"POST","url":"http://salt-master:4507/login","StatusCode":200,"duration":87}
{"level":"info","ts":1563868271.956724,"logger":"salt_api","msg":"POST","url":"http://salt-master:4507/","StatusCode":200,"duration":221}
{"level":"info","ts":1563868271.9570234,"logger":"controller_volume","msg":"ping","Request.Name":"example-volume","hostname":"bootstrap","result":true}
```

e.g.: Bearer Auth with `storage-operator` (`"msg":"Auth","username":"storage-operator","type":"Bearer"`) and `test.ping` result (`"hostname":"bootstrap","result":true`)

---

Closes: #1412 