### PR TITLE
Improve output in case of error during the doc building

### DIFF
--- a/docs/entrypoint.sh
+++ b/docs/entrypoint.sh
@@ -4,5 +4,5 @@ set -e
 set -u
 set -o pipefail
 
-tox --workdir /tmp/tox -e docs -- "$@"
+tox --workdir /tmp/tox -e docs -- "$@" 1>&2
 chown -R "${TARGET_UID}:${TARGET_GID}" /usr/src/metalk8s/docs/_build


### PR DESCRIPTION
**Component**:

build

**Context**: 

The doc-builder sometimes fail, but we won't know why (no error message are reported).

**Summary**:

Work around the weird behavior of `tox` (or what it calls) of printing error on `stdout`…

**Acceptance criteria**: 

- edit the `docs/entrypoint.sh` and replace `"$@"` by `xylospongium`
- run `./doit.sh doc:pdf`

You should see the `tox` output with the error message.

---

See: #1872