### PR TITLE
Bugfix/1705/improve the volume detail page when failed to create volume

### DIFF
--- a/ui/src/containers/VolumeInformation.js
+++ b/ui/src/containers/VolumeInformation.js
@@ -71,9 +71,7 @@ const VolumeInformation = props => {
   );
   const pV = pVList.find(pv => pv.metadata.name === currentVolumeName);
   const storageClass = storageClasses.find(
-    SC =>
-      SC.metadata.name ===
-      (volume && volume.spec && volume.spec.storageClassName),
+    SC => SC.metadata.name === volume?.spec?.storageClassName,
   );
 
   return (
@@ -112,28 +110,24 @@ const VolumeInformation = props => {
       <VolumeInformationListContainer>
         <InformationSpan>
           <InformationLabel>{intl.messages.name}</InformationLabel>
-          <InformationValue>
-            {volume && volume.metadata && volume.metadata.name}
-          </InformationValue>
+          <InformationValue>{volume?.metadata?.name}</InformationValue>
         </InformationSpan>
         <InformationSpan>
           <InformationLabel>{intl.messages.status}</InformationLabel>
           <InformationValue>
-            {(volume && volume.status && volume.status.phase) ||
-              intl.messages.unknown}
+            {volume?.status?.phase ?? intl.messages.unknown}
           </InformationValue>
         </InformationSpan>
         <InformationSpan>
           <InformationLabel>{intl.messages.size}</InformationLabel>
           <InformationValue>
-            {(pV && pV.spec && pV.spec.capacity && pV.spec.capacity.storage) ||
-              intl.messages.unknown}
+            {pV?.spec?.capacity?.storage ?? intl.messages.unknown}
           </InformationValue>
         </InformationSpan>
         <InformationSpan>
           <InformationLabel>{intl.messages.type}</InformationLabel>
           <InformationValue>
-            {volume && volume.spec && volume.spec.rawBlockDevice
+            {volume?.spec?.rawBlockDevice
               ? RAW_BLOCK_DEVICE
               : SPARSE_LOOP_DEVICE}
           </InformationValue>
@@ -141,39 +135,37 @@ const VolumeInformation = props => {
         <InformationSpan>
           <InformationLabel>{intl.messages.bound}</InformationLabel>
           <InformationValue>
-            {pV && pV.status && pV.status.phase === STATUS_BOUND
+            {pV?.status?.phase === STATUS_BOUND
               ? intl.messages.yes
               : intl.messages.no}
           </InformationValue>
         </InformationSpan>
         <InformationSpan>
           <InformationLabel>{intl.messages.storageClass}</InformationLabel>
-          <InformationValue>
-            {volume && volume.spec && volume.spec.storageClassName}
-          </InformationValue>
+          <InformationValue>{volume?.spec?.storageClassName}</InformationValue>
         </InformationSpan>
         <InformationSpan>
           <InformationLabel>{intl.messages.path}</InformationLabel>
           <InformationValue>
-            {volume?.spec?.rawBlockDevice?.devicePath ||
+            {volume?.spec?.rawBlockDevice?.devicePath ??
               intl.messages.not_applicable}
           </InformationValue>
         </InformationSpan>
         <InformationSpan>
           <InformationLabel>{intl.messages.access_mode}</InformationLabel>
           <InformationValue>
-            {(pV && pV.spec && pV.spec.accessModes) || intl.messages.unknown}
+            {pV?.spec?.accessModes ?? intl.messages.unknown}
           </InformationValue>
         </InformationSpan>
         <InformationSpan>
           <InformationLabel>{intl.messages.mount_option}</InformationLabel>
           <InformationValue>
-            {storageClass && storageClass.mountOptions.join(', ')}
+            {storageClass?.mountOptions.join(', ')}
           </InformationValue>
         </InformationSpan>
         <InformationSpan>
           <InformationLabel>{intl.messages.creationTime}</InformationLabel>
-          {volume && volume.metadata && volume.metadata.creationTimestamp ? (
+          {volume?.metadata?.creationTimestamp ? (
             <InformationValue>
               <FormattedDate value={volume.metadata.creationTimestamp} />{' '}
               <FormattedTime

--- a/ui/src/containers/VolumeInformation.js
+++ b/ui/src/containers/VolumeInformation.js
@@ -3,13 +3,15 @@ import { useSelector, useDispatch } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { injectIntl, FormattedDate, FormattedTime } from 'react-intl';
 import styled from 'styled-components';
-import { padding } from '@scality/core-ui/dist/style/theme';
+import { padding, fontSize } from '@scality/core-ui/dist/style/theme';
 import { Breadcrumb } from '@scality/core-ui';
 import { makeGetNodeFromUrl, makeGetVolumesFromUrl } from '../services/utils';
 import {
   SPARSE_LOOP_DEVICE,
   RAW_BLOCK_DEVICE,
   STATUS_BOUND,
+  STATUS_BANNER_ERROR,
+  STATUS_FAILED,
 } from '../constants';
 import {
   fetchVolumesAction,
@@ -22,6 +24,7 @@ import {
   BreadcrumbLabel,
   StyledLink,
 } from '../components/BreadcrumbStyle';
+import Banner from '../components/Banner';
 import {
   InformationListContainer,
   InformationSpan,
@@ -38,6 +41,12 @@ const VolumeInformationContainer = styled.div`
   flex-direction: column;
   box-sizing: border-box;
   padding: ${padding.base};
+  width: 750px;
+`;
+
+const VolumeInformationTitle = styled.div`
+  font-size: ${fontSize.larger};
+  margin-left: ${padding.larger};
 `;
 
 const VolumeInformation = props => {
@@ -66,6 +75,7 @@ const VolumeInformation = props => {
       SC.metadata.name ===
       (volume && volume.spec && volume.spec.storageClassName),
   );
+
   return (
     <VolumeInformationContainer>
       <BreadcrumbContainer>
@@ -82,6 +92,23 @@ const VolumeInformation = props => {
           ]}
         />
       </BreadcrumbContainer>
+      <VolumeInformationTitle>
+        {intl.messages.detailed_information}
+      </VolumeInformationTitle>
+
+      {volume?.status?.phase === STATUS_FAILED ? (
+        <Banner
+          type={STATUS_BANNER_ERROR}
+          icon={<i className="fas fa-exclamation-triangle" />}
+          title={
+            volume?.status?.errorCode === 'CreationError'
+              ? intl.messages.failed_to_create_volume
+              : intl.messages.error
+          }
+          messages={[volume?.status?.errorMessage]}
+        />
+      ) : null}
+
       <VolumeInformationListContainer>
         <InformationSpan>
           <InformationLabel>{intl.messages.name}</InformationLabel>
@@ -99,7 +126,8 @@ const VolumeInformation = props => {
         <InformationSpan>
           <InformationLabel>{intl.messages.size}</InformationLabel>
           <InformationValue>
-            {pV && pV.spec && pV.spec.capacity && pV.spec.capacity.storage}
+            {(pV && pV.spec && pV.spec.capacity && pV.spec.capacity.storage) ||
+              intl.messages.unknown}
           </InformationValue>
         </InformationSpan>
         <InformationSpan>
@@ -127,13 +155,14 @@ const VolumeInformation = props => {
         <InformationSpan>
           <InformationLabel>{intl.messages.path}</InformationLabel>
           <InformationValue>
-            {pV && pV.spec && pV.spec.local && pV.spec.local.path}
+            {volume?.spec?.rawBlockDevice?.devicePath ||
+              intl.messages.not_applicable}
           </InformationValue>
         </InformationSpan>
         <InformationSpan>
           <InformationLabel>{intl.messages.access_mode}</InformationLabel>
           <InformationValue>
-            {pV && pV.spec && pV.spec.accessModes}
+            {(pV && pV.spec && pV.spec.accessModes) || intl.messages.unknown}
           </InformationValue>
         </InformationSpan>
         <InformationSpan>

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -113,5 +113,8 @@
   "select_a_storageClass": "Select a Storage Class…",
   "select_a_type": "Select a type of volume…",
   "no_results": "No results",
-  "search": "Search…"
+  "search": "Search…",
+  "detailed_information": "Detailed Information",
+  "failed_to_create_volume":"Failed to create volume.",
+  "not_applicable": "Not applicable"
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -113,5 +113,8 @@
   "select_a_storageClass": "Sélectionner une classe de stockage…",
   "select_a_type": "Sélectionner un type de volume…",
   "no_results": "Aucun résultat",
-  "search": "Rechercher…"
+  "search": "Rechercher…",
+  "detailed_information": "Informations détaillées",
+  "failed_to_create_volume":"Échec de la création du volume.",
+  "not_applicable": "Non applicable"
 }


### PR DESCRIPTION
**Component**: ui, storage

**Context**: 
As a user, when I failed to create a volume of `rawBlockDevice` I would like to get the path instead of an empty field

**Summary**:
Add a banner to show the error message when failed to create volume.
rawBlockDevice: get the path from the volume.
sparseLoopDevice: the path from PV is not useful so we just show no applicable. 

**Acceptance criteria**: 
- on a running MetalK8s platform, try to create a Volume with of type rawBlockDevice with a path that doesn't exists
- wait for the Volume to go in Failed state
- click on the volume, you should see a banner with the error message and the path you've entered in the form is displayed in the details
![Screenshot 2019-09-20 at 16 32 54](https://user-images.githubusercontent.com/18453133/65335237-55bc7d80-dbc4-11e9-8789-a34f3eb73546.png)

Closes: #1705 