### PR TITLE
test/upgrade: compute metalk8s version properly

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -116,7 +116,7 @@ stages:
             echo "Could not reach Docker daemon from buildbot worker" >&2
             exit 1'
           haltOnFailure: true
-      - SetPropertyFromCommand:
+      - SetPropertyFromCommand: &set_product_version_prev
           name: set product_version_prev
           property: product_version_prev
           command: >
@@ -381,14 +381,15 @@ stages:
     steps:
       - Git: *git_pull
       - ShellCommand: *ssh_ip_setup
+      - SetPropertyFromCommand: *set_product_version_prev
       - SetPropertyFromCommand: &set_prev_version
           name: Set previous version
           property: metalk8s_prev_version
           command: >
             bash -c '
-              source VERSION &&
-              VERSION_MINOR=$((VERSION_MINOR-1))
-            echo $VERSION_MAJOR.$VERSION_MINOR.$VERSION_PATCH$VERSION_SUFFIX'
+              git checkout development/%(prop:product_version_prev)s --quiet &&
+              source VERSION ;
+              echo $VERSION_MAJOR.$VERSION_MINOR.$VERSION_PATCH$VERSION_SUFFIX'
       - ShellCommand: &get_prev_iso
           name: Get %(prop:metalk8s_prev_version)s image
           command: >


### PR DESCRIPTION
**Component**:

'upgrade', 'test'

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 


See #1793

**Summary**:

We need to properly compute the previous product version from the correct git branch.

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1793

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
Need to be backported