### PR TITLE
Fix script to retrieve Prometheus port

### DIFF
--- a/docs/developer/running/ui.rst
+++ b/docs/developer/running/ui.rst
@@ -35,7 +35,7 @@ Procedure
        'url_salt': 'https://{salt[ip]}:{salt[ports][api]}'.format(
            salt=pillar['endpoints']['salt-master']
        ),
-       'url_prometheus': 'http://{prom[ip]}:{prom[ports][api][node_port]}'.format(
+       'url_prometheus': 'http://{prom[ip]}:{prom[ports][web][node_port]}'.format(
            prom=pillar['endpoints']['prometheus']
        ),
    }


### PR DESCRIPTION
**Component**:

doc

**Context**: 

Fix the code snippet given to generate a `config.json` for the UI.

**Summary**:

Use `web`  instead of `api` for Prometheus port.

**Acceptance criteria**: 

If you run the script on a running bootstrap node, it works.
You should get something like:

```json
{                              
    "url": "https://172.21.254.14:6443",
    "url_salt": "https://172.21.254.13:4507",
    "url_prometheus": "http://172.21.254.45:30222"
}
```

Not a `KeyError`.

---

Closes: #1753