### PR TITLE
Revert "eve/downgrade: Deactivate downgrade in CI tests"

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -425,8 +425,7 @@ stages:
           name: Trigger single-node and multiple-nodes steps with built ISO
           stage_names:
             - single-node-upgrade-centos
-            # Downgrade is deactivated on this branch due to #2058
-            #- single-node-downgrade-centos
+            - single-node-downgrade-centos
             - single-node-install-rhel
             - multiple-nodes-centos
             - single-node-patch-version


### PR DESCRIPTION
**Component**:

'salt', 'downgrade'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

Downgrade is fixed by #2101

**Summary**:

This reverts commit c5ef29bf5ded01761e94d89f721d80eba8dd3936.

**Acceptance criteria**: 

Working downgrade in 2.5

---

Sees: #2058 
