### PR TITLE
Pre `2.4.0-beta1` release bugfixes

### DIFF
--- a/salt/metalk8s/kubernetes/mark-control-plane/deployed.sls.in
+++ b/salt/metalk8s/kubernetes/mark-control-plane/deployed.sls.in
@@ -1,4 +1,4 @@
-{% set hostname = pillar.get('mark_control_plane_hostname', salt['network.get_hostname']()) %}
+{% set node_name = pillar.bootstrap_id %}
 
 {% set kubeconfig = "/etc/kubernetes/admin.conf" %}
 {% set context = "kubernetes-admin@kubernetes" %}
@@ -8,7 +8,7 @@ Apply control-plane master role label:
     - name: "node-role.kubernetes.io/master"
     - kubeconfig: {{ kubeconfig }}
     - context: {{ context }}
-    - node: {{ hostname }}
+    - node: {{ node_name }}
     - value: ""
 
 Apply control-plane etcd role label:
@@ -16,7 +16,7 @@ Apply control-plane etcd role label:
     - name: "node-role.kubernetes.io/etcd"
     - kubeconfig: {{ kubeconfig }}
     - context: {{ context }}
-    - node: {{ hostname }}
+    - node: {{ node_name }}
     - value: ""
 
 Apply control-plane bootstrap role label:
@@ -24,7 +24,7 @@ Apply control-plane bootstrap role label:
     - name: "node-role.kubernetes.io/bootstrap"
     - kubeconfig: {{ kubeconfig }}
     - context: {{ context }}
-    - node: {{ hostname }}
+    - node: {{ node_name }}
     - value: ""
 
 Apply control-plane infra role label:
@@ -32,12 +32,12 @@ Apply control-plane infra role label:
     - name: "node-role.kubernetes.io/infra"
     - kubeconfig: {{ kubeconfig }}
     - context: {{ context }}
-    - node: {{ hostname }}
+    - node: {{ node_name }}
     - value: ""
 
 Apply control-plane taints:
   metalk8s_kubernetes.node_taints_present:
-    - name: {{ hostname }}
+    - name: {{ node_name }}
     - kubeconfig: {{ kubeconfig }}
     - context: {{ context }}
     - taints:
@@ -51,7 +51,7 @@ Apply node version label:
     - kubeconfig: {{ kubeconfig }}
     - context: {{ context }}
     - name: "metalk8s.scality.com/version"
-    - node: {{ hostname }}
+    - node: {{ node_name }}
     - value: "@@VERSION"
 
 Annotate with CRI socket information:
@@ -59,7 +59,7 @@ Annotate with CRI socket information:
     - name: "kubeadm.alpha.kubernetes.io/cri-socket"
     - kubeconfig: {{ kubeconfig }}
     - context: {{ context }}
-    - node: {{ hostname }}
+    - node: {{ node_name }}
     # TODO: the socket location may become configurable, we should make sure
     #       this value is accurate (hardcoded to the default value for now)
     - value: "/run/containerd/containerd.sock"

--- a/salt/metalk8s/orchestrate/bootstrap/init.sls
+++ b/salt/metalk8s/orchestrate/bootstrap/init.sls
@@ -31,6 +31,7 @@
 {% endif %}
 
 {%- set pillar_data = {
+        'bootstrap_id': pillar.bootstrap_id,
         'metalk8s': {
             'nodes': {
                 pillar.bootstrap_id: {

--- a/scripts/iso-manager.sh
+++ b/scripts/iso-manager.sh
@@ -174,7 +174,7 @@ _add_archives() {
     done
     echo "Updating bootstrap.yaml"
     $SALT_CALL state.single file.serialize "$BOOTSTRAP_CONFIG" \
-        dataset="{'archives': {'metalk8s': [$archive_list]}}" \
+        dataset="{'archives': [$archive_list]}" \
         merge_if_exists=True \
         formatter=yaml \
         show_changes=True \


### PR DESCRIPTION
Fix some small bugs required for the `2.4.0-beta1`:

- Remove the extra `metalk8s` level in `iso-manager.sh` script when adding archives
- Fix #1706 (`mark-control-plane` relying on hostname instead of `pillar.bootstrap_id` to accurately set labels and annotations on the good `Node` object)