### PR TITLE
salt: Add a version label on each Kubernetes objects

### DIFF
--- a/salt/_modules/metalk8s_kubernetes.py
+++ b/salt/_modules/metalk8s_kubernetes.py
@@ -10,6 +10,7 @@ module, while other methods can be found in `metalk8s_kubernetes_utils.py`,
 """
 
 import logging
+import re
 
 from salt.exceptions import CommandExecutionError
 from salt.utils import yaml
@@ -131,6 +132,13 @@ def _object_manipulation_function(action):
                     action
                 )
             )
+
+        # Adding label containing metalk8s version (retrieved from saltenv)
+        if action in ['create', 'replace']:
+            match = re.search(r'^metalk8s-(?P<version>.+)$', saltenv)
+            manifest.setdefault('metadata', {}).setdefault('labels', {})[
+                'metalk8s.scality.com/version'
+            ] = match.group('version') if match else "unknown"
 
         log.debug(
             '%sing object with manifest: %s',


### PR DESCRIPTION
**Component**:

'salt', 'kubernetes'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

For upgrade and downgrade we want to know from which version we come so
we need to have for each and every kubernetes objects we deploy the
current version deployed.

**Summary**:

 This commit add a label `metalk8s.scality.com/version` for deployed object
NOTE: this label only affect the direct object we deploy and not all the
child (e.g.: For a deployment only the `Deployment` will have this label
and not all the child `Pod`)

---

Fixes: #2132 
