### PR TITLE
Improvement/1558 encrypt k8s secrets on disk

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -256,6 +256,7 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/kubernetes/apiserver/files/htpasswd'),
     Path('salt/metalk8s/kubernetes/apiserver/init.sls'),
     Path('salt/metalk8s/kubernetes/apiserver/installed.sls'),
+    Path('salt/metalk8s/kubernetes/apiserver/cryptconfig.sls'),
     Path('salt/metalk8s/kubernetes/apiserver/kubeconfig.sls'),
 
     Path('salt/metalk8s/kubernetes/ca/advertised.sls'),

--- a/salt/metalk8s/kubernetes/apiserver/cryptconfig.sls
+++ b/salt/metalk8s/kubernetes/apiserver/cryptconfig.sls
@@ -1,0 +1,47 @@
+# If an encryption key is available via the pillar, use that one.
+# If not, and we are the bootstrap node:
+#   * we are responsible for generating the encryption key
+#   * we should immediately use the configuration
+#     (i.e. this state should always execute before `.installed`)
+# Either way, create the encryption configuration file using the computed key.
+
+include:
+  - .installed
+
+{% set encryption_source_path = '/etc/metalk8s/crypt/apiserver.key' %}
+{% set encryption_k8s_path = '/etc/kubernetes/encryption.conf' %}
+
+{% if 'apiserver_key' not in pillar.metalk8s.private %}
+
+{% set encryption_key = salt['random.get_str'](32) | base64_encode %}
+
+Create encryption configuration from scratch:
+  file.managed:
+    - name: {{ encryption_source_path }}
+    - mode: 0600
+    - makedirs: True
+    - contents: {{ encryption_key }}
+
+{% else %}
+
+{% set encryption_key = salt.pillar.get('metalk8s:private:apiserver_key') %}
+
+{% endif %}
+
+Recreate encryption configuration from pillar:
+  file.serialize:
+    - name: {{ encryption_k8s_path }}
+    - mode: 0600
+    - dataset:
+        apiVersion: v1
+        kind: EncryptionConfig
+        resources:
+          - resources:
+            - secrets
+            providers:
+            - aescbc:
+                keys:
+                - name: metalk8s-secrets-key
+                  secret: {{ encryption_key }}
+    - require_in:
+      - metalk8s: Create kube-apiserver Pod manifest

--- a/salt/metalk8s/kubernetes/apiserver/init.sls
+++ b/salt/metalk8s/kubernetes/apiserver/init.sls
@@ -11,3 +11,4 @@
 include:
   - .installed
   - .kubeconfig
+  - .cryptconfig

--- a/salt/metalk8s/kubernetes/apiserver/init.sls
+++ b/salt/metalk8s/kubernetes/apiserver/init.sls
@@ -6,6 +6,7 @@
 #
 # * installed     -> deploy apiserver manifest
 # * kubeconfig    -> create admin kubeconfig file
+# * cryptconfig   -> create apiserver encryption configuration
 #
 include:
   - .installed

--- a/salt/metalk8s/kubernetes/apiserver/installed.sls
+++ b/salt/metalk8s/kubernetes/apiserver/installed.sls
@@ -2,6 +2,7 @@
 {%- from "metalk8s/map.jinja" import networks with context %}
 
 {%- set htpasswd_path = "/etc/kubernetes/htpasswd" %}
+{%- set encryption_k8s_path = "/etc/kubernetes/encryption.conf" %}
 
 include:
   - metalk8s.kubernetes.ca.advertised
@@ -81,6 +82,7 @@ Create kube-apiserver Pod manifest:
     - name: /etc/kubernetes/manifests/kube-apiserver.yaml
     - source: salt://metalk8s/kubernetes/files/control-plane-manifest.yaml
     - config_files:
+        - {{ encryption_k8s_path }}
         - /etc/kubernetes/pki/apiserver.crt
         - /etc/kubernetes/pki/apiserver.key
         - /etc/kubernetes/pki/apiserver-etcd-client.crt
@@ -114,6 +116,7 @@ Create kube-apiserver Pod manifest:
           - --cors-allowed-origins=.*
           - --enable-admission-plugins=NodeRestriction
           - --enable-bootstrap-token-auth=true
+          - --experimental-encryption-provider-config={{ encryption_k8s_path }}
           - --etcd-cafile=/etc/kubernetes/pki/etcd/ca.crt
           - --etcd-certfile=/etc/kubernetes/pki/apiserver-etcd-client.crt
           - --etcd-keyfile=/etc/kubernetes/pki/apiserver-etcd-client.key
@@ -136,6 +139,9 @@ Create kube-apiserver Pod manifest:
           - --tls-private-key-file=/etc/kubernetes/pki/apiserver.key
         requested_cpu: 250m
         volumes:
+          - path: {{ encryption_k8s_path }}
+            type: File
+            name: k8s-encryption
           - path: /etc/pki
             name: etc-pki
           - path: /etc/kubernetes/pki


### PR DESCRIPTION
**Component**: salt/apiserver

**Context**:

Currently the K8s `Secret` objects are saved as plain text in etcd, which is perfectible™.

**Summary**:

* Set up an encryption configuration state pulled by the `kube-apiserver` installation state, which is itself pulled by the role setup.
* Use the private pillar to ensure that the encryption key is generated once and only once, and then replicated across the other nodes running `kube-apiserver`.
* Make `kube-apiserver` use that encryption configuration by mounting it into the container and adding the relevant flag to its launch options.

**Acceptance criteria**: 

1. Get a cluster up with this branch, go into any machine of the cluster and switch to root
2. Create a secret: `kubectl create secret generic secret1 -n default --from-literal=mykey=mydata`
3. Verify the secret is legible: `kubectl get secret secret1 -o yaml` - the data is encoded in base64.
4. Verify the secret is encrypted in etcd:
     a. exec into the etcd container: `kubectl -ti etcd-bootstrap sh -n kube-system --kubeconfig /etc/kubernetes/admin.conf`
     b. dump the secret: `ETCDCTL_API=3 etcdctl get /registry/secrets/default/secret1 --cert=/etc/kubernetes/pki/etcd/server.crt --key=/etc/kubernetes/pki/etcd/server.key --cacert=/etc/kubernetes/pki/etcd/ca.crt | hexdump -C`
     c. The data should be illegible, and should be prefixed by `:enc:aescbc:v1`

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1558 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
