### PR TITLE
Bugfix/fix some flakies 2 (check all logs, upgrade/downgrade deploy_node)

### DIFF
--- a/salt/metalk8s/orchestrate/deploy_node.sls
+++ b/salt/metalk8s/orchestrate/deploy_node.sls
@@ -79,6 +79,13 @@ Reconfigure salt-minion:
       - salt: Set grains
       - salt: Refresh the mine
       - salt: Refresh pillar before highstate
+
+Wait minion available:
+  salt.runner:
+    - name: metalk8s_saltutil.wait_minions
+    - tgt: {{ node_name }}
+    - require:
+      - salt: Reconfigure salt-minion
     - require_in:
       - salt: Run the highstate
 

--- a/tests/post/features/log_accessible.feature
+++ b/tests/post/features/log_accessible.feature
@@ -2,4 +2,5 @@
 Feature: logs should be accessible
     Scenario: check logs from all containers
         Given the Kubernetes API is available
+        And all Pod are 'Ready'
         Then all Pod logs should be non-empty


### PR DESCRIPTION
**Component**:

'tests'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

We get some test really flaky

**Summary**:

This PR should fix this two flaky issue:

- Pod not ready when checking all Pods logs: (`kube-state-metrics` in this example but could be potentially any pod)
```
        if not 200 <= r.status <= 299:
>           raise ApiException(http_resp=r)
E           kubernetes.client.rest.ApiException: (404)
E           Reason: Not Found
E           HTTP response headers: HTTPHeaderDict({'Content-Type': 'application/json', 'Date': 'Fri, 29 Nov 2019 17:09:18 GMT', 'Content-Length': '276'})
E           HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"pods \"prometheus-operator-kube-state-metrics-6cc9dd49b-hnvmz\" not found","reason":"NotFound","details":{"name":"prometheus-operator-kube-state-metrics-6cc9dd49b-hnvmz","kind":"pods"},"code":404}
```

- Sls still running when upgrading or downgrading in `deploy_node` orchestrate:
```
                          salt_|-Run the highstate_|-Run the highstate_|-state:
                              ----------
                              __id__:
                                  Run the highstate
                              __jid__:
                                  20191129165249244372
                              __run_num__:
                                  5
                              __sls__:
                                  metalk8s.orchestrate.deploy_node
                              changes:
                                  ----------
                                  out:
                                      highstate
                                  ret:
                                      ----------
                                      bootstrap:
                                          - The function "state.sls" is running as PID 16138 and was started at  with jid req
```
Note: This one will be fixed for downgrade only once this PR get merge as we use the `dev` branch

**Acceptance criteria**: 

No more flaky on this two steps
