### PR TITLE
salt: ensure yum versionlock plugin is installed & enabled

### DIFF
--- a/salt/metalk8s/repo/offline.sls
+++ b/salt/metalk8s/repo/offline.sls
@@ -9,6 +9,15 @@ Install yum-plugin-versionlock:
     - name: yum-plugin-versionlock
     - fromrepo: {{ repo.repositories.keys() | join(',') }}
 
+Ensure yum plugins are enabled:
+  ini.options_present:
+    - name: /etc/yum.conf
+    - sections:
+        main:
+          plugins: 1
+    - require_in:
+      - test: Repositories configured
+
 Ensure yum versionlock plugin is enabled:
   ini.options_present:
     - name: /etc/yum/pluginconf.d/versionlock.conf

--- a/salt/metalk8s/repo/offline.sls
+++ b/salt/metalk8s/repo/offline.sls
@@ -8,8 +8,17 @@ Install yum-plugin-versionlock:
   pkg.installed:
     - name: yum-plugin-versionlock
     - fromrepo: {{ repo.repositories.keys() | join(',') }}
+
+Ensure yum versionlock plugin is enabled:
+  ini.options_present:
+    - name: /etc/yum/pluginconf.d/versionlock.conf
+    - sections:
+        main:
+          enabled: 1
     - require_in:
       - test: Repositories configured
+    - require:
+      - pkg: Install yum-plugin-versionlock
 
 {%- for repo_name, repo_config in repo.repositories.items() %}
   {%- if repo.local_mode %}

--- a/salt/metalk8s/repo/offline.sls
+++ b/salt/metalk8s/repo/offline.sls
@@ -8,7 +8,7 @@ Install yum-plugin-versionlock:
   pkg.installed:
     - name: yum-plugin-versionlock
     - fromrepo: {{ repo.repositories.keys() | join(',') }}
-    - require:
+    - require_in:
       - test: Repositories configured
 
 {%- for repo_name, repo_config in repo.repositories.items() %}
@@ -41,6 +41,9 @@ Configure {{ repo_name }} repository:
     - refresh: false
     - onchanges_in:
       - cmd: Refresh yum cache
+    - require_in:
+      - pkg: Install yum-plugin-versionlock
+      - test: Repositories configured
 {%- endfor %}
 
 # Refresh cache manually as we use the same repo name for all versions
@@ -57,8 +60,4 @@ Refresh yum cache:
       - cmd: Refresh yum cache
 
 Repositories configured:
-  test.succeed_without_changes:
-    - require:
-{%- for repository_name in repo.repositories.keys() %}
-      - pkgrepo: Configure {{ repository_name }} repository
-{%- endfor %}
+  test.succeed_without_changes


### PR DESCRIPTION
**Component**: salt

**Context**:
bootstrap installation fails if yum versionlock plugin is disabled

**Summary**:
If the plugin is disabled, we can't install packages through our salt states because we lock each and every packages we install.
Plugin is enabled by default when installed, but it could have been disabled for some reasons, so we
need to ensure it's enabled before trying to install any package.

**Acceptance criteria**: bootstrap installation passes even if yum versionlock plugin is disabled prior to installation

---

Closes: #2077

