### PR TITLE
upgrade/test: Sync salt auth and roster before upgrade orchestrate

### DIFF
--- a/scripts/downgrade.sh
+++ b/scripts/downgrade.sh
@@ -181,6 +181,9 @@ downgrade_bootstrap () {
     --retcode-passthrough
   _check_salt_master
   $SALT salt-run saltutil.sync_all saltenv="metalk8s-$DESTINATION_VERSION"
+  $SALT salt-run metalk8s_saltutil.sync_auth saltenv="metalk8s-$DESTINATION_VERSION"
+  $SALT salt-run saltutil.sync_roster saltenv="metalk8s-$DESTINATION_VERSION"
+
   local bootstrap_id
   bootstrap_id=$(
     $SALT_CALL grains.get id --out txt \

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -170,6 +170,12 @@ launch_upgrade () {
     "${SALT_MASTER_CALL[@]}" salt-run saltutil.sync_all \
         saltenv="metalk8s-$DESTINATION_VERSION"
 
+    "${SALT_MASTER_CALL[@]}" salt-run metalk8s_saltutil.sync_auth  \
+        saltenv="metalk8s-$DESTINATION_VERSION"
+
+    "${SALT_MASTER_CALL[@]}" salt-run saltutil.sync_roster  \
+        saltenv="metalk8s-$DESTINATION_VERSION"
+
     "${SALT_MASTER_CALL[@]}" salt-run state.orchestrate \
         metalk8s.orchestrate.upgrade saltenv="metalk8s-$DESTINATION_VERSION"
 }


### PR DESCRIPTION

**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

'salt', 'upgrade', 'test'

**Context**: 

See #1819 

**Summary**:

Force sync salt `auth` and salt `roster` before launching an upgrade.

**Acceptance criteria**: 

- Working salt master with uptodate conf
- Successful upgrade from 2.3 to 2.4


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1819

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
