### PR TITLE
build,ci: stop quickly if a build step fails

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -64,11 +64,13 @@ stages:
           # most build steps running in Docker, set concurrency to 4.
           command: ./doit.sh -n 4
           usePTY: true
+          haltOnFailure: true
       - ShellCommand:
           name: Put the iso file in a separate folder
           command: >
             mkdir iso &&
             cp _build/metalk8s.iso _build/SHA256SUM _build/root/product.txt iso
+          haltOnFailure: true
       - Upload:
           name: upload artifacts
           source: iso/


### PR DESCRIPTION
**Component**:

'ci', 'build'

**Context**: 

Make sure we don't run unnecessarily steps if one build step is failing.

**Acceptance criteria**: 

* If the `build everything` step fails, we don't run the next ones
* If the `Put the iso file in a separate folder` step fails, we don't run the next one

---

Closes: #1842 