### PR TITLE
Wait for repo pod to check if it fails

### DIFF
--- a/salt/metalk8s/repo/installed.sls
+++ b/salt/metalk8s/repo/installed.sls
@@ -55,6 +55,13 @@ Install repositories manifest:
       - file: Deploy container registry nginx configuration
       - file: Generate container registry configuration
 
+Delay after new nginx pod deployment:
+  module.wait:
+    - test.sleep:
+      - length: 10
+    - watch:
+      - metalk8s: Install repositories manifest
+
 Ensure repositories container is up:
   module.wait:
     - cri.wait_container:
@@ -65,3 +72,4 @@ Ensure repositories container is up:
       - file: Deploy container registry nginx configuration
       - file: Generate container registry configuration
       - metalk8s: Install repositories manifest
+      - module: Delay after new nginx pod deployment


### PR DESCRIPTION
After changing the manifest we need to add a timeout
to enable the pod to crash before checking its state

Fixes: #1485

**Component**:
salt, repo
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
wait for repo pod to check if it fails or not
**Summary**:

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
