### PR TITLE
containerd: set `LimitNOFILE` on the service

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -255,6 +255,7 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/addons/nginx-ingress/deployed/namespace.sls'),
 
     Path('salt/metalk8s/container-engine/containerd/configured.sls'),
+    Path('salt/metalk8s/container-engine/containerd/files/50-metalk8s.conf'),
     Path('salt/metalk8s/container-engine/containerd/init.sls'),
     Path('salt/metalk8s/container-engine/containerd/installed.sls'),
     Path('salt/metalk8s/container-engine/init.sls'),

--- a/salt/metalk8s/container-engine/containerd/configured.sls
+++ b/salt/metalk8s/container-engine/containerd/configured.sls
@@ -11,6 +11,7 @@ Start and enable containerd:
       - metalk8s_package_manager: Install containerd
     - watch:
       - file: Configure registry IP in containerd conf
+      - file: Create containerd service drop-in
 
 Inject pause image:
   # The `containerd` states require the `cri` module, which requires `crictl`

--- a/salt/metalk8s/container-engine/containerd/files/50-metalk8s.conf
+++ b/salt/metalk8s/container-engine/containerd/files/50-metalk8s.conf
@@ -1,0 +1,4 @@
+[Service]
+# See https://github.com/containerd/containerd/issues/3201
+# See https://github.com/containerd/containerd/pull/3202
+LimitNOFILE=1048576

--- a/salt/metalk8s/container-engine/containerd/installed.sls
+++ b/salt/metalk8s/container-engine/containerd/installed.sls
@@ -26,7 +26,19 @@ Install containerd:
       - test: Repositories configured
       - metalk8s_package_manager: Install runc
       - metalk8s_package_manager: Install container-selinux
- 
+
+Create containerd service drop-in:
+  file.managed:
+    - name: /etc/systemd/system/containerd.service.d/50-metalk8s.conf
+    - source: salt://{{ slspath }}/files/50-metalk8s.conf
+    - user: root
+    - group: root
+    - mode: 0644
+    - makedirs: true
+    - dir_mode: 0755
+    - require:
+      - metalk8s_package_manager: Install containerd
+
 Install and configure cri-tools:
   {{ pkg_installed('cri-tools') }}
     - require:

--- a/salt/metalk8s/salt/master/files/salt-master-manifest.yaml.j2
+++ b/salt/metalk8s/salt/master/files/salt-master-manifest.yaml.j2
@@ -50,7 +50,7 @@ spec:
           - event.send
           - test
         periodSeconds: 20
-        timeoutSeconds: 2
+        timeoutSeconds: 10
         initialDelaySeconds: 10
       volumeMounts:
         - name: config


### PR DESCRIPTION
The default 'open files' limit, 1024, is way too low for some of our
applications. Since there's no way to bump this limit from within a
container, and the artificial limit of 1024 file descriptors stems from
an era where FDs were costly, bump the limit to a more reasonable (in
2019) default.

Manual test:

```
[root@bootstrap ~]# kubectl taint node bootstrap node-role.kubernetes.io/bootstrap-
node/bootstrap untainted
[root@bootstrap ~]# kubectl taint node bootstrap node-role.kubernetes.io/infra-
node/bootstrap untainted
[root@bootstrap ~]# kubectl run --restart=Never --image=busybox shell -- sleep 9999
pod/shell created
[root@bootstrap ~]# kubectl exec -ti shell -- sh -c 'ulimit -n'
1048576
```

Fixes: #1785
See: https://github.com/scality/metalk8s/issues/1785
See: https://github.com/containerd/containerd/issues/3201
See: https://github.com/containerd/containerd/pull/3202