### PR TITLE
Improvement/2078 store user credentials in localstorage

### DIFF
--- a/ui/config-overrides.js
+++ b/ui/config-overrides.js
@@ -15,7 +15,7 @@ const CompressionPlugin = require('compression-webpack-plugin');
 const setWebpackPerformance = () => config => {
   config.performance = {
     hints: 'error',
-    // ~586 KiB for production
+    // ~684 KiB for production
     // ~1953 KiB for development because flow increase the size of assets.
     maxAssetSize: process.env.NODE_ENV === 'production' ? 700000 : 2000000,
     assetFilter: assetFilename => {

--- a/ui/src/ducks/config.js
+++ b/ui/src/ducks/config.js
@@ -3,7 +3,7 @@ import { mergeTheme } from '@scality/core-ui/dist/utils';
 import * as defaultTheme from '@scality/core-ui/dist/style/theme';
 import { loadUser, createUserManager } from 'redux-oidc';
 import { USER_FOUND } from 'redux-oidc';
-
+import { WebStorageStateStore } from 'oidc-client';
 import { store } from '../index';
 import * as Api from '../services/api';
 import * as ApiK8s from '../services/k8s/api';
@@ -41,6 +41,7 @@ const defaultState = {
     authority: '',
     loadUserInfo: false,
     post_logout_redirect_uri: '/',
+    userStore: new WebStorageStateStore({ store: localStorage }),
   },
   userManager: null,
   isUserLoaded: false,


### PR DESCRIPTION
**Component**: UI, Dex

**Context**: 
We will want to share the user credentials across different tabs so that users won't need to be authenticated again.

**Summary**:
We set `userStore: new WebStorageStateStore({ store: localStorage }),` by default in userManagerConfig.

**Acceptance criteria**: 
Once login, we should find the `oidc.user:https://172.21.254.12:8443/oidc:metalk8s-ui` oidc credential stored in localStorage.

---


Closes: #2078 
