### PR TITLE
Use only needed pillar items to prevent invalid format

### DIFF
--- a/scripts/downgrade.sh
+++ b/scripts/downgrade.sh
@@ -169,10 +169,15 @@ launch_downgrade () {
 }
 
 downgrade_bootstrap () {
+  local saltmaster_endpoint repo_endpoint
+  saltmaster_endpoint="$($SALT_CALL pillar.get metalk8s:endpoints:salt-master --out txt \
+      | cut -d' ' -f2- )"
+  repo_endpoint="$($SALT_CALL pillar.get metalk8s:endpoints:repositories --out txt \
+      | cut -d' ' -f2- )"
   $SALT_CALL --local state.sls metalk8s.roles.bootstrap \
     saltenv="metalk8s-$DESTINATION_VERSION" \
-    pillar="{'metalk8s': {'endpoints': $(salt-call \
-    --out txt pillar.get metalk8s:endpoints | cut -c 8-)}}" \
+    pillar="{'metalk8s': {'endpoints': {'salt-master': $saltmaster_endpoint, \
+    'repositories': $repo_endpoint}}}" \
     --retcode-passthrough
   _check_salt_master
   $SALT salt-run saltutil.sync_all saltenv="metalk8s-$DESTINATION_VERSION"

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -153,11 +153,16 @@ get_salt_container() {
 }
 
 upgrade_bootstrap () {
+    local saltmaster_endpoint repo_endpoint
+    saltmaster_endpoint="$($SALT_CALL pillar.get \
+        metalk8s:endpoints:salt-master --out txt | cut -d' ' -f2- )"
+    repo_endpoint="$($SALT_CALL pillar.get \
+        metalk8s:endpoints:repositories --out txt | cut -d' ' -f2- )"
     "${SALT_CALL}" --local state.sls metalk8s.roles.bootstrap \
         saltenv="metalk8s-$DESTINATION_VERSION" \
-        pillar="{'metalk8s': {'endpoints': $(salt-call --out \
-        txt pillar.get metalk8s:endpoints \
-        | cut -c 8-)}}"
+        pillar="{'metalk8s': {'endpoints': {'salt-master': $saltmaster_endpoint, \
+        'repositories': $repo_endpoint}}}" \
+        --retcode-passthrough
 }
 
 launch_upgrade () {


### PR DESCRIPTION
prometheus and other endpoints error are introducing invalid
pillar format for bash this is a temporary fix until we migrate
everything to python

Fixes: #1740

**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

**Summary**:

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1740

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
