### PR TITLE
WIP: Update prometheus deployment to use a pvc

### DIFF
--- a/salt/metalk8s/addons/monitoring/prometheus/upstream.sls
+++ b/salt/metalk8s/addons/monitoring/prometheus/upstream.sls
@@ -1356,6 +1356,19 @@ spec:
   - key: "node-role.kubernetes.io/infra"
     operator: "Exists"
     effect: "NoSchedule"
+  storage:
+    volumeClaimTemplate:
+      apiVersion: v1
+      metadata:
+        name: prometheus-monitoring
+      kind: PersistentVolumeClaim
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 5Gi
+        storageClassName: metalk8s-prometheus
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/tests/post/features/monitoring.feature
+++ b/tests/post/features/monitoring.feature
@@ -1,5 +1,10 @@
 @post @ci @local @monitoring
 Feature: Monitoring is up and running
+    Scenario: Create Persistent Volume
+        Given the Kubernetes API is available
+        And Persistent Volume Claim 'prometheus-monitoring' in namespace 'monitoring' is available
+        Then create persistent volume 'test-prom-volume' for pods in monitoring namespace with storageclass 'metalk8s-prometheus' of size '5Gi'
+
     Scenario: List Pods
         Given the Kubernetes API is available
         Then the 'pods' list should not be empty in the 'monitoring' namespace


### PR DESCRIPTION
**Component**:

'salt', 'monitoring', 'tests', documentation
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

See: #1515 

**Summary**:

We should be able to use the Prometheus volume to store metrics even after pod restarts or upgrade.

For this, we need to add a persistent volume claim within the Prometheus deployment file, create a  persistent volume,  in the `metalk8s-Prometheus` storageclass and bind it to the PVC.

**Acceptance criteria**: 

- Boostrapping metalk8s should still work
- CI e2e test should continue to work.
- The Prometheus deployment should include a Persistent Volume Claim automatically.
- For e2e test,  create a PV that can satisfy the PVC
- Documentation on how to create a PV that binds to the PVC should be added.
---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1515 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
