### PR TITLE
salt: Rename storageClassName to storageClass

### DIFF
--- a/salt/_modules/metalk8s_volumes.py
+++ b/salt/_modules/metalk8s_volumes.py
@@ -226,7 +226,7 @@ class Volume(object):
         if device_info.has_partition:
             raise Exception('backing device `{}` contains a partition table'\
                             .format(self.path))
-        storage_class = self.get('spec.storageClassName')
+        storage_class = self.get('spec.storageClass')
         # If we got a string that means the name wasn't replaced by the object.
         if isinstance(storage_class, basestring):
             raise Exception('StorageClass {} not found'.format(storage_class))

--- a/salt/_pillar/metalk8s_nodes.py
+++ b/salt/_pillar/metalk8s_nodes.py
@@ -134,7 +134,7 @@ def list_volumes(api_client, minion_id):
             volume['spec']['storageClassName'],
             volume['spec']['storageClassName']
         )
-        volume['spec']['storageClassName'] = storageclass
+        volume['spec']['storageClass'] = storageclass
         name = volume['metadata']['name']
         results[name] = volume
 


### PR DESCRIPTION
**Component**:

'salt'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

Keep consistency

**Summary**:

The storageClassName key in the pillars actually contains the entire description
of a storageclass and not just the name. The key name should be reflected as such


**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
