### PR TITLE
Bugfix/scroll volume list and refresh volume information page

### DIFF
--- a/ui/src/containers/ClusterMonitoring.js
+++ b/ui/src/containers/ClusterMonitoring.js
@@ -40,6 +40,7 @@ const PageContainer = styled.div`
 `;
 
 const TableContainer = styled.div`
+  height: 100%;
   flex-grow: 1;
 
   .sc-table-column-cell-container-severity {

--- a/ui/src/containers/NodeVolumes.js
+++ b/ui/src/containers/NodeVolumes.js
@@ -39,10 +39,7 @@ import {
 const VolumeTable = styled.div`
   flex-grow: 1;
   margin-top: ${padding.small};
-  /*solve the tooltip display issue*/
-  .ReactVirtualized__Grid {
-    overflow: visible !important;
-  }
+  /* solve the tooltip display issue */
   .sc-table-column-cell-action {
     overflow: visible !important;
   }


### PR DESCRIPTION
**Component**: ui

**Context**: 
As a user, I want to see the update of the volume. ( For the moment, if I go to volumeInformation page right away creating the volume, I couldn't see the status changing)

**Summary**:

- Fix the two bugs:

1.  When there is no data in `clusterMonitoring`, the text `no data available` moving from top to down.
2. The volume list table is not scrollable.

- Add refresh in `volumeInfomation` page.

**Acceptance criteria**: 

- Add the update in volumeInformation page

![image](https://user-images.githubusercontent.com/18453133/70342905-43162400-1856-11ea-9bfb-283be9173b91.png)

- The volume list table is scrollable.
![image](https://user-images.githubusercontent.com/18453133/70343011-82447500-1856-11ea-9cb5-0bbcdef77eeb.png)


