### PR TITLE
Remove hard coded service ips for coredns and kubernetes service 

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -402,6 +402,7 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/_modules/metalk8s_etcd.py'),
     Path('salt/_modules/metalk8s_kubernetes_utils.py'),
     Path('salt/_modules/metalk8s.py'),
+    Path('salt/_modules/metalk8s_network.py'),
     Path('salt/_modules/metalk8s_package_manager.py'),
 
 

--- a/salt/_modules/metalk8s_network.py
+++ b/salt/_modules/metalk8s_network.py
@@ -1,0 +1,70 @@
+'''Metalk8s network related utilities.'''
+
+import itertools
+import logging
+
+from salt._compat import ipaddress
+from salt.exceptions import CommandExecutionError
+
+K8S_CLUSTER_ADDRESS_NUMBER = 0
+COREDNS_ADDRESS_NUMBER = 9
+
+
+log = logging.getLogger(__name__)
+
+__virtualname__ = 'metalk8s_network'
+
+
+def __virtual__():
+    return __virtualname__
+
+
+def _pick_nth_service_ip(n):
+    '''
+    Pick the nth IP address from a network range, based on pillar
+    configurations provided in CIDR notation.
+    '''
+    cidr = __pillar__.get('networks', {}).get('service')
+    if cidr is None:
+        raise CommandExecutionError(
+            'Pillar key "networks:service" must be set.'
+        )
+
+    network = ipaddress.IPv4Network(unicode(cidr))
+    # NOTE: hosts() method below returns usable hosts in a network.
+    # The usable hosts are all the IP addresses that belong to the network,
+    # except the network address itself and the network broadcast address.
+    ip = next(
+        itertools.islice(network.hosts(), n, None),
+        None
+    )
+    if ip is None:
+        raise CommandExecutionError(
+            'Could not obtain an IP in the network range {}'.format(
+                cidr
+            )
+        )
+    return str(ip)
+
+
+def get_kubernetes_service_ip():
+    '''
+    Return the Kubernetes service cluster IP.
+
+    This IP is arbitrarily selected as the first IP from the usable hosts
+    range.
+    Note:
+    In kube-apiserver Pod manifest, we define a service-cluster-ip-range which
+    sets the kube-api address to the first usable host.
+    '''
+    return _pick_nth_service_ip(K8S_CLUSTER_ADDRESS_NUMBER)
+
+
+def get_cluster_dns_ip():
+    '''
+    Return the CoreDNS cluster IP.
+
+    This IP is arbitrarily selected as the tenth IP from the usable hosts
+    range.
+    '''
+    return _pick_nth_service_ip(COREDNS_ADDRESS_NUMBER)

--- a/salt/metalk8s/defaults.yaml
+++ b/salt/metalk8s/defaults.yaml
@@ -113,7 +113,6 @@ kube_api:
   cert:
     server_signing_policy: kube_apiserver_server_policy
     client_signing_policy: kube_apiserver_client_policy
-  service_ip: "10.96.0.1"
 
 etcd:
   ca:
@@ -137,7 +136,6 @@ front_proxy:
     client_signing_policy: front_proxy_client_policy
 
 coredns:
-  cluster_dns_ip: 10.96.0.10
   cluster_domain: cluster.local
   reverse_cidrs: in-addr.arpa ip6.arpa
 

--- a/salt/metalk8s/kubernetes/apiserver/certs/server.sls
+++ b/salt/metalk8s/kubernetes/apiserver/certs/server.sls
@@ -1,5 +1,7 @@
 {%- from "metalk8s/map.jinja" import kube_api with context %}
 
+{%- set kubernetes_service_ip = salt.metalk8s_network.get_kubernetes_service_ip() %}
+
 include:
   - metalk8s.internal.m2crypto
 
@@ -22,7 +24,7 @@ Create kube-apiserver private key:
     'kubernetes.default',
     'kubernetes.default.svc',
     'kubernetes.default.svc.cluster.local',
-    kube_api.service_ip,
+    kubernetes_service_ip,
     grains['metalk8s']['control_plane_ip'],
     pillar['metalk8s']['api_server']['host'],
 ]

--- a/salt/metalk8s/kubernetes/cni/calico/configured.sls
+++ b/salt/metalk8s/kubernetes/cni/calico/configured.sls
@@ -1,6 +1,8 @@
 {%- from "metalk8s/map.jinja" import kube_api with context %}
 {%- from "metalk8s/map.jinja" import kubernetes with context %}
 
+{%- set kubernetes_service_ip = salt.metalk8s_network.get_kubernetes_service_ip() %}
+
 include:
   - metalk8s.internal.m2crypto
 
@@ -12,7 +14,7 @@ Create kubeconf file for calico:
     - client_cert_info:
         CN: {{ salt['network.get_hostname']() }}
         O: metalk8s:calico-node
-    - apiserver: https://{{ kube_api.service_ip }}:443
+    - apiserver: https://{{ kubernetes_service_ip }}:443
     - cluster: {{ kubernetes.cluster }}
     - require:
       - metalk8s_package_manager: Install m2crypto

--- a/salt/metalk8s/kubernetes/coredns/deployed.sls
+++ b/salt/metalk8s/kubernetes/coredns/deployed.sls
@@ -1,5 +1,7 @@
 {%- from "metalk8s/map.jinja" import coredns with context %}
 
+{%- set cluster_dns_ip = salt.metalk8s_network.get_cluster_dns_ip() %}
+
 {% set kubeconfig = "/etc/kubernetes/admin.conf" %}
 {% set context = "kubernetes-admin@kubernetes" %}
 
@@ -55,7 +57,7 @@ Create coredns service:
     - spec:
         selector:
           k8s-app: kube-dns
-        cluster_ip: {{ coredns.cluster_dns_ip }}
+        cluster_ip: {{ cluster_dns_ip }}
         ports:
         - name: dns
           port: 53

--- a/salt/metalk8s/kubernetes/kubelet/standalone.sls
+++ b/salt/metalk8s/kubernetes/kubelet/standalone.sls
@@ -1,5 +1,7 @@
 {%- from "metalk8s/map.jinja" import kubelet with context %}
 
+{%- set cluster_dns_ip = salt.metalk8s_network.get_cluster_dns_ip() %}
+
 include:
   - .running
 
@@ -51,7 +53,7 @@ Create kubelet config file:
         cgroupDriver: cgroupfs
         cgroupsPerQOS: true
         clusterDNS:
-          - 10.96.0.10
+          - {{ cluster_dns_ip }}
         clusterDomain: cluster.local
         configMapAndSecretChangeDetectionStrategy: Watch
         containerLogMaxFiles: 5


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
'salt', 'kubernetes', 'networking'

**Context**: 

See #780 

**Summary**:

- We need to remove the hard-coded values related to the Coredns cluster IP and Kubernetes cluster IP.
For this, we have written a salt execution module to pick the following:
- The `kubernetes ClusterIP` address which is agreed to be the 2nd address in the service_network.
- The `coredns ClusterIP` address which is the 10th address in the service_network
 For this to work properly, we need to define a proper service network within the pillars

How to test?

```
[root@bootstrap vagrant]# kubectl get pods,svc --namespace=kube-system | grep dns

pod/coredns-69bb6dc74d-48glm                 0/1       ContainerCreating   0          1m
pod/coredns-69bb6dc74d-4tqtj                 0/1       ContainerCreating   0          1m
service/coredns                                        ClusterIP   10.96.0.10       <none>        53/UDP,53/TCP,9153/TCP       1m
```
**Acceptance criteria**: 

- Working metalk8s cluster after bootstrap
- CI build should still pass.

Needed:

Once this ticket is closed, I plan to open another to update the documentation.
---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #780 

