### PR TITLE
salt: Add salt pillar to get and list volumes per node

### DIFF
--- a/salt/_pillar/metalk8s_nodes.py
+++ b/salt/_pillar/metalk8s_nodes.py
@@ -1,9 +1,12 @@
 import os.path
 import logging
+import datetime
 
 try:
     import kubernetes.client
+    from kubernetes.client.rest import ApiException
     import kubernetes.config
+    from urllib3.exceptions import HTTPError
     HAS_DEPS = True
 except ImportError:
     HAS_DEPS = False
@@ -50,6 +53,101 @@ def node_info(node, ca_minion):
     return result
 
 
+def get_cluster_version(api_client):
+    coreV1 = kubernetes.client.CoreV1Api(api_client=api_client)
+    try:
+        namespace = coreV1.read_namespace(name="kube-system")
+    except (ApiException, HTTPError) as exc:
+        return __utils__['pillar_utils.errors_to_dict'](
+            'Unable to read namespace information {}'.format(exc)
+        )
+    annotations = namespace.metadata.annotations
+    annotation_key = 'metalk8s.scality.com/cluster-version'
+    if not annotations or annotation_key not in annotations:
+        return __utils__['pillar_utils.errors_to_dict'](
+            'Unable to retrieve cluster version'
+        )
+
+    return namespace.metadata.annotations[annotation_key]
+
+
+def iso_timestamp_converter(timestamp):
+    if timestamp is None:
+        return None
+    return timestamp.isoformat()
+
+
+def get_storage_classes(api_client):
+    storageV1 = kubernetes.client.StorageV1Api(api_client=api_client)
+    storage_classes = {}
+    storageclass_list = storageV1.list_storage_class()
+    for storageclass in storageclass_list.items:
+        # Need to convert the datetime object in storageclass to ISO format in
+        # order to make them serializable.
+        storageclass.metadata.creation_timestamp = iso_timestamp_converter(
+            storageclass.metadata.creation_timestamp
+        )
+        storageclass.metadata.deletion_timestamp = iso_timestamp_converter(
+            storageclass.metadata.deletion_timestamp
+        )
+        storage_classes[storageclass.metadata.name] = storageclass.to_dict()
+
+    return storage_classes
+
+
+def list_volumes(api_client, minion_id):
+    customObjectsApi = kubernetes.client.CustomObjectsApi(
+        api_client=api_client
+    )
+    try:
+        storage_classes = get_storage_classes(api_client)
+    except (ApiException, HTTPError) as exc:
+        error_tplt = (
+            'Exception while calling StorageV1->list_storage_class {}'
+        )
+        return __utils__['pillar_utils.errors_to_dict'](
+            [error_tplt.format(exc)]
+        )
+
+    if not storage_classes:
+        return {}
+
+    try:
+        volumes = customObjectsApi.list_cluster_custom_object(
+            group="storage.metalk8s.scality.com",
+            version="v1alpha1",
+            plural="volumes"
+        )
+    except (ApiException, HTTPError) as exc:
+        error_tplt = (
+            'Exception while calling CustomObjectsAPi->list_custom_object {}'
+        )
+        return __utils__['pillar_utils.errors_to_dict'](
+            [error_tplt.format(exc)]
+        )
+
+    results = {}
+    local_volumes = (
+        volume for volume in volumes['items']
+        if volume['spec']['nodeName'] == minion_id
+    )
+    for volume in local_volumes:
+        name = volume['metadata']['name']
+        storageclass = storage_classes.get(
+            volume['spec']['storageClassName']
+        )
+        if storageclass:
+            volume['spec']['storageClassName'] = storageclass
+            name = volume['metadata']['name']
+            results[name] = volume
+        else:
+            log.error('Unknown StorageClass "{}" for Volume "{}"'.format(
+                volume['spec']['storageClassName'], name)
+            )
+
+    return results
+
+
 def ext_pillar(minion_id, pillar, kubeconfig):
     if not os.path.isfile(kubeconfig):
         error_tplt = '{}: kubeconfig not found at {}'
@@ -57,6 +155,7 @@ def ext_pillar(minion_id, pillar, kubeconfig):
             error_tplt.format(__virtualname__, kubeconfig)
         ])
         cluster_version = pillar_nodes
+        volume_information = pillar_nodes
 
     else:
         ca_minion = None
@@ -72,29 +171,22 @@ def ext_pillar(minion_id, pillar, kubeconfig):
 
         node_list = coreV1.list_node()
 
-        cluster_version = None
-        namespace_information = coreV1.read_namespace(name="kube-system")
-
-        if namespace_information:
-            ns_info_dict = namespace_information.to_dict()
-            annotation_info = ns_info_dict.get(
-                'metadata', {}).get('annotations')
-            if annotation_info:
-                cluster_version = annotation_info.get(
-                    'metalk8s.scality.com/cluster-version'
-                )
-        if not cluster_version:
-            cluster_version = __utils__['pillar_utils.errors_to_dict'](
-                'Unable to retrieve cluster version'
-            )
+        cluster_version = get_cluster_version(api_client=client)
         pillar_nodes = dict(
             (node.metadata.name, node_info(node, ca_minion))
             for node in node_list.items
         )
 
-    return {
+        volume_information = list_volumes(client, minion_id)
+
+    result = {
         'metalk8s': {
             'nodes': pillar_nodes,
             'cluster_version': cluster_version,
+            'volumes': volume_information,
         },
     }
+    for key in ['nodes', 'volumes']:
+        __utils__['pillar_utils.promote_errors'](result['metalk8s'], key)
+
+    return result


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
'salt', 'kubernetes', 'storage'

**Context**: 

see: #1473

**Summary**:

- Be able to list all volumes on a node basis.
- Volume specific information is what we really want.

**Acceptance criteria**: 

1. You can test this locally by following : https://github.com/scality/metalk8s/pull/1452 (local deployment) to setup the storage operator and create test volumes.

2. Connect to the salt-master container and refresh the pillars  using `salt '*' saltutil.pillar_refresh`

3. On the bootstrap node, list the newly computed volume pillars using `salt-call pillar.get metalk8s:volumes`

4 The output should look like ;
```[root@bootstrap vagrant]# salt-call pillar.get metalk8s:volumes
    volumes:
            ----------
            example-volume:
                None
            example-volume3:
                ----------
                apiVersion:
                    storage.metalk8s.scality.com/v1alpha1
                kind:
                    Volume
                metadata:
                    ----------
                    annotations:
                        ----------
                        kubectl.kubernetes.io/last-applied-configuration:
                            {"apiVersion":"storage.metalk8s.scality.com/v1alpha1","kind":"Volume","metadata":{"annotations":{},"name":"example-volume3"},"spec":{"LoopDevice":{"size":"2Gi"},"nodeName":"bootstrap","storageClassName":"standard"}}
                    creationTimestamp:
                        2019-08-01T09:47:12Z
                    generation:
                        4
                    name:
                        example-volume3
                    resourceVersion:
                        104581
                    selfLink:
                        /apis/storage.metalk8s.scality.com/v1alpha1/volumes/example-volume3
                    uid:
                        a5fbfe40-c8e3-4623-ac59-c797739fa5d7
                spec:
                    ----------
                    LoopDevice:
                        ----------
                        size:
                            2Gi
                    nodeName:
                        bootstrap
                    storageClassName:
                        ----------
                        allow_volume_expansion:
                            None
                        allowed_topologies:
                            None
                        api_version:
                            None
                        kind:
                            None
                        metadata:
                            ----------
                            annotations:
                                ----------
                                kubectl.kubernetes.io/last-applied-configuration:
                                    {"apiVersion":"storage.k8s.io/v1","kind":"StorageClass","metadata":{"annotations":{},"name":"standard"},"mountOptions":["debug"],"parameters":{"type":"gp2"},"provisioner":"kubernetes.io/aws-ebs","reclaimPolicy":"Retain","volumeBindingMode":"Immediate"}
                            cluster_name:
                                None
                            creation_timestamp:
                                2019-07-31T10:02:11+00:00
                            deletion_grace_period_seconds:
                                None
                            deletion_timestamp:
                                None
                            finalizers:
                                None
                            generate_name:
                                None
                            generation:
                                None
                            initializers:
                                None
                            labels:
                                None
                            name:
                                standard
                            namespace:
                                None
                            owner_references:
                                None
                            resource_version:
                                1696
                            self_link:
                                /apis/storage.k8s.io/v1/storageclasses/standard
                            uid:
                                b1849754-e4bd-433a-b5de-8a1246febc4b
                        mount_options:
                            - debug
                        parameters:
                            ----------
                            type:
                                gp2
                        provisioner:
                            kubernetes.io/aws-ebs
                        reclaim_policy:
                            Retain
                        volume_binding_mode:
                            Immediate


```


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1473 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
