### PR TITLE
salt: use `tojson` when splicing in complex structures

### DIFF
--- a/salt/metalk8s/macro.sls
+++ b/salt/metalk8s/macro.sls
@@ -6,7 +6,7 @@
   {%- set package = repo.packages.get(package_name, {}) %}
   metalk8s_package_manager.installed:
     - name: {{ package_name }}
-    - pkgs_info: {{ repo.packages }}
+    - pkgs_info: {{ repo.packages | tojson }}
     {%- if package.version | default(None) %}
     - version: {{ package.version }}
     - hold: True

--- a/salt/metalk8s/repo/installed.sls
+++ b/salt/metalk8s/repo/installed.sls
@@ -50,8 +50,8 @@ Install repositories manifest:
         image: {{ image_fullname }}
         name: {{ repositories_name }}
         version: {{ repositories_version }}
-        archives: {{ archives }}
-        solutions: {{ solutions }}
+        archives: {{ archives | tojson }}
+        solutions: {{ solutions | tojson }}
         package_path: /{{ repo.relative_path }}
         image_path: '/images/'
         nginx_confd_path: {{ repo.config.directory }}

--- a/salt/metalk8s/salt/master/installed.sls
+++ b/salt/metalk8s/salt/master/installed.sls
@@ -31,7 +31,7 @@ Install and start salt master manifest:
     - context:
         image: {{ image_name }}
         version: {{ image_version }}
-        archives: {{ salt.metalk8s.get_archives() }}
+        archives: {{ salt.metalk8s.get_archives() | tojson }}
         salt_ip: "{{ salt_ip }}"
     - require:
       - file: Create salt master directories


### PR DESCRIPTION
Sometimes we use a complex structure as an interpolated value in an SLS
file. Whilst this works, this is merely by accident, and Salt 2019.2
changes the behaviour: complex values would be spliced in using their
`unicode` representation, including `u""` markers.

As such, use a proper `tojson` filter in the Jinja templates instead.

See: #650
See: https://github.com/scality/metalk8s/issues/650
See: https://docs.saltstack.com/en/latest/topics/releases/2019.2.0.html#non-backward-compatible-change-to-yaml-renderer