### PR TITLE
Integrate core-ui Select and Modal components

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1637,8 +1637,8 @@
       "integrity": "sha512-8/qcMh15507AnXJ3lBeuhsdFwnWQqnp68EpUuHlYPixJ5vjVmls7/Jq48cnUlrZI8Jd9U1jkhfCl0gaT5KMgVw=="
     },
     "@scality/core-ui": {
-      "version": "github:scality/core-ui#ef5a8561fdc76669d03bb8f648ac36d18f820616",
-      "from": "github:scality/core-ui#ef5a856"
+      "version": "github:scality/core-ui#094b88f4c1217683a57e0a7abd60955b08b8f419",
+      "from": "github:scality/core-ui#094b88f"
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "4.2.0",
@@ -6281,11 +6281,6 @@
           "dev": true
         }
       }
-    },
-    "exenv": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
-      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
     },
     "exit": {
       "version": "0.1.2",
@@ -12812,17 +12807,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
-    "react-modal": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.9.1.tgz",
-      "integrity": "sha512-k+TUkhGWpIVHLsEyjNmlyOYL0Uz03fNZvlkhCImd1h+6fhNgTi6H6jexVXPVhD2LMMDzJyfugxMN+APN/em+eQ==",
-      "requires": {
-        "exenv": "^1.2.0",
-        "prop-types": "^15.5.10",
-        "react-lifecycles-compat": "^3.0.0",
-        "warning": "^4.0.3"
-      }
     },
     "react-redux": {
       "version": "7.1.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1637,8 +1637,8 @@
       "integrity": "sha512-8/qcMh15507AnXJ3lBeuhsdFwnWQqnp68EpUuHlYPixJ5vjVmls7/Jq48cnUlrZI8Jd9U1jkhfCl0gaT5KMgVw=="
     },
     "@scality/core-ui": {
-      "version": "github:scality/core-ui#32af7cc9b0d5864fcb13da59fe7fbce81bdeb99a",
-      "from": "github:scality/core-ui#32af7cc"
+      "version": "github:scality/core-ui#ef5a8561fdc76669d03bb8f648ac36d18f820616",
+      "from": "github:scality/core-ui#ef5a856"
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "4.2.0",
@@ -3462,8 +3462,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3481,13 +3480,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3500,18 +3497,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3614,8 +3608,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3625,7 +3618,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3638,20 +3630,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3668,7 +3657,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3741,8 +3729,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3752,7 +3739,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3828,8 +3814,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3859,7 +3844,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3877,7 +3861,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3916,13 +3899,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -8456,8 +8437,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -8475,13 +8455,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -8494,18 +8472,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -8608,8 +8583,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -8619,7 +8593,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -8632,20 +8605,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -8662,7 +8632,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -8735,8 +8704,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -8746,7 +8714,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -8822,8 +8789,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -8853,7 +8819,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -8871,7 +8836,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -8910,13 +8874,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         }
@@ -12800,6 +12762,14 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
       "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
     },
+    "react-input-autosize": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.1.tgz",
+      "integrity": "sha512-3+K4CD13iE4lQQ2WlF8PuV5htfmTRLH6MDnfndHM6LuBRszuXnuyIfE7nhSKt8AzRBZ50bu0sAhkNMeS5pxQQA==",
+      "requires": {
+        "prop-types": "^15.5.8"
+      }
+    },
     "react-intl": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-2.9.0.tgz",
@@ -12965,6 +12935,16 @@
         "workbox-webpack-plugin": "4.3.1"
       }
     },
+    "react-select": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.3.0.tgz",
+      "integrity": "sha512-g/QAU1HZrzSfxkwMAo/wzi6/ezdWye302RGZevsATec07hI/iSxcpB1hejFIp7V63DJ8mwuign6KmB3VjdlinQ==",
+      "requires": {
+        "classnames": "^2.2.4",
+        "prop-types": "^15.5.8",
+        "react-input-autosize": "^2.1.2"
+      }
+    },
     "react-textarea-autosize": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-6.1.0.tgz",
@@ -12985,6 +12965,17 @@
         "loose-envify": "^1.3.0",
         "prop-types": "^15.6.0",
         "react-lifecycles-compat": "^3.0.4"
+      }
+    },
+    "react-virtualized-select": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/react-virtualized-select/-/react-virtualized-select-3.1.3.tgz",
+      "integrity": "sha512-u6j/EfynCB9s4Lz5GGZhNUCZHvFQdtLZws7W/Tcd/v03l19OjpQs3eYjK82iYS0FgD2+lDIBpqS8LpD/hjqDRQ==",
+      "requires": {
+        "babel-runtime": "^6.11.6",
+        "prop-types": "^15.5.8",
+        "react-select": "^1.0.0-rc.2",
+        "react-virtualized": "^9.0.0"
       }
     },
     "read-only-stream": {
@@ -15496,8 +15487,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -15518,14 +15508,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -15540,20 +15528,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -15670,8 +15655,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -15683,7 +15667,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -15698,7 +15681,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -15706,14 +15688,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -15732,7 +15712,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -15813,8 +15792,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -15826,7 +15804,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -15912,8 +15889,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -15949,7 +15925,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -15969,7 +15944,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -16013,14 +15987,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.7.2",
     "@kubernetes/client-node": "github:scality/kubernetes-client-javascript.git#browser-dist",
-    "@scality/core-ui": "github:scality/core-ui.git#32af7cc",
+    "@scality/core-ui": "github:scality/core-ui.git#ef5a856",
     "axios": "^0.18.0",
     "formik": "1.5.1",
     "lodash": "4.17.13",
@@ -22,6 +22,7 @@
     "react-router-dom": "^4.3.1",
     "react-scripts": "^3.0.1",
     "react-virtualized": "^9.21.0",
+    "react-virtualized-select": "3.1.3",
     "redux": "^4.0.1",
     "redux-saga": "^1.0.2",
     "reselect": "^2.5.4",

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.7.2",
     "@kubernetes/client-node": "github:scality/kubernetes-client-javascript.git#browser-dist",
-    "@scality/core-ui": "github:scality/core-ui.git#ef5a856",
+    "@scality/core-ui": "github:scality/core-ui.git#094b88f",
     "axios": "^0.18.0",
     "formik": "1.5.1",
     "lodash": "4.17.13",
@@ -16,7 +16,6 @@
     "react-dom": "^16.8.1",
     "react-intl": "^2.8.0",
     "react-json-view": "1.19.1",
-    "react-modal": "^3.9.1",
     "react-redux": "^7.1.0",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",

--- a/ui/src/containers/App.js
+++ b/ui/src/containers/App.js
@@ -1,10 +1,13 @@
+import '@fortawesome/fontawesome-free/css/all.css';
+import 'react-select/dist/react-select.css';
+import 'react-virtualized-select/styles.css';
+
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { withRouter, Route, Switch } from 'react-router-dom';
 import { IntlProvider, addLocaleData } from 'react-intl';
 import locale_en from 'react-intl/locale-data/en';
 import locale_fr from 'react-intl/locale-data/fr';
-import '@fortawesome/fontawesome-free/css/all.css';
 import Loader from '../components/Loader';
 
 import translations_en from '../translations/en';

--- a/ui/src/containers/CreateVolume.js
+++ b/ui/src/containers/CreateVolume.js
@@ -267,7 +267,7 @@ const CreateVolume = props => {
                     type="select"
                     options={optionsStorageClasses}
                     placeholder={intl.messages.select_a_storageClass}
-                    noResultsText={intl.messages.not_found}
+                    noResultsText={intl.messages.no_results}
                     name="storageClass"
                     onChange={handleSelectChange('storageClass')}
                     value={values.storageClass}
@@ -281,7 +281,7 @@ const CreateVolume = props => {
                     type="select"
                     options={optionsTypes}
                     placeholder={intl.messages.select_a_type}
-                    noResultsText={intl.messages.not_found}
+                    noResultsText={intl.messages.no_results}
                     name="type"
                     onChange={handleSelectChange('type')}
                     value={values.type}
@@ -308,7 +308,7 @@ const CreateVolume = props => {
                           type="select"
                           options={optionsSizeUnits}
                           placeholder={intl.messages.select_a_type}
-                          noResultsText={intl.messages.not_found}
+                          noResultsText={intl.messages.no_results}
                           name="selectedUnit"
                           onChange={handleSelectChange('selectedUnit')}
                           value={values.selectedUnit}

--- a/ui/src/containers/CreateVolume.js
+++ b/ui/src/containers/CreateVolume.js
@@ -218,7 +218,7 @@ const CreateVolume = props => {
             //touched is not "always" correctly set
             const handleOnBlur = e => setFieldTouched(e.target.name, true);
             const handleSelectChange = field => selectedObj => {
-              setFieldValue(field, selectedObj.value);
+              setFieldValue(field, selectedObj ? selectedObj.value : '');
             };
 
             const optionsStorageClasses = storageClassesName.map(SCName => {

--- a/ui/src/containers/CreateVolume.js
+++ b/ui/src/containers/CreateVolume.js
@@ -67,12 +67,10 @@ const CreateVolumeLayout = styled.div`
 
 const SizeFieldContainer = styled.div`
   display: inline-flex;
-  align-items: center;
-  .sc-input-wrapper {
-    width: 150px;
-  }
-  .size-unit-input {
-    width: 100%;
+  align-items: flex-start;
+  .sc-input-wrapper,
+  .sc-input-type {
+    width: 120px;
     box-sizing: border-box;
   }
 `;
@@ -294,7 +292,6 @@ const CreateVolume = props => {
                     <SizeFieldContainer>
                       <Input
                         name="sizeInput"
-                        className="size-unit-input"
                         type="number"
                         min="1"
                         value={values.sizeInput}

--- a/ui/src/containers/CreateVolume.js
+++ b/ui/src/containers/CreateVolume.js
@@ -12,7 +12,7 @@ import {
   fetchStorageClassAction,
   createVolumeAction
 } from '../ducks/app/volumes';
-import { fontSize, padding } from '@scality/core-ui/dist/style/theme';
+import { padding } from '@scality/core-ui/dist/style/theme';
 import {
   SPARSE_LOOP_DEVICE,
   RAW_BLOCK_DEVICE,
@@ -65,21 +65,6 @@ const CreateVolumeLayout = styled.div`
   }
 `;
 
-const SelectLabel = styled.label`
-  width: 200px;
-  padding: 10px;
-  font-size: ${fontSize.base};
-`;
-
-const SelectFieldContainer = styled.div`
-  display: inline-flex;
-  align-items: center;
-`;
-
-const SelectField = styled.select`
-  width: 200px;
-`;
-
 const SizeFieldContainer = styled.div`
   display: inline-flex;
   align-items: center;
@@ -93,8 +78,10 @@ const SizeFieldContainer = styled.div`
 `;
 
 const SizeUnitFieldSelectContainer = styled.div`
-  width: 50px;
-  padding-left: 5px;
+  .sc-select {
+    width: 75px;
+    padding-left: 5px;
+  }
 `;
 
 const CreateVolume = props => {
@@ -226,11 +213,44 @@ const CreateVolume = props => {
               errors,
               touched,
               setFieldTouched,
-              dirty
+              dirty,
+              setFieldValue
             } = formikProps;
 
             //touched is not "always" correctly set
             const handleOnBlur = e => setFieldTouched(e.target.name, true);
+            const handleSelectChange = field => selectedObj => {
+              setFieldValue(field, selectedObj.value);
+            };
+
+            const optionsStorageClasses = storageClassesName.map(SCName => {
+              return {
+                label: SCName,
+                value: SCName
+              };
+            });
+
+            const optionsTypes = types.map(({ label, value }) => {
+              return {
+                label,
+                value
+              };
+            });
+
+            const optionsSizeUnits = sizeUnits
+              /**
+               * `sizeUnits` have a base 2 and base 10 units
+               * (ie. KiB and KB).
+               * We chose to only display base 2 units
+               * to improve the UX.
+               */
+              .filter((size, idx) => idx < 6)
+              .map(({ label, value }) => {
+                return {
+                  label,
+                  value
+                };
+              });
             return (
               <Form>
                 <FormSection>
@@ -242,38 +262,34 @@ const CreateVolume = props => {
                     error={touched.name && errors.name}
                     onBlur={handleOnBlur}
                   />
-                  <SelectFieldContainer>
-                    <SelectLabel>{intl.messages.storageClass}</SelectLabel>
-                    <SelectField
-                      name="storageClass"
-                      onChange={handleChange('storageClass')}
-                      value={values.storageClass}
-                      error={touched.storageClass && errors.storageClass}
-                      onBlur={handleOnBlur}
-                    >
-                      {storageClassesName.map((SCName, idx) => (
-                        <option key={`storageClass_${idx}`} value={SCName}>
-                          {SCName}
-                        </option>
-                      ))}
-                    </SelectField>
-                  </SelectFieldContainer>
-                  <SelectFieldContainer>
-                    <SelectLabel>{intl.messages.type}</SelectLabel>
-                    <SelectField
-                      name="type"
-                      onChange={handleChange('type')}
-                      error={touched.type && errors.type}
-                      onBlur={handleOnBlur}
-                    >
-                      {types.map((type, idx) => (
-                        <option key={`type_${idx}`} value={type.value}>
-                          {type.label}
-                        </option>
-                      ))}
-                    </SelectField>
-                  </SelectFieldContainer>
-
+                  <Input
+                    id="storageClass_input"
+                    label={intl.messages.storageClass}
+                    clearable={false}
+                    type="select"
+                    options={optionsStorageClasses}
+                    placeholder={intl.messages.select_a_storageClass}
+                    noResultsText={intl.messages.not_found}
+                    name="storageClass"
+                    onChange={handleSelectChange('storageClass')}
+                    value={values.storageClass}
+                    error={touched.storageClass && errors.storageClass}
+                    onBlur={handleOnBlur}
+                  />
+                  <Input
+                    id="type_input"
+                    label={intl.messages.type}
+                    clearable={false}
+                    type="select"
+                    options={optionsTypes}
+                    placeholder={intl.messages.select_a_type}
+                    noResultsText={intl.messages.not_found}
+                    name="type"
+                    onChange={handleSelectChange('type')}
+                    value={values.type}
+                    error={touched.type && errors.type}
+                    onBlur={handleOnBlur}
+                  />
                   {values.type === SPARSE_LOOP_DEVICE ? (
                     <SizeFieldContainer>
                       <Input
@@ -288,29 +304,20 @@ const CreateVolume = props => {
                         onBlur={handleOnBlur}
                       />
                       <SizeUnitFieldSelectContainer>
-                        <select
+                        <Input
+                          id="unit_input"
+                          label=""
+                          clearable={false}
+                          type="select"
+                          options={optionsSizeUnits}
+                          placeholder={intl.messages.select_a_type}
+                          noResultsText={intl.messages.not_found}
                           name="selectedUnit"
+                          onChange={handleSelectChange('selectedUnit')}
                           value={values.selectedUnit}
-                          onChange={handleChange('selectedUnit')}
                           error={touched.selectedUnit && errors.selectedUnit}
                           onBlur={handleOnBlur}
-                        >
-                          {sizeUnits
-                            /**
-                             * `sizeUnits` have a base 2 and base 10 units
-                             * (ie. KiB and KB).
-                             * We chose to only display base 2 units
-                             * to improve the UX.
-                             */
-                            .filter((size, idx) => idx < 6)
-                            .map(({ label, value }, idx) => {
-                              return (
-                                <option key={`sizeUnits_${idx}`} value={value}>
-                                  {label}
-                                </option>
-                              );
-                            })}
-                        </select>
+                        />
                       </SizeUnitFieldSelectContainer>
                     </SizeFieldContainer>
                   ) : (

--- a/ui/src/containers/NodeVolumes.js
+++ b/ui/src/containers/NodeVolumes.js
@@ -4,8 +4,7 @@ import { injectIntl } from 'react-intl';
 import styled from 'styled-components';
 import { FormattedDate, FormattedTime } from 'react-intl';
 import { withRouter } from 'react-router-dom';
-import Modal from 'react-modal';
-import { Button, Table, Loader } from '@scality/core-ui';
+import { Button, Table, Loader, Modal } from '@scality/core-ui';
 import { padding, grayLight } from '@scality/core-ui/dist/style/theme';
 import NoRowsRenderer from '../components/NoRowsRenderer';
 import Tooltip from '../components/Tooltip';
@@ -46,24 +45,17 @@ const VolumeTable = styled.div`
   }
 `;
 
-const DeleteConfirmationModal = {
-  content: {
-    top: '50%',
-    left: '50%',
-    width: '540px',
-    height: '200px',
-    transform: 'translate(-50%, -50%)'
-  }
-};
-
 const NotificationButtonGroup = styled.div`
   display: flex;
   justify-content: flex-end;
-  margin-top: ${padding.larger};
 `;
 
 const DeleteButton = styled(Button)`
   margin-left: ${padding.small};
+`;
+
+const ModalBody = styled.div`
+  padding-bottom: ${padding.base};
 `;
 
 const IconButton = styled.button`
@@ -294,32 +286,36 @@ const NodeVolumes = props => {
   return (
     <>
       <Modal
+        close={() => setisDeleteConfirmationModalOpen(false)}
         isOpen={isDeleteConfirmationModalOpen}
-        ariaHideApp={false}
-        style={DeleteConfirmationModal}
+        title={intl.messages.delete_a_volume}
+        footer={
+          <NotificationButtonGroup>
+            <Button
+              outlined
+              text={intl.messages.cancel}
+              onClick={onClickCancelButton}
+            />
+            <DeleteButton
+              variant="danger"
+              text={intl.messages.delete}
+              onClick={e => {
+                e.stopPropagation();
+                onClickDeleteButton(deleteVolumeName);
+              }}
+            />
+          </NotificationButtonGroup>
+        }
       >
-        <h2>{intl.messages.delete_a_volume}</h2>
-        <div>{intl.messages.delete_a_volume_warning}</div>
-        <div>
-          {intl.messages.delete_a_volume_confirm}
-          <strong>{deleteVolumeName}</strong>?
-        </div>
-        <NotificationButtonGroup>
-          <Button
-            outlined
-            text={intl.messages.cancel}
-            onClick={onClickCancelButton}
-          />
-          <DeleteButton
-            variant="danger"
-            text={intl.messages.delete}
-            onClick={e => {
-              e.stopPropagation();
-              onClickDeleteButton(deleteVolumeName);
-            }}
-          />
-        </NotificationButtonGroup>
+        <ModalBody>
+          <div>{intl.messages.delete_a_volume_warning}</div>
+          <div>
+            {intl.messages.delete_a_volume_confirm}
+            <strong>{deleteVolumeName}</strong>?
+          </div>
+        </ModalBody>
       </Modal>
+
       <ButtonContainer>
         <Button
           text={intl.messages.create_new_volume}

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -110,6 +110,6 @@
   "delete_a_volume_warning": "Deleting this volume will permanently delete the data it contains.",
   "delete_a_volume_confirm": "Do you want to delete ",
   "select_a_storageClass": "Select a Storage Class…",
-  "select_a_type": "Select a type…",
+  "select_a_type": "Select a type of volume…",
   "no_results": "No results"
 }

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -109,7 +109,7 @@
   "delete_a_volume": "Delete a volume",
   "delete_a_volume_warning": "Deleting this volume will permanently delete the data it contains.",
   "delete_a_volume_confirm": "Do you want to delete ",
-  "select_a_storageClass": "Select a Storage Class...",
-  "select_a_type": "Select a type...",
-  "not_found": "Not found"
+  "select_a_storageClass": "Select a Storage Class…",
+  "select_a_type": "Select a type…",
+  "no_results": "No results"
 }

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -108,5 +108,8 @@
   "volume_statue_failed_pv_bound_hint": "The volume is bound to a storage request.",
   "delete_a_volume": "Delete a volume",
   "delete_a_volume_warning": "Deleting this volume will permanently delete the data it contains.",
-  "delete_a_volume_confirm": "Do you want to delete "
+  "delete_a_volume_confirm": "Do you want to delete ",
+  "select_a_storageClass": "Select a Storage Class...",
+  "select_a_type": "Select a type...",
+  "not_found": "Not found"
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -109,7 +109,7 @@
   "delete_a_volume": "Supprimer un volume",
   "delete_a_volume_warning": "La suppression de ce volume entraînera la perte des données qu'il contient.",
   "delete_a_volume_confirm": "Voulez-vous supprimez ",
-  "select_a_storageClass": "Sélectionner une classe de stockage...",
-  "select_a_type": "Sélectionner un type...",
+  "select_a_storageClass": "Sélectionner une classe de stockage…",
+  "select_a_type": "Sélectionner un type…",
   "no_results": "Aucun résultat"
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -111,5 +111,5 @@
   "delete_a_volume_confirm": "Voulez-vous supprimez ",
   "select_a_storageClass": "Sélectionner une classe de stockage...",
   "select_a_type": "Sélectionner un type...",
-  "not_found": "Pas trouvé"
+  "no_results": "Aucun résultat"
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -110,6 +110,6 @@
   "delete_a_volume_warning": "La suppression de ce volume entraînera la perte des données qu'il contient.",
   "delete_a_volume_confirm": "Voulez-vous supprimez ",
   "select_a_storageClass": "Sélectionner une classe de stockage…",
-  "select_a_type": "Sélectionner un type…",
+  "select_a_type": "Sélectionner un type de volume…",
   "no_results": "Aucun résultat"
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -108,5 +108,8 @@
   "volume_statue_failed_pv_bound_hint": "Le volume est lié à une demande de stockage.",
   "delete_a_volume": "Supprimer un volume",
   "delete_a_volume_warning": "La suppression de ce volume entraînera la perte des données qu'il contient.",
-  "delete_a_volume_confirm": "Voulez-vous supprimez "
+  "delete_a_volume_confirm": "Voulez-vous supprimez ",
+  "select_a_storageClass": "Sélectionner une classe de stockage...",
+  "select_a_type": "Sélectionner un type...",
+  "not_found": "Pas trouvé"
 }


### PR DESCRIPTION
**Component**: UI

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
- Currently we use the native select and react-modal's Modal, they should be replaced by Core-ui components.

**Summary**:

**Acceptance criteria**: 

![image](https://user-images.githubusercontent.com/47394132/63348463-9624a380-c359-11e9-8ee4-a9b9bb68df27.png)

![image](https://user-images.githubusercontent.com/47394132/63350669-24028d80-c35e-11e9-91b5-8b47c9caad75.png)

![image](https://user-images.githubusercontent.com/47394132/63361844-2a4e3500-c371-11e9-9ead-2763404a504c.png)

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: 

<!-- If you want to refer to an issue while not closing it, use:

See: https://github.com/scality/metalk8s/issues/1531

-->
