### PR TITLE
docs: Add a "when" do we need IP-in-IP

### DIFF
--- a/docs/operation/enable_ip_ip.rst
+++ b/docs/operation/enable_ip_ip.rst
@@ -10,6 +10,9 @@ Enable IP-in-IP encapsulation
 By default Calico_ in MetalK8s is configured to use IP-in-IP_ encapsulation
 only for cross-subnet communication.
 
+IP-in-IP_ is needed for any network which enforces source and
+destination fields of IP packets to correspond to the MAC address(es).
+
 To always use IP-in-IP_ encapsulation run the following command:
 
 .. code-block:: shell


### PR DESCRIPTION
**Component**:

'docs'

**Summary**:

Add a description about when we need to use `IP-in-IP`.
https://github.com/scality/metalk8s/pull/1951#issuecomment-545902611

---

Sees: #1951 
Fixes: #1949 
