### PR TITLE
Upgrade Kubernetes to 1.16.2

### DIFF
--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -18,7 +18,7 @@ Image = namedtuple('Image', ('name', 'version', 'digest'))
 # Project-wide versions {{{
 
 CALICO_VERSION     : str = '3.8.2'
-K8S_VERSION        : str = '1.15.5'
+K8S_VERSION        : str = '1.16.2'
 KEEPALIVED_VERSION : str = '1.3.5-16.el7'
 SALT_VERSION       : str = '2018.3.4'
 
@@ -121,22 +121,22 @@ CONTAINER_IMAGES : Tuple[Image, ...] = (
     Image(
         name='kube-apiserver',
         version=_version_prefix(K8S_VERSION),
-        digest='sha256:eba42853b39748c92b435338ac8f643b3378069376176ce1adbd6157ae389695',
+        digest='sha256:8c31925d4d86a8a4b45edbebba17f0a9bc00acb8a80796085f18218feb9471cf',
     ),
     Image(
         name='kube-controller-manager',
         version=_version_prefix(K8S_VERSION),
-        digest='sha256:8e7d9c4e74d582a0d6c576b2c60e12a1fc09caaecc8af5eb746d50a30b7b1b48',
+        digest='sha256:d24ea0e3d735fcd81801482e3ba14e60f2b5b71c639c60db303f7287fbfc5eec',
     ),
     Image(
         name='kube-proxy',
         version=_version_prefix(K8S_VERSION),
-        digest='sha256:c1de8f4c784a90d4e997e0b89fdd7392a289c3ed7abd7210713bb9f1f3b0a00d',
+        digest='sha256:dea8ba1d374a2e5bf0498d32a6fd32b6bf09d18f74db3758c641b54d7010a01f',
     ),
     Image(
         name='kube-scheduler',
         version=_version_prefix(K8S_VERSION),
-        digest='sha256:ec985e27f41e3ceec552440502dbfa723924d5e6d72fc9193d140972e24b8b77',
+        digest='sha256:00a8ef7932173272fc6352c799f4e9c33240e4f6b92580d24989008faa31cb0d',
     ),
     Image(
         name='kube-state-metrics',

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -105,8 +105,8 @@ CONTAINER_IMAGES : Tuple[Image, ...] = (
     ),
     Image(
         name='etcd',
-        version='3.3.10',
-        digest='sha256:17da501f5d2a675be46040422a27b7cc21b8a43895ac998b171db1c346f361f7',
+        version='3.3.15-0',
+        digest='sha256:12c2c5e5731c3bcd56e6f1c05c0f9198b6f06793fa7fca2fb43aab9622dc4afa',
     ),
     Image(
         name='grafana',

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -775,6 +775,12 @@ stages:
       - ShellCommand:
           <<: *run_bootstrap
           env: *_env_version_prev
+      - ShellCommand:
+          <<: *provision_prometheus_volumes
+          env:
+            BRANCH: "development/%(prop:product_version_prev)s"
+            PRODUCT_TXT: "/srv/scality/metalk8s-%(prop:metalk8s_version_prev)s/product.txt"
+            PRODUCT_MOUNT: "/srv/scality/metalk8s-%(prop:metalk8s_version_prev)s"
       # --- Test version N-1 ---
       - ShellCommand: *fast_tests_prev
       # --- Upgrade to version N ---

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -657,12 +657,13 @@ stages:
       - ShellCommand: *run_bootstrap
       - ShellCommand: &provision_prometheus_volumes
           name: Provision Prometheus and AlertManager storage
+          env:
+            BRANCH: "%(prop:branch)s"
+            PRODUCT_TXT: "/srv/scality/metalk8s-%(prop:metalk8s_version)s/product.txt"
+            PRODUCT_MOUNT: "/srv/scality/metalk8s-%(prop:metalk8s_version)s"
           command: >
-            git checkout %(prop:branch)s --quiet &&
-            sudo env
-            PRODUCT_TXT=/srv/scality/metalk8s-%(prop:metalk8s_version)s/product.txt
-            PRODUCT_MOUNT=/srv/scality/metalk8s-%(prop:metalk8s_version)s
-            eve/create-volumes.sh
+            git checkout "${BRANCH}" --quiet &&
+            sudo -E eve/create-volumes.sh
           haltOnFailure: true
       # --- Test version N ---
       - ShellCommand: &fast_tests

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -425,7 +425,8 @@ stages:
           name: Trigger single-node and multiple-nodes steps with built ISO
           stage_names:
             - single-node-upgrade-centos
-            - single-node-downgrade-centos
+            # Downgrade is deactivated on this branch due to #2058
+            #- single-node-downgrade-centos
             - single-node-install-rhel
             - multiple-nodes-centos
       - ShellCommand: *add_final_status_artifact_success

--- a/salt/_utils/kubernetes_utils.py
+++ b/salt/_utils/kubernetes_utils.py
@@ -282,30 +282,10 @@ if HAS_LIBS:
         ),
         # }}}
         # /apis/extensions/v1beta1/ {{{
-        ('extensions/v1beta1', 'DaemonSet'): KindInfo(
-            model=k8s_client.V1beta1DaemonSet,
-            api_cls=k8s_client.ExtensionsV1beta1Api,
-            name='namespaced_daemon_set',
-        ),
-        ('extensions/v1beta1', 'Deployment'): KindInfo(
-            model=k8s_client.ExtensionsV1beta1Deployment,
-            api_cls=k8s_client.ExtensionsV1beta1Api,
-            name='namespaced_deployment',
-        ),
         ('extensions/v1beta1', 'Ingress'): KindInfo(
             model=k8s_client.V1beta1Ingress,
             api_cls=k8s_client.ExtensionsV1beta1Api,
             name='namespaced_ingress'
-        ),
-        ('extensions/v1beta1', 'PodSecurityPolicy'): KindInfo(
-            model=k8s_client.ExtensionsV1beta1PodSecurityPolicy,
-            api_cls=k8s_client.ExtensionsV1beta1Api,
-            name='pod_security_policy',
-        ),
-        ('extensions/v1beta1', 'ReplicaSet'): KindInfo(
-            model=k8s_client.V1beta1ReplicaSet,
-            api_cls=k8s_client.ExtensionsV1beta1Api,
-            name='namespaced_replica_set',
         ),
         # }}}
         # /apis/apiextensions.k8s.io/v1beta1/ {{{

--- a/salt/metalk8s/addons/prometheus-operator/deployed/cleanup.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/cleanup.sls
@@ -7,7 +7,7 @@
 # corresponding entry may need to be removed here...
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: prometheus-operator-grafana-test

--- a/salt/metalk8s/kubernetes/kube-proxy/deployed.sls
+++ b/salt/metalk8s/kubernetes/kube-proxy/deployed.sls
@@ -115,7 +115,7 @@ Deploy kube-proxy (ConfigMap):
 Deploy kube-proxy (DaemonSet):
   metalk8s_kubernetes.object_present:
     - manifest:
-        apiVersion: extensions/v1beta1
+        apiVersion: apps/v1
         kind: DaemonSet
         metadata:
           name: kube-proxy

--- a/salt/metalk8s/orchestrate/downgrade/init.sls
+++ b/salt/metalk8s/orchestrate/downgrade/init.sls
@@ -109,7 +109,7 @@ Delete old nginx ingress daemon set:
     - name: nginx-ingress-controller
     - namespace: metalk8s-ingress
     - kind: DaemonSet
-    - apiVersion: extensions/v1beta1
+    - apiVersion: apps/v1
     - wait:
         attempts: 10
         sleep: 10
@@ -123,7 +123,7 @@ Delete old nginx ingress deployment:
     - name: nginx-ingress-default-backend
     - namespace: metalk8s-ingress
     - kind: Deployment
-    - apiVersion: extensions/v1beta1
+    - apiVersion: apps/v1
     - wait:
         attempts: 10
         sleep: 10

--- a/salt/metalk8s/orchestrate/upgrade/init.sls
+++ b/salt/metalk8s/orchestrate/upgrade/init.sls
@@ -116,7 +116,7 @@ Deploy node {{ node }}:
     ``` #}
 {%- set nginx_ingress_ds = salt.metalk8s_kubernetes.get_object(
         kind='DaemonSet',
-        apiVersion='extensions/v1beta1',
+        apiVersion='apps/v1',
         name='nginx-ingress-controller',
         namespace='metalk8s-ingress',
         kubeconfig=kubeconfig,
@@ -124,7 +124,7 @@ Deploy node {{ node }}:
     ) %}
 {%- set nginx_ingress_deploy = salt.metalk8s_kubernetes.get_object(
         kind='Deployment',
-        apiVersion='extensions/v1beta1',
+        apiVersion='apps/v1',
         name='nginx-ingress-default-backend',
         namespace='metalk8s-ingress',
         kubeconfig=kubeconfig,
@@ -146,7 +146,7 @@ Delete old nginx ingress daemon set:
     - name: nginx-ingress-controller
     - namespace: metalk8s-ingress
     - kind: DaemonSet
-    - apiVersion: extensions/v1beta1
+    - apiVersion: apps/v1
     - wait:
         attempts: 10
         sleep: 10
@@ -165,7 +165,7 @@ Delete old nginx ingress deployment:
     - name: nginx-ingress-default-backend
     - namespace: metalk8s-ingress
     - kind: Deployment
-    - apiVersion: extensions/v1beta1
+    - apiVersion: apps/v1
     - wait:
         attempts: 10
         sleep: 10


### PR DESCRIPTION
**Component**: kubernetes

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: New `development/2.5` branch

**Summary**:

- Some deprecated APIs were removed in K8s 1.16, so we need to update some objects and remove the support for those in our Salt modules
- Downgrade is disabled for this branch, due to an issue in the ordering (trying to deploy K8s objects for the destination version while `k-a` is not downgraded yet, hence conflicting on those deprecated APIs)
