### PR TITLE
Move ui to a new namespace

### DIFF
--- a/docs/quickstart/services.rst
+++ b/docs/quickstart/services.rst
@@ -24,7 +24,7 @@ Gather required information
 
    .. code-block:: shell
 
-      root@boostrap $ kubectl --kubeconfig=/etc/kubernetes/admin.conf get svc metalk8s-ui -n kube-system
+      root@boostrap $ kubectl --kubeconfig=/etc/kubernetes/admin.conf get svc metalk8s-ui -n metalk8s-ui
 
       NAME                  TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
       metalk8s-ui           NodePort    10.104.61.208   <none>        80:30923/TCP     3h

--- a/salt/metalk8s/addons/ui/deployed.sls
+++ b/salt/metalk8s/addons/ui/deployed.sls
@@ -8,10 +8,16 @@ include:
 {%- set saltapi = 'http://' ~ pillar.metalk8s.endpoints['salt-master'].ip ~ ':' ~ pillar.metalk8s.endpoints['salt-master'].ports.api %}
 {%- set prometheus = 'http://' ~ pillar.metalk8s.endpoints.prometheus.ip ~ ':' ~ pillar.metalk8s.endpoints.prometheus.ports.api.node_port  %}
 
+Create metalk8s-ui namespace:
+  metalk8s_kubernetes.namespace_present:
+    - name: metalk8s-ui
+    - kubeconfig: {{ kubeconfig }}
+    - context: {{ context }}
+
 Create metalk8s-ui deployment:
   metalk8s_kubernetes.deployment_present:
     - name: metalk8s-ui
-    - namespace: kube-system
+    - namespace: metalk8s-ui
     - kubeconfig: {{ kubeconfig }}
     - context: {{ context }}
     - source: salt://{{ slspath }}/files/metalk8s-ui-deployment.yaml
@@ -20,7 +26,7 @@ Create metalk8s-ui deployment:
 Create metalk8s-ui service:
   metalk8s_kubernetes.service_present:
     - name: metalk8s-ui
-    - namespace: kube-system
+    - namespace: metalk8s-ui
     - kubeconfig: {{ kubeconfig }}
     - context: {{ context }}
     - metadata:
@@ -39,7 +45,7 @@ Create metalk8s-ui service:
 Create metalk8s-ui ConfigMap:
   metalk8s_kubernetes.configmap_present:
     - name: metalk8s-ui
-    - namespace: kube-system
+    - namespace: metalk8s-ui
     - kubeconfig: {{ kubeconfig }}
     - context: {{ context }}
     - data:

--- a/tests/post/steps/test_ui.py
+++ b/tests/post/steps/test_ui.py
@@ -21,7 +21,7 @@ def reach_UI(host):
         ip = json.loads(output)['local']
 
         cmd_port = ('kubectl --kubeconfig=/etc/kubernetes/admin.conf'
-                    ' get svc -n kube-system metalk8s-ui --no-headers'
+                    ' get svc -n metalk8s-ui metalk8s-ui --no-headers'
                     ' -o custom-columns=":spec.ports[0].nodePort"')
         port = host.check_output(cmd_port)
 

--- a/ui/cypress.sh
+++ b/ui/cypress.sh
@@ -2,7 +2,7 @@
 
 # On single node WORKLOAD_IP = eth0
 WORKLOAD_IP=$(ip a show eth0 | grep -Po "inet \K[\d.]+")
-UI_NODEPORT=$(sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get svc metalk8s-ui -n kube-system -o jsonpath='{.spec.ports[0].nodePort}')
+UI_NODEPORT=$(sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get svc metalk8s-ui -n metalk8s-ui -o jsonpath='{.spec.ports[0].nodePort}')
 
 npm install --no-save --quiet --no-package-lock cypress@3.2.0 cypress-cucumber-preprocessor@1.12.0
 


### PR DESCRIPTION
**Component**: Build

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
-We currently deploy the UI in the kube-system namespace. This should become metalk8s-ui.

**Summary**:

**Acceptance criteria**: 
- We still can run the UI as usual with no regressions

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: https://github.com/scality/metalk8s/issues/1541

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
