### PR TITLE
fix test shadowing in salt API E2E tests

### DIFF
--- a/tests/post/features/salt_api.feature
+++ b/tests/post/features/salt_api.feature
@@ -1,6 +1,6 @@
 @post @ci @local @salt
 Feature: SaltAPI
-    Scenario: Login to SaltAPI
+    Scenario: Login to SaltAPI using Basic auth
         Given the Kubernetes API is available
         When we login to SaltAPI as 'admin' using password 'admin'
         Then we can ping all minions
@@ -9,7 +9,7 @@ Feature: SaltAPI
         And we have '@runner' perms
         And we have '@jobs' perms
 
-    Scenario: Login to SaltAPI
+    Scenario: Login to SaltAPI using a ServiceAccount
         Given the Kubernetes API is available
         When we login to SaltAPI with the ServiceAccount 'storage-operator'
         Then we can invoke '["disk.dump", "state.sls"]' on '*'

--- a/tests/post/steps/test_salt_api.py
+++ b/tests/post/steps/test_salt_api.py
@@ -11,10 +11,14 @@ from pytest_bdd import parsers, scenario, then, when
 # Scenario {{{
 
 
-@scenario('../features/salt_api.feature', 'Login to SaltAPI')
-def test_login_to_salt_api(host):
+@scenario('../features/salt_api.feature', 'Login to SaltAPI using Basic auth')
+def test_login_basic_auth_to_salt_api(host):
     pass
 
+@scenario('../features/salt_api.feature',
+          'Login to SaltAPI using a ServiceAccount')
+def test_login_bearer_auth_to_salt_api(host):
+    pass
 
 @scenario('../features/salt_api.feature', 'Login to SaltAPI using an incorrect password')
 def test_login_to_salt_api_using_an_incorrect_password(host, request):


### PR DESCRIPTION
**Component**:

tests

**Context**: 

The test for Basic Auth with Salt API is not executed.

**Summary**:

Rename the scenario to avoid shadowing.

**Acceptance criteria**: 

Now, both tests for auth with Basic Auth and ServiceAccount are executed.

---

Closes: #1652