### PR TITLE
CI: Add upgrade test for PATCH VERSIONS

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -428,6 +428,7 @@ stages:
             - single-node-downgrade-centos
             - single-node-install-rhel
             - multiple-nodes-centos
+            - single-node-patch-version
       - ShellCommand: *add_final_status_artifact_success
       - Upload: *upload_final_status_artifact
 
@@ -926,6 +927,131 @@ stages:
             TF_VAR_rhsm_username: "%(secret:rhel_ci_login)s"
             TF_VAR_rhsm_password: "%(secret:rhel_ci_password)s"
           workdir: build/eve/workers/openstack-single-node-rhel/terraform
+
+  single-node-patch-version:
+    worker: *single_node_worker
+    steps:
+      - SetPropertyFromCommand:
+          name: Set previous patch version to upgrade from and downgrade to
+          property: product_version_prev_patch
+          command: >
+              major=$(echo "%(prop:product_version)s" | cut -d'.' -f1) &&
+              minor=$(echo "%(prop:product_version)s" | cut -d'.' -f2) &&
+              patch=$(echo "%(prop:product_version)s" | cut -d'.' -f3) &&
+              echo "$major.$minor.$(( patch>0 ? patch-1 : 0 ))"
+      - SetPropertyFromCommand:
+          name: Set the patch version flag
+          property: patch_present
+          env:
+            PRODUCT_VERSION: "%(prop:product_version)s"
+            PRODUCT_VERSION_PREV_patch: "%(prop:product_version_prev_patch)s"
+          command: |-
+              if [ "$PRODUCT_VERSION" != "$PRODUCT_VERSION_PREV_patch" ]; then
+                echo "true"
+              else
+                echo "false"
+              fi
+      - TriggerStages:
+          name: Trigger single-node steps with patch Artifact ISO
+          doStepIf: "%(prop:patch_present)s"
+          stage_names:
+            - single-node-upgrade-patch-centos
+
+# --- Upgrade for patch versions ---
+  single-node-upgrade-patch-centos:
+    worker: *single_node_worker
+    steps:
+      - Git: *git_pull
+      - ShellCommand:
+          <<: *add_final_status_artifact_failed
+          env:
+            <<: *_env_final_status_artifact_failed
+            STEP_NAME: single-node-upgrade-patch-centos
+      - ShellCommand: *setup_cache
+      - ShellCommand: *ssh_ip_setup
+      # --- Get ISO for version N ---
+      - ShellCommand: *retrieve_iso
+      - ShellCommand: *retrieve_iso_checksum
+      - ShellCommand: *check_iso_checksum
+      # --- Get VERSION patch ISO for version N-1 from Artefacts ---
+      - ShellCommand: &retrieve_prev_patch_version_iso_checksum
+          <<: *retrieve_iso_checksum
+          name: Retrieve previous patch ISO image checksum
+          env: &_env_previous_patch
+            DEST_DIR: "/tmp"
+            BASE_URL: "http://artifacts/builds/github:scality:metalk8s:\
+                      promoted-%(prop:product_version_prev_patch)s"
+      - ShellCommand: &retrieve_prev_patch_version_iso
+          <<: *retrieve_iso
+          name: Retrieve previous patch ISO image
+          env:
+            <<: *_env_previous_patch
+            MAX_ATTEMPTS: "300"
+      - ShellCommand: &check_prev_patch_version_iso_checksum
+          <<: *check_iso_checksum
+          name: Check previous patch ISO image with checksum
+          workdir: "/tmp"
+      # --- Prepare for Bootstrap with patch version N-1 ---
+      - ShellCommand:
+          <<: *create_mountpoint
+          env: &_env_prev_patch_version
+            PRODUCT_VERSION: "%(prop:product_version_prev_patch)s"
+      - ShellCommand:
+          <<: *mount_iso
+          env:
+            <<: *_env_prev_patch_version
+            ISO_PATH: /tmp/metalk8s.iso
+      - ShellCommand:
+          <<: *bootstrap_config
+          env: *_env_prev_patch_version
+      # --- Install patch version N-1 ---
+      - ShellCommand:
+          <<: *run_bootstrap
+          env: *_env_prev_patch_version
+      - ShellCommand:
+          name: Provision Prometheus and AlertManager storage
+          command: >
+            git checkout %(prop:product_version_prev_patch)s --quiet &&
+            sudo env
+            PRODUCT_TXT=/srv/scality/metalk8s-%(prop:product_version_prev_patch)s/product.txt
+            PRODUCT_MOUNT=/srv/scality/metalk8s-%(prop:product_version_prev_patch)s
+            eve/create-volumes.sh
+          haltOnFailure: true
+      # --- We do not need to Test patch version N-1 ---
+      # --- Upgrade to version N ---
+      - ShellCommand:
+          <<: *add_archive
+          name: Add current ISO to cluster
+          env:
+            <<: *_env_add_archive
+            PRODUCT_VERSION: "%(prop:product_version_prev_patch)s"
+      - ShellCommand:
+          name: Run upgrade from previous patch version
+          command: >
+            sudo bash
+            /srv/scality/metalk8s-%(prop:metalk8s_version)s/upgrade.sh
+            --destination-version %(prop:metalk8s_version)s
+          haltOnFailure: true
+      - ShellCommand: *provision_prometheus_volumes
+      # --- Test version N ---
+      - ShellCommand: *fast_tests
+      # --- Collect logs ---
+      - ShellCommand: *collect_sosreport
+      - ShellCommand:
+          <<: *copy_report_artifacts
+          env:
+            DEST_DIR: sosreport/sosreport/single-node-upgrade-patch-centos
+      - Upload: *upload_report_artifacts
+      - ShellCommand:
+          <<: *add_final_status_artifact_success
+          env:
+            <<: *_env_final_status_artifact_success
+            STEP_NAME: single-node-upgrade-patch-centos
+      - Upload: *upload_final_status_artifact
+      - ShellCommand:
+          <<: *wait_debug
+          env:
+            STEP_NAME: single-node-upgrade-patch-centos
 
   multiple-nodes-centos:
     worker:

--- a/salt/metalk8s/orchestrate/downgrade/init.sls
+++ b/salt/metalk8s/orchestrate/downgrade/init.sls
@@ -124,6 +124,18 @@ Delete old nginx ingress deployment:
     - require_in:
       - salt: Sync module on salt-master
 
+Delete old nginx ingress control plane controller daemon set:
+  metalk8s_kubernetes.object_absent:
+    - name: nginx-ingress-control-plane-controller
+    - namespace: metalk8s-ingress
+    - kind: DaemonSet
+    - apiVersion: extensions/v1beta1
+    - wait:
+        attempts: 10
+        sleep: 10
+    - require_in:
+      - salt: Sync module on salt-master
+
 {%- endif %}
 
 Sync module on salt-master:

--- a/salt/metalk8s/orchestrate/upgrade/init.sls
+++ b/salt/metalk8s/orchestrate/upgrade/init.sls
@@ -88,10 +88,11 @@ Deploy node {{ node }}:
 
 {%- endfor %}
 
-{#- In MetalK8s-2.4.2 we added selector in nginx ingress controller DaemonSet
-    and nginx ingress default backend Deployment but `selector` are immutable
-    field so, in this case, we cannot replace the object we need to first
-    remove the current one and then deploy the desired one. #}
+{#- In MetalK8s-2.4.2 we added selector in nginx ingress controller DaemonSet,
+    nginx ingress control plane controller Daemonset and nginx ingress default
+    backend Deployment but `selector` are immutable field so, in this case,
+    we cannot replace the object we need to first remove the current one and
+    then deploy the desired one. #}
 {#- For upgrade we should use the current version to check whether or not we
     need to remove the nginx ingress objects
     `if current_version < 2.4.2`
@@ -116,6 +117,12 @@ Deploy node {{ node }}:
         name='nginx-ingress-controller',
         namespace='metalk8s-ingress'
     ) %}
+{%- set nginx_ingress_control_plane_ds = salt.metalk8s_kubernetes.get_object(
+        kind='DaemonSet',
+        apiVersion='extensions/v1beta1',
+        name='nginx-ingress-control-plane-controller',
+        namespace='metalk8s-ingress'
+    ) %}
 {%- set nginx_ingress_deploy = salt.metalk8s_kubernetes.get_object(
         kind='Deployment',
         apiVersion='extensions/v1beta1',
@@ -129,6 +136,13 @@ Deploy node {{ node }}:
         },
         'match_expressions': None
      } %}
+{%- set desired_selector_control_plane = {
+        'match_labels': {
+            'app': 'nginx-ingress',
+            'release': 'nginx-ingress-control-plane'
+        },
+        'match_expressions': None
+     } %}
 {%- if nginx_ingress_ds and
        nginx_ingress_ds.get('spec', {}).get('selector', {})
           != desired_selector %}
@@ -136,6 +150,23 @@ Deploy node {{ node }}:
 Delete old nginx ingress daemon set:
   metalk8s_kubernetes.object_absent:
     - name: nginx-ingress-controller
+    - namespace: metalk8s-ingress
+    - kind: DaemonSet
+    - apiVersion: extensions/v1beta1
+    - wait:
+        attempts: 10
+        sleep: 10
+    - require_in:
+      - salt: Sync module on salt-master
+
+{%- endif %}
+{%- if nginx_ingress_control_plane_ds and
+       nginx_ingress_control_plane_ds.get('spec', {}).get('selector', {})
+          != desired_selector_control_plane %}
+
+Delete old nginx ingress control plane daemon set:
+  metalk8s_kubernetes.object_absent:
+    - name: nginx-ingress-control-plane-controller
     - namespace: metalk8s-ingress
     - kind: DaemonSet
     - apiVersion: extensions/v1beta1


### PR DESCRIPTION

**Component**:

'ci', 'tests'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

See #2009 

**Summary**:

We should be able to automatically test patch versions using existing promoted artefacts.
Targeting 2.4 branches only because patch version inclusion was first introduced here.

**Acceptance criteria**: 

Please don't come with any more flakies

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2009 
