### PR TITLE
Add size limit to the assets

### DIFF
--- a/ui/config-overrides.js
+++ b/ui/config-overrides.js
@@ -6,8 +6,29 @@ const {
 } = require('customize-cra');
 const CompressionPlugin = require('compression-webpack-plugin');
 
+/**
+ * We might want to make that more generic and create a PR to `customize-cra`
+ * to handle this use case.
+ *
+ * https://webpack.js.org/configuration/performance/#performancehints
+ */
+const setWebpackPerformance = () => config => {
+  config.performance = {
+    hints: 'error',
+    // ~390 KiB
+    maxAssetSize: 400000,
+    assetFilter: assetFilename => {
+      return (
+        !assetFilename.endsWith('.map.gz') && assetFilename.endsWith('.gz')
+      );
+    },
+  };
+  return config;
+};
+
 module.exports = override(
   useBabelRc(),
   useEslintRc(),
   addWebpackPlugin(new CompressionPlugin()),
+  setWebpackPerformance(),
 );


### PR DESCRIPTION
**Component**: ui, build

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
This PR is here to make sure that the build size stay in a reasonable size.

**Summary**:
Limit the size of each asset to 390KiB.

**Acceptance criteria**: 
When a build pass over 390KiB, the build fail.
To test this PR, you can comment `metalk8s/ui/config-overrides.js` line 19 .

```
// maxAssetSize: 400000,
```

The try to build the ui `npm run build`
It should fail and show an error about the build size like this : 
``` bash
Failed to compile.

asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets:
  static/js/2.284a7137.chunk.js.gz (325 KiB)


npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! metalk8s-platform-ui@0.1.0 build: `react-app-rewired build`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the metalk8s-platform-ui@0.1.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/patrickear/.npm/_logs/2019-09-09T15_23_49_489Z-debug.log
```

---

<!-- Declare one or more issues to close once this PR gets merged -->

This PR is specificly targeting `js` and `css`. `svg` like `font-awesome` icons are not the scope of the PR.
See: #1639

Closes: #1619 