### PR TITLE
Unprepare volume with Salt

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -434,6 +434,7 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/volumes/prepared/init.sls'),
     Path('salt/metalk8s/volumes/prepared/installed.sls'),
     Path('salt/metalk8s/volumes/provisioned/init.sls'),
+    Path('salt/metalk8s/volumes/unprepared/init.sls'),
 
     Path('salt/_auth/kubernetes_rbac.py'),
 

--- a/salt/_modules/metalk8s_volumes.py
+++ b/salt/_modules/metalk8s_volumes.py
@@ -37,7 +37,7 @@ def exists(name):
 
     .. code-block:: bash
 
-        salt '*' metalk8s_volumes.exists example-volume
+        salt '<NODE_NAME>' metalk8s_volumes.exists example-volume
     """
     return _get_volume(name).exists
 
@@ -48,23 +48,20 @@ def create(name):
     Args:
         name (str): volume name
 
-    Returns:
-        None
-
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' metalk8s_volumes.create example-volume
+        salt '<NODE_NAME>' metalk8s_volumes.create example-volume
     """
-    return _get_volume(name).create()
+    _get_volume(name).create()
 
 
 def is_provisioned(name):
     """Check if the backing storage device is provisioned for the given volume.
 
     Args:
-        path (str): path of the sparse file
+        name (str): volume name
 
     Returns:
         bool: True if the backing storage device is provisioned, otherwise False
@@ -73,7 +70,7 @@ def is_provisioned(name):
 
     .. code-block:: bash
 
-        salt '*' metalk8s_volumes.is_provisioned example-volume
+        salt '<NODE_NAME>' metalk8s_volumes.is_provisioned example-volume
     """
     return _get_volume(name).is_provisioned
 
@@ -84,16 +81,13 @@ def provision(name):
     Args:
         name (str): volume name
 
-    Returns:
-        str: path to the associated loop device
-
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' metalk8s_volumes.provision example-volume
+        salt '<NODE_NAME>' metalk8s_volumes.provision example-volume
     """
-    return _get_volume(name).provision()
+    _get_volume(name).provision()
 
 
 def is_formatted(name):
@@ -109,7 +103,7 @@ def is_formatted(name):
 
     .. code-block:: bash
 
-        salt '*' metalk8s_volumes.volume_is_formatted example-volume
+        salt '<NODE_NAME>' metalk8s_volumes.volume_is_formatted example-volume
     """
     return _get_volume(name).is_formatted
 
@@ -120,14 +114,11 @@ def format(name):
     Args:
         name (str): volume name
 
-    Returns:
-        None
-
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' metalk8s_volumes.format example-volume
+        salt '<NODE_NAME>' metalk8s_volumes.format example-volume
     """
     _get_volume(name).format()
 

--- a/salt/_states/metalk8s_volumes.py
+++ b/salt/_states/metalk8s_volumes.py
@@ -19,7 +19,7 @@ def present(name):
     """Ensure that the backing storage exists for the specified volume.
 
     Args:
-        name   (str): Volume name
+        name (str): Volume name
 
     Returns:
         dict: state return value
@@ -55,7 +55,7 @@ def provisioned(name):
     """Provision the given volume.
 
     Args:
-        name   (str): Volume name
+        name (str): Volume name
 
     Returns:
         dict: state return value
@@ -92,7 +92,7 @@ def formatted(name):
     """Format the given volume.
 
     Args:
-        name   (str): Volume name
+        name (str): Volume name
 
     Returns:
         dict: state return value

--- a/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
+++ b/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
@@ -37,7 +37,6 @@ external_auth:
       - '@jobs'
     storage-operator:
       - '*':
-        - 'test.rand_sleep'
         - 'disk.dump'
         - 'state.sls'
       - '@jobs'

--- a/salt/metalk8s/volumes/unprepared/init.sls
+++ b/salt/metalk8s/volumes/unprepared/init.sls
@@ -1,0 +1,12 @@
+{%- set volumes = pillar.metalk8s.volumes %}
+{%- set volume  = pillar.get('volume', '') %}
+
+
+{%- if volume in volumes.keys() %}
+Clean up backing storage for {{ volume }}:
+  metalk8s_volumes.removed:
+    - name: {{ volume }}
+{%- else %}
+Volume "{{ volume }}" not found in pillar:
+  test.fail_without_changes: []
+{%- endif %}

--- a/storage-operator/pkg/salt/client.go
+++ b/storage-operator/pkg/salt/client.go
@@ -81,8 +81,9 @@ func (self *Client) PrepareVolume(
 	ans, err := self.authenticatedRequest(ctx, "POST", "/", payload)
 	if err != nil {
 		return "", errors.Wrapf(
-			err, "PrepareVolume failed (target=%s, volume=%s)",
-			nodeName, volumeName,
+			err,
+			"PrepareVolume failed (env=%s, target=%s, volume=%s)",
+			saltenv, nodeName, volumeName,
 		)
 	}
 	// TODO(#1461): make this more robust.
@@ -122,8 +123,9 @@ func (self *Client) UnprepareVolume(
 	ans, err := self.authenticatedRequest(ctx, "POST", "/", payload)
 	if err != nil {
 		return "", errors.Wrapf(
-			err, "UnrepareVolume failed (target=%s, volume=%s)",
-			nodeName, volumeName,
+			err,
+			"UnrepareVolume failed (env=%s, target=%s, volume=%s)",
+			saltenv, nodeName, volumeName,
 		)
 	}
 	// TODO(#1461): make this more robust.


### PR DESCRIPTION
**Component**:

salt

**Context**:

Cleanup resources when a `Volume` is deleted.

**Summary**:

Add a new Salt state to cleanup volumes.

**Acceptance criteria**: 

When you delete a `SparseLoopDevice`:
- the loop device disappeared from the output of `losetup -l`
- the backing file was removed from `/var/lib/metalk8s/storage/sparse/`

When you delete a `rawBlockDevice`:
- the disk is still formatted as before, data are left untouched

---

Closes: #1475