### PR TITLE
calico: update to Calico 3.10.2

### DIFF
--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -17,7 +17,7 @@ Image = namedtuple('Image', ('name', 'version', 'digest'))
 
 # Project-wide versions {{{
 
-CALICO_VERSION     : str = '3.8.2'
+CALICO_VERSION     : str = '3.10.2'
 K8S_VERSION        : str = '1.16.2'
 KEEPALIVED_VERSION : str = '1.3.5-16.el7'
 SALT_VERSION       : str = '2018.3.4'
@@ -86,12 +86,12 @@ CONTAINER_IMAGES : Tuple[Image, ...] = (
     Image(
         name='calico-node',
         version=_version_prefix(CALICO_VERSION),
-        digest='sha256:6679ccc9f19dba3eb084db991c788dc9661ad3b5d5bafaa3379644229dca6b05',
+        digest='sha256:0a16ddf391c06e065c5b4db75069da9e153f9fc9dd45f92ff64a55616e0bfe26',
     ),
     Image(
         name='calico-kube-controllers',
         version=_version_prefix(CALICO_VERSION),
-        digest='sha256:cf461efd25ee74d1855e1ee26db98fe87de00293f7d039212adb03c91fececcd',
+        digest='sha256:3a015bcc7304b13aaecbb35648fcef739f69a955d3b38af305c24f4c6d215902',
     ),
     Image(
         name='configmap-reload',

--- a/packages/redhat/calico-cni-plugin.spec
+++ b/packages/redhat/calico-cni-plugin.spec
@@ -6,12 +6,12 @@
 
 %ifarch x86_64
 %global built_arch              amd64
-%global calico_sha256           4675d8d195c0c30467161b459d99cbd0dd715496d4fadea1010e9deb7880f18b
-%global calico_ipam_sha256      ee2943609530e1ad429cae5315590671594b6dd795db259a81b919995ad9999e
+%global calico_sha256           fbc6588d6c83552403c5e75f108690f9f36fd65421552ae070dc1c93fa6f5139
+%global calico_ipam_sha256      522cc86264ae971625f68471c587fcecd9fbcfb362534b8fba03336702593e89
 %endif
 
 Name:           calico-cni-plugin
-Version:        3.8.2
+Version:        3.10.2
 Release:        1%{?dist}
 Summary:        Calico CNI plugin
 
@@ -49,6 +49,9 @@ install -p -m 755 %{SOURCE2} %{buildroot}/opt/cni/bin/calico-ipam
 %doc README.md
 
 %changelog
+* Sat Dec 14 2019 Nicolas Trangez <nicolas.trangez@scality.com> - 3.10.2-1
+- Version bump
+
 * Thu Aug 22 2019 Nicolas Trangez <nicolas.trangez@scality.com> - 3.8.2-1
 - Version bump
 


### PR DESCRIPTION
Deployment manifest updated based on upstream from
https://docs.projectcalico.org/v3.10/manifests/calico.yaml.

Fixes: #2107
See: https://github.com/scality/metalk8s/issues/2107