### PR TITLE
salt: Refresh pillar before highstate new node

### DIFF
--- a/salt/metalk8s/orchestrate/deploy_node.sls
+++ b/salt/metalk8s/orchestrate/deploy_node.sls
@@ -69,6 +69,11 @@ Drain the node:
 
 {%- endif %}
 
+Refresh pillar before highstate:
+  salt.function:
+    - name: saltutil.refresh_pillar
+    - tgt: {{ node_name }}
+
 Run the highstate:
   salt.state:
     - tgt: {{ node_name }}
@@ -77,6 +82,7 @@ Run the highstate:
       - salt: Set grains
       - salt: Refresh the mine
       - metalk8s_cordon: Cordon the node
+      - salt: Refresh pillar before highstate
 
 Wait for API server to be available:
   http.wait_for_successful_query:


### PR DESCRIPTION
**Component**:

'salt'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

Some endpoints not available in pillar when running the highstate on the node

**Summary**:

Refresh the pillar before calling the highstate on the node

---

Fixes: #1839 
