### PR TITLE
eve: Add retry logic in `enable_ipip` script

### DIFF
--- a/eve/workers/openstack-multiple-nodes/terraform/scripts/enable_ipip.sh
+++ b/eve/workers/openstack-multiple-nodes/terraform/scripts/enable_ipip.sh
@@ -8,8 +8,20 @@ cat > "$PATCH_FILE" << END
   value: Always
 END
 
-sudo kubectl patch ippool default-ipv4-ippool \
-     --kubeconfig=/etc/kubernetes/admin.conf  \
-     --type json --patch "$(cat $PATCH_FILE)"
+MAX_RETRIES=10
+ATTEMPTS=0
+RET=1
+
+while [ "$RET" -ne 0 ] && [ $ATTEMPTS -lt $MAX_RETRIES ]; do
+    (( ATTEMPTS++ ))
+    echo "Attempt $ATTEMPTS out of $MAX_RETRIES"
+    sudo kubectl patch ippool default-ipv4-ippool \
+        --kubeconfig=/etc/kubernetes/admin.conf  \
+        --type json --patch "$(cat $PATCH_FILE)"
+    RET=$?
+    sleep 5
+done
 
 rm "$PATCH_FILE"
+
+exit $RET


### PR DESCRIPTION
**Component**:

'build', 'tests'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

Time to time we have flaky about dns checking 

```
utils_pod = 'utils', host = <testinfra.host.Host object at 0x7f4807548588>
hostname = 'kubernetes.default'
    @then(parsers.parse("the hostname '{hostname}' should be resolved"))
    def resolve_hostname(utils_pod, host, hostname):
        with host.sudo():
            # test dns resolve
            result = host.run(
                "kubectl --kubeconfig=/etc/kubernetes/admin.conf "
                "exec %s nslookup %s",
                utils_pod,
                hostname,
            )
            if result.rc != 0:
>               pytest.fail("Cannot resolve {}: {}".format(hostname, result.stderr))
E               Failed: Cannot resolve kubernetes.default: command terminated with exit code 1
```
The root cause is that IPIP is not set to always because the enable_ipip script fail silently (always return 0)
```
Error from server (NotFound): ippools.crd.projectcalico.org "default-ipv4-ippool" not found
```
We get this error because ippool is not fully ready when we try to enable_ipip in the CI.

Note: This is a flaky because the test may succeed if the `utils` pod is created on the bootstrap node but fail if it's created on the node1

**Summary**:

Ippool may not be created when we try for the first time to enable_ipip
so the script may fail. Add a retry logic with a sleep to wait for this
ippool to be ready.
Also exit with the right exit code to no always succeed

**Acceptance criteria**: 

Less flaky :) 