### PR TITLE
Document how to run the cluster and the UI locally

### DIFF
--- a/docs/developer/building/index.rst
+++ b/docs/developer/building/index.rst
@@ -5,6 +5,5 @@ How to build MetalK8s
 
    requirements
    building
-   local_cluster
    configuration
    features

--- a/docs/developer/building/requirements.rst
+++ b/docs/developer/building/requirements.rst
@@ -4,6 +4,9 @@ Requirements
 In order to build MetalK8s we rely and third-party tools, some of them are
 mandatory, others are optional.
 
+
+.. _build-required-deps:
+
 Mandatory
 ---------
 

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -5,4 +5,5 @@ Developer Guide
 
    architecture/index
    building/index
+   running/index
    best_practices/index

--- a/docs/developer/running/cluster.rst
+++ b/docs/developer/running/cluster.rst
@@ -1,5 +1,16 @@
-Running a local cluster
-=======================
+Running a cluster locally
+=========================
+
+Requirements
+------------
+
+- the :ref:`mandatory requirements for the buildchain<build-required-deps>`
+- `Vagrant <https://www.vagrantup.com/>`_, 1.8 or higher: to spawn a local
+  cluster (VirtualBox is currently the only provider supported)
+- `VirtualBox <https://www.virtualbox.org>`_: to spawn a local cluster
+
+Procedure
+---------
 
 You can spawn a local MetalK8s cluster by running ``./doit.sh vagrant_up``.
 
@@ -21,6 +32,6 @@ This will:
 - spawn a virtual machine for the node 1
 - import the pre-shared SSH key into it
 
-You can then follow the cluster expansion procedure to add the frshly spawned
+You can then follow the cluster expansion procedure to add the freshly spawned
 node into your MetalK8s cluster (you can get the node's IP with
 ``vagrant ssh node1 -- sudo ip a show eth1``).

--- a/docs/developer/running/index.rst
+++ b/docs/developer/running/index.rst
@@ -4,3 +4,4 @@ How to run components locally
 .. toctree::
 
    cluster
+   ui

--- a/docs/developer/running/index.rst
+++ b/docs/developer/running/index.rst
@@ -1,0 +1,6 @@
+How to run components locally
+=============================
+
+.. toctree::
+
+   cluster

--- a/docs/developer/running/ui.rst
+++ b/docs/developer/running/ui.rst
@@ -1,0 +1,48 @@
+Running the platform UI locally
+===============================
+
+Requirements
+------------
+
+- `Node.js <https://nodejs.org/en/>`_, 10.16
+
+Prerequisites
+-------------
+
+- You should have a running Metalk8s cluster somewhere
+- You should have installed the dependencies locally with
+  ``cd ui; npm install``
+
+Procedure
+---------
+
+
+1. Connect to the boostrap node of your cluster, and execute the following
+   command as root:
+
+.. code-block:: console
+
+   python - <<EOF
+   import subprocess
+   import json
+
+   output = subprocess.check_output([
+       'salt-call', 'pillar.get', 'metalk8s', '--out', 'json'
+   ])
+   pillar = json.loads(output)['local']
+   ui_conf = {
+       'url': 'https://{}:6443'.format(pillar['api_server']['host']),
+       'url_salt': 'http://{salt[ip]}:{salt[ports][api]}'.format(
+           salt=pillar['endpoints']['salt-master']
+       ),
+       'url_prometheus': 'http://{prom[ip]}:{prom[ports][api][node_port]}'.format(
+           prom=pillar['endpoints']['prometheus']
+       ),
+   }
+   print(json.dumps(ui_conf, indent=4))
+   EOF
+
+
+2. Copy the output into ``ui/public/config.json``.
+
+3. Run the UI with ``cd ui; npm run start``


### PR DESCRIPTION
**Component**:

documentation

**Context**: 

Group scattered documentation into a single place.
Document tribal knowledge in a written form.

**Summary**:

- Create a new section in the developer guide
- Move the local cluster documentation
- Document how to run the UI

Storage operator will be done in another PR, because it's not introduced before 2.4

**Acceptance criteria**: 

The given instruction are working.

---

See: #1536