### PR TITLE
Change single node and multi node images to a more recent one

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -139,7 +139,7 @@ stages:
   single-node:
     worker:
       type: openstack
-      image: CentOS 7 (PVHVM)
+      image: CentOS-7-x86_64-GenericCloud-1809.qcow2
       flavor: m1.medium
       path: eve/workers/openstack-single-node
     steps:
@@ -265,7 +265,7 @@ stages:
   multiple-nodes:
     worker:
       type: openstack
-      image: CentOS 7 (PVHVM)
+      image: CentOS-7-x86_64-GenericCloud-1809.qcow2
       flavor: m1.medium
       path: eve/workers/openstack-multiple-nodes
     steps:


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
CentOS 7 (PVHVM) is not maintained anymore
We should use CentOS-7-x86_64-GenericCloud-1809.qcow2 instead

**Summary**:
Change centos image on single node and multi node from `CentOS 7 (PVHVM)` to `CentOS-7-x86_64-GenericCloud-1809.qcow2`

**Acceptance criteria**: 
It build correctly and we do not have issue like : 
```
7:14 failed 'terraform init' (failure) 'for host ...' (failure) 'for host ...' (failure) 'for _ ...' (failure)
```
or 
```
15:52 failed 'tox -e ...' (failure)
```

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
