### PR TITLE
Improvement/1099 set kubeconfig in master config

### DIFF
--- a/charts/render.py
+++ b/charts/render.py
@@ -25,7 +25,7 @@ import yaml
 
 
 BOILERPLATE = '''
-#!jinja | kubernetes kubeconfig=/etc/kubernetes/admin.conf&context=kubernetes-admin@kubernetes
+#!jinja | metalk8s_kubernetes kubeconfig=/etc/kubernetes/admin.conf&context=kubernetes-admin@kubernetes
 {%- from "metalk8s/repo/macro.sls" import build_image_name with context %}
 
 {% raw %}

--- a/charts/render.py
+++ b/charts/render.py
@@ -25,7 +25,7 @@ import yaml
 
 
 BOILERPLATE = '''
-#!jinja | metalk8s_kubernetes kubeconfig=/etc/kubernetes/admin.conf&context=kubernetes-admin@kubernetes
+#!jinja | metalk8s_kubernetes
 {%- from "metalk8s/repo/macro.sls" import build_image_name with context %}
 
 {% raw %}

--- a/salt/_modules/metalk8s_drain.py
+++ b/salt/_modules/metalk8s_drain.py
@@ -228,8 +228,7 @@ class Drain(object):
             kind=controller_ref['kind'],
             apiVersion=controller_ref['api_version'],
             namespace=namespace,
-            kubeconfig=self._kwargs.get('kubeconfig'),
-            context=self._kwargs.get('context')
+            **self._kwargs
         )
 
     def get_pod_controller(self, pod):
@@ -303,8 +302,7 @@ class Drain(object):
             apiVersion='v1',
             all_namespaces=True,
             field_selector='spec.nodeName={0}'.format(self.node_name),
-            kubeconfig=self._kwargs.get('kubeconfig'),
-            context=self._kwargs.get('context')
+            **self._kwargs
         )
 
         for pod in all_pods:
@@ -399,8 +397,7 @@ class Drain(object):
                 name=pod['metadata']['name'],
                 namespace=pod['metadata']['namespace'],
                 grace_period=self.grace_period,
-                kubeconfig=self._kwargs.get('kubeconfig'),
-                context=self._kwargs.get('context')
+                **self._kwargs
             )
 
         pending = self.wait_for_eviction(pods)
@@ -428,8 +425,7 @@ class Drain(object):
                     apiVersion='v1',
                     name=pod['metadata']['name'],
                     namespace=pod['metadata']['namespace'],
-                    kubeconfig=self._kwargs.get('kubeconfig'),
-                    context=self._kwargs.get('context')
+                    **self._kwargs
                 )
                 if not response or \
                         response['metadata']['uid'] != pod['metadata']['uid']:
@@ -445,7 +441,7 @@ class Drain(object):
 
 
 def evict_pod(name, namespace='default', grace_period=1,
-              kubeconfig=None, context=None):
+              **kwargs):
     '''Trigger the eviction process for a single pod.
 
     Args:
@@ -468,6 +464,10 @@ def evict_pod(name, namespace='default', grace_period=1,
         name=name,
         namespace=namespace
     )
+
+    kubeconfig, context = __salt__[
+        'metalk8s_kubernetes.get_kubeconfig'
+    ](**kwargs)
 
     client = kind_info.client
     client.configure(config_file=kubeconfig, context=context)

--- a/salt/_pillar/metalk8s.py
+++ b/salt/_pillar/metalk8s.py
@@ -84,6 +84,7 @@ def _load_apiserver(config_data):
             'virtualRouterId': 1,
             'authPassword': 'MeTaLk8s',
         },
+        'kubeconfig': '/etc/kubernetes/admin.conf'
     }
 
     errors = __utils__['pillar_utils.assert_keys'](as_data, ['host'])

--- a/salt/_renderers/metalk8s_kubernetes.py
+++ b/salt/_renderers/metalk8s_kubernetes.py
@@ -14,13 +14,11 @@ The shebang also supports passing options to this renderer, in the format
 string in the `application/x-www-form-urlencoded` format).
 The supported options are:
 - `kubeconfig`, the path to the kubeconfig file to use for communicating with
-  K8s API
-- `context`, the context from the kubeconfig to use
+  K8s API (defaults define in salt-master configuration)
+- `context`, the context from the kubeconfig to use (defaults define in
+  salt-master configuration
 - `absent`, a boolean to toggle which state function variant (`object_present`
   or `object_absent`) to use (defaults to False)
-
-TODO: improve management of `kubeconfig` and `context` parameters, relying on
-      master configuration and sane defaults - look into `__opts__`
 """
 import yaml
 

--- a/salt/metalk8s/addons/nginx-ingress/deployed/chart.sls
+++ b/salt/metalk8s/addons/nginx-ingress/deployed/chart.sls
@@ -1,4 +1,4 @@
-#!jinja | metalk8s_kubernetes kubeconfig=/etc/kubernetes/admin.conf&context=kubernetes-admin@kubernetes
+#!jinja | metalk8s_kubernetes
 {%- from "metalk8s/repo/macro.sls" import build_image_name with context %}
 
 apiVersion: v1

--- a/salt/metalk8s/addons/nginx-ingress/deployed/namespace.sls
+++ b/salt/metalk8s/addons/nginx-ingress/deployed/namespace.sls
@@ -1,4 +1,4 @@
-#! metalk8s_kubernetes kubeconfig=/etc/kubernetes/admin.conf&context=kubernetes-admin@kubernetes
+#! metalk8s_kubernetes
 
 apiVersion: v1
 kind: Namespace

--- a/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
@@ -1,4 +1,4 @@
-#!jinja | metalk8s_kubernetes kubeconfig=/etc/kubernetes/admin.conf&context=kubernetes-admin@kubernetes
+#!jinja | metalk8s_kubernetes
 {%- from "metalk8s/repo/macro.sls" import build_image_name with context %}
 
 {% raw %}

--- a/salt/metalk8s/addons/prometheus-operator/deployed/namespace.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/namespace.sls
@@ -1,4 +1,4 @@
-#! metalk8s_kubernetes kubeconfig=/etc/kubernetes/admin.conf&context=kubernetes-admin@kubernetes
+#! metalk8s_kubernetes
 
 apiVersion: v1
 kind: Namespace

--- a/salt/metalk8s/addons/prometheus-operator/deployed/prometheus-nodeport.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/prometheus-nodeport.sls
@@ -1,6 +1,3 @@
-{%- set kubeconfig = "/etc/kubernetes/admin.conf" %}
-{%- set context = "kubernetes-admin@kubernetes" %}
-
 Expose Prometheus:
   metalk8s_kubernetes.object_present:
     - manifest:
@@ -26,5 +23,3 @@ Expose Prometheus:
             app: prometheus
             prometheus: prometheus-operator-prometheus
           type: NodePort
-    - kubeconfig: {{ kubeconfig }}
-    - context: {{ context }}

--- a/salt/metalk8s/kubernetes/cni/calico/deployed.sls
+++ b/salt/metalk8s/kubernetes/cni/calico/deployed.sls
@@ -1,4 +1,4 @@
-#!jinja | metalk8s_kubernetes kubeconfig=/etc/kubernetes/admin.conf&context=kubernetes-admin@kubernetes
+#!jinja | metalk8s_kubernetes
 
 {%- from "metalk8s/repo/macro.sls" import build_image_name with context %}
 {%- from "metalk8s/map.jinja" import networks with context %}

--- a/salt/metalk8s/kubernetes/coredns/deployed.sls
+++ b/salt/metalk8s/kubernetes/coredns/deployed.sls
@@ -2,9 +2,6 @@
 
 {%- set cluster_dns_ip = salt.metalk8s_network.get_cluster_dns_ip() %}
 
-{% set kubeconfig = "/etc/kubernetes/admin.conf" %}
-{% set context = "kubernetes-admin@kubernetes" %}
-
 Create coredns ConfigMap:
   metalk8s_kubernetes.object_present:
     - manifest:
@@ -30,15 +27,11 @@ Create coredns ConfigMap:
                 reload
                 loadbalance
             }
-    - kubeconfig: {{ kubeconfig }}
-    - context: {{ context }}
 
 Create coredns deployment:
   metalk8s_kubernetes.object_present:
     - name: salt://{{ slspath }}/files/coredns-deployment.yaml.j2
     - template: jinja
-    - kubeconfig: {{ kubeconfig }}
-    - context: {{ context }}
     - require:
       - metalk8s_kubernetes: Create coredns ConfigMap
 
@@ -71,8 +64,6 @@ Create coredns service:
           - name: metrics
             port: 9153
             protocol: TCP
-    - kubeconfig: {{ kubeconfig }}
-    - context: {{ context }}
     - require:
       - metalk8s_kubernetes: Create coredns deployment
 
@@ -84,8 +75,6 @@ Create coredns service account:
         metadata:
           name: coredns
           namespace: kube-system
-    - kubeconfig: {{ kubeconfig }}
-    - context: {{ context }}
 
 Create coredns cluster role:
   metalk8s_kubernetes.object_present:
@@ -111,8 +100,6 @@ Create coredns cluster role:
           - nodes
           verbs:
           - get
-    - kubeconfig: {{ kubeconfig }}
-    - context: {{ context }}
 
 Create coredns cluster role binding:
   metalk8s_kubernetes.object_present:
@@ -129,6 +116,3 @@ Create coredns cluster role binding:
         - kind: ServiceAccount
           name: coredns
           namespace: kube-system
-    - kubeconfig: {{ kubeconfig }}
-    - context: {{ context }}
-

--- a/salt/metalk8s/kubernetes/kube-proxy/deployed.sls
+++ b/salt/metalk8s/kubernetes/kube-proxy/deployed.sls
@@ -3,9 +3,6 @@
 
 {%- set image = build_image_name("kube-proxy") -%}
 
-{%- set kubeconfig = "/etc/kubernetes/admin.conf" %}
-{%- set context = "kubernetes-admin@kubernetes" %}
-
 {%- set apiserver = 'https://' ~ pillar.metalk8s.api_server.host ~ ':6443' %}
 
 Deploy kube-proxy (ServiceAccount):
@@ -16,8 +13,6 @@ Deploy kube-proxy (ServiceAccount):
         metadata:
           name: kube-proxy
           namespace: kube-system
-    - kubeconfig: {{ kubeconfig }}
-    - context: {{ context }}
 
 Deploy kube-proxy (ClusterRoleBinding):
   metalk8s_kubernetes.object_present:
@@ -34,8 +29,6 @@ Deploy kube-proxy (ClusterRoleBinding):
         - kind: ServiceAccount
           name: kube-proxy
           namespace: kube-system
-    - kubeconfig: {{ kubeconfig }}
-    - context: {{ context }}
     - require:
       - metalk8s_kubernetes: Deploy kube-proxy (ServiceAccount)
 
@@ -108,8 +101,6 @@ Deploy kube-proxy (ConfigMap):
             - name: default
               user:
                 tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    - kubeconfig: {{ kubeconfig }}
-    - context: {{ context }}
 
 
 Deploy kube-proxy (DaemonSet):
@@ -179,8 +170,6 @@ Deploy kube-proxy (DaemonSet):
                 name: lib-modules
           updateStrategy:
             type: RollingUpdate
-    - kubeconfig: {{ kubeconfig }}
-    - context: {{ context }}
     - require:
       - metalk8s_kubernetes: Deploy kube-proxy (ServiceAccount)
       - metalk8s_kubernetes: Deploy kube-proxy (ClusterRoleBinding)
@@ -203,8 +192,6 @@ Deploy kube-proxy (Role):
           - configmaps
           verbs:
           - get
-    - kubeconfig: {{ kubeconfig }}
-    - context: {{ context }}
 
 Deploy kube-proxy (RoleBinding):
   metalk8s_kubernetes.object_present:
@@ -221,7 +208,5 @@ Deploy kube-proxy (RoleBinding):
         subjects:
         - kind: Group
           name: system:bootstrappers:kubeadm:default-node-token
-    - kubeconfig: {{ kubeconfig }}
-    - context: {{ context }}
     - require:
       - metalk8s_kubernetes: Deploy kube-proxy (Role)

--- a/salt/metalk8s/kubernetes/mark-control-plane/deployed.sls.in
+++ b/salt/metalk8s/kubernetes/mark-control-plane/deployed.sls.in
@@ -3,9 +3,6 @@
 {%- set node_name = pillar.bootstrap_id %}
 {%- set cri_socket = kubelet.service.options['container-runtime-endpoint'] %}
 
-{%- set kubeconfig = "/etc/kubernetes/admin.conf" %}
-{%- set context = "kubernetes-admin@kubernetes" %}
-
 Mark control plane node:
   metalk8s_kubernetes.object_updated:
     - name: {{ node_name }}
@@ -27,5 +24,3 @@ Mark control plane node:
             effect: "NoSchedule"
           - key: "node-role.kubernetes.io/infra"
             effect: "NoSchedule"
-    - kubeconfig: {{ kubeconfig }}
-    - context: {{ context }}

--- a/salt/metalk8s/orchestrate/bootstrap/init.sls
+++ b/salt/metalk8s/orchestrate/bootstrap/init.sls
@@ -1,7 +1,5 @@
 {# Because of the grain lookup below, the bootstrap minion *must* be available
    before invoking this SLS, otherwise rendering will fail #}
-{% set kubeconfig = "/etc/kubernetes/admin.conf" %}
-{% set context = "kubernetes-admin@kubernetes" %}
 {%- set bootstrap_control_plane_ip = salt.saltutil.cmd(
         tgt=pillar.bootstrap_id,
         fun='grains.get',
@@ -164,7 +162,5 @@ Store MetalK8s version in annotations:
         metadata:
           annotations:
             metalk8s.scality.com/cluster-version: "{{ version }}"
-    - kubeconfig: {{ kubeconfig }}
-    - context: {{ context }}
     - require:
       - http: Wait for API server to be available

--- a/salt/metalk8s/orchestrate/deploy_node.sls
+++ b/salt/metalk8s/orchestrate/deploy_node.sls
@@ -1,9 +1,6 @@
 {%- set node_name = pillar.orchestrate.node_name %}
 {%- set version = pillar.metalk8s.nodes[node_name].version %}
 
-{%- set kubeconfig = "/etc/kubernetes/admin.conf" %}
-{%- set context = "kubernetes-admin@kubernetes" %}
-
 {%- if node_name not in salt.saltutil.runner('manage.up') %}
 Deploy salt-minion on a new node:
   salt.state:
@@ -49,8 +46,6 @@ Refresh the mine:
 Cordon the node:
   metalk8s_cordon.node_cordoned:
     - name: {{ node_name }}
-    - kubeconfig: {{ kubeconfig }}
-    - context: {{ context }}
 
 {%- if not pillar.orchestrate.get('skip_draining', False) %}
 
@@ -60,8 +55,6 @@ Drain the node:
     - ignore_daemonset: True
     - delete_local_data: True
     - force: True
-    - kubeconfig: {{ kubeconfig }}
-    - context: {{ context }}
     - require:
       - metalk8s_cordon: Cordon the node
     - require_in:
@@ -112,8 +105,6 @@ Wait for API server to be available:
 Uncordon the node:
   metalk8s_cordon.node_uncordoned:
     - name: {{ node_name }}
-    - kubeconfig: {{ kubeconfig }}
-    - context: {{ context }}
     - require:
       - salt: Run the highstate
       - http: Wait for API server to be available

--- a/salt/metalk8s/orchestrate/downgrade/init.sls
+++ b/salt/metalk8s/orchestrate/downgrade/init.sls
@@ -1,6 +1,4 @@
 {%- set dest_version = pillar.metalk8s.cluster_version %}
-{%- set kubeconfig = "/etc/kubernetes/admin.conf" %}
-{%- set context = "kubernetes-admin@kubernetes" %}
 
 Execute the downgrade prechecks:
   salt.runner:
@@ -55,8 +53,6 @@ Set node {{ node }} version to {{ dest_version }}:
         metadata:
           labels:
             metalk8s.scality.com/version: "{{ dest_version }}"
-    - kubeconfig: {{ kubeconfig }}
-    - context: {{ context }}
     - require:
       - http: Wait for API server to be available on {{ node }}
 

--- a/salt/metalk8s/orchestrate/upgrade/init.sls
+++ b/salt/metalk8s/orchestrate/upgrade/init.sls
@@ -1,6 +1,4 @@
 {%- set dest_version = pillar.metalk8s.cluster_version %}
-{%- set kubeconfig = "/etc/kubernetes/admin.conf" %}
-{%- set context = "kubernetes-admin@kubernetes" %}
 
 Execute the upgrade prechecks:
   salt.runner:
@@ -62,8 +60,6 @@ Set node {{ node }} version to {{ dest_version }}:
         metadata:
           labels:
             metalk8s.scality.com/version: "{{ dest_version }}"
-    - kubeconfig: {{ kubeconfig }}
-    - context: {{ context }}
     - require:
       - http: Wait for API server to be available on {{ node }}
 

--- a/salt/metalk8s/repo/deployed.sls
+++ b/salt/metalk8s/repo/deployed.sls
@@ -1,9 +1,5 @@
 {%- from "metalk8s/map.jinja" import repo with context %}
 
-{% set kubeconfig = "/etc/kubernetes/admin.conf" %}
-{% set context = "kubernetes-admin@kubernetes" %}
-
-
 Deploy repo service object:
   metalk8s_kubernetes.object_present:
     - manifest:
@@ -28,5 +24,3 @@ Deploy repo service object:
           selector:
             app.kubernetes.io/name: repositories
           type: ClusterIP
-    - kubeconfig: {{ kubeconfig }}
-    - context: {{ context }}

--- a/salt/metalk8s/salt/master/configured.sls
+++ b/salt/metalk8s/salt/master/configured.sls
@@ -1,5 +1,3 @@
-{%- from "metalk8s/map.jinja" import metalk8s with context %}
-
 {%- set salt_ip = grains['metalk8s']['control_plane_ip'] -%}
 {%- set archives = salt.metalk8s.get_archives() %}
 
@@ -15,6 +13,10 @@ Configure salt master:
     - template: jinja
     - defaults:
         salt_ip: "{{ salt_ip }}"
+        kubeconfig: "{{ pillar['metalk8s']['api_server']['kubeconfig'] }}"
+        {%- if pillar['metalk8s']['api_server'].get('context') %}
+        kubecontext: "{{ pillar['metalk8s']['api_server']['context'] }}"
+        {%- endif %}
 
 Configure salt master roots paths:
   file.serialize:

--- a/salt/metalk8s/salt/master/deployed.sls
+++ b/salt/metalk8s/salt/master/deployed.sls
@@ -1,7 +1,3 @@
-{% set kubeconfig = "/etc/kubernetes/admin.conf" %}
-{% set context = "kubernetes-admin@kubernetes" %}
-
-
 Install and start salt master service manifest:
   metalk8s_kubernetes.object_present:
     - manifest:
@@ -36,5 +32,3 @@ Install and start salt master service manifest:
             app.kubernetes.io/component: salt
             app.kubernetes.io/name: salt-master
           type: ClusterIP
-    - kubeconfig: {{ kubeconfig }}
-    - context: {{ context }}

--- a/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
+++ b/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
@@ -38,3 +38,9 @@ external_auth:
       - '@wheel'
       - '@runner'
       - '@jobs'
+
+# `kubeconfig` file and `context` used by salt to interact with apiserver
+kubernetes.kubeconfig: {{ kubeconfig }}
+{%- if kubecontext is defined and kubecontext %}
+kubernetes.context: {{ kubecontext }}
+{%- endif %}

--- a/scripts/downgrade.sh.in
+++ b/scripts/downgrade.sh.in
@@ -187,7 +187,7 @@ downgrade_bootstrap () {
         | cut -d' ' -f2- )"
     repo_endpoint="$($SALT_CALL pillar.get metalk8s:endpoints:repositories --out txt \
         | cut -d' ' -f2- )"
-    $SALT_CALL --local state.sls metalk8s.roles.bootstrap \
+    $SALT_CALL --local state.sls metalk8s.roles.bootstrap sync_mods="all" \
         saltenv="metalk8s-$DESTINATION_VERSION" \
         pillar="{'metalk8s': {'endpoints': {'salt-master': $saltmaster_endpoint, \
         'repositories': $repo_endpoint}}}" \

--- a/scripts/downgrade.sh.in
+++ b/scripts/downgrade.sh.in
@@ -215,9 +215,7 @@ downgrade_bootstrap () {
         "$bootstrap_id" \
         kind=Node apiVersion=v1 \
         patch="{'metadata': {'labels': \
-        {'metalk8s.scality.com/version': '$DESTINATION_VERSION'}}}" \
-        kubeconfig="/etc/kubernetes/admin.conf" \
-        context="kubernetes-admin@kubernetes"
+        {'metalk8s.scality.com/version': '$DESTINATION_VERSION'}}}"
     "${SALT_MASTER_CALL[@]}" salt-run state.sls \
         metalk8s.orchestrate.deploy_node saltenv="$SALTENV" \
         pillar="{'orchestrate': {'node_name': '$bootstrap_id'}}"
@@ -237,8 +235,6 @@ patch_kubesystem_namespace() {
         kind=Namespace apiVersion=v1 \
         patch="{'metadata': {'annotations': \
         {'metalk8s.scality.com/cluster-version': '$DESTINATION_VERSION'}}}" \
-        kubeconfig="/etc/kubernetes/admin.conf" \
-        context="kubernetes-admin@kubernetes" \
         test="$DRY_RUN"
 }
 

--- a/scripts/upgrade.sh.in
+++ b/scripts/upgrade.sh.in
@@ -202,8 +202,6 @@ patch_kubesystem_namespace() {
         kind=Namespace apiVersion=v1 \
         patch="{'metadata': {'annotations': \
         {'metalk8s.scality.com/cluster-version': '$DESTINATION_VERSION'}}}" \
-        kubeconfig="/etc/kubernetes/admin.conf" \
-        context="kubernetes-admin@kubernetes" \
         test="$DRY_RUN"
 }
 

--- a/scripts/upgrade.sh.in
+++ b/scripts/upgrade.sh.in
@@ -158,7 +158,7 @@ upgrade_bootstrap () {
         metalk8s:endpoints:salt-master --out txt | cut -d' ' -f2- )"
     repo_endpoint="$($SALT_CALL pillar.get \
         metalk8s:endpoints:repositories --out txt | cut -d' ' -f2- )"
-    "${SALT_CALL}" --local state.sls metalk8s.roles.bootstrap \
+    "${SALT_CALL}" --local state.sls metalk8s.roles.bootstrap sync_mods="all" \
         saltenv="metalk8s-$DESTINATION_VERSION" \
         pillar="{'metalk8s': {'endpoints': {'salt-master': $saltmaster_endpoint, \
         'repositories': $repo_endpoint}}}" \


### PR DESCRIPTION
**Component**:

'salt', 'kubernetes'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

We need to have a `kubeconfig` to interact with kubernetes API, before this PR we give the `kubeconfig` to each and every call we do.

**Summary**:

Store the `kubeconfig` and `context` directly in the pillar and salt-master config

**Acceptance criteria**: 

Working bootstrap, upgrade, downgrade

---

Closes: #1099 
Closes: #1100
