### PR TITLE
set NO_PROXY env var for containerd

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -290,7 +290,7 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/addons/nginx-ingress-control-plane/pre-upgrade.sls'),
 
     Path('salt/metalk8s/container-engine/containerd/configured.sls'),
-    Path('salt/metalk8s/container-engine/containerd/files/50-metalk8s.conf'),
+    Path('salt/metalk8s/container-engine/containerd/files/50-metalk8s.conf.j2'),
     Path('salt/metalk8s/container-engine/containerd/init.sls'),
     Path('salt/metalk8s/container-engine/containerd/installed.sls'),
     Path('salt/metalk8s/container-engine/init.sls'),

--- a/docs/installation/bootstrap.rst
+++ b/docs/installation/bootstrap.rst
@@ -36,6 +36,12 @@ Configuration
       networks:
         controlPlane: <CIDR-notation>
         workloadPlane: <CIDR-notation>
+      proxies:
+        http: <http://proxy-ip:proxy-port>
+        https: <https://proxy-ip:proxy-port>
+        no_proxy:
+          - <host>
+          - <ip/cidr>
       ca:
         minion: <hostname-of-the-bootstrap-node>
       archives:
@@ -44,6 +50,13 @@ Configuration
 The ``archives`` field is a list of absolute paths to MetalK8s ISO files. When
 the bootstrap script is executed, those ISOs are automatically mounted and the
 system is configured to re-mount them automatically after a reboot.
+
+The ``proxies`` field can be omitted if there is no proxy to configure.
+The 2 entries ``http`` and ``https`` are used to configure the containerd
+daemon proxy to fetch extra container images from outstide the MetalK8s
+cluster.
+The ``no_proxy`` entry specifies IPs that should be excluded from proxying,
+it must a list of hosts, IP addresses or IP ranges in CIDR format.
 
 .. todo::
 

--- a/docs/installation/setup.rst
+++ b/docs/installation/setup.rst
@@ -23,14 +23,7 @@ partition larger than 40 GB.
 
 Proxies
 -------
-For nodes operating behind a proxy, add the following lines to each cluster
-member's :file:`/etc/environment` file:
-
-.. code-block:: shell
-
-   http_proxy=http://user;pass@<HTTP proxy IP address>:<port>
-   https_proxy=http://user;pass@<HTTPS proxy IP address>:<port>
-   no_proxy=localhost,127.0.0.1,<local IP of each node>
+For nodes operating behind a proxy, see :ref:`Bootstrap Configuration`
 
 Provisioning
 ------------

--- a/salt/_pillar/metalk8s.py
+++ b/salt/_pillar/metalk8s.py
@@ -104,7 +104,8 @@ def ext_pillar(minion_id, pillar, bootstrap_config):
 
     result = {
         'networks': _load_networks(config),
-        'metalk8s': metal_data
+        'metalk8s': metal_data,
+        'proxies': config.get('proxies', {})
     }
 
     if not isinstance(metal_data['archives'], list):

--- a/salt/metalk8s/container-engine/containerd/files/50-metalk8s.conf.j2
+++ b/salt/metalk8s/container-engine/containerd/files/50-metalk8s.conf.j2
@@ -2,3 +2,4 @@
 # See https://github.com/containerd/containerd/issues/3201
 # See https://github.com/containerd/containerd/pull/3202
 LimitNOFILE=1048576
+Environment="{{ environment }}"

--- a/salt/metalk8s/container-engine/containerd/installed.sls
+++ b/salt/metalk8s/container-engine/containerd/installed.sls
@@ -31,6 +31,8 @@ Install containerd:
     - require:
       - test: Repositories configured
       - metalk8s_package_manager: Install runc
+      - file: Create containerd service drop-in
+      - file: Configure registry IP in containerd conf
       {%- if grains['os_family'].lower() == 'redhat' %}
       - metalk8s_package_manager: Install container-selinux
       {%- endif %}
@@ -60,8 +62,6 @@ Create containerd service drop-in:
         HTTPS_PROXY={{ proxies.https }}
         {%- endif %}
       {%- endif %}
-    - require:
-      - metalk8s_package_manager: Install containerd
 
 Install and configure cri-tools:
   {{ pkg_installed('cri-tools') }}
@@ -85,5 +85,3 @@ Configure registry IP in containerd conf:
     - contents: |
         [plugins.cri.registry.mirrors."{{ repo.registry_endpoint }}"]
           endpoint = ["http://{{ registry_ip }}:{{ registry_port }}"]
-    - require:
-      - metalk8s_package_manager: Install containerd

--- a/salt/metalk8s/defaults.yaml
+++ b/salt/metalk8s/defaults.yaml
@@ -94,3 +94,5 @@ coredns:
   reverse_cidrs: in-addr.arpa ip6.arpa
 
 upgrade: false        # define if we're on an upgrade case
+
+proxies: {}

--- a/salt/metalk8s/map.jinja
+++ b/salt/metalk8s/map.jinja
@@ -217,3 +217,7 @@
 {% set nginx_ingress = salt['grains.filter_by']({
   'default': {}
 }, merge=defaults.get('nginx-ingress')) %}
+
+{% set proxies = salt['grains.filter_by']({
+  'default': {}
+}, merge=defaults.get('proxies')) %}

--- a/salt/metalk8s/repo/redhat.sls
+++ b/salt/metalk8s/repo/redhat.sls
@@ -61,6 +61,10 @@ Configure {{ repo_name }} repository:
   {%- endif %}
     - repo_gpg_check: {{ repo_config.repo_gpg_check }}
     - enabled: {{ repo_config.enabled }}
+    # URL to the proxy server for this repository.
+    # Set to '_none_' to disable the global proxy setting
+    # for this repository.
+    - proxy: _none_
     - refresh: false
     - onchanges_in:
       - cmd: Refresh yum cache


### PR DESCRIPTION
**Component**: salt

**Context**: Containerd is failing to pull images when a http(s) proxy is set system wide through environment variables in `/etc/environment`

**Summary**: Set NO_PROXY environment variable with control, workload plane and K8s internal
networks in containerd systemd unit file, to avoid using system wide defined HTTP(S)
proxy, if any, when trying to pull resources from metalk8s registry.

**Acceptance criteria**: Be able to install metalk8s with a proxy configured following the doc https://metal-k8s.readthedocs.io/en/latest/quickstart/setup.html#proxies

---

Closes: #2052

