### PR TITLE
build: Redirect `yum-builddep` output to stderr

### DIFF
--- a/packages/redhat/entrypoint.sh
+++ b/packages/redhat/entrypoint.sh
@@ -36,7 +36,7 @@ buildsrpm() {
 
 buildrpm() {
     set -x
-    yum-builddep -y "/rpmbuild/SRPMS/${SRPM}"
+    yum-builddep -y "/rpmbuild/SRPMS/${SRPM}" >&2
     chown build:build /home/build
     su -l build rpmdev-setuptree
     su -l build -c "rpmbuild --rebuild /rpmbuild/SRPMS/${SRPM}"


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

No information during build when error in `yum-builddep` step

**Summary**:

By default `yum-builddep` only output on stdout, in doit we only print
stderr, lets always redirect `yum-builddep` output to stderr

**Acceptance criteria**: 

Have more information when doit fail in builddep step

---

See: #1841
