### PR TITLE
Add missing argument in delete namespaced service

### DIFF
--- a/salt/_modules/metalk8s_kubernetes.py
+++ b/salt/_modules/metalk8s_kubernetes.py
@@ -900,8 +900,10 @@ def delete_service(name, namespace='default', **kwargs):
 
     try:
         api_instance = kubernetes.client.CoreV1Api()
+        body = kubernetes.client.V1DeleteOptions()
         api_response = api_instance.delete_namespaced_service(
             name=name,
+            body=body,
             namespace=namespace)
 
         return api_response.to_dict()


### PR DESCRIPTION
Fix: #1525

**Component**: salt, metalk8s_kubernetes

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
the state service_absent not working
**Summary**:
delete_namespaced_service require a `V1deleteOptions` body
**Acceptance criteria**: 
service_absent should be working

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #1525 

-->
