### PR TITLE
Generate and serve default certificate for Ingress

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -274,6 +274,8 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/addons/nginx-ingress/deployed/chart.sls'),
     Path('salt/metalk8s/addons/nginx-ingress/deployed/namespace.sls'),
 
+    Path('salt/metalk8s/addons/nginx-ingress-control-plane/certs/init.sls'),
+    Path('salt/metalk8s/addons/nginx-ingress-control-plane/certs/server.sls'),
     Path('salt/metalk8s/addons/nginx-ingress-control-plane/deployed/init.sls'),
     Path('salt/metalk8s/addons/nginx-ingress-control-plane/deployed/chart.sls'),
 

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -268,6 +268,8 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/addons/nginx-ingress/ca/init.sls'),
     Path('salt/metalk8s/addons/nginx-ingress/ca/installed.sls'),
     Path('salt/metalk8s/addons/nginx-ingress/ca/advertised.sls'),
+    Path('salt/metalk8s/addons/nginx-ingress/certs/init.sls'),
+    Path('salt/metalk8s/addons/nginx-ingress/certs/server.sls'),
     Path('salt/metalk8s/addons/nginx-ingress/deployed/init.sls'),
     Path('salt/metalk8s/addons/nginx-ingress/deployed/chart.sls'),
     Path('salt/metalk8s/addons/nginx-ingress/deployed/namespace.sls'),

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -265,6 +265,9 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
         file_dep=[VOLUME_CRD],
     ),
 
+    Path('salt/metalk8s/addons/nginx-ingress/ca/init.sls'),
+    Path('salt/metalk8s/addons/nginx-ingress/ca/installed.sls'),
+    Path('salt/metalk8s/addons/nginx-ingress/ca/advertised.sls'),
     Path('salt/metalk8s/addons/nginx-ingress/deployed/init.sls'),
     Path('salt/metalk8s/addons/nginx-ingress/deployed/chart.sls'),
     Path('salt/metalk8s/addons/nginx-ingress/deployed/namespace.sls'),

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -278,6 +278,8 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/addons/nginx-ingress-control-plane/certs/server.sls'),
     Path('salt/metalk8s/addons/nginx-ingress-control-plane/deployed/init.sls'),
     Path('salt/metalk8s/addons/nginx-ingress-control-plane/deployed/chart.sls'),
+    Path('salt/metalk8s/addons/nginx-ingress-control-plane/deployed/',
+         'tls-secret.sls'),
 
     Path('salt/metalk8s/container-engine/containerd/configured.sls'),
     Path('salt/metalk8s/container-engine/containerd/files/50-metalk8s.conf'),

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -273,6 +273,7 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/addons/nginx-ingress/deployed/init.sls'),
     Path('salt/metalk8s/addons/nginx-ingress/deployed/chart.sls'),
     Path('salt/metalk8s/addons/nginx-ingress/deployed/namespace.sls'),
+    Path('salt/metalk8s/addons/nginx-ingress/deployed/tls-secret.sls'),
 
     Path('salt/metalk8s/addons/nginx-ingress-control-plane/certs/init.sls'),
     Path('salt/metalk8s/addons/nginx-ingress-control-plane/certs/server.sls'),

--- a/charts/nginx-ingress-control-plane.yaml
+++ b/charts/nginx-ingress-control-plane.yaml
@@ -38,5 +38,8 @@ controller:
     ports:
       https: 8443
 
+  extraArgs:
+    default-ssl-certificate: "metalk8s-ingress/ingress-control-plane-default-certificate"
+
 defaultBackend:
   enabled: false

--- a/charts/nginx-ingress.yaml
+++ b/charts/nginx-ingress.yaml
@@ -18,6 +18,9 @@ controller:
   service:
     type: ClusterIP
 
+  extraArgs:
+    default-ssl-certificate: "metalk8s-ingress/ingress-workload-plane-default-certificate"
+
 defaultBackend:
   image:
     repository: '{%- endraw -%}{{ build_image_name(\"nginx-ingress-defaultbackend-amd64\", False) }}{%- raw -%}'

--- a/pillar/metalk8s/roles/ca.sls
+++ b/pillar/metalk8s/roles/ca.sls
@@ -55,3 +55,10 @@ x509_signing_policies:
     - keyUsage: critical digitalSignature, keyEncipherment
     - extendedKeyUsage: clientAuth
     - days_valid: 365
+  ingress_server_policy:
+    - minions: '*'
+    - signing_private_key: /etc/metalk8s/pki/nginx-ingress/ca.key
+    - signing_cert: /etc/metalk8s/pki/nginx-ingress/ca.crt
+    - keyUsage: critical digitalSignature, keyEncipherment
+    - extendedKeyUsage: serverAuth
+    - days_valid: 365

--- a/pillar/metalk8s/roles/ca.sls
+++ b/pillar/metalk8s/roles/ca.sls
@@ -15,6 +15,10 @@ mine_functions:
     mine_function: hashutil.base64_encodefile
     fname: /etc/kubernetes/pki/sa.pub
 
+  ingress_ca_b64:
+    mine_function: hashutil.base64_encodefile
+    fname: /etc/metalk8s/pki/nginx-ingress/ca.crt
+
 x509_signing_policies:
   kube_apiserver_client_policy:
     - minions: '*'

--- a/salt/metalk8s/addons/nginx-ingress-control-plane/certs/init.sls
+++ b/salt/metalk8s/addons/nginx-ingress-control-plane/certs/init.sls
@@ -1,0 +1,2 @@
+include:
+  - .server

--- a/salt/metalk8s/addons/nginx-ingress-control-plane/certs/server.sls
+++ b/salt/metalk8s/addons/nginx-ingress-control-plane/certs/server.sls
@@ -1,0 +1,45 @@
+{%- from "metalk8s/map.jinja" import nginx_ingress with context %}
+
+include:
+  - metalk8s.internal.m2crypto
+
+Create Control-Plane Ingress server private key:
+  x509.private_key_managed:
+    - name: /etc/metalk8s/pki/nginx-ingress/control-plane-server.key
+    - bits: 4096
+    - verbose: False
+    - user: root
+    - group: root
+    - mode: 600
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - metalk8s_package_manager: Install m2crypto
+
+{# TODO: add Ingress Service IP once stable (LoadBalancer probably) #}
+{%- set certSANs = [
+    grains.fqdn,
+    'localhost',
+    '127.0.0.1',
+    'nginx-ingress-control-plane',
+    'nginx-ingress-control-plane.metalk8s-ingress',
+    'nginx-ingress-control-plane.metalk8s-ingress.svc',
+    'nginx-ingress-control-plane.metalk8s-ingress.svc.cluster.local',
+    grains.metalk8s.control_plane_ip,
+] %}
+
+Generate Control-Plane Ingress server certificate:
+  x509.certificate_managed:
+    - name: /etc/metalk8s/pki/nginx-ingress/control-plane-server.crt
+    - public_key: /etc/metalk8s/pki/nginx-ingress/control-plane-server.key
+    - ca_server: {{ pillar.metalk8s.ca.minion }}
+    - signing_policy: {{ nginx_ingress.cert.server_signing_policy }}
+    - CN: nginx-ingress-control-plane-server
+    - subjectAltName: "{{ salt['metalk8s.format_san'](certSANs | unique) }}"
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - x509: Create Control-Plane Ingress server private key

--- a/salt/metalk8s/addons/nginx-ingress-control-plane/deployed/chart.sls
+++ b/salt/metalk8s/addons/nginx-ingress-control-plane/deployed/chart.sls
@@ -278,6 +278,7 @@ spec:
         - --election-id=ingress-control-plane-controller-leader
         - --ingress-class=nginx-control-plane
         - --configmap=metalk8s-ingress/nginx-ingress-control-plane-controller
+        - --default-ssl-certificate=metalk8s-ingress/ingress-control-plane-default-certificate
         env:
         - name: POD_NAME
           valueFrom:

--- a/salt/metalk8s/addons/nginx-ingress-control-plane/deployed/init.sls
+++ b/salt/metalk8s/addons/nginx-ingress-control-plane/deployed/init.sls
@@ -1,3 +1,4 @@
 include:
   - metalk8s.addons.nginx-ingress.deployed.namespace
+  - .tls-secret
   - .chart

--- a/salt/metalk8s/addons/nginx-ingress-control-plane/deployed/tls-secret.sls
+++ b/salt/metalk8s/addons/nginx-ingress-control-plane/deployed/tls-secret.sls
@@ -1,0 +1,19 @@
+#!jinja | metalk8s_kubernetes kubeconfig=/etc/kubernetes/admin.conf&context=kubernetes-admin@kubernetes
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ingress-control-plane-default-certificate
+  namespace: metalk8s-ingress
+type: Opaque
+data:
+  tls.crt: "{{
+    salt['hashutil.base64_encodefile'](
+        '/etc/metalk8s/pki/nginx-ingress/control-plane-server.crt'
+    ) | replace('\n', '')
+  }}"
+  tls.key: "{{
+    salt['hashutil.base64_encodefile'](
+        '/etc/metalk8s/pki/nginx-ingress/control-plane-server.key'
+    ) | replace('\n', '')
+  }}"

--- a/salt/metalk8s/addons/nginx-ingress/ca/advertised.sls
+++ b/salt/metalk8s/addons/nginx-ingress/ca/advertised.sls
@@ -1,0 +1,25 @@
+{%- set ingress_ca_b64_server = salt['mine.get'](
+    pillar.metalk8s.ca.minion, 'ingress_ca_b64'
+) %}
+
+{%- if ingress_ca_b64_server %}
+
+{%- set ingress_cert_b64 = ingress_ca_b64_server[pillar.metalk8s.ca.minion] %}
+{%- set ingress_ca_cert = salt['hashutil.base64_b64decode'](ingress_cert_b64) %}
+
+Ensure Ingress CA cert is present:
+  file.managed:
+    - name: /etc/metalk8s/pki/nginx-ingress/ca.crt
+    - user: root
+    - group : root
+    - mode: 644
+    - makedirs: True
+    - dir_mode: 755
+    - contents: {{ ingress_ca_cert.splitlines() }}
+
+{%- else %}
+
+Unable to get Ingress CA cert, no ingress_ca_b64 in mine:
+  test.fail_without_changes: []
+
+{%- endif %}

--- a/salt/metalk8s/addons/nginx-ingress/ca/init.sls
+++ b/salt/metalk8s/addons/nginx-ingress/ca/init.sls
@@ -1,0 +1,12 @@
+#
+# State to manage self-signed Ingress Certificate Authority
+#
+# Available states
+# ================
+#
+# * installed   -> install and advertise as Ingress CA
+# * advertised  -> deploy the Ingress CA certificate
+#
+
+include:
+  - .installed

--- a/salt/metalk8s/addons/nginx-ingress/ca/installed.sls
+++ b/salt/metalk8s/addons/nginx-ingress/ca/installed.sls
@@ -1,0 +1,42 @@
+{%- from "metalk8s/map.jinja" import nginx_ingress with context %}
+
+include:
+  - metalk8s.internal.m2crypto
+
+Create Ingress CA private key:
+  x509.private_key_managed:
+    - name: /etc/metalk8s/pki/nginx-ingress/ca.key
+    - bits: 4096
+    - verbose: False
+    - user: root
+    - group: root
+    - mode: 600
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - metalk8s_package_manager: Install m2crypto
+
+Generate Ingress CA certificate:
+  x509.certificate_managed:
+    - name: /etc/metalk8s/pki/nginx-ingress/ca.crt
+    - signing_private_key: /etc/metalk8s/pki/nginx-ingress/ca.key
+    - CN: ingress-ca
+    - keyUsage: "critical digitalSignature, keyEncipherment, keyCertSign"
+    - basicConstraints: "critical CA:true"
+    - days_valid: {{ nginx_ingress.ca.cert.days_valid }}
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - x509: Create Ingress CA private key
+
+Advertise Ingress CA certificate in the mine:
+  module.wait:
+    - mine.send:
+      - func: ingress_ca_b64
+      - mine_function: hashutil.base64_encodefile
+      - /etc/metalk8s/pki/nginx-ingress/ca.crt
+    - watch:
+      - x509: Generate Ingress CA certificate

--- a/salt/metalk8s/addons/nginx-ingress/certs/init.sls
+++ b/salt/metalk8s/addons/nginx-ingress/certs/init.sls
@@ -1,0 +1,2 @@
+include:
+  - .server

--- a/salt/metalk8s/addons/nginx-ingress/certs/server.sls
+++ b/salt/metalk8s/addons/nginx-ingress/certs/server.sls
@@ -1,0 +1,45 @@
+{%- from "metalk8s/map.jinja" import nginx_ingress with context %}
+
+include:
+  - metalk8s.internal.m2crypto
+
+Create Workload-Plane Ingress server private key:
+  x509.private_key_managed:
+    - name: /etc/metalk8s/pki/nginx-ingress/workload-plane-server.key
+    - bits: 4096
+    - verbose: False
+    - user: root
+    - group: root
+    - mode: 600
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - metalk8s_package_manager: Install m2crypto
+
+{# TODO: add Ingress Service IP once stable (LoadBalancer probably) #}
+{%- set certSANs = [
+    grains.fqdn,
+    'localhost',
+    '127.0.0.1',
+    'nginx-ingress-workload-plane',
+    'nginx-ingress-workload-plane.metalk8s-ingress',
+    'nginx-ingress-workload-plane.metalk8s-ingress.svc',
+    'nginx-ingress-workload-plane.metalk8s-ingress.svc.cluster.local',
+    grains.metalk8s.workload_plane_ip,
+] %}
+
+Generate Workload-Plane Ingress server certificate:
+  x509.certificate_managed:
+    - name: /etc/metalk8s/pki/nginx-ingress/workload-plane-server.crt
+    - public_key: /etc/metalk8s/pki/nginx-ingress/workload-plane-server.key
+    - ca_server: {{ pillar.metalk8s.ca.minion }}
+    - signing_policy: {{ nginx_ingress.cert.server_signing_policy }}
+    - CN: nginx-ingress-workload-plane-server
+    - subjectAltName: "{{ salt['metalk8s.format_san'](certSANs | unique) }}"
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - dir_mode: 755
+    - require:
+      - x509: Create Workload-Plane Ingress server private key

--- a/salt/metalk8s/addons/nginx-ingress/deployed/chart.sls
+++ b/salt/metalk8s/addons/nginx-ingress/deployed/chart.sls
@@ -322,6 +322,7 @@ spec:
         - --election-id=ingress-controller-leader
         - --ingress-class=nginx
         - --configmap=metalk8s-ingress/nginx-ingress-controller
+        - --default-ssl-certificate=metalk8s-ingress/ingress-workload-plane-default-certificate
         env:
         - name: POD_NAME
           valueFrom:

--- a/salt/metalk8s/addons/nginx-ingress/deployed/init.sls
+++ b/salt/metalk8s/addons/nginx-ingress/deployed/init.sls
@@ -1,3 +1,4 @@
 include:
   - .namespace
+  - .tls-secret
   - .chart

--- a/salt/metalk8s/addons/nginx-ingress/deployed/tls-secret.sls
+++ b/salt/metalk8s/addons/nginx-ingress/deployed/tls-secret.sls
@@ -1,0 +1,19 @@
+#!jinja | metalk8s_kubernetes kubeconfig=/etc/kubernetes/admin.conf&context=kubernetes-admin@kubernetes
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ingress-workload-plane-default-certificate
+  namespace: metalk8s-ingress
+type: Opaque
+data:
+  tls.crt: "{{
+    salt['hashutil.base64_encodefile'](
+        '/etc/metalk8s/pki/nginx-ingress/workload-plane-server.crt'
+    ) | replace('\n', '')
+  }}"
+  tls.key: "{{
+    salt['hashutil.base64_encodefile'](
+        '/etc/metalk8s/pki/nginx-ingress/workload-plane-server.key'
+    ) | replace('\n', '')
+  }}"

--- a/salt/metalk8s/defaults.yaml
+++ b/salt/metalk8s/defaults.yaml
@@ -80,6 +80,13 @@ front_proxy:
   cert:
     client_signing_policy: front_proxy_client_policy
 
+nginx-ingress:
+  ca:
+    cert:
+      days_valid: 3650
+    signing_policy:
+      days_valid: 365
+
 coredns:
   cluster_domain: cluster.local
   reverse_cidrs: in-addr.arpa ip6.arpa

--- a/salt/metalk8s/defaults.yaml
+++ b/salt/metalk8s/defaults.yaml
@@ -86,6 +86,8 @@ nginx-ingress:
       days_valid: 3650
     signing_policy:
       days_valid: 365
+  cert:
+    server_signing_policy: ingress_server_policy
 
 coredns:
   cluster_domain: cluster.local

--- a/salt/metalk8s/map.jinja
+++ b/salt/metalk8s/map.jinja
@@ -213,3 +213,7 @@
 {% set kubeadm_kubeconfig = salt['grains.filter_by']({
   'default': {}
 }, merge=defaults.get('kubeadm_kubeconfig')) %}
+
+{% set nginx_ingress = salt['grains.filter_by']({
+  'default': {}
+}, merge=defaults.get('nginx-ingress')) %}

--- a/salt/metalk8s/roles/ca/init.sls
+++ b/salt/metalk8s/roles/ca/init.sls
@@ -1,3 +1,4 @@
 include:
   - metalk8s.kubernetes.ca
   - metalk8s.kubernetes.sa
+  - metalk8s.addons.nginx-ingress.ca

--- a/salt/metalk8s/salt/master/certs/init.sls
+++ b/salt/metalk8s/salt/master/certs/init.sls
@@ -10,5 +10,6 @@
 include:
   # Some server certs are required to be published in K8s API by Salt master
   - metalk8s.addons.nginx-ingress-control-plane.certs
+  - metalk8s.addons.nginx-ingress.certs
   - .etcd-client
   - .salt-api

--- a/salt/metalk8s/salt/master/certs/init.sls
+++ b/salt/metalk8s/salt/master/certs/init.sls
@@ -8,5 +8,7 @@
 # * salt-api              -> generate Salt API key and certificate
 #
 include:
+  # Some server certs are required to be published in K8s API by Salt master
+  - metalk8s.addons.nginx-ingress-control-plane.certs
   - .etcd-client
   - .salt-api

--- a/scripts/downgrade.sh.in
+++ b/scripts/downgrade.sh.in
@@ -107,6 +107,17 @@ downgrade_bootstrap () {
         | cut -d' ' -f2- )"
     repo_endpoint="$($SALT_CALL pillar.get metalk8s:endpoints:repositories --out txt \
         | cut -d' ' -f2- )"
+
+    SALT_MASTER_CALL=(crictl exec -i "$(get_salt_container)")
+    ca_minion="$($SALT_CALL pillar.get \
+        metalk8s:ca:minion --out txt | cut -c 8-)"
+
+    "${SALT_MASTER_CALL[@]}" salt "$ca_minion" state.sls \
+        metalk8s.roles.ca saltenv="metalk8s-$DESTINATION_VERSION"
+
+    $SALT_CALL state.sls metalk8s.salt.master.certs \
+        saltenv="metalk8s-$DESTINATION_VERSION" --retcode-passthrough
+
     $SALT_CALL --local state.sls metalk8s.roles.bootstrap \
         saltenv="metalk8s-$DESTINATION_VERSION" \
         pillar="{'metalk8s': {'endpoints': {'salt-master': $saltmaster_endpoint, \

--- a/scripts/upgrade.sh.in
+++ b/scripts/upgrade.sh.in
@@ -78,6 +78,17 @@ upgrade_bootstrap () {
         metalk8s:endpoints:salt-master --out txt | cut -d' ' -f2- )"
     repo_endpoint="$($SALT_CALL pillar.get \
         metalk8s:endpoints:repositories --out txt | cut -d' ' -f2- )"
+
+    SALT_MASTER_CALL=(crictl exec -i "$(get_salt_container)")
+    ca_minion="$($SALT_CALL pillar.get \
+        metalk8s:ca:minion --out txt | cut -c 8-)"
+
+    "${SALT_MASTER_CALL[@]}" salt "$ca_minion" state.sls \
+        metalk8s.roles.ca saltenv="metalk8s-$DESTINATION_VERSION"
+
+    ${SALT_CALL} state.sls metalk8s.salt.master.certs \
+        saltenv="metalk8s-$DESTINATION_VERSION" --retcode-passthrough
+
     "${SALT_CALL}" --local state.sls metalk8s.roles.bootstrap \
         saltenv="metalk8s-$DESTINATION_VERSION" \
         pillar="{'metalk8s': {'endpoints': {'salt-master': $saltmaster_endpoint, \


### PR DESCRIPTION
**Component**: salt, ingress

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**:

Whenever an `nginx-ingress-controller` configures its NGINX for an Ingress without a host or without TLS configured, it will set it up to use a _Fake Certificate_ that it generates on startup.
As such, any restart of the Pods will imply new certs being generated, which will break clients trust.

We also would like to use a CA for those certificates, allowing one to trust this CA instead of self-signed certs (this will be particularly useful for Dex setup, where API Server needs to trust the Ingress endpoint of Dex - see #2025).

**Summary**:

- Generate a CA for Ingress controllers (`/etc/metalk8s/pki/nginx-ingress/ca.[crt|key]`)
- Generate default server certs for both Ingress controllers (`/etc/metalk8s/pki/nginx-ingress/[control|workload]-plane-server.[crt|key]`)
- Store control-plane server cert/key in a _Secret_ (`metalk8s-ingress/ingress-control-plane-default-certificate`)
- Use that _Secret_ as a default certificate for the `nginx-ingress-control-plane` controller

**Acceptance criteria**: 

- When accessing a path served by the control-plane Ingress (`{bootstrap_control_plane_ip}:8443/...`), one receives a certificate with CN `nginx-ingress-control-plane-server`, issued by a CA called `ingress-ca`
- After restarting the `nginx-ingress-control-plane` controller Pod(s), one can refresh the UI without the need to accept new certificates