### PR TITLE
Fix iso-manager script

### DIFF
--- a/scripts/iso-manager.sh
+++ b/scripts/iso-manager.sh
@@ -174,7 +174,7 @@ _add_archives() {
     done
     echo "Updating bootstrap.yaml"
     $SALT_CALL state.single file.serialize "$BOOTSTRAP_CONFIG" \
-        dataset="{'archives': {'metalk8s': [$archive_list]}}" \
+        dataset="{'archives': [$archive_list]}" \
         merge_if_exists=True \
         formatter=yaml \
         show_changes=True \


### PR DESCRIPTION
We forgot to remove the extra `metalk8s` level during renaming from
`products:metalk8s` to `archives`.

See #1332
See 1975ec5
See 6eccd63