### PR TITLE
github: add `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @scality/metalk8s


### PR DESCRIPTION
Currently, only setting @scality/metalk8s as the owners of everything.

See: https://help.github.com/en/articles/about-code-owners