### PR TITLE
salt: use `kube-system` annotation during upgrade/downgrade

### DIFF
--- a/salt/metalk8s/orchestrate/downgrade/init.sls
+++ b/salt/metalk8s/orchestrate/downgrade/init.sls
@@ -1,4 +1,4 @@
-{%- set dest_version = pillar.orchestrate.dest_version %}
+{%- set dest_version = pillar.metalk8s.cluster_version %}
 {%- set kubeconfig = "/etc/kubernetes/admin.conf" %}
 {%- set context = "kubernetes-admin@kubernetes" %}
 

--- a/salt/metalk8s/orchestrate/downgrade/precheck.sls
+++ b/salt/metalk8s/orchestrate/downgrade/precheck.sls
@@ -1,4 +1,4 @@
-{%- set dest_version = pillar.orchestrate.dest_version %}
+{%- set dest_version = pillar.metalk8s.cluster_version %}
 
 {#- When downgrading saltenv should be the newest version #}
 {%- set nodes_versions = pillar.metalk8s.nodes.values() | map(attribute='version') | list %}

--- a/salt/metalk8s/orchestrate/etcd.sls
+++ b/salt/metalk8s/orchestrate/etcd.sls
@@ -1,4 +1,4 @@
-{%- set dest_version = pillar.orchestrate.dest_version %}
+{%- set dest_version = pillar.metalk8s.cluster_version %}
 {%- set etcd_nodes = salt.metalk8s.minions_by_role('etcd') %}
 
 Check etcd cluster health:

--- a/salt/metalk8s/orchestrate/upgrade/init.sls
+++ b/salt/metalk8s/orchestrate/upgrade/init.sls
@@ -1,4 +1,4 @@
-{%- set dest_version = pillar.orchestrate.dest_version %}
+{%- set dest_version = pillar.metalk8s.cluster_version %}
 {%- set kubeconfig = "/etc/kubernetes/admin.conf" %}
 {%- set context = "kubernetes-admin@kubernetes" %}
 

--- a/salt/metalk8s/orchestrate/upgrade/precheck.sls
+++ b/salt/metalk8s/orchestrate/upgrade/precheck.sls
@@ -1,4 +1,4 @@
-{%- set dest_version = pillar.orchestrate.dest_version %}
+{%- set dest_version = pillar.metalk8s.cluster_version %}
 
 {#- When upgrading saltenv should be the destination version #}
 {%- if saltenv != 'metalk8s-' ~ dest_version %}


### PR DESCRIPTION

**Component**:

'salt', 'kubernetes', 'upgrade', 'downgrade'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

Issue: #1442

**Summary**:

This commit introduces a new way to  store and update the value of the kube-system namespace annotation
each time we initialize an upgrade or downgrade. 

The new annotation value comes from the input argument(--destination-version) passed to our upgrade/downgrade script.

**Acceptance criteria**: 

- Upgrade and downgrade script should update the kube-system namespace annotation with the destination version arguments value.
- Upgrade and downgrade orchestrate should use the version from the annotation instead of the value in pillar.orchestrate.dest_version.

WIP!!

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1442


