### PR TITLE
Fix sosreport pod log files for pods that have several containers

### DIFF
--- a/packages/redhat/metalk8s-sosreport/src/metalk8s.py
+++ b/packages/redhat/metalk8s-sosreport/src/metalk8s.py
@@ -98,7 +98,7 @@ class metalk8s(Plugin, RedHatPlugin, UbuntuPlugin):
                         pods = [p.split()[0] for p in
                                 r['output'].splitlines()[1:]]
                         for pod in pods:
-                            self.add_cmd_output('{0} logs {1}'.format(kube_namespaced_cmd, pod))
+                            self.add_cmd_output('{0} logs {1} --all-containers'.format(kube_namespaced_cmd, pod))
 
             if not self.get_option('all'):
                 kube_namespaced_cmd = '{} get --all-namespaces=true'.format(kube_cmd)


### PR DESCRIPTION
**Component**:

'ci', 'tests', 'sosreport'

**Context**: 

Because some pods have several containers, the sosreport command used to retrieve the pod logs can not work.

**Acceptance criteria**: 

In any sosreport, the `sos_commands/metalk8s/kubectl_--kubeconfig_.etc.kubernetes.admin.conf_--namespace_kube-system_logs_salt-master-bootstrap` file should contain some container logs and not the following error: `Error from server (BadRequest): a container name must be specified for pod salt-master-bootstrap, choose one of: [salt-master salt-api]`

---

Closes: #1825 