### PR TITLE
Sync pillar after bootstrap upgrade downgrade

### DIFF
--- a/scripts/downgrade.sh
+++ b/scripts/downgrade.sh
@@ -186,6 +186,8 @@ downgrade_bootstrap () {
     kubeconfig=/etc/kubernetes/admin.conf
   $SALT salt-run state.sls metalk8s.orchestrate.deploy_node saltenv="$SALTENV" \
     pillar="{'orchestrate': {'node_name': '$bootstrap_id'}}"
+   _check_salt_master
+  $SALT salt-run saltutil.sync_all saltenv="DESTINATION_VERSION"
 }
 
 # patch the kube-system namespace annotation with <destination-version> input

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -162,6 +162,8 @@ upgrade_bootstrap () {
 
 launch_upgrade () {
     SALT_MASTER_CALL=(crictl exec -i "$(get_salt_container)")
+    "${SALT_MASTER_CALL[@]}" salt-run saltutil.sync_all \
+        saltenv="metalk8s-$DESTINATION_VERSION"
 
     "${SALT_MASTER_CALL[@]}" salt-run state.orchestrate \
         metalk8s.orchestrate.upgrade saltenv="metalk8s-$DESTINATION_VERSION"


### PR DESCRIPTION
Because the main pillarenv changes after bootstrap
upgarde downgrade we need to refresh the salt-master

Fixes: #1758

**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

**Summary**:

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1758

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
