### PR TITLE
Rework management of Salt jobs in the UI

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1703,6 +1703,30 @@
       "resolved": "https://registry.npmjs.org/@redux-saga/symbols/-/symbols-1.0.1.tgz",
       "integrity": "sha512-akKkzcVnb1RzJaZV2LQFbi51abvdICMuAKwwLoCjjxLbLAGIw9EJxk5ucNnWSSCEsoEQMeol5tkAcK+Xzuv1Bg=="
     },
+    "@redux-saga/testing-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@redux-saga/testing-utils/-/testing-utils-1.1.3.tgz",
+      "integrity": "sha512-MGMcBHgt80CoC8s8i0Mc7svGJPysS9qkJuAINlg+NvudLZcV23myd+H4uaXA4zmiLf16C4M+97b+e6wFoTaGcw==",
+      "dev": true,
+      "requires": {
+        "@redux-saga/symbols": "^1.1.2",
+        "@redux-saga/types": "^1.1.0"
+      },
+      "dependencies": {
+        "@redux-saga/symbols": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@redux-saga/symbols/-/symbols-1.1.2.tgz",
+          "integrity": "sha512-EfdGnF423glv3uMwLsGAtE6bg+R9MdqlHEzExnfagXPrIiuxwr3bdiAwz3gi+PsrQ3yBlaBpfGLtDG8rf3LgQQ==",
+          "dev": true
+        },
+        "@redux-saga/types": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@redux-saga/types/-/types-1.1.0.tgz",
+          "integrity": "sha512-afmTuJrylUU/0OtqzaRkbyYFFNgCF73Bvel/sw90pvGrWIZ+vyoIJqA6eMSoA6+nb443kTmulmBtC9NerXboNg==",
+          "dev": true
+        }
+      }
+    },
     "@redux-saga/types": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@redux-saga/types/-/types-1.0.2.tgz",
@@ -3670,7 +3694,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "resolved": false,
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3691,12 +3716,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "resolved": false,
-              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "resolved": false,
               "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3711,17 +3738,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "resolved": false,
-              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "resolved": false,
-              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "resolved": false,
-              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3838,7 +3868,8 @@
             "inherits": {
               "version": "2.0.3",
               "resolved": false,
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3850,6 +3881,7 @@
               "version": "1.0.0",
               "resolved": false,
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3864,6 +3896,7 @@
               "version": "3.0.4",
               "resolved": false,
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -3871,12 +3904,14 @@
             "minimist": {
               "version": "0.0.8",
               "resolved": false,
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "resolved": false,
               "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3895,6 +3930,7 @@
               "version": "0.5.1",
               "resolved": false,
               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3975,7 +4011,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "resolved": false,
-              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3987,6 +4024,7 @@
               "version": "1.4.0",
               "resolved": false,
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -4072,7 +4110,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "resolved": false,
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -4108,6 +4147,7 @@
               "version": "1.0.2",
               "resolved": false,
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -4127,6 +4167,7 @@
               "version": "3.0.1",
               "resolved": false,
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -4170,12 +4211,14 @@
             "wrappy": {
               "version": "1.0.2",
               "resolved": false,
-              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "resolved": false,
-              "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+              "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+              "optional": true
             }
           }
         },
@@ -9035,7 +9078,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "resolved": false,
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -9056,12 +9100,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "resolved": false,
-              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "resolved": false,
               "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -9076,17 +9122,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "resolved": false,
-              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "resolved": false,
-              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "resolved": false,
-              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -9203,7 +9252,8 @@
             "inherits": {
               "version": "2.0.3",
               "resolved": false,
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -9215,6 +9265,7 @@
               "version": "1.0.0",
               "resolved": false,
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -9229,6 +9280,7 @@
               "version": "3.0.4",
               "resolved": false,
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -9236,12 +9288,14 @@
             "minimist": {
               "version": "0.0.8",
               "resolved": false,
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "resolved": false,
               "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -9260,6 +9314,7 @@
               "version": "0.5.1",
               "resolved": false,
               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -9340,7 +9395,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "resolved": false,
-              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -9352,6 +9408,7 @@
               "version": "1.4.0",
               "resolved": false,
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -9437,7 +9494,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "resolved": false,
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -9473,6 +9531,7 @@
               "version": "1.0.2",
               "resolved": false,
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -9492,6 +9551,7 @@
               "version": "3.0.1",
               "resolved": false,
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -9535,12 +9595,14 @@
             "wrappy": {
               "version": "1.0.2",
               "resolved": false,
-              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "resolved": false,
-              "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+              "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+              "optional": true
             }
           }
         }
@@ -16457,7 +16519,8 @@
               "version": "1.0.0",
               "resolved": false,
               "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
@@ -16486,7 +16549,8 @@
               "version": "0.0.1",
               "resolved": false,
               "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -52,6 +52,7 @@
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.4.4",
     "@babel/plugin-proposal-optional-chaining": "^7.2.0",
     "@babel/preset-flow": "^7.0.0",
+    "@redux-saga/testing-utils": "^1.0.2",
     "compression-webpack-plugin": "^3.0.0",
     "customize-cra": "^0.4.1",
     "cypress": "^3.2.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -66,6 +66,9 @@
     "nonGlobalStepDefinitions": true
   },
   "jest-junit": {
-    "output": "junit/jest-junit.xml"
+    "output": "junit/jest-junit.xml",
+    "suiteNameTemplate": "{filepath}",
+    "classNameTemplate": "{classname}",
+    "titleNameTemplate": "{classname} {title}"
   }
 }

--- a/ui/src/containers/Layout.js
+++ b/ui/src/containers/Layout.js
@@ -166,7 +166,7 @@ const Layout = props => {
           <PrivateRoute exact path="/nodes/create" component={NodeCreateForm} />
           <PrivateRoute
             exact
-            path="/nodes/deploy/:id"
+            path="/nodes/:id/deploy"
             component={NodeDeployment}
           />
           <PrivateRoute

--- a/ui/src/containers/NodeDeployment.js
+++ b/ui/src/containers/NodeDeployment.js
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import ReactJson from 'react-json-view';
 import { Button, Loader, Steppers } from '@scality/core-ui';
 import { useRouteMatch, useHistory } from 'react-router';
+import isEmpty from 'lodash.isempty';
 
 import {
   fontWeight,
@@ -19,6 +20,12 @@ const NodeDeploymentContainer = styled.div`
   flex-direction: column;
   padding: ${padding.larger};
   overflow: auto;
+`;
+
+const InfoMessage = styled.div`
+  color: ${props => props.theme.brand.text};
+  font-size: ${fontSize.base};
+  padding: ${padding.base};
 `;
 
 const NodeDeploymentTitle = styled.div`
@@ -122,6 +129,13 @@ const NodeDeployment = ({ intl }) => {
         <NodeDeploymentTitle>
           {intl.messages.node_deployment}
         </NodeDeploymentTitle>
+        {activeJob === undefined ? (
+          <InfoMessage>
+            {intl.translate('no_deployment_found', { name: nodeName })}
+          </InfoMessage>
+        ) : activeJob.completed && isEmpty(activeJob.status) ? (
+          <InfoMessage>{intl.messages.refreshing_job}</InfoMessage>
+        ) : (
           <NodeDeploymentContent>
             <NodeDeploymentStatus>
               <Steppers steps={steps} activeStep={activeStep} />
@@ -134,6 +148,7 @@ const NodeDeployment = ({ intl }) => {
               />
             </NodeDeploymentEvent>
           </NodeDeploymentContent>
+        )}
       </NodeDeploymentWrapper>
     </NodeDeploymentContainer>
   );

--- a/ui/src/containers/NodeDeployment.js
+++ b/ui/src/containers/NodeDeployment.js
@@ -1,18 +1,18 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { injectIntl } from 'react-intl';
 import styled from 'styled-components';
 import ReactJson from 'react-json-view';
-import { Button, Loader, Steppers } from '@scality/core-ui';
 import { useRouteMatch, useHistory } from 'react-router';
 import isEmpty from 'lodash.isempty';
-
+import { Button, Loader, Steppers } from '@scality/core-ui';
 import {
   fontWeight,
   grayLighter,
   padding,
   fontSize,
 } from '@scality/core-ui/dist/style/theme';
+
+import { intl } from '../translations/IntlGlobalProvider';
 
 const NodeDeploymentContainer = styled.div`
   height: 100%;
@@ -62,7 +62,7 @@ const ErrorLabel = styled.span`
   color: ${props => props.theme.brand.danger};
 `;
 
-const NodeDeployment = ({ intl }) => {
+const NodeDeployment = () => {
   const history = useHistory();
   const match = useRouteMatch();
   const nodeName = match?.params?.id;
@@ -82,22 +82,24 @@ const NodeDeployment = ({ intl }) => {
     activeJob = sortedJobs[0];
   }
 
-  let steps = [{ title: intl.messages.node_registered }];
+  let steps = [{ title: intl.translate('node_registered') }];
   let success = false;
   if (activeJob) {
     if (activeJob.events.find(event => event.tag.includes('/new'))) {
-      steps.push({ title: intl.messages.deployment_started });
+      steps.push({ title: intl.translate('deployment_started') });
     }
 
     if (activeJob.completed) {
       const status = activeJob.status;
       steps.push({
-        title: intl.messages.completed,
+        title: intl.translate('completed'),
         content: (
           <span>
             {!status.success && (
               <ErrorLabel>
-                {`${intl.messages.error}: ${status.step} - ${status.comment}`}
+                {`${intl.translate('error')}: ${status.step} - ${
+                  status.comment
+                }`}
               </ErrorLabel>
             )}
           </span>
@@ -106,7 +108,7 @@ const NodeDeployment = ({ intl }) => {
       success = status.success;
     } else {
       steps.push({
-        title: intl.messages.deploying,
+        title: intl.translate('deploying'),
         content: <Loader size="larger" />,
       });
     }
@@ -120,7 +122,7 @@ const NodeDeployment = ({ intl }) => {
     <NodeDeploymentContainer>
       <div>
         <Button
-          text={intl.messages.back_to_node_list}
+          text={intl.translate('back_to_node_list')}
           type="button"
           outlined
           onClick={() => history.push('/nodes')}
@@ -129,14 +131,14 @@ const NodeDeployment = ({ intl }) => {
       </div>
       <NodeDeploymentWrapper>
         <NodeDeploymentTitle>
-          {intl.messages.node_deployment}
+          {intl.translate('node_deployment')}
         </NodeDeploymentTitle>
         {activeJob === undefined ? (
           <InfoMessage>
             {intl.translate('no_deployment_found', { name: nodeName })}
           </InfoMessage>
         ) : activeJob.completed && isEmpty(activeJob.status) ? (
-          <InfoMessage>{intl.messages.refreshing_job}</InfoMessage>
+          <InfoMessage>{intl.translate('refreshing_job')}</InfoMessage>
         ) : (
           <NodeDeploymentContent>
             <NodeDeploymentStatus>
@@ -156,4 +158,4 @@ const NodeDeployment = ({ intl }) => {
   );
 };
 
-export default injectIntl(NodeDeployment);
+export default NodeDeployment;

--- a/ui/src/containers/NodeDeployment.js
+++ b/ui/src/containers/NodeDeployment.js
@@ -68,7 +68,9 @@ const NodeDeployment = ({ intl }) => {
   const nodeName = match?.params?.id;
 
   const jobs = useSelector(state =>
-    state.app.salt.jobs.filter(job => job.name === `deploy-node/${nodeName}`),
+    state.app.salt.jobs.filter(
+      job => job.type === 'deploy-node' && job.node === nodeName,
+    ),
   );
 
   let activeJob = jobs.find(job => !job.completed);

--- a/ui/src/containers/NodeList.js
+++ b/ui/src/containers/NodeList.js
@@ -92,7 +92,7 @@ const NodeList = ({ intl }) => {
       renderer: (data, rowData) => {
         if (
           (!rowData.status || rowData.status === API_STATUS_UNKNOWN) &&
-          !rowData.jid
+          !rowData.deploying
         ) {
           return (
             <span className="status">
@@ -107,14 +107,14 @@ const NodeList = ({ intl }) => {
             </span>
           );
         }
-        if (rowData.jid) {
+        if (rowData.deploying) {
           return (
             <span className="status">
               <Button
                 text={intl.messages.deploying}
                 onClick={event => {
                   event.stopPropagation();
-                  history.push(`/nodes/deploy/${rowData.jid}`);
+                  history.push(`/nodes/deploy/${rowData.name}`);
                 }}
                 icon={<Loader size="smaller" />}
                 size="smaller"

--- a/ui/src/containers/NodeList.js
+++ b/ui/src/containers/NodeList.js
@@ -114,7 +114,7 @@ const NodeList = ({ intl }) => {
                 text={intl.messages.deploying}
                 onClick={event => {
                   event.stopPropagation();
-                  history.push(`/nodes/deploy/${rowData.name}`);
+                  history.push(`/nodes/${rowData.name}/deploy`);
                 }}
                 icon={<Loader size="smaller" />}
                 size="smaller"

--- a/ui/src/ducks/app/layout.js
+++ b/ui/src/ducks/app/layout.js
@@ -9,8 +9,8 @@ export const SIDEBAR_EXPENDED = 'sidebar_expended';
 // Reducer
 const defaultState = {
   sidebar: {
-    expanded: true
-  }
+    expanded: true,
+  },
 };
 
 export default function reducer(state = defaultState, action = {}) {
@@ -20,8 +20,8 @@ export default function reducer(state = defaultState, action = {}) {
         ...state,
         sidebar: {
           ...state.sidebar,
-          expanded: !state.sidebar.expanded
-        }
+          expanded: !state.sidebar.expanded,
+        },
       };
     default:
       return state;
@@ -41,15 +41,20 @@ export const initToggleSideBarAction = () => {
   return { type: INIT_TOGGLE_SIDEBAR };
 };
 
+// Selectors
+export const isSidebarExpandedSelector = state =>
+  state.app.layout.sidebar.expanded;
+
+// Sagas
 export function* toggleSideBar() {
   yield put(setToggleSidebarAction());
-  const expanded = yield select(state => state.app.layout.sidebar.expanded);
+  const expanded = yield select(isSidebarExpandedSelector);
   localStorage.setItem(SIDEBAR_EXPENDED, expanded);
 }
 
 export function* initToggleSideBar() {
   if (localStorage.getItem(SIDEBAR_EXPENDED)) {
-    const expanded = yield select(state => state.app.layout.sidebar.expanded);
+    const expanded = yield select(isSidebarExpandedSelector);
     if (expanded !== JSON.parse(localStorage.getItem(SIDEBAR_EXPENDED))) {
       yield put(setToggleSidebarAction());
     }

--- a/ui/src/ducks/app/monitoring.js
+++ b/ui/src/ducks/app/monitoring.js
@@ -17,6 +17,7 @@ export const CLUSTER_STATUS_UNKNOWN = 'CLUSTER_STATUS_UNKNOWN ';
 
 export const SET_PROMETHEUS_API_AVAILABLE = 'SET_PROMETHEUS_API_AVAILABLE';
 
+// Reducer
 const defaultState = {
   alert: {
     list: [],
@@ -36,7 +37,7 @@ const defaultState = {
   isPrometheusApiUp: false,
 };
 
-export default function(state = defaultState, action = {}) {
+export default function reducer(state = defaultState, action = {}) {
   switch (action.type) {
     case SET_PROMETHEUS_API_AVAILABLE:
       return { ...state, isPrometheusApiUp: action.payload };
@@ -52,6 +53,7 @@ export default function(state = defaultState, action = {}) {
   }
 }
 
+// Action Creators
 export const refreshClusterStatusAction = () => {
   return { type: REFRESH_CLUSTER_STATUS };
 };
@@ -80,6 +82,13 @@ export const updateAlertsAction = payload => {
   return { type: UPDATE_ALERTS, payload };
 };
 
+// Selectors
+export const isAlertRefreshing = state =>
+  state.app.monitoring.alert.isRefreshing;
+export const isClusterRefreshing = state =>
+  state.app.monitoring.cluster.isRefreshing;
+
+// Sagas
 function getClusterQueryStatus(result) {
   return result &&
     result.status === 'success' &&
@@ -180,9 +189,7 @@ export function* refreshAlerts() {
   const resultAlerts = yield call(fetchAlerts);
   if (!resultAlerts.error) {
     yield delay(REFRESH_TIMEOUT);
-    const isRefreshing = yield select(
-      state => state.app.monitoring.alert.isRefreshing,
-    );
+    const isRefreshing = yield select(isClusterRefreshing);
     if (isRefreshing) {
       yield call(refreshAlerts);
     }
@@ -198,9 +205,7 @@ export function* refreshClusterStatus() {
   const errorResult = yield call(fetchClusterStatus);
   if (!errorResult) {
     yield delay(REFRESH_TIMEOUT);
-    const isRefreshing = yield select(
-      state => state.app.monitoring.cluster.isRefreshing,
-    );
+    const isRefreshing = yield select(isClusterRefreshing);
     if (isRefreshing) {
       yield call(refreshClusterStatus);
     }

--- a/ui/src/ducks/app/nodes.js
+++ b/ui/src/ducks/app/nodes.js
@@ -15,7 +15,7 @@ import * as ApiSalt from '../../services/salt/api';
 import history from '../../history';
 import {
   addNotificationSuccessAction,
-  addNotificationErrorAction
+  addNotificationErrorAction,
 } from './notifications';
 
 import { intl } from '../../translations/IntlGlobalProvider';
@@ -34,7 +34,7 @@ import {
 import {
   API_STATUS_READY,
   API_STATUS_NOT_READY,
-  API_STATUS_UNKNOWN
+  API_STATUS_UNKNOWN,
 } from '../../constants.js';
 
 // Actions
@@ -72,13 +72,13 @@ export const roleTaintMap = [
     taints: [
       {
         key: ROLE_BOOTSTRAP,
-        effect: 'NoSchedule'
+        effect: 'NoSchedule',
       },
       {
         key: ROLE_INFRA,
-        effect: 'NoSchedule'
-      }
-    ]
+        effect: 'NoSchedule',
+  },
+    ],
   },
   {
     control_plane: true,
@@ -89,20 +89,20 @@ export const roleTaintMap = [
     taints: [
       {
         key: ROLE_MASTER,
-        effect: 'NoSchedule'
+        effect: 'NoSchedule',
       },
       {
         key: ROLE_ETCD,
-        effect: 'NoSchedule'
-      }
-    ]
+        effect: 'NoSchedule',
+      },
+    ],
   },
   {
     control_plane: false,
     workload_plane: true,
     bootstrap: false,
     infra: false,
-    roles: [ROLE_NODE]
+    roles: [ROLE_NODE],
   },
   {
     control_plane: false,
@@ -113,16 +113,16 @@ export const roleTaintMap = [
     taints: [
       {
         key: ROLE_INFRA,
-        effect: 'NoSchedule'
-      }
-    ]
+        effect: 'NoSchedule',
+      },
+    ],
   },
   {
     control_plane: true,
     workload_plane: true,
     bootstrap: false,
     infra: false,
-    roles: [ROLE_ETCD, ROLE_MASTER, ROLE_NODE]
+    roles: [ROLE_ETCD, ROLE_MASTER, ROLE_NODE],
   },
   {
     control_plane: true,
@@ -133,24 +133,24 @@ export const roleTaintMap = [
     taints: [
       {
         key: ROLE_INFRA,
-        effect: 'NoSchedule'
-      }
-    ]
+        effect: 'NoSchedule',
+      },
+    ],
   },
   {
     control_plane: false,
     workload_plane: true,
     bootstrap: false,
     infra: true,
-    roles: [ROLE_INFRA]
+    roles: [ROLE_INFRA],
   },
   {
     control_plane: true,
     workload_plane: true,
     bootstrap: false,
     infra: true,
-    roles: [ROLE_ETCD, ROLE_MASTER, ROLE_INFRA]
-  }
+    roles: [ROLE_ETCD, ROLE_MASTER, ROLE_INFRA],
+  },
 ];
 
 // Reducer
@@ -159,7 +159,7 @@ const defaultState = {
   list: [],
   events: {},
   isRefreshing: false,
-  isLoading: false
+  isLoading: false,
 };
 
 export default function reducer(state = defaultState, action = {}) {
@@ -169,12 +169,12 @@ export default function reducer(state = defaultState, action = {}) {
     case CREATE_NODE_FAILED:
       return {
         ...state,
-        errors: { create_node: action.payload }
+        errors: { create_node: action.payload },
       };
     case CLEAR_CREATE_NODE_ERROR:
       return {
         ...state,
-        errors: { create_node: null }
+        errors: { create_node: null },
       };
     case UPDATE_EVENTS:
       return {
@@ -246,8 +246,8 @@ export function* fetchClusterVersion() {
           ? result.body.items[0].metadata.annotations[
               CLUSTER_VERSION_ANNOTATION
             ]
-          : ''
-      })
+          : '',
+      }),
     );
   }
 }
@@ -277,7 +277,7 @@ export function* fetchNodes() {
 
           const roleTaintMatched = roleTaintMap.find(item => {
             const nodeRoles = Object.keys(node.metadata.labels).filter(role =>
-              role.includes(ROLE_PREFIX)
+              role.includes(ROLE_PREFIX),
             );
 
             return (
@@ -285,7 +285,7 @@ export function* fetchNodes() {
               nodeRoles.every(role => item.roles.includes(role)) &&
               (item.taints && node.spec.taints
                 ? node.spec.taints.every(taint =>
-                    item.taints.find(item => item.key === taint.key)
+                    item.taints.find(item => item.key === taint.key),
                   )
                 : item.taints === node.spec.taints)
             );
@@ -318,8 +318,8 @@ export function* fetchNodes() {
             jid: getJidFromNameLocalStorage(node.metadata.name),
             roles: rolesLabel.join(' / ')
           };
-        })
-      })
+        }),
+      }),
     );
 
     yield all(
@@ -377,24 +377,24 @@ export function* createNode({ payload }) {
     metadata: {
       name: payload.name,
       labels: {
-        'metalk8s.scality.com/version': clusterVersion
+        'metalk8s.scality.com/version': clusterVersion,
       },
       annotations: {
         'metalk8s.scality.com/ssh-user': payload.ssh_user,
         'metalk8s.scality.com/ssh-port': payload.ssh_port,
         'metalk8s.scality.com/ssh-host': payload.hostName_ip,
         'metalk8s.scality.com/ssh-key-path': payload.ssh_key_path,
-        'metalk8s.scality.com/ssh-sudo': payload.sudo_required.toString()
-      }
+        'metalk8s.scality.com/ssh-sudo': payload.sudo_required.toString(),
     },
-    spec: {}
+    },
+    spec: {},
   };
 
   const roleTaintMatched = roleTaintMap.find(
     role =>
       role.control_plane === payload.control_plane &&
       role.workload_plane === payload.workload_plane &&
-      role.infra === payload.infra
+      role.infra === payload.infra,
   );
 
   if (roleTaintMatched) {
@@ -410,19 +410,21 @@ export function* createNode({ payload }) {
     yield put(
       addNotificationSuccessAction({
         title: intl.translate('node_creation'),
-        message: intl.translate('node_creation_success', { name: payload.name })
-      })
+        message: intl.translate('node_creation_success', {
+          name: payload.name,
+        }),
+      }),
     );
   } else {
     yield put({
       type: CREATE_NODE_FAILED,
-      payload: result.error.body.message
+      payload: result.error.body.message,
     });
     yield put(
       addNotificationErrorAction({
         title: intl.translate('node_creation'),
-        message: intl.translate('node_creation_failed', { name: payload.name })
-      })
+        message: intl.translate('node_creation_failed', { name: payload.name }),
+      }),
     );
   }
 }
@@ -434,8 +436,8 @@ export function* deployNode({ payload }) {
     yield put(
       addNotificationErrorAction({
         title: intl.translate('node_deployment'),
-        message: result.error
-      })
+        message: result.error,
+      }),
     );
   } else {
     yield call(subscribeDeployEvents, { jid: result.return[0].jid });
@@ -524,8 +526,8 @@ export function* subscribeDeployEvents({ jid }) {
 export function* refreshNodes() {
   yield put(
     updateNodesAction({
-      isRefreshing: true
-    })
+      isRefreshing: true,
+    }),
   );
 
   const result = yield call(fetchNodes);
@@ -541,8 +543,8 @@ export function* refreshNodes() {
 export function* stopRefreshNodes() {
   yield put(
     updateNodesAction({
-      isRefreshing: false
-    })
+      isRefreshing: false,
+    }),
   );
 }
 

--- a/ui/src/ducks/app/nodes.js
+++ b/ui/src/ducks/app/nodes.js
@@ -549,12 +549,13 @@ export function* stopRefreshNodes() {
 }
 
 export function* nodesSaga() {
-  yield takeEvery(FETCH_NODES, fetchNodes);
-  yield takeEvery(CREATE_NODE, createNode);
-  yield takeLatest(DEPLOY_NODE, deployNode);
-  yield takeEvery(CONNECT_SALT_API, sseSagas);
-  yield takeEvery(SUBSCRIBE_DEPLOY_EVENTS, subscribeDeployEvents);
-  yield takeEvery(REFRESH_NODES, refreshNodes);
-  yield takeEvery(STOP_REFRESH_NODES, stopRefreshNodes);
-  yield takeEvery(FETCH_CLUSTER_VERSION, fetchClusterVersion);
+  yield all([
+    takeEvery(FETCH_NODES, fetchNodes),
+    takeEvery(CREATE_NODE, createNode),
+    takeLatest(DEPLOY_NODE, deployNode),
+    takeEvery(REFRESH_NODES, refreshNodes),
+    takeEvery(STOP_REFRESH_NODES, stopRefreshNodes),
+    takeEvery(FETCH_CLUSTER_VERSION, fetchClusterVersion),
+    takeEvery(JOB_COMPLETED, notifyDeployJobCompleted),
+  ]);
 }

--- a/ui/src/ducks/app/nodes.js
+++ b/ui/src/ducks/app/nodes.js
@@ -1,14 +1,12 @@
 import {
   all,
-  take,
   call,
+  delay,
   put,
-  takeLatest,
-  takeEvery,
   select,
-  delay
+  takeEvery,
+  takeLatest,
 } from 'redux-saga/effects';
-import { eventChannel, END } from 'redux-saga';
 
 import * as ApiK8s from '../../services/k8s/api';
 import * as ApiSalt from '../../services/salt/api';
@@ -19,17 +17,8 @@ import {
 } from './notifications';
 
 import { intl } from '../../translations/IntlGlobalProvider';
-import { addJobAction, removeJobAction } from './salt.js';
+import { addJobAction, JOB_COMPLETED } from './salt';
 import { REFRESH_TIMEOUT } from '../../constants';
-
-import {
-  getJobStatusFromPrintJob,
-  getJidFromNameLocalStorage,
-  addJobLocalStorage,
-  removeJobLocalStorage,
-  getJobStatusFromEventRet,
-  getNameFromJidLocalStorage
-} from '../../services/salt/utils';
 
 import {
   API_STATUS_READY,
@@ -48,9 +37,6 @@ const CREATE_NODE = 'CREATE_NODE';
 export const CREATE_NODE_FAILED = 'CREATE_NODE_FAILED';
 const CLEAR_CREATE_NODE_ERROR = 'CLEAR_CREATE_NODE_ERROR';
 const DEPLOY_NODE = 'DEPLOY_NODE';
-const CONNECT_SALT_API = 'CONNECT_SALT_API';
-const UPDATE_EVENTS = 'UPDATE_EVENTS';
-const SUBSCRIBE_DEPLOY_EVENTS = 'SUBSCRIBE_DEPLOY_EVENTS';
 
 export const ROLE_MASTER = 'node-role.kubernetes.io/master';
 export const ROLE_NODE = 'node-role.kubernetes.io/node';
@@ -77,7 +63,7 @@ export const roleTaintMap = [
       {
         key: ROLE_INFRA,
         effect: 'NoSchedule',
-  },
+      },
     ],
   },
   {
@@ -157,7 +143,6 @@ export const roleTaintMap = [
 const defaultState = {
   clusterVersion: '',
   list: [],
-  events: {},
   isRefreshing: false,
   isLoading: false,
 };
@@ -175,16 +160,6 @@ export default function reducer(state = defaultState, action = {}) {
       return {
         ...state,
         errors: { create_node: null },
-      };
-    case UPDATE_EVENTS:
-      return {
-        ...state,
-        events: {
-          ...state.events,
-          [action.payload.jid]: state.events[action.payload.jid]
-            ? [...state.events[action.payload.jid], action.payload.msg]
-            : [action.payload.msg]
-        }
       };
     default:
       return state;
@@ -216,18 +191,6 @@ export const deployNodeAction = payload => {
   return { type: DEPLOY_NODE, payload };
 };
 
-export const connectSaltApiAction = payload => {
-  return { type: CONNECT_SALT_API, payload };
-};
-
-export const updateDeployEventsAction = payload => {
-  return { type: UPDATE_EVENTS, payload };
-};
-
-export const subscribeDeployEventsAction = jid => {
-  return { type: SUBSCRIBE_DEPLOY_EVENTS, jid };
-};
-
 export const refreshNodesAction = () => {
   return { type: REFRESH_NODES };
 };
@@ -253,11 +216,13 @@ export function* fetchClusterVersion() {
 }
 
 export function* fetchNodes() {
-  yield put(
-    updateNodesAction({
-      isLoading: true
-    })
-  );
+  yield put(updateNodesAction({ isLoading: true }));
+
+  const allJobs = yield select(state => state.app.salt.jobs);
+  const deployingNodes = allJobs
+    .filter(job => job.name.startsWith('deploy-node/') && !job.completed)
+    .map(job => job.name.replace(/^(deploy-node\/)/, ''));
+
   const result = yield call(ApiK8s.getNodes);
   if (!result.error) {
     yield put(
@@ -315,60 +280,16 @@ export function* fetchNodes() {
             workload_plane: roleTaintMatched && roleTaintMatched.workload_plane,
             bootstrap: roleTaintMatched && roleTaintMatched.bootstrap,
             infra: roleTaintMatched && roleTaintMatched.infra,
-            jid: getJidFromNameLocalStorage(node.metadata.name),
-            roles: rolesLabel.join(' / ')
+            roles: rolesLabel.join(' / '),
+            deploying: deployingNodes.includes(node.metadata.name),
           };
         }),
       }),
     );
-
-    yield all(
-      result.body.items.map(node => {
-        return call(getJobStatus, node.metadata.name);
-      })
-    );
   }
-  yield delay(1000); // To make sur that the loader is visible for at least 1s
-  yield put(
-    updateNodesAction({
-      isLoading: false
-    })
-  );
+  yield delay(1000); // To make sure that the loader is visible for at least 1s
+  yield put(updateNodesAction({ isLoading: false }));
   return result;
-}
-
-export function* getJobStatus(name) {
-  const jid = getJidFromNameLocalStorage(name);
-  if (jid) {
-    const result = yield call(ApiSalt.printJob, jid);
-    const status = {
-      name,
-      ...getJobStatusFromPrintJob(result, jid)
-    };
-    if (status.completed) {
-      yield put(removeJobAction(jid));
-      removeJobLocalStorage(jid);
-      if (status.success) {
-        yield put(
-          addNotificationSuccessAction({
-            title: intl.translate('node_deployment'),
-            message: intl.translate('node_deployment_success', { name })
-          })
-        );
-      } else {
-        yield put(
-          addNotificationErrorAction({
-            title: intl.translate('node_deployment'),
-            message: intl.translate('node_deployment_failed', {
-              name,
-              step: status.step_id,
-              reason: status.comment
-            })
-          })
-        );
-      }
-    }
-  }
 }
 
 export function* createNode({ payload }) {
@@ -385,7 +306,7 @@ export function* createNode({ payload }) {
         'metalk8s.scality.com/ssh-host': payload.hostName_ip,
         'metalk8s.scality.com/ssh-key-path': payload.ssh_key_path,
         'metalk8s.scality.com/ssh-sudo': payload.sudo_required.toString(),
-    },
+      },
     },
     spec: {},
   };
@@ -440,86 +361,42 @@ export function* deployNode({ payload }) {
       }),
     );
   } else {
-    yield call(subscribeDeployEvents, { jid: result.return[0].jid });
-    addJobLocalStorage(result.return[0].jid, payload.name);
+    yield put(
+      addJobAction({
+        name: `deploy-node/${payload.name}`,
+        jid: result.return[0].jid,
+      }),
+    );
     yield call(fetchNodes);
   }
 }
 
-export function subSSE(eventSrc) {
-  const subs = emitter => {
-    eventSrc.onmessage = msg => {
-      emitter(msg);
-    };
-    eventSrc.onerror = () => {
-      emitter(END);
-    };
-    return () => {
-      eventSrc.close();
-    };
-  };
-  return eventChannel(subs);
-}
-
-export function* sseSagas({ payload }) {
-  const eventSrc = new EventSource(
-    `${payload.url}/events?token=${payload.token}`
-  );
-  const channel = yield call(subSSE, eventSrc);
-  while (true) {
-    const msg = yield take(channel);
-    const data = JSON.parse(msg.data);
-    const jobs = yield select(state => state.app.salt.jobs);
-
-    yield all(
-      jobs.map(jid => {
-        if (data.tag.includes(jid)) {
-          return call(updateDeployEvents, jid, data);
-        }
-        return data;
-      })
-    );
-  }
-}
-
-export function* updateDeployEvents(jid, msg) {
-  yield put(updateDeployEventsAction({ jid, msg }));
-  if (msg.tag.includes('/ret')) {
-    const name = getNameFromJidLocalStorage(jid);
-    const status = {
-      name,
-      ...getJobStatusFromEventRet(msg.data)
-    };
-    if (status.completed) {
-      yield put(removeJobAction(jid));
-      removeJobLocalStorage(jid);
-      if (status.success) {
-        yield put(
-          addNotificationSuccessAction({
-            title: intl.translate('node_deployment'),
-            message: intl.translate('node_deployment_success', { name })
-          })
-        );
-      } else {
-        yield put(
-          addNotificationErrorAction({
-            title: intl.translate('node_deployment'),
-            message: intl.translate('node_deployment_failed', {
-              name,
-              step: status.step_id,
-              reason: status.comment
-            })
-          })
-        );
-      }
-    }
-  }
-}
-
-export function* subscribeDeployEvents({ jid }) {
+export function* notifyDeployJobCompleted({ payload: { jid, status } }) {
   const jobs = yield select(state => state.app.salt.jobs);
-  if (!jobs.includes(jid)) {
-    yield put(addJobAction(jid));
+  const jobName = jobs.find(job => job.jid === jid).name;
+  if (jobName.startsWith('deploy-node/')) {
+    const nodeName = jobName.replace(/^(deploy-node\/)/, '');
+    if (status.success) {
+      yield put(
+        addNotificationSuccessAction({
+          title: intl.translate('node_deployment'),
+          message: intl.translate('node_deployment_success', {
+            name: nodeName,
+          }),
+        }),
+      );
+    } else {
+      yield put(
+        addNotificationErrorAction({
+          title: intl.translate('node_deployment'),
+          message: intl.translate('node_deployment_failed', {
+            name: nodeName,
+            step: status.step,
+            reason: status.comment,
+          }),
+        }),
+      );
+    }
   }
 }
 

--- a/ui/src/ducks/app/nodes.test.js
+++ b/ui/src/ducks/app/nodes.test.js
@@ -156,7 +156,8 @@ describe('`fetchNodes` saga', () => {
     const clone = gen.clone();
     const jobs = [
       {
-        name: `deploy-node/${DEFAULT_NAME}`,
+        type: "deploy-node",
+        node: DEFAULT_NAME,
         jid: '12345',
         completed,
       },

--- a/ui/src/ducks/app/nodes.test.js
+++ b/ui/src/ducks/app/nodes.test.js
@@ -149,7 +149,31 @@ describe('`fetchNodes` saga', () => {
 
   test.todo('handles API errors');
 
-  test.todo('maps deployment Jobs to Nodes');
+  test.each([
+    ['completed', true],
+    ['in progress', false],
+  ])('maps %s deployment Jobs to Nodes', (_, completed) => {
+    const clone = gen.clone();
+    const jobs = [
+      {
+        name: `deploy-node/${DEFAULT_NAME}`,
+        jid: '12345',
+        completed,
+      },
+    ];
+
+    expect(clone.next(jobs).value).toEqual(call(ApiK8s.getNodes));
+
+    const apiResponse = { body: { items: [nodeForApi({})] } };
+    const expectedNode = { ...defaultNodeForState, deploying: !completed };
+
+    expect(clone.next(apiResponse).value).toEqual(
+      put({ type: UPDATE_NODES, payload: { list: [expectedNode] } }),
+    );
+  });
+
+  test.todo('ignores Jobs not related to Nodes deployment');
+  test.todo('attaches Jobs based on Node name');
 
   // FIXME: this logic is wrong anyway, we don't want to infer roles from
   // taints, maybe display them, but that's all

--- a/ui/src/ducks/app/nodes.test.js
+++ b/ui/src/ducks/app/nodes.test.js
@@ -1,958 +1,413 @@
-import { call, put, all, delay } from 'redux-saga/effects';
+import { call, put, all, delay, select } from 'redux-saga/effects';
+import * as ApiK8s from '../../services/k8s/api';
+import history from '../../history';
+import { REFRESH_TIMEOUT } from '../../constants';
 import {
   fetchNodes,
   createNode,
   refreshNodes,
   UPDATE_NODES,
-  CREATE_NODE_FAILED
+  CREATE_NODE_FAILED,
+  clusterVersionSelector,
+  nodesRefreshingSelector,
 } from './nodes';
-import * as ApiK8s from '../../services/k8s/api';
-import history from '../../history';
-import { getJobStatus } from './nodes.js';
-import { REFRESH_TIMEOUT } from '../../constants';
+import { allJobsSelector } from './salt';
+import {
+  ADD_NOTIFICATION_SUCCESS,
+  ADD_NOTIFICATION_ERROR,
+} from './notifications';
 
-const formPayload = {
-  control_plane: true,
-  hostName_ip: '172.21.254.44',
-  infra: true,
-  name: 'node1dd',
-  ssh_key_path: '/etc/metalk8s/pki/preshared_key_for_k8s_nodes',
-  ssh_port: '22',
-  ssh_user: 'dqsd',
-  sudo_required: true,
-  version: '2.0',
-  workload_plane: true
-};
+// Helpers {{{
 
-const bodyRequest = {
-  metadata: {
-    annotations: {
-      'metalk8s.scality.com/ssh-host': '172.21.254.44',
-      'metalk8s.scality.com/ssh-key-path':
-        '/etc/metalk8s/pki/preshared_key_for_k8s_nodes',
-      'metalk8s.scality.com/ssh-port': '22',
-      'metalk8s.scality.com/ssh-sudo': 'true',
-      'metalk8s.scality.com/ssh-user': 'dqsd'
-    },
-    labels: {
-      'metalk8s.scality.com/version': '2.0',
-      'node-role.kubernetes.io/etcd': '',
-      'node-role.kubernetes.io/infra': '',
-      'node-role.kubernetes.io/master': ''
-    },
-    name: 'node1dd'
+const DEFAULT_NAME = 'node1';
+const DEFAULT_CLUSTER_VERSION = '2.4.2';
+
+const nodeMetadata = ({
+  name = DEFAULT_NAME,
+  host = '10.0.0.1',
+  version = DEFAULT_CLUSTER_VERSION,
+  roles = ['node'],
+  keyPath = '/etc/metalk8s/pki/salt_bootstrap',
+  port = '22',
+  sudo = 'true',
+  user = 'centos',
+}) => ({
+  name: name,
+  labels: {
+    'metalk8s.scality.com/version': version,
+    ...roles.reduce(
+      (roleLabels, role) => ({
+        ...roleLabels,
+        [`node-role.kubernetes.io/${role}`]: '',
+      }),
+      {},
+    ),
   },
-  spec: {}
+  annotations: {
+    'metalk8s.scality.com/ssh-host': host,
+    'metalk8s.scality.com/ssh-key-path': keyPath,
+    'metalk8s.scality.com/ssh-port': port,
+    'metalk8s.scality.com/ssh-sudo': sudo,
+    'metalk8s.scality.com/ssh-user': user,
+  },
+});
+
+const nodeForApi = ({ taintRoles = [], showStatus = true, ...props }) => ({
+  metadata: nodeMetadata(props),
+  status: showStatus
+    ? {
+        // FIXME: make this generic
+        capacity: {
+          cpu: '2',
+          memory: '1000ki',
+        },
+        conditions: [
+          {
+            type: 'Ready',
+            status: 'True',
+          },
+        ],
+      }
+    : undefined,
+  spec: {
+    taints: taintRoles.length
+      ? taintRoles.map(role => ({
+          key: `node-role.kubernetes.io/${role}`,
+          effect: 'NoSchedule',
+        }))
+      : undefined,
+  },
+});
+
+const defaultNodeForState = {
+  name: DEFAULT_NAME,
+  metalk8s_version: DEFAULT_CLUSTER_VERSION,
+  workload_plane: true,
+  control_plane: false,
+  bootstrap: false,
+  infra: false,
+  status: 'ready',
+  deploying: false,
+  roles: 'Workload Plane',
 };
 
-it('update the control plane nodes state when fetchNodes', () => {
-  const gen = fetchNodes();
-  expect(gen.next().value).toEqual(
-    put({
-      type: UPDATE_NODES,
-      payload: { isLoading: true }
-    })
-  );
-  expect(gen.next().value).toEqual(call(ApiK8s.getNodes));
-  const result = {
-    body: {
-      items: [
-        {
-          metadata: {
-            name: 'boostrap',
-            creationTimestamp: '2019-29-03',
-            annotations: {
-              'metalk8s.scality.com/ssh-user': 'vagrant',
-              'metalk8s.scality.com/ssh-port': '22',
-              'metalk8s.scality.com/ssh-host': '172.21.254.7',
-              'metalk8s.scality.com/ssh-key-path':
-                '/etc/metalk8s/pki/preshared_key_for_k8s_nodes',
-              'metalk8s.scality.com/ssh-sudo': 'true'
-            },
-            labels: {
-              'node-role.kubernetes.io/etcd': '',
-              'node-role.kubernetes.io/master': '',
-              'metalk8s.scality.com/version': '2.0'
-            }
-          },
-          status: {
-            capacity: {
-              cpu: '2',
-              memory: '1000ki'
-            },
-            conditions: [
-              {
-                type: 'Ready',
-                status: 'True'
-              }
-            ]
-          },
-          spec: {
-            taints: [
-              {
-                key: 'node-role.kubernetes.io/master',
-                effect: 'NoSchedule'
-              },
-              {
-                key: 'node-role.kubernetes.io/etcd',
-                effect: 'NoSchedule'
-              }
-            ]
-          }
-        }
-      ]
-    }
-  };
-
-  const nodes = [
-    {
-      name: 'boostrap',
-      workload_plane: false,
-      control_plane: true,
-      bootstrap: false,
-      infra: false,
-      status: 'ready',
-      jid: undefined,
-      metalk8s_version: '2.0',
-      roles: 'Control Plane'
-    }
-  ];
-
-  expect(gen.next(result).value).toEqual(
-    put({ type: UPDATE_NODES, payload: { list: nodes } })
-  );
-  expect(gen.next(result).value).toEqual(all([call(getJobStatus, 'boostrap')]));
-  expect(gen.next().value).toEqual(delay(1000));
-  expect(gen.next().value).toEqual(
-    put({
-      type: UPDATE_NODES,
-      payload: { isLoading: false }
-    })
-  );
-  expect(gen.next().done).toEqual(true);
+const formPayload = ({
+  name = DEFAULT_NAME,
+  host = '10.0.0.1',
+  roles = [],
+  ssh = {
+    keyPath: '/etc/metalk8s/pki/salt_bootstrap',
+    port: '22',
+    user: 'centos',
+    sudo: true,
+  },
+}) => ({
+  name,
+  hostName_ip: host,
+  ssh_key_path: ssh.keyPath,
+  ssh_port: ssh.port,
+  ssh_user: ssh.user,
+  sudo_required: ssh.sudo,
+  control_plane: roles.includes('control-plane'),
+  workload_plane: roles.includes('workload-plane'),
+  infra: roles.includes('infra'),
 });
 
-it('update the bootstrap nodes state when fetchNodes', () => {
-  const gen = fetchNodes();
-  expect(gen.next().value).toEqual(
-    put({
-      type: UPDATE_NODES,
-      payload: { isLoading: true }
-    })
-  );
-  expect(gen.next().value).toEqual(call(ApiK8s.getNodes));
+// }}}
 
-  const result = {
-    body: {
-      items: [
-        {
-          metadata: {
-            name: 'boostrap',
-            creationTimestamp: '2019-29-03',
-            annotations: {
-              'metalk8s.scality.com/ssh-user': 'vagrant',
-              'metalk8s.scality.com/ssh-port': '22',
-              'metalk8s.scality.com/ssh-host': '172.21.254.7',
-              'metalk8s.scality.com/ssh-key-path':
-                '/etc/metalk8s/pki/preshared_key_for_k8s_nodes',
-              'metalk8s.scality.com/ssh-sudo': 'true'
-            },
-            labels: {
-              'node-role.kubernetes.io/bootstrap': '',
-              'node-role.kubernetes.io/etcd': '',
-              'node-role.kubernetes.io/master': '',
-              'node-role.kubernetes.io/infra': '',
-              'metalk8s.scality.com/version': '2.0'
-            }
-          },
-          status: {
-            capacity: {
-              cpu: '2',
-              memory: '1000ki'
-            },
-            conditions: [
-              {
-                type: 'Ready',
-                status: 'True'
-              }
-            ]
-          },
-          spec: {
-            taints: [
-              {
-                key: 'node-role.kubernetes.io/bootstrap',
-                effect: 'NoSchedule'
-              },
-              {
-                key: 'node-role.kubernetes.io/infra',
-                effect: 'NoSchedule'
-              }
-            ]
-          }
-        }
-      ]
-    }
-  };
+describe('`fetchNodes` saga', () => {
+  test('has the correct nominal flow', () => {
+    // Assumes empty responses everywhere
+    const gen = fetchNodes();
+    expect(gen.next().value).toEqual(
+      put({ type: UPDATE_NODES, payload: { isLoading: true } }),
+    );
 
-  const nodes = [
-    {
-      name: 'boostrap',
-      workload_plane: false,
-      control_plane: false,
-      infra: false,
-      bootstrap: true,
-      status: 'ready',
-      jid: undefined,
-      metalk8s_version: '2.0',
-      roles: 'Bootstrap'
-    }
-  ];
+    expect(gen.next().value).toEqual(select(allJobsSelector));
 
-  expect(gen.next(result).value).toEqual(
-    put({ type: UPDATE_NODES, payload: { list: nodes } })
-  );
+    const jobs = [];
+    expect(gen.next(jobs).value).toEqual(call(ApiK8s.getNodes));
 
-  expect(gen.next(result).value).toEqual(all([call(getJobStatus, 'boostrap')]));
-  expect(gen.next().value).toEqual(delay(1000));
-  expect(gen.next().value).toEqual(
-    put({
-      type: UPDATE_NODES,
-      payload: { isLoading: false }
-    })
-  );
-  expect(gen.next().done).toEqual(true);
-});
+    const apiResponse = { body: { items: [] } };
+    expect(gen.next(apiResponse).value).toEqual(
+      put({ type: UPDATE_NODES, payload: { list: [] } }),
+    );
 
-it('update the workload plane nodes state when fetchNodes', () => {
-  const gen = fetchNodes();
+    expect(gen.next().value).toEqual(delay(1000));
+    expect(gen.next().value).toEqual(
+      put({ type: UPDATE_NODES, payload: { isLoading: false } }),
+    );
+    expect(gen.next().done).toBe(true);
+  });
 
-  expect(gen.next().value).toEqual(
-    put({
-      type: UPDATE_NODES,
-      payload: { isLoading: true }
-    })
-  );
+  test.todo('handles API errors');
 
-  expect(gen.next().value).toEqual(call(ApiK8s.getNodes));
+  test.todo('maps deployment Jobs to Nodes');
 
-  const result = {
-    body: {
-      items: [
-        {
-          metadata: {
-            name: 'boostrap',
-            creationTimestamp: '2019-29-03',
-            annotations: {
-              'metalk8s.scality.com/ssh-user': 'vagrant',
-              'metalk8s.scality.com/ssh-port': '22',
-              'metalk8s.scality.com/ssh-host': '172.21.254.7',
-              'metalk8s.scality.com/ssh-key-path':
-                '/etc/metalk8s/pki/preshared_key_for_k8s_nodes',
-              'metalk8s.scality.com/ssh-sudo': 'true'
-            },
-            labels: {
-              'node-role.kubernetes.io/node': '',
-              'metalk8s.scality.com/version': '2.0'
-            }
-          },
-          status: {
-            capacity: {
-              cpu: '2',
-              memory: '1000ki'
-            },
-            conditions: [
-              {
-                type: 'Ready',
-                status: 'True'
-              }
-            ]
-          },
-          spec: {}
-        }
-      ]
-    }
-  };
-
-  const nodes = [
-    {
-      name: 'boostrap',
-      workload_plane: true,
-      control_plane: false,
-      bootstrap: false,
-      infra: false,
-      status: 'ready',
-      jid: undefined,
-      metalk8s_version: '2.0',
-      roles: 'Workload Plane'
-    }
-  ];
-
-  expect(gen.next(result).value).toEqual(
-    put({ type: UPDATE_NODES, payload: { list: nodes } })
-  );
-  expect(gen.next(result).value).toEqual(all([call(getJobStatus, 'boostrap')]));
-  expect(gen.next().value).toEqual(delay(1000));
-  expect(gen.next().value).toEqual(
-    put({
-      type: UPDATE_NODES,
-      payload: { isLoading: false }
-    })
-  );
-  expect(gen.next().done).toEqual(true);
-});
-
-it('update the control plane/workload plane nodes state when fetchNodes', () => {
-  const gen = fetchNodes();
-
-  expect(gen.next().value).toEqual(
-    put({
-      type: UPDATE_NODES,
-      payload: { isLoading: true }
-    })
-  );
-
-  expect(gen.next().value).toEqual(call(ApiK8s.getNodes));
-
-  const result = {
-    body: {
-      items: [
-        {
-          metadata: {
-            name: 'boostrap',
-            creationTimestamp: '2019-29-03',
-            annotations: {
-              'metalk8s.scality.com/ssh-user': 'vagrant',
-              'metalk8s.scality.com/ssh-port': '22',
-              'metalk8s.scality.com/ssh-host': '172.21.254.7',
-              'metalk8s.scality.com/ssh-key-path':
-                '/etc/metalk8s/pki/preshared_key_for_k8s_nodes',
-              'metalk8s.scality.com/ssh-sudo': 'true'
-            },
-            labels: {
-              'node-role.kubernetes.io/node': '',
-              'node-role.kubernetes.io/etcd': '',
-              'node-role.kubernetes.io/master': '',
-              'metalk8s.scality.com/version': '2.0'
-            }
-          },
-          status: {
-            capacity: {
-              cpu: '2',
-              memory: '1000ki'
-            },
-            conditions: [
-              {
-                type: 'Ready',
-                status: 'True'
-              }
-            ]
-          },
-          spec: {}
-        }
-      ]
-    }
-  };
-
-  const nodes = [
-    {
-      name: 'boostrap',
-      workload_plane: true,
-      control_plane: true,
-      infra: false,
-      bootstrap: false,
-      status: 'ready',
-      jid: undefined,
-      metalk8s_version: '2.0',
-      roles: 'Control Plane / Workload Plane'
-    }
-  ];
-  expect(gen.next(result).value).toEqual(
-    put({ type: UPDATE_NODES, payload: { list: nodes } })
-  );
-
-  expect(gen.next(result).value).toEqual(all([call(getJobStatus, 'boostrap')]));
-  expect(gen.next().value).toEqual(delay(1000));
-  expect(gen.next().value).toEqual(
-    put({
-      type: UPDATE_NODES,
-      payload: { isLoading: false }
-    })
-  );
-  expect(gen.next().done).toEqual(true);
-});
-
-it('update the control plane/workload plane/ infra nodes state when fetchNodes', () => {
-  const gen = fetchNodes();
-
-  expect(gen.next().value).toEqual(
-    put({
-      type: UPDATE_NODES,
-      payload: { isLoading: true }
-    })
-  );
-  expect(gen.next().value).toEqual(call(ApiK8s.getNodes));
-
-  const result = {
-    body: {
-      items: [
-        {
-          metadata: {
-            name: 'boostrap',
-            creationTimestamp: '2019-29-03',
-            annotations: {
-              'metalk8s.scality.com/ssh-user': 'vagrant',
-              'metalk8s.scality.com/ssh-port': '22',
-              'metalk8s.scality.com/ssh-host': '172.21.254.7',
-              'metalk8s.scality.com/ssh-key-path':
-                '/etc/metalk8s/pki/preshared_key_for_k8s_nodes',
-              'metalk8s.scality.com/ssh-sudo': 'true'
-            },
-            labels: {
-              'node-role.kubernetes.io/infra': '',
-              'node-role.kubernetes.io/etcd': '',
-              'node-role.kubernetes.io/master': '',
-              'metalk8s.scality.com/version': '2.0'
-            }
-          },
-          status: {
-            capacity: {
-              cpu: '2',
-              memory: '1000ki'
-            },
-            conditions: [
-              {
-                type: 'Ready',
-                status: 'True'
-              }
-            ]
-          },
-          spec: {}
-        }
-      ]
-    }
-  };
-
-  const nodes = [
-    {
-      name: 'boostrap',
-      workload_plane: true,
-      control_plane: true,
-      infra: true,
-      bootstrap: false,
-      status: 'ready',
-      jid: undefined,
-      metalk8s_version: '2.0',
-      roles: 'Control Plane / Workload Plane / Infra'
-    }
-  ];
-  expect(gen.next(result).value).toEqual(
-    put({ type: UPDATE_NODES, payload: { list: nodes } })
-  );
-
-  expect(gen.next(result).value).toEqual(all([call(getJobStatus, 'boostrap')]));
-  expect(gen.next().value).toEqual(delay(1000));
-  expect(gen.next().value).toEqual(
-    put({
-      type: UPDATE_NODES,
-      payload: { isLoading: false }
-    })
-  );
-  expect(gen.next().done).toEqual(true);
-});
-
-it('update the infra nodes state when fetchNodes', () => {
-  const gen = fetchNodes();
-
-  expect(gen.next().value).toEqual(
-    put({
-      type: UPDATE_NODES,
-      payload: { isLoading: true }
-    })
-  );
-  expect(gen.next().value).toEqual(call(ApiK8s.getNodes));
-
-  const result = {
-    body: {
-      items: [
-        {
-          metadata: {
-            name: 'boostrap',
-            creationTimestamp: '2019-29-03',
-            annotations: {
-              'metalk8s.scality.com/ssh-user': 'vagrant',
-              'metalk8s.scality.com/ssh-port': '22',
-              'metalk8s.scality.com/ssh-host': '172.21.254.7',
-              'metalk8s.scality.com/ssh-key-path':
-                '/etc/metalk8s/pki/preshared_key_for_k8s_nodes',
-              'metalk8s.scality.com/ssh-sudo': 'true'
-            },
-            labels: {
-              'node-role.kubernetes.io/infra': '',
-              'metalk8s.scality.com/version': '2.0'
-            }
-          },
-          status: {
-            capacity: {
-              cpu: '2',
-              memory: '1000ki'
-            },
-            conditions: [
-              {
-                type: 'Ready',
-                status: 'True'
-              }
-            ]
-          },
-          spec: {
-            taints: [
-              {
-                key: 'node-role.kubernetes.io/infra',
-                effect: 'NoSchedule'
-              }
-            ]
-          }
-        }
-      ]
-    }
-  };
-
-  const nodes = [
-    {
-      name: 'boostrap',
-      workload_plane: false,
-      control_plane: false,
-      infra: true,
-      bootstrap: false,
-      status: 'ready',
-      jid: undefined,
-      metalk8s_version: '2.0',
-      roles: 'Infra'
-    }
-  ];
-  expect(gen.next(result).value).toEqual(
-    put({ type: UPDATE_NODES, payload: { list: nodes } })
-  );
-
-  expect(gen.next(result).value).toEqual(all([call(getJobStatus, 'boostrap')]));
-  expect(gen.next().value).toEqual(delay(1000));
-  expect(gen.next().value).toEqual(
-    put({
-      type: UPDATE_NODES,
-      payload: { isLoading: false }
-    })
-  );
-  expect(gen.next().done).toEqual(true);
-});
-
-it('update the infra / Worload Plane  nodes state when fetchNodes', () => {
-  const gen = fetchNodes();
-  expect(gen.next().value).toEqual(
-    put({
-      type: UPDATE_NODES,
-      payload: { isLoading: true }
-    })
-  );
-  expect(gen.next().value).toEqual(call(ApiK8s.getNodes));
-
-  const result = {
-    body: {
-      items: [
-        {
-          metadata: {
-            name: 'boostrap',
-            creationTimestamp: '2019-29-03',
-            annotations: {
-              'metalk8s.scality.com/ssh-user': 'vagrant',
-              'metalk8s.scality.com/ssh-port': '22',
-              'metalk8s.scality.com/ssh-host': '172.21.254.7',
-              'metalk8s.scality.com/ssh-key-path':
-                '/etc/metalk8s/pki/preshared_key_for_k8s_nodes',
-              'metalk8s.scality.com/ssh-sudo': 'true'
-            },
-            labels: {
-              'node-role.kubernetes.io/infra': '',
-              'metalk8s.scality.com/version': '2.0'
-            }
-          },
-          status: {
-            capacity: {
-              cpu: '2',
-              memory: '1000ki'
-            },
-            conditions: [
-              {
-                type: 'Ready',
-                status: 'True'
-              }
-            ]
-          },
-          spec: {}
-        }
-      ]
-    }
-  };
-
-  const nodes = [
-    {
-      name: 'boostrap',
-      workload_plane: true,
-      control_plane: false,
-      infra: true,
-      bootstrap: false,
-      status: 'ready',
-      jid: undefined,
-      metalk8s_version: '2.0',
-      roles: 'Workload Plane / Infra'
-    }
-  ];
-  expect(gen.next(result).value).toEqual(
-    put({ type: UPDATE_NODES, payload: { list: nodes } })
-  );
-
-  expect(gen.next(result).value).toEqual(all([call(getJobStatus, 'boostrap')]));
-  expect(gen.next().value).toEqual(delay(1000));
-  expect(gen.next().value).toEqual(
-    put({
-      type: UPDATE_NODES,
-      payload: { isLoading: false }
-    })
-  );
-  expect(gen.next().done).toEqual(true);
-});
-
-it('update the infra / Controle Plane nodes state when fetchNodes', () => {
-  const gen = fetchNodes();
-
-  expect(gen.next().value).toEqual(
-    put({
-      type: UPDATE_NODES,
-      payload: { isLoading: true }
-    })
-  );
-  expect(gen.next().value).toEqual(call(ApiK8s.getNodes));
-
-  const result = {
-    body: {
-      items: [
-        {
-          metadata: {
-            name: 'boostrap',
-            creationTimestamp: '2019-29-03',
-            annotations: {
-              'metalk8s.scality.com/ssh-user': 'vagrant',
-              'metalk8s.scality.com/ssh-port': '22',
-              'metalk8s.scality.com/ssh-host': '172.21.254.7',
-              'metalk8s.scality.com/ssh-key-path':
-                '/etc/metalk8s/pki/preshared_key_for_k8s_nodes',
-              'metalk8s.scality.com/ssh-sudo': 'true'
-            },
-            labels: {
-              'node-role.kubernetes.io/infra': '',
-              'node-role.kubernetes.io/master': '',
-              'node-role.kubernetes.io/etcd': '',
-              'metalk8s.scality.com/version': '2.0'
-            }
-          },
-          status: {
-            capacity: {
-              cpu: '2',
-              memory: '1000ki'
-            },
-            conditions: [
-              {
-                type: 'Ready',
-                status: 'True'
-              }
-            ]
-          },
-          spec: {
-            taints: [
-              {
-                key: 'node-role.kubernetes.io/infra',
-                effect: 'NoSchedule'
-              }
-            ]
-          }
-        }
-      ]
-    }
-  };
-
-  const nodes = [
-    {
-      name: 'boostrap',
-      workload_plane: false,
-      control_plane: true,
-      infra: true,
-      bootstrap: false,
-      status: 'ready',
-      jid: undefined,
-      metalk8s_version: '2.0',
-      roles: 'Control Plane / Infra'
-    }
-  ];
-  expect(gen.next(result).value).toEqual(
-    put({ type: UPDATE_NODES, payload: { list: nodes } })
-  );
-
-  expect(gen.next(result).value).toEqual(all([call(getJobStatus, 'boostrap')]));
-  expect(gen.next().value).toEqual(delay(1000));
-  expect(gen.next().value).toEqual(
-    put({
-      type: UPDATE_NODES,
-      payload: { isLoading: false }
-    })
-  );
-  expect(gen.next().done).toEqual(true);
-});
-it('create Node success - CP,WP,I', () => {
-  const gen = createNode({ payload: formPayload });
-  expect(gen.next().value.type).toEqual('SELECT');
-  expect(gen.next('2.0').value).toEqual(call(ApiK8s.createNode, bodyRequest));
-  expect(gen.next({ data: null }).value).toEqual(call(fetchNodes));
-  expect(gen.next().value).toEqual(call(history.push, '/nodes'));
-});
-
-it('create Node fail - CP,WP,I', () => {
-  const gen = createNode({ payload: formPayload });
-  expect(gen.next().value.type).toEqual('SELECT');
-  expect(gen.next('2.0').value).toEqual(call(ApiK8s.createNode, bodyRequest));
-  expect(gen.next({ error: { body: { message: 'error' } } }).value).toEqual(
-    put({
-      type: CREATE_NODE_FAILED,
-      payload: 'error'
-    })
-  );
-});
-
-it('create Node success - CP', () => {
-  const request = {
-    metadata: {
-      annotations: {
-        'metalk8s.scality.com/ssh-host': '172.21.254.44',
-        'metalk8s.scality.com/ssh-key-path':
-          '/etc/metalk8s/pki/preshared_key_for_k8s_nodes',
-        'metalk8s.scality.com/ssh-port': '22',
-        'metalk8s.scality.com/ssh-sudo': 'true',
-        'metalk8s.scality.com/ssh-user': 'dqsd'
+  // FIXME: this logic is wrong anyway, we don't want to infer roles from
+  // taints, maybe display them, but that's all
+  test.each([
+    [
+      ['master', 'etcd'],
+      ['master', 'etcd'],
+      {
+        wp: false,
+        cp: true,
+        infra: false,
+        bootstrap: false,
+        labels: 'Control Plane',
       },
-      labels: {
-        'metalk8s.scality.com/version': '2.0',
-        'node-role.kubernetes.io/etcd': '',
-        'node-role.kubernetes.io/master': ''
+    ],
+    [
+      ['bootstrap', 'master', 'etcd', 'infra'],
+      ['bootstrap', 'infra'],
+      {
+        wp: false,
+        cp: false,
+        infra: false,
+        bootstrap: true,
+        labels: 'Bootstrap',
       },
-      name: 'node1dd'
-    },
-    spec: {
-      taints: [
-        {
-          effect: 'NoSchedule',
-          key: 'node-role.kubernetes.io/master'
+    ],
+    [
+      ['node'],
+      [],
+      {
+        wp: true,
+        cp: false,
+        infra: false,
+        bootstrap: false,
+        labels: 'Workload Plane',
+      },
+    ],
+    [
+      ['node', 'master', 'etcd'],
+      [],
+      {
+        wp: true,
+        cp: true,
+        infra: false,
+        bootstrap: false,
+        labels: 'Control Plane / Workload Plane',
+      },
+    ],
+    [
+      ['infra'],
+      ['infra'],
+      {
+        wp: false,
+        cp: false,
+        infra: true,
+        bootstrap: false,
+        labels: 'Infra',
+      },
+    ],
+    [
+      ['infra'],
+      [],
+      {
+        wp: true,
+        cp: false,
+        infra: true,
+        bootstrap: false,
+        labels: 'Workload Plane / Infra',
+      },
+    ],
+    [
+      ['infra', 'master', 'etcd'],
+      ['infra'],
+      {
+        wp: false,
+        cp: true,
+        infra: true,
+        bootstrap: false,
+        labels: 'Control Plane / Infra',
+      },
+    ],
+  ])('handles Node roles (%j) and taints (%j)', (roles, taints, expected) => {
+    const gen = fetchNodes();
+    expect(gen.next().value).toEqual(
+      put({ type: UPDATE_NODES, payload: { isLoading: true } }),
+    );
+    expect(gen.next().value).toEqual(select(allJobsSelector));
+    expect(gen.next([]).value).toEqual(call(ApiK8s.getNodes));
+
+    const apiResponse = {
+      body: { items: [nodeForApi({ roles, taintRoles: taints })] },
+    };
+
+    const expectedNode = {
+      ...defaultNodeForState,
+      workload_plane: expected.wp,
+      control_plane: expected.cp,
+      bootstrap: expected.bootstrap,
+      infra: expected.infra,
+      roles: expected.labels,
+    };
+
+    expect(gen.next(apiResponse).value).toEqual(
+      put({ type: UPDATE_NODES, payload: { list: [expectedNode] } }),
+    );
+    expect(gen.next().value).toEqual(delay(1000));
+    expect(gen.next().value).toEqual(
+      put({
+        type: UPDATE_NODES,
+        payload: { isLoading: false },
+      }),
+    );
+    expect(gen.next().done).toEqual(true);
+  });
+});
+
+describe('`createNode` saga', () => {
+  test('has the correct nominal flow', () => {
+    const gen = createNode({
+      payload: formPayload({ roles: ['workload-plane'] }),
+    });
+    expect(gen.next().value).toEqual(select(clusterVersionSelector));
+    expect(gen.next(DEFAULT_CLUSTER_VERSION).value).toEqual(
+      call(
+        ApiK8s.createNode,
+        nodeForApi({ showStatus: false, roles: ['node'] }),
+      ),
+    );
+    expect(gen.next({ whatever: 'nominal result' }).value).toEqual(
+      call(fetchNodes),
+    );
+    expect(gen.next().value).toEqual(call(history.push, '/nodes'));
+    expect(gen.next().value).toMatchObject(
+      put({
+        type: ADD_NOTIFICATION_SUCCESS,
+        payload: {
+          title: 'Node creation',
+          message: `Node ${DEFAULT_NAME} has been created successfully.`,
+          variant: 'success',
+          dismissAfter: 5000,
         },
-        {
-          effect: 'NoSchedule',
-          key: 'node-role.kubernetes.io/etcd'
-        }
-      ]
-    }
-  };
-
-  const gen = createNode({
-    payload: { ...formPayload, workload_plane: false, infra: false }
+      }),
+    );
+    expect(gen.next().done).toBe(true);
   });
-  expect(gen.next().value.type).toEqual('SELECT');
-  expect(gen.next('2.0').value).toEqual(call(ApiK8s.createNode, request));
-  expect(gen.next({ data: null }).value).toEqual(call(fetchNodes));
-  expect(gen.next().value).toEqual(call(history.push, '/nodes'));
-});
 
-it('create Node success - WP', () => {
-  const request = {
-    metadata: {
-      annotations: {
-        'metalk8s.scality.com/ssh-host': '172.21.254.44',
-        'metalk8s.scality.com/ssh-key-path':
-          '/etc/metalk8s/pki/preshared_key_for_k8s_nodes',
-        'metalk8s.scality.com/ssh-port': '22',
-        'metalk8s.scality.com/ssh-sudo': 'true',
-        'metalk8s.scality.com/ssh-user': 'dqsd'
-      },
-      labels: {
-        'metalk8s.scality.com/version': '2.0',
-        'node-role.kubernetes.io/node': ''
-      },
-      name: 'node1dd'
-    },
-    spec: {}
-  };
-
-  const gen = createNode({
-    payload: { ...formPayload, control_plane: false, infra: false }
+  test('handles API errors', () => {
+    const gen = createNode({
+      payload: formPayload({ roles: ['workload-plane'] }),
+    });
+    expect(gen.next().value).toEqual(select(clusterVersionSelector));
+    expect(gen.next(DEFAULT_CLUSTER_VERSION).value).toEqual(
+      call(
+        ApiK8s.createNode,
+        nodeForApi({ showStatus: false, roles: ['node'] }),
+      ),
+    );
+    expect(
+      gen.next({ error: { body: { message: 'some error happened' } } }).value,
+    ).toEqual(
+      put({ type: CREATE_NODE_FAILED, payload: 'some error happened' }),
+    );
+    expect(gen.next().value).toMatchObject(
+      put({
+        type: ADD_NOTIFICATION_ERROR,
+        payload: {
+          title: 'Node creation',
+          message: `Node ${DEFAULT_NAME} creation has failed.`,
+          variant: 'danger',
+        },
+      }),
+    );
+    expect(gen.next().done).toBe(true);
   });
-  expect(gen.next().value.type).toEqual('SELECT');
-  expect(gen.next('2.0').value).toEqual(call(ApiK8s.createNode, request));
-  expect(gen.next({ data: null }).value).toEqual(call(fetchNodes));
-  expect(gen.next().value).toEqual(call(history.push, '/nodes'));
-});
 
-it('create Node success - Infra', () => {
-  const request = {
-    metadata: {
-      annotations: {
-        'metalk8s.scality.com/ssh-host': '172.21.254.44',
-        'metalk8s.scality.com/ssh-key-path':
-          '/etc/metalk8s/pki/preshared_key_for_k8s_nodes',
-        'metalk8s.scality.com/ssh-port': '22',
-        'metalk8s.scality.com/ssh-sudo': 'true',
-        'metalk8s.scality.com/ssh-user': 'dqsd'
-      },
-      labels: {
-        'metalk8s.scality.com/version': '2.0',
-        'node-role.kubernetes.io/infra': ''
-      },
-      name: 'node1dd'
-    },
-    spec: {
-      taints: [
-        {
-          effect: 'NoSchedule',
-          key: 'node-role.kubernetes.io/infra'
-        }
-      ]
-    }
-  };
-
-  const gen = createNode({
-    payload: { ...formPayload, control_plane: false, workload_plane: false }
+  test.each([
+    [
+      ['control-plane'],
+      { roles: ['master', 'etcd'], taints: ['master', 'etcd'] },
+    ],
+    [['workload-plane'], { roles: ['node'], taints: [] }],
+    [['infra'], { roles: ['infra'], taints: ['infra'] }],
+    [
+      ['control-plane', 'workload-plane'],
+      { roles: ['master', 'etcd', 'node'], taints: [] },
+    ],
+    [
+      ['control-plane', 'infra'],
+      { roles: ['master', 'etcd', 'infra'], taints: ['infra'] },
+    ],
+    [['workload-plane', 'infra'], { roles: ['infra'], taints: [] }],
+    [
+      ['control-plane', 'workload-plane', 'infra'],
+      { roles: ['master', 'etcd', 'infra'], taints: [] },
+    ],
+  ])('handles high-level roles (%j)', (roles, expected) => {
+    const gen = createNode({
+      payload: formPayload({ roles }),
+    });
+    expect(gen.next().value).toEqual(select(clusterVersionSelector));
+    expect(gen.next(DEFAULT_CLUSTER_VERSION).value).toEqual(
+      call(
+        ApiK8s.createNode,
+        nodeForApi({
+          showStatus: false,
+          roles: expected.roles,
+          taintRoles: expected.taints,
+        }),
+      ),
+    );
+    expect(gen.next({ whatever: 'nominal result' }).value).toEqual(
+      call(fetchNodes),
+    );
+    expect(gen.next().value).toEqual(call(history.push, '/nodes'));
+    expect(gen.next().value).toMatchObject(
+      put({
+        type: ADD_NOTIFICATION_SUCCESS,
+        payload: {
+          title: 'Node creation',
+          message: `Node ${DEFAULT_NAME} has been created successfully.`,
+          variant: 'success',
+          dismissAfter: 5000,
+        },
+      }),
+    );
+    expect(gen.next().done).toBe(true);
   });
-  expect(gen.next().value.type).toEqual('SELECT');
-  expect(gen.next('2.0').value).toEqual(call(ApiK8s.createNode, request));
-  expect(gen.next({ data: null }).value).toEqual(call(fetchNodes));
-  expect(gen.next().value).toEqual(call(history.push, '/nodes'));
 });
 
-it('create Node success - CP,WP', () => {
-  const request = {
-    metadata: {
-      annotations: {
-        'metalk8s.scality.com/ssh-host': '172.21.254.44',
-        'metalk8s.scality.com/ssh-key-path':
-          '/etc/metalk8s/pki/preshared_key_for_k8s_nodes',
-        'metalk8s.scality.com/ssh-port': '22',
-        'metalk8s.scality.com/ssh-sudo': 'true',
-        'metalk8s.scality.com/ssh-user': 'dqsd'
-      },
-      labels: {
-        'metalk8s.scality.com/version': '2.0',
-        'node-role.kubernetes.io/master': '',
-        'node-role.kubernetes.io/etcd': '',
-        'node-role.kubernetes.io/node': ''
-      },
-      name: 'node1dd'
-    },
-    spec: {}
-  };
-
-  const gen = createNode({
-    payload: { ...formPayload, infra: false }
+describe('`refreshNodes` saga', () => {
+  // FIXME: avoid recursivity in this saga, see #2035
+  test("keeps refreshing if state didn't change", () => {
+    const gen = refreshNodes();
+    expect(gen.next().value).toEqual(
+      put({ type: UPDATE_NODES, payload: { isRefreshing: true } }),
+    );
+    expect(gen.next().value).toEqual(call(fetchNodes));
+    expect(gen.next({ whatever: 'nominal' }).value).toEqual(
+      delay(REFRESH_TIMEOUT),
+    );
+    expect(gen.next().value).toEqual(select(nodesRefreshingSelector));
+    // Still refreshing, recurse
+    expect(gen.next(true).value).toEqual(call(refreshNodes));
   });
-  expect(gen.next().value.type).toEqual('SELECT');
-  expect(gen.next('2.0').value).toEqual(call(ApiK8s.createNode, request));
-  expect(gen.next({ data: null }).value).toEqual(call(fetchNodes));
-  expect(gen.next().value).toEqual(call(history.push, '/nodes'));
-});
 
-it('create Node success - CP,Infra', () => {
-  const request = {
-    metadata: {
-      annotations: {
-        'metalk8s.scality.com/ssh-host': '172.21.254.44',
-        'metalk8s.scality.com/ssh-key-path':
-          '/etc/metalk8s/pki/preshared_key_for_k8s_nodes',
-        'metalk8s.scality.com/ssh-port': '22',
-        'metalk8s.scality.com/ssh-sudo': 'true',
-        'metalk8s.scality.com/ssh-user': 'dqsd'
-      },
-      labels: {
-        'metalk8s.scality.com/version': '2.0',
-        'node-role.kubernetes.io/master': '',
-        'node-role.kubernetes.io/etcd': '',
-        'node-role.kubernetes.io/infra': ''
-      },
-      name: 'node1dd'
-    },
-    spec: {
-      taints: [
-        {
-          effect: 'NoSchedule',
-          key: 'node-role.kubernetes.io/infra'
-        }
-      ]
-    }
-  };
-
-  const gen = createNode({
-    payload: { ...formPayload, workload_plane: false }
+  test('stops refreshing if state changed', () => {
+    const gen = refreshNodes();
+    expect(gen.next().value).toEqual(
+      put({ type: UPDATE_NODES, payload: { isRefreshing: true } }),
+    );
+    expect(gen.next().value).toEqual(call(fetchNodes));
+    expect(gen.next({ whatever: 'nominal' }).value).toEqual(
+      delay(REFRESH_TIMEOUT),
+    );
+    expect(gen.next().value).toEqual(select(nodesRefreshingSelector));
+    // Not refreshing anymore, stop this saga
+    expect(gen.next(false).done).toBe(true);
   });
-  expect(gen.next().value.type).toEqual('SELECT');
-  expect(gen.next('2.0').value).toEqual(call(ApiK8s.createNode, request));
-  expect(gen.next({ data: null }).value).toEqual(call(fetchNodes));
-  expect(gen.next().value).toEqual(call(history.push, '/nodes'));
-});
 
-it('create Node success - WP,Infra', () => {
-  const request = {
-    metadata: {
-      annotations: {
-        'metalk8s.scality.com/ssh-host': '172.21.254.44',
-        'metalk8s.scality.com/ssh-key-path':
-          '/etc/metalk8s/pki/preshared_key_for_k8s_nodes',
-        'metalk8s.scality.com/ssh-port': '22',
-        'metalk8s.scality.com/ssh-sudo': 'true',
-        'metalk8s.scality.com/ssh-user': 'dqsd'
-      },
-      labels: {
-        'metalk8s.scality.com/version': '2.0',
-        'node-role.kubernetes.io/infra': ''
-      },
-      name: 'node1dd'
-    },
-    spec: {}
-  };
-
-  const gen = createNode({
-    payload: { ...formPayload, control_plane: false }
+  test('stops refreshing on error', () => {
+    const gen = refreshNodes();
+    expect(gen.next().value).toEqual(
+      put({ type: UPDATE_NODES, payload: { isRefreshing: true } }),
+    );
+    expect(gen.next().value).toEqual(call(fetchNodes));
+    expect(gen.next({ error: 'something broke' }).done).toBe(true);
   });
-  expect(gen.next().value.type).toEqual('SELECT');
-  expect(gen.next('2.0').value).toEqual(call(ApiK8s.createNode, request));
-  expect(gen.next({ data: null }).value).toEqual(call(fetchNodes));
-  expect(gen.next().value).toEqual(call(history.push, '/nodes'));
-});
-
-it('should refresh nodes if no error', () => {
-  const gen = refreshNodes();
-  expect(gen.next().value).toEqual(
-    put({
-      type: UPDATE_NODES,
-      payload: { isRefreshing: true }
-    })
-  );
-  expect(gen.next().value).toEqual(call(fetchNodes));
-  expect(gen.next({}).value).toEqual(delay(REFRESH_TIMEOUT));
-  expect(gen.next().value.type).toEqual('SELECT');
-  expect(gen.next(true).value).toEqual(call(refreshNodes));
-});
-
-it('should stop refresh Nodes', () => {
-  const gen = refreshNodes();
-  expect(gen.next().value).toEqual(
-    put({
-      type: UPDATE_NODES,
-      payload: { isRefreshing: true }
-    })
-  );
-  expect(gen.next().value).toEqual(call(fetchNodes));
-  expect(gen.next({}).value).toEqual(delay(REFRESH_TIMEOUT));
-  expect(gen.next().value.type).toEqual('SELECT');
-  expect(gen.next(false).done).toEqual(true);
 });

--- a/ui/src/ducks/app/salt.js
+++ b/ui/src/ducks/app/salt.js
@@ -123,6 +123,9 @@ function setJobStatusAction(jid, status) {
   return { type: SET_JOB_STATUS, payload: { jid, status } };
 }
 
+// Selectors
+export const allJobsSelector = state => state.app.salt.jobs;
+
 // Sagas
 function* initialize(payload) {
   const savedJobs = listJobsFromLocalStorage();
@@ -214,7 +217,7 @@ export function* watchSaltEvents({ payload: { url, token } }) {
     const event = yield take(channel);
     const data = JSON.parse(event.data);
 
-    const jobs = yield select(state => state.app.salt.jobs);
+    const jobs = yield select(allJobsSelector);
     const relatedJob = jobs.find(job => data.tag.includes(job.jid));
 
     if (relatedJob !== undefined) {
@@ -241,7 +244,7 @@ function checkJobExpiry(job) {
 
 export function* garbageCollectJobs() {
   while (true) {
-    const jobs = yield select(state => state.app.salt.jobs);
+    const jobs = yield select(allJobsSelector);
     const toRemove = jobs.filter(checkJobExpiry);
     yield all(toRemove.map(job => put(removeJobAction(job))));
     yield delay(JOB_GC_DELAY);

--- a/ui/src/ducks/app/salt.js
+++ b/ui/src/ducks/app/salt.js
@@ -87,7 +87,7 @@ export default function reducer(state = defaultState, action = {}) {
 
 // Action Creators
 const defaultJob = {
-  name: '',
+  type: '',
   jid: null,
   completed: false,
   completedAt: null,
@@ -146,7 +146,13 @@ export function* manageLocalStorage() {
     const { type, payload: job } = yield take(channel);
     switch (type) {
       case ADD_JOB:
-        addJobToLocalStorage(job);
+        addJobToLocalStorage({
+          ...job,
+          // remove live data only useful in Redux store
+          events: undefined,
+          status: undefined,
+          completed: undefined,
+        });
         break;
       case REMOVE_JOB:
         removeJobFromLocalStorage(job.jid);

--- a/ui/src/ducks/app/salt.js
+++ b/ui/src/ducks/app/salt.js
@@ -1,31 +1,258 @@
+import {
+  actionChannel,
+  all,
+  call,
+  delay,
+  fork,
+  put,
+  select,
+  take,
+  takeEvery,
+} from 'redux-saga/effects';
+import { eventChannel, END } from 'redux-saga';
+import * as ApiSalt from '../../services/salt/api';
+import {
+  getJobStatusFromEventRet,
+  listJobsFromLocalStorage,
+  getJobStatusFromPrintJob,
+  addJobToLocalStorage,
+  removeJobFromLocalStorage,
+  markJobCompleteInLocalStorage,
+} from '../../services/salt/utils';
+
 // Actions
-const ADD_JOB = 'REMOVE_JOB';
-const REMOVE_JOB = 'UPDATE_JOBS';
+const ADD_JOB = 'ADD_JOB';
+const REMOVE_JOB = 'REMOVE_JOB';
+const ADD_JOB_EVENT = 'ADD_JOB_EVENT';
+const CONNECT_SALT_API = 'CONNECT_SALT_API';
+const SET_JOB_STATUS = 'SET_JOB_STATUS';
+export const JOB_COMPLETED = 'JOB_COMPLETED';
 
 // Reducer
 const defaultState = {
-  jobs: []
+  jobs: [],
+  connected: false,
 };
 
 export default function reducer(state = defaultState, action = {}) {
   switch (action.type) {
     case ADD_JOB:
-      return { ...state, jobs: [...state.jobs, action.payload] };
+      return {
+        ...state,
+        jobs: [...state.jobs, action.payload],
+      };
     case REMOVE_JOB:
       return {
         ...state,
-        jobs: state.jobs.filter(job => job !== action.payload)
+        jobs: state.jobs.filter(job => job.jid !== action.payload.jid),
       };
+    case ADD_JOB_EVENT:
+      return {
+        ...state,
+        jobs: state.jobs.map(job =>
+          job.jid === action.payload.jid
+            ? { ...job, events: [...job.events, action.payload.event] }
+            : job,
+        ),
+      };
+    case JOB_COMPLETED:
+      return {
+        ...state,
+        jobs: state.jobs.map(job =>
+          job.jid === action.payload.jid
+            ? {
+                ...job,
+                completed: true,
+                completedAt: action.payload.completedAt,
+                status: action.payload.status,
+              }
+            : job,
+        ),
+      };
+    case SET_JOB_STATUS:
+      return {
+        ...state,
+        jobs: state.jobs.map(job =>
+          job.jid === action.payload.jid
+            ? { ...job, status: action.payload.status }
+            : job,
+        ),
+      };
+    case CONNECT_SALT_API:
+      return { ...state, connected: true };
     default:
       return state;
   }
 }
 
 // Action Creators
+const defaultJob = {
+  name: '',
+  jid: null,
+  completed: false,
+  completedAt: null,
+  status: {},
+  events: [],
+};
+
 export function addJobAction(job) {
-  return { type: ADD_JOB, payload: job };
+  const payload = { ...defaultJob, ...job };
+  if (payload.completedAt !== null) {
+    payload.completed = true;
+  }
+  return { type: ADD_JOB, payload };
 }
 
 export function removeJobAction(job) {
   return { type: REMOVE_JOB, payload: job };
+}
+
+export function connectSaltApiAction(payload) {
+  return { type: CONNECT_SALT_API, payload };
+}
+
+function addJobEventAction(jid, event) {
+  return { type: ADD_JOB_EVENT, payload: { jid, event } };
+}
+
+function setJobCompletedAction(jid, completedAt, status) {
+  return { type: JOB_COMPLETED, payload: { jid, completedAt, status } };
+}
+
+function setJobStatusAction(jid, status) {
+  return { type: SET_JOB_STATUS, payload: { jid, status } };
+}
+
+// Sagas
+function* initialize(payload) {
+  const savedJobs = listJobsFromLocalStorage();
+  yield all(savedJobs.map(job => put(addJobAction(job))));
+  yield all(savedJobs.map(job => call(refreshJobStatus, job)));
+
+  // Once state is initialized from localStorage, we can start watching Salt
+  // Event bus (doing it before may loose some events since no job exists)
+  yield fork(watchSaltEvents, payload);
+}
+
+function* manageLocalStorage() {
+  // NOTE: instead of creating a saga per action type, since the operations on
+  // localStorage rely on its previous state, we need to execute them serially.
+  // We don't set up a buffer size as operations should be infrequent and fast.
+  const channel = actionChannel([ADD_JOB, REMOVE_JOB, JOB_COMPLETED]);
+  while (true) {
+    const { type, payload: job } = yield take(channel);
+    switch (type) {
+      case ADD_JOB:
+        addJobToLocalStorage(job);
+        break;
+      case REMOVE_JOB:
+        removeJobFromLocalStorage(job.jid);
+        break;
+      case JOB_COMPLETED:
+        markJobCompleteInLocalStorage(job.jid, job.completedAt);
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+function* refreshJobStatus(job) {
+  const result = yield call(ApiSalt.printJob, job.jid);
+  // TODO: error handling?
+  const status = getJobStatusFromPrintJob(result, job.jid);
+  yield call(updateJobStatus, job, status);
+}
+
+function* updateJobStatus(job, status) {
+  if (status.completed) {
+    // We only have useful info for the status of a completed Job
+    if (job.completedAt === null) {
+      // We only want to trigger the JOB_COMPLETED action if the Job wasn't
+      // already completed (usually this action will be watched to trigger
+      // notifications).
+      const completedTime = new Date();
+      yield put(
+        setJobCompletedAction(job.jid, completedTime.toISOString(), status),
+      );
+    } else {
+      yield put(setJobStatusAction(job.jid, status));
+    }
+  }
+}
+
+// Watch Salt events {{{
+function* readJobEvent(job, event) {
+  const eventTag = event?.tag ?? '';
+
+  if (eventTag.includes('/ret')) {
+    const status = getJobStatusFromEventRet(event.data);
+    yield call(updateJobStatus, job, status);
+  }
+}
+
+function createChannelFromSource(eventSrc) {
+  const subs = emitter => {
+    eventSrc.onmessage = msg => {
+      emitter(msg);
+    };
+    eventSrc.onerror = () => {
+      emitter(END);
+    };
+    return () => {
+      eventSrc.close();
+    };
+  };
+  return eventChannel(subs);
+}
+
+export function* watchSaltEvents({ payload: { url, token } }) {
+  const eventSrc = new EventSource(`${url}/events?token=${token}`);
+  const channel = yield call(createChannelFromSource, eventSrc);
+
+  while (true) {
+    const event = yield take(channel);
+    const data = JSON.parse(event.data);
+
+    const jobs = yield select(state => state.app.salt.jobs);
+    const relatedJob = jobs.find(job => data.tag.includes(job.jid));
+
+    if (relatedJob !== undefined) {
+      yield all([
+        put(addJobEventAction(relatedJob.jid, data)),
+        fork(readJobEvent, relatedJob, data),
+      ]);
+    }
+  }
+}
+// }}}
+
+// Garbage collection of jobs in the Redux state {{{
+const JOB_EXPIRATION_MS = 5 * 60 * 1000; // 5 minutes
+const JOB_GC_DELAY = 5 * 1000; // 5 seconds
+
+function checkJobExpiry(job) {
+  if (!job.completed) {
+    return false;
+  }
+  const timeSinceCompleted = Date.now() - Date.parse(job.completedAt);
+  return timeSinceCompleted > JOB_EXPIRATION_MS;
+}
+
+export function* garbageCollectJobs() {
+  while (true) {
+    const jobs = yield select(state => state.app.salt.jobs);
+    const toRemove = jobs.filter(checkJobExpiry);
+    yield all(toRemove.map(job => put(removeJobAction(job))));
+    yield delay(JOB_GC_DELAY);
+  }
+}
+// }}}
+
+export function* saltSaga() {
+  yield all([
+    fork(manageLocalStorage),
+    fork(garbageCollectJobs),
+    takeEvery(CONNECT_SALT_API, initialize),
+  ]);
 }

--- a/ui/src/ducks/app/salt.js
+++ b/ui/src/ducks/app/salt.js
@@ -21,8 +21,8 @@ import {
 } from '../../services/salt/utils';
 
 // Actions
-const ADD_JOB = 'ADD_JOB';
-const REMOVE_JOB = 'REMOVE_JOB';
+export const ADD_JOB = 'ADD_JOB';
+export const REMOVE_JOB = 'REMOVE_JOB';
 const ADD_JOB_EVENT = 'ADD_JOB_EVENT';
 const CONNECT_SALT_API = 'CONNECT_SALT_API';
 const SET_JOB_STATUS = 'SET_JOB_STATUS';
@@ -115,11 +115,11 @@ function addJobEventAction(jid, event) {
   return { type: ADD_JOB_EVENT, payload: { jid, event } };
 }
 
-function setJobCompletedAction(jid, completedAt, status) {
+export function setJobCompletedAction(jid, completedAt, status) {
   return { type: JOB_COMPLETED, payload: { jid, completedAt, status } };
 }
 
-function setJobStatusAction(jid, status) {
+export function setJobStatusAction(jid, status) {
   return { type: SET_JOB_STATUS, payload: { jid, status } };
 }
 
@@ -127,7 +127,7 @@ function setJobStatusAction(jid, status) {
 export const allJobsSelector = state => state.app.salt.jobs;
 
 // Sagas
-function* initialize(payload) {
+export function* initialize(payload) {
   const savedJobs = listJobsFromLocalStorage();
   yield all(savedJobs.map(job => put(addJobAction(job))));
   yield all(savedJobs.map(job => call(refreshJobStatus, job)));
@@ -137,11 +137,11 @@ function* initialize(payload) {
   yield fork(watchSaltEvents, payload);
 }
 
-function* manageLocalStorage() {
+export function* manageLocalStorage() {
   // NOTE: instead of creating a saga per action type, since the operations on
   // localStorage rely on its previous state, we need to execute them serially.
   // We don't set up a buffer size as operations should be infrequent and fast.
-  const channel = actionChannel([ADD_JOB, REMOVE_JOB, JOB_COMPLETED]);
+  const channel = yield actionChannel([ADD_JOB, REMOVE_JOB, JOB_COMPLETED]);
   while (true) {
     const { type, payload: job } = yield take(channel);
     switch (type) {
@@ -160,14 +160,14 @@ function* manageLocalStorage() {
   }
 }
 
-function* refreshJobStatus(job) {
+export function* refreshJobStatus(job) {
   const result = yield call(ApiSalt.printJob, job.jid);
   // TODO: error handling?
   const status = getJobStatusFromPrintJob(result, job.jid);
   yield call(updateJobStatus, job, status);
 }
 
-function* updateJobStatus(job, status) {
+export function* updateJobStatus(job, status) {
   if (status.completed) {
     // We only have useful info for the status of a completed Job
     if (job.completedAt === null) {
@@ -194,7 +194,7 @@ function* readJobEvent(job, event) {
   }
 }
 
-function createChannelFromSource(eventSrc) {
+export function createChannelFromSource(eventSrc) {
   const subs = emitter => {
     eventSrc.onmessage = msg => {
       emitter(msg);
@@ -232,7 +232,7 @@ export function* watchSaltEvents({ payload: { url, token } }) {
 
 // Garbage collection of jobs in the Redux state {{{
 const JOB_EXPIRATION_MS = 5 * 60 * 1000; // 5 minutes
-const JOB_GC_DELAY = 5 * 1000; // 5 seconds
+export const JOB_GC_DELAY = 5 * 1000; // 5 seconds
 
 function checkJobExpiry(job) {
   if (!job.completed) {

--- a/ui/src/ducks/app/salt.test.js
+++ b/ui/src/ducks/app/salt.test.js
@@ -1,0 +1,191 @@
+import { channel } from 'redux-saga';
+import {
+  all,
+  call,
+  put,
+  actionChannel,
+  take,
+  select,
+  delay,
+} from 'redux-saga/effects';
+
+import { JOBS } from '../../services/salt/utils';
+
+import {
+  // sagas to test
+  initialize,
+  manageLocalStorage,
+  garbageCollectJobs,
+  updateJobStatus,
+  watchSaltEvents,
+  // action creators to test
+  addJobAction,
+  // values to check in tests
+  ADD_JOB,
+  REMOVE_JOB,
+  JOB_COMPLETED,
+  JOB_GC_DELAY,
+  removeJobAction,
+  setJobCompletedAction,
+  setJobStatusAction,
+  allJobsSelector,
+  refreshJobStatus,
+  createChannelFromSource,
+} from './salt';
+
+const exampleJob = { name: 'example', jid: '12345', completedAt: null };
+
+describe('`addJobAction` action creator', () => {
+  test('handles a job in progress', () => {
+    const action = addJobAction(exampleJob);
+    expect(action).toEqual({
+      type: ADD_JOB,
+      payload: {
+        ...exampleJob,
+        completed: false,
+        status: {},
+        events: [],
+      },
+    });
+  });
+
+  test('handles a completed job', () => {
+    const action = addJobAction({ ...exampleJob, completedAt: 'now' });
+    expect(action).toEqual({
+      type: ADD_JOB,
+      payload: {
+        ...exampleJob,
+        completedAt: 'now',
+        completed: true,
+        status: {},
+        events: [],
+      },
+    });
+  });
+});
+
+describe('`initialize` saga', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('has the expected nominal flow', () => {
+    localStorage.setItem(JOBS, JSON.stringify([exampleJob]));
+    const gen = initialize();
+    // Add all jobs to state
+    expect(gen.next().value).toEqual(all([put(addJobAction(exampleJob))]));
+    // Refresh all jobs status
+    expect(gen.next().value).toEqual(all([call(refreshJobStatus, exampleJob)]));
+  });
+});
+
+describe('`manageLocalStorage` saga', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('has the expected nominal flow', () => {
+    const gen = manageLocalStorage();
+    const testChan = channel();
+
+    expect(gen.next().value).toEqual(
+      actionChannel([ADD_JOB, REMOVE_JOB, JOB_COMPLETED]),
+    );
+    expect(gen.next(testChan).value).toEqual(take(testChan));
+
+    let nextAction = addJobAction(exampleJob);
+    expect(gen.next(nextAction).value).toEqual(take(testChan));
+    expect(JSON.parse(localStorage.getItem(JOBS))).toEqual([exampleJob]);
+
+    nextAction = setJobCompletedAction(exampleJob.jid, 'now', null);
+    expect(gen.next(nextAction).value).toEqual(take(testChan));
+    expect(JSON.parse(localStorage.getItem(JOBS))).toEqual([
+      { ...exampleJob, completedAt: 'now' },
+    ]);
+
+    nextAction = removeJobAction(exampleJob);
+    expect(gen.next(nextAction).value).toEqual(take(testChan));
+    expect(localStorage.getItem(JOBS)).toBe(null);
+  });
+});
+
+describe('`updateJobStatus` saga', () => {
+  test('does nothing for jobs in progress', () => {
+    const gen = updateJobStatus(exampleJob, { completed: false });
+    expect(gen.next().done).toBe(true);
+  });
+
+  test("marks a job as completed if it wasn't already", () => {
+    const status = { completed: true };
+    const gen = updateJobStatus(exampleJob, status);
+    expect(gen.next().value).toMatchObject(
+      put({
+        type: JOB_COMPLETED,
+        // TODO: we can't know the 'completedAt' value unless we mock Date()...
+        payload: { jid: exampleJob.jid, status },
+      }),
+    );
+    expect(gen.next().done).toBe(true);
+  });
+
+  test("simply updates a job's status if it was already completed", () => {
+    const status = { completed: true };
+    const gen = updateJobStatus({ ...exampleJob, completedAt: 'now' }, status);
+    expect(gen.next().value).toEqual(
+      put(setJobStatusAction(exampleJob.jid, status)),
+    );
+    expect(gen.next().done).toBe(true);
+  });
+});
+
+describe('`garbageCollectJobs` saga', () => {
+  const gen = garbageCollectJobs();
+
+  beforeEach(() => {
+    // each loop first reads the existing jobs in the state
+    expect(gen.next().value).toEqual(select(allJobsSelector));
+  });
+
+  afterEach(() => {
+    // after each loop, the saga waits for some time
+    expect(gen.next().value).toEqual(delay(JOB_GC_DELAY));
+  });
+
+  test('does nothing by default', () => {
+    expect(gen.next([]).value).toEqual(all([]));
+  });
+
+  test('ignores jobs in progress', () => {
+    expect(gen.next([exampleJob]).value).toEqual(all([]));
+  });
+
+  const currentDate = new Date();
+  const recentJob = {
+    ...exampleJob,
+    completedAt: currentDate.toISOString(),
+    completed: true,
+  };
+
+  test('ignores recently completed jobs', () => {
+    expect(gen.next([recentJob]).value).toEqual(all([]));
+  });
+
+  const oldDate = new Date();
+  oldDate.setDate(currentDate.getDate() - 1); // 1 day old
+  const oldJob = {
+    ...exampleJob,
+    completedAt: oldDate.toISOString(),
+    completed: true,
+  };
+
+  test.each([
+    ['[old]', [oldJob]],
+    ['[recent, old]', [recentJob, oldJob]],
+  ])('removes old completed jobs: %s', (_, jobs) => {
+    expect(gen.next(jobs).value).toEqual(all([put(removeJobAction(oldJob))]));
+  });
+});
+
+describe('`watchSaltEvents` saga', () => {
+  test.todo('need to mock EventSource');
+});

--- a/ui/src/ducks/app/salt.test.js
+++ b/ui/src/ducks/app/salt.test.js
@@ -33,7 +33,7 @@ import {
   createChannelFromSource,
 } from './salt';
 
-const exampleJob = { name: 'example', jid: '12345', completedAt: null };
+const exampleJob = { type: 'example', jid: '12345', completedAt: null };
 
 describe('`addJobAction` action creator', () => {
   test('handles a job in progress', () => {
@@ -57,6 +57,20 @@ describe('`addJobAction` action creator', () => {
         ...exampleJob,
         completedAt: 'now',
         completed: true,
+        status: {},
+        events: [],
+      },
+    });
+  });
+
+  test('keeps custom job props', () => {
+    const action = addJobAction({ ...exampleJob, node: 'some-node' });
+    expect(action).toEqual({
+      type: ADD_JOB,
+      payload: {
+        ...exampleJob,
+        node: 'some-node',
+        completed: false,
         status: {},
         events: [],
       },

--- a/ui/src/ducks/app/solutions.js
+++ b/ui/src/ducks/app/solutions.js
@@ -38,8 +38,7 @@ export default function reducer(state = defaultState, action = {}) {
   }
 }
 
-// Actions Creator
-
+// Action Creators
 export function setSolutionsAction(solutions) {
   return { type: SET_SOLUTIONS, payload: solutions };
 }
@@ -68,6 +67,12 @@ export function createEnvironmentAction(newEnvironment) {
   return { type: CREATE_ENVIRONMENT, payload: newEnvironment };
 }
 
+// Selectors
+export const solutionsRefreshingSelector = state =>
+  state.app.solutions.isSolutionsRefreshing;
+export const solutionServicesSelector = state => state.app.solutions.services;
+
+// Sagas
 export function* createEnvironment(action) {
   const newEnvironment = action.payload;
 
@@ -110,7 +115,7 @@ export function* fetchSolutions() {
           versions: JSON.parse(solutionsConfigMap.data[key]),
         };
       });
-      const services = yield select(state => state.app.solutions.services);
+      const services = yield select(solutionServicesSelector);
       solutions.forEach(sol => {
         sol.versions.forEach(version => {
           if (version.deployed) {
@@ -155,9 +160,7 @@ export function* refreshSolutions() {
     !resultFetchEnvironments.error
   ) {
     yield delay(REFRESH_TIMEOUT);
-    const isRefreshing = yield select(
-      state => state.config.isSolutionsRefreshing,
-    );
+    const isRefreshing = yield select(solutionsRefreshingSelector);
     if (isRefreshing) {
       yield call(refreshSolutions);
     }

--- a/ui/src/ducks/app/volumes.js
+++ b/ui/src/ducks/app/volumes.js
@@ -143,6 +143,12 @@ export const updateVolumesAction = payload => {
   return { type: UPDATE_VOLUMES, payload };
 };
 
+// Selectors
+export const volumesRefreshingSelector = state =>
+  state.app.volumes.isRefreshing;
+export const persistentVolumesRefreshingSelector = state =>
+  state.app.volumes.isPVRefreshing;
+
 // Sagas
 export function* fetchVolumes() {
   yield put(
@@ -280,7 +286,7 @@ export function* refreshVolumes() {
   const result = yield call(fetchVolumes);
   if (!result.error) {
     yield delay(REFRESH_TIMEOUT);
-    const isRefreshing = yield select(state => state.app.volumes.isRefreshing);
+    const isRefreshing = yield select(volumesRefreshingSelector);
     if (isRefreshing) {
       yield call(refreshVolumes);
     }
@@ -303,9 +309,7 @@ export function* refreshPersistentVolumes() {
   const result = yield call(fetchPersistentVolumes);
   if (!result.error) {
     yield delay(REFRESH_TIMEOUT);
-    const isPVRefreshing = yield select(
-      state => state.app.volumes.isPVRefreshing,
-    );
+    const isPVRefreshing = yield select(persistentVolumesRefreshingSelector);
     if (isPVRefreshing) {
       yield call(refreshPersistentVolumes);
     }

--- a/ui/src/ducks/config.js
+++ b/ui/src/ducks/config.js
@@ -75,6 +75,10 @@ export function setThemesAction(themes) {
   return { type: SET_THEMES, payload: themes };
 }
 
+// Selectors
+export const languageSelector = state => state.config.language;
+export const apiConfigSelector = state => state.config.api;
+
 // Sagas
 export function* fetchTheme() {
   const result = yield call(Api.fetchTheme);
@@ -120,7 +124,7 @@ export function* setInitialLanguage() {
 
 export function* updateLanguage(action) {
   yield put(setLanguageAction(action.payload));
-  const language = yield select(state => state.config.language);
+  const language = yield select(languageSelector);
   localStorage.setItem(LANGUAGE, language);
 }
 

--- a/ui/src/ducks/login.js
+++ b/ui/src/ducks/login.js
@@ -1,8 +1,9 @@
 import { call, takeEvery, put, select } from 'redux-saga/effects';
 import * as ApiK8s from '../services/k8s/api';
 import * as ApiSalt from '../services/salt/api';
-
 import history from '../history';
+
+import { apiConfigSelector } from './config';
 import { connectSaltApiAction } from './app/salt';
 
 // Actions
@@ -83,6 +84,9 @@ export const setSaltAuthenticationSuccessAction = payload => {
   };
 };
 
+// Selectors
+export const userSelector = state => state.login.user;
+
 // Sagas
 export function* authenticate({ payload }) {
   const { username, password } = payload;
@@ -95,7 +99,7 @@ export function* authenticate({ payload }) {
       payload: result.error.response.data,
     });
   } else {
-    const api_server = yield select(state => state.config.api);
+    const api_server = yield select(apiConfigSelector);
     yield call(ApiK8s.updateApiServerConfig, api_server.url, token);
     localStorage.setItem(HASH_KEY, token);
     yield put(
@@ -111,8 +115,8 @@ export function* authenticate({ payload }) {
 }
 
 export function* authenticateSaltApi(redirect) {
-  const api = yield select(state => state.config.api);
-  const user = yield select(state => state.login.user);
+  const api = yield select(apiConfigSelector);
+  const user = yield select(userSelector);
   const result = yield call(ApiSalt.authenticate, user);
   if (!result.error) {
     yield call(ApiSalt.getClient().setHeaders, {
@@ -141,7 +145,7 @@ export function* logout() {
 export function* fetchUserInfo() {
   const token = localStorage.getItem(HASH_KEY);
   if (token) {
-    const api_server = yield select(state => state.config.api);
+    const api_server = yield select(apiConfigSelector);
     yield call(ApiK8s.updateApiServerConfig, api_server.url, token);
 
     const decryptedToken = atob(token);

--- a/ui/src/ducks/login.js
+++ b/ui/src/ducks/login.js
@@ -3,7 +3,7 @@ import * as ApiK8s from '../services/k8s/api';
 import * as ApiSalt from '../services/salt/api';
 
 import history from '../history';
-import { connectSaltApiAction } from './app/nodes';
+import { connectSaltApiAction } from './app/salt';
 
 // Actions
 const AUTHENTICATE = 'AUTHENTICATE';

--- a/ui/src/ducks/sagas.js
+++ b/ui/src/ducks/sagas.js
@@ -1,22 +1,24 @@
 import { all, fork } from 'redux-saga/effects';
+import { layoutSaga } from './app/layout';
+import { monitoringSaga } from './app/monitoring';
 import { nodesSaga } from './app/nodes';
 import { podsSaga } from './app/pods';
+import { saltSaga } from './app/salt';
+import { solutionsSaga } from './app/solutions';
 import { volumesSaga } from './app/volumes';
 import { authenticateSaga } from './login';
 import { configSaga } from './config';
-import { monitoringSaga } from './app/monitoring';
-import { layoutSaga } from './app/layout';
-import { solutionsSaga } from './app/solutions';
 
 export default function* rootSaga() {
   yield all([
-    fork(nodesSaga),
-    fork(podsSaga),
     fork(authenticateSaga),
     fork(configSaga),
-    fork(monitoringSaga),
     fork(layoutSaga),
-    fork(volumesSaga),
+    fork(monitoringSaga),
+    fork(nodesSaga),
+    fork(podsSaga),
+    fork(saltSaga),
     fork(solutionsSaga),
+    fork(volumesSaga),
   ]);
 }

--- a/ui/src/services/salt/utils.js
+++ b/ui/src/services/salt/utils.js
@@ -1,4 +1,4 @@
-const JOBS = 'JOBS';
+export const JOBS = 'JOBS';
 
 // Jobs in LocalStorage {{{
 // A job in localStorage is represented as { name, jid, completedAt }
@@ -64,7 +64,7 @@ export function parseJobError(returner) {
 
 export function getJobStatusFromPrintJob(result, jid) {
   let status = {
-    completed: false
+    completed: false,
   };
 
   const job = result.return[0][jid];
@@ -84,7 +84,7 @@ export function getJobStatusFromPrintJob(result, jid) {
 
 export function getJobStatusFromEventRet(result) {
   let status = {
-    completed: true
+    completed: true,
   };
   status.success = result.success;
 

--- a/ui/src/services/salt/utils.js
+++ b/ui/src/services/salt/utils.js
@@ -1,7 +1,7 @@
 export const JOBS = 'JOBS';
 
 // Jobs in LocalStorage {{{
-// A job in localStorage is represented as { name, jid, completedAt }
+// A job in localStorage is represented as { type, jid, completedAt, ...props }
 
 export function listJobsFromLocalStorage() {
   return JSON.parse(localStorage.getItem(JOBS)) || [];
@@ -11,11 +11,16 @@ function saveJobsToLocalStorage(jobs) {
   localStorage.setItem(JOBS, JSON.stringify(jobs));
 }
 
-export function addJobToLocalStorage({ jid, name, completedAt = null }) {
+export function addJobToLocalStorage({
+  jid,
+  type,
+  completedAt = null,
+  ...props
+}) {
   const jobs = listJobsFromLocalStorage();
   const job = jobs.find(item => item.jid === jid);
   if (!job) {
-    jobs.push({ jid, name, completedAt });
+    jobs.push({ jid, type, completedAt, ...props });
     saveJobsToLocalStorage(jobs);
   }
 }

--- a/ui/src/services/salt/utils.test.js
+++ b/ui/src/services/salt/utils.test.js
@@ -1,84 +1,59 @@
-import { data as dataPrintJob } from './mockDataPrintJob';
-import { data as dataEventRet } from './mockDataEventRet';
+import { JOB_ID, NODE_NAME } from '../../tests/mocks/salt/constants';
+import { data as dataPrintJob } from '../../tests/mocks/salt/printJob';
+import { data as dataEventRet } from '../../tests/mocks/salt/eventRet';
+
 import { getJobStatusFromPrintJob, getJobStatusFromEventRet } from './utils';
 
-test('getJobStatusFromPrintJob not completed', () => {
-  const data = {
-    return: [
-      {
-        '20190527213228970129': {
-          Result: {}
-        }
-      }
-    ]
-  };
+describe('`getJobStatusFromPrintJob` utility method', () => {
+  test('handles a job not yet completed', () => {
+    const data = { return: [{ [JOB_ID]: { Result: {} } }] };
 
-  const expectedResult = {
-    completed: false
-  };
-  expect(getJobStatusFromPrintJob(data, '20190527213228970129')).toEqual(
-    expectedResult
-  );
+    expect(getJobStatusFromPrintJob(data, JOB_ID)).toEqual({
+      completed: false,
+    });
+  });
+
+  test('handles a successful job', () => {
+    const data = {
+      return: [
+        {
+          [JOB_ID]: {
+            Result: { whateverMasterMinionName: { return: { success: true } } },
+          },
+        },
+      ],
+    };
+
+    expect(getJobStatusFromPrintJob(data, JOB_ID)).toEqual({
+      completed: true,
+      success: true,
+    });
+  });
+
+  test('handles a failed job', () => {
+    expect(getJobStatusFromPrintJob(dataPrintJob, JOB_ID)).toEqual({
+      completed: true,
+      success: false,
+      step: 'Set grains',
+      comment: `Updating ${NODE_NAME} failed`,
+    });
+  });
 });
 
-test('getJobStatusFromPrintJob completed success', () => {
-  const data = {
-    return: [
-      {
-        '20190527213228970129': {
-          Result: {
-            bootstrap_master: {
-              return: {
-                success: true
-              }
-            }
-          }
-        }
-      }
-    ]
-  };
+describe('`getJobStatusFromEventRet` utility method', () => {
+  test('handles a successful job', () => {
+    expect(getJobStatusFromEventRet({ success: true })).toEqual({
+      completed: true,
+      success: true,
+    });
+  });
 
-  const expectedResult = {
-    completed: true,
-    success: true
-  };
-  expect(getJobStatusFromPrintJob(data, '20190527213228970129')).toEqual(
-    expectedResult
-  );
-});
-
-test('getJobStatusFromPrintJob completed failed', () => {
-  const expectedResult = {
-    completed: true,
-    success: false,
-    step_id: 'Set grains',
-    comment: 'Updating node1 failed'
-  };
-  expect(
-    getJobStatusFromPrintJob(dataPrintJob, '20190527213228970129')
-  ).toEqual(expectedResult);
-});
-
-test('getJobStatusFromEventRet completed success', () => {
-  const data = {
-    success: true
-  };
-
-  const expectedResult = {
-    completed: true,
-    success: true
-  };
-  expect(getJobStatusFromEventRet(data, '20190527213228970129')).toEqual(
-    expectedResult
-  );
-});
-
-test('getJobStatusFromEventRet completed failed', () => {
-  const expectedResult = {
-    completed: true,
-    success: false,
-    step_id: 'Register the node into etcd cluster',
-    comment: "Runner function 'state.orchestrate' executed."
-  };
-  expect(getJobStatusFromEventRet(dataEventRet)).toEqual(expectedResult);
+  test('handles a failed job', () => {
+    expect(getJobStatusFromEventRet(dataEventRet)).toEqual({
+      completed: true,
+      success: false,
+      step: 'Register the node into etcd cluster',
+      comment: "Runner function 'state.orchestrate' executed.",
+    });
+  });
 });

--- a/ui/src/setupTests.js
+++ b/ui/src/setupTests.js
@@ -1,12 +1,15 @@
 import { IntlProvider, addLocaleData } from 'react-intl';
 import IntlGlobalProvider from './translations/IntlGlobalProvider';
 import translations_en from './translations/en';
+import { setupMock as setupLocalStorageMock } from './tests/mocks/localStorage';
 
 const intlProvider = new IntlProvider({
   locale: 'en',
-  messages: translations_en
+  messages: translations_en,
 });
 const { intl } = intlProvider.getChildContext();
 
-//init to test i18n in sagas
+// Setup i18n (used in sagas)
 IntlGlobalProvider({}, { intl });
+
+setupLocalStorageMock();

--- a/ui/src/tests/mocks/localStorage.js
+++ b/ui/src/tests/mocks/localStorage.js
@@ -1,0 +1,28 @@
+export class LocalStorageMock {
+  store = {};
+  clear = () => {
+    this.store = {};
+  };
+
+  setItem = (key, val) => {
+    this.store[key] = val;
+  };
+  getItem = key => this.store?.[key] ?? null;
+  removeItem = key => {
+    delete this.store[key];
+  };
+}
+
+export const setupMock = () => {
+  if (typeof global._localStorage !== 'undefined') {
+    // Special case where `jsdom` sets localStorage and we can't overwrite it
+    // See: https://github.com/jsdom/jsdom/commit/4d26c6773f011205d9c703cc5988e7c117efea31#diff-9b8fab691c00b9e5380b19ce882f3271R1
+    // See: https://github.com/clarkbw/jest-localstorage-mock/pull/80
+    Object.defineProperty(global, '_localStorage', {
+      value: new LocalStorageMock(),
+      writable: false,
+    });
+  } else {
+    global.localStorage = new LocalStorageMock();
+  }
+};

--- a/ui/src/tests/mocks/salt/constants.js
+++ b/ui/src/tests/mocks/salt/constants.js
@@ -1,0 +1,3 @@
+export const JOB_ID = '20190527152722429535';
+export const NODE_NAME = 'node1';
+export const METAL_VERSION = '2.4.2';

--- a/ui/src/tests/mocks/salt/eventRet.js
+++ b/ui/src/tests/mocks/salt/eventRet.js
@@ -1,47 +1,48 @@
+import { JOB_ID, NODE_NAME, METAL_VERSION } from './constants';
+
 export const data = {
   fun_args: [
     'metalk8s.orchestrate.deploy_node',
     {
-      saltenv: 'metalk8s-2.0',
+      saltenv: `metalk8s-${METAL_VERSION}`,
       pillar: {
         orchestrate: {
-          node_name: 'node1'
-        }
-      }
-    }
+          node_name: NODE_NAME,
+        },
+      },
+    },
   ],
-  jid: '20190527152722429535',
+  jid: JOB_ID,
   return: {
     outputter: 'highstate',
     data: {
       bootstrap_master: {
         'salt_|-Set grains_|-Set grains_|-state': {
-          comment: 'States ran successfully. Updating node1.',
+          comment: `States ran successfully. Updating ${NODE_NAME}.`,
           name: 'Set grains',
           start_time: '15:28:25.541001',
           result: true,
           duration: 1318.444,
           __run_num__: 3,
-          __jid__: '20190527152825671379'
+          __jid__: '20190527152825671379',
         },
-        'metalk8s_drain_|-Drain the node_|-node1_|-node_drained': {
+        [`metalk8s_drain_|-Drain the node_|-${NODE_NAME}_|-node_drained`]: {
           comment: 'Eviction complete.',
-          name: 'node1',
+          name: NODE_NAME,
           start_time: '15:28:28.923923',
           result: true,
           duration: 244.721,
           __run_num__: 6,
           __sls__: 'metalk8s.orchestrate.deploy_node',
           changes: {
-            node1: {
-              node1: 'drained'
-            }
+            [NODE_NAME]: {
+              [NODE_NAME]: 'drained',
+            },
           },
-          __id__: 'Drain the node'
+          __id__: 'Drain the node',
         },
         'salt_|-Kill kube-controller-manager on all master nodes_|-ps.pkill_|-function': {
-          comment:
-            'Function ran successfully. Function ps.pkill ran on node1, bootstrap.',
+          comment: `Function ran successfully. Function ps.pkill ran on ${NODE_NAME}, bootstrap.`,
           name: 'ps.pkill',
           start_time: '15:30:29.425156',
           result: true,
@@ -51,24 +52,24 @@ export const data = {
           __sls__: 'metalk8s.orchestrate.deploy_node',
           changes: {
             ret: {
-              node1: null,
+              [NODE_NAME]: null,
               bootstrap: {
-                killed: [14909]
-              }
+                killed: [14909],
+              },
             },
-            out: 'highstate'
+            out: 'highstate',
           },
-          __id__: 'Kill kube-controller-manager on all master nodes'
+          __id__: 'Kill kube-controller-manager on all master nodes',
         },
         'salt_|-Deploy salt-minion on a new node_|-Deploy salt-minion on a new node_|-state': {
-          comment: 'States ran successfully. Updating node1.',
+          comment: `States ran successfully. Updating ${NODE_NAME}.`,
           name: 'Deploy salt-minion on a new node',
           start_time: '15:27:25.134589',
           result: true,
           duration: 47344.676,
           __run_num__: 0,
           __jid__: '20190527152731311813',
-          __sls__: 'metalk8s.orchestrate.deploy_node'
+          __sls__: 'metalk8s.orchestrate.deploy_node',
         },
         'module_|-Accept key_|-Accept key_|-run': {
           comment: 'saltutil.wheel: Success',
@@ -76,44 +77,43 @@ export const data = {
           start_time: '15:28:12.482345',
           result: true,
           duration: 357.834,
-          __run_num__: 1
+          __run_num__: 1,
         },
         'salt_|-Run the highstate_|-Run the highstate_|-state': {
-          comment: 'States ran successfully. Updating node1.',
+          comment: `States ran successfully. Updating ${NODE_NAME}.`,
           name: 'Run the highstate',
           start_time: '15:28:29.169805',
           result: true,
           duration: 120024.083,
           __run_num__: 7,
-          __jid__: '20190527152829304045'
+          __jid__: '20190527152829304045',
         },
-        'metalk8s_cordon_|-Uncordon the node_|-node1_|-node_uncordoned': {
-          comment: 'Node node1 uncordoned',
-          name: 'node1',
+        [`metalk8s_cordon_|-Uncordon the node_|-${NODE_NAME}_|-node_uncordoned`]: {
+          comment: `Node ${NODE_NAME} uncordoned`,
+          name: NODE_NAME,
           start_time: '15:30:29.194902',
           result: true,
           duration: 229.821,
           __run_num__: 8,
-          __sls__: 'metalk8s.orchestrate.deploy_node'
+          __sls__: 'metalk8s.orchestrate.deploy_node',
         },
-        'metalk8s_cordon_|-Cordon the node_|-node1_|-node_cordoned': {
-          comment: 'Node node1 cordoned',
-          name: 'node1',
+        [`metalk8s_cordon_|-Cordon the node_|-${NODE_NAME}_|-node_cordoned`]: {
+          comment: `Node ${NODE_NAME} cordoned`,
+          name: NODE_NAME,
           start_time: '15:28:28.688465',
           result: true,
           duration: 232.145,
           __run_num__: 5,
-          __sls__: 'metalk8s.orchestrate.deploy_node'
+          __sls__: 'metalk8s.orchestrate.deploy_node',
         },
         'salt_|-Refresh the mine_|-mine.update_|-function': {
-          comment:
-            'Function ran successfully. Function mine.update ran on node1, bootstrap.',
+          comment: `Function ran successfully. Function mine.update ran on ${NODE_NAME}, bootstrap.`,
           name: 'mine.update',
           start_time: '15:28:26.859849',
           result: true,
           duration: 1824.89,
           __run_num__: 4,
-          __jid__: '20190527152826991322'
+          __jid__: '20190527152826991322',
         },
         'salt_|-Register the node into etcd cluster_|-state.orchestrate_|-runner': {
           comment: "Runner function 'state.orchestrate' executed.",
@@ -130,9 +130,9 @@ export const data = {
               outputter: 'highstate',
               data: {
                 bootstrap_master: {
-                  'metalk8s_etcd_|-Register host as part of etcd cluster_|-node1_|-member_present': {
+                  [`metalk8s_etcd_|-Register host as part of etcd cluster_|-${NODE_NAME}_|-member_present`]: {
                     comment: 'Node added in etcd cluster',
-                    name: 'node1',
+                    name: NODE_NAME,
                     start_time: '15:30:32.771762',
                     result: false,
                     duration: 1965.116,
@@ -142,16 +142,16 @@ export const data = {
                       peer_urls: 'https://172.21.254.13:2380',
                       client_urls: '',
                       id: 860341623853584300,
-                      name: ''
+                      name: '',
                     },
-                    __id__: 'Register host as part of etcd cluster'
-                  }
-                }
+                    __id__: 'Register host as part of etcd cluster',
+                  },
+                },
               },
-              retcode: 0
-            }
+              retcode: 0,
+            },
           },
-          __id__: 'Register the node into etcd cluster'
+          __id__: 'Register the node into etcd cluster',
         },
         'salt_|-Wait minion available_|-metalk8s_saltutil.wait_minions_|-runner': {
           comment: "Runner function 'metalk8s_saltutil.wait_minions' executed.",
@@ -161,14 +161,14 @@ export const data = {
           result: true,
           duration: 12699.302,
           __run_num__: 2,
-          __jid__: '20190527152813179108'
-        }
-      }
+          __jid__: '20190527152813179108',
+        },
+      },
     },
-    retcode: 0
+    retcode: 0,
   },
   success: false,
   _stamp: '2019-05-27T15:30:34.778305',
   user: 'admin',
-  fun: 'runner.state.orchestrate'
+  fun: 'runner.state.orchestrate',
 };

--- a/ui/src/tests/mocks/salt/printJob.js
+++ b/ui/src/tests/mocks/salt/printJob.js
@@ -1,18 +1,20 @@
+import { JOB_ID, NODE_NAME } from './constants';
+
 export const data = {
   return: [
     {
-      '20190527213228970129': {
+      [JOB_ID]: {
         Result: {
           bootstrap_master: {
             return: {
               fun_args: [],
-              jid: '20190527213228970129',
+              jid: JOB_ID,
               return: {
                 outputter: 'highstate',
                 data: {
                   bootstrap_master: {
                     'salt_|-Set grains_|-Set grains_|-state': {
-                      comment: 'Updating node1 failed',
+                      comment: `Updating ${NODE_NAME} failed`,
                       name: 'Set grains',
                       start_time: '21:33:33.408716',
                       result: false,
@@ -22,7 +24,7 @@ export const data = {
                       __sls__: 'metalk8s.orchestrate.deploy_node',
                       changes: {
                         ret: {
-                          node1: {
+                          [NODE_NAME]: {
                             'grains_|-Set control_plane_ip grain_|-metalk8s:control_plane_ip_|-present': {
                               comment:
                                 'Set grain metalk8s:control_plane_ip to 172.21.254.12',
@@ -30,7 +32,7 @@ export const data = {
                               start_time: '21:33:34.750189',
                               result: false,
                               duration: 11.342,
-                              __run_num__: 0
+                              __run_num__: 0,
                             },
                             'grains_|-Set workload_plane_ip grain_|-metalk8s:workload_plane_ip_|-present': {
                               comment:
@@ -39,21 +41,21 @@ export const data = {
                               start_time: '21:33:34.761797',
                               result: false,
                               duration: 4.798,
-                              __run_num__: 1
-                            }
-                          }
+                              __run_num__: 1,
+                            },
+                          },
                         },
-                        out: 'highstate'
+                        out: 'highstate',
                       },
-                      __id__: 'Set grains'
+                      __id__: 'Set grains',
                     },
-                    'metalk8s_drain_|-Drain the node_|-node1_|-node_drained': {
+                    [`metalk8s_drain_|-Drain the node_|-${NODE_NAME}_|-node_drained`]: {
                       comment: 'Eviction complete.',
-                      name: 'node1',
+                      name: NODE_NAME,
                       start_time: '21:33:36.057387',
                       result: true,
                       duration: 259.239,
-                      __run_num__: 6
+                      __run_num__: 6,
                     },
                     'salt_|-Kill kube-controller-manager on all master nodes_|-ps.pkill_|-function': {
                       comment:
@@ -68,21 +70,22 @@ export const data = {
                       changes: {
                         ret: {
                           bootstrap: {
-                            killed: [14939]
-                          }
+                            killed: [14939],
+                          },
                         },
-                        out: 'highstate'
+                        out: 'highstate',
                       },
-                      __id__: 'Kill kube-controller-manager on all master nodes'
+                      __id__:
+                        'Kill kube-controller-manager on all master nodes',
                     },
                     'salt_|-Deploy salt-minion on a new node_|-Deploy salt-minion on a new node_|-state': {
-                      comment: 'States ran successfully. Updating node1.',
+                      comment: `States ran successfully. Updating ${NODE_NAME}.`,
                       name: 'Deploy salt-minion on a new node',
                       start_time: '21:32:31.403702',
                       result: true,
                       duration: 48700.922,
                       __run_num__: 0,
-                      __jid__: '20190527213237875376'
+                      __jid__: '20190527213237875376',
                     },
                     'module_|-Accept key_|-Accept key_|-run': {
                       comment: 'saltutil.wheel: Success',
@@ -90,20 +93,20 @@ export const data = {
                       start_time: '21:33:20.106366',
                       result: true,
                       duration: 350.636,
-                      __run_num__: 1
+                      __run_num__: 1,
                     },
                     'salt_|-Run the highstate_|-Run the highstate_|-state': {
-                      comment: 'States ran successfully. Updating node1.',
+                      comment: `States ran successfully. Updating ${NODE_NAME}.`,
                       name: 'Run the highstate',
                       start_time: '21:33:36.318055',
                       result: true,
                       duration: 80352.861,
                       __run_num__: 7,
-                      __jid__: '20190527213336504932'
+                      __jid__: '20190527213336504932',
                     },
-                    'metalk8s_cordon_|-Uncordon the node_|-node1_|-node_uncordoned': {
-                      comment: 'Node node1 uncordoned',
-                      name: 'node1',
+                    [`metalk8s_cordon_|-Uncordon the node_|-${NODE_NAME}_|-node_uncordoned`]: {
+                      comment: `Node ${NODE_NAME} uncordoned`,
+                      name: NODE_NAME,
                       start_time: '21:34:56.671443',
                       result: true,
                       duration: 234.004,
@@ -111,17 +114,17 @@ export const data = {
                       __sls__: 'metalk8s.orchestrate.deploy_node',
                       changes: {
                         new: {
-                          unschedulable: null
+                          unschedulable: null,
                         },
                         old: {
-                          unschedulable: true
-                        }
+                          unschedulable: true,
+                        },
                       },
-                      __id__: 'Uncordon the node'
+                      __id__: 'Uncordon the node',
                     },
-                    'metalk8s_cordon_|-Cordon the node_|-node1_|-node_cordoned': {
-                      comment: 'Node node1 cordoned',
-                      name: 'node1',
+                    [`metalk8s_cordon_|-Cordon the node_|-${NODE_NAME}_|-node_cordoned`]: {
+                      comment: `Node ${NODE_NAME} cordoned`,
+                      name: NODE_NAME,
                       start_time: '21:33:35.818960',
                       result: true,
                       duration: 236.41,
@@ -129,17 +132,16 @@ export const data = {
                       __sls__: 'metalk8s.orchestrate.deploy_node',
                       changes: {
                         new: {
-                          unschedulable: true
+                          unschedulable: true,
                         },
                         old: {
-                          unschedulable: false
-                        }
+                          unschedulable: false,
+                        },
                       },
-                      __id__: 'Cordon the node'
+                      __id__: 'Cordon the node',
                     },
                     'salt_|-Refresh the mine_|-mine.update_|-function': {
-                      comment:
-                        'Function ran successfully. Function mine.update ran on node1, bootstrap.',
+                      comment: `Function ran successfully. Function mine.update ran on ${NODE_NAME}, bootstrap.`,
                       name: 'mine.update',
                       start_time: '21:33:34.887400',
                       result: true,
@@ -149,12 +151,12 @@ export const data = {
                       __sls__: 'metalk8s.orchestrate.deploy_node',
                       changes: {
                         ret: {
-                          node1: true,
-                          bootstrap: true
+                          [NODE_NAME]: true,
+                          bootstrap: true,
                         },
-                        out: 'highstate'
+                        out: 'highstate',
                       },
-                      __id__: 'Refresh the mine'
+                      __id__: 'Refresh the mine',
                     },
                     'salt_|-Wait minion available_|-metalk8s_saltutil.wait_minions_|-runner': {
                       comment:
@@ -169,27 +171,26 @@ export const data = {
                       __sls__: 'metalk8s.orchestrate.deploy_node',
                       changes: {
                         return: {
-                          comment:
-                            'All minions matching "node1" responded: node1',
-                          result: true
-                        }
+                          comment: `All minions matching "${NODE_NAME}" responded: ${NODE_NAME}`,
+                          result: true,
+                        },
                       },
-                      __id__: 'Wait minion available'
-                    }
-                  }
+                      __id__: 'Wait minion available',
+                    },
+                  },
                 },
-                retcode: 0
+                retcode: 0,
               },
               success: false,
               _stamp: '2019-05-27T21:32:29.351849',
               user: 'admin',
-              fun: 'runner.state.orchestrate'
-            }
-          }
+              fun: 'runner.state.orchestrate',
+            },
+          },
         },
         StartTime: '2019, May 27 21:32:28.970129',
-        Error: 'Cannot contact returner or no job with this jid'
-      }
-    }
-  ]
+        Error: 'Cannot contact returner or no job with this jid',
+      },
+    },
+  ],
 };

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -46,6 +46,8 @@
   "completed": "Completed",
   "node_registered": "Node registered",
   "deployment_started": "Deployment started",
+  "no_deployment_found": "No deployment job found for Node {name}.",
+  "refreshing_job": "Refreshing job info…",
   "cluster_status": "Cluster Status",
   "cluster_version": "Cluster Version",
   "monitoring": "Monitoring",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -46,6 +46,8 @@
   "completed": "Terminé",
   "node_registered": "Nœud enregistré",
   "deployment_started": "Déploiement commencé",
+  "no_deployment_found": "Aucune tâche de déploiement trouvée pour le nœud {name}.",
+  "refreshing_job": "Actualisation des informations de la tâche…",
   "cluster_status": "Statut du cluster",
   "cluster_version": "Version du cluster",
   "monitoring": "Monitoring",


### PR DESCRIPTION
**Component**: ui

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**:

As the UI will need to handle more and more long-running Salt operations (such as importing a Solution or preparing an Environment), the pattern introduced for deployment of Nodes needs to be extended.

**Summary**:

- extract all logic related to management of Salt jobs from `app.nodes` to `app.salt`
- refine the pattern to make it more generic: a deployment job is now named `deploy-node/<node-name>` to avoid future collisions
- store the completion time of a job in localStorage, to provide efficient reloading of the application
- keep jobs in localStorage after their completion and implement a garbage collection saga to clean them up after some time
- trigger notifications from the related duck (here, `app.nodes`), while the action gets sent from the `app.salt` duck
- rework the NodeDeployment page slightly (simplification and handling of some edge-cases)

(read commit messages for more info)

**Acceptance criteria**: 

Everything still works, and one can now find info about previously failed jobs even after a refresh. Unit tests were also slightly reworked to make use of features of `jest` to avoid code duplication - make sure you (UI devs) understand how this works and feel comfortable with it.
