### PR TITLE
ci: use `npm ci` instead of `npm install`

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -133,7 +133,7 @@ stages:
           name: Run all UI unit tests
           workdir: build/ui
           command: >
-            npm install
+            npm ci
             --no-cache
             --no-save
             -q

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -4,25 +4,23 @@ ARG NODE_IMAGE_VERSION=10.16.0
 FROM node:${NODE_IMAGE_VERSION} AS build-step
 
 WORKDIR /home/node
-# Install only dev dependencies that are necessary for the build.
-RUN npm install \
-    @babel/plugin-proposal-nullish-coalescing-operator@7.4.4 \
-    @babel/plugin-proposal-optional-chaining@7.2.0 \
-    customize-cra@0.4.1 \
-    react-app-rewired@2.1.3
-COPY package*.json /home/node/
-COPY config-overrides.js .babelrc /home/node/
-RUN npm install --only=prod
 
+# These are ordered by 'likeliness of change'
+COPY config-overrides.js .babelrc /home/node/
 COPY public /home/node/public
+
+COPY package*.json /home/node/
+RUN npm ci
+
 COPY src /home/node/src
 RUN npm run build
 
 FROM nginx:${NGINX_IMAGE_VERSION}
 
+COPY conf/nginx.conf /etc/nginx/conf.d/default.conf
+
 WORKDIR /usr/share/nginx/html/
 RUN rm -rf ./*
 COPY --from=build-step /home/node/build ./
-COPY conf/nginx.conf /etc/nginx/conf.d/default.conf
 
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
**Component**: ci, ui
**Summary**: Instead of using `npm install`, use `npm ci`
**Acceptance criteria**: CI succeeds

Rationale:
- `npm ci` ought to be faster than `npm install`
- `npm install` doesn't necessarily honor `package-lock.json`