### PR TITLE
Improvement/no longer use hostname in ci test

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -211,7 +211,7 @@ models:
           controlPlane: 10.100.0.0/16
           workloadPlane: 10.100.0.0/16
         ca:
-          minion: $(hostname)
+          minion: "bootstrap"
         apiServer:
           host: $(ip route get 10.100.0.0 | awk '/10.100.0.0/{ print $6 }')
         archives:
@@ -531,8 +531,7 @@ stages:
             OS_USERNAME: "%(secret:scality_cloud_username)s"
             OS_PASSWORD: "%(secret:scality_cloud_password)s"
             OS_TENANT_NAME: "%(secret:scality_cloud_tenant_name)s"
-            # FIXME: this makes hostnames too long
-            # TF_VAR_worker_uuid: "%(prop:worker_uuid)s"
+            TF_VAR_worker_uuid: "%(prop:worker_uuid)s"
             TF_VAR_nodes_count: "2"
           haltOnFailure: true
       - ShellCommand:

--- a/eve/workers/openstack-multiple-nodes/terraform/scripts/bootstrap-config.sh
+++ b/eve/workers/openstack-multiple-nodes/terraform/scripts/bootstrap-config.sh
@@ -7,7 +7,7 @@ OUTPUT_FILE="/etc/metalk8s/bootstrap.yaml"
 mkdir -p "$(dirname $OUTPUT_FILE)"
 
 mkdir -p /etc/salt
-hostname > /etc/salt/minion_id
+echo "bootstrap-node" > /etc/salt/minion_id
 
 cat > "$OUTPUT_FILE" << EOF
 apiVersion: metalk8s.scality.com/v1alpha2

--- a/eve/workers/openstack-single-node/requirements.sh
+++ b/eve/workers/openstack-single-node/requirements.sh
@@ -29,12 +29,7 @@ sudo -u eve pip3.6 install --user tox
 
 ## Configuration ##
 
-HOSTNAME=bootstrap
-
-# This step is needed so Kubelet registration doesn't fail for DNS entries
-# longer than 63 characters.
-hostnamectl set-hostname $HOSTNAME
-
-# Make sure Salt Minion ID is set to this same hostname
+# Set salt minion_id before lauching the bootstrap to not use the hostname as
+# minion id and kubernetes kubernetes node name
 mkdir -p /etc/salt
-echo $HOSTNAME > /etc/salt/minion_id
+echo "bootstrap" > /etc/salt/minion_id

--- a/salt/metalk8s/kubernetes/cni/calico/configured.sls
+++ b/salt/metalk8s/kubernetes/cni/calico/configured.sls
@@ -12,7 +12,7 @@ Create kubeconf file for calico:
     - ca_server: {{ pillar['metalk8s']['ca']['minion'] }}
     - signing_policy: {{ kube_api.cert.client_signing_policy }}
     - client_cert_info:
-        CN: {{ salt['network.get_hostname']() }}
+        CN: {{ grains.id }}
         O: metalk8s:calico-node
     - apiserver: https://{{ kubernetes_service_ip }}:443
     - cluster: {{ kubernetes.cluster }}


### PR DESCRIPTION
**Component**:

'tests', 'build'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

We no longer need to use hostname to deploy and extend metalk8s cluster.

**Summary**:

Do not use hostname to deploy, extend, test in CI tests

**Acceptance criteria**: 

Green build
