### PR TITLE
Allocate more RAM for the build step

### DIFF
--- a/eve/workers/pod-builder/pod.yaml
+++ b/eve/workers/pod-builder/pod.yaml
@@ -17,10 +17,10 @@ spec:
           # There's a limit of 4 CPUs, so we assign one to `doit`, and 3 to
           # Docker.
           cpu: "1"
-          memory: 1Gi
+          memory: 2Gi
         limits:
           cpu: "1"
-          memory: 1Gi
+          memory: 2Gi
       env:
         - name: DOCKER_HOST
           value: localhost:2375
@@ -32,10 +32,10 @@ spec:
       resources:
         requests:
           cpu: "3"
-          memory: 2Gi
+          memory: 3Gi
         limits:
           cpu: "3"
-          memory: 2Gi
+          memory: 3Gi
       env:
         - name: DOCKER_TLS_CERTDIR
           value: ''


### PR DESCRIPTION
**Component**:

ci

**Context**: 

Flaky build likely due to memory pressure.

**Summary**:

Bump the amound of requested memory.

**Acceptance criteria**: 

No more failure when building the doc in the CI

---

Closes: #1872