### PR TITLE
salt: persist k8s htpasswd file

### DIFF
--- a/salt/metalk8s/kubernetes/apiserver/installed.sls
+++ b/salt/metalk8s/kubernetes/apiserver/installed.sls
@@ -74,6 +74,7 @@ Set up default basic auth htpasswd:
     - mode: 600
     - makedirs: True
     - dir_mode: 750
+    - replace: False
 
 {%- set host = grains['metalk8s']['control_plane_ip'] %}
 


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
'salt', 'kubeapiserver'

**Context**: 

See #2109 

**Summary**:

- Persist customized k8s credentials after an upgrade or downgrade in order to improve user experience

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2109 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
