### PR TITLE
Improvement/1634 implement download packages

### DIFF
--- a/buildchain/buildchain/packaging.py
+++ b/buildchain/buildchain/packaging.py
@@ -280,17 +280,17 @@ for pkgs in RPM_TO_BUILD.values():
         _RPM_TO_BUILD_PKG_NAMES.append(pkg.name)
 
 # All packages not referenced in `RPM_TO_BUILD` but listed in
-# `versions.PACKAGES` are supposed to be downloaded.
+# `versions.RPM_PACKAGES` are supposed to be downloaded.
 RPM_TO_DOWNLOAD : FrozenSet[str] = frozenset(
     "{p.name}-{p.version}-{p.release}".format(p=package)
-    for package in versions.PACKAGES
+    for package in versions.RPM_PACKAGES
     if package.name not in _RPM_TO_BUILD_PKG_NAMES
 )
 
 # Store these versions in a dict to use with doit.tools.config_changed
 _TO_DOWNLOAD_CONFIG : Dict[str, str] = {
     pkg.name: "{p.version}-{p.release}".format(p=pkg)
-    for pkg in versions.PACKAGES
+    for pkg in versions.RPM_PACKAGES
     if pkg.name not in _RPM_TO_BUILD_PKG_NAMES
 }
 

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -196,7 +196,7 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
             'kubernetes': {'version': versions.K8S_VERSION},
             'packages': {
                 pkg.name: {'version': "{}-{}".format(pkg.version, pkg.release)}
-                for pkg in versions.PACKAGES
+                for pkg in versions.RPM_PACKAGES
             },
             'images': {
                 img.name: {'version': img.version}

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -230,7 +230,7 @@ CONTAINER_IMAGES_MAP = {image.name: image for image in CONTAINER_IMAGES}
 # }}}
 # Packages {{{
 
-PACKAGES = (
+RPM_PACKAGES = (
     # Remote packages
     Package(
         name='containerd',
@@ -360,6 +360,106 @@ PACKAGES = (
     ),
 )
 
-PACKAGES_MAP = {pkg.name: pkg for pkg in PACKAGES}
+PACKAGES_MAP = {pkg.name: pkg for pkg in RPM_PACKAGES}
+
+
+DEB_PACKAGES = (
+    Package(
+        name='containerd',
+        version='',
+        release='',
+    ),
+    Package(
+        name='cri-tools',
+        version='',
+        release='',
+    ),
+    Package(
+        name='coreutils',
+        version='',
+        release='',
+    ),
+    Package(
+        name='ebtables',
+        version='',
+        release='',
+    ),
+    Package(
+        name='ethtool',
+        version='',
+        release='',
+    ),
+    Package(
+        name='e2fsprogs',
+        version='',
+        release='',
+    ),
+    Package(
+        name='genisoimage',
+        version='',
+        release='',
+    ),
+    Package(
+        name='iproute2',
+        version='',
+        release='',
+    ),
+    Package(
+        name='iptables',
+        version='',
+        release='',
+    ),
+    Package(
+        name='salt-minion={}'.format(SALT_VERSION),
+        version='',
+        release='',
+    ),
+    Package(
+        name='kubectl={}'.format(K8S_VERSION),
+        version='',
+        release='',
+    ),
+    Package(
+        name='kubelet={}'.format(K8S_VERSION),
+        version='',
+        release='',
+    ),
+    Package(
+        name='kubernetes-cni',
+        version='',
+        release='',
+    ),
+    Package(
+        name='python-m2crypto',
+        version='',
+        release='',
+    ),
+    Package(
+        name='runc',
+        version='',
+        release='',
+    ),
+    Package(
+        name='socat',
+        version='',
+        release='',
+    ),
+    Package(
+        name='sosreport',
+        version='',
+        release='',
+    ),
+    Package(
+        name='util-linux',
+        version='',
+        release='',
+    ),
+    Package(
+        name='xfsprogs',
+        version='',
+        release='',
+    ),
+)
+
 
 # }}}

--- a/packages/debian/download_packages.py
+++ b/packages/debian/download_packages.py
@@ -176,6 +176,11 @@ def download_package(package: apt.package.Version) -> pathlib.Path:
 
 def main(packages: Sequence[str], env: Mapping[str, str]) -> None:
     """Download the packages specified on the command-line."""
+    witness_file = pathlib.Path('/repositories/.witness')
+    try:
+        witness_file.unlink()
+    except FileNotFoundError:
+        pass
     add_external_repositories(env['SALT_VERSION'])
     apt_pkg.init()
     cache = apt.cache.Cache()
@@ -190,7 +195,8 @@ def main(packages: Sequence[str], env: Mapping[str, str]) -> None:
     # TODO: need to be done by the build chain
     for directory in dest.iterdir():
         os.chown(directory, int(env['TARGET_UID']), int(env['TARGET_GID']))
-
+    witness_file.touch()
+    os.chown(witness_file, int(env['TARGET_UID']), int(env['TARGET_GID']))
 
 if __name__ == '__main__':
     _, *PACKAGES = sys.argv

--- a/packages/debian/download_packages.py
+++ b/packages/debian/download_packages.py
@@ -180,12 +180,16 @@ def main(packages: Sequence[str], env: Mapping[str, str]) -> None:
     apt_pkg.init()
     cache = apt.cache.Cache()
     to_download = {}
+    dest = pathlib.Path('/repositories')
     for package in packages:
         deps = get_package_deps(package, cache)
         to_download.update(deps)
     for pkg in to_download.values():
         filepath = download_package(pkg)
         os.chown(filepath, int(env['TARGET_UID']), int(env['TARGET_GID']))
+    # TODO: need to be done by the build chain
+    for directory in dest.iterdir():
+        os.chown(directory, int(env['TARGET_UID']), int(env['TARGET_GID']))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Component**: Buildchain, package

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: Metalk8s on Ubuntu

**Summary**: We need to implement the script download_packages.py in the buildchain to download some Debian packages from official repositories.

**Acceptance criteria**: 
Build the MetalK8s ISO with the Debian packages downloaded.

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1634 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
