### PR TITLE
Add automated tests for the entire volume workflow

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,6 +131,11 @@ def utils_image(registry_address, version):
     )
 
 
+@pytest.fixture
+def ssh_config(request):
+    return request.config.getoption('--ssh-config')
+
+
 # }}}
 # Given {{{
 

--- a/tests/install/steps/test_expansion.py
+++ b/tests/install/steps/test_expansion.py
@@ -11,9 +11,7 @@ import yaml
 from tests import utils
 
 # Scenarios
-@scenario('../features/expansion.feature',
-          'Add one node to the cluster',
-          strict_gherkin=False)
+@scenario('../features/expansion.feature', 'Add one node to the cluster')
 def test_cluster_expansion(host):
     pass
 

--- a/tests/install/steps/test_expansion.py
+++ b/tests/install/steps/test_expansion.py
@@ -15,13 +15,6 @@ from tests import utils
 def test_cluster_expansion(host):
     pass
 
-# Fixtures {{{
-
-@pytest.fixture
-def ssh_config(request):
-    return request.config.getoption('--ssh-config')
-
-# }}}
 # When {{{
 
 @when(parsers.parse('we declare a new "{node_type}" node on host "{hostname}"'))

--- a/tests/kube_utils.py
+++ b/tests/kube_utils.py
@@ -22,7 +22,7 @@ def get_pods(
     ).items
 
 
-def wait_for_pod(k8s_client, name, namespace="default", state="Running"):
+def check_pod_status(k8s_client, name, namespace="default", state="Running"):
     """Helper to generate a simple assertion method to check a Pod state.
 
     It is designed to be used with `tests.utils.retry`, and handles 404
@@ -30,7 +30,7 @@ def wait_for_pod(k8s_client, name, namespace="default", state="Running"):
     `retry`).
     """
 
-    def _wait_for_pod():
+    def _check_pod_status():
         try:
             pod = k8s_client.read_namespaced_pod(
                 name=name, namespace=namespace
@@ -44,4 +44,4 @@ def wait_for_pod(k8s_client, name, namespace="default", state="Running"):
 
         return pod
 
-    return _wait_for_pod
+    return _check_pod_status

--- a/tests/post/features/volume.feature
+++ b/tests/post/features/volume.feature
@@ -64,3 +64,16 @@ Feature: Volume management
               someRandomDevice:
                 capacity: 10Gi
         Then the Volume 'volume5' is 'Failed' with code 'InternalError' and message matches 'volume type not found'
+
+    Scenario: Test in-use protection
+        Given a Volume 'volume6' exist
+        And a PersistentVolumeClaim exists for 'volume6'
+        And a Pod using volume 'volume6' and running '["sleep", "60"]' exist
+        When I delete the Volume 'volume6'
+        Then the Volume 'volume6' is 'Available'
+        And the Volume 'volume6' is marked for deletion
+        And the PersistentVolume 'volume6' is marked for deletion
+        When I delete the Pod using 'volume6'
+        And I delete the PersistentVolumeClaim on 'volume6'
+        Then the Volume 'volume6' does not exist
+        And the PersistentVolume 'volume6' does not exist

--- a/tests/post/features/volume.feature
+++ b/tests/post/features/volume.feature
@@ -77,3 +77,11 @@ Feature: Volume management
         And I delete the PersistentVolumeClaim on 'volume6'
         Then the Volume 'volume6' does not exist
         And the PersistentVolume 'volume6' does not exist
+
+    Scenario: Volume usage (data persistency)
+        Given a Volume 'volume7' exist
+        And a PersistentVolumeClaim exists for 'volume7'
+        And a Pod using volume 'volume7' and running '["sh", "-c", "echo 'foo' > /mnt/bar.txt"]' exist
+        When I delete the Pod using 'volume7'
+        And I create a Pod using volume 'volume7' and running '["sleep", "60"]'
+        Then the Pod using volume 'volume7' has a file '/mnt/bar.txt' containing 'foo'

--- a/tests/post/features/volume.feature
+++ b/tests/post/features/volume.feature
@@ -50,3 +50,17 @@ Feature: Volume management
               nodeName: bootstrap
               storageClassName: metalk8s-prometheus
         Then the Volume 'volume4' is 'Failed' with code 'InternalError' and message matches 'volume type not found'
+
+    Scenario: Create a volume with an invalid volume type
+        Given the Kubernetes API is available
+        When I create the following Volume:
+            apiVersion: storage.metalk8s.scality.com/v1alpha1
+            kind: Volume
+            metadata:
+              name: volume5
+            spec:
+              nodeName: bootstrap
+              storageClassName: metalk8s-prometheus
+              someRandomDevice:
+                capacity: 10Gi
+        Then the Volume 'volume5' is 'Failed' with code 'InternalError' and message matches 'volume type not found'

--- a/tests/post/features/volume.feature
+++ b/tests/post/features/volume.feature
@@ -38,3 +38,15 @@ Feature: Volume management
         When I delete the Volume 'volume3'
         Then the Volume 'volume3' does not exist
         And the PersistentVolume 'volume3' does not exist
+
+    Scenario: Create a volume with no volume type
+        Given the Kubernetes API is available
+        When I create the following Volume:
+            apiVersion: storage.metalk8s.scality.com/v1alpha1
+            kind: Volume
+            metadata:
+              name: volume4
+            spec:
+              nodeName: bootstrap
+              storageClassName: metalk8s-prometheus
+        Then the Volume 'volume4' is 'Failed' with code 'InternalError' and message matches 'volume type not found'

--- a/tests/post/features/volume.feature
+++ b/tests/post/features/volume.feature
@@ -8,3 +8,18 @@ Feature: Volume management
     Scenario: The storage operator is up
         Given the Kubernetes API is available
         Then we have 1 running pod labeled 'name=storage-operator' in namespace 'kube-system'
+
+    Scenario: Test volume creation (sparseLoopDevice)
+        Given the Kubernetes API is available
+        When I create the following Volume:
+            apiVersion: storage.metalk8s.scality.com/v1alpha1
+            kind: Volume
+            metadata:
+              name: volume1
+            spec:
+              nodeName: bootstrap
+              storageClassName: metalk8s-prometheus
+              sparseLoopDevice:
+                size: 10Gi
+        Then the Volume 'volume1' is 'Available'
+        And the PersistentVolume 'volume1' has size '10Gi'

--- a/tests/post/features/volume.feature
+++ b/tests/post/features/volume.feature
@@ -29,3 +29,12 @@ Feature: Volume management
         When I delete the Volume 'volume2'
         Then the Volume 'volume2' does not exist
         And the PersistentVolume 'volume2' does not exist
+
+    Scenario: Test PersistentVolume protection
+        Given a Volume 'volume3' exist
+        When I delete the PersistentVolume 'volume3'
+        Then the PersistentVolume 'volume3' is marked for deletion
+        And the Volume 'volume3' is 'Available'
+        When I delete the Volume 'volume3'
+        Then the Volume 'volume3' does not exist
+        And the PersistentVolume 'volume3' does not exist

--- a/tests/post/features/volume.feature
+++ b/tests/post/features/volume.feature
@@ -23,3 +23,9 @@ Feature: Volume management
                 size: 10Gi
         Then the Volume 'volume1' is 'Available'
         And the PersistentVolume 'volume1' has size '10Gi'
+
+    Scenario: Test volume deletion (sparseLoopDevice)
+        Given a Volume 'volume2' exist
+        When I delete the Volume 'volume2'
+        Then the Volume 'volume2' does not exist
+        And the PersistentVolume 'volume2' does not exist

--- a/tests/post/steps/test_dns.py
+++ b/tests/post/steps/test_dns.py
@@ -27,7 +27,7 @@ def utils_pod(k8s_client, utils_image):
 
     # Wait for the Pod to be ready
     utils.retry(
-        kube_utils.wait_for_pod(
+        kube_utils.check_pod_status(
             k8s_client, name=pod_name, namespace="default", state="Running"
         ),
         times=10,

--- a/tests/post/steps/test_static_pods.py
+++ b/tests/post/steps/test_static_pods.py
@@ -105,7 +105,7 @@ def set_up_static_pod(
     fullname = "{}-{}".format(DEFAULT_POD_NAME, hostname)
 
     utils.retry(
-        kube_utils.wait_for_pod(k8s_client, fullname),
+        kube_utils.check_pod_status(k8s_client, fullname),
         times=10,
         wait=5,
         name="wait for Pod '{}'".format(fullname),
@@ -140,7 +140,7 @@ def manage_static_pod(host):
 def check_static_pod_changed(host, hostname, k8s_client, static_pod_id):
     fullname = "{}-{}".format(DEFAULT_POD_NAME, hostname)
 
-    wait_for_pod = kube_utils.wait_for_pod(
+    wait_for_pod = kube_utils.check_pod_status(
         k8s_client,
         name=fullname,
         namespace="default",

--- a/tests/post/steps/test_volume.py
+++ b/tests/post/steps/test_volume.py
@@ -473,7 +473,7 @@ def _create_pod(k8s_client, volume_name, image_name, full_command):
     )
 
     utils.retry(
-        kube_utils.wait_for_pod(k8s_client, pod_name),
+        kube_utils.check_pod_status(k8s_client, pod_name),
         times=30, wait=2,
         name="wait for pod {}".format(pod_name)
     )

--- a/tests/post/steps/test_volume.py
+++ b/tests/post/steps/test_volume.py
@@ -62,6 +62,11 @@ def test_pv_protection(host):
 def test_no_volume_type(host):
     pass
 
+@scenario('../features/volume.feature',
+          'Create a volume with an invalid volume type')
+def test_invalid_volume_type(host):
+    pass
+
 # }}}
 # Given {{{
 

--- a/tests/post/steps/test_volume.py
+++ b/tests/post/steps/test_volume.py
@@ -53,9 +53,7 @@ def test_volume_creation(host):
 def test_volume_deletion(host):
     pass
 
-@scenario('../features/volume.feature',
-          'Test PersistentVolume protection',
-          strict_gherkin=False)
+@scenario('../features/volume.feature', 'Test PersistentVolume protection')
 def test_pv_protection(host):
     pass
 

--- a/tests/post/steps/test_volume.py
+++ b/tests/post/steps/test_volume.py
@@ -1,10 +1,22 @@
 from urllib3.exceptions import HTTPError
 
+from kubernetes.client import CustomObjectsApi
 from kubernetes.client import StorageV1Api
 from kubernetes.client.rest import ApiException
 import pytest
-from pytest_bdd import scenario, then, parsers
+from pytest_bdd import given, when, scenario, then, parsers
+import yaml
 
+from tests import utils
+
+
+# Fixture {{{
+
+@pytest.fixture
+def k8s_custom_client(k8s_apiclient):
+    return CustomObjectsApi(api_client=k8s_apiclient)
+
+# }}}
 # Scenarios {{{
 
 @scenario('../features/volume.feature', 'Our StorageClass is deployed')
@@ -15,7 +27,25 @@ def test_deploy_storage_class(host):
 def test_deploy_operator(host):
     pass
 
+@scenario('../features/volume.feature',
+          'Test volume creation (sparseLoopDevice)')
+def test_volume_creation(host):
+    pass
+
 # }}}
+# When {{{
+
+@when(parsers.parse("I create the following Volume:\n{body}"))
+def create_volume(host, body, k8s_custom_client):
+    k8s_custom_client.create_cluster_custom_object(
+        group="storage.metalk8s.scality.com",
+        version="v1alpha1",
+        plural="volumes",
+        body=yaml.safe_load(body)
+    )
+
+# }}}
+# Then {{{
 
 @then(parsers.parse("we have a StorageClass '{name}'"))
 def check_storage_class(host, name, k8s_apiclient):
@@ -26,3 +56,54 @@ def check_storage_class(host, name, k8s_apiclient):
         if isinstance(exc, ApiException) and exc.status == 404:
             assert False, 'StorageClass {} not found'.format(name)
         raise
+
+
+@then(parsers.parse("the Volume '{name}' is '{status}'"))
+def check_volume_status(host, name, status, k8s_custom_client):
+    def _check_volume_status():
+        try:
+            volume = k8s_custom_client.get_cluster_custom_object(
+                group="storage.metalk8s.scality.com",
+                version="v1alpha1",
+                plural="volumes",
+                name=name
+            )
+        except (ApiException, HTTPError) as exc:
+            if isinstance(exc, ApiException) and exc.status == 404:
+                assert False, 'Volume {} not found'.format(name)
+            raise
+        try:
+            assert volume['status']['phase'] == status,\
+                'Unexpected status: expected {}, got {}'.format(
+                    status, volume['status']['phase']
+                )
+        except KeyError:
+            assert status == 'Unknown', \
+                'Unexpected status: expected {}, got none'.format(status)
+
+    utils.retry(
+        _check_volume_status, times=30, wait=2,
+        name='checking status of Volume {}'.format(name)
+    )
+
+
+@then(parsers.parse("the PersistentVolume '{name}' has size '{size}'"))
+def check_pv_size(host, name, size, k8s_client):
+    def _check_pv_size():
+        try:
+            pv = k8s_client.read_persistent_volume(name)
+        except (ApiException, HTTPError) as exc:
+            if isinstance(exc, ApiException) and exc.status == 404:
+                assert False, 'PersistentVolume {} not found'.format(name)
+            raise
+        assert pv.spec.capacity['storage'] == size, \
+            'Unexpected PersistentVolume size: expected {}, got {}'.format(
+                size, pv.spec.capacity['storage']
+            )
+
+    utils.retry(
+        _check_pv_size, times=10, wait=2,
+        name='checking size of PersistentVolume {}'.format(name)
+    )
+
+# }}}

--- a/tox.ini
+++ b/tox.ini
@@ -117,6 +117,7 @@ commands =
         {posargs:-m local} tests
 
 [pytest]
+bdd_strict_gherkin = false
 markers =
     ci: tag a BDD feature as part of CI test suite
     install: tag a BDD feature as an installation scenario


### PR DESCRIPTION
**Component**:

'test', 'storage', 'kubernetes'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

See issue #1417 
- The ticket contains an extensive description of some of the test scenarios we would like to have.

**Summary**:

- We would love to automate CI tests for volume creation, volume deletion, persistent volume creation and deletion including test cases where semantic errors might occur like a bad storage class naming, invalid filesystem types which we do not support and much more.

How to test?
`tox -e tests -- -m 'volume'
`

**Acceptance criteria**: 

- CI tests should continue to work normally
- All volume workflow scenarios should be accounted for in the test cases described. 

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1417 
