### PR TITLE
UI: Fix - Metalk8s version not displayed in Creation node page

### DIFF
--- a/ui/src/containers/Layout.js
+++ b/ui/src/containers/Layout.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
 import { ThemeProvider } from 'styled-components';
@@ -27,9 +27,14 @@ import {
   refreshSolutionsAction,
   stopRefreshSolutionsAction
 } from '../ducks/config';
+import { fetchClusterVersionAction } from '../ducks/app/nodes';
 
 const Layout = props => {
   useRefreshEffect(refreshSolutionsAction, stopRefreshSolutionsAction);
+  useEffect(() => {
+    props.fetchClusterVersion();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const help = [
     {
@@ -189,7 +194,8 @@ const mapDispatchToProps = dispatch => {
     logout: () => dispatch(logoutAction()),
     removeNotification: uid => dispatch(removeNotificationAction(uid)),
     updateLanguage: language => dispatch(updateLanguageAction(language)),
-    toggleSidebar: () => dispatch(toggleSideBarAction())
+    toggleSidebar: () => dispatch(toggleSideBarAction()),
+    fetchClusterVersion: () => dispatch(fetchClusterVersionAction())
   };
 };
 

--- a/ui/src/ducks/config.js
+++ b/ui/src/ducks/config.js
@@ -5,7 +5,6 @@ import * as Api from '../services/api';
 import * as ApiK8s from '../services/k8s/api';
 import * as ApiSalt from '../services/salt/api';
 import * as ApiPrometheus from '../services/prometheus/api';
-import { fetchClusterVersion } from './app/nodes';
 import { fetchUserInfo } from './login';
 import { EN_LANG, FR_LANG, LANGUAGE } from '../constants';
 import { REFRESH_TIMEOUT } from '../constants';
@@ -126,7 +125,6 @@ export function* fetchConfig() {
     yield call(ApiSalt.initialize, result.url_salt);
     yield call(ApiPrometheus.initialize, result.url_prometheus);
     yield call(fetchUserInfo);
-    yield call(fetchClusterVersion);
   }
 }
 

--- a/ui/src/ducks/config.test.js
+++ b/ui/src/ducks/config.test.js
@@ -61,6 +61,7 @@ it('update the config state when fetchConfig', () => {
     call(ApiPrometheus.initialize, 'http://172.21.254.46:30222')
   );
   expect(gen.next().value).toEqual(call(fetchUserInfo));
+  expect(gen.next().done).toEqual(true);
 });
 
 it('update the language when updateLanguage', () => {


### PR DESCRIPTION
**Component**:UI

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
- Metalk8s version currently are not displayed in Creation node page after logged in

**Summary**:
- metalk8s version fetch was not executed when redirecting to LoginForm

**Acceptance criteria**: 
- Metalk8s version are displayed correctly in Creation node page after logged in or refresh

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: https://github.com/scality/metalk8s/issues/1486

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
