### PR TITLE
salt,build: Add version label on static manifest deployed

### DIFF
--- a/salt/metalk8s/kubernetes/etcd/files/manifest.yaml
+++ b/salt/metalk8s/kubernetes/etcd/files/manifest.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     component: {{ name }}
     tier: "control-plane"
+    metalk8s.scality.com/version: {{ metalk8s_version }}
   name: {{ name }}
   namespace: "kube-system"
 spec:

--- a/salt/metalk8s/kubernetes/files/control-plane-manifest.yaml
+++ b/salt/metalk8s/kubernetes/files/control-plane-manifest.yaml
@@ -10,6 +10,7 @@ metadata:
   labels:
     component: {{ name }}
     tier: "control-plane"
+    metalk8s.scality.com/version: {{ metalk8s_version }}
 spec:
   containers:
     - name: {{ name }}

--- a/salt/metalk8s/orchestrate/downgrade/init.sls
+++ b/salt/metalk8s/orchestrate/downgrade/init.sls
@@ -70,7 +70,7 @@ Deploy node {{ node }}:
     - name: state.orchestrate
     - mods:
       - metalk8s.orchestrate.deploy_node
-    - saltenv: {{ saltenv }}
+    - saltenv: metalk8s-{{ dest_version }}
     - pillar:
         orchestrate:
           node_name: {{ node }}

--- a/salt/metalk8s/orchestrate/etcd.sls
+++ b/salt/metalk8s/orchestrate/etcd.sls
@@ -11,7 +11,8 @@ Sync {{ node }} minion:
   salt.function:
     - name: saltutil.sync_all
     - tgt: {{ node }}
-    - saltenv: metalk8s-{{ dest_version }}
+    - kwarg:
+        saltenv: metalk8s-{{ dest_version }}
 
 Deploy etcd {{ node }} to {{ dest_version }}:
   salt.state:

--- a/salt/metalk8s/repo/files/repositories-manifest.yaml.j2
+++ b/salt/metalk8s/repo/files/repositories-manifest.yaml.j2
@@ -10,6 +10,7 @@ metadata:
     heritage: metalk8s
     app.kubernetes.io/part-of: metalk8s
     app.kubernetes.io/managed-by: salt
+    metalk8s.scality.com/version: {{ metalk8s_version }}
   annotations:
     metalk8s.scality.com/config-digest: "{{ config_digest }}"
 spec:

--- a/salt/metalk8s/salt/master/files/salt-master-manifest.yaml.j2
+++ b/salt/metalk8s/salt/master/files/salt-master-manifest.yaml.j2
@@ -11,6 +11,7 @@ metadata:
     heritage: metalk8s
     app.kubernetes.io/part-of: metalk8s
     app.kubernetes.io/managed-by: salt
+    metalk8s.scality.com/version: {{ metalk8s_version }}
   annotations:
     metalk8s.scality.com/config-digest: '{{ config_digest }}'
 spec:


### PR DESCRIPTION
**Component**:

'salt', 'build'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

Add version in static manifest
Use `dest_version` on `deploy_node` in downgrade orchestrate

**Summary**:

For upgrade and downgrade we want to know from which version we come.
See dde1aa163c943fc68e0b6118e9a7156712ddee8f for more detail
