### PR TITLE
kubernetes: set `metricsBindAddress` of `kube-proxy` to `0.0.0.0`

### DIFF
--- a/salt/metalk8s/kubernetes/kube-proxy/deployed.sls
+++ b/salt/metalk8s/kubernetes/kube-proxy/deployed.sls
@@ -71,7 +71,7 @@ Deploy kube-proxy (ConfigMap):
             scheduler: ""
             syncPeriod: 30s
           kind: KubeProxyConfiguration
-          metricsBindAddress: 127.0.0.1:10249
+          metricsBindAddress: 0.0.0.0:10249
           mode: ""
           nodePortAddresses:
           - {{ networks.workload_plane }}


### PR DESCRIPTION
When binding to `127.0.0.1` only, Prometheus is unable to scrape the
`kube-proxy` metrics, because the address is not reachable from inside
the Prometheus container.

It'd be great if we could configure it to *only* listen to the
control-plane IP, however, the `kube-proxy` configuration is kept in a
(single) *ConfigMap*, and as such shared between all instances of the
service (running on different nodes, with different IP addresses...). If
`kube-proxy` were to take a network as configuration value, then pick
the right IP to bind to based on it, we could tighten this up (again).

See: #1766
See: https://github.com/scality/metalk8s/issues/1766