### PR TITLE
salt: Wait API server after bootstrap highstate

### DIFF
--- a/salt/metalk8s/orchestrate/bootstrap/init.sls
+++ b/salt/metalk8s/orchestrate/bootstrap/init.sls
@@ -98,6 +98,15 @@ Bring bootstrap minion to highstate:
     - salt: Sync bootstrap minion
     - salt: Deploy CA role on bootstrap minion
 
+Wait for API server to be available:
+  http.wait_for_successful_query:
+  - name: https://{{ pillar.metalk8s.api_server.host }}:6443/healthz
+  - match: 'ok'
+  - status: 200
+  - verify_ssl: false
+  - require:
+    - salt: Bring bootstrap minion to highstate
+
 Generate etcd client certs for salt master:
   salt.state:
   - sls:
@@ -107,15 +116,7 @@ Generate etcd client certs for salt master:
   - saltenv: {{ saltenv }}
   - require:
     - salt: Deploy CA role on bootstrap minion
-
-Wait for API server to be available:
-  http.wait_for_successful_query:
-  - name: https://{{ pillar.metalk8s.api_server.host }}:6443/healthz
-  - match: 'ok'
-  - status: 200
-  - verify_ssl: false
-  - require:
-    - salt: Bring bootstrap minion to highstate
+    - http: Wait for API server to be available
 
 Configure bootstrap Node object:
   salt.runner:


### PR DESCRIPTION
**Component**:

'salt'

**Context**: 

Timeout in ext_pillar when retrieving information from API server

**Summary**:

Wait for API Server to be available right after the bootstrap highstate

---

Fixes: #1835 
