### PR TITLE
ui/bug: fix the issue of select component for create volume e2e test

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -309,7 +309,6 @@ stages:
           name: Cypress test
           command: bash cypress.sh
           workdir: build/ui
-          doStepIf: false
           haltOnFailure: true
       - ShellCommand:
           name: Prepare upload folder

--- a/ui/cypress/integration/common/volume.js
+++ b/ui/cypress/integration/common/volume.js
@@ -6,7 +6,7 @@ And(
     cy.get('.sc-table-row')
       .eq(1)
       .click();
-  }
+  },
 );
 
 And('I choose the Volumes tag', () => {
@@ -28,42 +28,61 @@ Then(
     cy.get('input[name=name]').type(volumeNameRawBlockDevice);
     cy.get('input[name=path]').type(devicePath);
 
+    cy.get('.sc-select')
+      .eq(0)
+      .click();
+    cy.get('.sc-select__menu')
+      .find('[data-cy=storageClass-metalk8s-prometheus]')
+      .click();
+
+    cy.get('.sc-select')
+      .eq(1)
+      .click();
+    cy.get('.sc-select__menu')
+      .find('[data-cy="type-rawBlockDevice"]')
+      .click();
+
     cy.get('[data-cy="submit-create-volume"]').click();
 
     cy.get('.sc-table-column-cell-name').should(
       'contain',
-      volumeNameRawBlockDevice
+      volumeNameRawBlockDevice,
     );
-  }
+  },
 );
 
 Then(
   'I fill out the create volume form with SparseLoopDevice volume type and ckeck if the the volume I created is displayed on the volume list',
   () => {
     const volumeNameSparseLoopDevice = `volume-${new Date().getTime()}`;
-    const devicePath = Cypress.env('device_path');
     const volumeCapacity = Cypress.env('volume_capacity');
 
     cy.get('input[name=name]').type(volumeNameSparseLoopDevice);
-    cy.get('input[name=path]').type(devicePath);
-
-    cy.get('.Select')
-      .eq(1)
+    cy.get('.sc-select')
+      .eq(0)
+      .click();
+    cy.get('.sc-select__menu')
+      .find('[data-cy=storageClass-metalk8s-prometheus]')
       .click();
 
-    cy.get('[data-cy="type-sparseLoopDevice"]').click();
+    cy.get('.sc-select')
+      .eq(1)
+      .click();
+    cy.get('.sc-select__menu')
+      .find('[data-cy="type-sparseLoopDevice"]')
+      .click();
 
     cy.get('input[name=sizeInput]').type(volumeCapacity);
 
-    cy.get('.Select')
+    cy.get('.sc-select')
       .eq(2)
       .click();
-    cy.get('[data-cy="size-GiB"]').click();
+    cy.get('[data-cy="size-KiB"]').click();
 
     cy.get('[data-cy="submit-create-volume"]').click();
     cy.get('.sc-table-column-cell-name').should(
       'contain',
-      volumeNameSparseLoopDevice
+      volumeNameSparseLoopDevice,
     );
-  }
+  },
 );

--- a/ui/src/containers/CreateVolume.js
+++ b/ui/src/containers/CreateVolume.js
@@ -245,9 +245,9 @@ const CreateVolume = props => {
               return {
                 label: SCName,
                 value: SCName,
+                'data-cy': `storageClass-${SCName}`,
               };
             });
-
             const optionsTypes = types.map(({ label, value }) => {
               return {
                 label,


### PR DESCRIPTION
**Component**: ui

**Context**: 
createVolume E2E test failed because we cannot find the good item in the select list.
```CypressError: cy.click() can only be called on a single element. Your subject contained 2 elements. Pass { multiple: true } if you want to serially click each element.```

**Summary**:
The issue is that we have two [data-cy]. 
In order to get the one for the click, we could to first get the '.sc-select__menu' and the find the [data-cy]

**Acceptance criteria**: 
When execute the following CL, we should pass the two test of the create volume.
```./node_modules/cypress/bin/cypress run -b chrome -s cypress/integration/CreateVolume.feature -e username=admin,password=admin --no-exit```

Closes: #1764
