### PR TITLE
Increase single node VM size to decrease Cypress flakies

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -149,7 +149,7 @@ stages:
     worker:
       type: openstack
       image: CentOS-7-x86_64-GenericCloud-1809.qcow2
-      flavor: m1.medium
+      flavor: m1.large
       path: eve/workers/openstack-single-node
     steps:
       - Git: *git_pull


### PR DESCRIPTION
**Component**: tests, ui

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
Cypress flakies are likely because of a lack of ressouces.

**Summary**:
Increase the VM size of `single-node` from `m1.medium` to `m1.large` (we double the vCPU and RAM)

**Acceptance criteria**: 
It build and there is no Cypress errors during the build.

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
