### PR TITLE
ui/bug: enable to click on trash button when there is no pv

### DIFF
--- a/ui/src/services/NodeVolumesUtils.js
+++ b/ui/src/services/NodeVolumesUtils.js
@@ -26,7 +26,7 @@ export const isVolumeDeletable = (rowData, persistentVolumes) => {
           pv => pv?.metadata?.name === volumeName,
         );
         if (!persistentVolume) {
-          return false;
+          return true;
         }
         const persistentVolumeStatus = persistentVolume?.status?.phase;
 

--- a/ui/src/services/NodeVolumesUtils.test.js
+++ b/ui/src/services/NodeVolumesUtils.test.js
@@ -148,7 +148,7 @@ it('should return false when volume is failed and there is no PV', () => {
     testcaseVolumeFailedWithoutPv.rowData,
     testcaseVolumeFailedWithoutPv.persistentVolumes,
   );
-  expect(result).toEqual(false);
+  expect(result).toEqual(true);
 });
 
 it('should return true when volume is failed and PV is failed', () => {
@@ -252,5 +252,5 @@ it('should return false when volume is available and there is no PV', () => {
     testcaseVolumeAvailableWithoutPv.rowData,
     testcaseVolumeAvailableWithoutPv.persistentVolumes,
   );
-  expect(result).toEqual(false);
+  expect(result).toEqual(true);
 });


### PR DESCRIPTION
**Component**: ui

**Context**: 
When the status of volume is failed and no PV attached, we should be able to click on the trash button.

**Summary**:

**Acceptance criteria**: 
When there is no pv and status of volume is failed, the trash button should be enable and without hint message.
![image](https://user-images.githubusercontent.com/18453133/65601639-b40da580-dfa2-11e9-8f7e-6b2f6b90c9e0.png)

Fix this bug
Refs: #1673 