### PR TITLE
doc: change procedure in order to access grafana service

### DIFF
--- a/docs/quickstart/services.rst
+++ b/docs/quickstart/services.rst
@@ -8,17 +8,6 @@ Grafana
 
 You will first need the latest ``kubectl`` version installed on your host.
 
-From the bootstrap node, get the port used by Grafana:
-
-.. code-block:: shell
-
-   root@bootstrap $ kubectl --kubeconfig=/etc/kubernetes/admin.conf get service grafana -n metalk8s-monitoring
-
-   NAME      TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
-   grafana   ClusterIP   10.109.125.193   <none>        3000/TCP   1h
-
-Please note the port used by Grafana (here ``3000``)
-
 To authenticate with the cluster, retrieve the admin kubeconfig on your host:
 
 .. code-block:: shell
@@ -29,7 +18,7 @@ Forward the port used by Grafana:
 
 .. code-block:: shell
 
-   user@your-host $ kubectl --namespace metalk8s-monitoring port-forward svc/grafana 3000
+   user@your-host $ kubectl -n metalk8s-monitoring port-forward svc/prometheus-operator-grafana 3000:80
 
 Then open your web browser and navigate to ``http://localhost:3000``
 


### PR DESCRIPTION
**Component**:

doc: accessing cluster services

**Context**: 

procedure to access grafana service has to change since it is now deployed by prometheus operator 

**Summary**:

added a procedure to get grafana pod name and just port-forward it on client

**Acceptance criteria**: 

following the doc should be enough to access grafana and consult dashboards

---
Closes: #1724