### PR TITLE
Improvement/1767 build component one by one

### DIFF
--- a/packages/debian/distributions
+++ b/packages/debian/distributions
@@ -3,5 +3,5 @@ Label: metalk8s
 Suite: stable
 Codename: bionic
 Architectures: amd64
-Components: metalk8s-bionic metalk8s-bionic-backports metalk8s-bionic-updates metalk8s-kubernetes-xenial metalk8s-salt_ubuntu1804 metalk8s-scality
-Description: MetalK8s repository for bionic
+Components: _REPONAME_
+Description: _REPONAME_ repository for bionic

--- a/packages/debian/entrypoint.sh
+++ b/packages/debian/entrypoint.sh
@@ -38,15 +38,15 @@ rpm2deb() {
 
 buildrepo() {
     set -x
-    mkdir -p /repository/debian/{conf,incoming}
-    # All downloaded packages must be mounted in /metalk8s-deb
-    cp /metalk8s-deb/distributions /repository/debian/conf
-    #TODO: Mount `distributions` file in  /repository/debian/conf
-    reprepro -b /repository/debian export
-    for dir in /metalk8s-deb/metalk8s-*; do
-        reprepro -C "${dir##*/}" -b /repository/debian \
-            includedeb bionic "$dir"/*.deb
-    done
+
+    local -r reponame="$1"
+
+    mkdir /repository/conf
+    cp /distributions /repository/conf
+    sed -i 's/_REPONAME_/'"${reponame}"'/g' /repository/conf/distributions
+    reprepro -b /repository/ export
+    reprepro -C "$reponame" -b /repository/ includedeb bionic /packages/*.deb
+    chown -R "${TARGET_UID}:${TARGET_GID}" /repository
 }
 
 
@@ -55,7 +55,8 @@ case ${1:- } in
         builddeb
         ;;
     buildrepo)
-        buildrepo
+        shift
+        buildrepo "$1"
         ;;
     rpm2deb)
         rpm2deb


### PR DESCRIPTION
**Component**: build, entrypoint

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**:  MetalK8s on Ubuntu

**Summary**: We need to build several Debian repository and not a big one with several component.

**Acceptance criteria**: have several repositories built

1. Download the packages: `./doit.sh _download_deb_packages`
2. Move them to the right location (will be fixed in the next PR): `mv _build/root/packages/debian/* _build/packages/debian`
3. Create the directories for the repositories (in the next PR it will be done by the buildchain): `mkdir _build/root/packages/debian/{metalk8s-bionic,metalk8s-bionic-backports,metalk8s-bionic-updates,metalk8s-kubernetes-xenial,metalk8s-salt_ubuntu1804}`
4. Run the following shell command (in the next PR, this loop will be integrated in the buildchain):

```shell
for REPO in metalk8s-bionic  metalk8s-bionic-backports  metalk8s-bionic-updates  metalk8s-kubernetes-xenial  metalk8s-salt_ubuntu1804
do
docker run --rm -it                                                      \
  -v "$(pwd)/packages/debian/entrypoint.sh":/entrypoint.sh:ro            \
  -v "$(pwd)/_build/packages/debian/${REPO}":/packages:ro                \
  -v "$(pwd)/packages/debian/distributions":/distributions:ro            \
  -v "$(pwd)/_build/root/packages/debian/${REPO}":/repository            \
  --env TARGET_UID="$(id -u)" --env TARGET_GID="$(id -g)"                \
  metalk8s-deb-build:latest                                              \
  /entrypoint.sh buildrepo "$REPO"
done
```

5. Check that the repositories were created: `tree _build/root/packages/debian/`

6. Check that the repositories are working:

```
% docker run --rm -it -v $(pwd)/_build/root/packages/debian/:/repositories:ro metalk8s-deb-build:latest
# cat ->> /etc/apt/sources.list
deb [trusted=yes] file:///repositories/metalk8s-bionic bionic metalk8s-bionic
deb [trusted=yes] file:///repositories/metalk8s-bionic-backports bionic metalk8s-bionic-backports
deb [trusted=yes] file:///repositories/metalk8s-bionic-updates bionic metalk8s-bionic-updates
deb [trusted=yes] file:///repositories/metalk8s-kubernetes-xenial bionic metalk8s-kubernetes-xenial
deb [trusted=yes] file:///repositories/metalk8s-salt_ubuntu1804 bionic metalk8s-salt_ubuntu1804
# apt update
# apt install kubelet
```


---

Closes: #1767