### PR TITLE
Improvement/1899 show more info on test failure

### DIFF
--- a/tests/kube_utils.py
+++ b/tests/kube_utils.py
@@ -14,7 +14,11 @@ def get_pods(
     if node:
         nodename = utils.resolve_hostname(node, ssh_config)
         field_selector.append('spec.nodeName={}'.format(nodename))
-
+    if not label:
+        return k8s_client.list_namespaced_pod(
+            namespace,
+            field_selector=','.join(field_selector),
+        ).items
     return k8s_client.list_namespaced_pod(
         namespace,
         field_selector=','.join(field_selector),

--- a/tests/post/steps/test_dns.py
+++ b/tests/post/steps/test_dns.py
@@ -54,7 +54,7 @@ def test_dns(host):
 
 
 @then(parsers.parse("the hostname '{hostname}' should be resolved"))
-def resolve_hostname(utils_pod, host, hostname):
+def resolve_hostname(utils_pod, host, hostname, showpods):
     with host.sudo():
         # test dns resolve
         result = host.run(

--- a/tests/post/steps/test_ingress.py
+++ b/tests/post/steps/test_ingress.py
@@ -87,7 +87,7 @@ def perform_request(host, context, protocol, port, plane):
 @then(parsers.re(
     r"the server returns (?P<status_code>\d+) '(?P<reason>.+)'"),
     converters=dict(status_code=int))
-def server_returns(host, context, status_code, reason):
+def server_returns(host, context, status_code, reason, showpods):
     response = context.get('response')
     assert response is not None
     assert response.status_code == int(status_code)
@@ -95,7 +95,7 @@ def server_returns(host, context, status_code, reason):
 
 
 @then("the server should not respond")
-def server_does_not_respond(host, context):
+def server_does_not_respond(host, context, showpods):
     assert 'exception' in context
     assert isinstance(
         context['exception'] , requests.exceptions.ConnectionError)

--- a/tests/post/steps/test_salt_api.py
+++ b/tests/post/steps/test_salt_api.py
@@ -82,7 +82,7 @@ def login_salt_api(host, username, password, version, context, request):
 
 
 @then('we can ping all minions')
-def ping_all_minions(host, context):
+def ping_all_minions(host, context, showpods):
     result = requests.post(
         context['salt-api']['url'],
         json=[


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

**Summary**:

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1899 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
Test output
```
            if result.rc != 0:
                pytest.fail("Cannot resolve {}: {}".format(hostname, result.stderr))
>       pytest.fail("Dummy fail")
E       Failed: Dummy fail

tests/post/steps/test_dns.py:68: Failed
----------------------------- Captured stdout teardown ------------------------------
test failed! tests/post/steps/test_dns.py::test_dns[paramiko://bootstrap]
Running pods for namespace kube-system
calico-kube-controllers-6898dc8bd5-87xzm
calico-node-vjbgl
coredns-676c4dfdd9-6vzn9
coredns-676c4dfdd9-hq64c
etcd-bootstrap
kube-apiserver-bootstrap
kube-controller-manager-bootstrap
kube-proxy-zjrsk
kube-scheduler-bootstrap
repositories-bootstrap
salt-master-bootstrap
storage-operator-cccbfbf9-gtcm8
Running pods for namespace metalk8s-monitoring
alertmanager-prometheus-operator-alertmanager-0
prometheus-operator-grafana-6db87dcf6b-8qq65
prometheus-operator-kube-state-metrics-5ccc6d96ff-rqkp7
prometheus-operator-operator-5b597ff7b-ztl8x
prometheus-operator-prometheus-node-exporter-znlpx
prometheus-prometheus-operator-prometheus-0
Running pods for namespace metalk8s-ui
metalk8s-ui-854bf777c5-z4bwp
====================== 1 failed, 2 deselected in 12.63 seconds ======================
ERROR: InvocationError for command '/home/sayf/work/metalk8s/.tox/tests/bin/pytest --ssh-config=/home/sayf/work/metalk8s/.tox/tests/vagrant_ssh_config --hosts=bootstrap --iso-root=/vagrant/_build/root -m post and not slow and not multinode -x tests' (exited with code 1)
______________________________________ summary ______________________________________
ERROR:   tests: commands failed
```