### PR TITLE
Deploy dex in metalk8s from helm charts

### DIFF
--- a/buildchain/buildchain/constants.py
+++ b/buildchain/buildchain/constants.py
@@ -19,6 +19,7 @@ CMD_WIDTH : int = 14
 # URLs of the main container repositories.
 CALICO_REPOSITORY     : str = 'quay.io/calico'
 COREOS_REPOSITORY     : str = 'quay.io/coreos'
+DEX_REPOSITORY        : str = 'quay.io/dexidp'
 DOCKER_REPOSITORY     : str = 'docker.io/library'
 GOOGLE_REPOSITORY     : str = 'k8s.gcr.io'
 GRAFANA_REPOSITORY    : str = 'docker.io/grafana'

--- a/buildchain/buildchain/image.py
+++ b/buildchain/buildchain/image.py
@@ -170,6 +170,9 @@ IMGS_PER_REPOSITORY : Dict[str, List[str]] = {
         'prometheus-config-reloader',
         'prometheus-operator',
     ],
+    constants.DEX_REPOSITORY: [
+        'dex',
+    ],
     constants.DOCKER_REPOSITORY: [
         'nginx',
     ],

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -216,6 +216,16 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
         renderer=targets.Renderer.JSON,
     ),
 
+    Path('salt/metalk8s/addons/dex/ca/init.sls'),
+    Path('salt/metalk8s/addons/dex/ca/installed.sls'),
+    Path('salt/metalk8s/addons/dex/ca/advertised.sls'),
+    Path('salt/metalk8s/addons/dex/certs/init.sls'),
+    Path('salt/metalk8s/addons/dex/certs/server.sls'),
+    Path('salt/metalk8s/addons/dex/deployed/chart.sls'),
+    Path('salt/metalk8s/addons/dex/deployed/init.sls'),
+    Path('salt/metalk8s/addons/dex/deployed/namespace.sls'),
+    Path('salt/metalk8s/addons/dex/deployed/tls-secret.sls'),
+
     Path('salt/metalk8s/addons/prometheus-operator/deployed/chart.sls'),
     Path('salt/metalk8s/addons/prometheus-operator/deployed/cleanup.sls'),
     Path('salt/metalk8s/addons/prometheus-operator/deployed/dashboards.sls'),

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -225,6 +225,7 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/addons/dex/deployed/init.sls'),
     Path('salt/metalk8s/addons/dex/deployed/namespace.sls'),
     Path('salt/metalk8s/addons/dex/deployed/tls-secret.sls'),
+    Path('salt/metalk8s/addons/dex/deployed/clusterrolebinding.sls'),
 
     Path('salt/metalk8s/addons/prometheus-operator/deployed/chart.sls'),
     Path('salt/metalk8s/addons/prometheus-operator/deployed/cleanup.sls'),

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -292,6 +292,8 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/addons/nginx-ingress-control-plane/deployed/chart.sls'),
     Path('salt/metalk8s/addons/nginx-ingress-control-plane/deployed/',
          'tls-secret.sls'),
+    Path('salt/metalk8s/addons/nginx-ingress-control-plane/',
+         'control-plane-ip.sls'),
 
     Path('salt/metalk8s/container-engine/containerd/configured.sls'),
     Path('salt/metalk8s/container-engine/containerd/files/50-metalk8s.conf'),

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -104,6 +104,11 @@ CONTAINER_IMAGES : Tuple[Image, ...] = (
         digest='sha256:02382353821b12c21b062c59184e227e001079bb13ebd01f9d3270ba0fcbf1e4',
     ),
     Image(
+        name='dex',
+        version='v2.19.0',
+        digest='sha256:132523cc3e9402a5e12c3b7d837da6f0c96d8a05f27bf6ba42458c2a0d1c01f5',
+    ),
+    Image(
         name='etcd',
         version='3.3.15-0',
         digest='sha256:12c2c5e5731c3bcd56e6f1c05c0f9198b6f06793fa7fca2fb43aab9622dc4afa',

--- a/charts/dex.yaml
+++ b/charts/dex.yaml
@@ -1,0 +1,94 @@
+image: '{% endraw %}{{ build_image_name(\"dex\", False) }}{% raw %}'
+
+nodeSelector:
+  node-role.kubernetes.io/infra: ''
+
+tolerations:
+  - key: "node-role.kubernetes.io/bootstrap"
+    operator: "Exists"
+    effect: "NoSchedule"
+  - key: "node-role.kubernetes.io/infra"
+    operator: "Exists"
+    effect: "NoSchedule"
+
+replicas: 2
+
+# grpc support
+grpc: false
+
+# https termination by dex itself
+https: true
+
+service:
+  clusterIP: '{% endraw %}{{ salt.metalk8s_network.get_oidc_service_ip() }}{% raw %}'
+
+ingress:
+  enabled: true
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    kubernetes.io/ingress.class: "nginx-control-plane"
+  path: /oidc
+  hosts:
+    - null
+
+# extraVolumes:
+#   - name: theme
+#     configMap:
+#        name: dex-branding
+
+# extraVolumeMounts:
+#   - name: theme
+#     mountPath: /web/themes/custom/
+
+certs:
+  web:
+    create: false
+  grpc:
+    create: false
+
+config:
+  issuer: '{% endraw %}https://{{ grains.metalk8s.control_plane_ip }}:8443/oidc{% raw %}'
+  web:
+    tlsCert: /etc/dex/tls/https/server/tls.crt
+    tlsKey: /etc/dex/tls/https/server/tls.key
+  frontend:
+    theme: "coreos" #metalk8s-ui
+    # dir: /web/themes/custom/
+
+  connectors: {}
+
+  oauth2:
+    alwaysShowLoginScreen: true
+    skipApprovalScreen: true
+    responseTypes: ["code", "token", "id_token"]
+
+  expiry:
+    signingKeys: "6h"
+    idTokens: "24h"
+
+  staticClients:
+  - id: oidc-auth-client
+    redirectURIs:
+    - 'urn:ietf:wg:oauth:2.0:oob'
+    name: 'oidc-auth-client'
+    secret: "lkfa9jaf3kfakqyeoikfjakf93k2l"
+    trustedPeers:
+    - metalk8s-ui
+    - grafana-ui
+  - id: metalk8s-ui
+    redirectURIs:
+    - '{% endraw %}https://{{ grains.metalk8s.control_plane_ip }}:8443/oauth2/callback{% raw %}'
+    name: 'MetalK8s UI'
+    secret: "ybrMJpVMQxsiZw26MhJzCjA2ut"
+  - id: grafana-ui
+    name: 'Grafana UI'
+    redirectURIs:
+    - '{% endraw %}https://{{ grains.metalk8s.control_plane_ip }}:8443/grafana/login/generic_oauth{% raw %}'
+    secret: "4lqK98NcsWG5qBRHJUqYM1"
+
+  staticPasswords:
+    - email: "admin@metalk8s.invalid"
+      # bcrypt hash of the string "password"
+      hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+      username: "admin"
+      userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"

--- a/charts/dex/.helmignore
+++ b/charts/dex/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+appVersion: 2.19.0
+description: CoreOS Dex
+home: https://github.com/dexidp/dex/
+icon: https://github.com/dexidp/dex/raw/master/Documentation/logos/dex-glyph-color.png
+keywords:
+- dex
+- oidc
+maintainers:
+- email: Kevin.Fox@pnnl.gov
+  name: kfox1111
+- email: shane.starcher@gmail.com
+  name: sstarcher
+- email: pete.brown@powerhrg.com
+  name: rendhalver
+- email: vi7alya@gmail.com
+  name: vi7
+name: dex
+version: 2.4.0

--- a/charts/dex/OWNERS
+++ b/charts/dex/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- desaintmartin
+- vi7
+reviewers:
+- desaintmartin
+- vi7

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -1,0 +1,102 @@
+# dex
+
+[Dex][dex] is an identity service that uses OpenID Connect to drive authentication for other apps.
+
+## Introduction
+
+Dex acts as a portal to other identity providers through "connectors." This lets dex defer authentication to LDAP servers, SAML providers, or established identity providers like GitHub, Google, and Active Directory. Clients write their authentication logic once to talk to dex, then dex handles the protocols for a given backend.
+
+**Kubernetes authentication note**
+
+If you plan to use dex as a [Kubernetes OpenID Connect token authenticator plugin](http://kubernetes.io/docs/admin/authentication/#openid-connect-tokens) you'll need to additionally deploy some helper app which will provide authentication UI for users and talk to dex.
+
+Several helper apps are listed below:
+  - https://github.com/mintel/dex-k8s-authenticator
+  - https://github.com/heptiolabs/gangway
+  - https://github.com/micahhausler/k8s-oidc-helper
+  - https://github.com/negz/kuberos
+  - https://github.com/negz/kubehook
+  - https://github.com/fydrah/loginapp
+  - https://github.com/keycloak/keycloak
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```sh
+$ helm install --name my-release stable/dex
+```
+
+It'll install chart with the default parameters. However most probably it won't work for you as-is, thus before installing the chart you need to consult to the [values.yaml](values.yaml) notes as well as [dex documentation][dex].
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```sh
+$ helm delete --purge my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Upgrading an existing release to a new major version
+
+A major chart version change (like v1.5.1 -> v2.0.0) indicates that there is an incompatible breaking change which requires manual actions.
+
+### Upgrade to v2.0.0
+
+Breaking changes which should be considered and require manual actions during release upgrade:
+
+- ability to switch grpc and https on and off via dedicated chart parameters
+- port definition for Pod, Service and dex config re-written from scratch
+- dex config is _not_ taken from `.Values.config` as-is anymore, pay attention!
+
+See the [Configuration](#configuration) section for the details on the parameters introduced in version 2.0.0.
+
+Moreover, this release updates all the labels to the new [recommended labels](https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md#names-and-labels), most of them being immutable.
+
+In order to upgrade, please update your values file and uninstall/reinstall the chart.
+
+## Configuration
+
+Parameters introduced starting from v2
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `certs.grpc.pod.annotations` | Annotations for the pod created by the `grpc-certs` job | `{}` |
+| `certs.web.pod.annotations` | Annotations for the pod created by the `web-certs` job | `{}` |
+| `config.connectors` | Maps to the dex config `connectors` dict param | `{}` |
+| `config.enablePasswordDB` | Maps to the dex config `enablePasswordDB` param | `true` |
+| `config.frontend` | Maps to the dex config `frontend` dict param | `""` |
+| `config.grpc.address` | dex grpc listen address | `127.0.0.1` |
+| `config.grpc.tlsCert` | Maps to the dex config `grpc.tlsCert` param | `/etc/dex/tls/grpc/server/tls.crt` |
+| `config.grpc.tlsClientCA` | Maps to the dex config `grpc.tlsClientCA` param | `/etc/dex/tls/grpc/ca/tls.crt` |
+| `config.grpc.tlsKey` | Maps to the dex config `grpc.tlsKey` param | `/etc/dex/tls/grpc/server/tls.key` |
+| `config.issuer` | Maps to the dex config `issuer` param | `http://dex.io:8080` |
+| `config.logger` | Maps to the dex config `logger` dict param | `{"level": "debug"}` |
+| `config.oauth2.alwaysShowLoginScreen` | Maps to the dex config `oauth2.alwaysShowLoginScreen` param | `false` |
+| `config.oauth2.skipApprovalScreen` | Maps to the dex config `oauth2.skipApprovalScreen` param | `true` |
+| `config.staticClients` | Maps to the dex config `staticClients` list param | `""` |
+| `config.staticPasswords` | Maps to the dex config `staticPasswords` list param | `""` |
+| `config.storage` | Maps to the dex config `storage` dict param | `{"type": "kubernetes", "config": {"inCluster": true}}` |
+| `config.web.address` | dex http/https listen address | `0.0.0.0` |
+| `config.web.tlsCert` | Maps to the dex config `web.tlsCert` param | `/etc/dex/tls/https/server/tls.crt` |
+| `config.web.tlsKey` | Maps to the dex config `web.tlsKey` param | `/etc/dex/tls/https/server/tls.key` |
+| `config.expiry.signingKeys` | Maps to the dex config `expiry.signingKeys` param | `6h` |
+| `config.expiry.idTokens` | Maps to the dex config `expiry.idTokens` param | `24h` |
+| `grpc` | Enable dex grpc endpoint | `true` |
+| `https` | Enable TLS termination for the dex http endpoint | `false` |
+| `ports.grpc.containerPort` | grpc port listened by the dex | `5000` |
+| `ports.grpc.nodePort` | K8S Service node port for the dex grpc listener | `35000` |
+| `ports.grpc.servicePort` | K8S Service port for the dex grpc listener | `35000` |
+| `ports.web.containerPort` | http/https port listened by the dex | `5556` |
+| `ports.web.nodePort` | K8S Service node port for the dex http/https listener | `32000` |
+| `ports.web.servicePort` | K8S Service port for the dex http/https listener | `32000` |
+| `service.loadBalancerIP` | IP override for K8S LoadBalancer Service | `""` |
+
+
+
+Check [values.yaml](values.yaml) notes together with [dex documentation][dex] and [config examples](https://github.com/dexidp/dex/tree/master/examples) for all the possible configuration options.
+
+
+[dex]: https://github.com/dexidp/dex

--- a/charts/dex/config/openssl.conf
+++ b/charts/dex/config/openssl.conf
@@ -1,0 +1,82 @@
+# OpenSSL configuration file.
+# Adapted from https://github.com/coreos/matchbox/blob/master/examples/etc/matchbox/openssl.conf
+
+# default environment variable values
+SAN =
+
+[ ca ]
+# `man ca`
+default_ca = CA_default
+
+[ CA_default ]
+# Directory and file locations.
+dir               = .
+certs             = $dir/certs
+crl_dir           = $dir/crl
+new_certs_dir     = $dir/newcerts
+database          = $dir/index.txt
+serial            = $dir/serial
+# certificate revocation lists.
+crlnumber         = $dir/crlnumber
+crl               = $dir/crl/intermediate-ca.crl
+crl_extensions    = crl_ext
+default_crl_days  = 30
+default_md        = sha256
+
+name_opt          = ca_default
+cert_opt          = ca_default
+default_days      = 375
+preserve          = no
+policy            = policy_loose
+
+[ policy_loose ]
+# Allow the CA to sign a range of certificates.
+countryName             = optional
+stateOrProvinceName     = optional
+localityName            = optional
+organizationName        = optional
+organizationalUnitName  = optional
+commonName              = supplied
+emailAddress            = optional
+
+[ req ]
+# `man req`
+default_bits        = 4096
+distinguished_name  = req_distinguished_name
+string_mask         = utf8only
+default_md          = sha256
+
+[ req_distinguished_name ]
+countryName                    = Country Name (2 letter code)
+stateOrProvinceName            = State or Province Name
+localityName                   = Locality Name
+0.organizationName             = Organization Name
+organizationalUnitName         = Organizational Unit Name
+commonName                     = Common Name
+
+# Certificate extensions (`man x509v3_config`)
+
+[ v3_ca ]
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints = critical, CA:true, pathlen:0
+keyUsage = critical, digitalSignature, cRLSign, keyCertSign
+
+[ usr_cert ]
+basicConstraints = CA:FALSE
+nsCertType = client
+nsComment = "OpenSSL Generated Client Certificate"
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer
+keyUsage = critical, nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = clientAuth
+
+[ server_cert ]
+basicConstraints = CA:FALSE
+nsCertType = server
+nsComment = "OpenSSL Generated Server Certificate"
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer:always
+keyUsage = critical, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = $ENV::SAN

--- a/charts/dex/templates/NOTES.txt
+++ b/charts/dex/templates/NOTES.txt
@@ -1,0 +1,20 @@
+1. Get the application URL by running these commands:
+
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "dex.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo https://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "dex.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "dex.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo https://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "dex.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit https://127.0.0.1:8080/.well-known/openid-configuration to use your application"
+  kubectl port-forward $POD_NAME 8080:5556
+{{- end }}

--- a/charts/dex/templates/_helpers.tpl
+++ b/charts/dex/templates/_helpers.tpl
@@ -1,0 +1,56 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "dex.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "dex.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "dex.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "dex.labels" -}}
+app.kubernetes.io/name: {{ include "dex.name" . }}
+helm.sh/chart: {{ include "dex.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "dex.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "dex.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/dex/templates/clusterrole.yaml
+++ b/charts/dex/templates/clusterrole.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+{{ include "dex.labels" . | indent 4 }}
+  name: {{ template "dex.fullname" . }}
+rules:
+- apiGroups: ["dex.coreos.com"] # API group created by dex
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["create"] # To manage its own resources, dex must be able to create customresourcedefinitions
+{{- end -}}

--- a/charts/dex/templates/clusterrolebinding.yaml
+++ b/charts/dex/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+{{ include "dex.labels" . | indent 4 }}
+  name: {{ template "dex.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "dex.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "dex.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/dex/templates/config-openssl.yaml
+++ b/charts/dex/templates/config-openssl.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.grpc .Values.certs.grpc.create }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+{{ include "dex.labels" . | indent 4 }}
+  name: {{ template "dex.fullname" . }}-openssl-config
+data:
+  openssl.conf: |
+{{ .Files.Get "config/openssl.conf" | indent 4 }}
+{{- end }}

--- a/charts/dex/templates/deployment.yaml
+++ b/charts/dex/templates/deployment.yaml
@@ -1,0 +1,114 @@
+{{ $fullname := include "dex.fullname" . }}
+{{ $httpsTlsBuiltName := printf "%s-tls" $fullname }}
+{{ $httpsTlsSecretName := default $httpsTlsBuiltName .Values.certs.web.secret.tlsName }}
+{{ $grpcTlsServerBuiltName := printf "%s-server-tls" $fullname }}
+{{ $grpcTlsServerSecretName := default $grpcTlsServerBuiltName .Values.certs.grpc.secret.serverTlsName }}
+{{ $grpcCaBuiltName := printf "%s-ca" $fullname }}
+{{ $grpcCaSecretName := default $grpcCaBuiltName .Values.certs.grpc.secret.caName }}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "dex.fullname" . }}
+  labels:
+{{ include "dex.labels" . | indent 4 }}
+    app.kubernetes.io/component: dex
+spec:
+  replicas: {{ .Values.replicas }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "dex.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: dex
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "dex.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: dex
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ template "dex.serviceAccountName" . }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 10 }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      containers:
+      - name: main
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        command:
+        - /usr/local/bin/dex
+        - serve
+        - /etc/dex/cfg/config.yaml
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        ports:
+        - name: {{ if .Values.https }}https{{ else }}http{{ end }}
+          containerPort: {{ .Values.ports.web.containerPort }}
+          protocol: TCP
+        {{- if .Values.grpc }}
+        - name: grpc
+          containerPort: {{ .Values.ports.grpc.containerPort }}
+          protocol: TCP
+        {{- end }}
+        env:
+{{ toYaml .Values.env | indent 10 }}
+        volumeMounts:
+        - mountPath: /etc/dex/cfg
+          name: config
+{{- if .Values.https }}
+        - mountPath: /etc/dex/tls/https/server
+          name: https-tls
+{{- end }}
+{{- if .Values.grpc }}
+        - mountPath: /etc/dex/tls/grpc/server
+          name: grpc-tls-server
+        - mountPath: /etc/dex/tls/grpc/ca
+          name: grpc-tls-ca
+{{- end }}
+{{- if ne (len .Values.extraVolumeMounts) 0 }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
+{{- end }}
+      volumes:
+      - secret:
+          defaultMode: 420
+          items:
+          - key: config.yaml
+            path: config.yaml
+          secretName: {{ template "dex.fullname" . }}
+        name: config
+{{- if .Values.https }}
+      - name: https-tls
+        secret:
+          defaultMode: 420
+          secretName: {{ $httpsTlsSecretName | quote }}
+{{- end }}
+{{- if .Values.grpc }}
+      - name: grpc-tls-server
+        secret:
+          defaultMode: 420
+          secretName: {{ $grpcTlsServerSecretName | quote }}
+      - name: grpc-tls-ca
+        secret:
+          defaultMode: 420
+          secretName: {{ $grpcCaSecretName| quote }}
+{{- end }}
+{{- if ne (len .Values.extraVolumes) 0 }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+{{- end }}

--- a/charts/dex/templates/ingress.yaml
+++ b/charts/dex/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "dex.fullname" . -}}
+{{- $servicePort := .Values.ports.web.servicePort -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+{{ include "dex.labels" . | indent 4 }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $servicePort }}
+  {{- end }}
+{{- end }}

--- a/charts/dex/templates/job-grpc-certs.yaml
+++ b/charts/dex/templates/job-grpc-certs.yaml
@@ -1,0 +1,108 @@
+{{- if and .Values.grpc .Values.certs.grpc.create }}
+{{ $fullname := include "dex.fullname" . }}
+{{ $tlsServerBuiltName := printf "%s-server-tls" $fullname }}
+{{ $tlsServerSecretName := default $tlsServerBuiltName .Values.certs.grpc.secret.serverTlsName }}
+{{ $tlsClientBuiltName := printf "%s-client-tls" $fullname }}
+{{ $tlsClientSecretName := default $tlsClientBuiltName .Values.certs.grpc.secret.clientTlsName }}
+{{ $caBuiltName := printf "%s-ca" $fullname }}
+{{ $caName := default $caBuiltName .Values.certs.grpc.secret.caName }}
+{{ $openSslConfigName := printf "%s-openssl-config" $fullname }}
+{{ $local := dict "i" 0 }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": hook-succeeded
+  name: {{ $fullname }}-grpc-certs
+  labels:
+{{ include "dex.labels" . | indent 4 }}
+    app.kubernetes.io/component: "job-grpc-certs"
+spec:
+  activeDeadlineSeconds: {{ .Values.certs.grpc.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "dex.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: "job-grpc-certs"
+{{- if .Values.certs.grpc.pod.annotations }}
+      annotations:
+{{ toYaml .Values.certs.grpc.pod.annotations | trim | indent 8 }}
+{{- end }}
+    spec:
+      {{- if .Values.certs.securityContext.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.certs.securityContext.runAsUser }}
+        fsGroup: {{ .Values.certs.securityContext.fsGroup }}
+      {{- end }}
+      serviceAccountName: {{ template "dex.serviceAccountName" . }}
+      restartPolicy: OnFailure
+      containers:
+      - name: main
+        image: "{{ .Values.certs.image }}:{{ .Values.certs.imageTag }}"
+        imagePullPolicy: {{ .Values.certs.imagePullPolicy }}
+        env:
+        - name: HOME
+          value: /tmp
+        workingDir: /tmp
+        command:
+        - /bin/bash
+        - -exc
+        - |
+          export CONFIG=/etc/dex/tls/grpc/openssl.conf;
+          cat << EOF > san.cnf
+          {{- $_ := set $local "i" 1 }}
+          {{- range .Values.certs.grpc.altNames }}
+          DNS.{{ $local.i }}:{{ . }}
+          {{- $_ := set $local "i" ( add1 $local.i ) }}
+          {{- end }}
+          {{- $_ := set $local "i" 1 }}
+          {{- range .Values.certs.grpc.altIPs }}
+          IP.{{ $local.i }}:{{ . }}
+          {{- $_ := set $local "i" ( add1 $local.i ) }}
+          {{- end }}
+          EOF
+          export SAN=$(cat san.cnf |  paste -sd "," -)
+
+          # Creating basic files/directories
+          mkdir -p {certs,crl,newcerts}
+          touch index.txt
+          touch index.txt.attr
+          echo 1000 > serial
+          # CA private key (unencrypted)
+          openssl genrsa -out ca.key 4096;
+          # Certificate Authority (self-signed certificate)
+          openssl req -config $CONFIG -new -x509 -days 3650 -sha256 -key ca.key -extensions v3_ca -out ca.crt -subj "/CN=grpc-ca";
+          # Server private key (unencrypted)
+          openssl genrsa -out server.key 2048;
+          # Server certificate signing request (CSR)
+          openssl req -config $CONFIG -new -sha256 -key server.key -out server.csr -subj "/CN=grpc-server";
+          # Certificate Authority signs CSR to grant a certificate
+          openssl ca -batch -config $CONFIG  -extensions server_cert -days 365 -notext -md sha256 -in server.csr -out server.crt -cert ca.crt -keyfile ca.key;
+          # Client private key (unencrypted)
+          openssl genrsa -out client.key 2048;
+          # Signed client certificate signing request (CSR)
+          openssl req -config $CONFIG -new -sha256 -key client.key -out client.csr -subj "/CN=grpc-client";
+          # Certificate Authority signs CSR to grant a certificate
+          openssl ca -batch -config $CONFIG -extensions usr_cert -days 365 -notext -md sha256 -in client.csr -out client.crt -cert ca.crt -keyfile ca.key;
+          # Remove CSR's
+          rm *.csr;
+
+          # Cleanup the existing configmap and secrets
+          kubectl delete configmap {{ $caName }} --namespace {{ .Release.Namespace }} || true
+          kubectl delete secret {{ $caName }} {{ $tlsServerSecretName }} {{ $tlsClientSecretName }} --namespace {{ .Release.Namespace }} || true
+          kubectl create configmap {{ $caName }} --namespace {{ .Release.Namespace }} --from-file=ca.crt;
+          # Store all certficates in secrets
+          kubectl create secret tls {{ $caName }} --namespace {{ .Release.Namespace }} --cert=ca.crt --key=ca.key;
+          kubectl create secret tls {{ $tlsServerSecretName }} --namespace {{ .Release.Namespace }} --cert=server.crt --key=server.key;
+          kubectl create secret tls {{ $tlsClientSecretName }} --namespace {{ .Release.Namespace }} --cert=client.crt --key=client.key;
+        volumeMounts:
+        - name: openssl-config
+          mountPath: /etc/dex/tls/grpc
+      volumes:
+      - name: openssl-config
+        configMap:
+          name: {{ $openSslConfigName }}
+{{- end }}

--- a/charts/dex/templates/job-web-certs.yaml
+++ b/charts/dex/templates/job-web-certs.yaml
@@ -1,0 +1,99 @@
+{{- if .Values.certs.web.create }}
+{{ $fullname := include "dex.fullname" . }}
+{{ $tlsBuiltName := printf "%s-tls" $fullname }}
+{{ $tlsSecretName := default $tlsBuiltName .Values.certs.web.secret.tlsName }}
+{{ $caBuiltName := printf "%s-ca" $fullname }}
+{{ $caName := default $caBuiltName .Values.certs.web.secret.caName }}
+{{ $local := dict "i" 0 }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded
+  name: {{ $fullname  }}-web-certs
+  labels:
+{{ include "dex.labels" . | indent 4 }}
+    app.kubernetes.io/component: "job-web-certs"
+spec:
+  activeDeadlineSeconds: {{ .Values.certs.web.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "dex.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: "job"
+{{- if .Values.certs.web.pod.annotations }}
+      annotations:
+{{ toYaml .Values.certs.web.pod.annotations | trim | indent 8 }}
+{{- end }}
+    spec:
+      {{- if .Values.certs.securityContext.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.certs.securityContext.runAsUser }}
+        fsGroup: {{ .Values.certs.securityContext.fsGroup }}
+      {{- end }}
+      serviceAccountName: {{ template "dex.serviceAccountName" . }}
+      restartPolicy: OnFailure
+      containers:
+      - name: main
+        image: "{{ .Values.certs.image }}:{{ .Values.certs.imageTag }}"
+        imagePullPolicy: {{ .Values.certs.imagePullPolicy }}
+        env:
+        - name: HOME
+          value: /tmp
+        workingDir: /tmp
+        command:
+        - /bin/bash
+        - -exc
+        - |
+          cat << EOF > req.cnf
+          [req]
+          req_extensions = v3_req
+          distinguished_name = req_distinguished_name
+
+          [req_distinguished_name]
+
+          [ v3_req ]
+          basicConstraints = CA:FALSE
+          keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+          subjectAltName = @alt_names
+
+          [alt_names]
+          {{- $_ := set $local "i" 1 }}
+          {{- range .Values.certs.web.altNames }}
+          DNS.{{ $local.i }} = {{ . }}
+          {{- $_ := set $local "i" ( add1 $local.i ) }}
+          {{- end }}
+          {{- $_ := set $local "i" 1 }}
+          {{- range .Values.certs.web.altIPs }}
+          IP.{{ $local.i }} = {{ . }}
+          {{- $_ := set $local "i" ( add1 $local.i ) }}
+          {{- end }}
+          EOF
+
+          openssl genrsa -out ca-key.pem 2048;
+          openssl req -x509 -new -nodes -key ca-key.pem -days {{ .Values.certs.web.caDays }} -out ca.pem -subj "/CN=dex-ca";
+
+          openssl genrsa -out key.pem 2048;
+          openssl req -new -key key.pem -out csr.pem -subj "/CN=dex" -config req.cnf;
+          openssl x509 -req -in csr.pem -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out cert.pem -days {{ .Values.certs.web.certDays }} -extensions v3_req -extfile req.cnf;
+
+          kubectl delete configmap {{ $caName | quote }} --namespace {{ .Release.Namespace }} || true
+          kubectl delete secret {{ $caName | quote }} {{ $tlsSecretName }} --namespace {{ .Release.Namespace }} || true
+
+          kubectl create configmap {{ $caName | quote }} --namespace {{ .Release.Namespace }} --from-file dex-ca.pem=ca.pem;
+          kubectl create secret tls {{ $caName | quote }} --namespace {{ .Release.Namespace }} --cert=ca.pem --key=ca-key.pem;
+          kubectl create secret tls {{ $tlsSecretName }} --namespace {{ .Release.Namespace }} --cert=cert.pem --key=key.pem;
+{{- if .Values.inMiniKube }}
+          cp -a ca.pem /var/lib/localkube/oidc.pem
+        volumeMounts:
+        - mountPath: /var/lib/localkube
+          name: localkube
+      volumes:
+      - name: localkube
+        hostPath:
+          path: /var/lib/localkube
+{{- end }}
+{{- end }}

--- a/charts/dex/templates/poddisruptionbudget.yaml
+++ b/charts/dex/templates/poddisruptionbudget.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.podDisruptionBudget -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "dex.fullname" . }}
+  labels:
+{{ include "dex.labels" . | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "dex.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{ toYaml .Values.podDisruptionBudget | indent 2 }}
+{{- end -}}

--- a/charts/dex/templates/role.yaml
+++ b/charts/dex/templates/role.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.rbac.create }}
+{{- if or .Values.certs.grpc.create .Values.certs.web.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+{{ include "dex.labels" . | indent 4 }}
+  name: {{ template "dex.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups: [""]
+  resources: ["configmaps", "secrets"]
+  verbs: ["create", "delete"]
+{{- end -}}
+{{- end -}}

--- a/charts/dex/templates/rolebinding.yaml
+++ b/charts/dex/templates/rolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create }}
+{{- if or .Values.certs.grpc.create .Values.certs.web.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+{{ include "dex.labels" . | indent 4 }}
+  name: {{ template "dex.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "dex.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "dex.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}
+{{- end -}}

--- a/charts/dex/templates/secret.yaml
+++ b/charts/dex/templates/secret.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+{{ include "dex.labels" . | indent 4 }}
+  name: {{ template "dex.fullname" . }}
+stringData:
+  config.yaml: |-
+    {{- with .Values.config }}
+    issuer: {{ .issuer }}
+    storage:
+{{ toYaml .storage | indent 6 }}
+    logger:
+{{ toYaml .logger | indent 6 }}
+    web:
+      {{- if $.Values.https }}
+      https: {{ $.Values.config.web.address }}:{{ $.Values.ports.web.containerPort }}
+      tlsCert: {{ .web.tlsCert }}
+      tlsKey: {{ .web.tlsKey }}
+      {{- else }}
+      http: {{ $.Values.config.web.address }}:{{ $.Values.ports.web.containerPort }}
+      {{- end }}
+    {{- if $.Values.grpc }}
+    grpc:
+      addr: {{ $.Values.config.grpc.address }}:{{ $.Values.ports.grpc.containerPort }}
+      tlsCert: {{ .grpc.tlsCert }}
+      tlsKey: {{ .grpc.tlsKey }}
+      tlsClientCA: {{ .grpc.tlsClientCA }}
+    {{- end }}
+    {{- if .connectors }}
+    connectors:
+{{ toYaml .connectors | indent 4 }}
+    {{- end }}
+    oauth2: {{ toYaml .oauth2 | nindent 6 }}
+    {{- if .staticClients }}
+    staticClients:
+{{ toYaml .staticClients | indent 4 }}
+    {{- end }}
+    enablePasswordDB: {{ .enablePasswordDB }}
+    {{- if .staticPasswords }}
+    staticPasswords:
+{{ toYaml .staticPasswords | indent 4 }}
+    {{- end }}
+    {{- if .expiry }}
+    expiry:
+{{ toYaml .expiry | indent 6 }}
+    {{- end }}
+    {{- if .frontend }}
+    frontend: {{ toYaml .frontend | nindent 6 }}
+    {{- end }}
+    {{- end }}

--- a/charts/dex/templates/secret.yaml
+++ b/charts/dex/templates/secret.yaml
@@ -31,7 +31,8 @@ stringData:
     connectors:
 {{ toYaml .connectors | indent 4 }}
     {{- end }}
-    oauth2: {{ toYaml .oauth2 | nindent 6 }}
+    oauth2:
+{{ toYaml .oauth2 | indent 6 }}
     {{- if .staticClients }}
     staticClients:
 {{ toYaml .staticClients | indent 4 }}
@@ -46,6 +47,7 @@ stringData:
 {{ toYaml .expiry | indent 6 }}
     {{- end }}
     {{- if .frontend }}
-    frontend: {{ toYaml .frontend | nindent 6 }}
+    frontend:
+{{ toYaml .frontend | indent 6 }}
     {{- end }}
     {{- end }}

--- a/charts/dex/templates/service.yaml
+++ b/charts/dex/templates/service.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "dex.fullname" . }}
+  labels:
+{{ include "dex.labels" . | indent 4 }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type}}
+  sessionAffinity: None
+  ports:
+  - name: {{ if .Values.https }}https{{ else }}http{{ end }}
+    targetPort: {{ if .Values.https }}https{{ else }}http{{ end }}
+{{- if eq "NodePort" .Values.service.type }}
+    nodePort: {{ .Values.ports.web.nodePort }}
+{{- end }}
+    port: {{ .Values.ports.web.servicePort }}
+{{- if .Values.grpc }}
+  - name: grpc
+    targetPort: grpc
+  {{- if eq "NodePort" .Values.service.type }}
+    nodePort: {{ .Values.ports.grpc.nodePort }}
+  {{- end }}
+    port: {{ .Values.ports.grpc.servicePort }}
+{{- end }}
+{{- if hasKey .Values.service "externalIPs" }}
+  externalIPs:
+{{ toYaml .Values.service.externalIPs | indent 4 }}
+{{- end }}
+{{- if hasKey .Values.service "loadBalancerIP" }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+{{- end }}
+  selector:
+    app.kubernetes.io/name: {{ include "dex.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/dex/templates/service.yaml
+++ b/charts/dex/templates/service.yaml
@@ -33,6 +33,9 @@ spec:
 {{- if hasKey .Values.service "loadBalancerIP" }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
 {{- end }}
+{{- if hasKey .Values.service "clusterIP" }}
+  clusterIP: {{ .Values.service.clusterIP | quote }}
+{{- end }}
   selector:
     app.kubernetes.io/name: {{ include "dex.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/dex/templates/serviceaccount.yaml
+++ b/charts/dex/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+{{ include "dex.labels" . | indent 4 }}
+  name: {{ template "dex.serviceAccountName" . }}
+{{- end -}}

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -1,0 +1,192 @@
+# Default values for dex
+# This is a YAML-formatted file.
+# Declare name/value pairs to be passed into your templates.
+# name: value
+
+image: quay.io/dexidp/dex
+imageTag: "v2.19.0"
+imagePullPolicy: "IfNotPresent"
+
+inMiniKube: false
+
+nodeSelector: {}
+
+podAnnotations: {}
+
+tolerations: []
+  # - key: CriticalAddonsOnly
+  #   operator: Exists
+  # - key: foo
+  #   operator: Equal
+  #   value: bar
+  #   effect: NoSchedule
+
+replicas: 1
+
+# resources:
+  # limits:
+    # cpu: 100m
+    # memory: 50Mi
+  # requests:
+    # cpu: 100m
+    # memory: 50Mi
+
+# grpc support
+grpc: true
+
+# https termination by dex itself
+https: false
+
+ports:
+  web:
+    containerPort: 5556
+    # for service.type: NodePort
+    nodePort: 32000
+    servicePort: 32000
+# Relevant only when grpc support is enabled
+  grpc:
+    containerPort: 5000
+    # for service.type: NodePort
+    nodePort: 35000
+    servicePort: 35000
+
+service:
+  type: ClusterIP
+  # Override IP for the Service Type: LoadBalancer.
+  # This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created.
+  # loadBalancerIP: 127.0.0.1
+  annotations: {}
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - dex.example.com
+  tls: []
+  #  - secretName: dex-example-tls
+  #    hosts:
+  #      - dex.example.com
+
+extraVolumes: []
+extraVolumeMounts: []
+
+certs:
+  securityContext:
+    enabled: true
+    runAsUser: 65534
+    fsGroup: 65534
+  image: gcr.io/google_containers/kubernetes-dashboard-init-amd64
+  imageTag: "v1.0.0"
+  imagePullPolicy: "IfNotPresent"
+  # Section below is relevant only when https termination is enabled
+  web:
+    create: true
+    activeDeadlineSeconds: 300
+    caDays: 10000
+    certDays: 10000
+    altNames:
+      - dex.io
+    altIPs: {}
+    secret:
+      tlsName: dex-web-server-tls
+      caName: dex-web-server-ca
+    pod:
+      annotations: {}
+  # Section below is relevant only when grpc support is enabled
+  grpc:
+    create: true
+    activeDeadlineSeconds: 300
+    altNames:
+      - dex.io
+    altIPs: {}
+    secret:
+      serverTlsName: dex-grpc-server-tls
+      clientTlsName: dex-grpc-client-tls
+      caName: dex-grpc-ca
+    pod:
+      annotations: {}
+
+env: []
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+affinity: {}
+  # podAntiAffinity:
+  #   preferredDuringSchedulingIgnoredDuringExecution:
+  #   - weight: 5
+  #     podAffinityTerm:
+  #       topologyKey: "kubernetes.io/hostname"
+  #       labelSelector:
+  #         matchLabels:
+  #           app: {{ template "dex.name" . }}
+  #           release: "{{ .Release.Name }}"
+
+podDisruptionBudget: {}
+  # maxUnavailable: 1
+
+config:
+  issuer: http://dex.io:8080
+  storage:
+    type: kubernetes
+    config:
+      inCluster: true
+  logger:
+    level: debug
+  web:
+    # port is taken from ports section above
+    address: 0.0.0.0
+    tlsCert: /etc/dex/tls/https/server/tls.crt
+    tlsKey: /etc/dex/tls/https/server/tls.key
+# Section below is relevant only when grpc support is enabled
+  grpc:
+    # port is taken from ports section above
+    address: 127.0.0.1
+    tlsCert: /etc/dex/tls/grpc/server/tls.crt
+    tlsKey: /etc/dex/tls/grpc/server/tls.key
+    tlsClientCA: /etc/dex/tls/grpc/ca/tls.crt
+  connectors: {}
+#  - type: github
+#    id: github
+#    name: GitHub
+#    config:
+#      clientID: xxxxxxxxxxxxxxx
+#      clientSecret: yyyyyyyyyyyyyyyyyyyyy
+#      redirectURI: https://dex.minikube.local:5556/callback
+#      org: kubernetes
+  oauth2:
+    alwaysShowLoginScreen: false
+    skipApprovalScreen: true
+
+#  expiry:
+#    signingKeys: "6h"
+#    idTokens: "24h"
+
+#  staticClients:
+#  - id: example-app
+#    redirectURIs:
+#    - 'http://192.168.42.219:31850/oauth2/callback'
+#    name: 'Example App'
+#    secret: ZXhhbXBsZS1hcHAtc2VjcmV0
+#
+  enablePasswordDB: true
+#  staticPasswords:
+#   - email: "admin@example.com"
+#     # bcrypt hash of the string "password"
+#     hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+#     username: "admin"
+#     userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
+
+# frontend:
+#   logoURL: https://example.com/yourlogo.png

--- a/pillar/metalk8s/roles/ca.sls
+++ b/pillar/metalk8s/roles/ca.sls
@@ -15,6 +15,10 @@ mine_functions:
     mine_function: hashutil.base64_encodefile
     fname: /etc/kubernetes/pki/sa.pub
 
+  dex_ca_b64:
+    mine_function: hashutil.base64_encodefile
+    fname: /etc/metalk8s/pki/dex/ca.crt
+
   ingress_ca_b64:
     mine_function: hashutil.base64_encodefile
     fname: /etc/metalk8s/pki/nginx-ingress/ca.crt
@@ -59,6 +63,13 @@ x509_signing_policies:
     - minions: '*'
     - signing_private_key: /etc/metalk8s/pki/nginx-ingress/ca.key
     - signing_cert: /etc/metalk8s/pki/nginx-ingress/ca.crt
+    - keyUsage: critical digitalSignature, keyEncipherment
+    - extendedKeyUsage: serverAuth
+    - days_valid: 365
+  dex_server_policy:
+    - minions: '*'
+    - signing_private_key: /etc/metalk8s/pki/dex/ca.key
+    - signing_cert: /etc/metalk8s/pki/dex/ca.crt
     - keyUsage: critical digitalSignature, keyEncipherment
     - extendedKeyUsage: serverAuth
     - days_valid: 365

--- a/salt/_modules/metalk8s_network.py
+++ b/salt/_modules/metalk8s_network.py
@@ -7,6 +7,7 @@ from salt._compat import ipaddress
 from salt.exceptions import CommandExecutionError
 
 K8S_CLUSTER_ADDRESS_NUMBER = 0
+OIDC_ADDRESS_NUMBER = 6
 COREDNS_ADDRESS_NUMBER = 9
 
 
@@ -68,3 +69,13 @@ def get_cluster_dns_ip():
     range.
     '''
     return _pick_nth_service_ip(COREDNS_ADDRESS_NUMBER)
+
+
+def get_oidc_service_ip():
+    '''
+    Return the OIDC service cluster IP.
+
+    This IP is arbitrarily selected as the seventh IP from the usable hosts
+    range.
+    '''
+    return _pick_nth_service_ip(OIDC_ADDRESS_NUMBER)

--- a/salt/metalk8s/addons/dex/ca/advertised.sls
+++ b/salt/metalk8s/addons/dex/ca/advertised.sls
@@ -1,0 +1,25 @@
+{%- set dex_ca_b64_server = salt['mine.get'](
+    pillar.metalk8s.ca.minion, 'dex_ca_b64'
+) %}
+
+{%- if dex_ca_b64_server %}
+
+{%- set dex_cert_b64 = dex_ca_b64_server[pillar.metalk8s.ca.minion] %}
+{%- set dex_ca_cert = salt['hashutil.base64_b64decode'](dex_cert_b64) %}
+
+Ensure Dex CA cert is present:
+  file.managed:
+    - name: /etc/metalk8s/pki/dex/ca.crt
+    - user: root
+    - group : root
+    - mode: 644
+    - makedirs: True
+    - dir_mode: 755
+    - contents: {{ dex_ca_cert.splitlines() }}
+
+{%- else %}
+
+Unable to get Dex CA cert, no kubernetes_dex_ca_b64 in mine:
+  test.fail_without_changes: []
+
+{%- endif %}

--- a/salt/metalk8s/addons/dex/ca/init.sls
+++ b/salt/metalk8s/addons/dex/ca/init.sls
@@ -1,0 +1,11 @@
+#
+# State to manage Dex Certificate Authority
+#
+# Available states
+# ================
+#
+# * installed   -> install and advertise as Dex CA
+# * advertised  -> deploy the Dex CA certificate
+#
+include:
+  - .installed

--- a/salt/metalk8s/addons/dex/ca/installed.sls
+++ b/salt/metalk8s/addons/dex/ca/installed.sls
@@ -1,0 +1,42 @@
+{%- from "metalk8s/map.jinja" import dex with context %}
+
+include:
+  - metalk8s.internal.m2crypto
+
+Create dex CA private key:
+  x509.private_key_managed:
+    - name: /etc/metalk8s/pki/dex/ca.key
+    - bits: 4096
+    - verbose: False
+    - user: root
+    - group: root
+    - mode: 600
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - metalk8s_package_manager: Install m2crypto
+
+Generate dex CA certificate:
+  x509.certificate_managed:
+    - name: /etc/metalk8s/pki/dex/ca.crt
+    - signing_private_key: /etc/metalk8s/pki/dex/ca.key
+    - CN: dex-ca
+    - keyUsage: "critical digitalSignature, keyEncipherment, keyCertSign"
+    - basicConstraints: "critical CA:true"
+    - days_valid: {{ dex.ca.cert.days_valid }}
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - x509: Create dex CA private key
+
+Advertise dex CA certificate in the mine:
+  module.wait:
+    - mine.send:
+      - func: dex_ca_b64
+      - mine_function: hashutil.base64_encodefile
+      - /etc/metalk8s/pki/dex/ca.crt
+    - watch:
+      - x509: Generate dex CA certificate

--- a/salt/metalk8s/addons/dex/certs/init.sls
+++ b/salt/metalk8s/addons/dex/certs/init.sls
@@ -1,0 +1,2 @@
+include:
+  - .server

--- a/salt/metalk8s/addons/dex/certs/server.sls
+++ b/salt/metalk8s/addons/dex/certs/server.sls
@@ -1,0 +1,47 @@
+{%- from "metalk8s/map.jinja" import dex with context %}
+
+{%- set oidc_service_ip = salt.metalk8s_network.get_oidc_service_ip() %}
+
+include:
+  - metalk8s.internal.m2crypto
+
+Create Dex server private key:
+  x509.private_key_managed:
+    - name: /etc/metalk8s/pki/dex/server.key
+    - bits: 4096
+    - verbose: False
+    - user: root
+    - group: root
+    - mode: 600
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - metalk8s_package_manager: Install m2crypto
+
+{%- set certSANs = [
+    grains.fqdn,
+    'localhost',
+    '127.0.0.1',
+    'dex',
+    'dex.metalk8s-auth',
+    'dex.metalk8s-auth.svc',
+    'dex.metalk8s-auth.svc.cluster.local',
+    oidc_service_ip,
+    grains.metalk8s.control_plane_ip,
+] %}
+
+Generate Dex server certificate:
+  x509.certificate_managed:
+    - name: /etc/metalk8s/pki/dex/server.crt
+    - public_key: /etc/metalk8s/pki/dex/server.key
+    - ca_server: {{ pillar.metalk8s.ca.minion }}
+    - signing_policy: {{ dex.cert.server_signing_policy }}
+    - CN: dex-server
+    - subjectAltName: "{{ salt['metalk8s.format_san'](certSANs | unique) }}"
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - x509: Create Dex server private key

--- a/salt/metalk8s/addons/dex/deployed/chart.sls
+++ b/salt/metalk8s/addons/dex/deployed/chart.sls
@@ -1,0 +1,264 @@
+#!jinja | metalk8s_kubernetes kubeconfig=/etc/kubernetes/admin.conf&context=kubernetes-admin@kubernetes
+{%- from "metalk8s/repo/macro.sls" import build_image_name with context %}
+
+{% raw %}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: dex
+    app.kubernetes.io/managed-by: salt
+    app.kubernetes.io/name: dex
+    app.kubernetes.io/part-of: metalk8s
+    app.kubernetes.io/version: 2.19.0
+    helm.sh/chart: dex-2.4.0
+    heritage: metalk8s
+  name: dex
+  namespace: metalk8s-auth
+stringData:
+  config.yaml: |-
+    issuer: {% endraw %}https://{{ grains.metalk8s.control_plane_ip }}:8443/oidc{% raw %}
+    storage:
+      config:
+        inCluster: true
+      type: kubernetes
+    logger:
+      level: debug
+    web:
+      https: 0.0.0.0:5556
+      tlsCert: /etc/dex/tls/https/server/tls.crt
+      tlsKey: /etc/dex/tls/https/server/tls.key
+    oauth2:
+      alwaysShowLoginScreen: true
+      responseTypes:
+      - code
+      - token
+      - id_token
+      skipApprovalScreen: true
+    staticClients:
+    - id: oidc-auth-client
+      name: oidc-auth-client
+      redirectURIs:
+      - urn:ietf:wg:oauth:2.0:oob
+      secret: lkfa9jaf3kfakqyeoikfjakf93k2l
+      trustedPeers:
+      - metalk8s-ui
+      - grafana-ui
+    - id: metalk8s-ui
+      name: MetalK8s UI
+      redirectURIs:
+      - '{% endraw %}https://{{ grains.metalk8s.control_plane_ip }}:8443/oauth2/callback{%
+        raw %}'
+      secret: ybrMJpVMQxsiZw26MhJzCjA2ut
+    - id: grafana-ui
+      name: Grafana UI
+      redirectURIs:
+      - '{% endraw %}https://{{ grains.metalk8s.control_plane_ip }}:8443/grafana/login/generic_oauth{%
+        raw %}'
+      secret: 4lqK98NcsWG5qBRHJUqYM1
+    enablePasswordDB: true
+    staticPasswords:
+    - email: admin@metalk8s.invalid
+      hash: $2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W
+      userID: 08a8684b-db88-4b73-90a9-3cd1661f5466
+      username: admin
+    expiry:
+      idTokens: 24h
+      signingKeys: 6h
+    frontend:
+      theme: coreos
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: dex
+    app.kubernetes.io/managed-by: salt
+    app.kubernetes.io/name: dex
+    app.kubernetes.io/part-of: metalk8s
+    app.kubernetes.io/version: 2.19.0
+    helm.sh/chart: dex-2.4.0
+    heritage: metalk8s
+  name: dex
+  namespace: metalk8s-auth
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: dex
+    app.kubernetes.io/managed-by: salt
+    app.kubernetes.io/name: dex
+    app.kubernetes.io/part-of: metalk8s
+    app.kubernetes.io/version: 2.19.0
+    helm.sh/chart: dex-2.4.0
+    heritage: metalk8s
+  name: dex
+  namespace: metalk8s-auth
+rules:
+- apiGroups:
+  - dex.coreos.com
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: dex
+    app.kubernetes.io/managed-by: salt
+    app.kubernetes.io/name: dex
+    app.kubernetes.io/part-of: metalk8s
+    app.kubernetes.io/version: 2.19.0
+    helm.sh/chart: dex-2.4.0
+    heritage: metalk8s
+  name: dex
+  namespace: metalk8s-auth
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dex
+subjects:
+- kind: ServiceAccount
+  name: dex
+  namespace: metalk8s-auth
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: dex
+    app.kubernetes.io/managed-by: salt
+    app.kubernetes.io/name: dex
+    app.kubernetes.io/part-of: metalk8s
+    app.kubernetes.io/version: 2.19.0
+    helm.sh/chart: dex-2.4.0
+    heritage: metalk8s
+  name: dex
+  namespace: metalk8s-auth
+spec:
+  clusterIP: '{% endraw %}{{ salt.metalk8s_network.get_oidc_service_ip() }}{% raw
+    %}'
+  ports:
+  - name: https
+    port: 32000
+    targetPort: https
+  selector:
+    app.kubernetes.io/instance: dex
+    app.kubernetes.io/name: dex
+  sessionAffinity: None
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: dex
+    app.kubernetes.io/instance: dex
+    app.kubernetes.io/managed-by: salt
+    app.kubernetes.io/name: dex
+    app.kubernetes.io/part-of: metalk8s
+    app.kubernetes.io/version: 2.19.0
+    helm.sh/chart: dex-2.4.0
+    heritage: metalk8s
+  name: dex
+  namespace: metalk8s-auth
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: dex
+      app.kubernetes.io/instance: dex
+      app.kubernetes.io/name: dex
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 4fbe3973776c030cad8db8e2535206ba87b870089216d34b6a049f87d00697f5
+      labels:
+        app.kubernetes.io/component: dex
+        app.kubernetes.io/instance: dex
+        app.kubernetes.io/name: dex
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/dex
+        - serve
+        - /etc/dex/cfg/config.yaml
+        env: []
+        image: '{% endraw %}{{ build_image_name("dex", False) }}{% raw %}:v2.19.0'
+        imagePullPolicy: IfNotPresent
+        name: main
+        ports:
+        - containerPort: 5556
+          name: https
+          protocol: TCP
+        resources: null
+        volumeMounts:
+        - mountPath: /etc/dex/cfg
+          name: config
+        - mountPath: /etc/dex/tls/https/server
+          name: https-tls
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      serviceAccountName: dex
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/bootstrap
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
+      volumes:
+      - name: config
+        secret:
+          defaultMode: 420
+          items:
+          - key: config.yaml
+            path: config.yaml
+          secretName: dex
+      - name: https-tls
+        secret:
+          defaultMode: 420
+          secretName: dex-web-server-tls
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx-control-plane
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+  labels:
+    app.kubernetes.io/instance: dex
+    app.kubernetes.io/managed-by: salt
+    app.kubernetes.io/name: dex
+    app.kubernetes.io/part-of: metalk8s
+    app.kubernetes.io/version: 2.19.0
+    helm.sh/chart: dex-2.4.0
+    heritage: metalk8s
+  name: dex
+  namespace: metalk8s-auth
+spec:
+  rules:
+  - host: null
+    http:
+      paths:
+      - backend:
+          serviceName: dex
+          servicePort: 32000
+        path: /oidc
+
+{% endraw %}

--- a/salt/metalk8s/addons/dex/deployed/clusterrolebinding.sls
+++ b/salt/metalk8s/addons/dex/deployed/clusterrolebinding.sls
@@ -1,0 +1,14 @@
+#!jinja | metalk8s_kubernetes kubeconfig=/etc/kubernetes/admin.conf&context=kubernetes-admin@kubernetes
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dex-administrator
+subjects:
+- kind: User
+  name: "admin@metalk8s.invalid"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/salt/metalk8s/addons/dex/deployed/init.sls
+++ b/salt/metalk8s/addons/dex/deployed/init.sls
@@ -1,0 +1,14 @@
+#
+# States to deploy Dex
+#
+# Available states
+# ================
+#
+# * namespace              -> creates a namespace metalk8s-auth
+# * tls-secret             -> store Dex server cert and key in a Secret
+# * chart                  -> charts used to deploy Dex
+
+include:
+- .namespace
+- .tls-secret
+- .chart

--- a/salt/metalk8s/addons/dex/deployed/init.sls
+++ b/salt/metalk8s/addons/dex/deployed/init.sls
@@ -7,8 +7,10 @@
 # * namespace              -> creates a namespace metalk8s-auth
 # * tls-secret             -> store Dex server cert and key in a Secret
 # * chart                  -> charts used to deploy Dex
+# * clusterrolebinding     -> binds dex static user to cluster admin
 
 include:
 - .namespace
 - .tls-secret
 - .chart
+- .clusterrolebinding

--- a/salt/metalk8s/addons/dex/deployed/namespace.sls
+++ b/salt/metalk8s/addons/dex/deployed/namespace.sls
@@ -1,0 +1,10 @@
+#!jinja | metalk8s_kubernetes kubeconfig=/etc/kubernetes/admin.conf&context=kubernetes-admin@kubernetes
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metalk8s-auth
+  labels:
+    app.kubernetes.io/managed-by: salt
+    app.kubernetes.io/part-of: metalk8s
+    heritage: metalk8s

--- a/salt/metalk8s/addons/dex/deployed/tls-secret.sls
+++ b/salt/metalk8s/addons/dex/deployed/tls-secret.sls
@@ -1,0 +1,17 @@
+#!jinja | metalk8s_kubernetes kubeconfig=/etc/kubernetes/admin.conf&context=kubernetes-admin@kubernetes
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dex-web-server-tls
+  namespace: metalk8s-auth
+type: Opaque
+data:
+  tls.crt: "{{
+    salt['hashutil.base64_encodefile']('/etc/metalk8s/pki/dex/server.crt')
+    | replace('\n', '')
+  }}"
+  tls.key: "{{
+    salt['hashutil.base64_encodefile']('/etc/metalk8s/pki/dex/server.key')
+    | replace('\n', '')
+  }}"

--- a/salt/metalk8s/addons/nginx-ingress-control-plane/control-plane-ip.sls
+++ b/salt/metalk8s/addons/nginx-ingress-control-plane/control-plane-ip.sls
@@ -1,0 +1,29 @@
+{# This whole block is used to "know" the Ingress external IP used by Dex.
+  It will be removed once we can have a known LoadBalancer IP for Ingress. #}
+{% if '_errors' in pillar.metalk8s.nodes %}
+  {# Assume this is the bootstrap Node and we haven't an apiserver yet #}
+  {%- set bootstrap_id = grains.id %}
+{%- elif pillar.metalk8s.nodes | length <= 1 %}
+  {# Only one node (or even, zero) can/should only happen during bootstrap #}
+  {%- set bootstrap_id = grains.id %}
+{%- else %}
+  {%- set bootstrap_nodes = salt.metalk8s.minions_by_role('bootstrap') %}
+  {%- if bootstrap_nodes %}
+    {%- set bootstrap_id = bootstrap_nodes | first %}
+  {%- else %}
+    {{ raise('Missing bootstrap node') }}
+  {%- endif %}
+{%- endif %}
+
+{%- if bootstrap_id is none %}
+  {{ raise('Missing bootstrap Node in pillar, cannot proceed.') }}
+{%- elif bootstrap_id == grains.id %}
+  {%- set bootstrap_control_plane_ip = grains.metalk8s.control_plane_ip %}
+{%- else %}
+  {%- set bootstrap_control_plane_ip = salt['mine.get'](bootstrap_id,
+   'control_plane_ip')[bootstrap_id]
+  %}
+{%- endif %}
+
+{%- set ingress_control_plane = bootstrap_control_plane_ip ~ ':8443' %}
+{# (end of Ingress URL retrieval) #}

--- a/salt/metalk8s/defaults.yaml
+++ b/salt/metalk8s/defaults.yaml
@@ -80,6 +80,15 @@ front_proxy:
   cert:
     client_signing_policy: front_proxy_client_policy
 
+dex:
+  ca:
+    cert:
+      days_valid: 3650
+    signing_policy:
+      days_valid: 365
+  cert:
+    server_signing_policy: dex_server_policy
+
 nginx-ingress:
   ca:
     cert:

--- a/salt/metalk8s/deployed.sls
+++ b/salt/metalk8s/deployed.sls
@@ -10,3 +10,4 @@ include:
   - metalk8s.addons.volumes.deployed
   - metalk8s.addons.solutions.deployed
   - metalk8s.addons.ui.deployed
+  - metalk8s.addons.dex.deployed

--- a/salt/metalk8s/map.jinja
+++ b/salt/metalk8s/map.jinja
@@ -214,6 +214,10 @@
   'default': {}
 }, merge=defaults.get('kubeadm_kubeconfig')) %}
 
+{% set dex = salt['grains.filter_by']({
+  'default': {}
+}, merge=defaults.get('dex')) %}
+
 {% set nginx_ingress = salt['grains.filter_by']({
   'default': {}
 }, merge=defaults.get('nginx-ingress')) %}

--- a/salt/metalk8s/roles/ca/init.sls
+++ b/salt/metalk8s/roles/ca/init.sls
@@ -2,3 +2,4 @@ include:
   - metalk8s.kubernetes.ca
   - metalk8s.kubernetes.sa
   - metalk8s.addons.nginx-ingress.ca
+  - metalk8s.addons.dex.ca

--- a/salt/metalk8s/salt/master/certs/init.sls
+++ b/salt/metalk8s/salt/master/certs/init.sls
@@ -11,5 +11,6 @@ include:
   # Some server certs are required to be published in K8s API by Salt master
   - metalk8s.addons.nginx-ingress-control-plane.certs
   - metalk8s.addons.nginx-ingress.certs
+  - metalk8s.addons.dex.certs
   - .etcd-client
   - .salt-api

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -170,6 +170,8 @@ backup_cas() {
     local -a metalk8s_ca_files=(
         'nginx-ingress/ca.crt'
         'nginx-ingress/ca.key'
+        'dex/ca.crt'
+        'dex/ca.key'
     )
     for metalk8s_ca in "${metalk8s_ca_files[@]}"; do
         _save_cp "${metalk8s_ca_dir}$metalk8s_ca" "${BACKUP_DIR}/pki_metalk8s/$metalk8s_ca"

--- a/scripts/restore.sh.in
+++ b/scripts/restore.sh.in
@@ -139,6 +139,8 @@ restore_cas() {
     local -a metalk8s_ca_files=(
         'nginx-ingress/ca.crt'
         'nginx-ingress/ca.key'
+        'dex/ca.crt'
+        'dex/ca.key'
     )
     for metalk8s_ca in "${metalk8s_ca_files[@]}"; do
         _save_cp "${BACKUP_DIR}/pki_metalk8s/$metalk8s_ca" "${metalk8s_ca_dir}$metalk8s_ca"


### PR DESCRIPTION
**Component**:

'authentication', 'salt', 'kubernetes'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

See #2007 

**Summary**:




**Acceptance criteria**: 

- Have Dex pods running in MetalK8s cluster deployed from helm charts
- Access the dex URL exposed by ingress and verify that it works : https://{{ control_plane_address }}:8443/oidc/.well-known/openid-configuration

```
{
  "issuer": "https://172.21.254.3:8443/oidc",
  "authorization_endpoint": "https://172.21.254.3:8443/oidc/auth",
  "token_endpoint": "https://172.21.254.3:8443/oidc/token",
  "jwks_uri": "https://172.21.254.3:8443/oidc/keys",
  "userinfo_endpoint": "https://172.21.254.3:8443/oidc/userinfo",
  "response_types_supported": [
    "code",
    "id_token",
    "token"
  ],
  "subject_types_supported": [
    "public"
  ],
  "id_token_signing_alg_values_supported": [
    "RS256"
  ],
  "scopes_supported": [
    "openid",
    "email",
    "groups",
    "profile",
    "offline_access"
  ],
  "token_endpoint_auth_methods_supported": [
    "client_secret_basic"
  ],
  "claims_supported": [
    "aud",
    "email",
    "email_verified",
    "exp",
    "iat",
    "iss",
    "locale",
    "name",
    "sub"
  ]
}
```

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2007 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
