### PR TITLE
Use python-apt to download DEB packages

### DIFF
--- a/.pylint-dict
+++ b/.pylint-dict
@@ -44,8 +44,10 @@ timestamp
 tmp
 tmpfs
 txt
+xenial
 yaml
 ConsoleReporter
 Dockerfile
+GPG
 LZ77
 Mio

--- a/packages/debian/Dockerfile
+++ b/packages/debian/Dockerfile
@@ -12,6 +12,7 @@ RUN apt update -y \
         build-essential \
         lintian \
         apt-rdepends \
+        python-apt \
         alien
 
 RUN useradd -m build

--- a/packages/debian/download_packages.py
+++ b/packages/debian/download_packages.py
@@ -3,12 +3,18 @@
 
 """Script that download a list of packages, and all of their dependencies."""
 
+import itertools
 import os
 import sys
 import subprocess
-from typing import Mapping, Sequence
+from typing import Dict, Mapping, Optional, Sequence
 import urllib.parse
 import urllib.request
+
+# pylint: disable=import-error
+import apt      # type: ignore
+import apt_pkg  # type: ignore
+# pylint: enable=import-error
 
 
 # Helpers {{{
@@ -26,6 +32,25 @@ def add_source_list(name: str, url: str) -> None:
     filepath = '/etc/apt/sources.list.d/{}.list'.format(name)
     with open(filepath, 'w', encoding='utf-8') as fp:
         print(url, file=fp)
+
+
+def select_package_version(
+    package: apt.package.Package, version: Optional[str]
+) -> apt.package.Version:
+    """Select one version of the given package.
+
+    If a version is specified we return this one (ValueError is raised if the
+    specified version is not available). Otherwise, we simply return the most
+    recent version available.
+    """
+    if version is None:
+        return sorted(package.versions)[-1]
+    for candidate in package.versions:
+        if version in candidate.version:
+            return candidate
+    raise ValueError('package {} not found in version {}: {}'.format(
+        package.name, version, package.versions
+    ))
 
 
 # }}}
@@ -61,9 +86,55 @@ def add_external_repositories(salt_version: str) -> None:
     subprocess.check_call(['apt', 'update'])
 
 
-def main(_: Sequence[str], env: Mapping[str, str]) -> None:
+def get_package_deps(
+    root_package_name: str, cache: apt.cache.Cache
+) -> Dict[str, apt.package.Version]:
+    """Return the given package and all of its dependencies.
+
+    This function works recursively, traversing the whole dependency tree
+    starting from `root_package`.
+
+    Arguments:
+        root_package_name: name of the package you want to explicitly install
+        cache:             packages cache
+
+    Returns:
+        A list of package versions, for the root package and its dependency
+        tree.
+    """
+    dependencies : Dict[str, apt.package.Version] = {}
+
+    name, _, version = root_package_name.partition('=')
+    root_package = cache[name]
+    stack = [root_package]
+    while stack:
+        package = stack.pop()
+        candidate = select_package_version(
+            package, version if package is root_package else None
+        )
+        # Skip already added dependency.
+        if candidate.sha256 in dependencies:
+            continue
+        dependencies[candidate.sha256] = candidate
+        # `dependencies` is a list of Or-Group, let's flatten it.
+        for dep in itertools.chain(*candidate.dependencies):
+            # Skip virtual package (there is no corresponding DEB).
+            if cache.is_virtual_package(dep.name):
+                continue
+            stack.append(cache[dep.name])
+    return dependencies
+
+
+def main(packages: Sequence[str], env: Mapping[str, str]) -> None:
     """Download the packages specified on the command-line."""
     add_external_repositories(env['SALT_VERSION'])
+    apt_pkg.init()
+    cache = apt.cache.Cache()
+    to_download = {}
+    for package in packages:
+        deps = get_package_deps(package, cache)
+        to_download.update(deps)
+
 
 
 if __name__ == '__main__':

--- a/packages/debian/download_packages.py
+++ b/packages/debian/download_packages.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+"""Script that download a list of packages, and all of their dependencies."""
+
+import os
+import sys
+import subprocess
+from typing import Mapping, Sequence
+import urllib.parse
+import urllib.request
+
+
+# Helpers {{{
+
+
+def apt_key_add(key_url: str) -> None:
+    """Add the GPG key at `key_url` to the list of trusted keys."""
+    with urllib.request.urlopen(key_url) as response:
+        key = response.read()
+    subprocess.run(['apt-key', 'add', '-'], input=key, check=True)
+
+
+def add_source_list(name: str, url: str) -> None:
+    """Add a new packages source called `name` using the give URL as source."""
+    filepath = '/etc/apt/sources.list.d/{}.list'.format(name)
+    with open(filepath, 'w', encoding='utf-8') as fp:
+        print(url, file=fp)
+
+
+# }}}
+
+
+def add_external_repositories(salt_version: str) -> None:
+    """Register Salt and Kubernetes repository."""
+    # Only keep the major and minor version number.
+    salt_version = '.'.join(salt_version.split('.')[:2])
+    # TODO: move these static info in `versions.py`.
+    repositories = [
+        {
+            'name': 'kubernetes',
+            'key': 'https://packages.cloud.google.com/apt/doc/apt-key.gpg',
+            # TODO: use `xenial` because there is no `bionic` repo…
+            'source': 'deb http://apt.kubernetes.io/ kubernetes-xenial main',
+        }, {
+            'name': 'saltstack',
+            'key': urllib.parse.urljoin(
+                'https://repo.saltstack.com/',
+                'apt/ubuntu/18.04/amd64/{}/SALTSTACK-GPG-KEY.pub'.format(
+                    salt_version
+                )
+            ),
+            'source': 'deb http://repo.saltstack.com/apt/ubuntu/'\
+                      '18.04/amd64/{} bionic main'.format(salt_version)
+        }
+    ]
+    for repo in repositories:
+        print('Adding {} repository: '.format(repo['name']), end='', flush=True)
+        apt_key_add(repo['key'])
+        add_source_list(repo['name'], repo['source'])
+    subprocess.check_call(['apt', 'update'])
+
+
+def main(_: Sequence[str], env: Mapping[str, str]) -> None:
+    """Download the packages specified on the command-line."""
+    add_external_repositories(env['SALT_VERSION'])
+
+
+if __name__ == '__main__':
+    _, *PACKAGES = sys.argv
+    main(PACKAGES, os.environ)

--- a/packages/debian/entrypoint.sh
+++ b/packages/debian/entrypoint.sh
@@ -66,20 +66,20 @@ download_packages() {
     chown "${TARGET_UID}:${TARGET_GID}" *
 }
 
-    case ${1:- } in
-        builddeb)
-            builddeb
-            ;;
-        rpm2deb)
-            rpm2deb
-            ;;
-        download_packages)
-            download_packages
-            ;;
-        '')
-            exec /bin/bash
-            ;;
-        *)
-            exec "$@"
-            ;;
-    esac
+case ${1:- } in
+    builddeb)
+        builddeb
+        ;;
+    rpm2deb)
+        rpm2deb
+        ;;
+    download_packages)
+        download_packages
+        ;;
+    '')
+        exec /bin/bash
+        ;;
+    *)
+        exec "$@"
+        ;;
+esac

--- a/packages/debian/entrypoint.sh
+++ b/packages/debian/entrypoint.sh
@@ -36,45 +36,12 @@ rpm2deb() {
 }
 
 
-download_packages() {
-    set -x
-    local -a list_pkg=("$@")
-
-    # Salt-minion GPG Key
-    curl -s https://repo.saltstack.com/apt/ubuntu/18.04/amd64/2018.3/SALTSTACK-GPG-KEY.pub | apt-key add -
-    echo 'deb http://repo.saltstack.com/apt/ubuntu/18.04/amd64/2018.3 bionic main' >> /etc/apt/sources.list.d/saltstack.list
-
-    # Kubectl & Kubelet GPG key
-    echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" >>/etc/apt/sources.list.d/kubernetes.list
-    curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-    apt update
-
-    for pkg in $(list_pkg)
-    do
-        echo "$pkg" >> packages_list.txt
-        for dep in $(apt-rdepends "$pkg" | grep -E 'Depends' | cut -d " " -f4)
-            do echo "$dep" >> packages_list.txt
-        done
-    done
-
-    mkdir /packages/pkg_downloaded
-    pushd /packages/pkg_downloaded
-    while IFS=$'\n' read -r pkg2dl
-    do
-    	apt-get download "$pkg2dl"
-    done
-    chown "${TARGET_UID}:${TARGET_GID}" *
-}
-
 case ${1:- } in
     builddeb)
         builddeb
         ;;
     rpm2deb)
         rpm2deb
-        ;;
-    download_packages)
-        download_packages
         ;;
     '')
         exec /bin/bash

--- a/tox.ini
+++ b/tox.ini
@@ -63,8 +63,8 @@ deps =
     -r{toxinidir}/buildchain/requirements-{env:OSTYPE}.txt
     -r{toxinidir}/buildchain/requirements-dev.txt
 commands =
-    pylint        buildchain/dodo.py buildchain/buildchain
-    mypy --strict buildchain/dodo.py buildchain/buildchain
+    pylint        buildchain/dodo.py buildchain/buildchain packages/debian/download_packages.py
+    mypy --strict buildchain/dodo.py buildchain/buildchain packages/debian/download_packages.py
 
 [testenv:lint-shell]
 description =


### PR DESCRIPTION
**Component**:

buildchain

**Context**: 

Got more logic than expected to download the package, move away from Bash and use Python.

**Summary**:

We use `python-apt` to compute the list of packages to download from a list of packages to explicitly install (possibly with a pinned version).
Then we download the required DEB package, dispatching them between repositories according to their origins.

**Acceptance criteria**: 

Spawn the build container:

```
% docker run --rm -it                                                         \
    -v $(pwd)/packages/debian/download_packages.py:/download_packages.py:ro \
    -v $(pwd)/_build/root/packages/debian:/repositories                     \
    --env SALT_VERSION=2018.3.4                                             \
    --env TARGET_UID=1000                                                   \
    --env TARGET_GID=100                                                    \
    metalk8s-deb-build:latest bash
```

Run the script:

```
# /download_packages.py containerd cri-tools coreutils ebtables ethtool e2fsprogs genisoimage iproute2 iptables salt-minion=2018.3.4 kubectl=1.15.3 kubelet=1.15.3 kubernetes-cni python-m2crypto runc socat sosreport util-linux xfsprogs 
```

Check that the packages are present and have the right permissions:

```
% ls -l $(pwd)/_build/root/packages/debian/*
```

---

Closes: #1668