### PR TITLE
Prepare environment for calico integration for Debian

### DIFF
--- a/buildchain/buildchain/constants.py
+++ b/buildchain/buildchain/constants.py
@@ -33,12 +33,16 @@ ISO_ROOT : Path = config.BUILD_ROOT/'root'
 REPO_ROOT : Path = ISO_ROOT/'packages'
 # Root of the RedHat repositories on the ISO.
 REPO_RPM_ROOT : Path = REPO_ROOT/'redhat'
+# Root of the Debian repositories on the ISO.
+REPO_DEB_ROOT : Path = REPO_ROOT/'debian'
 # Root for the images on the ISO.
 ISO_IMAGE_ROOT : Path = ISO_ROOT/'images'
 # Root for the packages that we build ourselves.
 PKG_ROOT : Path = config.BUILD_ROOT/'packages'
 # Root for the RPM packages that we build ourselves.
 PKG_RPM_ROOT : Path = PKG_ROOT/'redhat'
+# Root for the Debian packages that we build ourselves.
+PKG_DEB_ROOT : Path = PKG_ROOT/'debian'
 # Root of the Vagrant environment folder.
 VAGRANT_ROOT : Path = ROOT/'.vagrant'
 # Path to the static-container-registry module.

--- a/buildchain/buildchain/packaging.py
+++ b/buildchain/buildchain/packaging.py
@@ -73,6 +73,12 @@ def task__package_mkdir_rpm_root() -> types.TaskDict:
         directory=constants.PKG_RPM_ROOT, task_dep=['_package_mkdir_root']
     ).task
 
+def task__package_mkdir_deb_root() -> types.TaskDict:
+    """Create the Debian packages root directory."""
+    return targets.Mkdir(
+        directory=constants.PKG_DEB_ROOT, task_dep=['_package_mkdir_root']
+    ).task
+
 def task__package_mkdir_iso_root() -> types.TaskDict:
     """Create the packages root directory on the ISO."""
     return targets.Mkdir(
@@ -83,6 +89,12 @@ def task__package_mkdir_rpm_iso_root() -> types.TaskDict:
     """Create the RedHat packages root directory on the ISO."""
     return targets.Mkdir(
         directory=constants.REPO_RPM_ROOT, task_dep=['_package_mkdir_iso_root']
+    ).task
+
+def task__package_mkdir_deb_iso_root() -> types.TaskDict:
+    """Create the Debian packages root directory on the ISO."""
+    return targets.Mkdir(
+        directory=constants.REPO_DEB_ROOT, task_dep=['_package_mkdir_iso_root']
     ).task
 
 def task__download_packages() -> types.TaskDict:

--- a/packages/debian/Dockerfile
+++ b/packages/debian/Dockerfile
@@ -1,0 +1,16 @@
+# Equal to Ubuntu:18.04
+# SHA256 digest of the base image
+ARG BUILD_IMAGE_SHA256=d1d454df0f579c6be4d8161d227462d69e163a8ff9d20a847533989cf0c94d90
+
+ARG BUILD_IMAGE=docker.io/ubuntu
+FROM ${BUILD_IMAGE}@sha256:${BUILD_IMAGE_SHA256} as build
+
+RUN apt update -y \
+        && \
+    apt install -y \
+        devscripts \
+        build-essential \
+        lintian \
+        alien
+
+RUN useradd -m build


### PR DESCRIPTION
**Component**: Buildchain

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: Metalk8s on Ubuntu 

**Summary**: Prepare the environment before to modify buildchain scrits to integrate calico for Debian.

**Acceptance criteria**: 
- Deploy cluster as usual.


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1538 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
