### PR TITLE
UI: Add grafana link in the navbar

### DIFF
--- a/salt/metalk8s/addons/ui/deployed/ui.sls
+++ b/salt/metalk8s/addons/ui/deployed/ui.sls
@@ -43,7 +43,8 @@ Create metalk8s-ui ConfigMap:
           {
             "url": "/api/kubernetes",
             "url_salt": "/api/salt",
-            "url_prometheus": "/api/prometheus"
+            "url_prometheus": "/api/prometheus",
+            "url_grafana": "/grafana"
           }
 
 Create ui-branding ConfigMap:

--- a/ui/public/config.json
+++ b/ui/public/config.json
@@ -1,5 +1,6 @@
 {
-    "url": "https://172.21.254.13:6443",
-    "url_salt": "http://172.21.254.13:4507",
-    "url_prometheus": "http://172.21.254.46:31266"
+    "url": "https://{ip}:8443/api/kubernetes",
+    "url_salt": "https://{ip}:8443/api/salt",
+    "url_prometheus": "https://{ip}:8443/api/prometheus",
+    "url_grafana": "https://{ip}:8443/grafana"
 }

--- a/ui/src/containers/ClusterMonitoring.js
+++ b/ui/src/containers/ClusterMonitoring.js
@@ -4,7 +4,11 @@ import { injectIntl, FormattedDate, FormattedTime } from 'react-intl';
 import styled from 'styled-components';
 import { Loader as LoaderCoreUI } from '@scality/core-ui';
 import { Table, Tooltip } from '@scality/core-ui';
-import { padding, fontWeight } from '@scality/core-ui/dist/style/theme';
+import {
+  padding,
+  fontWeight,
+  fontSize,
+} from '@scality/core-ui/dist/style/theme';
 import CircleStatus from '../components/CircleStatus';
 import {
   refreshClusterStatusAction,
@@ -47,9 +51,27 @@ const PageSubtitle = styled.h3`
 const ClusterStatusTitleContainer = styled.div`
   display: flex;
   align-items: center;
+  justify-content: space-between;
+`;
+
+const LeftClusterStatusContainer = styled.div`
+  display: flex;
+  align-items: center;
   .sc-tooltip-overlay-text {
     white-space: nowrap;
     text-align: left;
+  }
+`;
+
+const RightClusterStatusContainer = styled.div`
+  display: flex;
+  i {
+    font-size: ${fontSize.larger};
+    color: ${props => props.theme.brand.primary};
+    &:hover {
+      color: ${props => props.theme.brand.secondary};
+      cursor: pointer;
+    }
   }
 `;
 
@@ -165,40 +187,62 @@ const ClusterMonitoring = props => {
   return (
     <PageContainer>
       <ClusterStatusTitleContainer>
-        <PageSubtitle>{props.intl.messages.cluster_status + ' :'}</PageSubtitle>
-        <ClusterStatusValue
-          isUp={props.clusterStatus.value === CLUSTER_STATUS_UP}
-        >
-          {props.clusterStatus.label}
-        </ClusterStatusValue>
-        <Tooltip
-          placement="right"
-          overlay={
-            <TooltipContent>
-              <div>
-                <CircleStatus status={apiServerStatus} />
-                <ControlPlaneStatusLabel>
-                  {props.intl.messages.api_server}
-                </ControlPlaneStatusLabel>
-              </div>
-              <div>
-                <CircleStatus status={kubeSchedulerStatus} />
-                <ControlPlaneStatusLabel>
-                  {props.intl.messages.kube_scheduler}
-                </ControlPlaneStatusLabel>
-              </div>
-              <div>
-                <CircleStatus status={kubeControllerManagerStatus} />
-                <ControlPlaneStatusLabel>
-                  {props.intl.messages.kube_controller_manager}
-                </ControlPlaneStatusLabel>
-              </div>
-            </TooltipContent>
-          }
-        >
-          <QuestionMarkIcon className="fas fa-question-circle" />
-        </Tooltip>
-        {props.clusterStatus.isLoading ? <LoaderCoreUI size="small" /> : null}
+        <LeftClusterStatusContainer>
+          <PageSubtitle>
+            {props.intl.messages.cluster_status + ' :'}
+          </PageSubtitle>
+          <ClusterStatusValue
+            isUp={props.clusterStatus.value === CLUSTER_STATUS_UP}
+          >
+            {props.clusterStatus.label}
+          </ClusterStatusValue>
+          <Tooltip
+            placement="right"
+            overlay={
+              <TooltipContent>
+                <div>
+                  <CircleStatus status={apiServerStatus} />
+                  <ControlPlaneStatusLabel>
+                    {props.intl.messages.api_server}
+                  </ControlPlaneStatusLabel>
+                </div>
+                <div>
+                  <CircleStatus status={kubeSchedulerStatus} />
+                  <ControlPlaneStatusLabel>
+                    {props.intl.messages.kube_scheduler}
+                  </ControlPlaneStatusLabel>
+                </div>
+                <div>
+                  <CircleStatus status={kubeControllerManagerStatus} />
+                  <ControlPlaneStatusLabel>
+                    {props.intl.messages.kube_controller_manager}
+                  </ControlPlaneStatusLabel>
+                </div>
+              </TooltipContent>
+            }
+          >
+            <QuestionMarkIcon className="fas fa-question-circle" />
+          </Tooltip>
+          {props.clusterStatus.isLoading ? <LoaderCoreUI size="small" /> : null}
+        </LeftClusterStatusContainer>
+        <RightClusterStatusContainer>
+          <Tooltip
+            placement="left"
+            overlay={
+              <TooltipContent>
+                {props.intl.messages.advanced_monitoring}
+              </TooltipContent>
+            }
+          >
+            <div
+              onClick={() => {
+                window.open(props.config.api.url_grafana, '_blank');
+              }}
+            >
+              <i className="fas fa-chart-line" />
+            </div>
+          </Tooltip>
+        </RightClusterStatusContainer>
       </ClusterStatusTitleContainer>
 
       <PageSubtitle>
@@ -228,6 +272,7 @@ const mapStateToProps = (state, props) => {
     alerts: state.app.monitoring.alert,
     clusterStatus: makeClusterStatus(state, props),
     cluster: state.app.monitoring.cluster,
+    config: state.config,
   };
 };
 

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -123,5 +123,6 @@
   "description": "Description",
   "add_solution_to_environment": "Add solution to the environment {environment}",
   "version_env": "Versions",
-  "add_solution": "Add the solution"
+  "add_solution": "Add the solution",
+  "advanced_monitoring": "Advanced Monitoring"
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -123,5 +123,6 @@
   "description": "Description",
   "add_solution_to_environment": "Ajout d'une solution à l'environnement {environment}",
   "version_env": "Versions",
-  "add_solution": "Ajout de la solution"
+  "add_solution": "Ajout de la solution",
+  "advanced_monitoring": "Supervision Avancée"
 }


### PR DESCRIPTION
**Component**:UI

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
- Once logged in metalk8s UI (or any other solution admin UI actually), I would like to quickly access grafana dashboard in case I need to do deeper investigation.

**Summary**:

**Acceptance criteria**: 
- Build and launch the UI 
- Click on the "Advanced Monitoring" button in the Cluster Health Page to access Grafana dashboard in a new tab.

![image](https://user-images.githubusercontent.com/47394132/66404435-b92e1400-e9e8-11e9-8bc9-7380caa9346c.png)


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: https://github.com/scality/metalk8s/issues/1817

-->
