### PR TITLE
Delete truncated/corrupted ISO on failure

### DIFF
--- a/buildchain/buildchain/iso.py
+++ b/buildchain/buildchain/iso.py
@@ -29,6 +29,7 @@ Overview:
 
 import datetime as dt
 import socket
+import subprocess
 from pathlib import Path
 from typing import Sequence
 
@@ -188,21 +189,36 @@ def task__iso_generate_product_txt() -> types.TaskDict:
 @doit.create_after(executed='populate_iso')  # type: ignore
 def task__iso_build() -> types.TaskDict:
     """Create the ISO from the files in ISO_ROOT."""
-    mkisofs = [
-        config.ExtCommand.MKISOFS.value, '-output',  ISO_FILE,
-        '-quiet',
-        '-rock',
-        '-joliet',
-        '-joliet-long',
-        '-full-iso9660-filenames',
-        '-volid', '{} {}'.format(config.PROJECT_NAME, versions.VERSION),
-        '--iso-level', '3',
-        '-gid', '0',
-        '-uid', '0',
-        '-input-charset', 'utf-8',
-        '-output-charset', 'utf-8',
-        constants.ISO_ROOT
-    ]
+    def unlink_if_exist(filepath: Path) -> None:
+        """Delete a file if it exists."""
+        try:
+            filepath.unlink()
+        except FileNotFoundError:
+            pass
+
+    def mkisofs() -> None:
+        """Create an ISO file (delete on error)."""
+        cmd = [
+            config.ExtCommand.MKISOFS.value, '-output',  ISO_FILE,
+            '-quiet',
+            '-rock',
+            '-joliet',
+            '-joliet-long',
+            '-full-iso9660-filenames',
+            '-volid', '{} {}'.format(config.PROJECT_NAME, versions.VERSION),
+            '--iso-level', '3',
+            '-gid', '0',
+            '-uid', '0',
+            '-input-charset', 'utf-8',
+            '-output-charset', 'utf-8',
+            constants.ISO_ROOT
+        ]
+        try:
+            subprocess.run(cmd, check=True)
+        except:
+            unlink_if_exist(ISO_FILE)
+            raise
+
     doc = 'Create the ISO from the files in {}.'.format(
         utils.build_relpath(constants.ISO_ROOT)
     )


### PR DESCRIPTION
**Component**:

build

**Context**: 

We want to cleanup truncated/corrupted ISO to avoid them being used by mistake.

**Summary**:

Use a `try/except` block to handle failure of `mkisofs` and cleanup afterward.

**Acceptance criteria**: 


- Run the build once `./doit.sh -n4`
- Forbid processes to create big files (so that ISO creation will fail): `ulimit -f 262144`
- Run the build again `./doit.sh` to recreate the ISO, this time it should fails
- the file `_build/metalk8s.iso` doesn't exist

---

Closes: #1735