### PR TITLE
build: fix output alignment

### DIFF
--- a/buildchain/buildchain/constants.py
+++ b/buildchain/buildchain/constants.py
@@ -14,7 +14,7 @@ from buildchain import config
 
 # Max length of a "command".
 # (used in task display, for a nice aligned output).
-CMD_WIDTH : int = 12
+CMD_WIDTH : int = 14
 
 # URLs of the main container repositories.
 CALICO_REPOSITORY     : str = 'quay.io/calico'


### PR DESCRIPTION
**Component**:

buildchain

**Context**: 

Fix alignment in the build output

**Summary**:

Bump the max width to 14 to restore it.

**Acceptance criteria**: 

Check that the output is aligned when running `./doit.sh -n4`

---

Closes: #1832