### PR TITLE
Split classes to handle different kind of packages

### DIFF
--- a/.pylint-dict
+++ b/.pylint-dict
@@ -12,6 +12,7 @@ checksum
 checksums
 containerd
 de
+debuild
 dockerfile
 doit
 dedup

--- a/buildchain/buildchain/docker_command.py
+++ b/buildchain/buildchain/docker_command.py
@@ -39,6 +39,17 @@ RPM_BASE_CONFIG = {
     'remove': True
 }
 
+DEB_BASE_CONFIG = {
+    'hostname': 'build',
+    'mounts': [utils.get_entrypoint_mount('debian')],
+    'environment': {
+        'TARGET_UID': os.geteuid(),
+        'TARGET_GID': os.getegid()
+    },
+    'tmpfs': {'/tmp': ''},
+    'remove': True
+}
+
 
 def default_error_handler(exc: Exception) -> str:
     """Default string formatting exception handler."""

--- a/buildchain/buildchain/docker_command.py
+++ b/buildchain/buildchain/docker_command.py
@@ -18,42 +18,26 @@ from docker.types import Mount                        # type: ignore
 from doit.exceptions import TaskError                 # type: ignore
 
 from buildchain import constants
+from buildchain import utils
 from buildchain.targets import image
 
 DOCKER_CLIENT : docker.DockerClient = docker.from_env()
 
+RPMLINTRC_MOUNT : Mount = utils.bind_ro_mount(
+    target=Path('/rpmbuild/rpmlintrc'),
+    source=constants.ROOT/'packages'/'redhat'/'rpmlintrc',
+)
 
-def bind_mount(source: Path, target: Path, **kwargs: Any) -> Mount:
-    """Helper for Docker mount objects.
-
-    Arguments:
-        source: the host path to be mounted
-        target: the container path the source should be mounted to
-
-    Keyword arguments:
-        Passed through to the underlying docker.services.Mount object
-        initialization
-    """
-    return Mount(
-        source=str(source),
-        target=str(target),
-        type='bind',
-        **kwargs
-    )
-
-
-def bind_ro_mount(source: Path, target: Path) -> Mount:
-    """Helper for Docker *read-only* mount objects.
-
-    Arguments:
-        source: the host path to be mounted
-        target: the container path the source should be mounted to
-    """
-    return bind_mount(
-        source=source,
-        target=target,
-        read_only=True
-    )
+RPM_BASE_CONFIG = {
+    'hostname': 'build',
+    'mounts': [utils.get_entrypoint_mount('redhat')],
+    'environment': {
+        'TARGET_UID': os.geteuid(),
+        'TARGET_GID': os.getegid()
+    },
+    'tmpfs': {'/tmp': ''},
+    'remove': True
+}
 
 
 def default_error_handler(exc: Exception) -> str:
@@ -153,33 +137,14 @@ class DockerBuild:
 class DockerRun:
     """A class to expose the `docker run` command through the API client."""
 
-    RPMLINTRC_MOUNT : Mount = bind_ro_mount(
-        target=Path('/rpmbuild/rpmlintrc'),
-        source=constants.ROOT/'packages'/'redhat'/'rpmlintrc',
-    )
-    ENTRYPOINT_MOUNT : Mount = bind_ro_mount(
-        target=Path('/entrypoint.sh'),
-        source=constants.ROOT/'packages'/'redhat'/'entrypoint.sh',
-    )
-    _BASE_CONFIG = {
-        'hostname': 'build',
-        'mounts': [ENTRYPOINT_MOUNT],
-        'environment': {
-            'TARGET_UID': os.geteuid(),
-            'TARGET_GID': os.getegid()
-        },
-        'tmpfs': {'/tmp': ''},
-        'remove': True
-    }
-
     def __init__(
         self,
         command:     List[str],
         builder:     image.ContainerImage,
+        run_config:  Dict[str, Any],
         environment: Optional[Dict[str, Any]]=None,
         mounts:      Optional[List[Mount]]=None,
         tmpfs:       Optional[Dict[str, str]]=None,
-        run_config:  Optional[Dict[str, Any]]=None,
         read_only:   bool=False
     ):
         """Initialize a `docker run` callable object.
@@ -199,13 +164,8 @@ class DockerRun:
         self.environment = environment or {}
         self.mounts = mounts or []
         self.tmpfs = tmpfs or {}
-        self.run_config = run_config or self.builder_config()
+        self.run_config = run_config
         self.read_only = read_only
-
-    @classmethod
-    def builder_config(cls) -> Dict[str, Any]:
-        """Docker run command base configuration."""
-        return copy.deepcopy(cls._BASE_CONFIG)
 
     def expand_config(self) -> Dict[str, Any]:
         """Expand the run configuration with given data.

--- a/buildchain/buildchain/packaging.py
+++ b/buildchain/buildchain/packaging.py
@@ -47,6 +47,7 @@ def task_packaging() -> types.TaskDict:
         'actions': None,
         'task_dep': [
             '_build_rpm_container',
+            '_build_deb_container',
             '_package_mkdir_root',
             '_package_mkdir_iso_root',
             '_download_rpm_packages',
@@ -58,6 +59,12 @@ def task_packaging() -> types.TaskDict:
 def task__build_rpm_container() -> types.TaskDict:
     """Build the container image used to build the packages/repositories."""
     task = RPM_BUILDER.task
+    task.pop('name')  # `name` is only used for sub-task.
+    return task
+
+def task__build_deb_container() -> types.TaskDict:
+    """Build the container image used to build the packages/repositories."""
+    task = DEB_BUILDER.task
     task.pop('name')  # `name` is only used for sub-task.
     return task
 
@@ -178,6 +185,16 @@ RPM_BUILDER : targets.LocalImage = targets.LocalImage(
         'SALT_VERSION': versions.SALT_VERSION,
     },
 )
+
+DEB_BUILDER : targets.LocalImage = targets.LocalImage(
+    name='metalk8s-deb-build',
+    version='latest',
+    dockerfile=constants.ROOT/'packages'/'debian'/'Dockerfile',
+    destination=config.BUILD_ROOT,
+    save_on_disk=False,
+    task_dep=['_build_root'],
+)
+
 
 # Packages to build, per repository.
 def _rpm_package(name: str, sources: List[Path]) -> targets.RPMPackage:

--- a/buildchain/buildchain/packaging.py
+++ b/buildchain/buildchain/packaging.py
@@ -111,10 +111,10 @@ def task__download_rpm_packages() -> types.TaskDict:
             coreutils.rm_rf(repository.rootdir)
 
     mounts = [
-        docker_command.bind_mount(
+        utils.bind_mount(
             source=constants.PKG_RPM_ROOT, target=Path('/install_root')
         ),
-        docker_command.bind_mount(
+        utils.bind_mount(
             source=constants.REPO_RPM_ROOT, target=Path('/repositories')
         ),
     ]
@@ -122,7 +122,8 @@ def task__download_rpm_packages() -> types.TaskDict:
         command=['/entrypoint.sh', 'download_packages', *RPM_TO_DOWNLOAD],
         builder=RPM_BUILDER,
         mounts=mounts,
-        environment={'RELEASEVER': 7}
+        environment={'RELEASEVER': 7},
+        run_config=docker_command.RPM_BASE_CONFIG
     )
     return {
         'title': utils.title_with_target1('GET PKGS'),

--- a/buildchain/buildchain/packaging.py
+++ b/buildchain/buildchain/packaging.py
@@ -49,9 +49,9 @@ def task_packaging() -> types.TaskDict:
             '_build_rpm_container',
             '_package_mkdir_root',
             '_package_mkdir_iso_root',
-            '_download_packages',
+            '_download_rpm_packages',
             '_build_rpm_packages:*',
-            '_build_repositories:*',
+            '_build_rpm_repositories:*',
         ],
     }
 
@@ -97,12 +97,12 @@ def task__package_mkdir_deb_iso_root() -> types.TaskDict:
         directory=constants.REPO_DEB_ROOT, task_dep=['_package_mkdir_iso_root']
     ).task
 
-def task__download_packages() -> types.TaskDict:
+def task__download_rpm_packages() -> types.TaskDict:
     """Download packages locally."""
     def clean() -> None:
         """Delete cache and repositories on the ISO."""
         coreutils.rm_rf(constants.PKG_RPM_ROOT/'var')
-        for repository in REPOSITORIES:
+        for repository in RPM_REPOSITORIES:
             # Repository with an explicit list of packages are created by a
             # dedicated task that will also handle their cleaning, so we skip
             # them here.
@@ -145,9 +145,9 @@ def task__build_rpm_packages() -> Iterator[types.TaskDict]:
         for package in repo_pkgs:
             yield from package.execution_plan
 
-def task__build_repositories() -> Iterator[types.TaskDict]:
-    """Build a repository."""
-    for repository in REPOSITORIES:
+def task__build_rpm_repositories() -> Iterator[types.TaskDict]:
+    """Build a RPM repository."""
+    for repository in RPM_REPOSITORIES:
         yield from repository.execution_plan
 
 # Image used to build the packages
@@ -244,49 +244,49 @@ _TO_DOWNLOAD_CONFIG : Dict[str, str] = {
 }
 
 
-REPOSITORIES : Tuple[targets.Repository, ...] = (
-    targets.Repository(
-        basename='_build_repositories',
+RPM_REPOSITORIES : Tuple[targets.RPMRepository, ...] = (
+    targets.RPMRepository(
+        basename='_build_rpm_repositories',
         name='scality',
         builder=RPM_BUILDER,
         packages=RPM_TO_BUILD['scality'],
         task_dep=['_package_mkdir_rpm_iso_root'],
     ),
-    targets.Repository(
-        basename='_build_repositories',
+    targets.RPMRepository(
+        basename='_build_rpm_repositories',
         name='base',
         builder=RPM_BUILDER,
-        task_dep=['_download_packages'],
+        task_dep=['_download_rpm_packages'],
     ),
-    targets.Repository(
-        basename='_build_repositories',
+    targets.RPMRepository(
+        basename='_build_rpm_repositories',
         name='extras',
         builder=RPM_BUILDER,
-        task_dep=['_download_packages'],
+        task_dep=['_download_rpm_packages'],
     ),
-    targets.Repository(
-        basename='_build_repositories',
+    targets.RPMRepository(
+        basename='_build_rpm_repositories',
         name='updates',
         builder=RPM_BUILDER,
-        task_dep=['_download_packages'],
+        task_dep=['_download_rpm_packages'],
     ),
-    targets.Repository(
-        basename='_build_repositories',
+    targets.RPMRepository(
+        basename='_build_rpm_repositories',
         name='epel',
         builder=RPM_BUILDER,
-        task_dep=['_download_packages'],
+        task_dep=['_download_rpm_packages'],
     ),
-    targets.Repository(
-        basename='_build_repositories',
+    targets.RPMRepository(
+        basename='_build_rpm_repositories',
         name='kubernetes',
         builder=RPM_BUILDER,
-        task_dep=['_download_packages'],
+        task_dep=['_download_rpm_packages'],
     ),
-    targets.Repository(
-        basename='_build_repositories',
+    targets.RPMRepository(
+        basename='_build_rpm_repositories',
         name='saltstack',
         builder=RPM_BUILDER,
-        task_dep=['_download_packages'],
+        task_dep=['_download_rpm_packages'],
     ),
 )
 

--- a/buildchain/buildchain/targets/__init__.py
+++ b/buildchain/buildchain/targets/__init__.py
@@ -10,7 +10,7 @@ from buildchain.targets.directory import Mkdir
 from buildchain.targets.file_tree import FileTree
 from buildchain.targets.local_image import LocalImage
 from buildchain.targets.operator_image import OperatorImage
-from buildchain.targets.package import Package
+from buildchain.targets.package import Package, RPMPackage
 from buildchain.targets.remote_image import RemoteImage
 from buildchain.targets.repository import Repository
 from buildchain.targets.serialize import SerializedData

--- a/buildchain/buildchain/targets/__init__.py
+++ b/buildchain/buildchain/targets/__init__.py
@@ -12,6 +12,6 @@ from buildchain.targets.local_image import LocalImage
 from buildchain.targets.operator_image import OperatorImage
 from buildchain.targets.package import Package, RPMPackage
 from buildchain.targets.remote_image import RemoteImage
-from buildchain.targets.repository import Repository
+from buildchain.targets.repository import Repository, RPMRepository
 from buildchain.targets.serialize import SerializedData
 from buildchain.targets.template import TemplateFile

--- a/buildchain/buildchain/targets/__init__.py
+++ b/buildchain/buildchain/targets/__init__.py
@@ -10,7 +10,7 @@ from buildchain.targets.directory import Mkdir
 from buildchain.targets.file_tree import FileTree
 from buildchain.targets.local_image import LocalImage
 from buildchain.targets.operator_image import OperatorImage
-from buildchain.targets.package import Package, RPMPackage
+from buildchain.targets.package import Package, RPMPackage, DEBPackage
 from buildchain.targets.remote_image import RemoteImage
 from buildchain.targets.repository import Repository, RPMRepository
 from buildchain.targets.serialize import SerializedData

--- a/buildchain/buildchain/targets/package.py
+++ b/buildchain/buildchain/targets/package.py
@@ -167,11 +167,11 @@ class RPMPackage(Package):
         spec_guest_file = Path('/rpmbuild/SPECS', self.spec.name)
         meta_guest_file = Path('/rpmbuild/META', self.meta.name)
         mounts = [
-            docker_command.DockerRun.ENTRYPOINT_MOUNT,
-            docker_command.bind_ro_mount(
+            utils.get_entrypoint_mount('redhat'),
+            utils.bind_ro_mount(
                 source=self.spec, target=spec_guest_file
             ),
-            docker_command.bind_mount(
+            utils.bind_mount(
                 source=self.meta.parent, target=meta_guest_file.parent
             )
         ]
@@ -237,7 +237,8 @@ class RPMPackage(Package):
             environment=env,
             tmpfs={'/home/build': '', '/var/tmp': ''},
             mounts=self._get_buildsrpm_mounts(self.srpm.parent),
-            read_only=True
+            read_only=True,
+            run_config=docker_command.RPM_BASE_CONFIG
         )
 
         task = self.basic_task
@@ -291,23 +292,23 @@ class RPMPackage(Package):
         """Return the list of container mounts required by `buildsrpm`."""
         mounts = [
             # .spec file
-            docker_command.bind_ro_mount(
+            utils.bind_ro_mount(
                 source=self.spec,
                 target=Path('/rpmbuild/SPECS', self.spec.name)
             ),
             # SRPM directory.
-            docker_command.bind_mount(
+            utils.bind_mount(
                 source=srpm_dir,
                 target=Path('/rpmbuild/SRPMS'),
             ),
             # rpmlint configuration file
-            docker_command.DockerRun.RPMLINTRC_MOUNT
+            docker_command.RPMLINTRC_MOUNT
         ]
 
         # Source files.
         for source in self.sources:
             mounts.append(
-                docker_command.bind_ro_mount(
+                utils.bind_ro_mount(
                     source=source,
                     target=Path('/rpmbuild/SOURCES', source.name)
                 )

--- a/buildchain/buildchain/targets/repository.py
+++ b/buildchain/buildchain/targets/repository.py
@@ -173,7 +173,7 @@ class RPMRepository(Repository):
                 base=self.basename, name=MKDIR_ROOT_TASK_NAME
             ))
             task['file_dep'].extend([
-                self._get_rpm_path(pkg) for pkg in self.packages
+                self.get_rpm_path(pkg) for pkg in self.packages
             ])
         return task
 
@@ -181,7 +181,7 @@ class RPMRepository(Repository):
         """Build the RPMs from SRPMs."""
         tasks = [self._mkdir_repo_root(), self._mkdir_repo_arch()]
         for pkg in self.packages:
-            rpm = self._get_rpm_path(pkg)
+            rpm = self.get_rpm_path(pkg)
             env = {
                 'RPMS': '{arch}/{rpm}'.format(arch=self.ARCH, rpm=rpm.name),
                 'SRPM': pkg.srpm.name,
@@ -204,7 +204,7 @@ class RPMRepository(Repository):
                     pkg=pkg.name, repo=self.name
                 ),
                 'title': utils.title_with_target1('BUILD RPM'),
-                'targets': [self._get_rpm_path(pkg)],
+                'targets': [self.get_rpm_path(pkg)],
                 # Prevent Docker from polluting our output.
                 'verbosity': 0,
             })
@@ -251,7 +251,7 @@ class RPMRepository(Repository):
         ))
         return task
 
-    def _get_rpm_path(self, pkg: package.RPMPackage) -> Path:
+    def get_rpm_path(self, pkg: package.RPMPackage) -> Path:
         """Return the path of the RPM of a given package."""
         filename = pkg.srpm.name.replace(
             '.src.rpm', '.{}.rpm'.format(self.ARCH)

--- a/buildchain/buildchain/targets/repository.py
+++ b/buildchain/buildchain/targets/repository.py
@@ -63,7 +63,7 @@ class Repository(base.CompositeTarget):
         basename: str,
         name: str,
         builder: image.ContainerImage,
-        packages: Optional[Sequence[package.Package]]=None,
+        packages: Optional[Sequence[package.RPMPackage]]=None,
         **kwargs: Any
     ):
         """Initialize the repository.
@@ -181,7 +181,7 @@ class Repository(base.CompositeTarget):
             task['task_dep'].append('{base}:{name}'.format(
                 base=self.basename, name=MKDIR_ARCH_TASK_NAME,
             ))
-            task['task_dep'].append('_build_container')
+            task['task_dep'].append('_build_rpm_container')
             tasks.append(task)
         return tasks
 
@@ -220,7 +220,7 @@ class Repository(base.CompositeTarget):
         ))
         return task
 
-    def _get_rpm_path(self, pkg: package.Package) -> Path:
+    def _get_rpm_path(self, pkg: package.RPMPackage) -> Path:
         """Return the path of the RPM of a given package."""
         filename = pkg.srpm.name.replace(
             '.src.rpm', '.{}.rpm'.format(self.ARCH)

--- a/packages/debian/entrypoint.sh
+++ b/packages/debian/entrypoint.sh
@@ -35,7 +35,7 @@ rpm2deb() {
     chown "${TARGET_UID}:${TARGET_GID}" * 
 }
 
-case ${1:-''} in
+case ${1:- } in
     builddeb)
         builddeb
         ;;

--- a/packages/debian/entrypoint.sh
+++ b/packages/debian/entrypoint.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+
+set -e
+set -u
+set -o pipefail
+
+
+# Build a DEB from the source files, using debuild.
+builddeb() {
+    set -x
+
+    mkdir -p /debbuild/build-pkg/src
+    cp -r /debbuild/pkg-meta/* /debbuild/build-pkg
+    cp -r /debbuild/pkg-src/* /debbuild/build-pkg/src
+
+    # Overwrite version if supported
+    sed -i 's/_VERSION_/'"${VERSION}"'/g' "/debbuild/build-pkg/debian/changelog"
+
+    pushd /debbuild/build-pkg 1>/dev/null
+    debuild -b -uc -us
+
+    cp /debbuild/*.deb /debbuild/result
+    chown -R "${TARGET_UID}:${TARGET_GID}" /debbuild/result
+}
+
+
+# Build a DEB from an RPM file, using alien.
+rpm2deb() {
+    set -x
+
+    pushd /debbuild/result 1> /dev/null
+    alien --bump=0 /rpmbuild/source.rpm
+
+    chown "${TARGET_UID}:${TARGET_GID}" * 
+}
+
+case ${1:-''} in
+    builddeb)
+        builddeb
+        ;;
+    rpm2deb)
+        rpm2deb
+        ;;
+    '')
+        exec /bin/bash
+        ;;
+    *)
+        exec "$@"
+        ;;
+esac

--- a/packages/debian/metalk8s-sosreport/debian/changelog
+++ b/packages/debian/metalk8s-sosreport/debian/changelog
@@ -1,4 +1,4 @@
-metalk8s-sosreport (2.4.0) bionic; urgency=low
+metalk8s-sosreport (_VERSION_) bionic; urgency=low
 
   * Initial release.
 

--- a/packages/debian/metalk8s-sosreport/debian/control
+++ b/packages/debian/metalk8s-sosreport/debian/control
@@ -1,13 +1,12 @@
 Source: metalk8s-sosreport
-Section: base
-Priority: extra
 Maintainer: Scality Platform <moonshot-platform@scality.com>
+Section: admin
+Priority: optional
+Standards-Version: 4.2.1
 Build-Depends: debhelper (>=9)
-Standards-Version: 2.4.0 
 Homepage: https://github.com/scality/metalk8s
 
 Package: metalk8s-sosreport
 Architecture: any
-Multi-Arch: foreign
 Depends: sosreport
 Description: Metalk8s SOS report custom plugins.

--- a/packages/debian/metalk8s-sosreport/debian/files
+++ b/packages/debian/metalk8s-sosreport/debian/files
@@ -1,2 +1,0 @@
-metalk8s-sosreport-deb_2.4.0_amd64.deb base extra
-metalk8s-sosreport_2.4.0_amd64.buildinfo base extra

--- a/packages/debian/metalk8s-sosreport/debian/install
+++ b/packages/debian/metalk8s-sosreport/debian/install
@@ -1,2 +1,2 @@
-../../common/metalk8s-sosreport/metalk8s.py /usr/share/sosreport/sos/plugins/
-../../common/metalk8s-sosreport/containerd.py /usr/share/sosreport/sos/plugins/
+src/metalk8s.py /usr/share/sosreport/sos/plugins/
+src/containerd.py /usr/share/sosreport/sos/plugins/

--- a/packages/debian/metalk8s-sosreport/debian/install
+++ b/packages/debian/metalk8s-sosreport/debian/install
@@ -1,2 +1,2 @@
-../../../common/metalk8s-sosreport/metalk8s.py /usr/share/sosreport/sos/plugins/
-../../../common/metalk8s-sosreport/containerd.py /usr/share/sosreport/sos/plugins/
+../../common/metalk8s-sosreport/metalk8s.py /usr/share/sosreport/sos/plugins/
+../../common/metalk8s-sosreport/containerd.py /usr/share/sosreport/sos/plugins/

--- a/packages/redhat/entrypoint.sh
+++ b/packages/redhat/entrypoint.sh
@@ -125,7 +125,7 @@ download_packages() {
         -not -path "$repo_cache_root")
 }
 
-case ${1:-''} in
+case ${1:- } in
     buildmeta)
         buildmeta
         ;;


### PR DESCRIPTION
**Component**: Buildchain, package

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: Metalk8s on Ubuntu

**Summary**: We need to to split some classes in the buildchain to integrate Debian and build its packages.

**Acceptance criteria**: 
- classes separated
- Build still available 
- Centos cluster deployment available


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1472 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
