### PR TITLE
Create a proper log folder for metalk8s

### DIFF
--- a/packages/metalk8s-sosreport/src/metalk8s.py
+++ b/packages/metalk8s-sosreport/src/metalk8s.py
@@ -27,7 +27,7 @@ class metalk8s(Plugin, RedHatPlugin, UbuntuPlugin):
     def setup(self):
         self.add_copy_spec('/etc/kubernetes/manifests')
         self.add_copy_spec('/var/log/pods')
-        self.add_copy_spec('/var/log/metalk8s-bootstrap.log')
+        self.add_copy_spec('/var/log/metalk8s')
 
         services = [
             'kubelet',

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -8,7 +8,7 @@ set -u
 if test -z "$(type -p)"; then set -o pipefail; fi
 
 VERBOSE=${VERBOSE:-0}
-LOGFILE=/var/log/metalk8s-bootstrap.log
+LOGFILE=/var/log/metalk8s/bootstrap.log
 
 if ! options=$(getopt --options v --long verbose,log-file: -- "$@"); then
     echo 1>&2 "Incorrect arguments provided"
@@ -35,6 +35,8 @@ while true; do
 done
 
 TMPFILES=$(mktemp -d)
+
+mkdir -p "$(dirname "${LOGFILE}")"
 
 cat << EOF >> "${LOGFILE}"
 --- Bootstrap started on $(date -u -R) ---

--- a/scripts/downgrade.sh
+++ b/scripts/downgrade.sh
@@ -4,7 +4,7 @@ set -u
 set -o pipefail
 
 VERBOSE=${VERBOSE:-0}
-LOGFILE=/var/log/metalk8s-downgrade.log
+LOGFILE=/var/log/metalk8s/downgrade.log
 DRY_RUN=0
 SALTENV=""
 DESTINATION_VERSION=""
@@ -23,7 +23,6 @@ _usage() {
     echo "-d/--dry-run:                    Run actions in dry run mode"
     echo "-h/--help:                       Show this help menu"
 }
-
 
 while (( "$#" )); do
   case "$1" in
@@ -56,6 +55,8 @@ while (( "$#" )); do
 done
 
 TMPFILES=$(mktemp -d)
+
+mkdir -p "$(dirname "${LOGFILE}")"
 
 cat << EOF >> "${LOGFILE}"
 --- MetalK8s downgrade started on $(date -u -R) ---

--- a/scripts/iso-manager.sh
+++ b/scripts/iso-manager.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 BOOTSTRAP_CONFIG="/etc/metalk8s/bootstrap.yaml"
 VERBOSE=${VERBOSE:-0}
-LOGFILE="/var/log/metalk8s-iso-manager.log"
+LOGFILE="/var/log/metalk8s/iso-manager.log"
 SALT_CALL=${SALT_CALL:-salt-call}
 DRY_RUN="False"
 SALTENV=""
@@ -50,6 +50,8 @@ while (( "$#" )); do
 done
 
 TMPFILES=$(mktemp -d)
+
+mkdir -p "$(dirname "${LOGFILE}")"
 
 cat << EOF >> "${LOGFILE}"
 --- MetalK8s ISO manager started on $(date -u -R) ---

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -4,7 +4,7 @@ set -u
 set -o pipefail
 
 VERBOSE=${VERBOSE:-0}
-LOGFILE=/var/log/metalk8s-upgrade.log
+LOGFILE=/var/log/metalk8s/upgrade.log
 DRY_RUN=0
 DESTINATION_VERSION=""
 SALT_CALL=${SALT_CALL:-salt-call}
@@ -52,6 +52,8 @@ while (( "$#" )); do
 done
 
 TMPFILES=$(mktemp -d)
+
+mkdir -p "$(dirname "${LOGFILE}")"
 
 cat << EOF >> "${LOGFILE}"
 --- MetalK8s Upgrade started on $(date -u -R) ---


### PR DESCRIPTION
Instead of files direclty under /var/log
Fixes: #1583

**Component**:
scripts, bash
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
log files were dropped directly under /var/log/xxxxxx.log
**Summary**:
log files are now under /var/log/metalk8s/xxxx.log
**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1583 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
