### PR TITLE
Install only production dependency during build

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -5,7 +5,7 @@ FROM node:${NODE_IMAGE_VERSION} AS build-step
 
 WORKDIR /home/node
 COPY package*.json /home/node/
-RUN npm install
+RUN npm install --only=prod
 
 COPY public /home/node/public
 COPY src /home/node/src


### PR DESCRIPTION
**Component**: ui, build

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
During the build, `npm install` install all the dependency.
Cypress dependency is useless and take time to install (>3min).

**Summary**:
We install only production dependency.

**Acceptance criteria**: 
It's still build and pass the CI.

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1496

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
