### PR TITLE
Use XXXX_ca_b64 for an encoded cert

### DIFF
--- a/pillar/metalk8s/roles/ca.sls
+++ b/pillar/metalk8s/roles/ca.sls
@@ -1,5 +1,5 @@
 mine_functions:
-  kubernetes_ca_server:
+  kubernetes_root_ca_b64:
     mine_function: hashutil.base64_encodefile
     fname: /etc/kubernetes/pki/ca.crt
 

--- a/salt/_states/kubeconfig.py
+++ b/salt/_states/kubeconfig.py
@@ -123,7 +123,7 @@ def managed(name,
     try:
         b64_ca_cert = __salt__['mine.get'](
             ca_server,
-            'kubernetes_ca_server'
+            'kubernetes_root_ca_b64'
         )[ca_server]
     except KeyError:
         ret.update({

--- a/salt/metalk8s/kubernetes/ca/kubernetes/advertised.sls
+++ b/salt/metalk8s/kubernetes/ca/kubernetes/advertised.sls
@@ -1,4 +1,4 @@
-{%- set ca_server = salt['mine.get'](pillar['metalk8s']['ca']['minion'], 'kubernetes_ca_server') %}
+{%- set ca_server = salt['mine.get'](pillar['metalk8s']['ca']['minion'], 'kubernetes_root_ca_b64') %}
 
 {%- if ca_server %}
 
@@ -17,7 +17,7 @@ Ensure kubernetes CA cert is present:
 
 {%- else %}
 
-Unable to get kubernetes CA cert, no kubernetes_ca_server in mine:
+Unable to get kubernetes CA cert, no kubernetes_root_ca_b64 in mine:
   test.fail_without_changes: []
 
 {%- endif %}

--- a/salt/metalk8s/kubernetes/ca/kubernetes/installed.sls
+++ b/salt/metalk8s/kubernetes/ca/kubernetes/installed.sls
@@ -35,7 +35,7 @@ Generate CA certificate:
 Advertise CA certificate in the mine:
   module.wait:
     - mine.send:
-      - func: 'kubernetes_ca_server'
+      - func: 'kubernetes_root_ca_b64'
       - mine_function: hashutil.base64_encodefile
       - /etc/kubernetes/pki/ca.crt
     - watch:


### PR DESCRIPTION
Instead of XXXX_ca_server

Fixes: #890

**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

**Summary**:

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes:  #890

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
