### PR TITLE
test: Add retry when checking pod state

### DIFF
--- a/tests/post/steps/conftest.py
+++ b/tests/post/steps/conftest.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 from pytest_bdd import given, parsers
 
-from tests import kube_utils
+from tests import kube_utils, utils
 
 
 # Given {{{
@@ -9,9 +9,22 @@ from tests import kube_utils
 @given(parsers.parse("pods with label '{label}' are '{state}'"))
 def check_pod_state(request, host, k8s_client, label, state):
     ssh_config = request.config.getoption('--ssh-config')
-    pods = kube_utils.get_pods(
-        k8s_client, ssh_config, label,
-        namespace="kube-system", state="Running",
+
+    # Helper to use retry utils
+    def _wait_for_state():
+        pods = kube_utils.get_pods(
+            k8s_client, ssh_config, label,
+            namespace="kube-system", state="Running"
+        )
+        assert pods
+        return pods
+
+    # Wait for pod to be in the correct state
+    pods = utils.retry(
+        _wait_for_state,
+        times=12,
+        wait=5,
+        name="wait for pods with label '{}'".format(label)
     )
 
     assert pods, "No {} pod with label '{}' found".format(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -14,7 +14,7 @@ LOGGER = logging.getLogger(__name__)
 def retry(operation, times=1, wait=1, error_msg=None, name="default"):
     for idx in range(times):
         try:
-            operation()
+            res = operation()
         except AssertionError as exc:
             LOGGER.info(
                 "[%s] Attempt %d/%d failed: %s", name, idx, times, str(exc)
@@ -22,7 +22,7 @@ def retry(operation, times=1, wait=1, error_msg=None, name="default"):
             time.sleep(wait)
         else:
             LOGGER.info("[%s] Attempt %d/%d succeeded", name, idx, times)
-            break
+            return res
     else:
         if error_msg is None:
             error_msg = (


### PR DESCRIPTION

**Component**:

'tests'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

Time to time pod take time to get created/recreated so when launching test a test may fail if a pod is not fully ready

**Summary**:

Add a retry in `test/post/steps/conftest.py` when getting a pods with label

---

Fixes: #1907
