### PR TITLE
tests: make 'static Pod changed' test more resilient

### DIFF
--- a/tests/kube_utils.py
+++ b/tests/kube_utils.py
@@ -42,4 +42,6 @@ def wait_for_pod(k8s_client, name, namespace="default", state="Running"):
 
         assert pod.status.phase == state, "Pod not yet '{}'".format(state)
 
+        return pod
+
     return _wait_for_pod


### PR DESCRIPTION
The original test implementation assumed that, if a static Pod whose
configuration file changed and was successfully redeployed *exists*,
this would (already) be the *new* Pod (i.e., after being recreated by
`kubelet`).

However, on systems under heavy load, this is not necessarily the case:
the *old* Pod can still run for a while until `kubelet` detects the
changed manifest, stops the old Pod/container, schedules a new one,...

Changing the test to retry until the new Pod is scheduled, rather than
until the Pod exists. In a sense, running the test multiple times until
it succeeds.

See: ae5aa0193f75812e55adf83b10b29b163456d6f9
See: d26e35655736c88ee58c9f63c2c9aa65564f416a
See: daad9449914064c91e48274db3f193fbe995c89f
See: ae5aa0193f75812e55adf83b10b29b163456d6f9