### PR TITLE
Add operation section to PDF doc

### DIFF
--- a/docs/index-latex.rst
+++ b/docs/index-latex.rst
@@ -8,6 +8,6 @@
 
    quickstart/index
    installation-guide/index
-   developer/index
    operation/index
+   developer/index
    glossary

--- a/docs/index-latex.rst
+++ b/docs/index-latex.rst
@@ -9,4 +9,5 @@
    quickstart/index
    installation-guide/index
    developer/index
+   operation/index
    glossary

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,8 +21,8 @@ Welcome to MetalK8s's documentation!
 
    quickstart/index
    installation-guide/index
-   developer/index
    operation/index
+   developer/index
    glossary
 
 


### PR DESCRIPTION
**Component**:

doc

**Context**: 

Add the `Operation` section in the PDF documentation

**Summary**:

Fix `index-latex.rst`

**Acceptance criteria**: 

Run `tox -e docs -- latexpdf` and check the generated PDF: there `Operation` section should be present.

---

Closes: #1751