### PR TITLE
UI - Fix intl.translate in react components

### DIFF
--- a/ui/src/containers/About.js
+++ b/ui/src/containers/About.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
-import { FormattedMessage, injectIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
+import { intl } from '../translations/IntlGlobalProvider';
 
 const Title = styled.h3`
   margin-top: 25px;
@@ -20,12 +20,10 @@ const About = props => {
   const clusterVersion = useSelector(state => state.app.nodes.clusterVersion);
   return (
     <AboutContainer>
-      <Title>
-        <FormattedMessage id="product_name" />
-      </Title>
-      {`${props.intl.messages.cluster_version}: ${clusterVersion}`}
+      <Title>{intl.translate('product_name')}</Title>
+      {`${intl.translate('cluster_version')}: ${clusterVersion}`}
     </AboutContainer>
   );
 };
 
-export default injectIntl(About);
+export default About;

--- a/ui/src/containers/ClusterMonitoring.js
+++ b/ui/src/containers/ClusterMonitoring.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { injectIntl, FormattedDate, FormattedTime } from 'react-intl';
+import { FormattedDate, FormattedTime } from 'react-intl';
 import styled from 'styled-components';
 import { Loader as LoaderCoreUI } from '@scality/core-ui';
 import { Table, Tooltip, Button } from '@scality/core-ui';
@@ -23,7 +23,7 @@ import {
 import { sortSelector } from '../services/utils';
 import NoRowsRenderer from '../components/NoRowsRenderer';
 import Banner from '../components/Banner';
-
+import { intl } from '../translations/IntlGlobalProvider';
 const VOLUME_PROVISION_DOC_REFERENCE =
   'MetalK8s Quickstart Guide > Deployment of the Bootstrap node > Installation > Provision storage for Prometheus services';
 
@@ -108,7 +108,6 @@ const ClusterMonitoring = props => {
   const clusterStatus = useSelector(state => makeClusterStatus(state, props));
   const cluster = useSelector(state => state.app.monitoring.cluster);
   const config = useSelector(state => state.config);
-  const { intl } = props;
 
   useEffect(() => {
     dispatch(refreshAlertsAction());
@@ -130,12 +129,12 @@ const ClusterMonitoring = props => {
 
   const columns = [
     {
-      label: intl.messages.name,
+      label: intl.translate('name'),
       dataKey: 'name',
       width: 250,
     },
     {
-      label: intl.messages.severity,
+      label: intl.translate('severity'),
       dataKey: 'severity',
       width: 100,
       renderer: data => {
@@ -143,12 +142,12 @@ const ClusterMonitoring = props => {
       },
     },
     {
-      label: intl.messages.message,
+      label: intl.translate('message'),
       dataKey: 'message',
       flexGrow: 1,
     },
     {
-      label: intl.messages.active_at,
+      label: intl.translate('active_at'),
       dataKey: 'activeAt',
       width: 200,
       renderer: data => (
@@ -193,7 +192,7 @@ const ClusterMonitoring = props => {
     <PageContainer>
       <ClusterStatusTitleContainer>
         <LeftClusterStatusContainer>
-          <PageSubtitle>{intl.messages.cluster_status + ' :'}</PageSubtitle>
+          <PageSubtitle>{intl.translate('cluster_status') + ' :'}</PageSubtitle>
           <ClusterStatusValue value={clusterStatus.value}>
             {clusterStatus.label}
           </ClusterStatusValue>
@@ -204,19 +203,19 @@ const ClusterMonitoring = props => {
                 <div>
                   <CircleStatus status={apiServerStatus} />
                   <ControlPlaneStatusLabel>
-                    {intl.messages.api_server}
+                    {intl.translate('api_server')}
                   </ControlPlaneStatusLabel>
                 </div>
                 <div>
                   <CircleStatus status={kubeSchedulerStatus} />
                   <ControlPlaneStatusLabel>
-                    {intl.messages.kube_scheduler}
+                    {intl.translate('kube_scheduler')}
                   </ControlPlaneStatusLabel>
                 </div>
                 <div>
                   <CircleStatus status={kubeControllerManagerStatus} />
                   <ControlPlaneStatusLabel>
-                    {intl.messages.kube_controller_manager}
+                    {intl.translate('kube_controller_manager')}
                   </ControlPlaneStatusLabel>
                 </div>
               </TooltipContent>
@@ -231,7 +230,7 @@ const ClusterMonitoring = props => {
             placement="left"
             overlay={
               <TooltipContent>
-                {intl.messages.advanced_monitoring}
+                {intl.translate('advanced_monitoring')}
               </TooltipContent>
             }
           >
@@ -250,16 +249,18 @@ const ClusterMonitoring = props => {
         <Banner
           type={STATUS_BANNER_WARNING}
           icon={<i className="fas fa-exclamation-triangle" />}
-          title={intl.messages.prometheus_not_available}
+          title={intl.translate('prometheus_not_available')}
           messages={[
             <>
-              {`${intl.messages.please_refer_to} ${VOLUME_PROVISION_DOC_REFERENCE}`}
+              {`${intl.translate(
+                'please_refer_to',
+              )} ${VOLUME_PROVISION_DOC_REFERENCE}`}
             </>,
           ]}
         />
       )}
       <PageSubtitle>
-        {intl.messages.alerts}
+        {intl.translate('alerts')}
         {alerts.isLoading ? <LoaderCoreUI size="small" /> : null}
       </PageSubtitle>
       <TableContainer>
@@ -272,7 +273,7 @@ const ClusterMonitoring = props => {
           sortDirection={sortDirection}
           onSort={onSort}
           noRowsRenderer={() => (
-            <NoRowsRenderer content={intl.messages.no_data_available} />
+            <NoRowsRenderer content={intl.translate('no_data_available')} />
           )}
         />
       </TableContainer>
@@ -281,9 +282,8 @@ const ClusterMonitoring = props => {
 };
 
 const makeClusterStatus = (state, props) => {
-  const { intl } = props;
   const cluster = state.app.monitoring.cluster;
-  let label = intl.messages.down;
+  let label = intl.translate('down');
   let value = CLUSTER_STATUS_DOWN;
   if (
     cluster.apiServerStatus > 0 &&
@@ -291,17 +291,17 @@ const makeClusterStatus = (state, props) => {
     cluster.kubeControllerManagerStatus > 0
   ) {
     value = CLUSTER_STATUS_UP;
-    label = intl.messages.cluster_up_and_running;
+    label = intl.translate('cluster_up_and_running');
   }
   if (cluster.error) {
     value = CLUSTER_STATUS_DOWN;
-    label = intl.messages[cluster.error] || cluster.error;
+    label = intl.translate(cluster.error) || cluster.error;
   }
   if (!state.app.monitoring.isPrometheusApiUp) {
     value = CLUSTER_STATUS_UNKNOWN;
-    label = intl.messages[cluster.error] || cluster.error;
+    label = intl.translate(cluster.error) || cluster.error;
   }
   return { value, label, isLoading: cluster.isLoading };
 };
 
-export default injectIntl(ClusterMonitoring);
+export default ClusterMonitoring;

--- a/ui/src/containers/CreateVolume.js
+++ b/ui/src/containers/CreateVolume.js
@@ -3,7 +3,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useRouteMatch, useHistory } from 'react-router';
 import { Formik, Form } from 'formik';
 import * as yup from 'yup';
-import { injectIntl } from 'react-intl';
 import styled from 'styled-components';
 import Loader from '../components/Loader';
 import Banner from '../components/Banner';
@@ -29,6 +28,7 @@ import {
   StyledLink,
 } from '../components/BreadcrumbStyle';
 import { sizeUnits } from '../services/utils';
+import { intl } from '../translations/IntlGlobalProvider';
 
 // We might want to do a factorization later for
 // form styled components
@@ -137,7 +137,6 @@ const LabelsName = styled(LabelsValue)`
 `;
 
 const CreateVolume = props => {
-  const { intl } = props;
   const dispatch = useDispatch();
   const history = useHistory();
   const match = useRouteMatch();
@@ -187,39 +186,34 @@ const CreateVolume = props => {
   const validationSchema = yup.object().shape({
     name: yup
       .string()
-      .matches(volumeNameRegex, intl.messages.volume_name_error)
+      .matches(volumeNameRegex, intl.translate('volume_name_error'))
       .required(
-        intl.formatMessage(
-          { id: 'generic_missing_field' },
-          { field: intl.messages.name.toLowerCase() },
-        ),
+        intl.translate('generic_missing_field', {
+          field: intl.translate('name').toLowerCase(),
+        }),
       ),
     storageClass: yup.string().required(),
     type: yup.string().required(),
     path: yup
       .string()
-      .matches(/^\//, intl.messages.volume_path_error)
+      .matches(/^\//, intl.translate('volume_path_error'))
       .when('type', {
         is: RAW_BLOCK_DEVICE,
-        then: yup
-          .string()
-          .required(
-            intl.formatMessage(
-              { id: 'generic_missing_field' },
-              { field: intl.messages.device_path.toLowerCase() },
-            ),
-          ),
+        then: yup.string().required(
+          intl.translate('generic_missing_field', {
+            field: intl.translate('device_path').toLowerCase(),
+          }),
+        ),
       }),
     sizeInput: yup.string().when('type', {
       is: SPARSE_LOOP_DEVICE,
       then: yup
         .string()
-        .matches(positiveIntegerRegex, intl.messages.volume_size_error)
+        .matches(positiveIntegerRegex, intl.translate('volume_size_error'))
         .required(
-          intl.formatMessage(
-            { id: 'generic_missing_field' },
-            { field: intl.messages.volume_size.toLowerCase() },
-          ),
+          intl.translate('generic_missing_field', {
+            field: intl.translate('volume_size').toLowerCase(),
+          }),
         ),
     }),
     selectedUnit: yup.string().when('type', {
@@ -238,7 +232,7 @@ const CreateVolume = props => {
         <Breadcrumb
           activeColor={theme.brand.secondary}
           paths={[
-            <StyledLink to="/nodes">{intl.messages.nodes}</StyledLink>,
+            <StyledLink to="/nodes">{intl.translate('nodes')}</StyledLink>,
             <StyledLink
               to={`/nodes/${match.params.id}/volumes`}
               title={match.params.id}
@@ -246,7 +240,7 @@ const CreateVolume = props => {
               {match.params.id}
             </StyledLink>,
             <BreadcrumbLabel>
-              {intl.messages.create_new_volume}
+              {intl.translate('create_new_volume')}
             </BreadcrumbLabel>,
           ]}
         />
@@ -256,16 +250,16 @@ const CreateVolume = props => {
         <Banner
           type={STATUS_BANNER_WARNING}
           icon={<i className="fas fa-exclamation-triangle" />}
-          title={intl.messages.no_storage_class_found}
+          title={intl.translate('no_storage_class_found')}
           messages={[
             <>
-              {intl.messages.storage_class_is_required}
+              {intl.translate('storage_class_is_required')}
               <a
                 rel="noopener noreferrer"
                 target="_blank"
                 href="https://kubernetes.io/docs/concepts/storage/storage-classes/#the-storageclass-resource"
               >
-                {intl.messages.learn_more}
+                {intl.translate('learn_more')}
               </a>
             </>,
           ]}
@@ -353,19 +347,19 @@ const CreateVolume = props => {
                     name="name"
                     value={values.name}
                     onChange={handleChange('name')}
-                    label={intl.messages.name}
+                    label={intl.translate('name')}
                     error={touched.name && errors.name}
                     onBlur={handleOnBlur}
                   />
                   <InputContainer className="sc-input">
                     <InputLabel className="sc-input-label">
-                      {intl.messages.labels}
+                      {intl.translate('labels')}
                     </InputLabel>
                     <LabelsContainer>
                       <LabelsForm>
                         <Input
                           name="labelName"
-                          placeholder={intl.messages.enter_label_name}
+                          placeholder={intl.translate('enter_label_name')}
                           value={labelName}
                           onChange={e => {
                             setLabelName(e.target.value);
@@ -373,14 +367,14 @@ const CreateVolume = props => {
                         />
                         <Input
                           name="labelValue"
-                          placeholder={intl.messages.enter_label_value}
+                          placeholder={intl.translate('enter_label_value')}
                           value={labelValue}
                           onChange={e => {
                             setLabelValue(e.target.value);
                           }}
                         />
                         <Button
-                          text={intl.messages.add}
+                          text={intl.translate('add')}
                           type="button"
                           onClick={addLabel}
                           data-cy="add-volume-labels-button"
@@ -406,12 +400,12 @@ const CreateVolume = props => {
                   </InputContainer>
                   <Input
                     id="storageClass_input"
-                    label={intl.messages.storageClass}
+                    label={intl.translate('storageClass')}
                     clearable={false}
                     type="select"
                     options={optionsStorageClasses}
-                    placeholder={intl.messages.select_a_storageClass}
-                    noOptionsMessage={() => intl.messages.no_results}
+                    placeholder={intl.translate('select_a_storageClass')}
+                    noOptionsMessage={() => intl.translate('no_results')}
                     name="storageClass"
                     onChange={handleSelectChange('storageClass')}
                     value={getSelectedObjectItem(
@@ -423,12 +417,12 @@ const CreateVolume = props => {
                   />
                   <Input
                     id="type_input"
-                    label={intl.messages.type}
+                    label={intl.translate('type')}
                     clearable={false}
                     type="select"
                     options={optionsTypes}
-                    placeholder={intl.messages.select_a_type}
-                    noOptionsMessage={() => intl.messages.no_results}
+                    placeholder={intl.translate('select_a_type')}
+                    noOptionsMessage={() => intl.translate('no_results')}
                     name="type"
                     onChange={handleSelectChange('type')}
                     value={getSelectedObjectItem(optionsTypes, values?.type)}
@@ -443,7 +437,7 @@ const CreateVolume = props => {
                         min="1"
                         value={values.sizeInput}
                         onChange={handleChange('sizeInput')}
-                        label={intl.messages.volume_size}
+                        label={intl.translate('volume_size')}
                         error={touched.sizeInput && errors.sizeInput}
                         onBlur={handleOnBlur}
                       />
@@ -454,7 +448,7 @@ const CreateVolume = props => {
                           clearable={false}
                           type="select"
                           options={optionsSizeUnits}
-                          noOptionsMessage={() => intl.messages.no_results}
+                          noOptionsMessage={() => intl.translate('no_results')}
                           name="selectedUnit"
                           onChange={handleSelectChange('selectedUnit')}
                           value={getSelectedObjectItem(
@@ -471,7 +465,7 @@ const CreateVolume = props => {
                       name="path"
                       value={values.path}
                       onChange={handleChange('path')}
-                      label={intl.messages.device_path}
+                      label={intl.translate('device_path')}
                       error={touched.path && errors.path}
                       onBlur={handleOnBlur}
                     />
@@ -479,7 +473,7 @@ const CreateVolume = props => {
                 </FormSection>
                 <ActionContainer>
                   <Button
-                    text={intl.messages.cancel}
+                    text={intl.translate('cancel')}
                     type="button"
                     outlined
                     onClick={() =>
@@ -487,7 +481,7 @@ const CreateVolume = props => {
                     }
                   />
                   <Button
-                    text={intl.messages.create}
+                    text={intl.translate('create')}
                     type="submit"
                     disabled={!dirty || !isEmpty(errors)}
                     data-cy="submit-create-volume"
@@ -502,4 +496,4 @@ const CreateVolume = props => {
   );
 };
 
-export default injectIntl(CreateVolume);
+export default CreateVolume;

--- a/ui/src/containers/EnvironmentCreationForm.js
+++ b/ui/src/containers/EnvironmentCreationForm.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useHistory } from 'react-router';
-import { injectIntl } from 'react-intl';
 import { Formik, Form } from 'formik';
 import * as yup from 'yup';
 import styled from 'styled-components';
@@ -9,6 +8,7 @@ import isEmpty from 'lodash.isempty';
 import { Breadcrumb, Input, Button } from '@scality/core-ui';
 import { padding, fontSize } from '@scality/core-ui/dist/style/theme';
 
+import { intl } from '../translations/IntlGlobalProvider';
 import {
   BreadcrumbContainer,
   BreadcrumbLabel,
@@ -86,7 +86,6 @@ const FormSection = styled.div`
 `;
 
 const EnvironmentCreationForm = props => {
-  const { intl } = props;
   const dispatch = useDispatch();
   const history = useHistory();
   const theme = useSelector(state => state.config.theme);
@@ -97,14 +96,11 @@ const EnvironmentCreationForm = props => {
   };
 
   const validationSchema = yup.object().shape({
-    name: yup
-      .string()
-      .required(
-        intl.formatMessage(
-          { id: 'generic_missing_field' },
-          { field: intl.messages.name.toLowerCase() },
-        ),
-      ),
+    name: yup.string().required(
+      intl.translate('generic_missing_field', {
+        field: intl.translate('name').toLowerCase(),
+      }),
+    ),
     description: yup.string(),
   });
 
@@ -114,9 +110,11 @@ const EnvironmentCreationForm = props => {
         <Breadcrumb
           activeColor={theme.brand.secondary}
           paths={[
-            <StyledLink to="/solutions">{intl.messages.solutions}</StyledLink>,
+            <StyledLink to="/solutions">
+              {intl.translate('solutions')}
+            </StyledLink>,
             <BreadcrumbLabel>
-              {intl.messages.create_new_environment}
+              {intl.translate('create_new_environment')}
             </BreadcrumbLabel>,
           ]}
         />
@@ -143,12 +141,14 @@ const EnvironmentCreationForm = props => {
                 <FormSection>
                   <Input
                     name="name"
-                    label={intl.messages.name}
+                    label={intl.translate('name')}
                     onChange={handleChange('name')}
                     error={errors.name}
                   />
                   <TextAreaContainer>
-                    <TextAreaLabel>{intl.messages.description}</TextAreaLabel>
+                    <TextAreaLabel>
+                      {intl.translate('description')}
+                    </TextAreaLabel>
                     <TextArea
                       name="description"
                       rows="4"
@@ -159,7 +159,7 @@ const EnvironmentCreationForm = props => {
 
                 <ActionContainer>
                   <Button
-                    text={intl.messages.cancel}
+                    text={intl.translate('cancel')}
                     type="button"
                     outlined
                     onClick={() => {
@@ -167,7 +167,7 @@ const EnvironmentCreationForm = props => {
                     }}
                   />
                   <Button
-                    text={intl.messages.create}
+                    text={intl.translate('create')}
                     type="submit"
                     disabled={!dirty || !isEmpty(errors)}
                     data-cy="submit-create-environment"
@@ -182,4 +182,4 @@ const EnvironmentCreationForm = props => {
   );
 };
 
-export default injectIntl(EnvironmentCreationForm);
+export default EnvironmentCreationForm;

--- a/ui/src/containers/Layout.js
+++ b/ui/src/containers/Layout.js
@@ -1,11 +1,11 @@
 import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { injectIntl } from 'react-intl';
 import { ThemeProvider } from 'styled-components';
 import { useRouteMatch, useHistory } from 'react-router';
 import { Switch } from 'react-router-dom';
 import { Layout as CoreUILayout, Notifications } from '@scality/core-ui';
 
+import { intl } from '../translations/IntlGlobalProvider';
 import NodeCreateForm from './NodeCreateForm';
 import NodeList from './NodeList';
 import SolutionList from './SolutionList';
@@ -45,7 +45,6 @@ const Layout = props => {
   const removeNotification = uid => dispatch(removeNotificationAction(uid));
   const updateLanguage = language => dispatch(updateLanguageAction(language));
   const toggleSidebar = () => dispatch(toggleSideBarAction());
-  const { intl } = props;
   const history = useHistory();
   useRefreshEffect(refreshSolutionsAction, stopRefreshSolutionsAction);
   useEffect(() => {
@@ -55,7 +54,7 @@ const Layout = props => {
     expanded: sidebar.expanded,
     actions: [
       {
-        label: intl.messages.monitoring,
+        label: intl.translate('monitoring'),
         icon: <i className="fas fa-desktop" />,
         onClick: () => {
           history.push('/');
@@ -67,7 +66,7 @@ const Layout = props => {
         }),
       },
       {
-        label: intl.messages.nodes,
+        label: intl.translate('nodes'),
         icon: <i className="fas fa-server" />,
         onClick: () => {
           history.push('/nodes');
@@ -79,7 +78,7 @@ const Layout = props => {
         }),
       },
       {
-        label: intl.messages.solutions,
+        label: intl.translate('solutions'),
         icon: <i className="fas fa-th" />,
         onClick: () => {
           history.push('/solutions');
@@ -144,7 +143,7 @@ const Layout = props => {
       icon: <i className="fas fa-question-circle" />,
       items: [
         {
-          label: intl.messages.about,
+          label: intl.translate('about'),
           onClick: () => {
             history.push('/about');
           },
@@ -156,7 +155,7 @@ const Layout = props => {
       text: user?.profile?.name,
       icon: <i className="fas fa-user" />,
       items: [
-        { label: intl.messages.log_out, onClick: event => logout(event) },
+        { label: intl.translate('log_out'), onClick: event => logout(event) },
       ],
     },
   ];
@@ -173,7 +172,7 @@ const Layout = props => {
 
   const navbar = {
     onToggleClick: toggleSidebar,
-    productName: intl.messages.product_name,
+    productName: intl.translate('product_name'),
     rightActions,
     logo: (
       <img
@@ -221,4 +220,4 @@ const Layout = props => {
   );
 };
 
-export default injectIntl(Layout);
+export default Layout;

--- a/ui/src/containers/LoginCallback.js
+++ b/ui/src/containers/LoginCallback.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { CallbackComponent } from 'redux-oidc';
-import { injectIntl } from 'react-intl';
 import { useHistory } from 'react-router';
 import { useSelector } from 'react-redux';
 import Loader from '../components/Loader';
+import { intl } from '../translations/IntlGlobalProvider';
 
-const CallbackPage = ({ intl }) => {
+const CallbackPage = () => {
   const userManager = useSelector(state => state.config.userManager);
   const history = useHistory();
   return (
@@ -19,9 +19,9 @@ const CallbackPage = ({ intl }) => {
         history.push('/');
       }}
     >
-      <Loader>{intl.messages.redirecting}</Loader>
+      <Loader>{intl.translate('redirecting')}</Loader>
     </CallbackComponent>
   );
 };
 
-export default injectIntl(CallbackPage);
+export default CallbackPage;

--- a/ui/src/containers/NodeCreateForm.js
+++ b/ui/src/containers/NodeCreateForm.js
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import { Formik, Form } from 'formik';
 import * as yup from 'yup';
 import { useHistory } from 'react-router';
-import { injectIntl } from 'react-intl';
 import { Button, Input, Checkbox, Breadcrumb } from '@scality/core-ui';
 import { padding, fontSize, gray } from '@scality/core-ui/dist/style/theme';
 import isEmpty from 'lodash.isempty';
@@ -17,6 +16,8 @@ import {
   BreadcrumbLabel,
   StyledLink,
 } from '../components/BreadcrumbStyle';
+import { intl } from '../translations/IntlGlobalProvider';
+
 const CreateNodeContainter = styled.div`
   height: 100%;
   padding: ${padding.base};
@@ -118,7 +119,7 @@ const validationSchema = yup.object().shape({
   infra: yup.boolean().required(),
 });
 
-const NodeCreateForm = ({ intl }) => {
+const NodeCreateForm = () => {
   const asyncErrors = useSelector(state => state.app.nodes.errors);
   const clusterVersion = useSelector(state => state.app.nodes.clusterVersion);
   const theme = useSelector(state => state.config.theme);
@@ -138,8 +139,10 @@ const NodeCreateForm = ({ intl }) => {
         <Breadcrumb
           activeColor={theme.brand.secondary}
           paths={[
-            <StyledLink to="/nodes">{intl.messages.nodes}</StyledLink>,
-            <BreadcrumbLabel>{intl.messages.create_new_node}</BreadcrumbLabel>,
+            <StyledLink to="/nodes">{intl.translate('nodes')}</StyledLink>,
+            <BreadcrumbLabel>
+              {intl.translate('create_new_node')}
+            </BreadcrumbLabel>,
           ]}
         />
       </BreadcrumbContainer>
@@ -171,11 +174,11 @@ const NodeCreateForm = ({ intl }) => {
               <Form>
                 <FormSection>
                   <FormSectionTitle>
-                    {intl.messages.new_node_data}
+                    {intl.translate('new_node_data')}
                   </FormSectionTitle>
                   <Input
                     name="name"
-                    label={intl.messages.name}
+                    label={intl.translate('name')}
                     value={values.name}
                     onChange={handleChange('name')}
                     error={touched.name && errors.name}
@@ -183,18 +186,18 @@ const NodeCreateForm = ({ intl }) => {
                   />
                   <InputContainer className="sc-input">
                     <InputLabel className="sc-input-label">
-                      {intl.messages.version}
+                      {intl.translate('version')}
                     </InputLabel>
                     <InputValue>{clusterVersion}</InputValue>
                   </InputContainer>
                   <InputContainer className="sc-input">
                     <InputLabel className="sc-input-label">
-                      {intl.messages.roles}
+                      {intl.translate('roles')}
                     </InputLabel>
                     <CheckboxGroup>
                       <Checkbox
                         name="workload_plane"
-                        label={intl.messages.workload_plane}
+                        label={intl.translate('workload_plane')}
                         checked={values.workload_plane}
                         value={values.workload_plane}
                         onChange={handleChange('workload_plane')}
@@ -202,7 +205,7 @@ const NodeCreateForm = ({ intl }) => {
                       />
                       <Checkbox
                         name="control_plane"
-                        label={intl.messages.control_plane}
+                        label={intl.translate('control_plane')}
                         checked={values.control_plane}
                         value={values.control_plane}
                         onChange={handleChange('control_plane')}
@@ -210,7 +213,7 @@ const NodeCreateForm = ({ intl }) => {
                       />
                       <Checkbox
                         name="infra"
-                        label={intl.messages.infra}
+                        label={intl.translate('infra')}
                         checked={values.infra}
                         value={values.infra}
                         onChange={handleChange('infra')}
@@ -225,7 +228,7 @@ const NodeCreateForm = ({ intl }) => {
                           )
                         }
                       >
-                        {intl.messages.role_values_error}
+                        {intl.translate('role_values_error')}
                       </ErrorMessage>
                     </CheckboxGroup>
                   </InputContainer>
@@ -233,11 +236,11 @@ const NodeCreateForm = ({ intl }) => {
 
                 <FormSection>
                   <FormSectionTitle>
-                    {intl.messages.new_node_access}
+                    {intl.translate('new_node_access')}
                   </FormSectionTitle>
                   <Input
                     name="ssh_user"
-                    label={intl.messages.ssh_user}
+                    label={intl.translate('ssh_user')}
                     value={values.ssh_user}
                     onChange={handleChange('ssh_user')}
                     error={touched.ssh_user && errors.ssh_user}
@@ -245,7 +248,7 @@ const NodeCreateForm = ({ intl }) => {
                   />
                   <Input
                     name="hostName_ip"
-                    label={intl.messages.hostName_ip}
+                    label={intl.translate('hostName_ip')}
                     value={values.hostName_ip}
                     onChange={handleChange('hostName_ip')}
                     error={touched.hostName_ip && errors.hostName_ip}
@@ -253,7 +256,7 @@ const NodeCreateForm = ({ intl }) => {
                   />
                   <Input
                     name="ssh_port"
-                    label={intl.messages.ssh_port}
+                    label={intl.translate('ssh_port')}
                     value={values.ssh_port}
                     onChange={handleChange('ssh_port')}
                     error={touched.ssh_port && errors.ssh_port}
@@ -261,7 +264,7 @@ const NodeCreateForm = ({ intl }) => {
                   />
                   <Input
                     name="ssh_key_path"
-                    label={intl.messages.ssh_key_path}
+                    label={intl.translate('ssh_key_path')}
                     value={values.ssh_key_path}
                     onChange={handleChange('ssh_key_path')}
                     error={touched.ssh_key_path && errors.ssh_key_path}
@@ -270,7 +273,7 @@ const NodeCreateForm = ({ intl }) => {
                   <Input
                     name="sudo_required"
                     type="checkbox"
-                    label={intl.messages.sudo_required}
+                    label={intl.translate('sudo_required')}
                     value={values.sudo_required}
                     checked={values.sudo_required}
                     onChange={handleChange('sudo_required')}
@@ -281,13 +284,13 @@ const NodeCreateForm = ({ intl }) => {
                   <div>
                     <div>
                       <Button
-                        text={intl.messages.cancel}
+                        text={intl.translate('cancel')}
                         type="button"
                         outlined
                         onClick={() => history.push('/nodes')}
                       />
                       <Button
-                        text={intl.messages.create}
+                        text={intl.translate('create')}
                         type="submit"
                         disabled={
                           !dirty ||
@@ -316,4 +319,4 @@ const NodeCreateForm = ({ intl }) => {
   );
 };
 
-export default injectIntl(NodeCreateForm);
+export default NodeCreateForm;

--- a/ui/src/containers/NodeDeployment.js
+++ b/ui/src/containers/NodeDeployment.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { injectIntl } from 'react-intl';
 import styled from 'styled-components';
 import ReactJson from 'react-json-view';
 import { Button, Loader, Steppers } from '@scality/core-ui';
@@ -14,6 +13,7 @@ import {
   padding,
   fontSize,
 } from '@scality/core-ui/dist/style/theme';
+import { intl } from '../translations/IntlGlobalProvider';
 
 const NodeDeploymentContainer = styled.div`
   height: 100%;
@@ -57,7 +57,7 @@ const ErrorLabel = styled.span`
   color: ${props => props.theme.brand.danger};
 `;
 
-const NodeDeployment = ({ intl }) => {
+const NodeDeployment = () => {
   const dispatch = useDispatch();
   const history = useHistory();
   const match = useRouteMatch();
@@ -72,8 +72,8 @@ const NodeDeployment = ({ intl }) => {
 
   const [activeStep, setActiveStep] = useState(1);
   const [steps, setSteps] = useState([
-    { title: intl.messages.node_registered },
-    { title: intl.messages.deploying, content: <Loader size="larger" /> },
+    { title: intl.translate('node_registered') },
+    { title: intl.translate('deploying'), content: <Loader size="larger" /> },
   ]);
 
   useEffect(() => {
@@ -87,12 +87,14 @@ const NodeDeployment = ({ intl }) => {
   useEffect(() => {
     if (
       //To improve
-      !steps.find(step => step.title === intl.messages.deployment_started) &&
+      !steps.find(
+        step => step.title === intl.translate('deployment_started'),
+      ) &&
       events.find(event => event.tag.includes('/new'))
     ) {
       const newSteps = steps;
       newSteps.splice(steps.length - 1, 0, {
-        title: intl.messages.deployment_started,
+        title: intl.translate('deployment_started'),
       });
       setSteps(newSteps);
       setActiveStep(2);
@@ -103,12 +105,14 @@ const NodeDeployment = ({ intl }) => {
       const status = getJobStatusFromEventRet(result.data);
       const newSteps = steps;
       newSteps.splice(steps.length - 1, 1, {
-        title: intl.messages.completed,
+        title: intl.translate('completed'),
         content: (
           <span>
             {!status.success && (
               <ErrorLabel>
-                {`${intl.messages.error}: ${status.step_id} - ${status.comment}`}
+                {`${intl.translate('error')}: ${status.step_id} - ${
+                  status.comment
+                }`}
               </ErrorLabel>
             )}
           </span>
@@ -117,19 +121,13 @@ const NodeDeployment = ({ intl }) => {
       setSteps(newSteps);
       setActiveStep(status.success ? steps.length : steps.length - 1);
     }
-  }, [
-    events,
-    intl.messages.completed,
-    intl.messages.deployment_started,
-    intl.messages.error,
-    steps,
-  ]);
+  }, [events, steps]);
 
   return (
     <NodeDeploymentContainer>
       <div>
         <Button
-          text={intl.messages.back_to_node_list}
+          text={intl.translate('back_to_node_list')}
           type="button"
           outlined
           onClick={() => history.push('/nodes')}
@@ -138,7 +136,7 @@ const NodeDeployment = ({ intl }) => {
       </div>
       <NodeDeploymentWrapper>
         <NodeDeploymentTitle>
-          {intl.messages.node_deployment}
+          {intl.translate('node_deployment')}
         </NodeDeploymentTitle>
         <NodeDeploymentContent>
           <NodeDeploymentStatus>
@@ -153,4 +151,4 @@ const NodeDeployment = ({ intl }) => {
   );
 };
 
-export default injectIntl(NodeDeployment);
+export default NodeDeployment;

--- a/ui/src/containers/NodeInformation.js
+++ b/ui/src/containers/NodeInformation.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { injectIntl, FormattedDate, FormattedTime } from 'react-intl';
+import { FormattedDate, FormattedTime } from 'react-intl';
 import styled from 'styled-components';
 import { useLocation, useHistory, useRouteMatch } from 'react-router';
 import { Switch, Route } from 'react-router-dom';
@@ -35,6 +35,7 @@ import {
 } from '../components/InformationList';
 import { STATUS_BOUND } from '../constants';
 import { computeVolumeGlobalStatus } from '../services/NodeVolumesUtils';
+import { intl } from '../translations/IntlGlobalProvider';
 
 const NodeInformationContainer = styled.div`
   display: flex;
@@ -70,7 +71,6 @@ const PodsContainer = styled.div`
 `;
 
 const NodeInformation = props => {
-  const { intl } = props;
   const history = useHistory();
   const match = useRouteMatch();
   const location = useLocation();
@@ -94,20 +94,20 @@ const NodeInformation = props => {
 
   const columns = [
     {
-      label: props.intl.messages.name,
+      label: intl.translate('name'),
       dataKey: 'name',
       flexGrow: 1,
     },
     {
-      label: props.intl.messages.status,
+      label: intl.translate('status'),
       dataKey: 'status',
     },
     {
-      label: props.intl.messages.namespace,
+      label: intl.translate('namespace'),
       dataKey: 'namespace',
     },
     {
-      label: props.intl.messages.start_time,
+      label: intl.translate('start_time'),
       dataKey: 'startTime',
       renderer: data => (
         <span>
@@ -116,7 +116,7 @@ const NodeInformation = props => {
       ),
     },
     {
-      label: props.intl.messages.restart,
+      label: intl.translate('restart'),
       dataKey: 'restartCount',
     },
   ];
@@ -131,21 +131,21 @@ const NodeInformation = props => {
   const NodeDetails = () => (
     <InformationListContainer>
       <InformationSpan>
-        <InformationLabel>{intl.messages.name}</InformationLabel>
+        <InformationLabel>{intl.translate('name')}</InformationLabel>
         <InformationMainValue>{node.name}</InformationMainValue>
       </InformationSpan>
       <InformationSpan>
-        <InformationLabel>{intl.messages.status}</InformationLabel>
+        <InformationLabel>{intl.translate('status')}</InformationLabel>
         <InformationValue>
-          {intl.messages[node.status] || node.status}
+          {intl.translate(node.status) || node.status}
         </InformationValue>
       </InformationSpan>
       <InformationSpan>
-        <InformationLabel>{intl.messages.roles}</InformationLabel>
+        <InformationLabel>{intl.translate('roles')}</InformationLabel>
         <InformationValue>{node.roles}</InformationValue>
       </InformationSpan>
       <InformationSpan>
-        <InformationLabel>{intl.messages.version}</InformationLabel>
+        <InformationLabel>{intl.translate('version')}</InformationLabel>
         <InformationValue>{node.metalk8s_version}</InformationValue>
       </InformationSpan>
     </InformationListContainer>
@@ -165,7 +165,7 @@ const NodeInformation = props => {
           onSort={onSort}
           onRowClick={() => {}}
           noRowsRenderer={() => (
-            <NoRowsRenderer content={intl.messages.no_data_available} />
+            <NoRowsRenderer content={intl.translate('no_data_available')} />
           )}
         />
       </PodsContainer>
@@ -181,14 +181,14 @@ const NodeInformation = props => {
       status: computeVolumeGlobalStatus(volume.metadata.name, volume?.status),
       bound:
         volumePV?.status?.phase === STATUS_BOUND
-          ? intl.messages.yes
-          : intl.messages.no,
+          ? intl.translate('yes')
+          : intl.translate('no'),
       storageCapacity:
         (volumePV &&
           volumePV.spec &&
           volumePV.spec.capacity &&
           volumePV.spec.capacity.storage) ||
-        intl.messages.unknown,
+        intl.translate('unknown'),
       storageClass: volume.spec.storageClassName,
       creationTime: volume.metadata.creationTimestamp,
     };
@@ -199,17 +199,17 @@ const NodeInformation = props => {
   const items = [
     {
       selected: !isVolumesPage && !isPodsPage,
-      title: intl.messages.details,
+      title: intl.translate('details'),
       onClick: () => history.push(match.url),
     },
     {
       selected: isVolumesPage,
-      title: intl.messages.volumes,
+      title: intl.translate('volumes'),
       onClick: () => history.push(`${match.url}/volumes`),
     },
     {
       selected: isPodsPage,
-      title: intl.messages.pods,
+      title: intl.translate('pods'),
       onClick: () => history.push(`${match.url}/pods`),
     },
   ];
@@ -220,7 +220,7 @@ const NodeInformation = props => {
         <Breadcrumb
           activeColor={theme.brand.secondary}
           paths={[
-            <StyledLink to="/nodes">{intl.messages.nodes} </StyledLink>,
+            <StyledLink to="/nodes">{intl.translate('nodes')} </StyledLink>,
             <BreadcrumbLabel title={node.name}>{node.name}</BreadcrumbLabel>,
           ]}
         />
@@ -241,4 +241,4 @@ const NodeInformation = props => {
   );
 };
 
-export default injectIntl(NodeInformation);
+export default NodeInformation;

--- a/ui/src/containers/NodeList.js
+++ b/ui/src/containers/NodeList.js
@@ -4,7 +4,6 @@ import React, { useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useHistory } from 'react-router';
 import styled from 'styled-components';
-import { injectIntl } from 'react-intl';
 import { Table, Button, Loader, Breadcrumb } from '@scality/core-ui';
 import { padding } from '@scality/core-ui/dist/style/theme';
 import {
@@ -19,6 +18,7 @@ import {
   BreadcrumbContainer,
   BreadcrumbLabel,
 } from '../components/BreadcrumbStyle';
+import { intl } from '../translations/IntlGlobalProvider';
 
 const PageContainer = styled.div`
   box-sizing: border-box;
@@ -64,7 +64,7 @@ const TableContainer = styled.div`
   }
 `;
 
-const NodeList = ({ intl }) => {
+const NodeList = () => {
   const nodes = useSelector(state => state.app.nodes);
   const theme = useSelector(state => state.config.theme);
   const dispatch = useDispatch();
@@ -77,17 +77,17 @@ const NodeList = ({ intl }) => {
   const history = useHistory();
   const columns = [
     {
-      label: intl.messages.name,
+      label: intl.translate('name'),
       dataKey: 'name',
       flexGrow: 1,
     },
     {
-      label: intl.messages.status,
+      label: intl.translate('status'),
       dataKey: 'status',
-      renderer: data => <span> {intl.messages[data] || data}</span>,
+      renderer: data => <span> {intl.translate(data) || data}</span>,
     },
     {
-      label: intl.messages.deployment,
+      label: intl.translate('deployment'),
       dataKey: 'deployment',
       renderer: (data, rowData) => {
         if (
@@ -97,7 +97,7 @@ const NodeList = ({ intl }) => {
           return (
             <span className="status">
               <Button
-                text={intl.messages.deploy}
+                text={intl.translate('deploy')}
                 onClick={event => {
                   event.stopPropagation();
                   deployNode(rowData);
@@ -111,7 +111,7 @@ const NodeList = ({ intl }) => {
           return (
             <span className="status">
               <Button
-                text={intl.messages.deploying}
+                text={intl.translate('deploying')}
                 onClick={event => {
                   event.stopPropagation();
                   history.push(`/nodes/deploy/${rowData.jid}`);
@@ -126,12 +126,12 @@ const NodeList = ({ intl }) => {
       },
     },
     {
-      label: intl.messages.roles,
+      label: intl.translate('roles'),
       dataKey: 'roles',
       flexGrow: 1,
     },
     {
-      label: intl.messages.version,
+      label: intl.translate('version'),
       dataKey: 'metalk8s_version',
     },
   ];
@@ -154,12 +154,12 @@ const NodeList = ({ intl }) => {
       <BreadcrumbContainer>
         <Breadcrumb
           activeColor={theme.brand.secondary}
-          paths={[<BreadcrumbLabel>{intl.messages.nodes}</BreadcrumbLabel>]}
+          paths={[<BreadcrumbLabel>{intl.translate('nodes')}</BreadcrumbLabel>]}
         />
       </BreadcrumbContainer>
       <ActionContainer>
         <Button
-          text={intl.messages.create_new_node}
+          text={intl.translate('create_new_node')}
           onClick={() => history.push('/nodes/create')}
           icon={<i className="fas fa-plus" />}
         />
@@ -186,7 +186,7 @@ const NodeList = ({ intl }) => {
             }
           }}
           noRowsRenderer={() => (
-            <NoRowsRenderer content={intl.messages.no_data_available} />
+            <NoRowsRenderer content={intl.translate('no_data_available')} />
           )}
         />
       </TableContainer>
@@ -194,4 +194,4 @@ const NodeList = ({ intl }) => {
   );
 };
 
-export default injectIntl(NodeList);
+export default NodeList;

--- a/ui/src/containers/NodeVolumes.js
+++ b/ui/src/containers/NodeVolumes.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { injectIntl } from 'react-intl';
 import styled from 'styled-components';
 import { FormattedDate, FormattedTime } from 'react-intl';
 import { useHistory } from 'react-router';
@@ -35,6 +34,7 @@ import {
   STATUS_AVAILABLE,
   STATUS_BOUND,
 } from '../constants';
+import { intl } from '../translations/IntlGlobalProvider';
 
 const VolumeTable = styled.div`
   flex-grow: 1;
@@ -88,7 +88,6 @@ const LoaderContainer = styled(Loader)`
 `;
 
 const NodeVolumes = props => {
-  const { intl } = props;
   const dispatch = useDispatch();
   const deleteVolume = deleteVolumeName =>
     dispatch(deleteVolumeAction(deleteVolumeName));
@@ -115,28 +114,28 @@ const NodeVolumes = props => {
   };
   const columns = [
     {
-      label: intl.messages.name,
+      label: intl.translate('name'),
       dataKey: 'name',
       flexGrow: 1,
     },
     {
-      label: intl.messages.status,
+      label: intl.translate('status'),
       dataKey: 'status',
     },
     {
-      label: intl.messages.bound,
+      label: intl.translate('bound'),
       dataKey: 'bound',
     },
     {
-      label: intl.messages.storageCapacity,
+      label: intl.translate('storageCapacity'),
       dataKey: 'storageCapacity',
     },
     {
-      label: intl.messages.storageClass,
+      label: intl.translate('storageClass'),
       dataKey: 'storageClass',
     },
     {
-      label: intl.messages.creationTime,
+      label: intl.translate('creationTime'),
       dataKey: 'creationTime',
       renderer: data => (
         <span>
@@ -151,7 +150,7 @@ const NodeVolumes = props => {
       ),
     },
     {
-      label: intl.messages.action,
+      label: intl.translate('action'),
       dataKey: 'action',
       disableSort: true,
       width: 150,
@@ -163,13 +162,13 @@ const NodeVolumes = props => {
 
           switch (rowData.status) {
             case STATUS_PENDING:
-              hintMessage = intl.messages.volume_status_pending_hint;
+              hintMessage = intl.translate('volume_status_pending_hint');
               break;
             case STATUS_TERMINATING:
-              hintMessage = intl.messages.volume_status_terminating_hint;
+              hintMessage = intl.translate('volume_status_terminating_hint');
               break;
             case STATUS_UNKNOWN:
-              hintMessage = intl.messages.volume_status_unknown_hint;
+              hintMessage = intl.translate('volume_status_unknown_hint');
               break;
             case STATUS_FAILED:
             case STATUS_AVAILABLE:
@@ -179,12 +178,14 @@ const NodeVolumes = props => {
               const persistentVolumeStatus = persistentVolume?.status?.phase;
               switch (persistentVolumeStatus) {
                 case STATUS_BOUND:
-                  hintMessage =
-                    intl.messages.volume_statue_failed_pv_bound_hint;
+                  hintMessage = intl.translate(
+                    'volume_statue_failed_pv_bound_hint',
+                  );
                   break;
                 case STATUS_PENDING:
-                  hintMessage =
-                    intl.messages.volume_status_failed_pv_pending_hint;
+                  hintMessage = intl.translate(
+                    'volume_status_failed_pv_pending_hint',
+                  );
                   break;
                 default:
                   hintMessage = '';
@@ -255,17 +256,17 @@ const NodeVolumes = props => {
       <Modal
         close={() => setisDeleteConfirmationModalOpen(false)}
         isOpen={isDeleteConfirmationModalOpen}
-        title={intl.messages.delete_a_volume}
+        title={intl.translate('delete_a_volume')}
         footer={
           <NotificationButtonGroup>
             <Button
               outlined
-              text={intl.messages.cancel}
+              text={intl.translate('cancel')}
               onClick={onClickCancelButton}
             />
             <DeleteButton
               variant="danger"
-              text={intl.messages.delete}
+              text={intl.translate('delete')}
               onClick={e => {
                 e.stopPropagation();
                 onClickDeleteButton(deleteVolumeName);
@@ -275,9 +276,9 @@ const NodeVolumes = props => {
         }
       >
         <ModalBody>
-          <div>{intl.messages.delete_a_volume_warning}</div>
+          <div>{intl.translate('delete_a_volume_warning')}</div>
           <div>
-            {intl.messages.delete_a_volume_confirm}
+            {intl.translate('delete_a_volume_confirm')}
             <strong>{deleteVolumeName}</strong>?
           </div>
         </ModalBody>
@@ -287,7 +288,7 @@ const NodeVolumes = props => {
         <SearchContainer>
           <SearchInput
             value={searchedVolumeName}
-            placeholder={intl.messages.search}
+            placeholder={intl.translate('search')}
             disableToggle={true}
             onChange={handleChange}
           ></SearchInput>
@@ -295,7 +296,10 @@ const NodeVolumes = props => {
 
         <ButtonContainer>
           {volumes.isLoading && <LoaderContainer size="small" />}
-          <Tooltip placement="left" overlay={intl.messages.create_new_volume}>
+          <Tooltip
+            placement="left"
+            overlay={intl.translate('create_new_volume')}
+          >
             <Button
               text={<i className="fas fa-plus "></i>}
               type="button"
@@ -323,10 +327,10 @@ const NodeVolumes = props => {
           }}
           noRowsRenderer={() =>
             searchedVolumeName === '' ? (
-              <NoRowsRenderer content={intl.messages.no_volume_found} />
+              <NoRowsRenderer content={intl.translate('no_volume_found')} />
             ) : (
               <NoRowsRenderer
-                content={intl.messages.no_searched_volume_found}
+                content={intl.translate('no_searched_volume_found')}
               />
             )
           }
@@ -336,4 +340,4 @@ const NodeVolumes = props => {
   );
 };
 
-export default injectIntl(NodeVolumes);
+export default NodeVolumes;

--- a/ui/src/containers/SolutionList.js
+++ b/ui/src/containers/SolutionList.js
@@ -4,7 +4,6 @@ import { useHistory } from 'react-router';
 import { Formik, Form } from 'formik';
 import * as yup from 'yup';
 import styled from 'styled-components';
-import { injectIntl } from 'react-intl';
 import {
   Table,
   Button,
@@ -22,6 +21,7 @@ import {
   BreadcrumbContainer,
   BreadcrumbLabel,
 } from '../components/BreadcrumbStyle';
+import { intl } from '../translations/IntlGlobalProvider';
 
 const PageContainer = styled.div`
   box-sizing: border-box;
@@ -99,7 +99,6 @@ const SolutionsList = props => {
   const solutions = useSelector(state => state.app.solutions.solutions);
   const environments = useSelector(state => state.app.solutions.environments);
   const history = useHistory();
-  const { intl } = props;
 
   const onSort = (setSortBy, setSortDirection) => ({
     sortBy,
@@ -111,12 +110,12 @@ const SolutionsList = props => {
 
   const solutionColumns = [
     {
-      label: intl.messages.name,
+      label: intl.translate('name'),
       dataKey: 'name',
       flexGrow: 1,
     },
     {
-      label: intl.messages.versions,
+      label: intl.translate('versions'),
       dataKey: 'versions',
       renderer: versions =>
         versions.map((version, index) => (
@@ -130,16 +129,16 @@ const SolutionsList = props => {
 
   const environmentsColumn = [
     {
-      label: intl.messages.name,
+      label: intl.translate('name'),
       dataKey: 'name',
     },
     {
-      label: intl.messages.description,
+      label: intl.translate('description'),
       dataKey: 'description',
       flexGrow: 1,
     },
     {
-      label: intl.messages.solutions,
+      label: intl.translate('solutions'),
       dataKey: 'solutions',
       renderer: (solutions, row) => {
         const solutionsLinks = solutions
@@ -236,17 +235,17 @@ const SolutionsList = props => {
           <Breadcrumb
             activeColor={theme.brand.secondary}
             paths={[
-              <BreadcrumbLabel title={intl.messages.solutions}>
-                {intl.messages.solutions}
+              <BreadcrumbLabel title={intl.translate('solutions')}>
+                {intl.translate('solutions')}
               </BreadcrumbLabel>,
             ]}
           />
         </BreadcrumbContainer>
         <TableContainer>
           <EnvironmentHeader>
-            <PageSubtitle>{intl.messages.environments}</PageSubtitle>
+            <PageSubtitle>{intl.translate('environments')}</PageSubtitle>
             <Button
-              text={intl.messages.create_new_environment}
+              text={intl.translate('create_new_environment')}
               onClick={() => history.push('/solutions/create-environment')}
               icon={<i className="fas fa-plus" />}
             />
@@ -263,13 +262,13 @@ const SolutionsList = props => {
             onSort={onSort(setEnvSortBy, setEnvSortDirection)}
             onRowClick={() => {}}
             noRowsRenderer={() => (
-              <NoRowsRenderer content={intl.messages.no_data_available} />
+              <NoRowsRenderer content={intl.translate('no_data_available')} />
             )}
           />
         </TableContainer>
 
         <TableContainer>
-          <PageSubtitle>{intl.messages.available_solutions}</PageSubtitle>
+          <PageSubtitle>{intl.translate('available_solutions')}</PageSubtitle>
           <Table
             list={sortedSolutions}
             columns={solutionColumns}
@@ -281,7 +280,7 @@ const SolutionsList = props => {
             onSort={onSort(setSolutionSortBy, setSolutionSortDirection)}
             onRowClick={() => {}}
             noRowsRenderer={() => (
-              <NoRowsRenderer content={intl.messages.no_data_available} />
+              <NoRowsRenderer content={intl.translate('no_data_available')} />
             )}
           />
         </TableContainer>
@@ -293,10 +292,9 @@ const SolutionsList = props => {
           setSelectedEnvironment('');
         }}
         isOpen={isAddSolutionModalOpen}
-        title={intl.formatMessage(
-          { id: 'add_solution_to_environment' },
-          { environment: selectedEnvironment },
-        )}
+        title={intl.translate('add_solution_to_environment', {
+          environment: selectedEnvironment,
+        })}
       >
         {isSolutionReady ? (
           <Formik
@@ -353,20 +351,20 @@ const SolutionsList = props => {
                         <Input
                           type="select"
                           name="solutions"
-                          label={intl.messages.solutions}
+                          label={intl.translate('solutions')}
                           options={solutionsSelectOptions}
-                          placeholder={intl.messages.select_a_type}
-                          noOptionsMessage={() => intl.messages.no_results}
+                          placeholder={intl.translate('select_a_type')}
+                          noOptionsMessage={() => intl.translate('no_results')}
                           onChange={handleSelectChange('solution')}
                           value={values.solution}
                         />
                         <Input
                           type="select"
                           name="version"
-                          label={intl.messages.version_env}
+                          label={intl.translate('version_env')}
                           options={selectedSolutionVersionsOptions}
-                          placeholder={intl.messages.select_a_type}
-                          noOptionsMessage={() => intl.messages.no_results}
+                          placeholder={intl.translate('select_a_type')}
+                          noOptionsMessage={() => intl.translate('no_results')}
                           onChange={handleSelectChange('version')}
                           value={values.version}
                         />
@@ -375,14 +373,14 @@ const SolutionsList = props => {
                       <ActionContainer>
                         <Button
                           outlined
-                          text={intl.messages.cancel}
+                          text={intl.translate('cancel')}
                           onClick={() => {
                             setisAddSolutionModalOpen(false);
                             setSelectedEnvironment('');
                           }}
                         />
                         <Button
-                          text={intl.messages.add_solution}
+                          text={intl.translate('add_solution')}
                           type="submit"
                         />
                       </ActionContainer>
@@ -393,11 +391,11 @@ const SolutionsList = props => {
             }}
           </Formik>
         ) : (
-          <Loader size="large">{intl.messages.import_solution_hint}</Loader>
+          <Loader size="large">{intl.translate('import_solution_hint')}</Loader>
         )}
       </Modal>
     </>
   );
 };
 
-export default injectIntl(SolutionsList);
+export default SolutionsList;

--- a/ui/src/containers/VolumeInformation.js
+++ b/ui/src/containers/VolumeInformation.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useRouteMatch } from 'react-router';
-import { injectIntl, FormattedDate, FormattedTime } from 'react-intl';
+import { FormattedDate, FormattedTime } from 'react-intl';
 import styled from 'styled-components';
 import { padding } from '@scality/core-ui/dist/style/theme';
 import { Breadcrumb, Table, Loader } from '@scality/core-ui';
@@ -42,6 +42,7 @@ import {
   computeVolumeGlobalStatus,
   volumeGetError,
 } from '../services/NodeVolumesUtils';
+import { intl } from '../translations/IntlGlobalProvider';
 
 const VolumeInformationListContainer = styled(InformationListContainer)`
   margin: ${padding.larger};
@@ -78,7 +79,6 @@ const LoaderContainer = styled(Loader)`
 `;
 
 const VolumeInformation = props => {
-  const { intl } = props;
   const dispatch = useDispatch();
   const match = useRouteMatch();
 
@@ -115,11 +115,11 @@ const VolumeInformation = props => {
   const [errorCode, errorMessage] = volumeGetError(volume?.status);
   const columns = [
     {
-      label: intl.messages.name,
+      label: intl.translate('name'),
       dataKey: 'name',
     },
     {
-      label: intl.messages.value,
+      label: intl.translate('value'),
       dataKey: 'value',
     },
   ];
@@ -137,15 +137,15 @@ const VolumeInformation = props => {
         <Breadcrumb
           activeColor={theme.brand.secondary}
           paths={[
-            <StyledLink to="/nodes">{intl.messages.nodes}</StyledLink>,
+            <StyledLink to="/nodes">{intl.translate('nodes')}</StyledLink>,
             <StyledLink to={`/nodes/${node.name}`} title={node.name}>
               {node.name}
             </StyledLink>,
             <StyledLink
               to={`/nodes/${node.name}/volumes`}
-              title={intl.messages.volumes}
+              title={intl.translate('volumes')}
             >
-              {intl.messages.volumes}
+              {intl.translate('volumes')}
             </StyledLink>,
             <BreadcrumbLabel title={match.params.volumeName}>
               {match.params.volumeName}
@@ -160,8 +160,8 @@ const VolumeInformation = props => {
           icon={<i className="fas fa-exclamation-triangle" />}
           title={
             errorCode === 'CreationError'
-              ? intl.messages.failed_to_create_volume
-              : intl.messages.error
+              ? intl.translate('failed_to_create_volume')
+              : intl.translate('error')
           }
           messages={[errorMessage]}
         />
@@ -171,23 +171,23 @@ const VolumeInformation = props => {
 
       <VolumeInformationListContainer>
         <InformationSpan>
-          <InformationLabel>{intl.messages.name}</InformationLabel>
+          <InformationLabel>{intl.translate('name')}</InformationLabel>
           <InformationMainValue>{volume?.metadata?.name}</InformationMainValue>
         </InformationSpan>
         <InformationSpan>
-          <InformationLabel>{intl.messages.status}</InformationLabel>
+          <InformationLabel>{intl.translate('status')}</InformationLabel>
           <InformationValue>
-            {volumeStatus ?? intl.messages.unknown}
+            {volumeStatus ?? intl.translate('unknown')}
           </InformationValue>
         </InformationSpan>
         <InformationSpan>
-          <InformationLabel>{intl.messages.size}</InformationLabel>
+          <InformationLabel>{intl.translate('size')}</InformationLabel>
           <InformationValue>
-            {pV?.spec?.capacity?.storage ?? intl.messages.unknown}
+            {pV?.spec?.capacity?.storage ?? intl.translate('unknown')}
           </InformationValue>
         </InformationSpan>
         <InformationSpan>
-          <InformationLabel>{intl.messages.type}</InformationLabel>
+          <InformationLabel>{intl.translate('type')}</InformationLabel>
           <InformationValue>
             {volume?.spec?.rawBlockDevice
               ? RAW_BLOCK_DEVICE
@@ -195,38 +195,38 @@ const VolumeInformation = props => {
           </InformationValue>
         </InformationSpan>
         <InformationSpan>
-          <InformationLabel>{intl.messages.bound}</InformationLabel>
+          <InformationLabel>{intl.translate('bound')}</InformationLabel>
           <InformationValue>
             {pV?.status?.phase === STATUS_BOUND
-              ? intl.messages.yes
-              : intl.messages.no}
+              ? intl.translate('yes')
+              : intl.translate('no')}
           </InformationValue>
         </InformationSpan>
         <InformationSpan>
-          <InformationLabel>{intl.messages.storageClass}</InformationLabel>
+          <InformationLabel>{intl.translate('storageClass')}</InformationLabel>
           <InformationValue>{volume?.spec?.storageClassName}</InformationValue>
         </InformationSpan>
         <InformationSpan>
-          <InformationLabel>{intl.messages.path}</InformationLabel>
+          <InformationLabel>{intl.translate('path')}</InformationLabel>
           <InformationValue>
             {volume?.spec?.rawBlockDevice?.devicePath ??
-              intl.messages.not_applicable}
+              intl.translate('not_applicable')}
           </InformationValue>
         </InformationSpan>
         <InformationSpan>
-          <InformationLabel>{intl.messages.access_mode}</InformationLabel>
+          <InformationLabel>{intl.translate('access_mode')}</InformationLabel>
           <InformationValue>
-            {pV?.spec?.accessModes ?? intl.messages.unknown}
+            {pV?.spec?.accessModes ?? intl.translate('unknown')}
           </InformationValue>
         </InformationSpan>
         <InformationSpan>
-          <InformationLabel>{intl.messages.mount_option}</InformationLabel>
+          <InformationLabel>{intl.translate('mount_option')}</InformationLabel>
           <InformationValue>
             {storageClass?.mountOptions.join(', ')}
           </InformationValue>
         </InformationSpan>
         <InformationSpan>
-          <InformationLabel>{intl.messages.creationTime}</InformationLabel>
+          <InformationLabel>{intl.translate('creationTime')}</InformationLabel>
           {volume?.metadata?.creationTimestamp ? (
             <InformationValue>
               <FormattedDate value={volume.metadata.creationTimestamp} />{' '}
@@ -243,7 +243,7 @@ const VolumeInformation = props => {
         </InformationSpan>
         {!!labels?.length && (
           <InformationContainer>
-            <InformationLabel>{intl.messages.labels}</InformationLabel>
+            <InformationLabel>{intl.translate('labels')}</InformationLabel>
             <InformationValueSection>
               <Table
                 list={labels}
@@ -260,4 +260,4 @@ const VolumeInformation = props => {
   );
 };
 
-export default injectIntl(VolumeInformation);
+export default VolumeInformation;

--- a/ui/src/translations/IntlGlobalProvider.js
+++ b/ui/src/translations/IntlGlobalProvider.js
@@ -36,6 +36,9 @@ class IntlTranslator {
   // Formatting Functions
   // ------------------------------------
   translate(key, values) {
+    if (!key) {
+      return '';
+    }
     const description = defineMessages({
       message: {
         id: key


### PR DESCRIPTION
**Component**:UI

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

- Once IntlGlobalProvider is introduced to allow us to translate text in sagas, intl.translate does not work anymore in React components, only intl.messages works. It triggers an JS error 'translate is not a function'. We need to use ONLY IntlGlobalProvider's intl.translate everywhere (saga and react components) for translation to be consistent. Thus we can get rid of HOC injectIntl

**Summary**:

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: https://github.com/scality/metalk8s/issues/2122

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
