### PR TITLE
Fix release in debpackage definition

### DIFF
--- a/buildchain/buildchain/packaging.py
+++ b/buildchain/buildchain/packaging.py
@@ -352,14 +352,11 @@ def _deb_package(name: str, sources: Path) -> targets.DEBPackage:
             'Missing version for package "{}"'.format(name)
         )
 
-    # In case the `release` is of form "{build_id}.{os}", which is standard
-    build_id_str, _, _ = pkg_info.release.partition('.')
-
     return targets.DEBPackage(
         basename='_build_deb_packages',
         name=name,
         version=pkg_info.version,
-        build_id=int(build_id_str),
+        build_id=int(pkg_info.release),
         sources=sources,
         builder=DEB_BUILDER,
         task_dep=['_package_mkdir_deb_root', '_build_deb_container'],

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -350,13 +350,13 @@ PACKAGES: Dict[str, Tuple[PackageVersion, ...]] = {
         PackageVersion(
             name='calico-cni-plugin',
             version=CALICO_VERSION,
-            release='0'
+            release='1'
         ),
         PackageVersion(name='iproute2', override='iproute'),
         PackageVersion(
             name='metalk8s-sosreport',
             version=SHORT_VERSION,
-            release='0'
+            release='1'
         ),
         PackageVersion(name='python-m2crypto', override='m2crypto'),
         PackageVersion(name='sosreport', override='sos'),


### PR DESCRIPTION
**Component**: Build

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: MetalK8s on Ubuntu

**Summary**: We need to pin the release version of Calico and use it for the package naming.

**Acceptance criteria**: 
- launch `./doit iso` 
- launch `./doit.sh info _build_deb_packages:calico-cni-plugin:convert_rpm_pkg_to_deb`
- verify that the status is up-to-date 

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1721 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
