### PR TITLE
Use fake endpoint for registry name

### DIFF
--- a/salt/metalk8s/container-engine/containerd/installed.sls
+++ b/salt/metalk8s/container-engine/containerd/installed.sls
@@ -1,6 +1,7 @@
 {%- from "metalk8s/macro.sls" import pkg_installed with context %}
 {%- from "metalk8s/map.jinja" import metalk8s with context %}
 {%- from "metalk8s/map.jinja" import kubelet with context %}
+{%- from "metalk8s/map.jinja" import repo with context %}
 
 {%- set registry_ip = metalk8s.endpoints['repositories'].ip %}
 {%- set registry_port = metalk8s.endpoints['repositories'].ports.http %}
@@ -46,7 +47,7 @@ Configure registry IP in containerd conf:
     - name: /etc/containerd/config.toml
     - makedirs: true
     - contents: |
-        [plugins.cri.registry.mirrors."{{ registry_ip }}:{{ registry_port }}"]
+        [plugins.cri.registry.mirrors."{{ repo.registry_endpoint }}"]
           endpoint = ["http://{{ registry_ip }}:{{ registry_port }}"]
     - require:
       - metalk8s_package_manager: Install containerd

--- a/salt/metalk8s/defaults.yaml
+++ b/salt/metalk8s/defaults.yaml
@@ -37,6 +37,7 @@ repo:
   local_mode: false
   relative_path: packages     # relative to ISO root (configured in pillar)
   port: 8080
+  registry_endpoint: 'metalk8s-registry-from-config.invalid'
   repositories:
     metalk8s-base:
       humanname: CentOS - Base

--- a/salt/metalk8s/repo/macro.sls
+++ b/salt/metalk8s/repo/macro.sls
@@ -1,8 +1,7 @@
 {%- from "metalk8s/map.jinja" import metalk8s with context %}
 {%- from "metalk8s/map.jinja" import repo with context %}
 
-{%- set repo_endpoint = metalk8s.endpoints.repositories %}
-{%- set repo_prefix = repo_endpoint.ip ~ ':' ~ repo_endpoint.ports.http %}
+{%- set repo_prefix = repo.registry_endpoint %}
 {%- set metalk8s_repository = repo_prefix ~ '/' ~ saltenv %}
 
 {%- macro build_image_name(name='') -%}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,14 +112,15 @@ def bootstrap_config(host):
 
 
 @pytest.fixture
-def registry_address(host):
+def registry_address(host, version):
     with host.sudo():
         registry_json = host.check_output(
-            "salt-call pillar.get metalk8s:endpoints:repositories --out json"
+            "salt-call --out json slsutil.renderer string='"
+            "{% from \"metalk8s/map.jinja\" import repo with context %}"
+            "{{ repo.registry_endpoint }}' "
+            "saltenv='metalk8s-" + str(version) + "'"
         )
-    registry = json.loads(registry_json)["local"]
-
-    return "{}:{}".format(registry["ip"], registry["ports"]["http"])
+    return json.loads(registry_json)["local"]
 
 
 @pytest.fixture


### PR DESCRIPTION
**Component**:

'salt', 'containers'

**Summary**:

Using registry name instead of ip:port for endpoint allow for futur
HA registry and able to change the registry without re-configuring and
restarting all pods

---

Fixes: #1684
