### PR TITLE
salt/auth: Add groups support for bearer auth

### DIFF
--- a/tests/post/features/salt_api.feature
+++ b/tests/post/features/salt_api.feature
@@ -9,6 +9,15 @@ Feature: SaltAPI
         And we have '@runner' perms
         And we have '@jobs' perms
 
+    Scenario: Login to SaltAPI using an admin ServiceAccount
+        Given the Kubernetes API is available
+        When we login to SaltAPI with an admin ServiceAccount
+        Then we can ping all minions
+        And we can invoke '[".*"]' on '*'
+        And we have '@wheel' perms
+        And we have '@runner' perms
+        And we have '@jobs' perms
+
     Scenario: Login to SaltAPI using a ServiceAccount
         Given the Kubernetes API is available
         When we login to SaltAPI with the ServiceAccount 'storage-operator'


### PR DESCRIPTION
**Component**:

'salt', 'tests'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

Currently we have no permissions when using bearer token auth

**Summary**:

add a `groups` function to authenticate bearer auth using the same approach as
the basic auth for the moment
Also update test accordingly
