### PR TITLE
charts: update `prometheus-operator` to 6.11.0

### DIFF
--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -80,8 +80,8 @@ CONTAINER_IMAGES : Tuple[Image, ...] = (
     # Remote images
     Image(
         name='alertmanager',
-        version='v0.17.0',
-        digest='sha256:3db6eccdbf4bdaea3407b7a9e6a41fc50abcf272a1356227260948e73414ec09',
+        version='v0.19.0',
+        digest='sha256:7dbf4949a317a056d11ed8f379826b04d0665fad5b9334e1d69b23e946056cd3',
     ),
     Image(
         name='calico-node',

--- a/charts/prometheus-operator/Chart.yaml
+++ b/charts/prometheus-operator/Chart.yaml
@@ -16,4 +16,4 @@ name: prometheus-operator
 sources:
 - https://github.com/coreos/prometheus-operator
 - https://coreos.com/operators/prometheus
-version: 6.10.0
+version: 6.11.0

--- a/charts/prometheus-operator/README.md
+++ b/charts/prometheus-operator/README.md
@@ -302,7 +302,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `alertmanager.alertmanagerSpec.containers` | Containers allows injecting additional containers. This is meant to allow adding an authentication proxy to an Alertmanager pod. | `[]` |
 | `alertmanager.alertmanagerSpec.externalUrl` | The external URL the Alertmanager instances will be available under. This is necessary to generate correct URLs. This is necessary if Alertmanager is not served from root of a DNS name. | `""` |
 | `alertmanager.alertmanagerSpec.image.repository` | Base image that is used to deploy pods, without tag. | `quay.io/prometheus/alertmanager` |
-| `alertmanager.alertmanagerSpec.image.tag` | Tag of Alertmanager container image to be deployed. | `v0.17.0` |
+| `alertmanager.alertmanagerSpec.image.tag` | Tag of Alertmanager container image to be deployed. | `v0.19.0` |
 | `alertmanager.alertmanagerSpec.listenLocal` | ListenLocal makes the Alertmanager server listen on loopback, so that it does not bind against the Pod IP. Note this is only for the Alertmanager UI, not the gossip communication. | `false` |
 | `alertmanager.alertmanagerSpec.logFormat` | Log format for Alertmanager to be configured with. | `logfmt` |
 | `alertmanager.alertmanagerSpec.logLevel` | Log level for Alertmanager to be configured with. | `info` |

--- a/charts/prometheus-operator/values.yaml
+++ b/charts/prometheus-operator/values.yaml
@@ -229,7 +229,7 @@ alertmanager:
     ##
     image:
       repository: quay.io/prometheus/alertmanager
-      tag: v0.17.0
+      tag: v0.19.0
 
     ## If true then the user will be responsible to provide a secret with alertmanager configuration
     ## So when true the config part will be ignored (including templateFiles) and the one in the secret will be used

--- a/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-alertmanager
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-alertmanager
@@ -221,7 +221,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-operator
@@ -262,7 +262,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-prometheus
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-prometheus
@@ -324,7 +324,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-alertmanager
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: alertmanager-prometheus-operator-alertmanager
@@ -415,7 +415,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-grafana
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     grafana_datasource: '1'
     heritage: metalk8s
     release: prometheus-operator
@@ -1034,7 +1034,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-grafana
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     grafana_dashboard: '1'
     heritage: metalk8s
     release: prometheus-operator
@@ -1568,7 +1568,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-grafana
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     grafana_dashboard: '1'
     heritage: metalk8s
     release: prometheus-operator
@@ -2155,7 +2155,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-grafana
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     grafana_dashboard: '1'
     heritage: metalk8s
     release: prometheus-operator
@@ -2720,7 +2720,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-grafana
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     grafana_dashboard: '1'
     heritage: metalk8s
     release: prometheus-operator
@@ -3466,7 +3466,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-grafana
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     grafana_dashboard: '1'
     heritage: metalk8s
     release: prometheus-operator
@@ -3957,7 +3957,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-grafana
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     grafana_dashboard: '1'
     heritage: metalk8s
     release: prometheus-operator
@@ -4482,7 +4482,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-grafana
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     grafana_dashboard: '1'
     heritage: metalk8s
     release: prometheus-operator
@@ -4992,7 +4992,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-grafana
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     grafana_dashboard: '1'
     heritage: metalk8s
     release: prometheus-operator
@@ -5519,7 +5519,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-grafana
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     grafana_dashboard: '1'
     heritage: metalk8s
     release: prometheus-operator
@@ -6712,7 +6712,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-grafana
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     grafana_dashboard: '1'
     heritage: metalk8s
     release: prometheus-operator
@@ -7185,7 +7185,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-grafana
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     grafana_dashboard: '1'
     heritage: metalk8s
     release: prometheus-operator
@@ -7657,7 +7657,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-grafana
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     grafana_dashboard: '1'
     heritage: metalk8s
     release: prometheus-operator
@@ -8141,7 +8141,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-grafana
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     grafana_dashboard: '1'
     heritage: metalk8s
     release: prometheus-operator
@@ -8422,7 +8422,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-grafana
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     grafana_dashboard: '1'
     heritage: metalk8s
     release: prometheus-operator
@@ -8751,7 +8751,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-grafana
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     grafana_dashboard: '1'
     heritage: metalk8s
     release: prometheus-operator
@@ -9214,7 +9214,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-grafana
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     grafana_dashboard: '1'
     heritage: metalk8s
     release: prometheus-operator
@@ -9801,7 +9801,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-grafana
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     grafana_dashboard: '1'
     heritage: metalk8s
     release: prometheus-operator
@@ -10372,7 +10372,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-grafana
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     grafana_dashboard: '1'
     heritage: metalk8s
     release: prometheus-operator
@@ -10886,7 +10886,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-grafana
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     grafana_dashboard: '1'
     heritage: metalk8s
     release: prometheus-operator
@@ -11347,7 +11347,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-grafana
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     grafana_dashboard: '1'
     heritage: metalk8s
     release: prometheus-operator
@@ -11420,7 +11420,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-alertmanager
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-alertmanager
@@ -11435,7 +11435,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-operator
@@ -11450,7 +11450,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-prometheus
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-prometheus
@@ -11467,7 +11467,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: alertmanagers.monitoring.coreos.com
@@ -13951,7 +13951,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: podmonitors.monitoring.coreos.com
@@ -14198,7 +14198,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheuses.monitoring.coreos.com
@@ -17746,7 +17746,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheusrules.monitoring.coreos.com
@@ -18183,7 +18183,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: servicemonitors.monitoring.coreos.com
@@ -18744,7 +18744,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-alertmanager
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-alertmanager
@@ -18767,7 +18767,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-operator
@@ -18847,7 +18847,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-operator-psp
@@ -18870,7 +18870,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-prometheus
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-prometheus
@@ -18918,7 +18918,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-prometheus
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-prometheus-psp
@@ -19028,7 +19028,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-alertmanager
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-alertmanager
@@ -19050,7 +19050,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-operator
@@ -19072,7 +19072,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-operator-psp
@@ -19094,7 +19094,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-prometheus
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-prometheus
@@ -19116,7 +19116,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-prometheus
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-prometheus-psp
@@ -19304,7 +19304,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-alertmanager
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-alertmanager
@@ -19328,7 +19328,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-coredns
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     jobLabel: coredns
     release: prometheus-operator
@@ -19352,7 +19352,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-kube-controller-manager
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     jobLabel: kube-controller-manager
     release: prometheus-operator
@@ -19377,7 +19377,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-kube-etcd
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     jobLabel: kube-etcd
     release: prometheus-operator
@@ -19402,7 +19402,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-kube-proxy
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     jobLabel: kube-proxy
     release: prometheus-operator
@@ -19427,7 +19427,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-kube-scheduler
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     jobLabel: kube-scheduler
     release: prometheus-operator
@@ -19452,7 +19452,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-operator
@@ -19475,7 +19475,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-prometheus
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-prometheus
@@ -19811,7 +19811,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-operator
@@ -19829,7 +19829,7 @@ spec:
         app.kubernetes.io/managed-by: salt
         app.kubernetes.io/name: prometheus-operator-operator
         app.kubernetes.io/part-of: metalk8s
-        chart: prometheus-operator-6.10.0
+        chart: prometheus-operator-6.11.0
         heritage: metalk8s
         release: prometheus-operator
     spec:
@@ -19876,7 +19876,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-alertmanager
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-alertmanager
@@ -19927,7 +19927,7 @@ spec:
   - effect: NoSchedule
     key: node-role.kubernetes.io/infra
     operator: Exists
-  version: v0.17.0
+  version: v0.19.0
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
@@ -19937,7 +19937,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-prometheus
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-prometheus
@@ -20014,7 +20014,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-alertmanager.rules
@@ -20062,7 +20062,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-etcd
@@ -20206,7 +20206,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-general.rules
@@ -20251,7 +20251,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-k8s.rules
@@ -20310,7 +20310,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-kube-apiserver.rules
@@ -20343,7 +20343,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-kube-prometheus-node-recording.rules
@@ -20380,7 +20380,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-kube-scheduler.rules
@@ -20443,7 +20443,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-kubernetes-absent
@@ -20536,7 +20536,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-kubernetes-apps
@@ -20688,7 +20688,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-kubernetes-resources
@@ -20769,7 +20769,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-kubernetes-storage
@@ -20821,7 +20821,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-kubernetes-system
@@ -20970,7 +20970,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-node-exporter.rules
@@ -21019,7 +21019,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-node-exporter
@@ -21161,7 +21161,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-node-network
@@ -21187,7 +21187,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-node-time
@@ -21213,7 +21213,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-node.rules
@@ -21243,7 +21243,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-prometheus-operator
@@ -21278,7 +21278,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-prometheus
@@ -21478,7 +21478,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-alertmanager
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-alertmanager
@@ -21503,7 +21503,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-coredns
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-coredns
@@ -21529,7 +21529,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-apiserver
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-apiserver
@@ -21560,7 +21560,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-kube-controller-manager
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-kube-controller-manager
@@ -21586,7 +21586,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-kube-etcd
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-kube-etcd
@@ -21612,7 +21612,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-kube-proxy
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-kube-proxy
@@ -21638,7 +21638,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-kube-scheduler
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-kube-scheduler
@@ -21664,7 +21664,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-kube-state-metrics
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-kube-state-metrics
@@ -21687,7 +21687,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-kubelet
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-kubelet
@@ -21725,7 +21725,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-node-exporter
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-node-exporter
@@ -21747,7 +21747,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-grafana
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-grafana
@@ -21772,7 +21772,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-operator
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-operator
@@ -21797,7 +21797,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: prometheus-operator-prometheus
     app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-6.10.0
+    chart: prometheus-operator-6.11.0
     heritage: metalk8s
     release: prometheus-operator
   name: prometheus-operator-prometheus


### PR DESCRIPTION
The chart was updated using

```
$ rm -rf charts/prometheus-operator/
$ helm fetch -d charts --untar stable/prometheus-operator
```

Note: this is only OK because no local changes to the chart were made.

Subsequently, it was re-rendered using

```
$ ./charts/render.py prometheus-operator metalk8s-monitoring charts/prometheus-operator.yaml charts/prometheus-operator/ > salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
```

Finally, the buildchain is updated to pull the new version of the
AlertManager container image.