### PR TITLE
Backport Salt K8s module fixes

### DIFF
--- a/salt/_modules/metalk8s_kubernetes.py
+++ b/salt/_modules/metalk8s_kubernetes.py
@@ -1690,6 +1690,7 @@ def __dict_to_api_service_spec(spec):
         group_priority_minimum=spec['groupPriorityMinimum'],
         service=service_ref,
         version_priority=spec['versionPriority'],
+        insecure_skip_tls_verify=spec.get('insecureSkipTLSVerify', None),
     )
     for key, value in iteritems(spec):
         if hasattr(spec_obj, key):

--- a/salt/_modules/metalk8s_kubernetes.py
+++ b/salt/_modules/metalk8s_kubernetes.py
@@ -1665,6 +1665,10 @@ def __dict_to_service_spec(spec):
                     for port_key, port_value in iteritems(port):
                         if port_key in ("name", "port", "protocol", "node_port", "target_port"):
                             port_kwargs[port_key] = port_value
+                        elif port_key == 'nodePort':
+                            port_kwargs['node_port'] = port_value
+                        elif port_key == 'targetPort':
+                            port_kwargs['target_port'] = port_value
                 else:
                     port_kwargs = {"port": port}
                 kube_port = kubernetes.client.V1ServicePort(**port_kwargs)

--- a/salt/_modules/metalk8s_kubernetes.py
+++ b/salt/_modules/metalk8s_kubernetes.py
@@ -1673,6 +1673,8 @@ def __dict_to_service_spec(spec):
                     port_kwargs = {"port": port}
                 kube_port = kubernetes.client.V1ServicePort(**port_kwargs)
                 spec_obj.ports.append(kube_port)
+        elif key == 'clusterIP':
+            spec_obj.cluster_ip = value
         elif hasattr(spec_obj, key):
             setattr(spec_obj, key, value)
 

--- a/tests/post/features/ingress.feature
+++ b/tests/post/features/ingress.feature
@@ -3,12 +3,12 @@ Feature: Ingress
     Scenario: Access HTTP services
         Given the Kubernetes API is available
         When we perform an HTTP request on port 80 on a workload-plane IP
-        Then the server returns 502 'Bad Gateway'
+        Then the server returns 404 'Not Found'
 
     Scenario: Access HTTPS services
         Given the Kubernetes API is available
         When we perform an HTTPS request on port 443 on a workload-plane IP
-        Then the server returns 502 'Bad Gateway'
+        Then the server returns 404 'Not Found'
 
     Scenario: Access HTTP services on control-plane IP
         Given the Kubernetes API is available


### PR DESCRIPTION
These only landed in `development/2.1`, which causes trouble when upgrading/downgrading from/to `development/2.0`, while the code in `development/2.0` is as wrong as the code in `development/2.1` was before the fixes landed.