### PR TITLE
Bugfix/fix some flakies 3 (Ingress test)

### DIFF
--- a/tests/post/features/ingress.feature
+++ b/tests/post/features/ingress.feature
@@ -2,16 +2,19 @@
 Feature: Ingress
     Scenario: Access HTTP services
         Given the Kubernetes API is available
+        And pods with label 'app=nginx-ingress' are 'Ready'
         When we perform an HTTP request on port 80 on a workload-plane IP
         Then the server returns 404 'Not Found'
 
     Scenario: Access HTTPS services
         Given the Kubernetes API is available
+        And pods with label 'app=nginx-ingress' are 'Ready'
         When we perform an HTTPS request on port 443 on a workload-plane IP
         Then the server returns 404 'Not Found'
 
     Scenario: Access HTTP services on control-plane IP
         Given the Kubernetes API is available
+        And pods with label 'app=nginx-ingress' are 'Ready'
         And the node control-plane IP is not equal to its workload-plane IP
         When we perform an HTTP request on port 80 on a control-plane IP
         Then the server should not respond

--- a/tests/post/steps/conftest.py
+++ b/tests/post/steps/conftest.py
@@ -12,7 +12,7 @@ def _check_pods_status(k8s_client, expected_status, ssh_config,
     def _wait_for_status():
         pods = kube_utils.get_pods(
             k8s_client, ssh_config, label,
-            namespace=namespace, state="Running"
+            namespace=namespace
         )
         assert pods
 
@@ -38,7 +38,7 @@ def _check_pods_status(k8s_client, expected_status, ssh_config,
         name += " with label '{}'".format(label)
 
     # Wait for pod to be in the correct state
-    pods = utils.retry(
+    utils.retry(
         _wait_for_status,
         times=12,
         wait=5,
@@ -50,11 +50,11 @@ def _check_pods_status(k8s_client, expected_status, ssh_config,
 
 
 @given(parsers.parse("pods with label '{label}' are '{expected_status}'"))
-def check_system_pod_status(request, host, k8s_client, label, expected_status):
+def check_pod_status(request, host, k8s_client, label, expected_status):
     ssh_config = request.config.getoption('--ssh-config')
 
     _check_pods_status(
-        k8s_client, expected_status, ssh_config, 'kube-system', label
+        k8s_client, expected_status, ssh_config, label=label
     )
 
 


### PR DESCRIPTION
**Component**:

'tests'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

We get some test really flaky

**Summary**:

This PR should fix this flaky ingress test:

```
    @then(parsers.re(
        r"the server returns (?P<status_code>\d+) '(?P<reason>.+)'"),
        converters=dict(status_code=int))
    def server_returns(host, context, status_code, reason):
        response = context.get('response')
        assert response is not None
>       assert response.status_code == int(status_code)
E       assert 502 == 404
E        +  where 502 = <Response [502]>.status_code
E        +  and   404 = int(404)
```

**Acceptance criteria**: 

No more flaky on this step
