### PR TITLE
add loader for refresh volumes

### DIFF
--- a/ui/src/containers/NodeVolumes.js
+++ b/ui/src/containers/NodeVolumes.js
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
 import { injectIntl } from 'react-intl';
 import styled from 'styled-components';
 import { FormattedDate, FormattedTime } from 'react-intl';
 import { withRouter } from 'react-router-dom';
-import { Button, Table } from '@scality/core-ui';
+import { Button, Table, Loader } from '@scality/core-ui';
 import { padding } from '@scality/core-ui/dist/style/theme';
 import NoRowsRenderer from '../components/NoRowsRenderer';
 import {
@@ -13,11 +14,16 @@ import {
 } from '../services/utils';
 import {
   refreshVolumesAction,
-  stopRefreshVolumesAction
+  stopRefreshVolumesAction,
+  refreshPersistentVolumesAction,
+  stopRefreshPersistentVolumesAction
 } from '../ducks/app/volumes';
 
 const ButtonContainer = styled.div`
   margin-top: ${padding.small};
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 `;
 
 const VolumeTable = styled.div`
@@ -27,7 +33,11 @@ const VolumeTable = styled.div`
 
 const NodeVolumes = props => {
   useRefreshEffect(refreshVolumesAction, stopRefreshVolumesAction);
-
+  useRefreshEffect(
+    refreshPersistentVolumesAction,
+    stopRefreshPersistentVolumesAction
+  );
+  const volumes = useSelector(state => state.app.volumes);
   const [sortBy, setSortBy] = useState('name');
   const [sortDirection, setSortDirection] = useState('ASC');
   const onSort = ({ sortBy, sortDirection }) => {
@@ -58,7 +68,7 @@ const NodeVolumes = props => {
       dataKey: 'creationTime',
       renderer: data => (
         <span>
-          <FormattedDate value={data} />{' '}
+          <FormattedDate value={data} />
           <FormattedTime
             hour="2-digit"
             minute="2-digit"
@@ -95,6 +105,7 @@ const NodeVolumes = props => {
             props.history.push('createVolume');
           }}
         />
+        {volumes.isLoading && <Loader size="small" />}
       </ButtonContainer>
       <VolumeTable>
         <Table

--- a/ui/src/ducks/app/volumes.js
+++ b/ui/src/ducks/app/volumes.js
@@ -275,6 +275,7 @@ export function* fetchPersistentVolumeClaims() {
     yield put(setPersistentVolumeClaimAction(result.body.items));
   }
 }
+
 export function* refreshPersistentVolumes() {
   yield put(updatePersistentVolumesRefreshingAction(true));
   const result = yield call(fetchPersistentVolumes);

--- a/ui/src/ducks/app/volumes.js
+++ b/ui/src/ducks/app/volumes.js
@@ -25,6 +25,11 @@ const STOP_REFRESH_VOLUMES = 'STOP_REFRESH_VOLUMES';
 const UPDATE_VOLUMES_REFRESHING = 'UPDATE_VOLUMES_REFRESHING';
 const FETCH_PERSISTENT_VOLUME_CLAIMS = 'FETCH_PERSISTENT_VOLUME_CLAIMS';
 const SET_PERSISTENT_VOLUME_CLAIMS = 'SET_PERSISTENT_VOLUME_CLAIMS';
+const REFRESH_PERSISTENT_VOLUMES = 'REFRESH_PERSISTENT_VOLUMES';
+const STOP_REFRESH_PERSISTENT_VOLUMES = 'STOP_REFRESH_PERSISTENT_VOLUMES';
+const UPDATE_PERSISTENT_VOLUMES_REFRESHING =
+  'UPDATE_PERSISTENT_VOLUMES_REFRESHING';
+const UPDATE_VOLUMES = 'UPDATE_VOLUMES';
 
 // Reducer
 const defaultState = {
@@ -32,7 +37,9 @@ const defaultState = {
   storageClass: [],
   pVList: [],
   isRefreshing: false,
-  pVCList: []
+  pVCList: [],
+  isPVRefreshing: false,
+  isLoading: false
 };
 
 export default function reducer(state = defaultState, action = {}) {
@@ -47,6 +54,12 @@ export default function reducer(state = defaultState, action = {}) {
       return { ...state, isRefreshing: action.payload };
     case SET_PERSISTENT_VOLUME_CLAIMS:
       return { ...state, pVCList: action.payload };
+    case UPDATE_PERSISTENT_VOLUMES_REFRESHING: {
+      return { ...state, isPVRefreshing: action.payload };
+    }
+    case UPDATE_VOLUMES: {
+      return { ...state, ...action.payload };
+    }
     default:
       return state;
   }
@@ -100,12 +113,39 @@ export const stopRefreshVolumesAction = () => {
   return { type: STOP_REFRESH_VOLUMES };
 };
 
+export const refreshPersistentVolumesAction = () => {
+  return { type: REFRESH_PERSISTENT_VOLUMES };
+};
+
+export const updatePersistentVolumesRefreshingAction = payload => {
+  return { type: UPDATE_PERSISTENT_VOLUMES_REFRESHING, payload };
+};
+
+export const stopRefreshPersistentVolumesAction = () => {
+  return { type: STOP_REFRESH_PERSISTENT_VOLUMES };
+};
+
+export const updateVolumesAction = payload => {
+  return { type: UPDATE_VOLUMES, payload };
+};
+
 // Sagas
 export function* fetchVolumes() {
+  yield put(
+    updateVolumesAction({
+      isLoading: true
+    })
+  );
   const result = yield call(ApiK8s.getVolumes);
   if (!result.error) {
     yield put(setVolumesAction(result?.body?.items ?? []));
   }
+  yield delay(1000); // To make sure that the loader is visible for at least 1s
+  yield put(
+    updateVolumesAction({
+      isLoading: false
+    })
+  );
   return result;
 }
 
@@ -114,6 +154,7 @@ export function* fetchPersistentVolumes() {
   if (!result.error) {
     yield put(setPersistentVolumesAction(result?.body?.items ?? []));
   }
+  return result;
 }
 
 export function* fetchStorageClass() {
@@ -234,6 +275,23 @@ export function* fetchPersistentVolumeClaims() {
     yield put(setPersistentVolumeClaimAction(result.body.items));
   }
 }
+export function* refreshPersistentVolumes() {
+  yield put(updatePersistentVolumesRefreshingAction(true));
+  const result = yield call(fetchPersistentVolumes);
+  if (!result.error) {
+    yield delay(REFRESH_TIMEOUT);
+    const isPVRefreshing = yield select(
+      state => state.app.volumes.isPVRefreshing
+    );
+    if (isPVRefreshing) {
+      yield call(refreshPersistentVolumes);
+    }
+  }
+}
+
+export function* stopRefreshPersistentVolumes() {
+  yield put(updatePersistentVolumesRefreshingAction(false));
+}
 
 export function* volumesSaga() {
   yield takeLatest(FETCH_VOLUMES, fetchVolumes);
@@ -243,4 +301,9 @@ export function* volumesSaga() {
   yield takeLatest(REFRESH_VOLUMES, refreshVolumes);
   yield takeLatest(STOP_REFRESH_VOLUMES, stopRefreshVolumes);
   yield takeLatest(FETCH_PERSISTENT_VOLUME_CLAIMS, fetchPersistentVolumeClaims);
+  yield takeLatest(REFRESH_PERSISTENT_VOLUMES, refreshPersistentVolumes);
+  yield takeLatest(
+    STOP_REFRESH_PERSISTENT_VOLUMES,
+    stopRefreshPersistentVolumes
+  );
 }


### PR DESCRIPTION
**Component**: ui

**Context**: As a user, I would like to see the loader when the volume list is refreshing.

**Summary**: We add a loader above the volume list when the volume is refreshing.

**Acceptance criteria**: 
![image](https://user-images.githubusercontent.com/18453133/62359207-a134a280-b516-11e9-9bfa-3a4759e341d0.png)

See: #1459 
