### PR TITLE
Fix task callables signatures and type hints

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -47,7 +47,6 @@ disable=abstract-method,     # Too many false positive :/
         bad-continuation,    # I kindly disagree :)
         locally-disabled,    # Sometime we need to disable a warning locally.
         suppressed-message,  # Don't pollute the output with useless info.
-        useless-return       # Disagreement with mypy, see https://github.com/python/mypy/issues/3974
 
 # }}}
 # Basic {{{


### PR DESCRIPTION
In an attempt to clean the signature of the `docker_command` task
callables, we used the `Optional[TaskError]` return type hint.
However, this expressely required us to add a `return None` statement
for `mypy`, and disable a `pylint` rule to do so.

Instead, we use the return type hint `None` and don't `return` from such
callables, leaving the `Optional[TaskError]` to the `task_error`
decorator.

Fixes: #1489
See: #1477
