### PR TITLE
build/debian: Do not build repo if no package

### DIFF
--- a/packages/debian/entrypoint.sh
+++ b/packages/debian/entrypoint.sh
@@ -45,7 +45,9 @@ buildrepo() {
     cp /distributions /repository/conf
     sed -i 's/_REPONAME_/'"${reponame}"'/g' /repository/conf/distributions
     reprepro -b /repository/ export
-    reprepro -C "$reponame" -b /repository/ includedeb bionic /packages/*.deb
+    if ls /packages/*.deb ; then
+        reprepro -C "$reponame" -b /repository/ includedeb bionic /packages/*.deb
+    fi
     chown -R "${TARGET_UID}:${TARGET_GID}" /repository
 }
 


### PR DESCRIPTION
**Component**:

'build'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Summary**:

When building debian repo `metalk8s-bionic-security` we get an error
because repo has no `.deb` package.
```
Error 2 opening /packages/*.deb: No such file or directory
There have been errors!
```

---

Lets fix the build (and the queue) and investigate what need to be done here after 
