### PR TITLE
ci: don't re-run bootstrap in multi-node tests

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -251,7 +251,7 @@ models:
         export SSH_CONFIG_FILE=\"${SSH_CONFIG_FILE}\" &&
         export ISO_MOUNTPOINT=\"${ISO_MOUNTPOINT}\" &&
         export TEST_HOSTS_LIST=\"${TEST_HOSTS_LIST}\" &&
-        tox -e tests -- -m \"${PYTEST_FILTERS}\""
+        tox -e tests -- ${PYTEST_ARGS:-""} -m \"${PYTEST_FILTERS}\""
       workdir: build/eve/workers/openstack-multiple-nodes/terraform/
       haltOnFailure: true
   - ShellCommand: &add_final_status_artifact
@@ -639,7 +639,8 @@ stages:
           name: Run slow tests on the bastion
           env:
             <<: *_env_bastion_tests
-            PYTEST_FILTERS: "post and ci and slow"
+            PYTEST_ARGS: "--suppress-no-test-exit-code"
+            PYTEST_FILTERS: "post and ci and slow and not bootstrap"
       - ShellCommand:
           name: Generate sosreport on every machine
           env:

--- a/tests/post/features/bootstrap.feature
+++ b/tests/post/features/bootstrap.feature
@@ -1,4 +1,4 @@
-@post @ci @local @slow
+@post @ci @local @slow @bootstrap
 Feature: Bootstrap
     Scenario: Re-run bootstrap
         Given the Kubernetes API is available

--- a/tests/requirements.in
+++ b/tests/requirements.in
@@ -4,3 +4,4 @@ testinfra >=2.0.0
 paramiko >=2.4.2 # testinfra backend
 cryptography >=2.4.2
 kubernetes >= 8.0.0
+pytest-custom_exit_code >=0.3.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -206,6 +206,9 @@ pynacl==1.3.0 \
     # via paramiko
 pytest-bdd==3.1.0 \
     --hash=sha256:17dfc2b65c275641a4e76fa1f913ab737604815c275dc2afe7133956c6ab6743
+pytest-custom-exit-code==0.3.0 \
+    --hash=sha256:51ffff0ee2c1ddcc1242e2ddb2a5fd02482717e33a2326ef330e3aa430244635 \
+    --hash=sha256:6e0ce6e57ce3a583cb7e5023f7d1021e19dfec22be41d9ad345bae2fc61caf3b
 pytest==4.5.0 \
     --hash=sha256:1a8aa4fa958f8f451ac5441f3ac130d9fc86ea38780dd2715e6d5c5882700b24 \
     --hash=sha256:b8bf138592384bd4e87338cb0f256bf5f615398a649d4bd83915f0e4047a5ca6

--- a/tox.ini
+++ b/tox.ini
@@ -127,6 +127,7 @@ markers =
     salt: tag a BDD feature as related to Salt operations
     monitoring: tag a BDD feature as related to monitoring
     ingress: tag a BDD feature as related to ingress
+    bootstrap: tag a BDD feature as related to bootstrap
 filterwarnings =
     ignore:encode_point has been deprecated on EllipticCurvePublicNumbers and will be removed in a future version. Please use EllipticCurvePublicKey.public_bytes to obtain both compressed and uncompressed point encoding.:UserWarning
     ignore:Support for unsafe construction of public numbers from encoded data will be removed in a future version. Please use EllipticCurvePublicKey.from_encoded_point:UserWarning


### PR DESCRIPTION
Re-running bootstrap should not affect anything but the bootstrap node.
Since we run it in single-node CI tests, there's not much use re-running
it in a multi-node environment, especially since we don't actually
*validate* there's no impact on the cluster.

If we were to extend the test-suite to validate this, or when putting
less focus on the single-node environments, we could enable this again.