### PR TITLE
Pin Terraform providers versions

### DIFF
--- a/eve/workers/openstack-multiple-nodes/terraform/provider.tf
+++ b/eve/workers/openstack-multiple-nodes/terraform/provider.tf
@@ -1,1 +1,11 @@
-provider "openstack" {}
+provider "null" {
+    version = "~> 2.1.2"
+}
+
+provider "openstack" {
+    version = "~> 1.20.0"
+}
+
+provider "random" {
+    version = "~> 2.1.2"
+}


### PR DESCRIPTION
A breaking change was introduced with the OpenStack provider in version
1.21, preventing the spawn from working.

We pin all versions to prevent such problems from happening again in the
future, although this means manual upgrades will be required.