### PR TITLE
#1693: Refactor versions listing for packages

### DIFF
--- a/.pylint-dict
+++ b/.pylint-dict
@@ -6,6 +6,7 @@ buildrepo
 buildrpm
 buildsrpm
 cli
+cni
 cmd
 cp
 checksum
@@ -22,7 +23,9 @@ gofmt
 filename
 init
 io
-Kubernetes
+kubernetes
+kubectl
+kubelet
 linter
 metadata
 mkdir

--- a/buildchain/buildchain/packaging.py
+++ b/buildchain/buildchain/packaging.py
@@ -56,11 +56,10 @@ def _list_packages_to_download(
     packages_to_build: List[str]
 ) -> Dict[str,str]:
     return {
-        pkg.name: "{p.version}-{p.release}".format(p=pkg)
+        pkg.name: pkg.full_version
         for pkg in package_versions
         if pkg.name not in packages_to_build
     }
-
 
 # }}}
 # Tasks {{{
@@ -323,7 +322,7 @@ _RPM_TO_BUILD_PKG_NAMES : List[str] = _list_packages_to_build(RPM_TO_BUILD)
 # All packages not referenced in `RPM_TO_BUILD` but listed in
 # `versions.RPM_PACKAGES` are supposed to be downloaded.
 RPM_TO_DOWNLOAD : FrozenSet[str] = frozenset(
-    "{p.name}-{p.version}-{p.release}".format(p=package)
+    package.rpm_full_name
     for package in versions.RPM_PACKAGES
     if package.name not in _RPM_TO_BUILD_PKG_NAMES
 )
@@ -331,7 +330,7 @@ RPM_TO_DOWNLOAD : FrozenSet[str] = frozenset(
 
 # Store these versions in a dict to use with doit.tools.config_changed
 _TO_DOWNLOAD_RPM_CONFIG : Dict[str, str] = _list_packages_to_download(
-    versions.PACKAGES,
+    versions.RPM_PACKAGES,
     _RPM_TO_BUILD_PKG_NAMES
 )
 
@@ -395,7 +394,7 @@ _TO_DOWNLOAD_DEB_CONFIG : Dict[str, str] = _list_packages_to_download(
 
 
 DEB_TO_DOWNLOAD : FrozenSet[str] = frozenset(
-    "{p.name}".format(p=package)
+    package.deb_full_name
     for package in versions.DEB_PACKAGES
     if package.name not in _DEB_TO_BUILD_PKG_NAMES
 )

--- a/buildchain/buildchain/packaging.py
+++ b/buildchain/buildchain/packaging.py
@@ -144,7 +144,7 @@ def task__download_rpm_packages() -> types.TaskDict:
             '_build_rpm_container'
         ],
         'clean': [clean],
-        'uptodate': [config_changed(_TO_DOWNLOAD_CONFIG)],
+        'uptodate': [config_changed(_TO_DOWNLOAD_RPM_CONFIG)],
         # Prevent Docker from polluting our output.
         'verbosity': 0,
     }
@@ -324,18 +324,27 @@ RPM_TO_DOWNLOAD : FrozenSet[str] = frozenset(
 )
 
 
-# Store these versions in a dict to use with doit.tools.config_changed
-_TO_DOWNLOAD_CONFIG : Dict[str, str] = {
-    pkg.name: "{p.version}-{p.release}".format(p=pkg)
-    for pkg in versions.RPM_PACKAGES
-    if pkg.name not in _RPM_TO_BUILD_PKG_NAMES
-}
+def _list_packages_to_download(
+    package_versions: Tuple[versions.Package, ...],
+    packages_to_build: List[str]
+) -> Dict[str,str]:
+    return {
+        pkg.name: "{p.version}-{p.release}".format(p=pkg)
+        for pkg in package_versions
+        if pkg.name not in packages_to_build
+    }
 
-_TO_DOWNLOAD_DEB_CONFIG : Dict[str, str] = {
-    pkg.name: "{p.version}-{p.release}".format(p=pkg)
-    for pkg in versions.DEB_PACKAGES
-    if pkg.name not in _DEB_TO_BUILD_PKG_NAMES
-}
+# Store these versions in a dict to use with doit.tools.config_changed
+_TO_DOWNLOAD_RPM_CONFIG : Dict[str, str] = _list_packages_to_download(
+    versions.PACKAGES,
+    _RPM_TO_BUILD_PKG_NAMES
+)
+
+# Store these versions in a dict to use with doit.tools.config_changed
+_TO_DOWNLOAD_DEB_CONFIG : Dict[str, str] = _list_packages_to_download(
+    versions.DEB_PACKAGES,
+    _DEB_TO_BUILD_PKG_NAMES
+)
 
 
 SCALITY_RPM_REPOSITORY = targets.RPMRepository(

--- a/buildchain/buildchain/packaging.py
+++ b/buildchain/buildchain/packaging.py
@@ -272,7 +272,7 @@ DEB_BUILDER : targets.LocalImage = targets.LocalImage(
 # Packages to build, per repository.
 def _rpm_package(name: str, sources: List[Path]) -> targets.RPMPackage:
     try:
-        pkg_info = versions.PACKAGES_MAP[name]
+        pkg_info = versions.RPM_PACKAGES_MAP[name]
     except KeyError:
         raise ValueError(
             'Missing version for package "{}"'.format(name)

--- a/buildchain/buildchain/packaging.py
+++ b/buildchain/buildchain/packaging.py
@@ -27,7 +27,7 @@ Overview;
 
 
 from pathlib import Path
-from typing import Dict, FrozenSet, Iterator, List, Tuple
+from typing import Dict, FrozenSet, Iterator, List, Mapping, Optional, Tuple
 
 from doit.tools import config_changed  # type: ignore
 
@@ -44,7 +44,7 @@ from buildchain import versions
 # Utilities {{{
 
 def _list_packages_to_build(
-    pkg_cats: Dict[str, Tuple[targets.Package, ...]]
+    pkg_cats: Mapping[str, Tuple[targets.Package, ...]]
 ) -> List[str]:
     return [
         pkg.name for pkg_list in pkg_cats.values() for pkg in pkg_list
@@ -54,7 +54,7 @@ def _list_packages_to_build(
 def _list_packages_to_download(
     package_versions: Tuple[versions.PackageVersion, ...],
     packages_to_build: List[str]
-) -> Dict[str,str]:
+) -> Dict[str, Optional[str]]:
     return {
         pkg.name: pkg.full_version
         for pkg in package_versions
@@ -329,10 +329,8 @@ RPM_TO_DOWNLOAD : FrozenSet[str] = frozenset(
 
 
 # Store these versions in a dict to use with doit.tools.config_changed
-_TO_DOWNLOAD_RPM_CONFIG : Dict[str, str] = _list_packages_to_download(
-    versions.RPM_PACKAGES,
-    _RPM_TO_BUILD_PKG_NAMES
-)
+_TO_DOWNLOAD_RPM_CONFIG: Dict[str, Optional[str]] = \
+    _list_packages_to_download(versions.RPM_PACKAGES, _RPM_TO_BUILD_PKG_NAMES)
 
 
 SCALITY_RPM_REPOSITORY = targets.RPMRepository(
@@ -387,10 +385,8 @@ _DEB_TO_BUILD_PKG_NAMES : List[str] = _list_packages_to_build(DEB_TO_BUILD)
 
 
 # Store these versions in a dict to use with doit.tools.config_changed
-_TO_DOWNLOAD_DEB_CONFIG : Dict[str, str] = _list_packages_to_download(
-    versions.DEB_PACKAGES,
-    _DEB_TO_BUILD_PKG_NAMES
-)
+_TO_DOWNLOAD_DEB_CONFIG: Dict[str, Optional[str]] = \
+    _list_packages_to_download(versions.DEB_PACKAGES, _DEB_TO_BUILD_PKG_NAMES)
 
 
 DEB_TO_DOWNLOAD : FrozenSet[str] = frozenset(

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -196,7 +196,7 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
             'kubernetes': {'version': versions.K8S_VERSION},
             'packages': {
                 pkg.name: {'version': pkg.full_version}
-                for pkg in versions.PACKAGES
+                for pkg in versions.RPM_PACKAGES
             },
             'images': {
                 img.name: {'version': img.version}

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -195,8 +195,8 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
         data={
             'kubernetes': {'version': versions.K8S_VERSION},
             'packages': {
-                pkg.name: {'version': "{}-{}".format(pkg.version, pkg.release)}
-                for pkg in versions.RPM_PACKAGES
+                pkg.name: {'version': pkg.full_version}
+                for pkg in versions.PACKAGES
             },
             'images': {
                 img.name: {'version': img.version}

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -10,7 +10,7 @@ import operator
 
 from collections import namedtuple
 from pathlib import Path
-from typing import cast, Optional, Tuple
+from typing import cast, Dict, Optional, Tuple
 
 
 Image = namedtuple('Image', ('name', 'version', 'digest'))
@@ -243,7 +243,8 @@ class PackageVersion:
         self,
         name: str,
         version: Optional[str] = None,
-        release: Optional[str] = None
+        release: Optional[str] = None,
+        override: Optional[str] = None
     ):
         """Initializes a package version.
 
@@ -255,10 +256,12 @@ class PackageVersion:
         self._name     = name
         self._version  = version
         self._release  = release
+        self._override = override
 
     name = property(operator.attrgetter('_name'))
     version = property(operator.attrgetter('_version'))
     release = property(operator.attrgetter('_release'))
+    override = property(operator.attrgetter('_override'))
 
     @property
     def full_version(self) -> Optional[str]:
@@ -285,201 +288,113 @@ class PackageVersion:
         return cast(str, self.name)
 
 
-RPM_PACKAGES = (
-    # Remote packages
-    PackageVersion(
-        name='containerd',
-        version='1.2.4',
-        release='1.el7',
+# The authoritative list of packages required.
+#
+# Common packages are packages for which we need not care about OS-specific
+# divergences.
+#
+# In this case, either:
+#   * the _latest_ version is good enough, and will be the one
+#     selected by the package managers (so far: apt and yum).
+#   * we have strict version requirements that span OS families, and the
+#     version schemes _and_ package names do not diverge
+#
+# Strict version requirements are notably:
+#   * kubelet and kubectl which _make_ the K8s version of the cluster
+#   * salt-minion which _makes_ the Salt version of the cluster
+#
+# These common packages may be overridden by OS-specific packages if package
+# names or version conventions diverge.
+#
+# Packages that we build ourselves require a version and release as part of
+# their build process.
+PACKAGES: Dict[str, Tuple[PackageVersion, ...]] = {
+    'common': (
+        # Pinned packages
+        PackageVersion(name='kubectl', version=K8S_VERSION),
+        PackageVersion(name='kubelet', version=K8S_VERSION),
+        # Latest packages
+        PackageVersion(name='containerd'),
+        PackageVersion(name='coreutils'),
+        PackageVersion(name='cri-tools'),
+        PackageVersion(name='e2fsprogs'),
+        PackageVersion(name='ebtables'),
+        PackageVersion(name='ethtool'),
+        PackageVersion(name='genisoimage'),
+        PackageVersion(name='iproute'),
+        PackageVersion(name='iptables'),
+        PackageVersion(name='kubernetes-cni'),
+        PackageVersion(name='m2crypto'),
+        PackageVersion(name='runc'),
+        PackageVersion(name='salt-minion', version=SALT_VERSION),
+        PackageVersion(name='socat'),
+        PackageVersion(name='sos'),  # TODO download built package dependencies
+        PackageVersion(name='util-linux'),
+        PackageVersion(name='xfsprogs'),
     ),
-    PackageVersion(
-        name='cri-tools',
-        version='1.13.0',
-        release='0',
+    'redhat': (
+        PackageVersion(
+            name='calico-cni-plugin',
+            version=CALICO_VERSION,
+            release='1.el7'
+        ),
+        PackageVersion(name='container-selinux'),  # TODO #1710
+        PackageVersion(
+            name='metalk8s-sosreport',
+            version=SHORT_VERSION,
+            release='1.el7'
+        ),
+        PackageVersion(name='yum-plugin-versionlock'),
     ),
-    PackageVersion(
-        name='container-selinux',
-        version='2.99',
-        release='1.el7_6',
+    'debian': (
+        PackageVersion(
+            name='calico-cni-plugin',
+            version=CALICO_VERSION,
+            release='0'
+        ),
+        PackageVersion(name='iproute2', override='iproute'),
+        PackageVersion(
+            name='metalk8s-sosreport',
+            version=SHORT_VERSION,
+            release='0'
+        ),
+        PackageVersion(name='python-m2crypto', override='m2crypto'),
+        PackageVersion(name='sosreport', override='sos'),
     ),
-    PackageVersion(
-        name='coreutils',
-        version='8.22',
-        release='23.el7',
-    ),
-    PackageVersion(
-        name='ebtables',
-        version='2.0.10',
-        release='16.el7',
-    ),
-    PackageVersion(
-        name='ethtool',
-        version='4.8',
-        release='9.el7',
-    ),
-    PackageVersion(
-        name='e2fsprogs',
-        version='1.42.9',
-        release='13.el7',
-    ),
-    PackageVersion(
-        name='genisoimage',
-        version='1.1.11',
-        release='25.el7',
-    ),
-    PackageVersion(
-        name='iproute',
-        version='4.11.0',
-        release='14.el7_6.2',
-    ),
-    PackageVersion(
-        name='iptables',
-        version='1.4.21',
-        release='28.el7',
-    ),
-    PackageVersion(
-        name='kubectl',
-        version=K8S_VERSION,
-        release='0',
-    ),
-    PackageVersion(
-        name='kubelet',
-        version=K8S_VERSION,
-        release='0',
-    ),
-    PackageVersion(
-        name='kubernetes-cni',
-        version='0.7.5',
-        release='0',
-    ),
-    PackageVersion(
-        name='m2crypto',
-        version='0.31.0',
-        release='3.el7',
-    ),
-    PackageVersion(
-        name='python2-kubernetes',
-        version='8.0.1',
-        release='1.el7',
-    ),
-    PackageVersion(
-        name='runc',
-        version='1.0.0',
-        release='59.dev.git2abd837.el7.centos',
-    ),
-    PackageVersion(
-        name='salt-minion',
-        version=SALT_VERSION,
-        release='1.el7',
-    ),
-    PackageVersion(
-        name='skopeo',
-        version='0.1.35',
-        release='2.git404c5bd.el7.centos',
-    ),
-    PackageVersion(
-        name='socat',
-        version='1.7.3.2',
-        release='2.el7',
-    ),
-    PackageVersion(
-        name='sos',
-        version='3.6',
-        release='17.el7.centos',
-    ),
-    PackageVersion(
-        name='util-linux',
-        version='2.23.2',
-        release='59.el7_6.1',
-    ),
-    PackageVersion(
-        name='xfsprogs',
-        version='4.5.0',
-        release='18.el7',
-    ),
-    PackageVersion(
-        name='yum-plugin-versionlock',
-        version='1.1.31',
-        release='50.el7',
-    ),
-    # Local packages
-    PackageVersion(
-        name='metalk8s-sosreport',
-        version=SHORT_VERSION,
-        release='1.el7',
-    ),
-    PackageVersion(
-        name='calico-cni-plugin',
-        version=CALICO_VERSION,
-        release='1.el7',
-    ),
-)
-
-PACKAGES_MAP = {pkg.name: pkg for pkg in RPM_PACKAGES}
+}
 
 
-DEB_PACKAGES = (
-    PackageVersion(
-        name='containerd',
-    ),
-    PackageVersion(
-        name='cri-tools',
-    ),
-    PackageVersion(
-        name='coreutils',
-    ),
-    PackageVersion(
-        name='ebtables',
-    ),
-    PackageVersion(
-        name='ethtool',
-    ),
-    PackageVersion(
-        name='e2fsprogs',
-    ),
-    PackageVersion(
-        name='genisoimage',
-    ),
-    PackageVersion(
-        name='iproute2',
-    ),
-    PackageVersion(
-        name='iptables',
-    ),
-    PackageVersion(
-        name='salt-minion',
-        version=SALT_VERSION,
-    ),
-    PackageVersion(
-        name='kubectl',
-        version=K8S_VERSION,
-    ),
-    PackageVersion(
-        name='kubelet',
-        version=K8S_VERSION,
-    ),
-    PackageVersion(
-        name='kubernetes-cni',
-    ),
-    PackageVersion(
-        name='python-m2crypto',
-    ),
-    PackageVersion(
-        name='runc',
-    ),
-    PackageVersion(
-        name='socat',
-    ),
-    PackageVersion(
-        name='sosreport',
-    ),
-    PackageVersion(
-        name='util-linux',
-    ),
-    PackageVersion(
-        name='xfsprogs',
-    ),
-)
+def _list_pkgs_for_os_family(os_family: str) -> Tuple[PackageVersion, ...]:
+    """List downloaded packages for a given OS family.
 
+    Arguments:
+        os_family: OS_family for which to list packages
+    """
+    common_pkgs = PACKAGES['common']
+    os_family_pkgs = PACKAGES.get(os_family)
+
+    if os_family_pkgs is None:
+        raise Exception('No packages for OS family: {}'.format(os_family))
+
+    os_override_names = [
+        pkg.override for pkg in os_family_pkgs
+        if pkg.override is not None
+    ]
+
+    overridden = filter(
+        lambda item: item.name not in os_override_names,
+        common_pkgs
+    )
+
+    return tuple(overridden) + os_family_pkgs
+
+
+RPM_PACKAGES = _list_pkgs_for_os_family('redhat')
+
+RPM_PACKAGES_MAP = {pkg.name: pkg for pkg in RPM_PACKAGES}
+
+DEB_PACKAGES = _list_pkgs_for_os_family('debian')
+
+DEB_PACKAGES_MAP = {pkg.name: pkg for pkg in DEB_PACKAGES}
 
 # }}}

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -6,14 +6,14 @@
 This module MUST be kept valid in a standalone context, since it is intended
 for use in tests and documentation as well.
 """
+import operator
 
 from collections import namedtuple
 from pathlib import Path
-from typing import Tuple
+from typing import cast, Optional, Tuple
 
 
 Image = namedtuple('Image', ('name', 'version', 'digest'))
-Package = namedtuple('Package', ('name', 'version', 'release'))
 
 # Project-wide versions {{{
 
@@ -228,132 +228,187 @@ CONTAINER_IMAGES : Tuple[Image, ...] = (
 CONTAINER_IMAGES_MAP = {image.name: image for image in CONTAINER_IMAGES}
 
 # }}}
+
 # Packages {{{
+
+class PackageVersion:
+    """A package's authoritative version data.
+
+    This class contains version information for a named package, and
+    provides helper methods for formatting version/release data as well
+    as version-enriched package name, for all supported OS families.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        version: Optional[str] = None,
+        release: Optional[str] = None
+    ):
+        """Initializes a package version.
+
+        Arguments:
+            name: the name of the package
+            version: the version of the package
+            release: the release of the package
+        """
+        self._name     = name
+        self._version  = version
+        self._release  = release
+
+    name = property(operator.attrgetter('_name'))
+    version = property(operator.attrgetter('_version'))
+    release = property(operator.attrgetter('_release'))
+
+    @property
+    def full_version(self) -> Optional[str]:
+        """The full package version string."""
+        full_version = None
+        if self.version:
+            full_version = self.version
+            if self.release:
+                full_version = '{}-{}'.format(self.version, self.release)
+        return full_version
+
+    @property
+    def rpm_full_name(self) -> str:
+        """The package's full name in RPM conventions."""
+        if self.full_version:
+            return '{}-{}'.format(self.name, self.full_version)
+        return cast(str, self.name)
+
+    @property
+    def deb_full_name(self) -> str:
+        """The package's full name in DEB conventions."""
+        if self.full_version:
+            return '{}={}'.format(self.name, self.full_version)
+        return cast(str, self.name)
+
 
 RPM_PACKAGES = (
     # Remote packages
-    Package(
+    PackageVersion(
         name='containerd',
         version='1.2.4',
         release='1.el7',
     ),
-    Package(
+    PackageVersion(
         name='cri-tools',
         version='1.13.0',
         release='0',
     ),
-    Package(
+    PackageVersion(
         name='container-selinux',
         version='2.99',
         release='1.el7_6',
     ),
-    Package(
+    PackageVersion(
         name='coreutils',
         version='8.22',
         release='23.el7',
     ),
-    Package(
+    PackageVersion(
         name='ebtables',
         version='2.0.10',
         release='16.el7',
     ),
-    Package(
+    PackageVersion(
         name='ethtool',
         version='4.8',
         release='9.el7',
     ),
-    Package(
+    PackageVersion(
         name='e2fsprogs',
         version='1.42.9',
         release='13.el7',
     ),
-    Package(
+    PackageVersion(
         name='genisoimage',
         version='1.1.11',
         release='25.el7',
     ),
-    Package(
+    PackageVersion(
         name='iproute',
         version='4.11.0',
         release='14.el7_6.2',
     ),
-    Package(
+    PackageVersion(
         name='iptables',
         version='1.4.21',
         release='28.el7',
     ),
-    Package(
+    PackageVersion(
         name='kubectl',
         version=K8S_VERSION,
         release='0',
     ),
-    Package(
+    PackageVersion(
         name='kubelet',
         version=K8S_VERSION,
         release='0',
     ),
-    Package(
+    PackageVersion(
         name='kubernetes-cni',
         version='0.7.5',
         release='0',
     ),
-    Package(
+    PackageVersion(
         name='m2crypto',
         version='0.31.0',
         release='3.el7',
     ),
-    Package(
+    PackageVersion(
         name='python2-kubernetes',
         version='8.0.1',
         release='1.el7',
     ),
-    Package(
+    PackageVersion(
         name='runc',
         version='1.0.0',
         release='59.dev.git2abd837.el7.centos',
     ),
-    Package(
+    PackageVersion(
         name='salt-minion',
         version=SALT_VERSION,
         release='1.el7',
     ),
-    Package(
+    PackageVersion(
         name='skopeo',
         version='0.1.35',
         release='2.git404c5bd.el7.centos',
     ),
-    Package(
+    PackageVersion(
         name='socat',
         version='1.7.3.2',
         release='2.el7',
     ),
-    Package(
+    PackageVersion(
         name='sos',
         version='3.6',
         release='17.el7.centos',
     ),
-    Package(
+    PackageVersion(
         name='util-linux',
         version='2.23.2',
         release='59.el7_6.1',
     ),
-    Package(
+    PackageVersion(
         name='xfsprogs',
         version='4.5.0',
         release='18.el7',
     ),
-    Package(
+    PackageVersion(
         name='yum-plugin-versionlock',
         version='1.1.31',
         release='50.el7',
     ),
     # Local packages
-    Package(
+    PackageVersion(
         name='metalk8s-sosreport',
         version=SHORT_VERSION,
         release='1.el7',
     ),
-    Package(
+    PackageVersion(
         name='calico-cni-plugin',
         version=CALICO_VERSION,
         release='1.el7',
@@ -364,100 +419,65 @@ PACKAGES_MAP = {pkg.name: pkg for pkg in RPM_PACKAGES}
 
 
 DEB_PACKAGES = (
-    Package(
+    PackageVersion(
         name='containerd',
-        version='',
-        release='',
     ),
-    Package(
+    PackageVersion(
         name='cri-tools',
-        version='',
-        release='',
     ),
-    Package(
+    PackageVersion(
         name='coreutils',
-        version='',
-        release='',
     ),
-    Package(
+    PackageVersion(
         name='ebtables',
-        version='',
-        release='',
     ),
-    Package(
+    PackageVersion(
         name='ethtool',
-        version='',
-        release='',
     ),
-    Package(
+    PackageVersion(
         name='e2fsprogs',
-        version='',
-        release='',
     ),
-    Package(
+    PackageVersion(
         name='genisoimage',
-        version='',
-        release='',
     ),
-    Package(
+    PackageVersion(
         name='iproute2',
-        version='',
-        release='',
     ),
-    Package(
+    PackageVersion(
         name='iptables',
-        version='',
-        release='',
     ),
-    Package(
-        name='salt-minion={}'.format(SALT_VERSION),
-        version='',
-        release='',
+    PackageVersion(
+        name='salt-minion',
+        version=SALT_VERSION,
     ),
-    Package(
-        name='kubectl={}'.format(K8S_VERSION),
-        version='',
-        release='',
+    PackageVersion(
+        name='kubectl',
+        version=K8S_VERSION,
     ),
-    Package(
-        name='kubelet={}'.format(K8S_VERSION),
-        version='',
-        release='',
+    PackageVersion(
+        name='kubelet',
+        version=K8S_VERSION,
     ),
-    Package(
+    PackageVersion(
         name='kubernetes-cni',
-        version='',
-        release='',
     ),
-    Package(
+    PackageVersion(
         name='python-m2crypto',
-        version='',
-        release='',
     ),
-    Package(
+    PackageVersion(
         name='runc',
-        version='',
-        release='',
     ),
-    Package(
+    PackageVersion(
         name='socat',
-        version='',
-        release='',
     ),
-    Package(
+    PackageVersion(
         name='sosreport',
-        version='',
-        release='',
     ),
-    Package(
+    PackageVersion(
         name='util-linux',
-        version='',
-        release='',
     ),
-    Package(
+    PackageVersion(
         name='xfsprogs',
-        version='',
-        release='',
     ),
 )
 


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: We're adding a new OS, so we need OS-aware versions definition.

**Summary**:

The goal is to provide an authoritative listing of required packages that it as easy as possible to manage.

```
# Common packages are packages for which we need not care about OS-specific
# divergences.
#
# In this case, either:
#   * the _latest_ version is good enough, and will be the one
#     selected by the package managers (so far: apt and yum).
#   * we have strict version requirements that span OS families, and the
#     versioning schemes _and_ package names do not diverge
#
# Strict version requirements are notably:
#   * kubelet and kubectl which _make_ the K8s version of the cluster
#   * salt-minion which _makes_ the Salt version of the cluster
#
# These common packages may be overridden by OS-specific packages if package
# names or versioning conventions diverge.
#
# Packages that we build ourselves require a version and release as part of
# their build process.
```

**Acceptance criteria**: tests pass, debian files are generated with the correct versions.

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1693

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
