### PR TITLE
Remove prometheus checking after the login

### DIFF
--- a/ui/cypress/integration/common/login.js
+++ b/ui/cypress/integration/common/login.js
@@ -5,7 +5,6 @@ Given('I log in', () => {
   cy.visit(target_url);
   cy.server();
   cy.route('GET', '/api/v1').as('getAPIResourceList');
-  cy.route('GET', '**/alerts').as('getAlerts');
 
   const userName = Cypress.env('username');
   const userPassword = Cypress.env('password');
@@ -13,10 +12,10 @@ Given('I log in', () => {
   cy.get('input[type=text]').type(userName);
   cy.get('input[type=password]').type(userPassword);
   cy.get('button').click();
-  cy.wait(['@getAPIResourceList', '@getAlerts'], {
+  cy.wait('@getAPIResourceList', {
     log: true,
-    requestTimeout: 20000,
-    responseTimeout: 20000
+    requestTimeout: 30000,
+    responseTimeout: 30000
   });
 
   cy.get('.sc-navbar .sc-dropdown > .trigger > .sc-trigger-text').should(

--- a/ui/cypress/integration/common/login.js
+++ b/ui/cypress/integration/common/login.js
@@ -5,6 +5,7 @@ Given('I log in', () => {
   cy.visit(target_url);
   cy.server();
   cy.route('GET', '/api/v1').as('getAPIResourceList');
+  cy.route('POST', '/login').as('saltAuthentication');
 
   const userName = Cypress.env('username');
   const userPassword = Cypress.env('password');
@@ -12,11 +13,13 @@ Given('I log in', () => {
   cy.get('input[type=text]').type(userName);
   cy.get('input[type=password]').type(userPassword);
   cy.get('button').click();
-  cy.wait('@getAPIResourceList', {
-    log: true,
+
+  const timeOut = {
     requestTimeout: 30000,
     responseTimeout: 30000
-  });
+  };
+  cy.wait('@getAPIResourceList', timeOut);
+  cy.wait('@saltAuthentication', timeOut);
 
   cy.get('.sc-navbar .sc-dropdown > .trigger > .sc-trigger-text').should(
     'contain',


### PR DESCRIPTION

**Component**: ui, tests

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
There is a lot of Cypress flackies because of the call on `/api/v1/alerts`
For some reason prometheus api is not totally available some time.

Since prometheus is not really related to the login, we can remove the
checking and do it in an another test.

**Summary**:
- Remove the checking on `/api/v1/alerts` during the login test.
- Increase the timeout from 20sec to 30sec for `apiserver` checking.

**Acceptance criteria**: 
The build pass, and there is no more flackies link to Cypress (we can only see that in future PR)
