### PR TITLE
Sync pillar after bootstrap upgrade downgrade

### DIFF
--- a/scripts/downgrade.sh
+++ b/scripts/downgrade.sh
@@ -175,6 +175,7 @@ downgrade_bootstrap () {
     --out txt pillar.get metalk8s:endpoints | cut -c 8-)}}" \
     --retcode-passthrough
   _check_salt_master
+  $SALT salt-run saltutil.sync_all saltenv="metalk8s-$DESTINATION_VERSION"
   local bootstrap_id
   bootstrap_id=$(
     $SALT_CALL grains.get id --out txt \

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -162,6 +162,8 @@ upgrade_bootstrap () {
 
 launch_upgrade () {
     SALT_MASTER_CALL=(crictl exec -i "$(get_salt_container)")
+    "${SALT_MASTER_CALL[@]}" salt-run saltutil.sync_all \
+        saltenv="metalk8s-$DESTINATION_VERSION"
 
     "${SALT_MASTER_CALL[@]}" salt-run state.orchestrate \
         metalk8s.orchestrate.upgrade saltenv="metalk8s-$DESTINATION_VERSION"


### PR DESCRIPTION
Because the main pillarenv changes after bootstrap
upgarde downgrade we need to refresh the salt-master

Fixes: #1758

**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

**Summary**:

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1758 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
