### PR TITLE
Add Ubuntu bootstrap VM in Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -155,9 +155,54 @@ SCRIPT
 # To support VirtualBox linked clones
 Vagrant.require_version(">= 1.8")
 
+def declare_bootstrap(machine, os_data)
+  machine.vm.box = os_data[:name]
+  machine.vm.box_version = os_data[:version]
+
+  machine.vm.hostname = "bootstrap"
+  machine.vm.provider "virtualbox" do |v|
+    v.memory = 4086
+    machine.vm.synced_folder ".", "/vagrant", type: "virtualbox"
+  end
+
+  machine.vm.provision "import-release",
+    type: "shell",
+    inline: IMPORT_RELEASE
+
+  machine.vm.provision "import-ssh-private-key",
+    type: "shell",
+    inline: IMPORT_SSH_PRIVATE_KEY
+
+  machine.vm.provision "bootstrap",
+    type: "shell",
+    inline: BOOTSTRAP
+
+  machine.vm.provision "create-volumes",
+    type: "shell",
+    inline: CREATE_VOLUMES
+
+  machine
+end
+
 Vagrant.configure("2") do |config|
-  config.vm.box = "centos/7"
-  config.vm.box_version = "1811.02"
+
+  os_data = {
+    centos: {
+      name: 'centos/7',
+      version: '1811.02'
+    },
+    ubuntu: {
+      name: 'ubuntu/bionic64',
+      version: '20190514.0.0'
+    }
+  }
+
+  INSTALL_PYTHON = <<-SCRIPT
+  #!/bin/bash
+  apt install python -y
+  SCRIPT
+  config.vm.box = os_data[:centos][:name]
+  config.vm.box_version = os_data[:centos][:version]
 
   config.vm.provider "virtualbox" do |v|
     v.linked_clone = true
@@ -175,46 +220,13 @@ Vagrant.configure("2") do |config|
     nic_type: 'virtio',
     **WORKLOAD_PLANE_NETWORK
 
-  config.vm.define :bootstrap, primary: true do |bootstrap|
-    bootstrap.vm.hostname = "bootstrap"
-
-    bootstrap.vm.provider "virtualbox" do |v|
-      v.memory = 4096
-      bootstrap.vm.synced_folder ".", "/vagrant", type: "virtualbox"
-    end
-
-    bootstrap.vm.provision "import-release",
-      type: "shell",
-      inline: IMPORT_RELEASE
-
-    bootstrap.vm.provision "import-ssh-private-key",
-      type: "shell",
-      inline: IMPORT_SSH_PRIVATE_KEY
-
-    bootstrap.vm.provision "bootstrap",
-      type: "shell",
-      inline: BOOTSTRAP
-
-    bootstrap.vm.provision "create-volumes",
-      type: "shell",
-      inline: CREATE_VOLUMES
+  config.vm.define :bootstrap, primary: true do |machine|
+    declare_bootstrap machine, os_data[:centos]
   end
 
-  os_data = {
-    centos: {
-      name: 'centos/7',
-      version: '1811.02'
-    },
-    ubuntu: {
-      name: 'ubuntu/bionic64',
-      version: '20190514.0.0'
-    }
-  }
-
-  INSTALL_PYTHON = <<-SCRIPT
-  #!/bin/bash
-  apt install python -y
-  SCRIPT
+  config.vm.define :bootstrap_ubuntu, autostart: false do |machine|
+    declare_bootstrap machine, os_data[:ubuntu]
+  end
 
   os_data.each do |os, os_data|
     (1..5).each do |i|


### PR DESCRIPTION
**Component**: local build

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: #1726 is the tipping point at which we'd like to start testing the bootstrap process on an Ubuntu node. We provide an Ubuntu bootstrap VM in Vagrant that will serve hereafter for local tests on Ubuntu.

CI testing should follow when an Ubuntu bootstrap is fully functional.

**Summary**:

* Refactor bootstrap node creation into a separate function
* Provide an Ubuntu bootstrap VM
* Allow the definition of custom scripts to be called for provisioning depending on OS.

**Acceptance criteria**: 

The Ubuntu bootstrap node can be provisioned (and predictably fails early on the bootstrap for now).

```
vagrant up bootstrap_ubuntu
```

<!-- Declare one or more issues to close once this PR gets merged -->


<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
