### PR TITLE
Build internal Debian repository

### DIFF
--- a/packages/debian/Dockerfile
+++ b/packages/debian/Dockerfile
@@ -11,7 +11,6 @@ RUN apt update -y \
         devscripts \
         build-essential \
         lintian \
-        apt-rdepends \
         python-apt \
         reprepro \
         alien

--- a/packages/debian/Dockerfile
+++ b/packages/debian/Dockerfile
@@ -13,6 +13,7 @@ RUN apt update -y \
         lintian \
         apt-rdepends \
         python-apt \
+        reprepro \
         alien
 
 RUN useradd -m build

--- a/packages/debian/distributions
+++ b/packages/debian/distributions
@@ -1,0 +1,7 @@
+Origin: Scality
+Label: metalk8s
+Suite: stable
+Codename: bionic
+Architectures: amd64
+Components: metalk8s-bionic metalk8s-bionic-backports metalk8s-bionic-updates metalk8s-kubernetes-xenial metalk8s-salt_ubuntu1804 metalk8s-scality
+Description: MetalK8s repository for bionic

--- a/packages/debian/entrypoint.sh
+++ b/packages/debian/entrypoint.sh
@@ -36,9 +36,26 @@ rpm2deb() {
 }
 
 
+buildrepo() {
+    set -x
+    mkdir -p /repository/debian/{conf,incoming}
+    # All downloaded packages must be mounted in /metalk8s-deb
+    cp /metalk8s-deb/distributions /repository/debian/conf
+    #TODO: Mount `distributions` file in  /repository/debian/conf
+    reprepro -b /repository/debian export
+    for dir in /metalk8s-deb/metalk8s-*; do
+        reprepro -C "${dir##*/}" -b /repository/debian \
+            includedeb bionic "$dir"/*.deb
+    done
+}
+
+
 case ${1:- } in
     builddeb)
         builddeb
+        ;;
+    buildrepo)
+        buildrepo
         ;;
     rpm2deb)
         rpm2deb


### PR DESCRIPTION
**Component**: Repository, container

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: MetalK8s on Ubuntu

**Summary**: We need to build a Debian repository to dispense Debian packages required for Ubuntu nodes deployment.

**Acceptance criteria**: 
- We need to create a script to execute the `reprepro` command to build a repository inside a container.

**Tests**: (Need to bue done after ISO buit with `./doit.sh`)
- go on the branch `improvement/1617-implement-Debian-repository`
- build Docker image from the Debian Dockerfile (`docker build -t myubuntu:18.04 packages/debian/` )
- Lauch the container with the good volumes mounted:
  `docker run --rm -it -v $(pwd)/packages/debian/entrypoint.sh:/entrypoint.sh -v $(pwd)/packages/debian/distributions:/distributions -v $(pwd)/_build/root/packages/debian/:/metalk8s-deb myubuntu:18.04 bash`
- copie the file `distributions` in the good path (it will be automatically mounted after):
`cp distributions metalk8s-deb/`
- Then lauch the script entrypoint.sh calling `buildrepo` : `./entrypoint.sh buildrepo`

- Once the execution finished, verify in the folder `/repository/debian/dists/bionic/metalk8s-*` that the file `Release` is well here ! (the packages are in the folder `/repository/debian/pool`)
---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
