### PR TITLE
monitoring: use persistent storage for Prometheus

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -140,6 +140,8 @@ echo "Launching bootstrap"
 exec "/srv/scality/metalk8s-$VERSION/bootstrap.sh"
 SCRIPT
 
+CREATE_VOLUMES = File.read(__dir__ + "/eve/create-volumes.sh")
+
 DEPLOY_SSH_PUBLIC_KEY = <<-SCRIPT
 #!/bin/bash
 
@@ -192,6 +194,10 @@ Vagrant.configure("2") do |config|
     bootstrap.vm.provision "bootstrap",
       type: "shell",
       inline: BOOTSTRAP
+
+    bootstrap.vm.provision "create-volumes",
+      type: "shell",
+      inline: CREATE_VOLUMES
   end
 
   os_data = {

--- a/buildchain/buildchain/iso.py
+++ b/buildchain/buildchain/iso.py
@@ -80,7 +80,7 @@ def task_populate_iso() -> types.TaskDict:
             '_iso_mkdir_root',
             '_iso_render_bootstrap',
             '_iso_render_restore',
-            '_iso_add_node_manifest',
+            '_iso_add_example_manifests',
             '_iso_generate_product_txt',
             '_iso_add_utilities_scripts',
             'images',
@@ -96,25 +96,27 @@ def task__iso_mkdir_examples() -> types.TaskDict:
     ).task
 
 
-def task__iso_add_node_manifest() -> types.TaskDict:
-    """Copy the node announcement manifest to examples."""
-    # generic node manifest
-    src_generic = constants.ROOT/'examples'/'new-node.yaml'
-    dest_generic = constants.ISO_ROOT/'examples'/'new-node.yaml'
-    new_node_generic = [src_generic, dest_generic]
-    # vagrant node manifest
-    src_vagrant = constants.ROOT/'examples'/'new-node_vagrant.yaml'
-    dest_vagrant = constants.ISO_ROOT/'examples'/'new-node_vagrant.yaml'
-    new_node_vagrant = [src_vagrant, dest_vagrant]
+def task__iso_add_example_manifests() -> types.TaskDict:
+    """Copy the example manifests to examples."""
+
+    examples = [
+        (constants.ROOT/'examples'/name, constants.ISO_ROOT/'examples'/name)
+        for name in [
+            'new-node.yaml',
+            'new-node_vagrant.yaml',
+            'prometheus-sparse.yaml',
+        ]
+    ]
+
     return {
          'title': utils.title_with_target1('COPY'),
          'actions': [
-             (coreutils.cp_file, new_node_generic),
-             (coreutils.cp_file, new_node_vagrant)
+             (coreutils.cp_file, example)
+             for example in examples
          ],
-         'targets': [dest_generic, dest_vagrant],
+         'file_dep': [example[0] for example in examples],
+         'targets': [example[1] for example in examples],
          'task_dep': ['_iso_mkdir_examples'],
-         'file_dep': [src_generic, src_vagrant],
          'clean': True,
      }
 

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -212,13 +212,13 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/addons/prometheus-operator/deployed/namespace.sls'),
     Path('salt/metalk8s/addons/prometheus-operator/deployed/'
             'prometheus-nodeport.sls'),
+    Path('salt/metalk8s/addons/prometheus-operator/deployed/storageclass.sls'),
 
     Path('salt/metalk8s/addons/ui/deployed.sls'),
     Path('salt/metalk8s/addons/ui/files/metalk8s-ui-deployment.yaml'),
     Path('salt/metalk8s/addons/ui/precheck.sls'),
 
     Path('salt/metalk8s/addons/volumes/deployed.sls'),
-    Path('salt/metalk8s/addons/volumes/storage-classes.sls'),
     targets.TemplateFile(
         task_name='storage-operator.sls',
         source=constants.ROOT.joinpath(

--- a/charts/prometheus-operator.yaml
+++ b/charts/prometheus-operator.yaml
@@ -24,6 +24,19 @@ alertmanager:
         operator: 'Exists'
         effect: 'NoSchedule'
 
+    storage:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: metalk8s-prometheus
+          accessModes: ['ReadWriteOnce']
+          resources:
+            requests:
+              storage: 1Gi
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus-operator-alertmanager
+
+
 prometheusOperator:
   tlsProxy:
     enabled: false
@@ -73,6 +86,17 @@ prometheus:
 
     podAntiAffinity: 'soft'
 
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: metalk8s-prometheus
+          accessModes: ['ReadWriteOnce']
+          resources:
+            requests:
+              storage: 10Gi
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus-operator-prometheus
 
 grafana:
   image:

--- a/docs/operation/volume_management/index.rst
+++ b/docs/operation/volume_management/index.rst
@@ -1,3 +1,5 @@
+.. _volume-management:
+
 Volume Management
 =================
 

--- a/docs/quickstart/bootstrap.rst
+++ b/docs/quickstart/bootstrap.rst
@@ -104,6 +104,24 @@ Bootstrap node.
 
    root@bootstrap $ /srv/scality/metalk8s-|release|/bootstrap.sh
 
+Provision storage for Prometheus services
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+After bootstrapping the cluster, the Prometheus and AlertManager services used
+to monitor the system will not be running (the respective :term:`Pods <Pod>`
+will remain in *Pending* state), because they require persistent storage to be
+available. You can either provision these storage volumes on the bootstrap
+node, or later on other nodes joining the cluster. Templates for the required
+volumes are available in :download:`examples/prometheus-sparse.yaml
+<../../examples/prometheus-sparse.yaml>`. Note, however, these templates use
+the `sparseLoopDevice` *Volume* type, which is not suitable for production
+installations. Refer to :ref:`volume-management` for more information on how to
+provision persistent storage.
+
+.. note::
+
+   When deploying using Vagrant, persistent volumes for Prometheus and
+   AlertManager are already provisioned.
+
 Validate the install
 ^^^^^^^^^^^^^^^^^^^^
 Check if all :term:`Pods <Pod>` on the Bootstrap node are in the

--- a/eve/create-volumes.sh
+++ b/eve/create-volumes.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Note: this script's *defaults* must adhere to the Vagrant environment in
+# which it is used.
+
+set -eu -o pipefail
+
+BOOTSTRAP_NODE_NAME=${BOOTSTRAP_NODE_NAME:-$(hostname)}
+PRODUCT_TXT=${PRODUCT_TXT:-/vagrant/_build/root/product.txt}
+
+# shellcheck disable=SC1090
+source "${PRODUCT_TXT}"
+
+PRODUCT_MOUNT=${PRODUCT_MOUNT:-/srv/scality/metalk8s-${VERSION}}
+
+if ! test -f "${PRODUCT_MOUNT}/examples/prometheus-sparse.yaml"; then
+    echo 1>&2 "Storage provisioning template not found."
+    exit 1
+fi
+
+KUBECONFIG=${KUBECONFIG:-/etc/kubernetes/admin.conf}
+export KUBECONFIG
+
+echo "Creating storage volumes"
+sed "s/BOOTSTRAP_NODE_NAME/${BOOTSTRAP_NODE_NAME}/" "${PRODUCT_MOUNT}/examples/prometheus-sparse.yaml" | \
+    kubectl apply -f -
+
+OK=0
+echo "Waiting for PV 'bootstrap-alertmanager' to be provisioned"
+for _ in $(seq 1 60); do
+    if kubectl get pv bootstrap-alertmanager > /dev/null 2>&1; then
+        OK=1
+        break
+    fi
+    sleep 1
+done
+[ $OK -eq 1 ] || (echo "PV not created"; false)
+
+OK=0
+echo "Waiting for PV 'bootstrap-prometheus' to be provisioned"
+for _ in $(seq 1 60); do
+    if kubectl get pv bootstrap-prometheus > /dev/null 2>&1; then
+        OK=1
+        break
+    fi
+    sleep 1
+done
+[ $OK -eq 1 ] || (echo "PV not created"; false)
+
+OK=0
+echo 'Waiting for AlertManager to be running'
+for _ in $(seq 1 60); do
+    PHASE=$(kubectl -n metalk8s-monitoring get pod alertmanager-prometheus-operator-alertmanager-0 -o jsonpath="{.status.phase}")
+    if [ "x${PHASE}" = "xRunning" ]; then
+        OK=1
+        break
+    fi
+    sleep 1
+done
+[ $OK -eq 1 ] || (echo "AlertManager not Running"; false)
+
+OK=0
+echo 'Waiting for Prometheus to be running'
+for _ in $(seq 1 60); do
+    PHASE=$(kubectl -n metalk8s-monitoring get pod prometheus-prometheus-operator-prometheus-0 -o jsonpath="{.status.phase}")
+    if [ "x${PHASE}" = "xRunning" ]; then
+        OK=1
+        break
+    fi
+    sleep 1
+done
+[ $OK -eq 1 ] || (echo "Prometheus not Running"; false)

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -290,6 +290,14 @@ stages:
             --verbose
           haltOnFailure: true
       - ShellCommand:
+          name: Provision Prometheus and AlertManager storage
+          command: >
+            sudo env
+            PRODUCT_TXT=/srv/scality/metalk8s-%(prop:metalk8s_version)s/product.txt
+            PRODUCT_MOUNT=/srv/scality/metalk8s-%(prop:metalk8s_version)s
+            eve/create-volumes.sh
+          haltOnFailure: true
+      - ShellCommand:
           name: Install kubectl for running tests
           command: >
             sudo yum install -y kubectl --disablerepo=*
@@ -445,6 +453,19 @@ stages:
             sudo bash
             /var/tmp/metalk8s/bootstrap.sh --verbose
           workdir: build/eve/workers/openstack-multiple-nodes/terraform/
+          haltOnFailure: true
+      - ShellCommand:
+          name: Provision Prometheus and AlertManager storage
+          env:
+            SSH_CONFIG: >-
+              eve/workers/openstack-multiple-nodes/terraform/ssh_config
+          command: >
+            scp -F $SSH_CONFIG eve/create-volumes.sh bootstrap:/tmp/create-volumes.sh &&
+            ssh -F $SSH_CONFIG bootstrap
+            sudo env
+            PRODUCT_TXT=/var/tmp/metalk8s/product.txt
+            PRODUCT_MOUNT=/var/tmp/metalk8s
+            /tmp/create-volumes.sh
           haltOnFailure: true
       - ShellCommand:
           name: Install kubectl on the boostrap node

--- a/examples/prometheus-sparse.yaml
+++ b/examples/prometheus-sparse.yaml
@@ -1,0 +1,32 @@
+# This file contains manifests to create `sparseLoopDevice` volumes for
+# Prometheus and AlertManager to be deployed.
+# Make sure to change the `nodeName` to the node name of your bootstrap node.
+---
+apiVersion: storage.metalk8s.scality.com/v1alpha1
+kind: Volume
+metadata:
+  name: bootstrap-prometheus
+spec:
+  nodeName: BOOTSTRAP_NODE_NAME
+  storageClassName: metalk8s-prometheus
+  sparseLoopDevice:
+    size: 10Gi
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: 'prometheus-operator-prometheus'
+---
+apiVersion: storage.metalk8s.scality.com/v1alpha1
+kind: Volume
+metadata:
+  name: bootstrap-alertmanager
+spec:
+  nodeName: BOOTSTRAP_NODE_NAME
+  storageClassName: metalk8s-prometheus
+  sparseLoopDevice:
+    size: 1Gi
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: 'prometheus-operator-alertmanager'
+---

--- a/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
@@ -19908,6 +19908,18 @@ spec:
     runAsNonRoot: true
     runAsUser: 1000
   serviceAccountName: prometheus-operator-alertmanager
+  storage:
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+        selector:
+          matchLabels:
+            app.kubernetes.io/name: prometheus-operator-alertmanager
+        storageClassName: metalk8s-prometheus
   tolerations:
   - effect: NoSchedule
     key: node-role.kubernetes.io/bootstrap
@@ -19973,6 +19985,18 @@ spec:
   serviceMonitorSelector:
     matchLabels:
       release: prometheus-operator
+  storage:
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+        selector:
+          matchLabels:
+            app.kubernetes.io/name: prometheus-operator-prometheus
+        storageClassName: metalk8s-prometheus
   tolerations:
   - effect: NoSchedule
     key: node-role.kubernetes.io/bootstrap

--- a/salt/metalk8s/addons/prometheus-operator/deployed/init.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/init.sls
@@ -1,4 +1,5 @@
 include:
   - .namespace
+  - .storageclass
   - .chart
   - .prometheus-nodeport

--- a/salt/metalk8s/addons/prometheus-operator/deployed/storageclass.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/storageclass.sls
@@ -1,14 +1,18 @@
-#!jinja | kubernetes kubeconfig=/etc/kubernetes/admin.conf&context=kubernetes-admin@kubernetes
+#! kubernetes kubeconfig=/etc/kubernetes/admin.conf&context=kubernetes-admin@kubernetes
 
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: metalk8s-prometheus
+  labels:
+    app.kubernetes.io/managed-by: salt
+    app.kubernetes.io/part-of: metalk8s
 provisioner: kubernetes.io/no-provisioner
 reclaimPolicy: Retain
 volumeBindingMode: WaitForFirstConsumer
 mountOptions:
   - rw
+  - discard
 parameters:
   fsType: ext4
   mkfsOptions: '["-m", "0"]'

--- a/salt/metalk8s/addons/ui/deployed.sls
+++ b/salt/metalk8s/addons/ui/deployed.sls
@@ -6,7 +6,7 @@ include:
 
 {%- set apiserver = 'https://' ~ pillar.metalk8s.api_server.host ~ ':6443' %}
 {%- set saltapi = 'https://' ~ pillar.metalk8s.endpoints['salt-master'].ip ~ ':' ~ pillar.metalk8s.endpoints['salt-master'].ports.api %}
-{%- set prometheus = 'http://' ~ pillar.metalk8s.endpoints.prometheus.ip ~ ':' ~ pillar.metalk8s.endpoints.prometheus.ports.web.node_port  %}
+{%- set prometheus = 'http://' ~ grains.metalk8s.workload_plane_ip ~ ':30222'  %}
 
 Create metalk8s-ui namespace:
   metalk8s_kubernetes.namespace_present:

--- a/salt/metalk8s/addons/ui/precheck.sls
+++ b/salt/metalk8s/addons/ui/precheck.sls
@@ -3,7 +3,5 @@ Check pillar for MetalK8s UI:
     - string:
       - metalk8s:api_server:host
       - metalk8s:endpoints:salt-master:ip
-      - metalk8s:endpoints:prometheus:ip
     - integer:
       - metalk8s:endpoints:salt-master:ports:api
-      - metalk8s:endpoints:prometheus:ports:web:node_port

--- a/salt/metalk8s/addons/volumes/deployed.sls
+++ b/salt/metalk8s/addons/volumes/deployed.sls
@@ -1,4 +1,3 @@
 include:
   - .storage-operator
-  - .storage-classes
   - .volume-crd

--- a/tests/post/features/volume.feature
+++ b/tests/post/features/volume.feature
@@ -15,7 +15,7 @@ Feature: Volume management
             apiVersion: storage.metalk8s.scality.com/v1alpha1
             kind: Volume
             metadata:
-              name: volume1
+              name: test-volume1
             spec:
               nodeName: bootstrap
               storageClassName: metalk8s-prometheus
@@ -25,26 +25,26 @@ Feature: Volume management
                 metadata:
                   labels:
                     random-key: random-value
-        Then the Volume 'volume1' is 'Available'
-        And the PersistentVolume 'volume1' has size '10Gi'
-        And the PersistentVolume 'volume1' has label 'random-key' with value 'random-value'
-        And the backing storage for Volume 'volume1' is created
+        Then the Volume 'test-volume1' is 'Available'
+        And the PersistentVolume 'test-volume1' has size '10Gi'
+        And the PersistentVolume 'test-volume1' has label 'random-key' with value 'random-value'
+        And the backing storage for Volume 'test-volume1' is created
 
     Scenario: Test volume deletion (sparseLoopDevice)
-        Given a Volume 'volume2' exist
-        When I delete the Volume 'volume2'
-        Then the Volume 'volume2' does not exist
-        And the PersistentVolume 'volume2' does not exist
-        And the backing storage for Volume 'volume2' is deleted
+        Given a Volume 'test-volume2' exist
+        When I delete the Volume 'test-volume2'
+        Then the Volume 'test-volume2' does not exist
+        And the PersistentVolume 'test-volume2' does not exist
+        And the backing storage for Volume 'test-volume2' is deleted
 
     Scenario: Test PersistentVolume protection
-        Given a Volume 'volume3' exist
-        When I delete the PersistentVolume 'volume3'
-        Then the PersistentVolume 'volume3' is marked for deletion
-        And the Volume 'volume3' is 'Available'
-        When I delete the Volume 'volume3'
-        Then the Volume 'volume3' does not exist
-        And the PersistentVolume 'volume3' does not exist
+        Given a Volume 'test-volume3' exist
+        When I delete the PersistentVolume 'test-volume3'
+        Then the PersistentVolume 'test-volume3' is marked for deletion
+        And the Volume 'test-volume3' is 'Available'
+        When I delete the Volume 'test-volume3'
+        Then the Volume 'test-volume3' does not exist
+        And the PersistentVolume 'test-volume3' does not exist
 
     Scenario: Create a volume with no volume type
         Given the Kubernetes API is available
@@ -52,11 +52,11 @@ Feature: Volume management
             apiVersion: storage.metalk8s.scality.com/v1alpha1
             kind: Volume
             metadata:
-              name: volume4
+              name: test-volume4
             spec:
               nodeName: bootstrap
               storageClassName: metalk8s-prometheus
-        Then the Volume 'volume4' is 'Failed' with code 'InternalError' and message matches 'volume type not found'
+        Then the Volume 'test-volume4' is 'Failed' with code 'InternalError' and message matches 'volume type not found'
 
     Scenario: Create a volume with an invalid volume type
         Given the Kubernetes API is available
@@ -64,34 +64,34 @@ Feature: Volume management
             apiVersion: storage.metalk8s.scality.com/v1alpha1
             kind: Volume
             metadata:
-              name: volume5
+              name: test-volume5
             spec:
               nodeName: bootstrap
               storageClassName: metalk8s-prometheus
               someRandomDevice:
                 capacity: 10Gi
-        Then the Volume 'volume5' is 'Failed' with code 'InternalError' and message matches 'volume type not found'
+        Then the Volume 'test-volume5' is 'Failed' with code 'InternalError' and message matches 'volume type not found'
 
     Scenario: Test in-use protection
-        Given a Volume 'volume6' exist
-        And a PersistentVolumeClaim exists for 'volume6'
-        And a Pod using volume 'volume6' and running '["sleep", "60"]' exist
-        When I delete the Volume 'volume6'
-        Then the Volume 'volume6' is 'Available'
-        And the Volume 'volume6' is marked for deletion
-        And the PersistentVolume 'volume6' is marked for deletion
-        When I delete the Pod using 'volume6'
-        And I delete the PersistentVolumeClaim on 'volume6'
-        Then the Volume 'volume6' does not exist
-        And the PersistentVolume 'volume6' does not exist
+        Given a Volume 'test-volume6' exist
+        And a PersistentVolumeClaim exists for 'test-volume6'
+        And a Pod using volume 'test-volume6' and running '["sleep", "60"]' exist
+        When I delete the Volume 'test-volume6'
+        Then the Volume 'test-volume6' is 'Available'
+        And the Volume 'test-volume6' is marked for deletion
+        And the PersistentVolume 'test-volume6' is marked for deletion
+        When I delete the Pod using 'test-volume6'
+        And I delete the PersistentVolumeClaim on 'test-volume6'
+        Then the Volume 'test-volume6' does not exist
+        And the PersistentVolume 'test-volume6' does not exist
 
     Scenario: Volume usage (data persistency)
-        Given a Volume 'volume7' exist
-        And a PersistentVolumeClaim exists for 'volume7'
-        And a Pod using volume 'volume7' and running '["sh", "-c", "echo 'foo' > /mnt/bar.txt"]' exist
-        When I delete the Pod using 'volume7'
-        And I create a Pod using volume 'volume7' and running '["sleep", "60"]'
-        Then the Pod using volume 'volume7' has a file '/mnt/bar.txt' containing 'foo'
+        Given a Volume 'test-volume7' exist
+        And a PersistentVolumeClaim exists for 'test-volume7'
+        And a Pod using volume 'test-volume7' and running '["sh", "-c", "echo 'foo' > /mnt/bar.txt"]' exist
+        When I delete the Pod using 'test-volume7'
+        And I create a Pod using volume 'test-volume7' and running '["sleep", "60"]'
+        Then the Pod using volume 'test-volume7' has a file '/mnt/bar.txt' containing 'foo'
 
     Scenario: Create a volume with unsupported FS type
         When I create the following StorageClass:
@@ -110,13 +110,13 @@ Feature: Volume management
             apiVersion: storage.metalk8s.scality.com/v1alpha1
             kind: Volume
             metadata:
-              name: volume8
+              name: test-volume8
             spec:
               nodeName: bootstrap
               storageClassName: test-sc-btrfs
               sparseLoopDevice:
                 size: 10Gi
-        Then the Volume 'volume8' is 'Failed' with code 'CreationError' and message matches 'unsupported filesystem: btrfs'
+        Then the Volume 'test-volume8' is 'Failed' with code 'CreationError' and message matches 'unsupported filesystem: btrfs'
 
     Scenario: Create a volume using a non-existing StorageClass
         Given the StorageClass 'not-found' does not exist
@@ -124,13 +124,13 @@ Feature: Volume management
             apiVersion: storage.metalk8s.scality.com/v1alpha1
             kind: Volume
             metadata:
-              name: volume9
+              name: test-volume9
             spec:
               nodeName: bootstrap
               storageClassName: not-found
               sparseLoopDevice:
                 size: 10Gi
-        Then the Volume 'volume9' is 'Failed' with code 'CreationError' and message matches 'not found in pillar'
+        Then the Volume 'test-volume9' is 'Failed' with code 'CreationError' and message matches 'not found in pillar'
 
     Scenario: Delete a Volume with missing StorageClass
         Given a StorageClass 'test-sc-delete' exist
@@ -138,13 +138,13 @@ Feature: Volume management
             apiVersion: storage.metalk8s.scality.com/v1alpha1
             kind: Volume
             metadata:
-              name: volume10
+              name: test-volume10
             spec:
               nodeName: bootstrap
               storageClassName: test-sc-delete
               sparseLoopDevice:
                 size: 10Gi
         And I delete the StorageClass 'test-sc-delete'
-        And I delete the Volume 'volume10'
-        Then the Volume 'volume10' does not exist
-        And the PersistentVolume 'volume10' does not exist
+        And I delete the Volume 'test-volume10'
+        Then the Volume 'test-volume10' does not exist
+        And the PersistentVolume 'test-volume10' does not exist

--- a/tests/post/steps/test_volume.py
+++ b/tests/post/steps/test_volume.py
@@ -116,7 +116,7 @@ def teardown(pod_client, pvc_client, volume_client, sc_client):
     yield
     pod_client.delete_all(sync=True)
     pvc_client.delete_all(sync=True)
-    volume_client.delete_all(sync=True)
+    volume_client.delete_all(sync=True, prefix='test-')
     sc_client.delete_all(sync=True, prefix='test-')
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
These changes configure the Prometheus stateful services (i.e.,
Prometheus and AlertManager) to use a persistent volume for storage
instead of ephemeral `emptyDir` volumes.

As a result, these services don't 'work' out of the box after initial
deployment. We add some example `Volume` templates using the
`sparseLoopDevice` storage type to create proper volumes on a node after
deployment, which should allow the services to start.

Furthermore, the Vagrant deployment and CI are extended to create the
required `Volume`s such that the Prometheus services *are* available
after bootstrapping the system.

Note: during an earlier implementation of this feature (#1523), we ran
into a dependency issue between Prometheus deployment and the MetalK8s
UI deployment, which requires the first to be available. Instead, given
this PR, we use a hard-coded `NodePort` port number to access
Prometheus, not requiring the service to be available during bootstrap,
and point the UI to the workload-plane IP of the bootstrap node. This
ought to be improved once we use an `Ingress` to access the UI.

Fixes: #1515
See: https://github.com/scality/metalk8s/issues/1515
See: https://github.com/scality/metalk8s/pull/1523
