### PR TITLE
Backport: kubernetes, salt: raise `salt-run` readiness probe timeout

### DIFF
--- a/salt/metalk8s/salt/master/files/salt-master-manifest.yaml.j2
+++ b/salt/metalk8s/salt/master/files/salt-master-manifest.yaml.j2
@@ -49,7 +49,7 @@ spec:
           - event.send
           - test
         periodSeconds: 20
-        timeoutSeconds: 2
+        timeoutSeconds: 10
         initialDelaySeconds: 10
       volumeMounts:
         - name: config


### PR DESCRIPTION
Oddly enough, the `ulimit` change of the next commit (cfr. #1785) causes
the readiness probe of the `salt-master` container (which runs `salt-run
event.send test` in the container) to timeout (i.e., not return
successfully within the currently configured timeout of 2s).

Not entirely sure why ¯\_(ツ)_/¯

However, on a somewhat loaded Salt system, such 2s timeout is way too
low anyway, at which point the system (e.g., our `ext_pillar` modules
that retrieve *Endpoints* of various *Services*, including the
`salt-master` one...) could start to behave oddly (which is how this was
detected in the first place).

As such, bumping the timeout to a (hopefully) more reasonable 10
seconds.

See: #1785
See: https://github.com/scality/metalk8s/issues/1785
(cherry picked from commit b1553dbac02a605417da8ecc9f753585f4098834)

---

Fixes: #1918 
