### PR TITLE
UI: Add cluster status warning before provisioning the volume in Prometheus

### DIFF
--- a/ui/src/containers/ClusterMonitoring.js
+++ b/ui/src/containers/ClusterMonitoring.js
@@ -28,6 +28,9 @@ import { sortSelector } from '../services/utils';
 import NoRowsRenderer from '../components/NoRowsRenderer';
 import Banner from '../components/Banner';
 
+const VOLUME_PROVISION_DOC_REFERENCE =
+  'MetalK8s Quickstart Guide > Deployment of the Bootstrap node > Installation > Provision storage for Prometheus services';
+
 const PageContainer = styled.div`
   box-sizing: border-box;
   display: flex;
@@ -258,12 +261,10 @@ const ClusterMonitoring = props => {
         <Banner
           type={STATUS_BANNER_WARNING}
           icon={<i className="fas fa-exclamation-triangle" />}
-          title={'Prometheus is not available.'}
+          title={intl.messages.prometheus_not_available}
           messages={[
             <>
-              {
-                'Please refer to MetalK8s Quickstart Guide > Deployment of the Bootstrap node > Installation > Provision storage for Prometheus services'
-              }
+              {`${intl.messages.please_refer_to} ${VOLUME_PROVISION_DOC_REFERENCE}`}
             </>,
           ]}
         />

--- a/ui/src/containers/ClusterMonitoring.js
+++ b/ui/src/containers/ClusterMonitoring.js
@@ -255,9 +255,7 @@ const ClusterMonitoring = props => {
           </Tooltip>
         </RightClusterStatusContainer>
       </ClusterStatusTitleContainer>
-      {clusterStatus.value === CLUSTER_STATUS_UNKNOWN &&
-      cluster.prometheusPodStatusMessage ===
-        `0/1 nodes are available: 1 node(s) didn't find available persistent volumes to bind.` ? (
+      {cluster.isPrometheusVolumeProvisioned ? null : (
         <Banner
           type={STATUS_BANNER_WARNING}
           icon={<i className="fas fa-exclamation-triangle" />}
@@ -268,7 +266,7 @@ const ClusterMonitoring = props => {
             </>,
           ]}
         />
-      ) : null}
+      )}
       <PageSubtitle>
         {intl.messages.alerts}
         {alerts.isLoading ? <LoaderCoreUI size="small" /> : null}
@@ -308,7 +306,7 @@ const makeClusterStatus = (state, props) => {
     value = CLUSTER_STATUS_DOWN;
     label = intl.messages[cluster.error] || cluster.error;
   }
-  if (cluster.prometheusPodStatusMessage) {
+  if (!state.app.monitoring.isPrometheusApiUp) {
     value = CLUSTER_STATUS_UNKNOWN;
     label = intl.messages[cluster.error] || cluster.error;
   }

--- a/ui/src/containers/ClusterMonitoring.js
+++ b/ui/src/containers/ClusterMonitoring.js
@@ -17,10 +17,16 @@ import {
   stopRefreshClusterStatusAction,
   CLUSTER_STATUS_UP,
   CLUSTER_STATUS_DOWN,
+  CLUSTER_STATUS_UNKNOWN,
 } from '../ducks/app/monitoring';
-import { STATUS_CRITICAL, STATUS_SUCCESS } from '../constants';
+import {
+  STATUS_CRITICAL,
+  STATUS_SUCCESS,
+  STATUS_BANNER_WARNING,
+} from '../constants';
 import { sortSelector } from '../services/utils';
 import NoRowsRenderer from '../components/NoRowsRenderer';
+import Banner from '../components/Banner';
 
 const PageContainer = styled.div`
   box-sizing: border-box;
@@ -78,8 +84,16 @@ const RightClusterStatusContainer = styled.div`
 const ClusterStatusValue = styled.span`
   margin: 0 ${padding.small};
   font-weight: bold;
-  color: ${props =>
-    props.isUp ? props.theme.brand.success : props.theme.brand.danger};
+  color: ${props => {
+    switch (props.value) {
+      case CLUSTER_STATUS_UNKNOWN:
+        return props.theme.brand.warning;
+      case CLUSTER_STATUS_UP:
+        return props.theme.brand.success;
+      default:
+        return props.theme.brand.danger;
+    }
+  }};
 `;
 
 const QuestionMarkIcon = styled.i`
@@ -187,7 +201,7 @@ const ClusterMonitoring = props => {
       <ClusterStatusTitleContainer>
         <LeftClusterStatusContainer>
           <PageSubtitle>{intl.messages.cluster_status + ' :'}</PageSubtitle>
-          <ClusterStatusValue isUp={clusterStatus.value === CLUSTER_STATUS_UP}>
+          <ClusterStatusValue value={clusterStatus.value}>
             {clusterStatus.label}
           </ClusterStatusValue>
           <Tooltip
@@ -238,7 +252,22 @@ const ClusterMonitoring = props => {
           </Tooltip>
         </RightClusterStatusContainer>
       </ClusterStatusTitleContainer>
-
+      {clusterStatus.value === CLUSTER_STATUS_UNKNOWN &&
+      cluster.prometheusPodStatusMessage ===
+        `0/1 nodes are available: 1 node(s) didn't find available persistent volumes to bind.` ? (
+        <Banner
+          type={STATUS_BANNER_WARNING}
+          icon={<i className="fas fa-exclamation-triangle" />}
+          title={'Prometheus is not available.'}
+          messages={[
+            <>
+              {
+                'Please refer to MetalK8s Quickstart Guide > Deployment of the Bootstrap node > Installation > Provision storage for Prometheus services'
+              }
+            </>,
+          ]}
+        />
+      ) : null}
       <PageSubtitle>
         {intl.messages.alerts}
         {alerts.isLoading ? <LoaderCoreUI size="small" /> : null}
@@ -266,7 +295,6 @@ const makeClusterStatus = (state, props) => {
   const cluster = state.app.monitoring.cluster;
   let label = intl.messages.down;
   let value = CLUSTER_STATUS_DOWN;
-
   if (
     cluster.apiServerStatus > 0 &&
     cluster.kubeSchedulerStatus > 0 &&
@@ -275,12 +303,14 @@ const makeClusterStatus = (state, props) => {
     value = CLUSTER_STATUS_UP;
     label = intl.messages.cluster_up_and_running;
   }
-
   if (cluster.error) {
     value = CLUSTER_STATUS_DOWN;
     label = intl.messages[cluster.error] || cluster.error;
   }
-
+  if (cluster.prometheusPodStatusMessage) {
+    value = CLUSTER_STATUS_UNKNOWN;
+    label = intl.messages[cluster.error] || cluster.error;
+  }
   return { value, label, isLoading: cluster.isLoading };
 };
 

--- a/ui/src/ducks/app/monitoring.js
+++ b/ui/src/ducks/app/monitoring.js
@@ -105,7 +105,7 @@ export function* handlePrometheusError(clusterHealth, result) {
         c => c.type === 'PodScheduled',
       );
       if (
-        scheduledCondition.message.includes(
+        scheduledCondition?.message?.includes(
           `didn't find available persistent volumes to bind`,
         )
       ) {

--- a/ui/src/ducks/app/monitoring.js
+++ b/ui/src/ducks/app/monitoring.js
@@ -1,6 +1,7 @@
 import { put, takeEvery, call, all, delay, select } from 'redux-saga/effects';
 import { getAlerts, queryPrometheus } from '../../services/prometheus/api';
 import { REFRESH_TIMEOUT } from '../../constants';
+import * as ApiK8s from '../../services/k8s/api';
 
 const REFRESH_CLUSTER_STATUS = 'REFRESH_CLUSTER_STATUS';
 const STOP_REFRESH_CLUSTER_STATUS = 'STOP_REFRESH_CLUSTER_STATUS';
@@ -12,6 +13,7 @@ export const UPDATE_ALERTS = 'UPDATE_ALERTS';
 
 export const CLUSTER_STATUS_UP = 'CLUSTER_STATUS_UP';
 export const CLUSTER_STATUS_DOWN = 'CLUSTER_STATUS_DOWN';
+export const CLUSTER_STATUS_UNKNOWN = 'CLUSTER_STATUS_UNKNOWN ';
 
 export const SET_PROMETHEUS_API_AVAILABLE = 'SET_PROMETHEUS_API_AVAILABLE';
 
@@ -20,17 +22,18 @@ const defaultState = {
     list: [],
     error: null,
     isLoading: false,
-    isRefreshing: false
+    isRefreshing: false,
   },
   cluster: {
     apiServerStatus: 0,
     kubeSchedulerStatus: 0,
     kubeControllerManagerStatus: 0,
     error: null,
+    prometheusPodStatusMessage: null,
     isLoading: false,
-    isRefreshing: false
+    isRefreshing: false,
   },
-  isPrometheusApiUp: false
+  isPrometheusApiUp: false,
 };
 
 export default function(state = defaultState, action = {}) {
@@ -42,7 +45,7 @@ export default function(state = defaultState, action = {}) {
     case UPDATE_CLUSTER_STATUS:
       return {
         ...state,
-        cluster: { ...state.cluster, ...action.payload }
+        cluster: { ...state.cluster, ...action.payload },
       };
     default:
       return state;
@@ -90,6 +93,9 @@ export function* handleClusterError(clusterHealth, result) {
   if (result.error.response) {
     yield put(setPrometheusApiAvailable(true));
     clusterHealth.error = `Prometheus - ${result.error.response.statusText}`;
+  } else if (clusterHealth.prometheusPodStatusMessage) {
+    yield put(setPrometheusApiAvailable(false));
+    clusterHealth.error = 'Unknown';
   } else {
     yield put(setPrometheusApiAvailable(false));
     clusterHealth.error = 'prometheus_unavailable';
@@ -102,7 +108,8 @@ export function* fetchClusterStatus() {
     apiServerStatus: 0,
     kubeSchedulerStatus: 0,
     kubeControllerManagerStatus: 0,
-    error: null
+    error: null,
+    prometheusPodStatusMessage: null,
   };
 
   const apiserverQuery = 'sum(up{job="apiserver"})';
@@ -112,7 +119,7 @@ export function* fetchClusterStatus() {
   const results = yield all([
     call(queryPrometheus, apiserverQuery),
     call(queryPrometheus, kubeSchedulerQuery),
-    call(queryPrometheus, kubeControllerManagerQuery)
+    call(queryPrometheus, kubeControllerManagerQuery),
   ]);
 
   const errorResult = results.find(result => result.error);
@@ -121,14 +128,31 @@ export function* fetchClusterStatus() {
     clusterHealth.apiServerStatus = getClusterQueryStatus(results[0]);
     clusterHealth.kubeSchedulerStatus = getClusterQueryStatus(results[1]);
     clusterHealth.kubeControllerManagerStatus = getClusterQueryStatus(
-      results[2]
+      results[2],
     );
     yield put(setPrometheusApiAvailable(true));
   } else {
+    const prometheusPod = yield call(
+      ApiK8s.getPodInNamespace,
+      'metalk8s-monitoring',
+      'prometheus',
+    );
+    if (!prometheusPod.error) {
+      const prometheusPodCondition =
+        prometheusPod?.body?.items[0]?.status?.conditions[0]?.type;
+      if (prometheusPodCondition === 'PodScheduled') {
+        clusterHealth.prometheusPodStatusMessage =
+          prometheusPod?.body?.items[0]?.status?.conditions[0]?.message;
+      } else {
+        console.error('This is an error in the cluster.');
+      }
+    } else {
+      console.error('Cannot find the Prometheus pod.');
+    }
     yield call(handleClusterError, clusterHealth, errorResult);
   }
   yield put(updateClusterStatusAction(clusterHealth));
-  yield delay(1000); // To make sur that the loader is visible for at least 1s
+  yield delay(1000); // To make sure that the loader is visible for at least 1s
   yield put(updateClusterStatusAction({ isLoading: false }));
   return errorResult;
 }
@@ -138,7 +162,7 @@ export function* fetchAlerts() {
   const resultAlerts = yield call(getAlerts);
   let alert = {
     list: [],
-    error: null
+    error: null,
   };
 
   if (!resultAlerts.error) {
@@ -148,7 +172,7 @@ export function* fetchAlerts() {
     yield call(handleClusterError, alert, resultAlerts);
   }
   yield put(updateAlertsAction(alert));
-  yield delay(1000); // To make sur that the loader is visible for at least 1s
+  yield delay(1000); // To make sure that the loader is visible for at least 1s
   yield put(updateAlertsAction({ isLoading: false }));
   return resultAlerts;
 }
@@ -159,7 +183,7 @@ export function* refreshAlerts() {
   if (!resultAlerts.error) {
     yield delay(REFRESH_TIMEOUT);
     const isRefreshing = yield select(
-      state => state.app.monitoring.alert.isRefreshing
+      state => state.app.monitoring.alert.isRefreshing,
     );
     if (isRefreshing) {
       yield call(refreshAlerts);
@@ -177,7 +201,7 @@ export function* refreshClusterStatus() {
   if (!errorResult) {
     yield delay(REFRESH_TIMEOUT);
     const isRefreshing = yield select(
-      state => state.app.monitoring.cluster.isRefreshing
+      state => state.app.monitoring.cluster.isRefreshing,
     );
     if (isRefreshing) {
       yield call(refreshClusterStatus);

--- a/ui/src/ducks/app/monitoring.test.js
+++ b/ui/src/ducks/app/monitoring.test.js
@@ -11,6 +11,7 @@ import {
 } from './monitoring';
 import { REFRESH_TIMEOUT } from '../../constants';
 import { queryPrometheus, getAlerts } from '../../services/prometheus/api';
+import * as ApiK8s from '../../services/k8s/api';
 
 const alertsResult = {
   data: {
@@ -289,7 +290,7 @@ it('should set cluster status as DOWN because api-server value is []', () => {
   );
 });
 
-it('should set cluster error if a query failed', () => {
+it('should set cluster error if a query failed and it is not due to Prometheus volume provision', () => {
   const gen = fetchClusterStatus();
   expect(gen.next().value).toEqual(
     put({

--- a/ui/src/ducks/app/monitoring.test.js
+++ b/ui/src/ducks/app/monitoring.test.js
@@ -7,7 +7,7 @@ import {
   fetchAlerts,
   fetchClusterStatus,
   refreshAlerts,
-  refreshClusterStatus
+  refreshClusterStatus,
 } from './monitoring';
 import { REFRESH_TIMEOUT } from '../../constants';
 import { queryPrometheus, getAlerts } from '../../services/prometheus/api';
@@ -27,19 +27,19 @@ const alertsResult = {
           pod: 'kube-state-metrics-6f76945b5b-g9mtf',
           service: 'kube-state-metrics',
           severity: 'warning',
-          status: 'true'
+          status: 'true',
         },
         annotations: {
           message: 'node1 has been unready for more than an hour.',
           runbook_url:
-            'https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodenotready'
+            'https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodenotready',
         },
         state: 'firing',
         activeAt: '2019-06-27T06:10:17.588420806Z',
-        value: 0
-      }
-    ]
-  }
+        value: 0,
+      },
+    ],
+  },
 };
 
 it('should set cluster status as UP', () => {
@@ -47,8 +47,8 @@ it('should set cluster status as UP', () => {
   expect(gen.next().value).toEqual(
     put({
       type: UPDATE_CLUSTER_STATUS,
-      payload: { isLoading: true }
-    })
+      payload: { isLoading: true },
+    }),
   );
   const result = [
     {
@@ -58,10 +58,10 @@ it('should set cluster status as UP', () => {
         result: [
           {
             metric: {},
-            value: [1561562554.553, '1']
-          }
-        ]
-      }
+            value: [1561562554.553, '1'],
+          },
+        ],
+      },
     },
     {
       status: 'success',
@@ -70,10 +70,10 @@ it('should set cluster status as UP', () => {
         result: [
           {
             metric: {},
-            value: [1561562554.611, '1']
-          }
-        ]
-      }
+            value: [1561562554.611, '1'],
+          },
+        ],
+      },
     },
     {
       status: 'success',
@@ -82,25 +82,25 @@ it('should set cluster status as UP', () => {
         result: [
           {
             metric: {},
-            value: [1561562554.559, '1']
-          }
-        ]
-      }
-    }
+            value: [1561562554.559, '1'],
+          },
+        ],
+      },
+    },
   ];
 
   expect(gen.next().value).toEqual(
     all([
       call(queryPrometheus, 'sum(up{job="apiserver"})'),
       call(queryPrometheus, 'sum(up{job="kube-scheduler"})'),
-      call(queryPrometheus, 'sum(up{job="kube-controller-manager"})')
-    ])
+      call(queryPrometheus, 'sum(up{job="kube-controller-manager"})'),
+    ]),
   );
   expect(gen.next(result).value).toEqual(
     put({
       type: SET_PROMETHEUS_API_AVAILABLE,
-      payload: true
-    })
+      payload: true,
+    }),
   );
   expect(gen.next(result).value).toEqual(
     put({
@@ -109,16 +109,17 @@ it('should set cluster status as UP', () => {
         apiServerStatus: 1,
         kubeControllerManagerStatus: 1,
         kubeSchedulerStatus: 1,
-        error: null
-      }
-    })
+        error: null,
+        prometheusPodStatusMessage: null,
+      },
+    }),
   );
   expect(gen.next().value).toEqual(delay(1000));
   expect(gen.next().value).toEqual(
     put({
       type: UPDATE_CLUSTER_STATUS,
-      payload: { isLoading: false }
-    })
+      payload: { isLoading: false },
+    }),
   );
 });
 
@@ -127,8 +128,8 @@ it('should set cluster status as DOWN because there is no kube-controller-manage
   expect(gen.next().value).toEqual(
     put({
       type: UPDATE_CLUSTER_STATUS,
-      payload: { isLoading: true }
-    })
+      payload: { isLoading: true },
+    }),
   );
   const result = [
     {
@@ -138,10 +139,10 @@ it('should set cluster status as DOWN because there is no kube-controller-manage
         result: [
           {
             metric: {},
-            value: [1561562554.553, '1']
-          }
-        ]
-      }
+            value: [1561562554.553, '1'],
+          },
+        ],
+      },
     },
     {
       status: 'success',
@@ -150,10 +151,10 @@ it('should set cluster status as DOWN because there is no kube-controller-manage
         result: [
           {
             metric: {},
-            value: [1561562554.611, '1']
-          }
-        ]
-      }
+            value: [1561562554.611, '1'],
+          },
+        ],
+      },
     },
     {
       status: 'success',
@@ -162,26 +163,26 @@ it('should set cluster status as DOWN because there is no kube-controller-manage
         result: [
           {
             metric: {},
-            value: [1561562554.559, '0']
-          }
-        ]
-      }
-    }
+            value: [1561562554.559, '0'],
+          },
+        ],
+      },
+    },
   ];
 
   expect(gen.next().value).toEqual(
     all([
       call(queryPrometheus, 'sum(up{job="apiserver"})'),
       call(queryPrometheus, 'sum(up{job="kube-scheduler"})'),
-      call(queryPrometheus, 'sum(up{job="kube-controller-manager"})')
-    ])
+      call(queryPrometheus, 'sum(up{job="kube-controller-manager"})'),
+    ]),
   );
 
   expect(gen.next(result).value).toEqual(
     put({
       type: SET_PROMETHEUS_API_AVAILABLE,
-      payload: true
-    })
+      payload: true,
+    }),
   );
 
   expect(gen.next(result).value).toEqual(
@@ -191,16 +192,17 @@ it('should set cluster status as DOWN because there is no kube-controller-manage
         apiServerStatus: 1,
         kubeControllerManagerStatus: 0,
         kubeSchedulerStatus: 1,
-        error: null
-      }
-    })
+        error: null,
+        prometheusPodStatusMessage: null,
+      },
+    }),
   );
   expect(gen.next().value).toEqual(delay(1000));
   expect(gen.next().value).toEqual(
     put({
       type: UPDATE_CLUSTER_STATUS,
-      payload: { isLoading: false }
-    })
+      payload: { isLoading: false },
+    }),
   );
 });
 
@@ -209,8 +211,8 @@ it('should set cluster status as DOWN because api-server value is []', () => {
   expect(gen.next().value).toEqual(
     put({
       type: UPDATE_CLUSTER_STATUS,
-      payload: { isLoading: true }
-    })
+      payload: { isLoading: true },
+    }),
   );
   const result = [
     {
@@ -220,10 +222,10 @@ it('should set cluster status as DOWN because api-server value is []', () => {
         result: [
           {
             metric: {},
-            value: []
-          }
-        ]
-      }
+            value: [],
+          },
+        ],
+      },
     },
     {
       status: 'success',
@@ -232,10 +234,10 @@ it('should set cluster status as DOWN because api-server value is []', () => {
         result: [
           {
             metric: {},
-            value: [1561562554.611, '1']
-          }
-        ]
-      }
+            value: [1561562554.611, '1'],
+          },
+        ],
+      },
     },
     {
       status: 'success',
@@ -244,26 +246,26 @@ it('should set cluster status as DOWN because api-server value is []', () => {
         result: [
           {
             metric: {},
-            value: [1561562554.559, '1']
-          }
-        ]
-      }
-    }
+            value: [1561562554.559, '1'],
+          },
+        ],
+      },
+    },
   ];
 
   expect(gen.next().value).toEqual(
     all([
       call(queryPrometheus, 'sum(up{job="apiserver"})'),
       call(queryPrometheus, 'sum(up{job="kube-scheduler"})'),
-      call(queryPrometheus, 'sum(up{job="kube-controller-manager"})')
-    ])
+      call(queryPrometheus, 'sum(up{job="kube-controller-manager"})'),
+    ]),
   );
 
   expect(gen.next(result).value).toEqual(
     put({
       type: SET_PROMETHEUS_API_AVAILABLE,
-      payload: true
-    })
+      payload: true,
+    }),
   );
 
   expect(gen.next(result).value).toEqual(
@@ -273,16 +275,17 @@ it('should set cluster status as DOWN because api-server value is []', () => {
         apiServerStatus: 0,
         kubeControllerManagerStatus: 1,
         kubeSchedulerStatus: 1,
-        error: null
-      }
-    })
+        error: null,
+        prometheusPodStatusMessage: null,
+      },
+    }),
   );
   expect(gen.next().value).toEqual(delay(1000));
   expect(gen.next().value).toEqual(
     put({
       type: UPDATE_CLUSTER_STATUS,
-      payload: { isLoading: false }
-    })
+      payload: { isLoading: false },
+    }),
   );
 });
 
@@ -291,8 +294,8 @@ it('should set cluster error if a query failed', () => {
   expect(gen.next().value).toEqual(
     put({
       type: UPDATE_CLUSTER_STATUS,
-      payload: { isLoading: true }
-    })
+      payload: { isLoading: true },
+    }),
   );
   const result = [
     {
@@ -302,10 +305,10 @@ it('should set cluster error if a query failed', () => {
         result: [
           {
             metric: {},
-            value: []
-          }
-        ]
-      }
+            value: [],
+          },
+        ],
+      },
     },
     {
       status: 'success',
@@ -314,26 +317,26 @@ it('should set cluster error if a query failed', () => {
         result: [
           {
             metric: {},
-            value: [1561562554.611, '1']
-          }
-        ]
-      }
+            value: [1561562554.611, '1'],
+          },
+        ],
+      },
     },
     {
       error: {
         response: {
-          statusText: 'Bad Request'
-        }
-      }
-    }
+          statusText: 'Bad Request',
+        },
+      },
+    },
   ];
 
   expect(gen.next().value).toEqual(
     all([
       call(queryPrometheus, 'sum(up{job="apiserver"})'),
       call(queryPrometheus, 'sum(up{job="kube-scheduler"})'),
-      call(queryPrometheus, 'sum(up{job="kube-controller-manager"})')
-    ])
+      call(queryPrometheus, 'sum(up{job="kube-controller-manager"})'),
+    ]),
   );
 
   expect(gen.next(result).value).toEqual(
@@ -343,10 +346,11 @@ it('should set cluster error if a query failed', () => {
         apiServerStatus: 0,
         error: null,
         kubeControllerManagerStatus: 0,
-        kubeSchedulerStatus: 0
+        kubeSchedulerStatus: 0,
+        prometheusPodStatusMessage: null,
       },
-      { error: { response: { statusText: 'Bad Request' } } }
-    )
+      { error: { response: { statusText: 'Bad Request' } } },
+    ),
   );
 
   expect(gen.next(result).value).toEqual(
@@ -356,16 +360,17 @@ it('should set cluster error if a query failed', () => {
         apiServerStatus: 0,
         kubeControllerManagerStatus: 0,
         kubeSchedulerStatus: 0,
-        error: null
-      }
-    })
+        error: null,
+        prometheusPodStatusMessage: null,
+      },
+    }),
   );
   expect(gen.next().value).toEqual(delay(1000));
   expect(gen.next().value).toEqual(
     put({
       type: UPDATE_CLUSTER_STATUS,
-      payload: { isLoading: false }
-    })
+      payload: { isLoading: false },
+    }),
   );
 });
 
@@ -375,8 +380,8 @@ it('should handleClusterError when prometheus is up', () => {
   expect(gen.next().value).toEqual(
     put({
       type: SET_PROMETHEUS_API_AVAILABLE,
-      payload: true
-    })
+      payload: true,
+    }),
   );
 });
 
@@ -386,8 +391,8 @@ it('should handleClusterError when prometheus is down', () => {
   expect(gen.next().value).toEqual(
     put({
       type: SET_PROMETHEUS_API_AVAILABLE,
-      payload: false
-    })
+      payload: false,
+    }),
   );
 });
 
@@ -396,8 +401,8 @@ it('should refresh Alerts if no error', () => {
   expect(gen.next().value).toEqual(
     put({
       type: UPDATE_ALERTS,
-      payload: { isRefreshing: true }
-    })
+      payload: { isRefreshing: true },
+    }),
   );
   expect(gen.next().value).toEqual(call(fetchAlerts));
   expect(gen.next({}).value).toEqual(delay(REFRESH_TIMEOUT));
@@ -410,8 +415,8 @@ it('should stop refresh Alerts', () => {
   expect(gen.next().value).toEqual(
     put({
       type: UPDATE_ALERTS,
-      payload: { isRefreshing: true }
-    })
+      payload: { isRefreshing: true },
+    }),
   );
   expect(gen.next().value).toEqual(call(fetchAlerts));
   expect(gen.next({}).value).toEqual(delay(REFRESH_TIMEOUT));
@@ -424,8 +429,8 @@ it('should not refresh Alerts if error', () => {
   expect(gen.next().value).toEqual(
     put({
       type: UPDATE_ALERTS,
-      payload: { isRefreshing: true }
-    })
+      payload: { isRefreshing: true },
+    }),
   );
   expect(gen.next().value).toEqual(call(fetchAlerts));
   expect(gen.next({ error: '404' }).done).toEqual(true);
@@ -436,8 +441,8 @@ it('should refresh ClusterStatus if no error', () => {
   expect(gen.next().value).toEqual(
     put({
       type: UPDATE_CLUSTER_STATUS,
-      payload: { isRefreshing: true }
-    })
+      payload: { isRefreshing: true },
+    }),
   );
   expect(gen.next().value).toEqual(call(fetchClusterStatus));
   expect(gen.next().value).toEqual(delay(REFRESH_TIMEOUT));
@@ -450,8 +455,8 @@ it('should stop refresh ClusterStatus', () => {
   expect(gen.next().value).toEqual(
     put({
       type: UPDATE_CLUSTER_STATUS,
-      payload: { isRefreshing: true }
-    })
+      payload: { isRefreshing: true },
+    }),
   );
   expect(gen.next().value).toEqual(call(fetchClusterStatus));
   expect(gen.next().value).toEqual(delay(REFRESH_TIMEOUT));
@@ -464,9 +469,89 @@ it('should not refresh ClusterStatus if error', () => {
   expect(gen.next().value).toEqual(
     put({
       type: UPDATE_CLUSTER_STATUS,
-      payload: { isRefreshing: true }
-    })
+      payload: { isRefreshing: true },
+    }),
   );
   expect(gen.next().value).toEqual(call(fetchClusterStatus));
   expect(gen.next({ error: '404' }).done).toEqual(true);
+});
+
+it('should set the unknown status for cluster when there is no provision volume', () => {
+  const gen = fetchClusterStatus();
+  expect(gen.next().value).toEqual(
+    put({
+      type: UPDATE_CLUSTER_STATUS,
+      payload: { isLoading: true },
+    }),
+  );
+  const result = [{ error: '504' }];
+
+  expect(gen.next().value).toEqual(
+    all([
+      call(queryPrometheus, 'sum(up{job="apiserver"})'),
+      call(queryPrometheus, 'sum(up{job="kube-scheduler"})'),
+      call(queryPrometheus, 'sum(up{job="kube-controller-manager"})'),
+    ]),
+  );
+
+  expect(gen.next(result).value).toEqual(
+    call(ApiK8s.getPodInNamespace, 'metalk8s-monitoring', 'prometheus'),
+  );
+
+  const prometheusPod = {
+    body: {
+      items: [
+        {
+          status: {
+            conditions: [
+              {
+                status: 'False',
+                reason: 'Unschedulable',
+                type: 'PodScheduled',
+                message:
+                  "0/1 nodes are available: 1 node(s) didn't find available persistent volumes to bind.",
+              },
+            ],
+          },
+        },
+      ],
+      kind: 'PodList',
+    },
+    response: {},
+  };
+
+  expect(gen.next(prometheusPod).value).toEqual(
+    call(
+      handleClusterError,
+      {
+        apiServerStatus: 0,
+        kubeControllerManagerStatus: 0,
+        kubeSchedulerStatus: 0,
+        error: null,
+        prometheusPodStatusMessage: `0/1 nodes are available: 1 node(s) didn't find available persistent volumes to bind.`,
+      },
+      { error: '504' },
+    ),
+  );
+
+  expect(gen.next(result).value).toEqual(
+    put({
+      type: UPDATE_CLUSTER_STATUS,
+      payload: {
+        apiServerStatus: 0,
+        kubeControllerManagerStatus: 0,
+        kubeSchedulerStatus: 0,
+        error: null,
+        prometheusPodStatusMessage: `0/1 nodes are available: 1 node(s) didn't find available persistent volumes to bind.`,
+      },
+    }),
+  );
+  expect(gen.next().value).toEqual(delay(1000));
+  expect(gen.next().value).toEqual(
+    put({
+      type: UPDATE_CLUSTER_STATUS,
+      payload: { isLoading: false },
+    }),
+  );
+  expect(gen.next().done).toEqual(true);
 });

--- a/ui/src/services/k8s/api.js
+++ b/ui/src/services/k8s/api.js
@@ -183,3 +183,18 @@ export async function createEnvironment(body) {
     return { error };
   }
 }
+
+export async function getPodInNamespace(namespace, podLabel) {
+  try {
+    return await coreV1.listNamespacedPod(
+      namespace,
+      null,
+      null,
+      null,
+      null,
+      `app=${podLabel}`,
+    );
+  } catch (error) {
+    return { error };
+  }
+}

--- a/ui/src/services/k8s/api.js
+++ b/ui/src/services/k8s/api.js
@@ -184,7 +184,7 @@ export async function createEnvironment(body) {
   }
 }
 
-export async function getPodInNamespace(namespace, podLabel) {
+export async function queryPodInNamespace(namespace, podLabel) {
   try {
     return await coreV1.listNamespacedPod(
       namespace,

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -128,5 +128,7 @@
   "labels": "Labels",
   "enter_label_name": "Enter label name",
   "enter_label_value": "Enter label value",
-  "value": "Value"
+  "value": "Value",
+  "prometheus_not_available":"Prometheus is not available.",
+  "please_refer_to":"Please refer to"
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -128,5 +128,7 @@
   "labels": "Labels",
   "enter_label_name": "Saisir le nom du label",
   "enter_label_value": "Saisir la valeur du label",
-  "value": "Valeur"
+  "value": "Valeur",
+  "prometheus_not_available":"Prometheus n'est pas disponible.",
+  "please_refer_to":"Veuillez vous référer à"
 }


### PR DESCRIPTION
**Component**: ui/monitoring

**Context**:  
As a TS user, I would like to know how to deal with the error status of the cluster(no volume provisioned for Prometheus pod) instead of the red state of Prometheus.

**Summary**:

- Add the `Unknown` status for the cluster when there isn't provision volume for Prometheus. 

- Add a warning banner to explain the status `Prometheus is not available.` and how to deal with the issue which should refer the position of the doc.

**Acceptance criteria**: 
In order to reproduce the issue, you can simply comment on the following line in `Vagrantfile` and then do `vagrant up` so that we won't provision any volume during deploy the bootstrap node.
```
machine.vm.provision "create-volumes",
type: "shell",
inline: CREATE_VOLUMES
```
When you go to the monitoring page, you will wait a moment(until the api timeout) and get the following page.
![image](https://user-images.githubusercontent.com/18453133/68218040-fbe10d00-ffe3-11e9-8c2d-aed84e02e68e.png)

Closes: #1890
