### PR TITLE
Fix some flaky tests (expansions, test dns)

### DIFF
--- a/tests/kube_utils.py
+++ b/tests/kube_utils.py
@@ -2,6 +2,12 @@ from kubernetes.client.rest import ApiException
 
 from tests import utils
 
+# See https://kubernetes.io/docs/concepts/architecture/nodes/#condition
+# And https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions
+MAP_STATUS = {
+    'True': 'Ready', 'False': 'NotReady', 'Unknown': 'Unknown'
+}
+
 
 def get_pods(
     k8s_client, ssh_config, label,

--- a/tests/post/features/dns_resolution.feature
+++ b/tests/post/features/dns_resolution.feature
@@ -1,5 +1,5 @@
 @ci @local @post
 Feature: CoreDNS resolution
     Scenario: check DNS
-        Given pods with label 'k8s-app=kube-dns' are 'Running'
+        Given pods with label 'k8s-app=kube-dns' are 'Ready'
         Then the hostname 'kubernetes.default' should be resolved

--- a/tests/post/steps/conftest.py
+++ b/tests/post/steps/conftest.py
@@ -6,29 +6,41 @@ from tests import kube_utils, utils
 
 # Given {{{
 
-@given(parsers.parse("pods with label '{label}' are '{state}'"))
-def check_pod_state(request, host, k8s_client, label, state):
+@given(parsers.parse("pods with label '{label}' are '{expected_status}'"))
+def check_pod_status(request, host, k8s_client, label, expected_status):
     ssh_config = request.config.getoption('--ssh-config')
 
     # Helper to use retry utils
-    def _wait_for_state():
+    def _wait_for_status():
         pods = kube_utils.get_pods(
             k8s_client, ssh_config, label,
             namespace="kube-system", state="Running"
         )
         assert pods
+
+        for pod in pods:
+            # If really not ready, status may not have been pushed yet.
+            if pod.status.conditions is None:
+                assert expected_status == 'NotReady'
+                continue
+
+            for condition in pod.status.conditions:
+                if condition.type == 'Ready':
+                    break
+            assert kube_utils.MAP_STATUS[condition.status] == expected_status
+
         return pods
 
     # Wait for pod to be in the correct state
     pods = utils.retry(
-        _wait_for_state,
+        _wait_for_status,
         times=12,
         wait=5,
         name="wait for pods with label '{}'".format(label)
     )
 
     assert pods, "No {} pod with label '{}' found".format(
-        state.lower(), label
+        expected_status.lower(), label
     )
 
 


### PR DESCRIPTION
**Component**:

'tests'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

We get some test really flaky

**Summary**:

This PR should fix this two flaky issue:
- Test dns failing (unable to do a dns resolution)
```
            if result.rc != 0:
>               pytest.fail("Cannot resolve {}: {}".format(hostname, result.stderr))
E               Failed: Cannot resolve kubernetes.default: command terminated with exit code 1
```
- Expansions test failing (unable to get node status)
```
    @then(parsers.parse('node "{hostname}" status is "{expected_status}"'))
    def check_node_status(ssh_config, k8s_client, hostname, expected_status):
        """Check if the given node has the expected status."""
        node_name = utils.resolve_hostname(hostname, ssh_config)
        try:
            status = k8s_client.read_node_status(node_name).status
        except k8s.client.rest.ApiException as exn:
>           pytest.fail(str(exn))
E           Failed: (504)
E           Reason: Gateway Timeout
E           HTTP response headers: HTTPHeaderDict({'Date': 'Fri, 29 Nov 2019 11:55:00 GMT', 'Content-Length': '136', 'Content-Type': 'text/plain; charset=utf-8'})
E           HTTP response body: {"metadata":{},"status":"Failure","message":"Timeout: request did not complete within 1m0s","reason":"Timeout","details":{},"code":504}
```

**Acceptance criteria**: 

No more flaky on this two steps
