### PR TITLE
CI: Fix sosreport folder creation for multiple-nodes stage

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -360,9 +360,6 @@ stages:
           workdir: build/eve/workers/openstack-multiple-nodes/terraform/
           haltOnFailure: true
       - ShellCommand:
-          name: Create sosreport directory on the bastion
-          command: mkdir -p sosreport/sosreport/multi-node
-      - ShellCommand:
           name: Generate sosreport on every machine
           env:
             SSH_CONFIG: >-
@@ -382,6 +379,7 @@ stages:
             SSH_CONFIG: >-
               eve/workers/openstack-multiple-nodes/terraform/ssh_config
           command: >
+            mkdir -p sosreport/sosreport/multi-node &&
             for host in bootstrap node1; do
               scp -F $SSH_CONFIG \
               $host:/var/tmp/sosreport-* \


### PR DESCRIPTION
**Component**:

'ci', 'tests', 'sosreport'

**Context**: 

The creation step was not always run so when there was a failure
the sosreport was generated correctly but was not downloaded because
of the missing destination folder.

**Acceptance criteria**: 

When the multiple-nodes stage is not successful, we should have the sosreport in the `sosreport/multi-node` folder in the build artifacts.

---

Closes: #1826