### PR TITLE
docs: Add enable IP-in-IP encapsulation

### DIFF
--- a/docs/operation/enable_ip_ip.rst
+++ b/docs/operation/enable_ip_ip.rst
@@ -1,0 +1,22 @@
+.. _enable IP-in-IP:
+
+Enable IP-in-IP encapsulation
+=============================
+
+.. _IP-in-IP: https://en.wikipedia.org/wiki/IP_in_IP
+.. _Calico: https://docs.projectcalico.org/
+.. _IP-in-IP Calico configuration: https://docs.projectcalico.org/v3.7/networking/vxlan-ipip
+
+By default Calico_ in MetalK8s is configured to use IP-in-IP_ encapsulation
+only for cross-subnet communication.
+
+To always use IP-in-IP_ encapsulation run the following command:
+
+.. code-block:: shell
+
+    $ kubectl --kubeconfig /etc/kubernetes/admin.conf \
+      patch ippool default-ipv4-ippool --type=merge \
+      --patch '{"spec": {"ipipMode": "Always"}}'
+
+
+For more details refer to `IP-in-IP Calico configuration`_.

--- a/docs/operation/index.rst
+++ b/docs/operation/index.rst
@@ -11,6 +11,7 @@ do not have a working MetalK8s_ setup.
 .. toctree::
 
    bootstrap_backup_restore
+   enable_ip_ip
    preparation
    upgrade
    downgrade

--- a/docs/quickstart/bootstrap.rst
+++ b/docs/quickstart/bootstrap.rst
@@ -104,6 +104,12 @@ Bootstrap node.
 
    root@bootstrap $ /srv/scality/metalk8s-|release|/bootstrap.sh
 
+.. warning::
+
+    In case of virtual network (or any network which enforces source and
+    destination fields of IP packets to correspond to the MAC address(es))
+    :ref:`IP-in-IP needs to be enabled<enable IP-in-IP>`.
+
 Provision storage for Prometheus services
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 After bootstrapping the cluster, the Prometheus and AlertManager services used


### PR DESCRIPTION
**Component**:

'docs'

**Context**: 

Currently Calico encapsulation method is not configurable before the
installation it's always "CrossSubnet" by default.

**Summary**:

Add documentation about how to enable IP-in-IP "Always".

---

Sees: #1234
Fixes: #1949
