### PR TITLE
Don't use matchFields in generated PersistentVolume

### DIFF
--- a/storage-operator/pkg/controller/volume/volume_controller.go
+++ b/storage-operator/pkg/controller/volume/volume_controller.go
@@ -824,13 +824,6 @@ func nodeAffinity(node types.NodeName) *corev1.VolumeNodeAffinity {
 						Values:   []string{string(node)},
 					},
 				},
-				MatchFields: []corev1.NodeSelectorRequirement{
-					{
-						Key:      "metadata.name",
-						Operator: corev1.NodeSelectorOpIn,
-						Values:   []string{string(node)},
-					},
-				},
 			},
 		},
 	}


### PR DESCRIPTION
**Component**:

operator

**Context**: 

Workaround https://github.com/kubernetes/kubernetes/issues/81725

**Summary**:

Don't use `matchFields` in the generated PersistentVolume.

**Acceptance criteria**: 

Created PV can be used by Pod.

---

Closes: #1542