### PR TITLE
images: don't use `etcd3` 0.11.0 in `salt-master`

### DIFF
--- a/images/salt-master/Dockerfile
+++ b/images/salt-master/Dockerfile
@@ -26,7 +26,7 @@ gpgkey=https://repo.saltstack.com/yum/redhat/\$releasever/\$basearch/archive/%s/
  && yum install -y python2-kubernetes salt-master salt-api salt-ssh openssh-clients \
  && yum install -y python-pip \
  && yum clean all \
- && pip install etcd3 \
+ && pip install "etcd3 != 0.11.0" \
  && chmod +x /tini
 
 # salt-master, salt-api


### PR DESCRIPTION
Install of this version is broken (missing `requirements/base.txt` file used by `setup.py` in the package).

See: https://github.com/kragniz/python-etcd3/issues/952
(cherry picked from commit 2d6af2647b352daf7acee3aa6ee6f23d2771ceca)