### PR TITLE
docs: Add repo configuration documentation

### DIFF
--- a/docs/quickstart/setup.rst
+++ b/docs/quickstart/setup.rst
@@ -4,6 +4,10 @@ Setup of the environment
 .. _MetalK8s: https://github.com/scality/metalk8s
 .. _CentOS: https://www.centos.org
 .. _RHEL: https://access.redhat.com/products/red-hat-enterprise-linux
+.. _RHSM register: https://access.redhat.com/solutions/253273
+.. _Enable Optional repositories with RHSM: https://access.redhat.com/solutions/392003
+.. _Configure repositories with YUM: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/sec-configuring_yum_and_yum_repositories#sec-Managing_Yum_Repositories
+.. _Advanced repositories configuration: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/sec-configuring_yum_and_yum_repositories#sec-Setting_repository_Options
 
 General requirements
 --------------------
@@ -49,6 +53,64 @@ networks can overlap, and nodes need not have distinct IPs for each plane.
 
 In order to reach the cluster-provided UIs from your host, the host needs to be
 able to connect to workload-plane IPs of the machines.
+
+Repositories provisioning
+^^^^^^^^^^^^^^^^^^^^^^^^^
+Each machine needs to have repositories properly configured and having access
+to basic repository packages (depending on the operating systems).
+
+CentOS_:
+
+    - base
+    - extras
+    - updates
+
+RHEL_:
+
+    - rhel-7-server-rpms
+    - rhel-7-server-extras-rpms
+    - rhel-7-server-optional-rpms
+
+    .. note::
+
+        For RHEL_ you should have
+        `a system properly registered <RHSM register_>`_.
+
+.. note::
+
+    The repository names and configurations do not necessarily need to be the
+    same as the official ones but all packages must be made available.
+
+Enable an existing repository:
+
+    CentOS_:
+
+        .. code-block:: shell
+
+            yum-config-manager --enable <repo_name>
+
+    RHEL_:
+
+        .. code-block:: shell
+
+            subscription-manager repos --enable=<repo_name>
+
+Add a new repository:
+
+    .. code-block:: shell
+
+        yum-config-manager --add-repo <repo_url>
+
+    .. note::
+
+        `repo_url` can be remote url using prefix `http://`, `https://`,
+        `ftp://`, ... or a local path using `file://`.
+
+For more detail(s), refer to the official documentation:
+
+    - `Enable Optional repositories with RHSM`_
+    - `Configure repositories with YUM`_
+    - `Advanced repositories configuration`_
 
 
 Example OpenStack deployment


### PR DESCRIPTION
**Component**:

'docs'

**Context**: 

We no longer include "base", "extras" and "updates" repositories in the
builded ISO this changes is introduced by the RedHat support PR as we
don't want to include all RHEL packages.
So we need a documentation to explain how to configure
repositories on the differents machine RHEL and CentOS.We no longer include "base", "extras" and "updates" repositories in the
builded ISO this changes is introduced by the RedHat support PR as we
don't want to include all RHEL packages.

**Summary**:

Documentation to explain how to configure
repositories on the differents machine RHEL and CentOS.

---

Refs: #1552
Fixes: #1939
