### PR TITLE
Remove UI check pre 2.4 in downgrade orchestrate

### DIFF
--- a/salt/metalk8s/orchestrate/downgrade/init.sls
+++ b/salt/metalk8s/orchestrate/downgrade/init.sls
@@ -93,6 +93,9 @@ Deploy Kubernetes objects:
     - require:
       - salt: Downgrade etcd cluster
 
+{#- UI is not present before version 2.4 #}
+{%- set version_list = (dest_version|string).split('.') %}
+{%- if version_list[0] == "2" and version_list[1]|int >= 4 %}
 Precheck for MetalK8s UI:
   salt.runner:
     - name: state.orchestrate
@@ -112,3 +115,4 @@ Deploy MetalK8s UI:
     - saltenv: metalk8s-{{ dest_version }}
     - require:
       - salt: Precheck for MetalK8s UI
+{%- endif %}


### PR DESCRIPTION
UI has been removed pre version 2.4 so the downgrade
orchestration will fail on older version

Fixes: #1762

**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

**Summary**:

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
