### PR TITLE
1952: flaky downgrade/upgrade

### DIFF
--- a/salt/metalk8s/orchestrate/deploy_node.sls
+++ b/salt/metalk8s/orchestrate/deploy_node.sls
@@ -74,6 +74,23 @@ Refresh pillar before highstate:
     - name: saltutil.refresh_pillar
     - tgt: {{ node_name }}
 
+{%- if node_name in salt.saltutil.runner('manage.up') %}
+
+Reconfigure salt-minion:
+  salt.state:
+    - tgt: {{ node_name }}
+    - saltenv: metalk8s-{{ version }}
+    - sls:
+      - metalk8s.salt.minion.configured
+    - require:
+      - salt: Set grains
+      - salt: Refresh the mine
+      - salt: Refresh pillar before highstate
+    - require_in:
+      - salt: Run the highstate
+
+{%- endif %}
+
 Run the highstate:
   salt.state:
     - tgt: {{ node_name }}


### PR DESCRIPTION
**Component**: salt

**Context**: flaky upgrade / downgrade tests

**Summary**: Salt is checking every X seconds the liveness of a running job, sometimes it sends the request during the minion restart, so the query fails & the master assumes that the job has also failed.

**Acceptance criteria**: green build
