### PR TITLE
UI: fix Add Solution Modal display when no solution is imported

### DIFF
--- a/ui/src/containers/SolutionList.js
+++ b/ui/src/containers/SolutionList.js
@@ -5,11 +5,18 @@ import { Formik, Form } from 'formik';
 import * as yup from 'yup';
 import styled from 'styled-components';
 import { injectIntl } from 'react-intl';
-import { Table, Button, Breadcrumb, Modal, Input } from '@scality/core-ui';
+import {
+  Table,
+  Button,
+  Breadcrumb,
+  Modal,
+  Input,
+  Loader,
+} from '@scality/core-ui';
 import { padding } from '@scality/core-ui/dist/style/theme';
 
 import { sortSelector } from '../services/utils';
-import Loader from '../components/Loader';
+
 import NoRowsRenderer from '../components/NoRowsRenderer';
 import {
   BreadcrumbContainer,
@@ -386,7 +393,7 @@ const SolutionsList = props => {
             }}
           </Formik>
         ) : (
-          <Loader />
+          <Loader size="large">{intl.messages.import_solution_hint}</Loader>
         )}
       </Modal>
     </>

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -130,5 +130,6 @@
   "enter_label_value": "Enter label value",
   "value": "Value",
   "prometheus_not_available":"Prometheus is not available.",
-  "please_refer_to":"Please refer to"
+  "please_refer_to":"Please refer to",
+  "import_solution_hint":"You should import a solution to prepare your environment"
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -130,5 +130,6 @@
   "enter_label_value": "Saisir la valeur du label",
   "value": "Valeur",
   "prometheus_not_available":"Prometheus n'est pas disponible.",
-  "please_refer_to":"Veuillez vous référer à"
+  "please_refer_to":"Veuillez vous référer à",
+  "import_solution_hint":"Vous devez importer une solution pour préparer votre environnement"
 }


### PR DESCRIPTION


**Component**:UI

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
- Add Solution Modal does not display correctly when no solution is imported

**Summary**:

**Acceptance criteria**: 
<img width="1438" alt="Screenshot 2019-12-06 at 17 58 57" src="https://user-images.githubusercontent.com/47394132/70341261-d77e8780-1852-11ea-882c-3a2fd4412ed4.png">


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: https://github.com/scality/metalk8s/issues/1937

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
