### PR TITLE
Improvement/1621 add a search to find the specific volumes by name

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1628,8 +1628,8 @@
       "integrity": "sha512-8/qcMh15507AnXJ3lBeuhsdFwnWQqnp68EpUuHlYPixJ5vjVmls7/Jq48cnUlrZI8Jd9U1jkhfCl0gaT5KMgVw=="
     },
     "@scality/core-ui": {
-      "version": "github:scality/core-ui#3865b894d2026d46552a0ec2378f7d0ae56f106e",
-      "from": "github:scality/core-ui#3865b89"
+      "version": "github:scality/core-ui#81703e0e29829b0530b404c0238933af3d8501f9",
+      "from": "github:scality/core-ui#81703e0"
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "4.2.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.7.2",
     "@kubernetes/client-node": "github:scality/kubernetes-client-javascript.git#browser-0.10.2-62-g61d8543",
-    "@scality/core-ui": "github:scality/core-ui.git#3865b89",
+    "@scality/core-ui": "github:scality/core-ui.git#81703e0",
     "axios": "^0.18.0",
     "formik": "1.5.1",
     "lodash": "4.17.13",

--- a/ui/src/containers/NodeInformation.js
+++ b/ui/src/containers/NodeInformation.js
@@ -167,6 +167,7 @@ const NodeInformation = props => {
       </PodsContainer>
     </>
   );
+
   const volumeData = volumes.map(volume => {
     const volumePV = pVList.find(
       pV => pV.metadata.name === volume.metadata.name,

--- a/ui/src/containers/NodeVolumes.js
+++ b/ui/src/containers/NodeVolumes.js
@@ -344,9 +344,15 @@ const NodeVolumes = props => {
           onRowClick={item => {
             onRowClick(item);
           }}
-          noRowsRenderer={() => (
-            <NoRowsRenderer content={intl.messages.no_volume_found} />
-          )}
+          noRowsRenderer={() =>
+            searchedVolumeName === '' ? (
+              <NoRowsRenderer content={intl.messages.no_volume_found} />
+            ) : (
+              <NoRowsRenderer
+                content={intl.messages.no_searched_volume_found}
+              />
+            )
+          }
         />
       </VolumeTable>
     </>

--- a/ui/src/containers/NodeVolumes.js
+++ b/ui/src/containers/NodeVolumes.js
@@ -4,7 +4,7 @@ import { injectIntl } from 'react-intl';
 import styled from 'styled-components';
 import { FormattedDate, FormattedTime } from 'react-intl';
 import { withRouter } from 'react-router-dom';
-import { Button, Table, Loader, Modal } from '@scality/core-ui';
+import { Button, Table, Loader, Modal, SearchInput } from '@scality/core-ui';
 import { padding, grayLight } from '@scality/core-ui/dist/style/theme';
 import NoRowsRenderer from '../components/NoRowsRenderer';
 import Tooltip from '../components/Tooltip';
@@ -29,13 +29,6 @@ import {
   STATUS_BOUND,
   STATUS_RELEASED,
 } from '../constants';
-
-const ButtonContainer = styled.div`
-  margin-top: ${padding.small};
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-`;
 
 const VolumeTable = styled.div`
   flex-grow: 1;
@@ -82,6 +75,26 @@ const IconButton = styled.button`
   }
 `;
 
+const ActionContainer = styled.div`
+  margin-top: ${padding.small};
+  display: flex;
+  justify-content: space-between;
+`;
+
+const SearchContainer = styled.div`
+  width: 250px;
+`;
+
+const ButtonContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const LoaderContainer = styled(Loader)`
+  padding-right: ${padding.smaller};
+`;
+
 const NodeVolumes = props => {
   const { intl } = props;
 
@@ -93,6 +106,7 @@ const NodeVolumes = props => {
 
   const volumes = useSelector(state => state.app.volumes);
   const persistentVolumes = useSelector(state => state.app.volumes.pVList);
+  const [searchedVolumeName, setSearchedVolumeName] = useState('');
   const [sortBy, setSortBy] = useState('name');
   const [sortDirection, setSortDirection] = useState('ASC');
   const [
@@ -271,7 +285,12 @@ const NodeVolumes = props => {
     }
   };
 
-  let volumeSortedList = props.data;
+  const volumeDataList = props.data;
+
+  let volumeSortedList = volumeDataList.filter(volume =>
+    volume.name.includes(searchedVolumeName),
+  );
+
   if (sortBy === 'storageCapacity') {
     volumeSortedList = sortCapacity(volumeSortedList, sortBy, sortDirection);
   } else {
@@ -285,6 +304,10 @@ const NodeVolumes = props => {
 
   const onClickCancelButton = () => {
     setisDeleteConfirmationModalOpen(false);
+  };
+
+  const handleChange = e => {
+    setSearchedVolumeName(e.target.value);
   };
 
   return (
@@ -320,17 +343,31 @@ const NodeVolumes = props => {
         </ModalBody>
       </Modal>
 
-      <ButtonContainer>
-        <Button
-          text={intl.messages.create_new_volume}
-          type="button"
-          onClick={() => {
-            props.history.push('createVolume');
-          }}
-          data-cy="create-volume-button"
-        />
-        {volumes.isLoading && <Loader size="small" />}
-      </ButtonContainer>
+      <ActionContainer>
+        <SearchContainer>
+          <SearchInput
+            value={searchedVolumeName}
+            placeholder={intl.messages.search}
+            disableToggle={true}
+            onChange={handleChange}
+          ></SearchInput>
+        </SearchContainer>
+
+        <ButtonContainer>
+          {volumes.isLoading && <LoaderContainer size="small" />}
+          <Tooltip placement="left" overlay={intl.messages.create_new_volume}>
+            <Button
+              text={<i className="fas fa-plus "></i>}
+              type="button"
+              onClick={() => {
+                props.history.push('createVolume');
+              }}
+              data-cy="create-volume-button"
+            />
+          </Tooltip>
+        </ButtonContainer>
+      </ActionContainer>
+
       <VolumeTable>
         <Table
           list={volumeSortedList}

--- a/ui/src/ducks/app/volumes.js
+++ b/ui/src/ducks/app/volumes.js
@@ -4,12 +4,12 @@ import history from '../../history';
 import { intl } from '../../translations/IntlGlobalProvider';
 import {
   addNotificationErrorAction,
-  addNotificationSuccessAction
+  addNotificationSuccessAction,
 } from './notifications';
 import {
   SPARSE_LOOP_DEVICE,
   RAW_BLOCK_DEVICE,
-  REFRESH_TIMEOUT
+  REFRESH_TIMEOUT,
 } from '../../constants';
 
 // Actions
@@ -42,7 +42,7 @@ const defaultState = {
   pVCList: [],
   isPVRefreshing: false,
   isLoading: false,
-  isSCLoading: false
+  isSCLoading: false,
 };
 
 export default function reducer(state = defaultState, action = {}) {
@@ -147,8 +147,8 @@ export const updateVolumesAction = payload => {
 export function* fetchVolumes() {
   yield put(
     updateVolumesAction({
-      isLoading: true
-    })
+      isLoading: true,
+    }),
   );
   const result = yield call(ApiK8s.getVolumes);
   if (!result.error) {
@@ -157,8 +157,8 @@ export function* fetchVolumes() {
   yield delay(1000); // To make sure that the loader is visible for at least 1s
   yield put(
     updateVolumesAction({
-      isLoading: false
-    })
+      isLoading: false,
+    }),
   );
   return result;
 }
@@ -211,12 +211,12 @@ export function* createVolumes({ payload }) {
     apiVersion: 'storage.metalk8s.scality.com/v1alpha1',
     kind: 'Volume',
     metadata: {
-      name: newVolume.name
+      name: newVolume.name,
     },
     spec: {
       nodeName,
-      storageClassName: newVolume.storageClass
-    }
+      storageClassName: newVolume.storageClass,
+    },
   };
 
   /**
@@ -244,18 +244,18 @@ export function* createVolumes({ payload }) {
         addNotificationSuccessAction({
           title: intl.translate('volume_creation'),
           message: intl.translate('volume_creation_success', {
-            name: newVolume.name
-          })
-        })
+            name: newVolume.name,
+          }),
+        }),
       );
     } else {
       yield put(
         addNotificationErrorAction({
           title: intl.translate('volume_creation'),
           message: intl.translate('volume_creation_failed', {
-            name: newVolume.name
-          })
-        })
+            name: newVolume.name,
+          }),
+        }),
       );
     }
   } else {
@@ -263,8 +263,8 @@ export function* createVolumes({ payload }) {
     yield put(
       addNotificationErrorAction({
         title: 'Volume Form Error',
-        message: 'Volume not created, some fields are missing.'
-      })
+        message: 'Volume not created, some fields are missing.',
+      }),
     );
   }
 }
@@ -298,7 +298,7 @@ export function* refreshPersistentVolumes() {
   if (!result.error) {
     yield delay(REFRESH_TIMEOUT);
     const isPVRefreshing = yield select(
-      state => state.app.volumes.isPVRefreshing
+      state => state.app.volumes.isPVRefreshing,
     );
     if (isPVRefreshing) {
       yield call(refreshPersistentVolumes);
@@ -317,18 +317,18 @@ export function* deleteVolume({ payload }) {
       addNotificationSuccessAction({
         title: intl.translate('volume_deletion'),
         message: intl.translate('volume_delete_success', {
-          name: payload
-        })
-      })
+          name: payload,
+        }),
+      }),
     );
   } else {
     yield put(
       addNotificationErrorAction({
         title: intl.translate('volume_deletion'),
         message: intl.translate('volume_delete_failed', {
-          name: payload
-        })
-      })
+          name: payload,
+        }),
+      }),
     );
   }
   yield call(fetchVolumes);
@@ -346,6 +346,6 @@ export function* volumesSaga() {
   yield takeLatest(REFRESH_PERSISTENT_VOLUMES, refreshPersistentVolumes);
   yield takeLatest(
     STOP_REFRESH_PERSISTENT_VOLUMES,
-    stopRefreshPersistentVolumes
+    stopRefreshPersistentVolumes,
   );
 }

--- a/ui/src/ducks/app/volumes.test.js
+++ b/ui/src/ducks/app/volumes.test.js
@@ -2,7 +2,7 @@ import { call, put, delay } from 'redux-saga/effects';
 import history from '../../history';
 import {
   ADD_NOTIFICATION_ERROR,
-  ADD_NOTIFICATION_SUCCESS
+  ADD_NOTIFICATION_SUCCESS,
 } from './notifications';
 import {
   fetchVolumes,
@@ -19,7 +19,7 @@ import {
   updateVolumesAction,
   stopRefreshPersistentVolumes,
   updateStorageClassAction,
-  deleteVolume
+  deleteVolume,
 } from './volumes';
 import * as ApiK8s from '../../services/k8s/api';
 import { SET_STORAGECLASS } from './volumes.js';
@@ -30,9 +30,9 @@ it('update the volume', () => {
   expect(gen.next().value).toEqual(
     put(
       updateVolumesAction({
-        isLoading: true
-      })
-    )
+        isLoading: true,
+      }),
+    ),
   );
   expect(gen.next().value).toEqual(call(ApiK8s.getVolumes));
 
@@ -49,30 +49,30 @@ it('update the volume', () => {
             resourceVersion: '24324',
             selfLink:
               '/apis/storage.metalk8s.scality.com/v1alpha1/volumes/yanjin-test',
-            uid: '5e417a13-71cd-4b80-81e9-112dff5da750'
+            uid: '5e417a13-71cd-4b80-81e9-112dff5da750',
           },
           spec: {
             nodeName: 'metalk8s-bootstrap.novalocal',
             sparseLoopDevice: {
-              size: '1Gi'
+              size: '1Gi',
             },
-            storageClassName: 'standard'
-          }
-        }
-      ]
-    }
+            storageClassName: 'standard',
+          },
+        },
+      ],
+    },
   };
 
   expect(gen.next(result).value).toEqual(
-    put(setVolumesAction(result.body.items))
+    put(setVolumesAction(result.body.items)),
   );
   expect(gen.next().value).toEqual(delay(1000));
   expect(gen.next().value).toEqual(
     put(
       updateVolumesAction({
-        isLoading: false
-      })
-    )
+        isLoading: false,
+      }),
+    ),
   );
   const finalGen = gen.next();
   expect(finalGen.value).toEqual(result);
@@ -84,9 +84,9 @@ it('does not update volume if there is an error', () => {
   expect(gen.next().value).toEqual(
     put(
       updateVolumesAction({
-        isLoading: true
-      })
-    )
+        isLoading: true,
+      }),
+    ),
   );
   expect(gen.next().value).toEqual(call(ApiK8s.getVolumes));
 
@@ -96,9 +96,9 @@ it('does not update volume if there is an error', () => {
   expect(gen.next().value).toEqual(
     put(
       updateVolumesAction({
-        isLoading: false
-      })
-    )
+        isLoading: false,
+      }),
+    ),
   );
   const finalGen = gen.next(result);
   expect(finalGen.done).toEqual(true);
@@ -110,9 +110,9 @@ it('should put a empty array if Volumes is not correct', () => {
   expect(gen.next().value).toEqual(
     put(
       updateVolumesAction({
-        isLoading: true
-      })
-    )
+        isLoading: true,
+      }),
+    ),
   );
   expect(gen.next().value).toEqual(call(ApiK8s.getVolumes));
 
@@ -122,9 +122,9 @@ it('should put a empty array if Volumes is not correct', () => {
   expect(gen.next().value).toEqual(
     put(
       updateVolumesAction({
-        isLoading: false
-      })
-    )
+        isLoading: false,
+      }),
+    ),
   );
   const finalGen = gen.next();
   expect(finalGen.done).toEqual(true);
@@ -145,21 +145,21 @@ it('update the storage class', () => {
             selfLink: '/apis/storage.k8s.io/v1/storageclasses/standard',
             uid: 'ad65238e-c860-4782-bdda-f8468998086e',
             resourceVersion: '21491',
-            creationTimestamp: '2019-07-25T15:52:24Z'
+            creationTimestamp: '2019-07-25T15:52:24Z',
           },
           provisioner: 'kubernetes.io/aws-ebs',
           parameters: {
-            type: 'gp2'
+            type: 'gp2',
           },
           reclaimPolicy: 'Retain',
           mountOptions: ['debug'],
-          volumeBindingMode: 'Immediate'
-        }
-      ]
-    }
+          volumeBindingMode: 'Immediate',
+        },
+      ],
+    },
   };
   expect(gen.next(result).value).toEqual(
-    put({ type: SET_STORAGECLASS, payload: result.body.items })
+    put({ type: SET_STORAGECLASS, payload: result.body.items }),
   );
   expect(gen.next().value).toEqual(put(updateStorageClassAction(false)));
   expect(gen.next().done).toEqual(true);
@@ -171,7 +171,7 @@ it('does not update the storage class if there is an error', () => {
   expect(gen.next().value).toEqual(call(ApiK8s.getStorageClass));
 
   const result = {
-    error: {}
+    error: {},
   };
   expect(gen.next(result).value).toEqual(put(updateStorageClassAction(false)));
   expect(gen.next().done).toEqual(true);
@@ -198,20 +198,20 @@ it('update PVs', () => {
                 name: 'yanjin-test',
                 uid: '5e417a13-71cd-4b80-81e9-112dff5da750',
                 controller: true,
-                blockOwnerDeletion: true
-              }
+                blockOwnerDeletion: true,
+              },
             ],
             finalizers: [
               'storage.metalk8s.scality.com/volume-protection',
-              'kubernetes.io/pv-protection'
-            ]
+              'kubernetes.io/pv-protection',
+            ],
           },
           spec: {
             capacity: {
-              storage: '1Gi'
+              storage: '1Gi',
             },
             local: {
-              path: '/tmp/foo'
+              path: '/tmp/foo',
             },
             accessModes: ['ReadWriteOnce'],
             persistentVolumeReclaimPolicy: 'Retain',
@@ -225,31 +225,31 @@ it('update PVs', () => {
                       {
                         key: 'kubernetes.io/hostname',
                         operator: 'In',
-                        values: ['metalk8s-bootstrap.novalocal']
-                      }
+                        values: ['metalk8s-bootstrap.novalocal'],
+                      },
                     ],
                     matchFields: [
                       {
                         key: 'metadata.name',
                         operator: 'In',
-                        values: ['metalk8s-bootstrap.novalocal']
-                      }
-                    ]
-                  }
-                ]
-              }
-            }
+                        values: ['metalk8s-bootstrap.novalocal'],
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
           },
           status: {
-            phase: 'Available'
-          }
-        }
-      ]
-    }
+            phase: 'Available',
+          },
+        },
+      ],
+    },
   };
 
   expect(gen.next(result).value).toEqual(
-    put(setPersistentVolumesAction(result.body.items))
+    put(setPersistentVolumesAction(result.body.items)),
   );
   expect(gen.next().done).toEqual(true);
 });
@@ -270,7 +270,7 @@ it('does not update PV if there is an error', () => {
   expect(gen.next().value).toEqual(call(ApiK8s.getPersistentVolumes));
 
   const result = {
-    error: {}
+    error: {},
   };
 
   expect(gen.next(result).done).toEqual(true);
@@ -283,10 +283,10 @@ it('create volume with the type sparseloopdevice', () => {
         name: 'volume1',
         storageClass: 'metalk8s-default',
         type: 'sparseLoopDevice',
-        size: '1Gi'
+        size: '1Gi',
       },
-      nodeName: 'bootstrap'
-    }
+      nodeName: 'bootstrap',
+    },
   };
 
   const { newVolume, nodeName } = action.payload;
@@ -297,13 +297,13 @@ it('create volume with the type sparseloopdevice', () => {
     apiVersion: 'storage.metalk8s.scality.com/v1alpha1',
     kind: 'Volume',
     metadata: {
-      name: newVolume.name
+      name: newVolume.name,
     },
     spec: {
       nodeName: nodeName,
       storageClassName: newVolume.storageClass,
-      sparseLoopDevice: { size: newVolume.size }
-    }
+      sparseLoopDevice: { size: newVolume.size },
+    },
   };
 
   expect(gen.next(body).value).toEqual(call(ApiK8s.createVolume, body));
@@ -318,24 +318,24 @@ it('create volume with the type sparseloopdevice', () => {
         resourceVersion: '345964',
         selfLink:
           '/apis/storage.metalk8s.scality.com/v1alpha1/volumes/patrick-098765',
-        uid: 'd432d9f1-7247-44d4-868e-1d4599723516'
+        uid: 'd432d9f1-7247-44d4-868e-1d4599723516',
       },
       spec: {
         nodeName: 'metalk8s-bootstrap.novalocal',
         sparseLoopDevice: {
-          size: '42Gi'
+          size: '42Gi',
         },
-        storageClassName: 'standard'
-      }
-    }
+        storageClassName: 'standard',
+      },
+    },
   };
 
   expect(gen.next(result).value).toEqual(
-    call(history.push, `/nodes/${nodeName}/volumes`)
+    call(history.push, `/nodes/${nodeName}/volumes`),
   );
 
   expect(gen.next().value.payload.action.type).toEqual(
-    ADD_NOTIFICATION_SUCCESS
+    ADD_NOTIFICATION_SUCCESS,
   );
 
   expect(gen.next().done).toEqual(true);
@@ -348,10 +348,10 @@ it('create a volume with the type rawBlockdevice', () => {
         name: 'volume1',
         storageClass: 'metalk8s-default',
         type: 'rawBlockDevice',
-        path: '/dev/disk1'
+        path: '/dev/disk1',
       },
-      nodeName: 'bootstrap'
-    }
+      nodeName: 'bootstrap',
+    },
   };
   const { newVolume, nodeName } = action.payload;
   const gen = createVolumes(action);
@@ -360,13 +360,13 @@ it('create a volume with the type rawBlockdevice', () => {
     apiVersion: 'storage.metalk8s.scality.com/v1alpha1',
     kind: 'Volume',
     metadata: {
-      name: newVolume.name
+      name: newVolume.name,
     },
     spec: {
       nodeName: nodeName,
       storageClassName: newVolume.storageClass,
-      rawBlockDevice: { devicePath: newVolume.path }
-    }
+      rawBlockDevice: { devicePath: newVolume.path },
+    },
   };
 
   expect(gen.next(body).value).toEqual(call(ApiK8s.createVolume, body));
@@ -381,21 +381,21 @@ it('create a volume with the type rawBlockdevice', () => {
         resourceVersion: '345964',
         selfLink:
           '/apis/storage.metalk8s.scality.com/v1alpha1/volumes/patrick-098765',
-        uid: 'd432d9f1-7247-44d4-868e-1d4599723516'
+        uid: 'd432d9f1-7247-44d4-868e-1d4599723516',
       },
       spec: {
         nodeName: 'metalk8s-bootstrap.novalocal',
         rawBlockDevice: { devicePath: '/dev/disk1' },
-        storageClassName: 'standard'
-      }
-    }
+        storageClassName: 'standard',
+      },
+    },
   };
 
   expect(gen.next(result).value).toEqual(
-    call(history.push, `/nodes/${nodeName}/volumes`)
+    call(history.push, `/nodes/${nodeName}/volumes`),
   );
   expect(gen.next().value.payload.action.type).toEqual(
-    ADD_NOTIFICATION_SUCCESS
+    ADD_NOTIFICATION_SUCCESS,
   );
 
   expect(gen.next().done).toEqual(true);
@@ -408,10 +408,10 @@ it('display a notification when the params are wrong', () => {
         name: 'volume1',
         storageClass: 'metalk8s-default',
         type: 'rawBlockDevice',
-        path: ''
+        path: '',
       },
-      nodeName: 'bootstrap'
-    }
+      nodeName: 'bootstrap',
+    },
   };
 
   const gen = createVolumes(action);
@@ -427,10 +427,10 @@ it('does not create a volume when there is an error', () => {
         name: 'volume1',
         storageClass: 'metalk8s-default',
         type: 'rawBlockDevice',
-        path: '/dev/disk1'
+        path: '/dev/disk1',
       },
-      nodeName: 'bootstrap'
-    }
+      nodeName: 'bootstrap',
+    },
   };
   const { newVolume, nodeName } = action.payload;
   const gen = createVolumes(action);
@@ -438,19 +438,19 @@ it('does not create a volume when there is an error', () => {
     apiVersion: 'storage.metalk8s.scality.com/v1alpha1',
     kind: 'Volume',
     metadata: {
-      name: newVolume.name
+      name: newVolume.name,
     },
     spec: {
       nodeName: nodeName,
       storageClassName: newVolume.storageClass,
-      rawBlockDevice: { devicePath: newVolume.path }
-    }
+      rawBlockDevice: { devicePath: newVolume.path },
+    },
   };
   expect(gen.next(body).value).toEqual(call(ApiK8s.createVolume, body));
   const result = { error: {} };
 
   expect(gen.next(result).value.payload.action.type).toEqual(
-    ADD_NOTIFICATION_ERROR
+    ADD_NOTIFICATION_ERROR,
   );
 
   expect(gen.next().done).toEqual(true);
@@ -496,7 +496,7 @@ it('should stop refresh volume', () => {
 it('should refresh the pesistent volume', () => {
   const gen = refreshPersistentVolumes();
   expect(gen.next().value).toEqual(
-    put(updatePersistentVolumesRefreshingAction(true))
+    put(updatePersistentVolumesRefreshingAction(true)),
   );
   expect(gen.next().value).toEqual(call(fetchPersistentVolumes));
   const result = {
@@ -515,21 +515,21 @@ it('should refresh the pesistent volume', () => {
               name: 'gdmlgerml',
               uid: '316c0dc0-3cfc-48f3-8062-eb0dd4ce6108',
               controller: true,
-              blockOwnerDeletion: true
-            }
+              blockOwnerDeletion: true,
+            },
           ],
           finalizers: [
             'storage.metalk8s.scality.com/volume-protection',
-            'kubernetes.io/pv-protection'
-          ]
+            'kubernetes.io/pv-protection',
+          ],
         },
         spec: {
           capacity: {
-            storage: '12345676432'
+            storage: '12345676432',
           },
           local: {
             path:
-              '/var/lib/metalk8s/storage/sparse/316c0dc0-3cfc-48f3-8062-eb0dd4ce6108'
+              '/var/lib/metalk8s/storage/sparse/316c0dc0-3cfc-48f3-8062-eb0dd4ce6108',
           },
           accessModes: ['ReadWriteOnce'],
           persistentVolumeReclaimPolicy: 'Retain',
@@ -543,26 +543,26 @@ it('should refresh the pesistent volume', () => {
                     {
                       key: 'kubernetes.io/hostname',
                       operator: 'In',
-                      values: ['metalk8s-bootstrap.novalocal']
-                    }
+                      values: ['metalk8s-bootstrap.novalocal'],
+                    },
                   ],
                   matchFields: [
                     {
                       key: 'metadata.name',
                       operator: 'In',
-                      values: ['metalk8s-bootstrap.novalocal']
-                    }
-                  ]
-                }
-              ]
-            }
-          }
+                      values: ['metalk8s-bootstrap.novalocal'],
+                    },
+                  ],
+                },
+              ],
+            },
+          },
         },
         status: {
-          phase: 'Available'
-        }
-      }
-    ]
+          phase: 'Available',
+        },
+      },
+    ],
   };
   expect(gen.next(result).value).toEqual(delay(REFRESH_TIMEOUT));
   expect(gen.next().value.type).toEqual('SELECT');
@@ -573,7 +573,7 @@ it('should refresh the pesistent volume', () => {
 it('should not refresh the pesistent volume if there is error', () => {
   const gen = refreshPersistentVolumes();
   expect(gen.next().value).toEqual(
-    put(updatePersistentVolumesRefreshingAction(true))
+    put(updatePersistentVolumesRefreshingAction(true)),
   );
   expect(gen.next().value).toEqual(call(fetchPersistentVolumes));
   const result = { error: {} };
@@ -583,7 +583,7 @@ it('should not refresh the pesistent volume if there is error', () => {
 it('should stop refresh persistent volume', () => {
   const gen = stopRefreshPersistentVolumes();
   expect(gen.next().value).toEqual(
-    put(updatePersistentVolumesRefreshingAction(false))
+    put(updatePersistentVolumesRefreshingAction(false)),
   );
   expect(gen.next().done).toEqual(true);
 });
@@ -591,7 +591,7 @@ it('should stop refresh persistent volume', () => {
 it('should not refresh persistent volume if you leave the page', () => {
   const gen = refreshPersistentVolumes();
   expect(gen.next().value).toEqual(
-    put(updatePersistentVolumesRefreshingAction(true))
+    put(updatePersistentVolumesRefreshingAction(true)),
   );
   expect(gen.next().value).toEqual(call(fetchPersistentVolumes));
   const result = {};
@@ -603,7 +603,7 @@ it('should not refresh persistent volume if you leave the page', () => {
 it('should not refresh volume if volume have an error', () => {
   const gen = refreshPersistentVolumes();
   expect(gen.next().value).toEqual(
-    put(updatePersistentVolumesRefreshingAction(true))
+    put(updatePersistentVolumesRefreshingAction(true)),
   );
   expect(gen.next().value).toEqual(call(fetchPersistentVolumes));
   const result = { error: {} };
@@ -628,22 +628,22 @@ it('should delete volume', () => {
         resourceVersion: '1870920',
         selfLink:
           '/apis/storage.metalk8s.scality.com/v1alpha1/volumes/yanjin-volume-for-test',
-        uid: 'dcf7e212-16aa-48df-a275-0bcb73410a8c'
+        uid: 'dcf7e212-16aa-48df-a275-0bcb73410a8c',
       },
       spec: {
         nodeName: 'metalk8s-bootstrap.novalocal',
         sparseLoopDevice: {
-          size: '45Gi'
+          size: '45Gi',
         },
-        storageClassName: 'metalk8s-prometheus'
+        storageClassName: 'metalk8s-prometheus',
       },
       status: {
-        phase: 'Available'
-      }
-    }
+        phase: 'Available',
+      },
+    },
   };
   expect(gen.next(result).value.payload.action.type).toEqual(
-    ADD_NOTIFICATION_SUCCESS
+    ADD_NOTIFICATION_SUCCESS,
   );
   expect(gen.next().value).toEqual(call(fetchVolumes));
   expect(gen.next().done).toEqual(true);
@@ -655,7 +655,7 @@ it('should display the error notification when there is error in delete volume',
   expect(gen.next().value).toEqual(call(ApiK8s.deleteVolume, 'test-volume'));
   const result = { error: {} };
   expect(gen.next(result).value.payload.action.type).toEqual(
-    ADD_NOTIFICATION_ERROR
+    ADD_NOTIFICATION_ERROR,
   );
   expect(gen.next().value).toEqual(call(fetchVolumes));
   expect(gen.next().done).toEqual(true);

--- a/ui/src/ducks/login.js
+++ b/ui/src/ducks/login.js
@@ -21,7 +21,7 @@ export const HASH_KEY = 'token';
 const defaultState = {
   user: null,
   error: null,
-  isUserInfoLoaded: false
+  isUserInfoLoaded: false,
 };
 
 export default function reducer(state = defaultState, action = {}) {
@@ -29,22 +29,22 @@ export default function reducer(state = defaultState, action = {}) {
     case AUTHENTICATION_SUCCESS:
       return {
         ...state,
-        user: action.payload
+        user: action.payload,
       };
     case SALT_AUTHENTICATION_SUCCESS:
       return {
         ...state,
-        salt: action.payload
+        salt: action.payload,
       };
     case AUTHENTICATION_FAILED:
       return {
         ...state,
-        errors: { authentication: action.payload.message }
+        errors: { authentication: action.payload.message },
       };
     case SET_USER_INFO_LOADED:
       return {
         ...state,
-        isUserInfoLoaded: action.payload
+        isUserInfoLoaded: action.payload,
       };
 
     default:
@@ -72,14 +72,14 @@ export const setUserInfoLoadedAction = payload => {
 export const setAuthenticationSuccessAction = payload => {
   return {
     type: AUTHENTICATION_SUCCESS,
-    payload
+    payload,
   };
 };
 
 export const setSaltAuthenticationSuccessAction = payload => {
   return {
     type: SALT_AUTHENTICATION_SUCCESS,
-    payload
+    payload,
   };
 };
 
@@ -92,7 +92,7 @@ export function* authenticate({ payload }) {
   if (result.error) {
     yield put({
       type: AUTHENTICATION_FAILED,
-      payload: result.error.response.data
+      payload: result.error.response.data,
     });
   } else {
     const api_server = yield select(state => state.config.api);
@@ -102,8 +102,8 @@ export function* authenticate({ payload }) {
       setAuthenticationSuccessAction({
         username,
         password,
-        token
-      })
+        token,
+      }),
     );
     yield call(authenticateSaltApi, true);
   }
@@ -116,14 +116,14 @@ export function* authenticateSaltApi(redirect) {
   const result = yield call(ApiSalt.authenticate, user);
   if (!result.error) {
     yield call(ApiSalt.getClient().setHeaders, {
-      'X-Auth-Token': result.return[0].token
+      'X-Auth-Token': result.return[0].token,
     });
     yield put(setSaltAuthenticationSuccessAction(result));
     yield put(
       connectSaltApiAction({
         url: api.url_salt,
-        token: result.return[0].token
-      })
+        token: result.return[0].token,
+      }),
     );
     if (redirect) {
       yield call(history.push, '/');
@@ -152,8 +152,8 @@ export function* fetchUserInfo() {
       setAuthenticationSuccessAction({
         username,
         password,
-        token
-      })
+        token,
+      }),
     );
     yield call(authenticateSaltApi);
   } else {

--- a/ui/src/ducks/login.test.js
+++ b/ui/src/ducks/login.test.js
@@ -7,7 +7,7 @@ import {
   AUTHENTICATION_SUCCESS,
   SET_USER_INFO_LOADED,
   fetchUserInfo,
-  authenticateSaltApi
+  authenticateSaltApi,
 } from './login';
 import * as ApiK8s from '../services/k8s/api';
 
@@ -21,21 +21,21 @@ it('authentication failed', () => {
   const result = {
     error: {
       response: {
-        data: 'Unauthorized'
-      }
-    }
+        data: 'Unauthorized',
+      },
+    },
   };
   expect(gen.next(result).value).toEqual(
     put({
       type: AUTHENTICATION_FAILED,
-      payload: 'Unauthorized'
-    })
+      payload: 'Unauthorized',
+    }),
   );
   expect(gen.next(result).value).toEqual(
     put({
       type: SET_USER_INFO_LOADED,
-      payload: true
-    })
+      payload: true,
+    }),
   );
 });
 
@@ -47,12 +47,12 @@ it('authentication success', () => {
   expect(gen.next().value).toEqual(call(ApiK8s.authenticate, token));
 
   const result = {
-    data: {}
+    data: {},
   };
 
   expect(gen.next(result).value.type).toEqual('SELECT');
   expect(gen.next({ url: 'localhost:8080' }).value).toEqual(
-    call(ApiK8s.updateApiServerConfig, 'localhost:8080', token)
+    call(ApiK8s.updateApiServerConfig, 'localhost:8080', token),
   );
 
   expect(gen.next().value).toEqual(
@@ -61,9 +61,9 @@ it('authentication success', () => {
       payload: {
         username: 'admin',
         password: 'admin',
-        token
-      }
-    })
+        token,
+      },
+    }),
   );
 
   expect(gen.next().value).toEqual(call(authenticateSaltApi, true));
@@ -71,22 +71,22 @@ it('authentication success', () => {
   expect(gen.next(result).value).toEqual(
     put({
       type: SET_USER_INFO_LOADED,
-      payload: true
-    })
+      payload: true,
+    }),
   );
 });
 
 it('fetchUserInfo success', () => {
   localStorage.setItem(HASH_KEY, 'dGVzdDp0ZXN0');
-  const gen = fetchUserInfo();
 
+  const gen = fetchUserInfo();
   expect(gen.next().value.type).toEqual('SELECT');
   expect(gen.next({ url: 'localhost:8080' }).value).toEqual(
-    call(ApiK8s.updateApiServerConfig, 'localhost:8080', 'dGVzdDp0ZXN0')
+    call(ApiK8s.updateApiServerConfig, 'localhost:8080', 'dGVzdDp0ZXN0'),
   );
 
   const result = {
-    data: {}
+    data: {},
   };
   expect(gen.next(result).value).toEqual(
     put({
@@ -94,9 +94,9 @@ it('fetchUserInfo success', () => {
       payload: {
         username: 'test',
         password: 'test',
-        token: 'dGVzdDp0ZXN0'
-      }
-    })
+        token: 'dGVzdDp0ZXN0',
+      },
+    }),
   );
 
   expect(gen.next().value).toEqual(call(authenticateSaltApi));
@@ -104,22 +104,22 @@ it('fetchUserInfo success', () => {
   expect(gen.next(result).value).toEqual(
     put({
       type: SET_USER_INFO_LOADED,
-      payload: true
-    })
+      payload: true,
+    }),
   );
   localStorage.removeItem(HASH_KEY);
 });
 
 it('fetchUserInfo failed', () => {
   localStorage.removeItem(HASH_KEY);
-  const gen = fetchUserInfo();
 
+  const gen = fetchUserInfo();
   expect(gen.next().value).toEqual(call(history.push, '/login'));
 
   expect(gen.next().value).toEqual(
     put({
       type: SET_USER_INFO_LOADED,
-      payload: true
-    })
+      payload: true,
+    }),
   );
 });

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -70,6 +70,7 @@
   "creationTime": "Creation Time",
   "create_new_volume": "Create a New Volume",
   "no_volume_found": "No volumes on this node",
+  "no_searched_volume_found": "No volumes matching the search",
   "type": "Type",
   "volume_size": "Volume Capacity",
   "device_path": "Device path",
@@ -111,5 +112,6 @@
   "delete_a_volume_confirm": "Do you want to delete ",
   "select_a_storageClass": "Select a Storage Class…",
   "select_a_type": "Select a type of volume…",
-  "no_results": "No results"
+  "no_results": "No results",
+  "search": "Search…"
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -70,6 +70,7 @@
   "creationTime": "Date de création",
   "create_new_volume": "Créer un nouveau volume",
   "no_volume_found": "Aucun volume sur ce nœud",
+  "no_searched_volume_found": "Aucun volume correspondant à la recherche",
   "type": "Type",
   "volume_size": "Capacité du volume",
   "device_path": "Chemin du disque",
@@ -111,5 +112,6 @@
   "delete_a_volume_confirm": "Voulez-vous supprimez ",
   "select_a_storageClass": "Sélectionner une classe de stockage…",
   "select_a_type": "Sélectionner un type de volume…",
-  "no_results": "Aucun résultat"
+  "no_results": "Aucun résultat",
+  "search": "Rechercher…"
 }


### PR DESCRIPTION
**Component**: ui, storage

**Context**: 
As a user, it's more user-friendly to have the search bar in order to check the specific volume.

**Summary**:
The volume list will be updated according to what the user input in the search bar.

**Acceptance criteria**: 
The UI is as follows:
![image](https://user-images.githubusercontent.com/18453133/64520600-c7f4ae80-d2f6-11e9-96ec-f8ee2908d532.png)

The volume list will display the volume whose name included in the text the user input in the search bar.
For example, if you put `d`, then =>
the volume list will be filtered into 
![image](https://user-images.githubusercontent.com/18453133/64521035-903a3680-d2f7-11e9-8111-560ac7127f8b.png)

If there isn't volume meet the search, it should display `No volumes matching the search`
![image](https://user-images.githubusercontent.com/18453133/64610819-656fe100-d3d0-11e9-84b7-85758d4068ed.png)

Closes: #1621 
