### PR TITLE
salt: Fix etcd health check in salt states

### DIFF
--- a/salt/metalk8s/kubernetes/etcd/healthy.sls
+++ b/salt/metalk8s/kubernetes/etcd/healthy.sls
@@ -10,6 +10,6 @@ Waiting for etcd running:
       - /etc/kubernetes/pki/etcd/server.crt
       - /etc/kubernetes/pki/etcd/server.key
     - status: 200
-    - match: '{"health": "true"}'
+    - match: '{"health":"true"}'
     - require:
       - metalk8s: Create local etcd Pod manifest


### PR DESCRIPTION

**Component**:

'salt', 'kubernetes'

**Context**: 

Since etcd 3.3.10 `/health` of etcd return `{"health":"true"}` instead of `{"health": "true"}` for previous versions

**Summary**:

Update the health check

**Acceptance criteria**: 

Have a working `metalk8s.kubernetes.etcd.healthy` salt states for branch >= dev/2.3

---

Fixes: #1476
