### PR TITLE
Move UI in a 'metalk8s-ui' namespace

### DIFF
--- a/docs/quickstart/services.rst
+++ b/docs/quickstart/services.rst
@@ -24,7 +24,7 @@ Gather required information
 
    .. code-block:: shell
 
-      root@boostrap $ kubectl --kubeconfig=/etc/kubernetes/admin.conf get svc metalk8s-ui -n kube-system
+      root@boostrap $ kubectl --kubeconfig=/etc/kubernetes/admin.conf get svc metalk8s-ui -n metalk8s-ui
 
       NAME                  TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
       metalk8s-ui           NodePort    10.104.61.208   <none>        80:30923/TCP     3h

--- a/salt/metalk8s/addons/ui/deployed.sls
+++ b/salt/metalk8s/addons/ui/deployed.sls
@@ -8,10 +8,16 @@ include:
 {%- set saltapi = 'http://' ~ pillar.metalk8s.endpoints['salt-master'].ip ~ ':' ~ pillar.metalk8s.endpoints['salt-master'].ports.api %}
 {%- set prometheus = 'http://' ~ pillar.metalk8s.endpoints.prometheus.ip ~ ':' ~ pillar.metalk8s.endpoints.prometheus.ports.api.node_port  %}
 
+Create metalk8s-ui namespace:
+  metalk8s_kubernetes.namespace_present:
+    - name: metalk8s-ui
+    - kubeconfig: {{ kubeconfig }}
+    - context: {{ context }}
+
 Create metalk8s-ui deployment:
   metalk8s_kubernetes.deployment_present:
     - name: metalk8s-ui
-    - namespace: kube-system
+    - namespace: metalk8s-ui
     - kubeconfig: {{ kubeconfig }}
     - context: {{ context }}
     - source: salt://{{ slspath }}/files/metalk8s-ui-deployment.yaml
@@ -20,7 +26,7 @@ Create metalk8s-ui deployment:
 Create metalk8s-ui service:
   metalk8s_kubernetes.service_present:
     - name: metalk8s-ui
-    - namespace: kube-system
+    - namespace: metalk8s-ui
     - kubeconfig: {{ kubeconfig }}
     - context: {{ context }}
     - metadata:
@@ -39,7 +45,7 @@ Create metalk8s-ui service:
 Create metalk8s-ui ConfigMap:
   metalk8s_kubernetes.configmap_present:
     - name: metalk8s-ui
-    - namespace: kube-system
+    - namespace: metalk8s-ui
     - kubeconfig: {{ kubeconfig }}
     - context: {{ context }}
     - data:


### PR DESCRIPTION
**Component**: Build

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
-We currently deploy the UI in the kube-system namespace. This should become metalk8s-ui.

**Summary**:

**Acceptance criteria**: 
- We still can run the UI as usual with no regressions

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes:

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
