### PR TITLE
Implement storage operator reconciliation loop

### DIFF
--- a/storage-operator/README.md
+++ b/storage-operator/README.md
@@ -15,7 +15,7 @@
 
 ```shell
 export KUBECONFIG=<path-to-the-admin.cong-you-copied-locally>
-export METALK8S_SALT_MASTER_ADDRESS=http://<IP-OF-SALT-API-WITHOUT-PORT>
+export METALK8S_SALT_MASTER_ADDRESS=http://<IP-OF-SALT-API-WITH-PORT>
 cd storage-operator
 operator-sdk up local
 ```

--- a/storage-operator/README.md
+++ b/storage-operator/README.md
@@ -1,0 +1,21 @@
+# Storage Operator
+
+## How to run the operator locally
+
+1. Connect to the bootstrap node
+2. Deploy the CRD from `storage-operator/deploy/crds` into your cluster using
+   `kubectl apply`.
+3. Copy the /etc/kubernetes/admin.conf from the bootstrap node to your local
+   machine.
+4. Get the "public" IP of the Salt API server (the one that use the port 4507):
+
+    `kubectl --kubeconfig /etc/kubernetes/admin.conf -n kube-system describe svc salt-master | grep 'Endpoints'`
+
+5. Start the operator on your machine
+
+```shell
+export KUBECONFIG=<path-to-the-admin.cong-you-copied-locally>
+export METALK8S_SALT_MASTER_ADDRESS=http://<IP-OF-SALT-API-WITHOUT-PORT>
+cd storage-operator
+operator-sdk up local
+```

--- a/storage-operator/deploy/crds/storage_v1alpha1_volume_crd.yaml
+++ b/storage-operator/deploy/crds/storage_v1alpha1_volume_crd.yaml
@@ -67,6 +67,29 @@ spec:
           - storageClassName
           type: object
         status:
+          properties:
+            errorCode:
+              description: Volume failure error code
+              enum:
+              - InternalError
+              - CreationError
+              - DestructionError
+              - UnavailableError
+              type: string
+            errorMessage:
+              description: Volume failure error message
+              type: string
+            job:
+              description: Job in progress
+              type: string
+            phase:
+              description: Volume lifecycle phase
+              enum:
+              - Available
+              - Pending
+              - Failed
+              - Terminating
+              type: string
           type: object
   version: v1alpha1
   versions:

--- a/storage-operator/pkg/apis/storage/v1alpha1/volume_types.go
+++ b/storage-operator/pkg/apis/storage/v1alpha1/volume_types.go
@@ -42,12 +42,46 @@ type VolumeSpec struct {
 	VolumeSource `json:",inline"`
 }
 
+type VolumePhase string
+
+// "Enum" representing the phase/status of a volume.
+const (
+	VolumeFailed      VolumePhase = "Failed"
+	VolumePending     VolumePhase = "Pending"
+	VolumeAvailable   VolumePhase = "Available"
+	VolumeTerminating VolumePhase = "Terminating"
+)
+
+type VolumeErrorCode string
+
+// "Enum" representing the error codes of the Failed state.
+const (
+	InternalError    VolumeErrorCode = "InternalError"
+	CreationError    VolumeErrorCode = "CreationError"
+	DestructionError VolumeErrorCode = "DestructionError"
+	UnavailableError VolumeErrorCode = "UnavailableError"
+)
+
 // VolumeStatus defines the observed state of Volume
 // +k8s:openapi-gen=true
 type VolumeStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
+
+	// Volume lifecycle phase
+	// +kubebuilder:validation:Enum=Available,Pending,Failed,Terminating
+	Phase VolumePhase `json:"phase,omitempty"`
+
+	// Job in progress
+	Job string `json:"job,omitempty"`
+
+	// Volume failure error code
+	// +kubebuilder:validation:Enum=InternalError,CreationError,DestructionError,UnavailableError
+	ErrorCode VolumeErrorCode `json:"errorCode,omitempty"`
+
+	// Volume failure error message
+	ErrorMessage string `json:"errorMessage,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/storage-operator/pkg/apis/storage/v1alpha1/volume_types.go
+++ b/storage-operator/pkg/apis/storage/v1alpha1/volume_types.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -98,6 +100,52 @@ type Volume struct {
 
 	Spec   VolumeSpec   `json:"spec,omitempty"`
 	Status VolumeStatus `json:"status,omitempty"`
+}
+
+// Update the volume status to Failed phase.
+//
+// Arguments
+//     errorCode: the error code that triggered the shift to the Failed phase
+//     format:    the string format for the error message
+//     args:      values used in the error message
+func (self *Volume) SetFailedStatus(
+	errorCode VolumeErrorCode, format string, args ...interface{},
+) {
+	errorMsg := fmt.Sprintf(format, args...)
+
+	self.Status = VolumeStatus{
+		Phase:        VolumeFailed,
+		Job:          self.Status.Job, // Preserve job: can help for debug.
+		ErrorCode:    errorCode,
+		ErrorMessage: errorMsg,
+	}
+}
+
+// Update the volume status to Pending phase.
+//
+// Arguments
+//     job: job in progress
+func (self *Volume) SetPendingStatus(job string) {
+	self.Status = VolumeStatus{
+		Phase: VolumePending, Job: job, ErrorCode: "", ErrorMessage: "",
+	}
+}
+
+// Update the volume status to Available phase.
+func (self *Volume) SetAvailableStatus() {
+	self.Status = VolumeStatus{
+		Phase: VolumeAvailable, Job: "", ErrorCode: "", ErrorMessage: "",
+	}
+}
+
+// Update the volume status to Terminating phase.
+//
+// Arguments
+//     job: job in progress
+func (self *Volume) SetTerminatingStatus(job string) {
+	self.Status = VolumeStatus{
+		Phase: VolumeTerminating, Job: job, ErrorCode: "", ErrorMessage: "",
+	}
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/storage-operator/pkg/apis/storage/v1alpha1/volume_types.go
+++ b/storage-operator/pkg/apis/storage/v1alpha1/volume_types.go
@@ -176,6 +176,20 @@ func (self *Volume) IsInUnrecoverableFailedState() bool {
 		self.Status.ErrorCode != UnavailableError
 }
 
+// Return the volume size.
+func (self *Volume) GetSize(disk_size *resource.Quantity) resource.Quantity {
+	if self.Spec.SparseLoopDevice != nil {
+		return self.Spec.SparseLoopDevice.Size
+	}
+	// RawBlockDevice use the whole disk, so return the disk size as size.
+	return *disk_size
+}
+
+// Return the volume path on the node.
+func (self *Volume) GetPath() string {
+	return fmt.Sprintf("/dev/disk/by-uuid/%s", self.UID)
+}
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // VolumeList contains a list of Volume

--- a/storage-operator/pkg/apis/storage/v1alpha1/volume_types.go
+++ b/storage-operator/pkg/apis/storage/v1alpha1/volume_types.go
@@ -169,6 +169,13 @@ func (self *Volume) IsValid() error {
 	return nil
 }
 
+// Check if a volume is in an unrecoverable state.
+func (self *Volume) IsInUnrecoverableFailedState() bool {
+	// Only `UnavailableError` is recoverable.
+	return self.Status.Phase == VolumeFailed &&
+		self.Status.ErrorCode != UnavailableError
+}
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // VolumeList contains a list of Volume

--- a/storage-operator/pkg/apis/storage/v1alpha1/volume_types.go
+++ b/storage-operator/pkg/apis/storage/v1alpha1/volume_types.go
@@ -176,15 +176,6 @@ func (self *Volume) IsInUnrecoverableFailedState() bool {
 		self.Status.ErrorCode != UnavailableError
 }
 
-// Return the volume size.
-func (self *Volume) GetSize(disk_size *resource.Quantity) resource.Quantity {
-	if self.Spec.SparseLoopDevice != nil {
-		return self.Spec.SparseLoopDevice.Size
-	}
-	// RawBlockDevice use the whole disk, so return the disk size as size.
-	return *disk_size
-}
-
 // Return the volume path on the node.
 func (self *Volume) GetPath() string {
 	return fmt.Sprintf("/dev/disk/by-uuid/%s", self.UID)

--- a/storage-operator/pkg/apis/storage/v1alpha1/zz_generated.openapi.go
+++ b/storage-operator/pkg/apis/storage/v1alpha1/zz_generated.openapi.go
@@ -104,7 +104,36 @@ func schema_pkg_apis_storage_v1alpha1_VolumeStatus(ref common.ReferenceCallback)
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "VolumeStatus defines the observed state of Volume",
-				Properties:  map[string]spec.Schema{},
+				Properties: map[string]spec.Schema{
+					"phase": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Volume lifecycle phase",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"job": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Job in progress",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"errorCode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Volume failure error code",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"errorMessage": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Volume failure error message",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
 			},
 		},
 		Dependencies: []string{},

--- a/storage-operator/pkg/controller/volume/slice.go
+++ b/storage-operator/pkg/controller/volume/slice.go
@@ -1,0 +1,43 @@
+package volume
+
+// Some basic slice helpers that are lacking from Go stdlib…
+//
+// Note that we only defines the helpers for `[]string` because:
+// - we only need it for `[]string` for now
+// - Go doesn't support generics anyway…
+
+// Remove all the occurrences `target` from `slice` (if present).
+//
+// Arguments
+//     slice:  the slice to process
+//     target: the value to remove
+//
+// Returns
+//     A slice without `target`.
+func SliceRemoveValue(slice []string, target string) []string {
+	newSlice := slice[:0]
+	for _, value := range slice {
+		if value != target {
+			newSlice = append(newSlice, value)
+		}
+	}
+	return newSlice
+}
+
+// Append `value` to `slice (if not already present).
+//
+// Arguments
+//     slice:  the slice to process
+//     target: the value to add.
+//
+// Returns
+//     A slice with `target` in it.
+func SliceAppendUnique(slice []string, newValue string) []string {
+	for _, value := range slice {
+		// value already present: nothing to do.
+		if value == newValue {
+			return slice
+		}
+	}
+	return append(slice, newValue)
+}

--- a/storage-operator/pkg/controller/volume/volume_controller.go
+++ b/storage-operator/pkg/controller/volume/volume_controller.go
@@ -204,16 +204,16 @@ func getAuthCredential(config *rest.Config) *salt.Credential {
 	if config.BearerToken != "" {
 		log.Info("using ServiceAccount bearer token")
 		return salt.NewCredential(
-			"storage-operator", config.BearerToken, "Bearer",
+			"storage-operator", config.BearerToken, salt.BearerToken,
 		)
 	} else if config.Username != "" && config.Password != "" {
 		log.Info("using Basic HTTP authentication")
 		creds := fmt.Sprintf("%s:%s", config.Username, config.Password)
 		token := b64.StdEncoding.EncodeToString([]byte(creds))
-		return salt.NewCredential(config.Username, token, "Basic")
+		return salt.NewCredential(config.Username, token, salt.BasicToken)
 	} else {
 		log.Info("using default Basic HTTP authentication")
 		token := b64.StdEncoding.EncodeToString([]byte("admin:admin"))
-		return salt.NewCredential("admin", token, "Basic")
+		return salt.NewCredential("admin", token, salt.BasicToken)
 	}
 }

--- a/storage-operator/pkg/controller/volume/volume_controller.go
+++ b/storage-operator/pkg/controller/volume/volume_controller.go
@@ -90,9 +90,12 @@ func (r *ReconcileVolume) Reconcile(request reconcile.Request) (reconcile.Result
 	reqLogger := log.WithValues("Request.Name", request.Name)
 	reqLogger.Info("Reconciling Volume")
 
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
 	// Fetch the Volume instance
 	instance := &storagev1alpha1.Volume{}
-	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
+	err := r.client.Get(ctx, request.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -125,10 +128,10 @@ func (r *ReconcileVolume) Reconcile(request reconcile.Request) (reconcile.Result
 
 	// Check if this PV already exists
 	found := &corev1.PersistentVolume{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Namespace: "", Name: pv.Name}, found)
+	err = r.client.Get(ctx, types.NamespacedName{Namespace: "", Name: pv.Name}, found)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new PersistentVolume", "PersistentVolume.Name", pv.Name)
-		err = r.client.Create(context.TODO(), pv)
+		err = r.client.Create(ctx, pv)
 		if err != nil {
 			return reconcile.Result{}, err
 		}

--- a/storage-operator/pkg/controller/volume/volume_controller.go
+++ b/storage-operator/pkg/controller/volume/volume_controller.go
@@ -228,6 +228,12 @@ func (r *ReconcileVolume) Reconcile(request reconcile.Request) (reconcile.Result
 		reqLogger.Error(err, "cannot read Volume: requeue")
 		return reconcile.Result{}, err
 	}
+	if err := volume.IsValid(); err != nil {
+		return r.setFailedVolumeStatus(
+			ctx, volume, storagev1alpha1.InternalError,
+			"invalid volume: %s", err.Error(),
+		)
+	}
 
 	pv := newPersistentVolumeForCR(volume)
 

--- a/storage-operator/pkg/controller/volume/volume_controller.go
+++ b/storage-operator/pkg/controller/volume/volume_controller.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -35,9 +36,10 @@ func Add(mgr manager.Manager) error {
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 	return &ReconcileVolume{
-		client: mgr.GetClient(),
-		scheme: mgr.GetScheme(),
-		salt:   salt.NewClient(getAuthCredential(mgr.GetConfig())),
+		client:   mgr.GetClient(),
+		scheme:   mgr.GetScheme(),
+		recorder: mgr.GetRecorder("volume-controller"),
+		salt:     salt.NewClient(getAuthCredential(mgr.GetConfig())),
 	}
 }
 
@@ -74,9 +76,10 @@ var _ reconcile.Reconciler = &ReconcileVolume{}
 type ReconcileVolume struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
-	client client.Client
-	scheme *runtime.Scheme
-	salt   *salt.Client
+	client   client.Client
+	scheme   *runtime.Scheme
+	recorder record.EventRecorder
+	salt     *salt.Client
 }
 
 // Reconcile reads that state of the cluster for a Volume object and makes changes based on the state read

--- a/storage-operator/pkg/controller/volume/volume_controller.go
+++ b/storage-operator/pkg/controller/volume/volume_controller.go
@@ -235,6 +235,16 @@ func (r *ReconcileVolume) Reconcile(request reconcile.Request) (reconcile.Result
 		)
 	}
 
+	// Skip volume stuck waiting for deletion or a manual fix.
+	if volume.IsInUnrecoverableFailedState() {
+		reqLogger.Info(
+			"volume stuck in error state: do nothing",
+			"Error.Code", volume.Status.ErrorCode,
+			"Error.Message", volume.Status.ErrorMessage,
+		)
+		return reconcile.Result{}, nil
+	}
+
 	pv := newPersistentVolumeForCR(volume)
 
 	// Set Volume instance as the owner and controller

--- a/storage-operator/pkg/controller/volume/volume_controller.go
+++ b/storage-operator/pkg/controller/volume/volume_controller.go
@@ -88,7 +88,8 @@ type ReconcileVolume struct {
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileVolume) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := log.WithValues("Request.Name", request.Name)
-	reqLogger.Info("Reconciling Volume")
+	reqLogger.Info("reconciling volume: START")
+	defer reqLogger.Info("reconciling volume: STOP")
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()

--- a/storage-operator/pkg/controller/volume/volume_controller.go
+++ b/storage-operator/pkg/controller/volume/volume_controller.go
@@ -197,7 +197,7 @@ reclaim its storage and remove the finalizers to let the object be deleted.
 const VOLUME_PROTECTION = "storage.metalk8s.scality.com/volume-protection"
 const JOB_DONE_MARKER = "DONE"
 
-var log = logf.Log.WithName("controller_volume")
+var log = logf.Log.WithName("volume-controller")
 
 // Add creates a new Volume Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.

--- a/storage-operator/pkg/controller/volume/volume_controller.go
+++ b/storage-operator/pkg/controller/volume/volume_controller.go
@@ -108,7 +108,7 @@ func (r *ReconcileVolume) Reconcile(request reconcile.Request) (reconcile.Result
 		return reconcile.Result{}, err
 	}
 
-	result, err := r.salt.TestPing()
+	result, err := r.salt.TestPing(ctx)
 	if err != nil {
 		reqLogger.Error(err, "test.ping failed")
 		return reconcile.Result{}, err

--- a/storage-operator/pkg/controller/volume/volume_controller.go
+++ b/storage-operator/pkg/controller/volume/volume_controller.go
@@ -108,17 +108,6 @@ func (r *ReconcileVolume) Reconcile(request reconcile.Request) (reconcile.Result
 		return reconcile.Result{}, err
 	}
 
-	result, err := r.salt.TestPing(ctx)
-	if err != nil {
-		reqLogger.Error(err, "test.ping failed")
-		return reconcile.Result{}, err
-	}
-	for hostname := range result {
-		reqLogger.Info(
-			"ping", "hostname", hostname, "result", result[hostname].(bool),
-		)
-	}
-
 	pv := newPersistentVolumeForCR(instance)
 
 	// Set Volume instance as the owner and controller

--- a/storage-operator/pkg/controller/volume/volume_controller_test.go
+++ b/storage-operator/pkg/controller/volume/volume_controller_test.go
@@ -17,15 +17,21 @@ func TestGetAuthCredential(t *testing.T) {
 	}{
 		"ServiceAccount": {
 			token: "foo", username: "", password: "",
-			expected: salt.NewCredential("storage-operator", "foo", "Bearer"),
+			expected: salt.NewCredential(
+				"storage-operator", "foo", salt.BearerToken,
+			),
 		},
 		"BasicAuth": {
 			token: "", username: "foo", password: "bar",
-			expected: salt.NewCredential("foo", "Zm9vOmJhcg==", "Basic"),
+			expected: salt.NewCredential(
+				"foo", "Zm9vOmJhcg==", salt.BasicToken,
+			),
 		},
 		"DefaultCreds": {
 			token: "", username: "", password: "",
-			expected: salt.NewCredential("admin", "YWRtaW46YWRtaW4=", "Basic"),
+			expected: salt.NewCredential(
+				"admin", "YWRtaW46YWRtaW4=", salt.BasicToken,
+			),
 		},
 	}
 	for name, tc := range tests {

--- a/storage-operator/pkg/salt/client.go
+++ b/storage-operator/pkg/salt/client.go
@@ -69,7 +69,8 @@ func (self *Client) PrepareVolume(
 		)
 	}
 	// TODO(#1461): make this more robust.
-	return ans["jid"].(string), nil
+	result := ans["return"].([]interface{})[0].(map[string]interface{})
+	return result["jid"].(string), nil
 }
 
 // Send an authenticated request to Salt API.
@@ -141,7 +142,7 @@ func (self *Client) authenticate(ctx context.Context) error {
 	}
 	defer response.Body.Close()
 
-	output, err := decodeApiResponse(response)
+	result, err := decodeApiResponse(response)
 	if err != nil {
 		return errors.Wrapf(
 			err,
@@ -151,6 +152,7 @@ func (self *Client) authenticate(ctx context.Context) error {
 	}
 
 	// TODO(#1461): make this more robust.
+	output := result["return"].([]interface{})[0].(map[string]interface{})
 	self.token = newToken(
 		output["token"].(string), output["expire"].(float64),
 	)
@@ -285,7 +287,5 @@ func decodeApiResponse(response *http.Response) (map[string]interface{}, error) 
 	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
 		return nil, errors.Wrap(err, "cannot decode Salt API response")
 	}
-	// The real result is in a single-item list stored in the `return` field.
-	// TODO(#1461): make this more robust.
-	return result["return"].([]interface{})[0].(map[string]interface{}), nil
+	return result, nil
 }

--- a/storage-operator/pkg/salt/client.go
+++ b/storage-operator/pkg/salt/client.go
@@ -82,6 +82,37 @@ func (self *Client) PrepareVolume(
 	return result["jid"].(string), nil
 }
 
+// Spawn a job, asynchronously, to unprepare the volume on the specified node.
+//
+// Arguments
+//     ctx:      the request context (used for cancellation)
+//     nodeName: name of the node where the volume will be
+//
+// Returns
+//     The Salt job ID.
+func (self *Client) UnprepareVolume(
+	ctx context.Context, nodeName string,
+) (string, error) {
+	// Use rand_sleep to emulate slow operation for now
+	payload := map[string]interface{}{
+		"client": "local_async",
+		"tgt":    nodeName,
+		"fun":    "test.rand_sleep",
+	}
+
+	self.logger.Info("UnprepareVolume")
+
+	ans, err := self.authenticatedRequest(ctx, "POST", "/", payload)
+	if err != nil {
+		return "", errors.Wrapf(
+			err, "UnprepareVolume failed (target=%s)", nodeName,
+		)
+	}
+	// TODO(#1461): make this more robust.
+	result := ans["return"].([]interface{})[0].(map[string]interface{})
+	return result["jid"].(string), nil
+}
+
 // Poll the status of an asynchronous Salt job.
 //
 // Arguments

--- a/storage-operator/pkg/salt/client.go
+++ b/storage-operator/pkg/salt/client.go
@@ -42,6 +42,36 @@ func NewClient(creds *Credential) *Client {
 	}
 }
 
+// Spawn a job, asynchronously, to prepare the volume on the specified node.
+//
+// Arguments
+//     ctx:      the request context (used for cancellation)
+//     nodeName: name of the node where the volume will be
+//
+// Returns
+//     The Salt job ID.
+func (self *Client) PrepareVolume(
+	ctx context.Context, nodeName string,
+) (string, error) {
+	// Use rand_sleep to emulate slow operation for now
+	payload := map[string]string{
+		"client": "local_async",
+		"tgt":    nodeName,
+		"fun":    "test.rand_sleep",
+	}
+
+	self.logger.Info("PrepareVolume")
+
+	ans, err := self.authenticatedPost(ctx, "/", payload)
+	if err != nil {
+		return "", errors.Wrapf(
+			err, "PrepareVolume failed (target=%s)", nodeName,
+		)
+	}
+	// TODO(#1461): make this more robust.
+	return ans["jid"].(string), nil
+}
+
 // Send an authenticated POST request to Salt API.
 //
 // Automatically handle:

--- a/storage-operator/pkg/salt/client.go
+++ b/storage-operator/pkg/salt/client.go
@@ -195,12 +195,17 @@ func (self *Client) GetVolumeSize(
 			err, "disk.dump failed (target=%s, path=%s)", nodeName, devicePath,
 		)
 	}
-
 	// TODO(#1461): make this more robust.
 	result := ans["return"].([]interface{})[0].(map[string]interface{})
-	nodeResult := result[nodeName].(map[string]interface{})
-	size_str := nodeResult["getsize64"].(string)
-	return strconv.ParseInt(size_str, 10, 64)
+	if nodeResult, ok := result[nodeName].(map[string]interface{}); ok {
+		size_str := nodeResult["getsize64"].(string)
+		return strconv.ParseInt(size_str, 10, 64)
+	}
+
+	return 0, fmt.Errorf(
+		"no size in disk.dump response (target=%s, path=%s)",
+		nodeName, devicePath,
+	)
 }
 
 // Send an authenticated request to Salt API.

--- a/storage-operator/pkg/salt/client.go
+++ b/storage-operator/pkg/salt/client.go
@@ -109,7 +109,7 @@ func (self *Client) authenticate() error {
 		"eauth":      "kubernetes_rbac",
 		"username":   self.creds.username,
 		"token":      self.creds.token,
-		"token_type": self.creds.kind,
+		"token_type": string(self.creds.kind),
 	}
 
 	self.logger.Info(

--- a/storage-operator/pkg/salt/client.go
+++ b/storage-operator/pkg/salt/client.go
@@ -42,25 +42,6 @@ func NewClient(creds *Credential) *Client {
 	}
 }
 
-// Test function, will be removed later…
-func (self *Client) TestPing(
-	ctx context.Context,
-) (map[string]interface{}, error) {
-	payload := map[string]string{
-		"client": "local",
-		"tgt":    "*",
-		"fun":    "test.ping",
-	}
-
-	self.logger.Info("test.ping")
-
-	ans, err := self.authenticatedPost(ctx, "/", payload)
-	if err != nil {
-		return nil, errors.Wrap(err, "test.ping failed")
-	}
-	return ans, nil
-}
-
 // Send an authenticated POST request to Salt API.
 //
 // Automatically handle:

--- a/storage-operator/pkg/salt/client.go
+++ b/storage-operator/pkg/salt/client.go
@@ -39,13 +39,14 @@ func NewClient(creds *Credential) *Client {
 	if address == "" {
 		address = "http://salt-master:4507"
 	}
+	logger := log.Log.WithName("salt-api").WithValues("Salt.Address", address)
 
 	return &Client{
 		address: address,
 		client:  &http.Client{},
 		creds:   creds,
 		token:   nil,
-		logger:  log.Log.WithName("salt_api"),
+		logger:  logger,
 	}
 }
 
@@ -123,7 +124,7 @@ func (self *Client) UnprepareVolume(
 func (self *Client) PollJob(
 	ctx context.Context, jobId string, nodeName string,
 ) (map[string]interface{}, error) {
-	jobLogger := self.logger.WithValues("jobId", jobId)
+	jobLogger := self.logger.WithValues("Salt.JobId", jobId)
 	jobLogger.Info("polling Salt job")
 
 	endpoint := fmt.Sprintf("/jobs/%s", jobId)

--- a/storage-operator/pkg/salt/client.go
+++ b/storage-operator/pkg/salt/client.go
@@ -143,7 +143,11 @@ func (self *Client) authenticate(ctx context.Context) error {
 
 	output, err := decodeApiResponse(response)
 	if err != nil {
-		return errors.Wrap(err, "Salt API authentication failed")
+		return errors.Wrapf(
+			err,
+			"Salt API authentication failed (username=%s, type=%s)",
+			self.creds.username, string(self.creds.kind),
+		)
 	}
 
 	// TODO(#1461): make this more robust.

--- a/storage-operator/pkg/salt/client.go
+++ b/storage-operator/pkg/salt/client.go
@@ -35,15 +35,13 @@ type Client struct {
 
 // Create a new Salt API client.
 func NewClient(creds *Credential) *Client {
-	const SALT_API_PORT int = 4507 // As defined in master-99-metalk8s.conf
-
 	address := os.Getenv("METALK8S_SALT_MASTER_ADDRESS")
 	if address == "" {
-		address = "http://salt-master"
+		address = "http://salt-master:4507"
 	}
 
 	return &Client{
-		address: fmt.Sprintf("%s:%d", address, SALT_API_PORT),
+		address: address,
 		client:  &http.Client{},
 		creds:   creds,
 		token:   nil,

--- a/storage-operator/pkg/salt/client_test.go
+++ b/storage-operator/pkg/salt/client_test.go
@@ -70,7 +70,7 @@ func TestDecodeApiResponse(t *testing.T) {
 			result: nil, error: "cannot decode Salt API response",
 		},
 		"ok": {
-			status: 200, body: httpBody(`{"return": [{"token": "foo"}]}`),
+			status: 200, body: httpBody(`{"token": "foo"}`),
 			result: map[string]interface{}{"token": "foo"}, error: "",
 		},
 	}

--- a/storage-operator/pkg/salt/client_test.go
+++ b/storage-operator/pkg/salt/client_test.go
@@ -18,7 +18,7 @@ func TestNewClientDefault(t *testing.T) {
 		expected string
 	}{
 		"default": {value: "", expected: "http://salt-master:4507"},
-		"env_var": {value: "http://foo", expected: "http://foo:4507"},
+		"env_var": {value: "http://foo:4507", expected: "http://foo:4507"},
 	}
 
 	for name, tc := range tests {

--- a/storage-operator/pkg/salt/client_test.go
+++ b/storage-operator/pkg/salt/client_test.go
@@ -32,7 +32,7 @@ func TestNewClientDefault(t *testing.T) {
 	}
 }
 
-func TestNewPostRequest(t *testing.T) {
+func TestNewRequest(t *testing.T) {
 	tests := map[string]struct {
 		is_auth  bool
 		expected string
@@ -46,7 +46,7 @@ func TestNewPostRequest(t *testing.T) {
 			client := NewClient(nil)
 			client.token = newToken("foo", 0)
 
-			request, _ := client.newPostRequest("/", nil, tc.is_auth)
+			request, _ := client.newRequest("POST", "/", nil, tc.is_auth)
 			token := request.Header.Get("X-Auth-Token")
 
 			assert.Equal(t, tc.expected, token)

--- a/storage-operator/pkg/salt/creds.go
+++ b/storage-operator/pkg/salt/creds.go
@@ -2,11 +2,19 @@ package salt
 
 import "fmt"
 
+type TokenType string
+
+// "Enum" representing the preparation steps of a volume.
+const (
+	BasicToken  TokenType = "Basic"
+	BearerToken TokenType = "Bearer"
+)
+
 // Credentials for Salt API.
 type Credential struct {
-	username string // User name.
-	token    string // User token.
-	kind     string // Token type: Basic or Bearer.
+	username string    // User name.
+	token    string    // User token.
+	kind     TokenType // Token type: Basic or Bearer.
 }
 
 // Create a new Salt API client.
@@ -15,8 +23,8 @@ type Credential struct {
 //     username: user name
 //     token:    user token
 //     kind:     token type (must be either Basic or Bearer)
-func NewCredential(username string, token string, kind string) *Credential {
-	if kind != "Basic" && kind != "Bearer" {
+func NewCredential(username string, token string, kind TokenType) *Credential {
+	if kind != BasicToken && kind != BearerToken {
 		panic(fmt.Sprintf("invalid token type: %s", kind))
 	}
 	return &Credential{username: username, token: token, kind: kind}

--- a/storage-operator/pkg/salt/creds_test.go
+++ b/storage-operator/pkg/salt/creds_test.go
@@ -17,11 +17,11 @@ func TestNewCredential(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			creds := NewCredential(tc.username, tc.token, name)
+			creds := NewCredential(tc.username, tc.token, TokenType(name))
 
 			assert.Equal(t, tc.username, creds.username)
 			assert.Equal(t, tc.token, creds.token)
-			assert.Equal(t, name, creds.kind)
+			assert.Equal(t, TokenType(name), creds.kind)
 		})
 	}
 }


### PR DESCRIPTION
**Component**:

operator

**Context**:

PV should be "hidden" from the user, and thus all their handling (creation and deletion) should be automated by the reconciliation loop and Volume CR.

**Summary**:

Implement all the necessary logic to:
- create a PV when a volume is created
- delete a PV when a volume is deleted
- handle PV and Volume lifetimes (using finalizer and ownership)
- prevent the deletion of Volume/PV is the PV is bound

**Acceptance criteria**:

Start the operator locally following the instructions given in https://github.com/scality/metalk8s/pull/1452

#### Create a volume

Create new volume (using `kubectl apply` or the UI):
-  The volume should be picked up by the Operator and will go into `Pending` state.
-  After some random amount of time, a PV with the proper size/path will be created
- The volume will become `Available`.

You can monitor the progression by watching the UI or with `watch  kubectl --kubeconfig=/etc/kubernetes/admin.conf describe volume <VOLUME-NAME` (that way you'll also see the events, those are not yet shown in the UI)

##### Bonus test

Stop the `salt-api` container while the volume creation is in progress:
- the error should be handled gracefully (no crash)
- we have periodic retry
- the creation will resume automatically once `salt-api` is brought back up by Kubernetes.

#### Delete a volume

Use `kubectl delete` to delete the volume:
- the volume will go into `Terminating` state
- After a while it'll be deleted (and the backing PV with it).

##### Bonus test 1

Stop the `salt-api` container while the volume deletion is in progress:
- the error should be handled gracefully (no crash)
- we have periodic retry
- the deletion will resume automatically once `salt-api` is brought back up by Kubernetes.

##### Bonus test 2

Create a PVC to bound the PV, then delete the volume: the volume isn't be deleted.
Now, delete the PVC: the PV is no longer bound, the deletion is resumed automatically

#### Delete the PV

Use `kubctl delete` the PV directly: the PV becomes `Terminating` but isn't deleted until the volume exists

**How to review**:

To review, you'll need:
- to squat (remember tovarish: "heel on the ground: a comrade found, but heel in the sky: it's a Western spy")
- a shot of vodka
- a stack of блин

More seriously, it will be easier to do the review commit by commit (several of them are small, and the big ones have useful commit messages).

**Afterwords**

That was a big and long PR. It wouldn't have been possible without:
- the `artist-mode` of Emacs for the schemas
- блин and плов for brain's calories intake
- hardbass to keep the mind sharp during the wee hours

![](https://s3.gifyu.com/images/hardbass.gif)

Stay cheeki-breeki my friend!

---

Closes: #1462
