### PR TITLE
secrets: enable identity encryption provider

### DIFF
--- a/salt/metalk8s/kubernetes/apiserver/cryptconfig.sls
+++ b/salt/metalk8s/kubernetes/apiserver/cryptconfig.sls
@@ -43,5 +43,6 @@ Recreate encryption configuration from pillar:
                 keys:
                 - name: metalk8s-secrets-key
                   secret: {{ encryption_key }}
+            - identity: {}
     - require_in:
       - metalk8s: Create kube-apiserver Pod manifest


### PR DESCRIPTION

**Component**: salt

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

In case of the migration of a Kubernetes cluster to Metal 2.X, we
must allow plain-text secrets to exist.

**Summary**:

Added `identity` encryption provider as the lowest level provider, to provide compatibility with upgrades from clusters with plain-text secret storage.

**Acceptance criteria**: 

Isofunctional otherwise.

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1558 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
