### PR TITLE
Remove support for kubernetes basic auth

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -364,7 +364,6 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/kubernetes/apiserver/certs/init.sls'),
     Path('salt/metalk8s/kubernetes/apiserver/certs/kubelet-client.sls'),
     Path('salt/metalk8s/kubernetes/apiserver/certs/server.sls'),
-    Path('salt/metalk8s/kubernetes/apiserver/files/htpasswd'),
     Path('salt/metalk8s/kubernetes/apiserver/init.sls'),
     Path('salt/metalk8s/kubernetes/apiserver/installed.sls'),
     Path('salt/metalk8s/kubernetes/apiserver/cryptconfig.sls'),

--- a/docs/operation/account_administration.rst
+++ b/docs/operation/account_administration.rst
@@ -46,45 +46,14 @@ perform the following procedures:
 Administering MetalK8s GUI, Kubernetes API and Salt API
 *******************************************************
 
-During installation, MetalK8s configures the Kubernetes API to accept Basic
-authentication, with default credentials ``admin`` / ``admin``.
+During installation, MetalK8s configures the Kubernetes API to accept
+authentication via OpenID Connect(OIDC).
 
 Services exposed by MetalK8s, such as
 :ref:`its GUI <quickstart-services-admin-ui>` or
 :ref:`Salt API <quickstart-services-salt>`, rely on the Kubernetes API for
-authenticating their users. As such, changing the credentials of a
-Kubernetes API user will also change the credentials required to
-connect to either one of these services.
+authenticating their users.
 
-Managing Kubernetes API username and password
----------------------------------------------
+.. todo::
 
-  .. warning::
-
-     The procedures mentioned below must be carried out on every control-plane
-     :term:`Node`, or more specifically, any Node bearing the
-     ``node-role.kubernetes.io/master`` label.
-
-#. Edit the credentials file located at ``/etc/kubernetes/htpasswd``, replacing
-   the username and/or password fields as below:
-
-   .. code-block:: shell
-
-      <password-in-clear>,<username-in-clear>,123,"system:masters"
-
-#. Force a restart of the Kubernetes API server:
-
-   .. code-block:: shell
-
-      $ crictl stop \
-          $(crictl ps -q --label io.kubernetes.pod.namespace=kube-system \
-                         --label io.kubernetes.container.name=kube-apiserver \
-                         --state Running)
-
-#. Access a service (for example, MetalK8s GUI) and authenticate yourself
-   using the new Account credentials.
-
-   .. note::
-
-      Upon changing the username and/or password, a fresh logout then login is
-      required for accessing the MetalK8s GUI.
+    - Define how to create and administer users.

--- a/salt/_auth/kubernetes_rbac.py
+++ b/salt/_auth/kubernetes_rbac.py
@@ -93,43 +93,6 @@ def _get_groups(kubeconfig):
 
 
 @_log_exceptions
-def _auth_basic(kubeconfig, username, token):
-    decoded = base64.decodestring(token)
-    if ':' not in decoded:
-        log.warning('Invalid Basic token format: missing ":"')
-        return False
-
-    (token_username, _) = decoded.split(':', 1)
-    if token_username != username:
-        log.warning('Invalid Basic token: username mismatch')
-        return False
-
-    return _check_k8s_creds(kubeconfig, 'Basic {}'.format(token))
-
-
-@_log_exceptions
-def _groups_basic(kubeconfig, username, token):
-    kubeconfig.api_key = {
-        'authorization': token,
-    }
-    kubeconfig.api_key_prefix = {
-        'authorization': 'Basic',
-    }
-    kubeconfig.username = username
-    kubeconfig.password = None
-    kubeconfig.cert_file = None
-    kubeconfig.key_file = None
-
-    return _get_groups(kubeconfig)
-
-
-AUTH_HANDLERS['basic'] = {
-    'auth': _auth_basic,
-    'groups': _groups_basic,
-}
-
-
-@_log_exceptions
 def _auth_bearer(kubeconfig, username, token):
     return _check_k8s_creds(kubeconfig, 'Bearer {}'.format(token))
 

--- a/salt/metalk8s/kubernetes/apiserver/files/htpasswd
+++ b/salt/metalk8s/kubernetes/apiserver/files/htpasswd
@@ -1,1 +1,0 @@
-admin,admin,123,"system:masters"

--- a/tests/post/features/salt_api.feature
+++ b/tests/post/features/salt_api.feature
@@ -3,11 +3,7 @@ Feature: SaltAPI
     Scenario: Login to SaltAPI using Basic auth
         Given the Kubernetes API is available
         When we login to SaltAPI as 'admin' using password 'admin'
-        Then we can ping all minions
-        And we can invoke '[".*"]' on '*'
-        And we have '@wheel' perms
-        And we have '@runner' perms
-        And we have '@jobs' perms
+        Then authentication fails
 
     Scenario: Login to SaltAPI using an admin ServiceAccount
         Given the Kubernetes API is available
@@ -24,12 +20,3 @@ Feature: SaltAPI
         Then we can invoke '["disk.dump", "state.sls"]' on '*'
         And we have '@jobs' perms
 
-    Scenario: Login to SaltAPI using an incorrect password
-        Given the Kubernetes API is available
-        When we login to SaltAPI as 'admin' using password 'notadmin'
-        Then authentication fails
-
-    Scenario: Login to SaltAPI using an incorrect username
-        Given the Kubernetes API is available
-        When we login to SaltAPI as 'notadmin' using password 'admin'
-        Then authentication fails

--- a/tests/post/steps/test_salt_api.py
+++ b/tests/post/steps/test_salt_api.py
@@ -24,16 +24,6 @@ def test_login_bearer_auth_to_salt_api(host):
     pass
 
 
-@scenario('../features/salt_api.feature', 'Login to SaltAPI using an incorrect password')
-def test_login_to_salt_api_using_an_incorrect_password(host, request):
-    pass
-
-
-@scenario('../features/salt_api.feature', 'Login to SaltAPI using an incorrect username')
-def test_login_to_salt_api_using_an_incorrect_username(host, request):
-    pass
-
-
 @pytest.fixture(scope='function')
 def context():
     return {}


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
'kubernetes', 'tests'

**Context**: 

See #2072 

**Summary**:

- Kubernetes basic auth functionality on MetalK8s has reached end of life.
- Tests removed in this PR will henceforth be curated with cypress.

**Acceptance criteria**: 




---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2072 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
