### PR TITLE
kubernetes, monitoring: fix `etcd` metrics collection

### DIFF
--- a/charts/prometheus-operator.yaml
+++ b/charts/prometheus-operator.yaml
@@ -112,3 +112,9 @@ kube-state-metrics:
 prometheus-node-exporter:
   image:
     repository: '{%- endraw -%}{{ build_image_name(\"node-exporter\", False) }}{%- raw -%}'
+
+
+kubeEtcd:
+  service:
+    port: 2381
+    targetPort: 2381

--- a/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
@@ -19387,9 +19387,9 @@ spec:
   clusterIP: None
   ports:
   - name: http-metrics
-    port: 2379
+    port: 2381
     protocol: TCP
-    targetPort: 2379
+    targetPort: 2381
   selector:
     component: etcd
   type: ClusterIP

--- a/salt/metalk8s/kubernetes/etcd/installed.sls
+++ b/salt/metalk8s/kubernetes/etcd/installed.sls
@@ -51,6 +51,7 @@ Create local etcd Pod manifest:
           - --key-file=/etc/kubernetes/pki/etcd/server.key
           - --listen-client-urls=https://127.0.0.1:2379,https://{{ host }}:2379
           - --listen-peer-urls=https://{{ host }}:2380
+          - --listen-metrics-urls=http://127.0.0.1:2381,http://{{ host }}:2381
           - --name={{ host_name }}
           - --peer-cert-file=/etc/kubernetes/pki/etcd/peer.crt
           - --peer-client-cert-auth=true


### PR DESCRIPTION
Before this fix, Prometheus would be configured to scrape `etcd` metrics
from its client port, which is using HTTPS. However, Prometheus would
try to connect using HTTP, and as such the request would fail.

However, simply configuring the *ServiceMonitor* to connect using HTTPS
is not sufficient, since this would still require Prometheus to
authenticate to `etcd`, which would require a client certificate to be
provisioned, stored as a Kubernetes *Secret*, and configure the
*ServiceMonitor* to use this certificate.

An alternative approach is used, in which we configure `etcd` to accept
requests for `/metrics` on a different port, using plain HTTP, without
authentication, and the *Service* (which the *ServiceMonitor* uses to
configure Prometheus scraping) is redirected to this port.

These changes are done in the `prometheus-operator` chart's
`values.yaml`, after which the chart was re-rendered using the standard
procedure (cfr. the Git 'log' of
`salt/metalk8s/addons/prometheus-operator/deployed/chart.sls`).

Note: this change is only applied to `development/2.3` and up, because
the `--listen-metrics-urls` configuration option of `etcd` is only
available since version 3.3, and until `development/2.2` we use `etcd`
version 3.2. As such, the monitoring of `etcd` remains 'broken'
(according to #1766) in MetalK8s versions up to and including 2.2.

See: #1766
See: https://github.com/scality/metalk8s/issues/1766
(cherry picked from commit b58bbaf8f2888b782ebe50ac90d9a7f3552f0829)