### PR TITLE
ui/bug: fix the bug when there is no PV && add unit test for isVolumeDeletable

### DIFF
--- a/ui/src/services/NodeVolumesUtils.js
+++ b/ui/src/services/NodeVolumesUtils.js
@@ -1,0 +1,55 @@
+import {
+  STATUS_UNKNOWN,
+  STATUS_TERMINATING,
+  STATUS_PENDING,
+  STATUS_FAILED,
+  STATUS_AVAILABLE,
+  STATUS_BOUND,
+  STATUS_RELEASED,
+} from '../constants';
+
+export const isVolumeDeletable = (rowData, persistentVolumes) => {
+  const volumeStatus = rowData.status;
+  const volumeName = rowData.name;
+
+  switch (volumeStatus) {
+    case STATUS_UNKNOWN:
+    case STATUS_PENDING:
+    case STATUS_TERMINATING:
+      return false;
+    case STATUS_FAILED:
+    case STATUS_AVAILABLE:
+      if (persistentVolumes?.length === 0) {
+        return true;
+      } else {
+        const persistentVolume = persistentVolumes.find(
+          pv => pv?.metadata?.name === volumeName,
+        );
+        if (!persistentVolume) {
+          return false;
+        }
+        const persistentVolumeStatus = persistentVolume?.status?.phase;
+
+        switch (persistentVolumeStatus) {
+          case STATUS_FAILED:
+          case STATUS_AVAILABLE:
+          case STATUS_RELEASED:
+            return true;
+          case STATUS_PENDING:
+          case STATUS_BOUND:
+          case STATUS_UNKNOWN:
+            return false;
+          default:
+            console.error(
+              `Unexpected state for PersistentVolume ${volumeName}:${persistentVolumeStatus}`,
+            );
+            return false;
+        }
+      }
+    default:
+      console.error(
+        `Unexpected state for Volume ${volumeName}:${volumeStatus}`,
+      );
+      return false;
+  }
+};

--- a/ui/src/services/NodeVolumesUtils.test.js
+++ b/ui/src/services/NodeVolumesUtils.test.js
@@ -1,0 +1,256 @@
+import { isVolumeDeletable } from './NodeVolumesUtils';
+
+const testcaseVolumeUnknown = {
+  rowData: { status: 'Unknown', name: 'test' },
+  persistentVolumes: [
+    { metadata: { name: 'test' }, status: { phase: 'Available' } },
+  ],
+};
+
+const testcaseVolumePending = {
+  rowData: { status: 'Pending', name: 'test' },
+  persistentVolumes: [
+    { metadata: { name: 'test' }, status: { phase: 'Available' } },
+  ],
+};
+
+const testcaseVolumeTerminating = {
+  rowData: { status: 'Terminating', name: 'test' },
+  persistentVolumes: [
+    { metadata: { name: 'test' }, status: { phase: 'Available' } },
+  ],
+};
+
+const testcaseVolumeFailedWithoutPv = {
+  rowData: { status: 'Failed', name: 'test' },
+  persistentVolumes: [
+    { metadata: { name: 'testnoPV' }, status: { phase: 'Available' } },
+  ],
+};
+
+const testcaseVolumeFailedPvFailed = {
+  rowData: { status: 'Failed', name: 'test' },
+  persistentVolumes: [
+    { metadata: { name: 'test' }, status: { phase: 'Failed' } },
+  ],
+};
+
+const testcaseVolumeFailedPvAvailable = {
+  rowData: { status: 'Failed', name: 'test' },
+  persistentVolumes: [
+    { metadata: { name: 'test' }, status: { phase: 'Available' } },
+  ],
+};
+
+const testcaseVolumeFailedPvReleased = {
+  rowData: { status: 'Failed', name: 'test' },
+  persistentVolumes: [
+    { metadata: { name: 'test' }, status: { phase: 'Released' } },
+  ],
+};
+
+const testcaseVolumeFailedPvPending = {
+  rowData: { status: 'Failed', name: 'test' },
+  persistentVolumes: [
+    { metadata: { name: 'test' }, status: { phase: 'Pending' } },
+  ],
+};
+
+const testcaseVolumeFailedPvBound = {
+  rowData: { status: 'Failed', name: 'test' },
+  persistentVolumes: [
+    { metadata: { name: 'test' }, status: { phase: 'Bound' } },
+  ],
+};
+
+const testcaseVolumeFailedPvUnknown = {
+  rowData: { status: 'Failed', name: 'test' },
+  persistentVolumes: [
+    { metadata: { name: 'test' }, status: { phase: 'Unknown' } },
+  ],
+};
+
+const testcaseVolumeAvailablePvFailed = {
+  rowData: { status: 'Available', name: 'test' },
+  persistentVolumes: [
+    { metadata: { name: 'test' }, status: { phase: 'Failed' } },
+  ],
+};
+
+const testcaseVolumeAvailablePvAvailable = {
+  rowData: { status: 'Available', name: 'test' },
+  persistentVolumes: [
+    { metadata: { name: 'test' }, status: { phase: 'Available' } },
+  ],
+};
+
+const testcaseVolumeAvailablePvReleased = {
+  rowData: { status: 'Available', name: 'test' },
+  persistentVolumes: [
+    { metadata: { name: 'test' }, status: { phase: 'Released' } },
+  ],
+};
+
+const testcaseVolumeAvailablePvPending = {
+  rowData: { status: 'Available', name: 'test' },
+  persistentVolumes: [
+    { metadata: { name: 'test' }, status: { phase: 'Pending' } },
+  ],
+};
+
+const testcaseVolumeAvailablePvBound = {
+  rowData: { status: 'Available', name: 'test' },
+  persistentVolumes: [
+    { metadata: { name: 'test' }, status: { phase: 'Bound' } },
+  ],
+};
+
+const testcaseVolumeAvailablePvUnknown = {
+  rowData: { status: 'Available', name: 'test' },
+  persistentVolumes: [
+    { metadata: { name: 'test' }, status: { phase: 'Unknown' } },
+  ],
+};
+
+const testcaseVolumeAvailableWithoutPv = {
+  rowData: { status: 'Available', name: 'test' },
+  persistentVolumes: [
+    { metadata: { name: 'testnoPV' }, status: { phase: 'Available' } },
+  ],
+};
+
+it('should return false when volume is unknown', () => {
+  const result = isVolumeDeletable(
+    testcaseVolumeUnknown.rowData,
+    testcaseVolumeUnknown.persistentVolumes,
+  );
+  expect(result).toEqual(false);
+});
+
+it('should return false when volume is pending', () => {
+  const result = isVolumeDeletable(
+    testcaseVolumePending.rowData,
+    testcaseVolumePending.persistentVolumes,
+  );
+  expect(result).toEqual(false);
+});
+
+it('should return false when volume is terminating', () => {
+  const result = isVolumeDeletable(
+    testcaseVolumeTerminating.rowData,
+    testcaseVolumeTerminating.persistentVolumes,
+  );
+  expect(result).toEqual(false);
+});
+
+it('should return false when volume is failed and there is no PV', () => {
+  const result = isVolumeDeletable(
+    testcaseVolumeFailedWithoutPv.rowData,
+    testcaseVolumeFailedWithoutPv.persistentVolumes,
+  );
+  expect(result).toEqual(false);
+});
+
+it('should return true when volume is failed and PV is failed', () => {
+  const result = isVolumeDeletable(
+    testcaseVolumeFailedPvFailed.rowData,
+    testcaseVolumeFailedPvFailed.persistentVolumes,
+  );
+  expect(result).toEqual(true);
+});
+
+it('should return true when volume is failed and PV is available', () => {
+  const result = isVolumeDeletable(
+    testcaseVolumeFailedPvAvailable.rowData,
+    testcaseVolumeFailedPvAvailable.persistentVolumes,
+  );
+  expect(result).toEqual(true);
+});
+
+it('should return true when volume is failed and PV is released', () => {
+  const result = isVolumeDeletable(
+    testcaseVolumeFailedPvReleased.rowData,
+    testcaseVolumeFailedPvReleased.persistentVolumes,
+  );
+  expect(result).toEqual(true);
+});
+
+it('should return false when volume is failed and PV is pending', () => {
+  const result = isVolumeDeletable(
+    testcaseVolumeFailedPvPending.rowData,
+    testcaseVolumeFailedPvPending.persistentVolumes,
+  );
+  expect(result).toEqual(false);
+});
+
+it('should return false when volume is failed and PV is bound', () => {
+  const result = isVolumeDeletable(
+    testcaseVolumeFailedPvBound.rowData,
+    testcaseVolumeFailedPvBound.persistentVolumes,
+  );
+  expect(result).toEqual(false);
+});
+
+it('should return false when volume is failed and PV is unknown', () => {
+  const result = isVolumeDeletable(
+    testcaseVolumeFailedPvUnknown.rowData,
+    testcaseVolumeFailedPvUnknown.persistentVolumes,
+  );
+  expect(result).toEqual(false);
+});
+
+it('should return true when volume is available and PV is failed', () => {
+  const result = isVolumeDeletable(
+    testcaseVolumeAvailablePvFailed.rowData,
+    testcaseVolumeAvailablePvFailed.persistentVolumes,
+  );
+  expect(result).toEqual(true);
+});
+
+it('should return true when volume is available and PV is available', () => {
+  const result = isVolumeDeletable(
+    testcaseVolumeAvailablePvAvailable.rowData,
+    testcaseVolumeAvailablePvAvailable.persistentVolumes,
+  );
+  expect(result).toEqual(true);
+});
+
+it('should return true when volume is available and PV is released', () => {
+  const result = isVolumeDeletable(
+    testcaseVolumeAvailablePvReleased.rowData,
+    testcaseVolumeAvailablePvReleased.persistentVolumes,
+  );
+  expect(result).toEqual(true);
+});
+
+it('should return false when volume is available and PV is pending', () => {
+  const result = isVolumeDeletable(
+    testcaseVolumeAvailablePvPending.rowData,
+    testcaseVolumeAvailablePvPending.persistentVolumes,
+  );
+  expect(result).toEqual(false);
+});
+
+it('should return false when volume is available and PV is bound', () => {
+  const result = isVolumeDeletable(
+    testcaseVolumeAvailablePvBound.rowData,
+    testcaseVolumeAvailablePvBound.persistentVolumes,
+  );
+  expect(result).toEqual(false);
+});
+
+it('should return false when volume is available and PV is unknown', () => {
+  const result = isVolumeDeletable(
+    testcaseVolumeAvailablePvUnknown.rowData,
+    testcaseVolumeAvailablePvUnknown.persistentVolumes,
+  );
+  expect(result).toEqual(false);
+});
+
+it('should return false when volume is available and there is no PV', () => {
+  const result = isVolumeDeletable(
+    testcaseVolumeAvailableWithoutPv.rowData,
+    testcaseVolumeAvailableWithoutPv.persistentVolumes,
+  );
+  expect(result).toEqual(false);
+});


### PR DESCRIPTION
**Component**: ui

**Context**: 
When the volume is failed, if there is no PV found, the volume is not deletable.

**Summary**:
Fix the bug.
Add a unit test for `isVolumeDeletable` function in NodeVolumes. 
There are in total of 17 cases with the different combinations of volume and PV.

**Acceptance criteria**: 
Pass all the 17 cases

Closes: #1673
