### PR TITLE
Create deb repository root

### DIFF
--- a/buildchain/buildchain/packaging.py
+++ b/buildchain/buildchain/packaging.py
@@ -341,6 +341,48 @@ SCALITY_RPM_REPOSITORY = targets.RPMRepository(
     task_dep=['_package_mkdir_rpm_iso_root'],
 )
 
+
+RPM_REPOSITORIES : Tuple[targets.RPMRepository, ...] = (
+    SCALITY_RPM_REPOSITORY,
+    targets.RPMRepository(
+        basename='_build_rpm_repositories',
+        name='base',
+        builder=RPM_BUILDER,
+        task_dep=['_download_rpm_packages'],
+    ),
+    targets.RPMRepository(
+        basename='_build_rpm_repositories',
+        name='extras',
+        builder=RPM_BUILDER,
+        task_dep=['_download_rpm_packages'],
+    ),
+    targets.RPMRepository(
+        basename='_build_rpm_repositories',
+        name='updates',
+        builder=RPM_BUILDER,
+        task_dep=['_download_rpm_packages'],
+    ),
+    targets.RPMRepository(
+        basename='_build_rpm_repositories',
+        name='epel',
+        builder=RPM_BUILDER,
+        task_dep=['_download_rpm_packages'],
+    ),
+    targets.RPMRepository(
+        basename='_build_rpm_repositories',
+        name='kubernetes',
+        builder=RPM_BUILDER,
+        task_dep=['_download_rpm_packages'],
+    ),
+    targets.RPMRepository(
+        basename='_build_rpm_repositories',
+        name='saltstack',
+        builder=RPM_BUILDER,
+        task_dep=['_download_rpm_packages'],
+    ),
+)
+
+
 # }}}
 # Debian packages and repositories {{{
 
@@ -396,47 +438,46 @@ DEB_TO_DOWNLOAD : FrozenSet[str] = frozenset(
 )
 
 
-RPM_REPOSITORIES : Tuple[targets.RPMRepository, ...] = (
-    SCALITY_RPM_REPOSITORY,
-    targets.RPMRepository(
-        basename='_build_rpm_repositories',
-        name='base',
-        builder=RPM_BUILDER,
-        task_dep=['_download_rpm_packages'],
+DEB_REPOSITORIES : Tuple[targets.DEBRepository, ...] = (
+    targets.DEBRepository(
+        basename='_build_deb_repositories',
+        name='scality',
+        builder=DEB_BUILDER,
+        packages=DEB_TO_BUILD['scality'],
+        task_dep=['_package_mkdir_deb_iso_root'],
     ),
-    targets.RPMRepository(
-        basename='_build_rpm_repositories',
-        name='extras',
-        builder=RPM_BUILDER,
-        task_dep=['_download_rpm_packages'],
+    targets.DEBRepository(
+        basename='_build_deb_repositories',
+        name='bionic',
+        builder=DEB_BUILDER,
+        task_dep=['_download_deb_packages'],
     ),
-    targets.RPMRepository(
-        basename='_build_rpm_repositories',
-        name='updates',
-        builder=RPM_BUILDER,
-        task_dep=['_download_rpm_packages'],
+    targets.DEBRepository(
+        basename='_build_deb_repositories',
+        name='bionic-backports',
+        builder=DEB_BUILDER,
+        task_dep=['_download_deb_packages'],
     ),
-    targets.RPMRepository(
-        basename='_build_rpm_repositories',
-        name='epel',
-        builder=RPM_BUILDER,
-        task_dep=['_download_rpm_packages'],
+    targets.DEBRepository(
+        basename='_build_deb_repositories',
+        name='bionic-updates',
+        builder=DEB_BUILDER,
+        task_dep=['_download_deb_packages'],
     ),
-    targets.RPMRepository(
-        basename='_build_rpm_repositories',
-        name='kubernetes',
-        builder=RPM_BUILDER,
-        task_dep=['_download_rpm_packages'],
+    targets.DEBRepository(
+        basename='_build_deb_repositories',
+        name='kubernetes-xenial',
+        builder=DEB_BUILDER,
+        task_dep=['_download_deb_packages'],
     ),
-    targets.RPMRepository(
-        basename='_build_rpm_repositories',
-        name='saltstack',
-        builder=RPM_BUILDER,
-        task_dep=['_download_rpm_packages'],
+    targets.DEBRepository(
+        basename='_build_deb_repositories',
+        name='salt_ubuntu1804',
+        builder=DEB_BUILDER,
+        task_dep=['_download_deb_packages'],
     ),
 )
 
 # }}}
-
 
 __all__ = utils.export_only_tasks(__name__)

--- a/buildchain/buildchain/targets/__init__.py
+++ b/buildchain/buildchain/targets/__init__.py
@@ -12,6 +12,8 @@ from buildchain.targets.local_image import LocalImage
 from buildchain.targets.operator_image import OperatorImage
 from buildchain.targets.package import Package, RPMPackage, DEBPackage
 from buildchain.targets.remote_image import RemoteImage
-from buildchain.targets.repository import Repository, RPMRepository
+from buildchain.targets.repository import (
+    Repository, RPMRepository, DEBRepository
+)
 from buildchain.targets.serialize import SerializedData
 from buildchain.targets.template import TemplateFile

--- a/buildchain/buildchain/targets/repository.py
+++ b/buildchain/buildchain/targets/repository.py
@@ -161,7 +161,7 @@ class RPMRepository(Repository):
             'name': 'build_repodata',
             'actions': actions,
             'doc': 'Build the {} repository metadata.'.format(self.name),
-            'title': utils.title_with_target1('BUILD REPO'),
+            'title': utils.title_with_target1('BUILD RPM REPO'),
             'targets': targets,
             'uptodate': [True],
             'clean': [clean],
@@ -299,3 +299,52 @@ class RPMRepository(Repository):
         )
 
         return buildrepo_callable
+
+
+class DEBRepository(Repository):
+    """A software repository for Debian."""
+
+    def __init__(
+        self,
+        basename: str,
+        name: str,
+        builder: image.ContainerImage,
+        **kwargs: Any
+    ):
+        super ().__init__(
+            basename, name, builder, constants.REPO_DEB_ROOT,
+            **kwargs
+        )
+        task = self.basic_task
+        task['task_dep'].append('_download_deb_packages')
+
+
+    @property
+    def fullname(self) -> str:
+        """Repository full name."""
+        return '{project}-{repo}'.format(
+            project=config.PROJECT_NAME.lower(),
+            repo=self.name,
+        )
+
+    def _mkdir_deb_repo_root(self) -> types.TaskDict:
+        """Create the root directory for the repository."""
+        task = self.basic_task
+        mkdir = directory.Mkdir(directory=self.rootdir).task
+        task.update({
+            'name': MKDIR_ROOT_TASK_NAME,
+            'doc': 'Create root directory for the {} repository.'.format(
+                self.name
+            ),
+            'title': mkdir['title'],
+            'actions': mkdir['actions'],
+            'uptodate': [True],
+            'targets': mkdir['targets'],
+        })
+        return task
+
+    def build_packages(self) -> List[types.TaskDict]:
+        return []
+
+    def build_repo(self) -> types.TaskDict:
+        return self.basic_task

--- a/packages/debian/download_packages.py
+++ b/packages/debian/download_packages.py
@@ -75,8 +75,6 @@ def fetch_binary(
     package: apt.package.Version, destdir: pathlib.Path
 ) -> pathlib.Path:
     """Download the DEB file corresponding to the given package."""
-    destdir.mkdir(exist_ok=True)  # TODO: to be done by the build chain.
-
     filename = pathlib.Path(package.filename).name
     destfile = destdir/filename
     print('Downloading package {}'.format(filename))
@@ -185,16 +183,12 @@ def main(packages: Sequence[str], env: Mapping[str, str]) -> None:
     apt_pkg.init()
     cache = apt.cache.Cache()
     to_download = {}
-    dest = pathlib.Path('/repositories')
     for package in packages:
         deps = get_package_deps(package, cache)
         to_download.update(deps)
     for pkg in to_download.values():
         filepath = download_package(pkg)
         os.chown(filepath, int(env['TARGET_UID']), int(env['TARGET_GID']))
-    # TODO: need to be done by the build chain
-    for directory in dest.iterdir():
-        os.chown(directory, int(env['TARGET_UID']), int(env['TARGET_GID']))
     witness_file.touch()
     os.chown(witness_file, int(env['TARGET_UID']), int(env['TARGET_GID']))
 


### PR DESCRIPTION
**Component**: Buildchain

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: MetalK8son Ubuntu

**Summary**: We need to create Debian repository root directly in the buildchain and not in the script which download packages.

**Acceptance criteria**: Execute task download_deb_packages with the command: `./doit.sh _download_deb_packages` the verify in the folder ` _build/root/packages/` that you have all repository folder with .deb corresponding inside


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1701

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
