### PR TITLE
Fix sosreport location for single node upgrade test step

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -269,7 +269,7 @@ stages:
             --batch --tmp-dir /var/tmp &&
             sudo chown eve:eve /var/tmp/sosreport*
           alwaysRun: true
-      - ShellCommand: &copy_sosreport
+      - ShellCommand:
           name: Copy sosreport to correct directory structure
           command: >
             mkdir -p sosreport/sosreport/single-node &&
@@ -372,7 +372,12 @@ stages:
             --destination-version %(prop:metalk8s_version)s
           haltOnFailure: true
       - ShellCommand: *collect_sosreport
-      - ShellCommand: *copy_sosreport
+      - ShellCommand:
+          name: Copy sosreport to correct directory structure
+          command: >
+            mkdir -p sosreport/sosreport/single-node-upgrade-test &&
+            cp /var/tmp/sosreport* sosreport/sosreport/single-node-upgrade-test
+          alwaysRun: true
       - Upload: *upload_report_artifact
       - ShellCommand:
           name: Debug step - wait 1 hour before allowing resource destruction


### PR DESCRIPTION
**Component**:

'ci', 'tests', 'sosreport'

**Context**: 

When looking at the sosreport files, the one for the single-node-upgrade-test is in the same folder as the one for the single-node stage. We want it to have its own folder.

**Acceptance criteria**: 

The sosreport for the single-node-upgrade-test stage is in its own folder matching the stage name.

---

Closes: #1824 