### PR TITLE
scripts: Upgrade/downgrade set version after pre-checks

### DIFF
--- a/scripts/downgrade.sh.in
+++ b/scripts/downgrade.sh.in
@@ -234,8 +234,7 @@ patch_kubesystem_namespace() {
         "kube-system" \
         kind=Namespace apiVersion=v1 \
         patch="{'metadata': {'annotations': \
-        {'metalk8s.scality.com/cluster-version': '$DESTINATION_VERSION'}}}" \
-        test="$DRY_RUN"
+        {'metalk8s.scality.com/cluster-version': '$DESTINATION_VERSION'}}}"
 }
 
 get_cluster_version() {
@@ -245,14 +244,13 @@ get_cluster_version() {
 
 # Main
 _init
-if [ -n "$DESTINATION_VERSION" ]; then
-    run "Setting cluster version to $DESTINATION_VERSION" patch_kubesystem_namespace
-else
+if [ -z "$DESTINATION_VERSION" ]; then
     get_cluster_version
     run "Getting cluster version $DESTINATION_VERSION"
 fi
 
 run "Performing Pre-Downgrade checks" precheck_downgrade
 [ $DRY_RUN -eq 1 ] && exit 0
+run "Setting cluster version to $DESTINATION_VERSION" patch_kubesystem_namespace
 run "Launching the downgrade" launch_downgrade
 run "Downgrading bootstrap" downgrade_bootstrap

--- a/scripts/upgrade.sh.in
+++ b/scripts/upgrade.sh.in
@@ -201,8 +201,7 @@ patch_kubesystem_namespace() {
         "kube-system" \
         kind=Namespace apiVersion=v1 \
         patch="{'metadata': {'annotations': \
-        {'metalk8s.scality.com/cluster-version': '$DESTINATION_VERSION'}}}" \
-        test="$DRY_RUN"
+        {'metalk8s.scality.com/cluster-version': '$DESTINATION_VERSION'}}}"
 }
 
 get_cluster_version() {
@@ -210,9 +209,7 @@ get_cluster_version() {
         pillar.get metalk8s:cluster_version --out txt | cut -c 8-)
 }
 
-if [ -n "$DESTINATION_VERSION" ]; then
-    run "Setting cluster version to $DESTINATION_VERSION" patch_kubesystem_namespace
-else
+if [ -z "$DESTINATION_VERSION" ]; then
     get_cluster_version
     run "Getting cluster version $DESTINATION_VERSION"
 fi
@@ -220,4 +217,5 @@ fi
 run "Performing Pre-Upgrade checks" precheck_upgrade
 [ $DRY_RUN -eq 1 ] && exit 0
 run "Upgrading bootstrap" upgrade_bootstrap
+run "Setting cluster version to $DESTINATION_VERSION" patch_kubesystem_namespace
 run "Launching the upgrade" launch_upgrade


### PR DESCRIPTION
**Component**:

'salt', 'kubernetes', 'upgrade'

**Context**: 

Our salt module/utils is only compatible with a specific version of `python-kubernetes` so if we want to interact with the k8s APIserver we first need to change the salt-master version

**Summary**:

In upgrade and downgrade script move the setting of the desired version
`kube-system` namespace right after the upgrade of the bootstrap for
upgrade and just after pre-checks for downgrade

---

Fixes #2094 
