### PR TITLE
salt: add a delay after containerd service start

### DIFF
--- a/salt/metalk8s/container-engine/containerd/configured.sls
+++ b/salt/metalk8s/container-engine/containerd/configured.sls
@@ -7,6 +7,7 @@ Start and enable containerd:
   service.running:
     - name: containerd
     - enable: True
+    - init_delay: 2
     - require:
       - metalk8s_package_manager: Install containerd
     - watch:


### PR DESCRIPTION
**Component**: salt

**Context**: 
Sometimes, this state may fail because we try to inject pause image right after restarting containerd, but the service is not ready yet.

**Summary**:
We wait 2 seconds, before continuing to ensure the service is ready.

**Acceptance criteria**:  Green build

---

Closes: #2170