### PR TITLE
ui: add a new column to in volume list to indicate if the volume is bound

### DIFF
--- a/ui/src/containers/NodeInformation.js
+++ b/ui/src/containers/NodeInformation.js
@@ -10,27 +10,27 @@ import { fetchPodsAction } from '../ducks/app/pods';
 import { refreshNodesAction, stopRefreshNodesAction } from '../ducks/app/nodes';
 import {
   fetchVolumesAction,
-  fetchPersistentVolumeAction
+  fetchPersistentVolumeAction,
 } from '../ducks/app/volumes';
 import {
   sortSelector,
   makeGetNodeFromUrl,
   makeGetPodsFromUrl,
   makeGetVolumesFromUrl,
-  useRefreshEffect
+  useRefreshEffect,
 } from '../services/utils';
 import NodeVolumes from './NodeVolumes';
 import {
   BreadcrumbContainer,
   BreadcrumbLabel,
-  StyledLink
+  StyledLink,
 } from '../components/BreadcrumbStyle';
 import {
   InformationListContainer,
   InformationSpan,
   InformationLabel,
   InformationValue,
-  InformationMainValue
+  InformationMainValue,
 } from '../components/InformationList';
 import { STATUS_UNKNOWN } from '../constants';
 
@@ -92,15 +92,15 @@ const NodeInformation = props => {
     {
       label: props.intl.messages.name,
       dataKey: 'name',
-      flexGrow: 1
+      flexGrow: 1,
     },
     {
       label: props.intl.messages.status,
-      dataKey: 'status'
+      dataKey: 'status',
     },
     {
       label: props.intl.messages.namespace,
-      dataKey: 'namespace'
+      dataKey: 'namespace',
     },
     {
       label: props.intl.messages.start_time,
@@ -109,12 +109,12 @@ const NodeInformation = props => {
         <span>
           <FormattedDate value={data} /> <FormattedTime value={data} />
         </span>
-      )
+      ),
     },
     {
       label: props.intl.messages.restart,
-      dataKey: 'restartCount'
-    }
+      dataKey: 'restartCount',
+    },
   ];
 
   const podsSortedList = sortSelector(pods, sortBy, sortDirection);
@@ -169,7 +169,7 @@ const NodeInformation = props => {
   );
   const volumeData = volumes.map(volume => {
     const volumePV = pVList.find(
-      pV => pV.metadata.name === volume.metadata.name
+      pV => pV.metadata.name === volume.metadata.name,
     );
 
     return {
@@ -183,7 +183,7 @@ const NodeInformation = props => {
           volumePV.spec.capacity.storage) ||
         intl.messages.unknown,
       storageClass: volume.spec.storageClassName,
-      creationTime: volume.metadata.creationTimestamp
+      creationTime: volume.metadata.creationTimestamp,
     };
   });
 
@@ -193,18 +193,18 @@ const NodeInformation = props => {
     {
       selected: !isVolumesPage && !isPodsPage,
       title: intl.messages.details,
-      onClick: () => history.push(match.url)
+      onClick: () => history.push(match.url),
     },
     {
       selected: isVolumesPage,
       title: intl.messages.volumes,
-      onClick: () => history.push(`${match.url}/volumes`)
+      onClick: () => history.push(`${match.url}/volumes`),
     },
     {
       selected: isPodsPage,
       title: intl.messages.pods,
-      onClick: () => history.push(`${match.url}/pods`)
-    }
+      onClick: () => history.push(`${match.url}/pods`),
+    },
   ];
 
   return (
@@ -214,7 +214,7 @@ const NodeInformation = props => {
           activeColor={theme.brand.secondary}
           paths={[
             <StyledLink to="/nodes">{intl.messages.nodes}</StyledLink>,
-            <BreadcrumbLabel>{node.name}</BreadcrumbLabel>
+            <BreadcrumbLabel>{node.name}</BreadcrumbLabel>,
           ]}
         />
       </BreadcrumbContainer>

--- a/ui/src/containers/NodeInformation.js
+++ b/ui/src/containers/NodeInformation.js
@@ -32,7 +32,7 @@ import {
   InformationValue,
   InformationMainValue,
 } from '../components/InformationList';
-import { STATUS_UNKNOWN } from '../constants';
+import { STATUS_UNKNOWN, STATUS_BOUND } from '../constants';
 
 const NodeInformationContainer = styled.div`
   display: flex;
@@ -171,11 +171,13 @@ const NodeInformation = props => {
     const volumePV = pVList.find(
       pV => pV.metadata.name === volume.metadata.name,
     );
-
     return {
       name: volume.metadata.name,
-      status:
-        (volume && volume.status && volume.status.phase) || STATUS_UNKNOWN,
+      status: volume?.status?.phase || STATUS_UNKNOWN,
+      bound:
+        volumePV?.status?.phase === STATUS_BOUND
+          ? intl.messages.yes
+          : intl.messages.no,
       storageCapacity:
         (volumePV &&
           volumePV.spec &&

--- a/ui/src/containers/NodeVolumes.js
+++ b/ui/src/containers/NodeVolumes.js
@@ -155,7 +155,11 @@ const NodeVolumes = props => {
     },
     {
       label: intl.messages.status,
-      dataKey: 'status'
+      dataKey: 'status',
+    },
+    {
+      label: intl.messages.bound,
+      dataKey: 'bound',
     },
     {
       label: intl.messages.storageCapacity,

--- a/ui/src/containers/NodeVolumes.js
+++ b/ui/src/containers/NodeVolumes.js
@@ -11,14 +11,14 @@ import Tooltip from '../components/Tooltip';
 import {
   sortSelector,
   sortCapacity,
-  useRefreshEffect
+  useRefreshEffect,
 } from '../services/utils';
 import {
   refreshVolumesAction,
   stopRefreshVolumesAction,
   refreshPersistentVolumesAction,
   stopRefreshPersistentVolumesAction,
-  deleteVolumeAction
+  deleteVolumeAction,
 } from '../ducks/app/volumes';
 import {
   STATUS_UNKNOWN,
@@ -27,7 +27,7 @@ import {
   STATUS_FAILED,
   STATUS_AVAILABLE,
   STATUS_BOUND,
-  STATUS_RELEASED
+  STATUS_RELEASED,
 } from '../constants';
 
 const ButtonContainer = styled.div`
@@ -88,7 +88,7 @@ const NodeVolumes = props => {
   useRefreshEffect(refreshVolumesAction, stopRefreshVolumesAction);
   useRefreshEffect(
     refreshPersistentVolumesAction,
-    stopRefreshPersistentVolumesAction
+    stopRefreshPersistentVolumesAction,
   );
 
   const volumes = useSelector(state => state.app.volumes);
@@ -97,7 +97,7 @@ const NodeVolumes = props => {
   const [sortDirection, setSortDirection] = useState('ASC');
   const [
     isDeleteConfirmationModalOpen,
-    setisDeleteConfirmationModalOpen
+    setisDeleteConfirmationModalOpen,
   ] = useState(false);
   const [deleteVolumeName, setDeleteVolumeName] = useState('');
   const onSort = ({ sortBy, sortDirection }) => {
@@ -120,7 +120,7 @@ const NodeVolumes = props => {
           return true;
         } else {
           const persistentVolume = persistentVolumes.find(
-            pv => pv?.metadata?.name === volumeName
+            pv => pv?.metadata?.name === volumeName,
           );
           const persistentVolumeStatus = persistentVolume?.status?.phase;
 
@@ -134,14 +134,14 @@ const NodeVolumes = props => {
               return false;
             default:
               console.error(
-                `Unexpected state for PersistentVolume ${volumeName}:${persistentVolumeStatus}`
+                `Unexpected state for PersistentVolume ${volumeName}:${persistentVolumeStatus}`,
               );
               return false;
           }
         }
       default:
         console.error(
-          `Unexpected state for Volume ${volumeName}:${volumeStatus}`
+          `Unexpected state for Volume ${volumeName}:${volumeStatus}`,
         );
         return false;
     }
@@ -151,7 +151,7 @@ const NodeVolumes = props => {
     {
       label: intl.messages.name,
       dataKey: 'name',
-      flexGrow: 1
+      flexGrow: 1,
     },
     {
       label: intl.messages.status,
@@ -159,11 +159,11 @@ const NodeVolumes = props => {
     },
     {
       label: intl.messages.storageCapacity,
-      dataKey: 'storageCapacity'
+      dataKey: 'storageCapacity',
     },
     {
       label: intl.messages.storageClass,
-      dataKey: 'storageClass'
+      dataKey: 'storageClass',
     },
     {
       label: intl.messages.creationTime,
@@ -178,7 +178,7 @@ const NodeVolumes = props => {
             value={data}
           />
         </span>
-      )
+      ),
     },
     {
       label: intl.messages.action,
@@ -211,7 +211,7 @@ const NodeVolumes = props => {
             case STATUS_FAILED:
             case STATUS_AVAILABLE:
               const persistentVolume = persistentVolumes.find(
-                pv => pv?.metadata?.name === rowData.name
+                pv => pv?.metadata?.name === rowData.name,
               );
               const persistentVolumeStatus = persistentVolume?.status?.phase;
               switch (persistentVolumeStatus) {
@@ -255,14 +255,14 @@ const NodeVolumes = props => {
             </Tooltip>
           </div>
         );
-      }
-    }
+      },
+    },
   ];
 
   const onRowClick = row => {
     if (row.rowData && row.rowData.name) {
       props.history.push(
-        `/nodes/${props.nodeName}/volumes/${row.rowData.name}`
+        `/nodes/${props.nodeName}/volumes/${row.rowData.name}`,
       );
     }
   };
@@ -352,7 +352,7 @@ const NodeVolumes = props => {
 const mapDispatchToProps = dispatch => {
   return {
     deleteVolume: deleteVolumeName =>
-      dispatch(deleteVolumeAction(deleteVolumeName))
+      dispatch(deleteVolumeAction(deleteVolumeName)),
   };
 };
 
@@ -360,7 +360,7 @@ export default injectIntl(
   withRouter(
     connect(
       null,
-      mapDispatchToProps
-    )(NodeVolumes)
-  )
+      mapDispatchToProps,
+    )(NodeVolumes),
+  ),
 );


### PR DESCRIPTION
**Component**: ui, storage

**Context**: 
As a user, I would like to know if the volume is bound.

**Summary**:
Add a new column in volume list, `bound`. 
When the persistent volume is bound, it displays `Yes/Oui`. Otherwise, it displays `No/Non`.

**Acceptance criteria**: 
The ui should look like the following screenshot.
![image](https://user-images.githubusercontent.com/18453133/64343094-2b779700-cfec-11e9-9bc6-2ce159a33633.png)

Closes: #1620 