### PR TITLE
tests/logs: Fix name of helper method

### DIFF
--- a/tests/post/steps/test_logs.py
+++ b/tests/post/steps/test_logs.py
@@ -38,7 +38,7 @@ def check_logs(k8s_client):
             if pod.status.phase != pod_status:
                 # Wait for the Pod to be ready
                 utils.retry(
-                    kube_utils.wait_for_pod(
+                    kube_utils.check_pod_status(
                         k8s_client,
                         name=pod_name,
                         namespace=namespace,


### PR DESCRIPTION
The helper method `wait_for_pod`, from `tests.kube_utils`, was renamed
in 5b82a73, but not taken into account by ce6ff39.