### PR TITLE
Add .final_status to artifacts

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -311,6 +311,11 @@ stages:
     steps:
       - ShellCommand: *wait_for_docker
       - Git: *git_pull
+      - ShellCommand:
+          <<: *add_final_status_artifact_failed
+          env:
+            <<: *_env_final_status_artifact_failed
+            STEP_NAME: build
       - ShellCommand: *setup_cache
       - ShellCommand: *build_all
       - ShellCommand:
@@ -323,6 +328,12 @@ stages:
               _build/SHA256SUM
               _build/root/product.txt
       - Upload: *upload_artifacts
+      - ShellCommand:
+          <<: *add_final_status_artifact_success
+          env:
+            <<: *_env_final_status_artifact_success
+            STEP_NAME: build
+      - Upload: *upload_final_status_artifact
 
   docs:
     worker:

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -345,6 +345,11 @@ stages:
           dockerfile: docs/Dockerfile
     steps:
       - Git: *git_pull
+      - ShellCommand:
+          <<: *add_final_status_artifact_failed
+          env:
+            <<: *_env_final_status_artifact_failed
+            STEP_NAME: docs
       - ShellCommand: *setup_cache
       - ShellCommand:
           name: Build documentation
@@ -358,6 +363,12 @@ stages:
           source: docs/_build
           urls:
             - ['docs/\1', '*']
+      - ShellCommand:
+          <<: *add_final_status_artifact_success
+          env:
+            <<: *_env_final_status_artifact_success
+            STEP_NAME: docs
+      - Upload: *upload_final_status_artifact
 
   lint:
     worker:

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -407,6 +407,11 @@ stages:
       path: eve/workers/openstack-single-node
     steps:
       - Git: *git_pull
+      - ShellCommand:
+          <<: *add_final_status_artifact_failed
+          env:
+            <<: *_env_final_status_artifact_failed
+            STEP_NAME: single-node
       - ShellCommand: *setup_cache
       - ShellCommand: *ssh_ip_setup
       # --- Retrieve ISO ---
@@ -439,6 +444,12 @@ stages:
           env:
             DEST_DIR: sosreport/sosreport/single-node-downgrade
       - Upload: *upload_report_artifacts
+      - ShellCommand:
+          <<: *add_final_status_artifact_success
+          env:
+            <<: *_env_final_status_artifact_success
+            STEP_NAME: single-node
+      - Upload: *upload_final_status_artifact
       - ShellCommand:
           <<: *wait_debug
           env:

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -378,12 +378,23 @@ stages:
         docker-linter: eve/workers/pod-linter
     steps:
       - Git: *git_pull
+      - ShellCommand:
+          <<: *add_final_status_artifact_failed
+          env:
+            <<: *_env_final_status_artifact_failed
+            STEP_NAME: lint
       - ShellCommand: *setup_cache
       - ShellCommand:
           name: Run all linting targets
           command: ./doit.sh lint
           usePTY: true
           haltOnFailure: false
+      - ShellCommand:
+          <<: *add_final_status_artifact_success
+          env:
+            <<: *_env_final_status_artifact_success
+            STEP_NAME: lint
+      - Upload: *upload_final_status_artifact
 
   single-node:
     worker: &single_node_worker

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -288,6 +288,7 @@ stages:
     worker:
       type: local
     steps:
+      - ShellCommand: *add_final_status_artifact_failed
       - TriggerStages:
           name: Trigger build, docs and lint stages simultaneously
           stage_names:
@@ -301,6 +302,8 @@ stages:
           stage_names:
             - single-node
             - multiple-nodes
+      - ShellCommand: *add_final_status_artifact_success
+      - Upload: *upload_final_status_artifact
 
   build:
     worker: &build_worker

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -462,6 +462,11 @@ stages:
       path: eve/workers/openstack-multiple-nodes
     steps:
       - Git: *git_pull
+      - ShellCommand:
+          <<: *add_final_status_artifact_failed
+          env:
+            <<: *_env_final_status_artifact_failed
+            STEP_NAME: multiple-nodes
       - ShellCommand: *setup_cache
       - ShellCommand: *ssh_ip_setup
       - ShellCommand: *retrieve_iso
@@ -663,6 +668,12 @@ stages:
             done
           alwaysRun: true
       - Upload: *upload_report_artifacts
+      - ShellCommand:
+          <<: *add_final_status_artifact_success
+          env:
+            <<: *_env_final_status_artifact_success
+            STEP_NAME: multiple-nodes
+      - Upload: *upload_final_status_artifact
       - ShellCommand:
           <<: *wait_debug
           timeout: 14400

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -254,6 +254,34 @@ models:
         tox -e tests -- -m \"${PYTEST_FILTERS}\""
       workdir: build/eve/workers/openstack-multiple-nodes/terraform/
       haltOnFailure: true
+  - ShellCommand: &add_final_status_artifact
+      name: Add final status to artifacts
+      command: |-
+        bash -c '
+          declare -r BUILD_STATUS_DIR=build_status/build_status/${STEP_NAME:-}
+          mkdir -p "$BUILD_STATUS_DIR"
+          echo -n "$FINAL_STATUS" > "$BUILD_STATUS_DIR/.final_status"
+        '
+      env: &_env_final_status_artifact
+        STEP_NAME: ''
+        FINAL_STATUS: ''
+      haltOnFailure: True
+  - ShellCommand: &add_final_status_artifact_success
+      <<: *add_final_status_artifact
+      name: Add successful status to artifacts
+      env: &_env_final_status_artifact_success
+        <<: *_env_final_status_artifact
+        FINAL_STATUS: "SUCCESSFUL"
+  - ShellCommand: &add_final_status_artifact_failed
+      <<: *add_final_status_artifact
+      name: Add failed status to artifacts
+      env: &_env_final_status_artifact_failed
+        <<: *_env_final_status_artifact
+        FINAL_STATUS: "FAILED"
+  - Upload: &upload_final_status_artifact
+      name: Upload final status to artifacts
+      source: build_status
+      alwaysRun: True
 
 stages:
   pre-merge:


### PR DESCRIPTION
**Component**: ci

**Summary**: Add .final_status containing whether SUCCESSFUL or FAILED depending if the step successfully ended or not, for each build step in the CI

**Acceptance criteria**: Green build & build_status directory presence in artifacts with .final_status files for all steps  


---

Closes: #1985
