### PR TITLE
Replace etcd endpoints mine by ext pillar

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -466,6 +466,7 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/_pillar/metalk8s_nodes.py'),
     Path('salt/_pillar/metalk8s_private.py'),
     Path('salt/_pillar/metalk8s_solutions.py'),
+    Path('salt/_pillar/metalk8s_etcd.py'),
 
     Path('salt/_renderers/metalk8s_kubernetes.py'),
 

--- a/pillar/metalk8s/roles/etcd.sls
+++ b/pillar/metalk8s/roles/etcd.sls
@@ -1,3 +1,0 @@
-mine_functions:
-  etcd_endpoints:
-    mine_function: metalk8s.get_etcd_endpoint

--- a/salt/_pillar/metalk8s_etcd.py
+++ b/salt/_pillar/metalk8s_etcd.py
@@ -1,0 +1,33 @@
+import logging
+
+log = logging.getLogger(__name__)
+
+__virtualname__ = "metalk8s_etcd"
+
+
+def __virtual__():
+    return __virtualname__
+
+
+def _load_members(pillar):
+    errors = []
+    try:
+        members = __salt__['metalk8s_etcd.get_etcd_member_list'](
+                    nodes = pillar['metalk8s']['nodes']
+                  )
+    except Exception as exc:
+        members = []
+        errors.append(
+            'Error while retrieving etcd cluster members: {}'.format(
+                exc
+            )
+        )
+    result = {'members': members}
+
+    if errors:
+        result.update(__utils__['pillar_utils.errors_to_dict'](errors))
+    return result
+
+
+def ext_pillar(minion_id, pillar):
+    return {"metalk8s": {'etcd': _load_members(pillar)}}

--- a/salt/metalk8s/kubernetes/etcd/installed.sls
+++ b/salt/metalk8s/kubernetes/etcd/installed.sls
@@ -10,7 +10,7 @@ include:
 {%- set endpoint  = host_name ~ '=https://' ~ host ~ ':2380' %}
 
 {#- Get the list of existing etcd node. #}
-{%- set etcd_endpoints = salt['mine.get']('*', 'etcd_endpoints').values() %}
+{%- set etcd_endpoints = pillar.metalk8s.etcd.members %}
 
 {#- Compute the initial state according to the existing list of node. #}
 {%- set state = "existing" if etcd_endpoints else "new" %}

--- a/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
+++ b/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
@@ -13,6 +13,7 @@ ext_pillar:
   - metalk8s_nodes: /etc/kubernetes/admin.conf
   - metalk8s_private: {}
   - metalk8s_solutions: {}
+  - metalk8s_etcd: {}
 
 roster_defaults:
   minion_opts:


### PR DESCRIPTION
Ext pillar is calculated each time it is accessed, so it makes
sense to use it to hold etcd endpoints rather than the occasionally
updated mine

Fixes: #877

**Component**:
salt, etcd
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
etcd enpoints were set in the salt mine, but the latter is occasionally updated and will not hold the correct information always, this is an issue when in expansion the new etcd member does not have the correct information about the state of the existing cluster
**Summary**:
The etcd endpoints have been moved into the ext pillar
**Acceptance criteria**: 
node expansion should work perfectly, the new etcd instance should be in **existing** mode rather than **new** and the initial cluster should be correct

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
