### PR TITLE
Change relative path for upgrade in development/2.4

### DIFF
--- a/salt/metalk8s/defaults.yaml
+++ b/salt/metalk8s/defaults.yaml
@@ -35,7 +35,7 @@ repo:
     registry: '90-registry-config.inc'
     common_registry: '99-registry-common.inc'
   local_mode: false
-  relative_path: packages/redhat  # relative to ISO root (configured in pillar)
+  relative_path: packages  # relative to ISO root (configured in pillar)
   port: 8080
   registry_endpoint: 'metalk8s-registry-from-config.invalid'
   repositories:

--- a/salt/metalk8s/repo/offline.sls
+++ b/salt/metalk8s/repo/offline.sls
@@ -13,12 +13,14 @@ Install yum-plugin-versionlock:
 
 {%- for repo_name, repo_config in repo.repositories.items() %}
   {%- if repo.local_mode %}
-    {%- set repo_base_url = "file://" ~ 
+    {%- set repo_base_url = "file://" ~
                             salt.metalk8s.get_archives()[saltenv].path ~ "/" ~
-                            repo.relative_path %}
+                            repo.relative_path ~ "/" ~
+                            grains['os_family'].lower() %}
   {%- else %}
-    {%- set repo_base_url = "http://" ~ repo_host ~ ':' ~ repo_port ~ 
-                            "/" ~ saltenv %}
+    {%- set repo_base_url = "http://" ~ repo_host ~ ':' ~ repo_port ~
+                            "/" ~ saltenv ~ "/" ~
+                            grains['os_family'].lower() %}
   {%- endif %}
   {%- set repo_url = repo_base_url ~ "/" ~ repo_name ~ "-el$releasever" %}
   {%- set gpg_keys = [] %}


### PR DESCRIPTION
**Component**: Salt

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: MetalK8s on Ubuntu

**Summary**: We need to change the relative path to permit the upgrade in the context of multi OS - Centos/Ubuntu

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #1728 

-->
