### PR TITLE
UI: Fix logout problem when changing languages

### DIFF
--- a/ui/cypress/integration/EditLanguage.feature
+++ b/ui/cypress/integration/EditLanguage.feature
@@ -2,3 +2,4 @@ Feature: EditLanguage
    Scenario: EditLanguage
      Given I log in
      Then I change the language by click the dropdown in the narbar
+     Then I log out

--- a/ui/cypress/integration/common/login.js
+++ b/ui/cypress/integration/common/login.js
@@ -34,7 +34,7 @@ Given('I log in', () => {
   };
   cy.wait('@saltAuthentication', timeOut);
 
-  cy.get('.sc-navbar .sc-dropdown > .trigger > .sc-trigger-text').should(
+  cy.get('[data-cy="user_dropdown"] .trigger > .sc-trigger-text').should(
     'contain',
     userName,
   );

--- a/ui/cypress/integration/common/login.js
+++ b/ui/cypress/integration/common/login.js
@@ -1,4 +1,4 @@
-import { Given } from 'cypress-cucumber-preprocessor/steps';
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps';
 
 Given('I log in', () => {
   const target_url = Cypress.env('target_url');
@@ -38,4 +38,12 @@ Given('I log in', () => {
     'contain',
     userName,
   );
+});
+
+Then('I log out', () => {
+  cy.get('[data-cy="user_dropdown"] .trigger > .sc-trigger-text').click();
+  cy.get('[data-cy="logout_button"]').click();
+
+  //Check if we are redirected to the DEX login page
+  cy.location('pathname').should('eq', '/oidc/auth');
 });

--- a/ui/src/containers/App.js
+++ b/ui/src/containers/App.js
@@ -37,7 +37,8 @@ const App = props => {
     dispatch(fetchConfigAction());
     dispatch(setInitialLanguageAction());
     dispatch(initToggleSideBarAction());
-  }, [language, dispatch]);
+    // eslint-disable-next-line
+  }, []);
 
   return api && theme && userManager && isUserLoaded ? (
     <OidcProvider store={store} userManager={userManager}>

--- a/ui/src/containers/Layout.js
+++ b/ui/src/containers/Layout.js
@@ -154,8 +154,13 @@ const Layout = props => {
       type: 'dropdown',
       text: user?.profile?.name,
       icon: <i className="fas fa-user" />,
+      'data-cy': 'user_dropdown',
       items: [
-        { label: intl.translate('log_out'), onClick: event => logout(event) },
+        {
+          label: intl.translate('log_out'),
+          onClick: event => logout(event),
+          'data-cy': 'logout_button',
+        },
       ],
     },
   ];


### PR DESCRIPTION
**Component**:UI

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
- When the French language is set, the logout function doesn't work.

**Summary**:
- When the French language is set in localStorage and the users log in, they have to log in twice because the `fetchConfigAction` is executed twice due to the language state changes. Thus, 2 "user" sessions in the localStorage. When log out, only one user is clear from localStorage. That's why the logout does not work.

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: https://github.com/scality/metalk8s/issues/2148

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
