### PR TITLE
Recurse when getting list of what requires a package to remove duplicates

### DIFF
--- a/salt/_modules/metalk8s_package_manager.py
+++ b/salt/_modules/metalk8s_package_manager.py
@@ -15,12 +15,58 @@ def __virtual__():
     return __virtualname__
 
 
+def _list_requires(pkg_name, version, fromrepo=None, result=None):
+    '''
+    Helper to list what requires a specific package without duplications
+    '''
+    if not result:
+        result = {pkg_name: version}
+
+    log.info(
+        'Listing requires for "%s" with version "%s"',
+        str(pkg_name),
+        str(version)
+    )
+
+    command = [
+        'repoquery', '--whatrequires', '--qf',
+        '%{NAME} %{VERSION}-%{RELEASE}',
+        '{}-{}'.format(str(pkg_name), str(version))
+    ]
+
+    if fromrepo:
+        command.extend(['--disablerepo', '*', '--enablerepo', fromrepo])
+
+    ret = __salt__['cmd.run_all'](command)
+
+    if ret['retcode'] != 0:
+        log.error(
+            'Failed to list package "%s" requires: %s',
+            str(pkg_name),
+            ret['stderr'] or ret['stdout']
+        )
+        return result
+
+    pkgs_dict = {}
+    for line in ret['stdout'].splitlines():
+        pkg, vers = line.strip().split()
+        # Does not take the pkg two time even if it's different version
+        if pkg not in result:
+            result[pkg] = vers
+            pkgs_dict[pkg] = vers
+
+    for pkg, vers in pkgs_dict.items():
+        result = _list_requires(pkg, vers, fromrepo=fromrepo, result=result)
+
+    return result
+
+
 def list_pkg_deps(pkg_name, version=None, fromrepo=None):
     '''
     Check dependencies related to the packages installed so that we can pass
     this information to pkg.installed
 
-    name
+    pkg_name
         Name of the package installed
 
     version
@@ -28,50 +74,25 @@ def list_pkg_deps(pkg_name, version=None, fromrepo=None):
 
         Use : salt '*' metalk8s_package_manager.list_pkg_deps kubelet 1.11.9
     '''
-    log.info(
-        'Listing deps for "%s" with version "%s"',
-        str(pkg_name),
-        str(version)
-    )
     pkgs_dict = {pkg_name: version}
 
     if not version:
         return pkgs_dict
 
-    command_all = [
-        'repoquery', '--whatrequires', '--recursive', '--qf',
-        '%{NAME} %{VERSION}-%{RELEASE}',
-        '{}-{}'.format(str(pkg_name), str(version))
-    ]
+    pkgs_dict = _list_requires(pkg_name, version, fromrepo=fromrepo)
 
-    if fromrepo:
-        command_all.extend(['--disablerepo', '*', '--enablerepo', fromrepo])
-
-    deps_list = __salt__['cmd.run_all'](command_all)
-
-    if deps_list['retcode'] != 0:
-        log.error(
-            'Failed to list package dependencies: %s',
-            deps_list['stderr'] or deps_list['stdout']
-        )
-        return None
-
-    out = deps_list['stdout'].splitlines()
-    for line in out:
-        name, version = line.strip().split()
-        pkgs_dict[name] = version
-
-    for key in pkgs_dict.keys():
-        package_query = __salt__['cmd.run_all'](
-            ['rpm', '-qa', key]
+    for pkg in pkgs_dict.keys():
+        ret = __salt__['cmd.run_all'](
+            ['rpm', '-qa', pkg]
         )
 
-        if package_query['retcode'] == 1:
-            pkgs_dict.pop(key)
-        elif package_query['retcode'] != 0:
+        if ret['retcode'] == 1:
+            del pkgs_dict[pkg]
+        elif ret['retcode'] != 0:
             log.error(
-                'Failed to check if package is installed: %s',
-                deps_list['stderr'] or deps_list['stdout']
+                'Failed to check if package "%s" is installed: %s',
+                pkg,
+                ret['stderr'] or ret['stdout']
             )
             return None
 


### PR DESCRIPTION
**Component**:

'salt'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

If several version of a package is available in our repos then the module `metalk8s_package_manager.list_pkg_deps` will take the wrong one

**Summary**:

Does not use `--recursive` with repoquery to always take the closer requires version instead of the last one.

**Acceptance criteria**: 

Have the right list of package when 2 version available in the same repo

```
[root@bootstrap ~]# repoquery --whatrequires --qf '%{NAME} %{VERSION}-%{RELEASE}' kubelet-1.12.9 --disablerepo '*' --enablerepo 'metalk8s-*' --recursive
calico-cni-plugin 3.8.0-1.el7
kubelet 1.12.9-0
kubelet 1.13.7-0
kubernetes-cni 0.7.5-0
[root@bootstrap ~]# salt-call metalk8s_package_manager.list_pkg_deps kubelet 1.12.9 fromrepo="metalk8s-*"
local:
    ----------
    calico-cni-plugin:
        3.8.0-1.el7
    kubelet:
        1.12.9
    kubernetes-cni:
        0.7.5-0

```

---

Fixes: #1455
