### PR TITLE
Vagrant/ubuntu: Add a repo update on Ubuntu VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -152,6 +152,7 @@ if ! grep -Fxq "$(cat .ssh/#{PRESHARED_SSH_KEY_NAME}.pub)" .ssh/authorized_keys 
 fi
 SCRIPT
 
+UPDATE_REPO = 'DEBIAN_FRONTEND=noninteractive apt update -yq'
 INSTALL_PYTHON = 'DEBIAN_FRONTEND=noninteractive apt install python -yq'
 
 # To support VirtualBox linked clones
@@ -204,6 +205,11 @@ Vagrant.configure("2") do |config|
       name: 'ubuntu/bionic64',
       version: '20190514.0.0',
       scripts: [
+        {
+          name: 'update-repository-list',
+          type: 'shell',
+          data: UPDATE_REPO,
+        },
         {
           name: 'install-python',
           type: 'shell',
@@ -265,6 +271,9 @@ Vagrant.configure("2") do |config|
           inline: DEPLOY_SSH_PUBLIC_KEY
 
         if os == :ubuntu
+          node.vm.provision "update-repository-list",
+            type: "shell",
+            inline: UPDATE_REPO
           node.vm.provision "install-python",
             type: "shell",
             inline: INSTALL_PYTHON


### PR DESCRIPTION
**Component**: Vagrant

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**:  MetalK8s on Ubuntu

**Summary**: We need to install Python2.7 on the Ubuntu VM that we deploy with Vangrant.
Sometimes, some packages are moved to a Canonical repo to another one.
To avoid to have an error during the python2.7 installation, we want to
do an update.

**Acceptance criteria**: 
- build the iso: `./doit.sh`
- generate ssh key: `./doit.sh _vagrantkey`
- launch a Ubuntu VM creation `vagrant up ubuntu1`

Verify that the provision is well done, with no error


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #1931 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
