### PR TITLE
ci: remove workaround

### DIFF
--- a/storage-operator/go.mod
+++ b/storage-operator/go.mod
@@ -33,5 +33,3 @@ replace (
 replace github.com/operator-framework/operator-sdk => github.com/operator-framework/operator-sdk v0.9.0
 
 go 1.13
-
-// EVE-1098: Dummy comment to force image rebuild


### PR DESCRIPTION
**Component**:

ci

**Context**: 

A dummy comment was added to work around the bug EVE-1098.
Now that it's merged and deployed, we can remove it.


**Summary**:

Remove the dummy comment that was introduced as workaround.

**Acceptance criteria**: 

No visible impact.