### PR TITLE
Add support for bionic-security repository

### DIFF
--- a/buildchain/buildchain/packaging.py
+++ b/buildchain/buildchain/packaging.py
@@ -431,6 +431,7 @@ DEB_REPOSITORIES : Tuple[targets.DEBRepository, ...] = (
     _deb_repository(name='scality', packages=DEB_TO_BUILD['scality']),
     _deb_repository(name='bionic'),
     _deb_repository(name='bionic-backports'),
+    _deb_repository(name='bionic-security'),
     _deb_repository(name='bionic-updates'),
     _deb_repository(name='kubernetes-xenial'),
     _deb_repository(name='salt_ubuntu1804'),


### PR DESCRIPTION
**Component**:

buildchain

**Context**: 

Downloading DEB packages to build Ubuntu offline repositories is broken.

We use a declarative approach (like for CentOS) about which repositories we need to build.
Looks like some dependencies were moved from a repository we handle into a new one (`bionic-security`) which we don't support.

**Summary**:

Add `bionic-security` to the buildchain.

**Acceptance criteria**: 

Build an ISO is now working.