### PR TITLE
Fix python2 kubernetes 10.0.1 changes

### DIFF
--- a/eve/workers/openstack-multiple-nodes/terraform/scripts/enable_ipip.sh
+++ b/eve/workers/openstack-multiple-nodes/terraform/scripts/enable_ipip.sh
@@ -8,8 +8,20 @@ cat > "$PATCH_FILE" << END
   value: Always
 END
 
-sudo kubectl patch ippool default-ipv4-ippool \
-     --kubeconfig=/etc/kubernetes/admin.conf  \
-     --type json --patch "$(cat $PATCH_FILE)"
+MAX_RETRIES=10
+ATTEMPTS=0
+RET=1
+
+while [ "$RET" -ne 0 ] && [ $ATTEMPTS -lt $MAX_RETRIES ]; do
+    (( ATTEMPTS++ ))
+    echo "Attempt $ATTEMPTS out of $MAX_RETRIES"
+    sudo kubectl patch ippool default-ipv4-ippool \
+        --kubeconfig=/etc/kubernetes/admin.conf  \
+        --type json --patch "$(cat $PATCH_FILE)"
+    RET=$?
+    sleep 5
+done
 
 rm "$PATCH_FILE"
+
+exit $RET

--- a/salt/_utils/kubernetes_utils.py
+++ b/salt/_utils/kubernetes_utils.py
@@ -293,7 +293,7 @@ if HAS_LIBS:
             name='namespaced_deployment',
         ),
         ('extensions/v1beta1', 'Ingress'): KindInfo(
-            model=k8s_client.V1beta1Ingress,
+            model=k8s_client.ExtensionsV1beta1Ingress,
             api_cls=k8s_client.ExtensionsV1beta1Api,
             name='namespaced_ingress'
         ),


### PR DESCRIPTION
**Component**:

'salt', 'kubernetes'

**Context**: 

`python2-kubernetes` version 10.0.1 just get pushed in epel repository so we need to add compatibilty with this.

**Summary**:

For example model `V1beta1Ingress` get removed from this version

---

