### PR TITLE
buildchain - Fix rendering tasks title

### DIFF
--- a/buildchain/buildchain/targets/serialize.py
+++ b/buildchain/buildchain/targets/serialize.py
@@ -67,7 +67,7 @@ class SerializedData(base.AtomicTarget):
         task = self.basic_task
         task.update({
             'title': utils.title_with_target1(
-                'RENDER {}'.format(self._renderer)
+                'RENDER {}'.format(self._renderer.value)
             ),
             'doc': 'Render file "{}" with "{}"'.format(
                 self._dest, self._renderer


### PR DESCRIPTION
**Component**: build

**Context**:

Build output showed `.  RENDER Renderer.JSON _build/root/salt/metalk8s/versions.json`, which was not nicely aligned with the other build steps.

**Summary**:

The `targets.serialize.SerializedData` target was generating a title from the chosen `targets.serialize.Renderer` member, which is an `Enum` member. However, it should have been using only the `value` attribute, to avoid prefixing with the `Renderer` class name.

**Acceptance criteria**: 

Build output now shows `.  RENDER JSON  _build/root/salt/metalk8s/versions.json`, which aligns nicely.