### PR TITLE
UI: Bugfix - provision volumes with labels

### DIFF
--- a/ui/cypress.json
+++ b/ui/cypress.json
@@ -4,8 +4,10 @@
     "username": "admin",
     "password": "admin",
     "device_path": "/dev/disk1",
-    "volume_capacity": "1",
-    "storage_class":"metalk8s-prometheus"
+    "volume_capacity": 1,
+    "storage_class":"metalk8s-prometheus",
+    "volume_label_name":"kubernetest.io/name",
+    "volume_label_value":"test"
   },
   "reporter": "junit",
   "reporterOptions": {

--- a/ui/cypress.sh
+++ b/ui/cypress.sh
@@ -6,7 +6,7 @@ CONTROL_PLANE_IP=$(ip a show eth0 | grep -Po "inet \K[\d.]+")
 # The version of Cypress we install below requires GTK3 to be available
 test -n "${IN_CI}" && sudo yum install -y gtk3
 
-npm install --no-save --quiet --no-package-lock cypress@3.5.0 cypress-cucumber-preprocessor@1.12.0
+npm install --no-save --quiet --no-package-lock cypress@3.5.0 cypress-cucumber-preprocessor@1.12.0 cypress-wait-until@1.6.0
 
 test -n "${IN_CI}" && \
     sudo chown root:root /home/eve/.cache/Cypress/3.5.0/Cypress/chrome-sandbox && \

--- a/ui/cypress/integration/CreateVolume.feature
+++ b/ui/cypress/integration/CreateVolume.feature
@@ -5,9 +5,9 @@ Feature: CreateVolume
      And I go to the bootstrap node by click on the bootstrap row in the list
      And I choose the Volumes tag
      And I go to create volume page by click on Create a New Volume button
-     Then I fill out the create volume form with SparseLoopDevice volume type and ckeck if the the volume I created is displayed on the volume list
+     Then I fill out the create volume form with SparseLoopDevice volume type and ckeck if the volume is created correctly
 
- Scenario: CreateVolume with RawBlockDevice
+Scenario: CreateVolume with RawBlockDevice
      Given I log in
      When I go to the nodes list by click the node icon in the sidebar
      And I go to the bootstrap node by click on the bootstrap row in the list

--- a/ui/cypress/support/commands.js
+++ b/ui/cypress/support/commands.js
@@ -23,3 +23,4 @@
 //
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+import 'cypress-wait-until';

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -5466,6 +5466,12 @@
         }
       }
     },
+    "cypress-wait-until": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/cypress-wait-until/-/cypress-wait-until-1.6.0.tgz",
+      "integrity": "sha512-uGbEKZQ8tnCvq+G058jvcj1zMb6dF2lg5KxsWXnkk1EQ/5lZewvqGWb/RV7hiPvwxQblUDBH1Chb8tyjH2ZmLg==",
+      "dev": true
+    },
     "d": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",

--- a/ui/package.json
+++ b/ui/package.json
@@ -56,6 +56,7 @@
     "customize-cra": "^0.4.1",
     "cypress": "^3.2.0",
     "cypress-cucumber-preprocessor": "1.12.0",
+    "cypress-wait-until": "1.6.0",
     "flow-bin": "^0.107.0",
     "jest-junit": "^7.0.0",
     "react-app-rewired": "^2.1.3",

--- a/ui/src/containers/CreateVolume.js
+++ b/ui/src/containers/CreateVolume.js
@@ -128,10 +128,12 @@ const LabelsValue = styled.div`
   width: 200px;
   padding: ${padding.small} 0;
   margin-right: ${padding.small};
+  color: ${props => props.theme.brand.text};
 `;
 
 const LabelsName = styled(LabelsValue)`
   font-weight: ${fontWeight.bold};
+  color: ${props => props.theme.brand.text};
 `;
 
 const CreateVolume = props => {

--- a/ui/src/containers/CreateVolume.js
+++ b/ui/src/containers/CreateVolume.js
@@ -383,6 +383,7 @@ const CreateVolume = props => {
                           text={intl.messages.add}
                           type="button"
                           onClick={addLabel}
+                          data-cy="add-volume-labels-button"
                         />
                       </LabelsForm>
                       {!!Object.keys(values.labels).length && (

--- a/ui/src/containers/VolumeInformation.js
+++ b/ui/src/containers/VolumeInformation.js
@@ -99,11 +99,11 @@ const VolumeInformation = props => {
       dataKey: 'value',
     },
   ];
-  const labels = volume?.metadata?.labels
-    ? Object.keys(volume.metadata.labels).map(key => {
+  const labels = pV?.metadata?.labels //persistent Volume labels
+    ? Object.keys(pV.metadata.labels).map(key => {
         return {
           name: key,
-          value: volume.metadata.labels[key],
+          value: pV.metadata.labels[key],
         };
       })
     : [];

--- a/ui/src/ducks/app/volumes.js
+++ b/ui/src/ducks/app/volumes.js
@@ -217,6 +217,11 @@ export function* createVolumes({ payload }) {
     spec: {
       nodeName,
       storageClassName: newVolume.storageClass,
+      template: {
+        metadata: {
+          labels: newVolume.labels,
+        },
+      },
     },
   };
 

--- a/ui/src/ducks/app/volumes.test.js
+++ b/ui/src/ducks/app/volumes.test.js
@@ -284,6 +284,9 @@ it('create volume with the type sparseloopdevice', () => {
         storageClass: 'metalk8s-default',
         type: 'sparseLoopDevice',
         size: '1Gi',
+        labels: {
+          name: 'carlito',
+        },
       },
       nodeName: 'bootstrap',
     },
@@ -298,11 +301,22 @@ it('create volume with the type sparseloopdevice', () => {
     kind: 'Volume',
     metadata: {
       name: newVolume.name,
+      labels: {
+        name: 'carlito',
+      },
     },
     spec: {
       nodeName: nodeName,
       storageClassName: newVolume.storageClass,
       sparseLoopDevice: { size: newVolume.size },
+      storageClassName: 'metalk8s-default',
+      template: {
+        metadata: {
+          labels: {
+            name: 'carlito',
+          },
+        },
+      },
     },
   };
 
@@ -349,6 +363,9 @@ it('create a volume with the type rawBlockdevice', () => {
         storageClass: 'metalk8s-default',
         type: 'rawBlockDevice',
         path: '/dev/disk1',
+        labels: {
+          name: 'carlito',
+        },
       },
       nodeName: 'bootstrap',
     },
@@ -361,11 +378,21 @@ it('create a volume with the type rawBlockdevice', () => {
     kind: 'Volume',
     metadata: {
       name: newVolume.name,
+      labels: {
+        name: 'carlito',
+      },
     },
     spec: {
       nodeName: nodeName,
       storageClassName: newVolume.storageClass,
       rawBlockDevice: { devicePath: newVolume.path },
+      template: {
+        metadata: {
+          labels: {
+            name: 'carlito',
+          },
+        },
+      },
     },
   };
 
@@ -428,6 +455,9 @@ it('does not create a volume when there is an error', () => {
         storageClass: 'metalk8s-default',
         type: 'rawBlockDevice',
         path: '/dev/disk1',
+        labels: {
+          name: 'carlito',
+        },
       },
       nodeName: 'bootstrap',
     },
@@ -439,11 +469,21 @@ it('does not create a volume when there is an error', () => {
     kind: 'Volume',
     metadata: {
       name: newVolume.name,
+      labels: {
+        name: 'carlito',
+      },
     },
     spec: {
       nodeName: nodeName,
       storageClassName: newVolume.storageClass,
       rawBlockDevice: { devicePath: newVolume.path },
+      template: {
+        metadata: {
+          labels: {
+            name: 'carlito',
+          },
+        },
+      },
     },
   };
   expect(gen.next(body).value).toEqual(call(ApiK8s.createVolume, body));


### PR DESCRIPTION
**Component**: UI 

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
- We need to add labels in the templates instead of the Volume object itself when creating volumes so labels can be propagated to PersistentVolume.

**Summary**:

**Acceptance criteria**: 

<img width="741" alt="Screenshot 2019-11-22 at 10 08 17" src="https://user-images.githubusercontent.com/47394132/69413619-75316d00-0d11-11ea-8484-b1f219223844.png">

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: https://github.com/scality/metalk8s/issues/1891

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
