### PR TITLE
Fix shell scripts linting (and YAML one on the fly)

### DIFF
--- a/buildchain/buildchain/lint.py
+++ b/buildchain/buildchain/lint.py
@@ -76,7 +76,10 @@ def lint_yaml() -> types.TaskDict:
         'name': 'yaml',
         'doc': lint_yaml.__doc__,
         'actions': [['tox', '-e', 'lint-yaml']],
-        'file_dep': list(constants.ROOT.glob('salt/**/*.yaml')),
+        'file_dep': [
+            constants.ROOT/'eve/main.yml',
+            constants.ROOT/'salt/metalk8s/defaults.yaml'
+        ],
     }
 
 

--- a/buildchain/buildchain/lint.py
+++ b/buildchain/buildchain/lint.py
@@ -59,9 +59,9 @@ def lint_python() -> types.TaskDict:
 
 def lint_shell() -> types.TaskDict:
     """Run shell scripts linting."""
-    shell_scripts : List[Path] = [constants.ROOT/'doit.sh']
-    for ext in ('.sh', '.sh.in'):
-        shell_scripts.extend(constants.ROOT.glob('*/*{}'.format(ext)))
+    shell_scripts = [
+        filepath for filepath in utils.git_ls() if '.sh' in filepath.suffixes
+    ]
     return {
         'name': 'shell',
         'doc': lint_shell.__doc__,

--- a/buildchain/buildchain/utils.py
+++ b/buildchain/buildchain/utils.py
@@ -5,9 +5,10 @@
 
 
 import inspect
+import subprocess
 import sys
 from pathlib import Path
-from typing import List
+from typing import Iterator, List, Optional
 
 from buildchain import config
 from buildchain import constants
@@ -61,3 +62,19 @@ def title_with_target1(command: str, task: types.Task) -> str:
         cmd=command, width=constants.CMD_WIDTH,
         path=build_relpath(Path(task.targets[0])),
     )
+
+
+def git_ls(directory: Optional[str]=None) -> Iterator[Path]:
+    """Return the list of files tracked by Git under `root` (recursively).
+
+    Arguments:
+        directory: directory to list (relative to the root of the repo).
+
+    Returns:
+        A list of files tracked by Git.
+    """
+    root = constants.ROOT if directory is None else constants.ROOT/directory
+    assert root.is_dir()
+    return map(Path, subprocess.check_output(
+        ['git', 'ls-files', '-z', root], encoding='utf-8'
+    ).split('\x00')[:-1])  # `:-1` to skip the last element (empty string).

--- a/buildchain/static-container-registry/test.sh
+++ b/buildchain/static-container-registry/test.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # This file is to be executed using `bash_unit`
 
 DOCKER=${DOCKER:-$(command -v docker || echo false)}

--- a/eve/workers/openstack-multiple-nodes/terraform/scripts/get-ip-leases.sh
+++ b/eve/workers/openstack-multiple-nodes/terraform/scripts/get-ip-leases.sh
@@ -36,11 +36,11 @@ chattr +i /etc/resolv.conf
 # Then, loop over interfaces and retry the dhclient call until an address is
 # found
 for ifname in "${INTERFACES[@]}"; do
-    echo $ifname
-    for i in $(seq 1 $MAX_RETRY); do
+    echo "$ifname"
+    for _ in $(seq 1 $MAX_RETRY); do
         request_ip "$ifname"
         sleep 1s
-        if [ $(check_ip "$ifname") ]; then
+        if [ "$(check_ip "$ifname")" ]; then
             echo "Found IP address for $ifname"
             break
         fi

--- a/tox.ini
+++ b/tox.ini
@@ -73,9 +73,8 @@ whitelist_externals =
     {[testenv]whitelist_externals}
     shellcheck
 commands =
-    shellcheck doit.sh
-    bash -c "shellcheck **/*.sh"
-    bash -c "shellcheck **/*.sh.in"
+    bash -c "shellcheck $(git ls-files | grep -P '\.sh$')"
+    bash -c "shellcheck $(git ls-files | grep -P '\.sh\.in$')"
 
 [testenv:lint-yaml]
 description =

--- a/tox.ini
+++ b/tox.ini
@@ -82,7 +82,7 @@ description =
 deps =
     yamllint==1.15.0
 commands =
-    bash -c "yamllint eve/main.yml salt/**/*.yaml"
+    bash -c "yamllint eve/main.yml salt/metalk8s/defaults.yaml"
 
 [testenv:tests]
 description =


### PR DESCRIPTION
**Component**:

build, tests

**Context**: 

Fix file listing for the shell script linter (and YAML one)

**Summary**:

Don't use glob pattern: they are not recursive (and even if they were, it wouldn't work as we want): rely on `git ls-files` instead.

**Acceptance criteria**: 

Intended files are linted.

---

Closes: #1637