### PR TITLE
NodeList: refresh improvement

### DIFF
--- a/ui/src/containers/NodeList.js
+++ b/ui/src/containers/NodeList.js
@@ -25,6 +25,9 @@ const PageContainer = styled.div`
 
 const ActionContainer = styled.div`
   margin-bottom: ${padding.base};
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 `;
 
 const TableContainer = styled.div`
@@ -135,7 +138,7 @@ const NodeList = props => {
     }
   };
 
-  const nodesSortedList = sortSelector(nodes, sortBy, sortDirection);
+  const nodesSortedList = sortSelector(nodes.list, sortBy, sortDirection);
 
   return (
     <PageContainer>
@@ -145,6 +148,7 @@ const NodeList = props => {
           onClick={() => history.push('/nodes/create')}
           icon={<i className="fas fa-plus" />}
         />
+        {nodes.isLoading && <Loader size="small" />}
       </ActionContainer>
       <TableContainer>
         <Table
@@ -177,7 +181,7 @@ const NodeList = props => {
 
 function mapStateToProps(state) {
   return {
-    nodes: state.app.nodes.list
+    nodes: state.app.nodes
   };
 }
 

--- a/ui/src/containers/NodeList.js
+++ b/ui/src/containers/NodeList.js
@@ -6,8 +6,12 @@ import { injectIntl } from 'react-intl';
 import { Table, Button, Loader } from '@scality/core-ui';
 import { padding } from '@scality/core-ui/dist/style/theme';
 
-import { fetchNodesAction, deployNodeAction } from '../ducks/app/nodes';
-import { REFRESH_TIMEOUT } from '../constants';
+import {
+  refreshNodesAction,
+  stopRefreshNodesAction,
+  deployNodeAction
+} from '../ducks/app/nodes';
+
 import { sortSelector } from '../services/utils';
 import NoRowsRenderer from '../components/NoRowsRenderer';
 
@@ -54,11 +58,10 @@ const TableContainer = styled.div`
 
 const NodeList = props => {
   useEffect(() => {
-    props.fetchNodes();
-    let interval = setInterval(() => props.fetchNodes(), REFRESH_TIMEOUT);
+    props.refreshNodes();
 
     return () => {
-      clearInterval(interval);
+      props.stopRefreshNodes();
     };
   }, []);
 
@@ -180,7 +183,8 @@ function mapStateToProps(state) {
 
 const mapDispatchToProps = dispatch => {
   return {
-    fetchNodes: () => dispatch(fetchNodesAction()),
+    refreshNodes: () => dispatch(refreshNodesAction()),
+    stopRefreshNodes: () => dispatch(stopRefreshNodesAction()),
     deployNode: payload => dispatch(deployNodeAction(payload))
   };
 };

--- a/ui/src/ducks/app/nodes.js
+++ b/ui/src/ducks/app/nodes.js
@@ -36,7 +36,8 @@ const FETCH_NODES = 'FETCH_NODES';
 const REFRESH_NODES = 'REFRESH_NODES';
 const STOP_REFRESH_NODES = 'STOP_REFRESH_NODES';
 export const SET_NODES = 'SET_NODES';
-const UPDATE_NODES_REFRESHING = 'UPDATE_NODES_REFRESHING';
+export const UPDATE_NODES_REFRESHING = 'UPDATE_NODES_REFRESHING';
+export const UPDATE_NODES_LOADING = 'UPDATE_NODES_LOADING';
 
 const CREATE_NODE = 'CREATE_NODE';
 export const CREATE_NODE_FAILED = 'CREATE_NODE_FAILED';
@@ -148,7 +149,8 @@ export const roleTaintMap = [
 const defaultState = {
   list: [],
   events: {},
-  isRefreshing: false
+  isRefreshing: false,
+  isLoading: false
 };
 
 export default function reducer(state = defaultState, action = {}) {
@@ -157,6 +159,8 @@ export default function reducer(state = defaultState, action = {}) {
       return { ...state, list: action.payload };
     case UPDATE_NODES_REFRESHING:
       return { ...state, isRefreshing: action.payload };
+    case UPDATE_NODES_LOADING:
+      return { ...state, isLoading: action.payload };
     case CREATE_NODE_FAILED:
       return {
         ...state,
@@ -199,6 +203,10 @@ export const updateNodesRefreshingAction = payload => {
   return { type: UPDATE_NODES_REFRESHING, payload };
 };
 
+export const updateNodesLoadingAction = payload => {
+  return { type: UPDATE_NODES_LOADING, payload };
+};
+
 export const clearCreateNodeErrorAction = () => {
   return { type: CLEAR_CREATE_NODE_ERROR };
 };
@@ -229,6 +237,7 @@ export const stopRefreshNodesAction = () => {
 
 // Sagas
 export function* fetchNodes() {
+  yield put(updateNodesLoadingAction(true));
   const result = yield call(ApiK8s.getNodes);
   if (!result.error) {
     yield put(
@@ -299,6 +308,8 @@ export function* fetchNodes() {
       })
     );
   }
+  yield delay(1000); // To make sur that the loader is visible for at least 1s
+  yield put(updateNodesLoadingAction(false));
   return result;
 }
 

--- a/ui/src/ducks/app/nodes.test.js
+++ b/ui/src/ducks/app/nodes.test.js
@@ -1,8 +1,17 @@
-import { call, put, all } from 'redux-saga/effects';
-import { fetchNodes, createNode, SET_NODES, CREATE_NODE_FAILED } from './nodes';
+import { call, put, all, delay } from 'redux-saga/effects';
+import {
+  fetchNodes,
+  createNode,
+  refreshNodes,
+  SET_NODES,
+  CREATE_NODE_FAILED,
+  UPDATE_NODES_LOADING,
+  UPDATE_NODES_REFRESHING
+} from './nodes';
 import * as ApiK8s from '../../services/k8s/api';
 import history from '../../history';
 import { getJobStatus } from './nodes.js';
+import { REFRESH_TIMEOUT } from '../../constants';
 
 const formPayload = {
   control_plane: true,
@@ -40,7 +49,12 @@ const bodyRequest = {
 
 it('update the control plane nodes state when fetchNodes', () => {
   const gen = fetchNodes();
-
+  expect(gen.next().value).toEqual(
+    put({
+      type: UPDATE_NODES_LOADING,
+      payload: true
+    })
+  );
   expect(gen.next().value).toEqual(call(ApiK8s.getNodes));
   const result = {
     body: {
@@ -110,11 +124,24 @@ it('update the control plane nodes state when fetchNodes', () => {
     put({ type: SET_NODES, payload: nodes })
   );
   expect(gen.next(result).value).toEqual(all([call(getJobStatus, 'boostrap')]));
+  expect(gen.next().value).toEqual(delay(1000));
+  expect(gen.next().value).toEqual(
+    put({
+      type: UPDATE_NODES_LOADING,
+      payload: false
+    })
+  );
+  expect(gen.next().done).toEqual(true);
 });
 
 it('update the bootstrap nodes state when fetchNodes', () => {
   const gen = fetchNodes();
-
+  expect(gen.next().value).toEqual(
+    put({
+      type: UPDATE_NODES_LOADING,
+      payload: true
+    })
+  );
   expect(gen.next().value).toEqual(call(ApiK8s.getNodes));
 
   const result = {
@@ -188,10 +215,25 @@ it('update the bootstrap nodes state when fetchNodes', () => {
   );
 
   expect(gen.next(result).value).toEqual(all([call(getJobStatus, 'boostrap')]));
+  expect(gen.next().value).toEqual(delay(1000));
+  expect(gen.next().value).toEqual(
+    put({
+      type: UPDATE_NODES_LOADING,
+      payload: false
+    })
+  );
+  expect(gen.next().done).toEqual(true);
 });
 
 it('update the workload plane nodes state when fetchNodes', () => {
   const gen = fetchNodes();
+
+  expect(gen.next().value).toEqual(
+    put({
+      type: UPDATE_NODES_LOADING,
+      payload: true
+    })
+  );
 
   expect(gen.next().value).toEqual(call(ApiK8s.getNodes));
 
@@ -251,10 +293,25 @@ it('update the workload plane nodes state when fetchNodes', () => {
     put({ type: SET_NODES, payload: nodes })
   );
   expect(gen.next(result).value).toEqual(all([call(getJobStatus, 'boostrap')]));
+  expect(gen.next().value).toEqual(delay(1000));
+  expect(gen.next().value).toEqual(
+    put({
+      type: UPDATE_NODES_LOADING,
+      payload: false
+    })
+  );
+  expect(gen.next().done).toEqual(true);
 });
 
 it('update the control plane/workload plane nodes state when fetchNodes', () => {
   const gen = fetchNodes();
+
+  expect(gen.next().value).toEqual(
+    put({
+      type: UPDATE_NODES_LOADING,
+      payload: true
+    })
+  );
 
   expect(gen.next().value).toEqual(call(ApiK8s.getNodes));
 
@@ -316,11 +373,25 @@ it('update the control plane/workload plane nodes state when fetchNodes', () => 
   );
 
   expect(gen.next(result).value).toEqual(all([call(getJobStatus, 'boostrap')]));
+  expect(gen.next().value).toEqual(delay(1000));
+  expect(gen.next().value).toEqual(
+    put({
+      type: UPDATE_NODES_LOADING,
+      payload: false
+    })
+  );
+  expect(gen.next().done).toEqual(true);
 });
 
 it('update the control plane/workload plane/ infra nodes state when fetchNodes', () => {
   const gen = fetchNodes();
 
+  expect(gen.next().value).toEqual(
+    put({
+      type: UPDATE_NODES_LOADING,
+      payload: true
+    })
+  );
   expect(gen.next().value).toEqual(call(ApiK8s.getNodes));
 
   const result = {
@@ -381,11 +452,25 @@ it('update the control plane/workload plane/ infra nodes state when fetchNodes',
   );
 
   expect(gen.next(result).value).toEqual(all([call(getJobStatus, 'boostrap')]));
+  expect(gen.next().value).toEqual(delay(1000));
+  expect(gen.next().value).toEqual(
+    put({
+      type: UPDATE_NODES_LOADING,
+      payload: false
+    })
+  );
+  expect(gen.next().done).toEqual(true);
 });
 
 it('update the infra nodes state when fetchNodes', () => {
   const gen = fetchNodes();
 
+  expect(gen.next().value).toEqual(
+    put({
+      type: UPDATE_NODES_LOADING,
+      payload: true
+    })
+  );
   expect(gen.next().value).toEqual(call(ApiK8s.getNodes));
 
   const result = {
@@ -451,11 +536,24 @@ it('update the infra nodes state when fetchNodes', () => {
   );
 
   expect(gen.next(result).value).toEqual(all([call(getJobStatus, 'boostrap')]));
+  expect(gen.next().value).toEqual(delay(1000));
+  expect(gen.next().value).toEqual(
+    put({
+      type: UPDATE_NODES_LOADING,
+      payload: false
+    })
+  );
+  expect(gen.next().done).toEqual(true);
 });
 
 it('update the infra / Worload Plane  nodes state when fetchNodes', () => {
   const gen = fetchNodes();
-
+  expect(gen.next().value).toEqual(
+    put({
+      type: UPDATE_NODES_LOADING,
+      payload: true
+    })
+  );
   expect(gen.next().value).toEqual(call(ApiK8s.getNodes));
 
   const result = {
@@ -514,11 +612,25 @@ it('update the infra / Worload Plane  nodes state when fetchNodes', () => {
   );
 
   expect(gen.next(result).value).toEqual(all([call(getJobStatus, 'boostrap')]));
+  expect(gen.next().value).toEqual(delay(1000));
+  expect(gen.next().value).toEqual(
+    put({
+      type: UPDATE_NODES_LOADING,
+      payload: false
+    })
+  );
+  expect(gen.next().done).toEqual(true);
 });
 
 it('update the infra / Controle Plane nodes state when fetchNodes', () => {
   const gen = fetchNodes();
 
+  expect(gen.next().value).toEqual(
+    put({
+      type: UPDATE_NODES_LOADING,
+      payload: true
+    })
+  );
   expect(gen.next().value).toEqual(call(ApiK8s.getNodes));
 
   const result = {
@@ -586,6 +698,14 @@ it('update the infra / Controle Plane nodes state when fetchNodes', () => {
   );
 
   expect(gen.next(result).value).toEqual(all([call(getJobStatus, 'boostrap')]));
+  expect(gen.next().value).toEqual(delay(1000));
+  expect(gen.next().value).toEqual(
+    put({
+      type: UPDATE_NODES_LOADING,
+      payload: false
+    })
+  );
+  expect(gen.next().done).toEqual(true);
 });
 it('create Node success - CP,WP,I', () => {
   const gen = createNode({ payload: formPayload });
@@ -801,4 +921,32 @@ it('create Node success - WP,Infra', () => {
   expect(gen.next().value).toEqual(call(ApiK8s.createNode, request));
   expect(gen.next({ data: null }).value).toEqual(call(fetchNodes));
   expect(gen.next().value).toEqual(call(history.push, '/nodes'));
+});
+
+it('should refresh nodes if no error', () => {
+  const gen = refreshNodes();
+  expect(gen.next().value).toEqual(
+    put({
+      type: UPDATE_NODES_REFRESHING,
+      payload: true
+    })
+  );
+  expect(gen.next().value).toEqual(call(fetchNodes));
+  expect(gen.next({}).value).toEqual(delay(REFRESH_TIMEOUT));
+  expect(gen.next().value.type).toEqual('SELECT');
+  expect(gen.next(true).value).toEqual(call(refreshNodes));
+});
+
+it('should stop refresh Nodes', () => {
+  const gen = refreshNodes();
+  expect(gen.next().value).toEqual(
+    put({
+      type: UPDATE_NODES_REFRESHING,
+      payload: true
+    })
+  );
+  expect(gen.next().value).toEqual(call(fetchNodes));
+  expect(gen.next({}).value).toEqual(delay(REFRESH_TIMEOUT));
+  expect(gen.next().value.type).toEqual('SELECT');
+  expect(gen.next(false).done).toEqual(true);
 });


### PR DESCRIPTION
**Component**:UI

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
- Actually, the nodes list refreshed is managed in the component, it should be managed in saga for error management.
- Add "loading" icon when refreshing

**Summary**:
<img width="1229" alt="Screenshot 2019-07-22 at 11 47 59" src="https://user-images.githubusercontent.com/47394132/61624621-4038df00-ac79-11e9-962a-0b54425ff8c2.png">



**Acceptance criteria**: 
- no regression

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
