### PR TITLE
Improvement/2149 documentation access from the ui

### DIFF
--- a/salt/metalk8s/addons/ui/deployed/ui.sls
+++ b/salt/metalk8s/addons/ui/deployed/ui.sls
@@ -39,7 +39,8 @@ Create metalk8s-ui ConfigMap:
               "url": "/api/kubernetes",
               "url_salt": "/api/salt",
               "url_prometheus": "/api/prometheus",
-              "url_grafana": "/grafana"
+              "url_grafana": "/grafana",
+              "url_doc": "/docs"
             }
 
 Create ui-branding ConfigMap:

--- a/ui/cypress/integration/AccessDocumentation.feature
+++ b/ui/cypress/integration/AccessDocumentation.feature
@@ -1,0 +1,4 @@
+Feature: AccessDocumentation
+ Scenario: Access documentation from the Navbar
+     Given I log in
+     Then I can access the documentation from the navbar

--- a/ui/cypress/integration/common/accessDocumentation.js
+++ b/ui/cypress/integration/common/accessDocumentation.js
@@ -1,0 +1,21 @@
+import { Then } from 'cypress-cucumber-preprocessor/steps';
+
+Then('I can access the documentation from the navbar', () => {
+  const target_url = Cypress.env('target_url');
+
+  cy.visit(target_url, {
+    onBeforeLoad(win) {
+      // win is the the remote page's window object
+      // `cy.stub()` stubs the window.open method
+      cy.stub(win, 'open', url => {
+        expect(url).to.have.string('/docs/index.html');
+      });
+    },
+  });
+
+  cy.get('.sc-dropdown')
+    .eq(1)
+    .click();
+
+  cy.get('[data-cy = documentation]').click();
+});

--- a/ui/public/config.json
+++ b/ui/public/config.json
@@ -2,5 +2,6 @@
     "url": "https://{ip}:8443/api/kubernetes",
     "url_salt": "https://{ip}:8443/api/salt",
     "url_prometheus": "https://{ip}:8443/api/prometheus",
-    "url_grafana": "https://{ip}:8443/grafana"
+    "url_grafana": "https://{ip}:8443/grafana",
+    "url_doc": "https://{ip}:8443/docs"
 }

--- a/ui/src/containers/ClusterMonitoring.js
+++ b/ui/src/containers/ClusterMonitoring.js
@@ -89,7 +89,7 @@ const ClusterStatusValue = styled.span`
   }};
 `;
 
-const QuestionMarkIcon = styled.i`
+const InformationMarkIcon = styled.i`
   color: ${props => props.theme.brand.primary};
 `;
 
@@ -222,7 +222,7 @@ const ClusterMonitoring = props => {
               </TooltipContent>
             }
           >
-            <QuestionMarkIcon className="fas fa-question-circle" />
+            <InformationMarkIcon className="fas fa-info-circle" />
           </Tooltip>
           {clusterStatus.isLoading ? <LoaderCoreUI size="small" /> : null}
         </LeftClusterStatusContainer>

--- a/ui/src/containers/CreateVolume.js
+++ b/ui/src/containers/CreateVolume.js
@@ -7,7 +7,7 @@ import { injectIntl } from 'react-intl';
 import styled from 'styled-components';
 import Loader from '../components/Loader';
 import Banner from '../components/Banner';
-import { Input, Button, Breadcrumb } from '@scality/core-ui';
+import { Input, Button, Breadcrumb, Tooltip } from '@scality/core-ui';
 import isEmpty from 'lodash.isempty';
 import {
   fetchStorageClassAction,
@@ -93,7 +93,9 @@ const SizeUnitFieldSelectContainer = styled.div`
 `;
 
 const InputContainer = styled.div`
-  display: inline-flex;
+  /* display: inline-flex; */
+  display: flex;
+  align-items: center;
 `;
 
 const InputLabel = styled.label`
@@ -136,6 +138,14 @@ const LabelsName = styled(LabelsValue)`
   color: ${props => props.theme.brand.text};
 `;
 
+const TooltipContent = styled.div`
+  width: 100px;
+`;
+
+const HelpIcon = styled.div`
+  padding-left: ${padding.small};
+`;
+
 const CreateVolume = props => {
   const { intl } = props;
   const dispatch = useDispatch();
@@ -146,6 +156,7 @@ const CreateVolume = props => {
 
   const storageClass = useSelector(state => state.app.volumes.storageClass);
   const theme = useSelector(state => state.config.theme);
+  const api = useSelector(state => state.config.api);
 
   useEffect(() => {
     dispatch(fetchStorageClassAction());
@@ -263,7 +274,7 @@ const CreateVolume = props => {
               <a
                 rel="noopener noreferrer"
                 target="_blank"
-                href="https://kubernetes.io/docs/concepts/storage/storage-classes/#the-storageclass-resource"
+                href={`${api.url_doc}/operation/volume_management/storageclass_creation.html`}
               >
                 {intl.messages.learn_more}
               </a>
@@ -405,23 +416,46 @@ const CreateVolume = props => {
                       )}
                     </LabelsContainer>
                   </InputContainer>
-                  <Input
-                    id="storageClass_input"
-                    label={intl.messages.storageClass}
-                    clearable={false}
-                    type="select"
-                    options={optionsStorageClasses}
-                    placeholder={intl.messages.select_a_storageClass}
-                    noOptionsMessage={() => intl.messages.no_results}
-                    name="storageClass"
-                    onChange={handleSelectChange('storageClass')}
-                    value={getSelectedObjectItem(
-                      optionsStorageClasses,
-                      values?.storageClass,
-                    )}
-                    error={touched.storageClass && errors.storageClass}
-                    onBlur={handleOnBlur}
-                  />
+                  <InputContainer>
+                    <Input
+                      id="storageClass_input"
+                      label={intl.messages.storageClass}
+                      clearable={false}
+                      type="select"
+                      options={optionsStorageClasses}
+                      placeholder={intl.messages.select_a_storageClass}
+                      noOptionsMessage={() => intl.messages.no_results}
+                      name="storageClass"
+                      onChange={handleSelectChange('storageClass')}
+                      value={getSelectedObjectItem(
+                        optionsStorageClasses,
+                        values?.storageClass,
+                      )}
+                      error={touched.storageClass && errors.storageClass}
+                      onBlur={handleOnBlur}
+                    />
+                    <HelpIcon>
+                      <Tooltip
+                        placement="right"
+                        overlay={
+                          <TooltipContent>
+                            {intl.messages.how_to_create_storage_class}
+                          </TooltipContent>
+                        }
+                      >
+                        <Button
+                          icon={<i className="fas fa-question-circle" />}
+                          inverted={true}
+                          type="button"
+                          onClick={() =>
+                            window.open(
+                              `${api.url_doc}/operation/volume_management/storageclass_creation.html`,
+                            )
+                          }
+                        />
+                      </Tooltip>
+                    </HelpIcon>
+                  </InputContainer>
                   <Input
                     id="type_input"
                     label={intl.messages.type}

--- a/ui/src/containers/CreateVolume.js
+++ b/ui/src/containers/CreateVolume.js
@@ -32,7 +32,7 @@ import { sizeUnits } from '../services/utils';
 
 // We might want to do a factorization later for
 // form styled components
-const CreateVolumeContainer = styled.div`
+const CreateVolumeFormContainer = styled.div`
   display: inline-block;
   height: 100%;
   padding: ${padding.base};
@@ -93,7 +93,6 @@ const SizeUnitFieldSelectContainer = styled.div`
 `;
 
 const InputContainer = styled.div`
-  /* display: inline-flex; */
   display: flex;
   align-items: center;
 `;
@@ -138,12 +137,18 @@ const LabelsName = styled(LabelsValue)`
   color: ${props => props.theme.brand.text};
 `;
 
-const TooltipContent = styled.div`
-  width: 100px;
+const PageContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
 `;
 
-const HelpIcon = styled.div`
-  padding-left: ${padding.small};
+const DocumentationIcon = styled.div`
+  margin: 60px 20px;
+  button {
+    :hover {
+      cursor: pointer;
+    }
+  }
 `;
 
 const CreateVolume = props => {
@@ -244,296 +249,291 @@ const CreateVolume = props => {
   return isStorageClassLoading ? (
     <Loader />
   ) : (
-    <CreateVolumeContainer>
-      <BreadcrumbContainer>
-        <Breadcrumb
-          activeColor={theme.brand.secondary}
-          paths={[
-            <StyledLink to="/nodes">{intl.messages.nodes}</StyledLink>,
-            <StyledLink
-              to={`/nodes/${match.params.id}/volumes`}
-              title={match.params.id}
-            >
-              {match.params.id}
-            </StyledLink>,
-            <BreadcrumbLabel>
-              {intl.messages.create_new_volume}
-            </BreadcrumbLabel>,
-          ]}
-        />
-      </BreadcrumbContainer>
-
-      {isStorageClassExist ? null : (
-        <Banner
-          type={STATUS_BANNER_WARNING}
-          icon={<i className="fas fa-exclamation-triangle" />}
-          title={intl.messages.no_storage_class_found}
-          messages={[
-            <>
-              {intl.messages.storage_class_is_required}
-              <a
-                rel="noopener noreferrer"
-                target="_blank"
-                href={`${api.url_doc}/operation/volume_management/storageclass_creation.html`}
+    <PageContainer>
+      <CreateVolumeFormContainer>
+        <BreadcrumbContainer>
+          <Breadcrumb
+            activeColor={theme.brand.secondary}
+            paths={[
+              <StyledLink to="/nodes">{intl.messages.nodes}</StyledLink>,
+              <StyledLink
+                to={`/nodes/${match.params.id}/volumes`}
+                title={match.params.id}
               >
-                {intl.messages.learn_more}
-              </a>
-            </>,
-          ]}
-        />
-      )}
-      <CreateVolumeLayout>
-        <Formik
-          initialValues={initialValues}
-          validationSchema={validationSchema}
-          onSubmit={values => {
-            const newVolume = { ...values };
-            newVolume.size = `${values.sizeInput}${values.selectedUnit}`;
-            createVolume(newVolume, nodeName);
-          }}
-        >
-          {formikProps => {
-            const {
-              values,
-              handleChange,
-              errors,
-              touched,
-              setFieldTouched,
-              dirty,
-              setFieldValue,
-            } = formikProps;
+                {match.params.id}
+              </StyledLink>,
+              <BreadcrumbLabel>
+                {intl.messages.create_new_volume}
+              </BreadcrumbLabel>,
+            ]}
+          />
+        </BreadcrumbContainer>
 
-            //touched is not "always" correctly set
-            const handleOnBlur = e => setFieldTouched(e.target.name, true);
-            const handleSelectChange = field => selectedObj => {
-              setFieldValue(field, selectedObj ? selectedObj.value : '');
-            };
-            //get the select item from the object array
-            const getSelectedObjectItem = (items, selectedValue) => {
-              return items.find(item => item.value === selectedValue);
-            };
+        {isStorageClassExist ? null : (
+          <Banner
+            type={STATUS_BANNER_WARNING}
+            icon={<i className="fas fa-exclamation-triangle" />}
+            title={intl.messages.no_storage_class_found}
+            messages={[
+              <>
+                {intl.messages.storage_class_is_required}
+                <a
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  href={`${api.url_doc}/operation/volume_management/storageclass_creation.html`}
+                >
+                  {intl.messages.learn_more}
+                </a>
+              </>,
+            ]}
+          />
+        )}
+        <CreateVolumeLayout>
+          <Formik
+            initialValues={initialValues}
+            validationSchema={validationSchema}
+            onSubmit={values => {
+              const newVolume = { ...values };
+              newVolume.size = `${values.sizeInput}${values.selectedUnit}`;
+              createVolume(newVolume, nodeName);
+            }}
+          >
+            {formikProps => {
+              const {
+                values,
+                handleChange,
+                errors,
+                touched,
+                setFieldTouched,
+                dirty,
+                setFieldValue,
+              } = formikProps;
 
-            const addLabel = () => {
-              const labels = values.labels;
-              labels[labelName] = labelValue;
-              setFieldValue('labels', labels);
-              setLabelName('');
-              setLabelValue('');
-            };
-
-            const removeLabel = key => {
-              const labels = values.labels;
-              delete labels[key];
-              setFieldValue('labels', labels);
-            };
-
-            const optionsStorageClasses = storageClassesName.map(SCName => {
-              return {
-                label: SCName,
-                value: SCName,
-                'data-cy': `storageClass-${SCName}`,
+              //touched is not "always" correctly set
+              const handleOnBlur = e => setFieldTouched(e.target.name, true);
+              const handleSelectChange = field => selectedObj => {
+                setFieldValue(field, selectedObj ? selectedObj.value : '');
               };
-            });
-            const optionsTypes = types.map(({ label, value }) => {
-              return {
-                label,
-                value,
-                'data-cy': `type-${value}`,
+              //get the select item from the object array
+              const getSelectedObjectItem = (items, selectedValue) => {
+                return items.find(item => item.value === selectedValue);
               };
-            });
 
-            const optionsSizeUnits = sizeUnits
-              /**
-               * `sizeUnits` have a base 2 and base 10 units
-               * (ie. KiB and KB).
-               * We chose to only display base 2 units
-               * to improve the UX.
-               */
-              .filter((size, idx) => idx < 6)
-              .map(({ label, value }) => {
+              const addLabel = () => {
+                const labels = values.labels;
+                labels[labelName] = labelValue;
+                setFieldValue('labels', labels);
+                setLabelName('');
+                setLabelValue('');
+              };
+
+              const removeLabel = key => {
+                const labels = values.labels;
+                delete labels[key];
+                setFieldValue('labels', labels);
+              };
+
+              const optionsStorageClasses = storageClassesName.map(SCName => {
+                return {
+                  label: SCName,
+                  value: SCName,
+                  'data-cy': `storageClass-${SCName}`,
+                };
+              });
+              const optionsTypes = types.map(({ label, value }) => {
                 return {
                   label,
                   value,
-                  'data-cy': `size-${label}`,
+                  'data-cy': `type-${value}`,
                 };
               });
-            return (
-              <Form>
-                <FormSection>
-                  <Input
-                    name="name"
-                    value={values.name}
-                    onChange={handleChange('name')}
-                    label={intl.messages.name}
-                    error={touched.name && errors.name}
-                    onBlur={handleOnBlur}
-                  />
-                  <InputContainer className="sc-input">
-                    <InputLabel className="sc-input-label">
-                      {intl.messages.labels}
-                    </InputLabel>
-                    <LabelsContainer>
-                      <LabelsForm>
-                        <Input
-                          name="labelName"
-                          placeholder={intl.messages.enter_label_name}
-                          value={labelName}
-                          onChange={e => {
-                            setLabelName(e.target.value);
-                          }}
-                        />
-                        <Input
-                          name="labelValue"
-                          placeholder={intl.messages.enter_label_value}
-                          value={labelValue}
-                          onChange={e => {
-                            setLabelValue(e.target.value);
-                          }}
-                        />
-                        <Button
-                          text={intl.messages.add}
-                          type="button"
-                          onClick={addLabel}
-                          data-cy="add-volume-labels-button"
-                          outlined
-                        />
-                      </LabelsForm>
-                      {!!Object.keys(values.labels).length && (
-                        <LabelsList>
-                          {Object.keys(values.labels).map((key, index) => (
-                            <LabelsKeyValue key={`labelKeyValue_${index}`}>
-                              <LabelsName>{key}</LabelsName>
-                              <LabelsValue>{values.labels[key]}</LabelsValue>
-                              <Button
-                                icon={<i className="fas fa-lg fa-trash" />}
-                                inverted={true}
-                                type="button"
-                                onClick={() => removeLabel(key)}
-                              />
-                            </LabelsKeyValue>
-                          ))}
-                        </LabelsList>
-                      )}
-                    </LabelsContainer>
-                  </InputContainer>
-                  <InputContainer>
+
+              const optionsSizeUnits = sizeUnits
+                /**
+                 * `sizeUnits` have a base 2 and base 10 units
+                 * (ie. KiB and KB).
+                 * We chose to only display base 2 units
+                 * to improve the UX.
+                 */
+                .filter((size, idx) => idx < 6)
+                .map(({ label, value }) => {
+                  return {
+                    label,
+                    value,
+                    'data-cy': `size-${label}`,
+                  };
+                });
+              return (
+                <Form>
+                  <FormSection>
                     <Input
-                      id="storageClass_input"
-                      label={intl.messages.storageClass}
-                      clearable={false}
-                      type="select"
-                      options={optionsStorageClasses}
-                      placeholder={intl.messages.select_a_storageClass}
-                      noOptionsMessage={() => intl.messages.no_results}
-                      name="storageClass"
-                      onChange={handleSelectChange('storageClass')}
-                      value={getSelectedObjectItem(
-                        optionsStorageClasses,
-                        values?.storageClass,
-                      )}
-                      error={touched.storageClass && errors.storageClass}
+                      name="name"
+                      value={values.name}
+                      onChange={handleChange('name')}
+                      label={intl.messages.name}
+                      error={touched.name && errors.name}
                       onBlur={handleOnBlur}
                     />
-                    <HelpIcon>
-                      <Tooltip
-                        placement="right"
-                        overlay={
-                          <TooltipContent>
-                            {intl.messages.how_to_create_storage_class}
-                          </TooltipContent>
-                        }
-                      >
-                        <Button
-                          icon={<i className="fas fa-question-circle" />}
-                          inverted={true}
-                          type="button"
-                          onClick={() =>
-                            window.open(
-                              `${api.url_doc}/operation/volume_management/storageclass_creation.html`,
-                            )
-                          }
-                        />
-                      </Tooltip>
-                    </HelpIcon>
-                  </InputContainer>
-                  <Input
-                    id="type_input"
-                    label={intl.messages.type}
-                    clearable={false}
-                    type="select"
-                    options={optionsTypes}
-                    placeholder={intl.messages.select_a_type}
-                    noOptionsMessage={() => intl.messages.no_results}
-                    name="type"
-                    onChange={handleSelectChange('type')}
-                    value={getSelectedObjectItem(optionsTypes, values?.type)}
-                    error={touched.type && errors.type}
-                    onBlur={handleOnBlur}
-                  />
-                  {values.type === SPARSE_LOOP_DEVICE ? (
-                    <SizeFieldContainer>
+                    <InputContainer className="sc-input">
+                      <InputLabel className="sc-input-label">
+                        {intl.messages.labels}
+                      </InputLabel>
+                      <LabelsContainer>
+                        <LabelsForm>
+                          <Input
+                            name="labelName"
+                            placeholder={intl.messages.enter_label_name}
+                            value={labelName}
+                            onChange={e => {
+                              setLabelName(e.target.value);
+                            }}
+                          />
+                          <Input
+                            name="labelValue"
+                            placeholder={intl.messages.enter_label_value}
+                            value={labelValue}
+                            onChange={e => {
+                              setLabelValue(e.target.value);
+                            }}
+                          />
+                          <Button
+                            text={intl.messages.add}
+                            type="button"
+                            onClick={addLabel}
+                            data-cy="add-volume-labels-button"
+                            outlined
+                          />
+                        </LabelsForm>
+                        {!!Object.keys(values.labels).length && (
+                          <LabelsList>
+                            {Object.keys(values.labels).map((key, index) => (
+                              <LabelsKeyValue key={`labelKeyValue_${index}`}>
+                                <LabelsName>{key}</LabelsName>
+                                <LabelsValue>{values.labels[key]}</LabelsValue>
+                                <Button
+                                  icon={<i className="fas fa-lg fa-trash" />}
+                                  inverted={true}
+                                  type="button"
+                                  onClick={() => removeLabel(key)}
+                                />
+                              </LabelsKeyValue>
+                            ))}
+                          </LabelsList>
+                        )}
+                      </LabelsContainer>
+                    </InputContainer>
+                    <InputContainer>
                       <Input
-                        name="sizeInput"
-                        type="number"
-                        min="1"
-                        value={values.sizeInput}
-                        onChange={handleChange('sizeInput')}
-                        label={intl.messages.volume_size}
-                        error={touched.sizeInput && errors.sizeInput}
+                        id="storageClass_input"
+                        label={intl.messages.storageClass}
+                        clearable={false}
+                        type="select"
+                        options={optionsStorageClasses}
+                        placeholder={intl.messages.select_a_storageClass}
+                        noOptionsMessage={() => intl.messages.no_results}
+                        name="storageClass"
+                        onChange={handleSelectChange('storageClass')}
+                        value={getSelectedObjectItem(
+                          optionsStorageClasses,
+                          values?.storageClass,
+                        )}
+                        error={touched.storageClass && errors.storageClass}
                         onBlur={handleOnBlur}
                       />
-                      <SizeUnitFieldSelectContainer>
-                        <Input
-                          id="unit_input"
-                          label=""
-                          clearable={false}
-                          type="select"
-                          options={optionsSizeUnits}
-                          noOptionsMessage={() => intl.messages.no_results}
-                          name="selectedUnit"
-                          onChange={handleSelectChange('selectedUnit')}
-                          value={getSelectedObjectItem(
-                            optionsSizeUnits,
-                            values?.selectedUnit,
-                          )}
-                          error={touched.selectedUnit && errors.selectedUnit}
-                          onBlur={handleOnBlur}
-                        />
-                      </SizeUnitFieldSelectContainer>
-                    </SizeFieldContainer>
-                  ) : (
+                    </InputContainer>
                     <Input
-                      name="path"
-                      value={values.path}
-                      onChange={handleChange('path')}
-                      label={intl.messages.device_path}
-                      error={touched.path && errors.path}
+                      id="type_input"
+                      label={intl.messages.type}
+                      clearable={false}
+                      type="select"
+                      options={optionsTypes}
+                      placeholder={intl.messages.select_a_type}
+                      noOptionsMessage={() => intl.messages.no_results}
+                      name="type"
+                      onChange={handleSelectChange('type')}
+                      value={getSelectedObjectItem(optionsTypes, values?.type)}
+                      error={touched.type && errors.type}
                       onBlur={handleOnBlur}
                     />
-                  )}
-                </FormSection>
-                <ActionContainer>
-                  <Button
-                    text={intl.messages.cancel}
-                    type="button"
-                    outlined
-                    onClick={() =>
-                      history.push(`/nodes/${match.params.id}/volumes`)
-                    }
-                  />
-                  <Button
-                    text={intl.messages.create}
-                    type="submit"
-                    disabled={!dirty || !isEmpty(errors)}
-                    data-cy="submit-create-volume"
-                  />
-                </ActionContainer>
-              </Form>
-            );
-          }}
-        </Formik>
-      </CreateVolumeLayout>
-    </CreateVolumeContainer>
+                    {values.type === SPARSE_LOOP_DEVICE ? (
+                      <SizeFieldContainer>
+                        <Input
+                          name="sizeInput"
+                          type="number"
+                          min="1"
+                          value={values.sizeInput}
+                          onChange={handleChange('sizeInput')}
+                          label={intl.messages.volume_size}
+                          error={touched.sizeInput && errors.sizeInput}
+                          onBlur={handleOnBlur}
+                        />
+                        <SizeUnitFieldSelectContainer>
+                          <Input
+                            id="unit_input"
+                            label=""
+                            clearable={false}
+                            type="select"
+                            options={optionsSizeUnits}
+                            noOptionsMessage={() => intl.messages.no_results}
+                            name="selectedUnit"
+                            onChange={handleSelectChange('selectedUnit')}
+                            value={getSelectedObjectItem(
+                              optionsSizeUnits,
+                              values?.selectedUnit,
+                            )}
+                            error={touched.selectedUnit && errors.selectedUnit}
+                            onBlur={handleOnBlur}
+                          />
+                        </SizeUnitFieldSelectContainer>
+                      </SizeFieldContainer>
+                    ) : (
+                      <Input
+                        name="path"
+                        value={values.path}
+                        onChange={handleChange('path')}
+                        label={intl.messages.device_path}
+                        error={touched.path && errors.path}
+                        onBlur={handleOnBlur}
+                      />
+                    )}
+                  </FormSection>
+                  <ActionContainer>
+                    <Button
+                      text={intl.messages.cancel}
+                      type="button"
+                      outlined
+                      onClick={() =>
+                        history.push(`/nodes/${match.params.id}/volumes`)
+                      }
+                    />
+                    <Button
+                      text={intl.messages.create}
+                      type="submit"
+                      disabled={!dirty || !isEmpty(errors)}
+                      data-cy="submit-create-volume"
+                    />
+                  </ActionContainer>
+                </Form>
+              );
+            }}
+          </Formik>
+        </CreateVolumeLayout>
+      </CreateVolumeFormContainer>
+      <DocumentationIcon>
+        <Tooltip placement="left" overlay={intl.messages.documentation}>
+          <Button
+            icon={<i className="fas fa-book-reader fa-lg" />}
+            inverted={true}
+            type="button"
+            onClick={() =>
+              window.open(
+                `${api.url_doc}/operation/volume_management/volume_creation_deletion_gui.html#volume-creation`,
+              )
+            }
+          />
+        </Tooltip>
+      </DocumentationIcon>
+    </PageContainer>
   );
 };
 

--- a/ui/src/containers/Layout.js
+++ b/ui/src/containers/Layout.js
@@ -63,6 +63,7 @@ const Layout = props => {
       onClick: () => {
         window.open(`${api.url_doc}/index.html`);
       },
+      'data-cy': 'documentation',
     },
   ];
 

--- a/ui/src/containers/Layout.js
+++ b/ui/src/containers/Layout.js
@@ -45,7 +45,7 @@ const Layout = props => {
   const toggleSidebar = () => dispatch(toggleSideBarAction());
   const { intl } = props;
   const history = useHistory();
-
+  const api = useSelector(state => state.config.api);
   useRefreshEffect(refreshSolutionsAction, stopRefreshSolutionsAction);
   useEffect(() => {
     dispatch(fetchClusterVersionAction());
@@ -56,6 +56,12 @@ const Layout = props => {
       label: intl.messages.about,
       onClick: () => {
         history.push('/about');
+      },
+    },
+    {
+      label: intl.messages.documentation,
+      onClick: () => {
+        window.open(`${api.url_doc}/index.html`);
       },
     },
   ];

--- a/ui/src/containers/NodeVolumes.js
+++ b/ui/src/containers/NodeVolumes.js
@@ -87,10 +87,6 @@ const LoaderContainer = styled(Loader)`
   padding-right: ${padding.smaller};
 `;
 
-const TooltipContent = styled.div`
-  background-color: ${props => props.theme.brand.backgroundContrast2};
-`;
-
 const NodeVolumes = props => {
   const { intl } = props;
   const dispatch = useDispatch();
@@ -202,10 +198,7 @@ const NodeVolumes = props => {
 
         return (
           <>
-            <Tooltip
-              placement="top"
-              overlay={<TooltipContent>{hintPopup()}</TooltipContent>}
-            >
+            <Tooltip placement="bottom" overlay={hintPopup()}>
               <Button
                 className="remove-volume-button"
                 onClick={e => {

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -131,7 +131,8 @@
   "enter_label_name": "Enter label name",
   "enter_label_value": "Enter label value",
   "value": "Value",
-  "prometheus_not_available":"Prometheus is not available.",
-  "please_refer_to":"Please refer to",
-  "import_solution_hint":"You should import a solution to prepare your environment"
+  "prometheus_not_available": "Prometheus is not available.",
+  "please_refer_to": "Please refer to",
+  "import_solution_hint": "You should import a solution to prepare your environment",
+  "documentation": "Documentation"
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -132,6 +132,7 @@
   "enter_label_value": "Saisir la valeur du label",
   "value": "Valeur",
   "prometheus_not_available":"Prometheus n'est pas disponible.",
-  "please_refer_to":"Veuillez vous référer à",
-  "import_solution_hint":"Vous devez importer une solution pour préparer votre environnement"
+  "please_refer_to": "Veuillez vous référer à",
+  "import_solution_hint": "Vous devez importer une solution pour préparer votre environnement",
+  "documentation": "Documentation"
 }


### PR DESCRIPTION
**Component**: ui, doc

**Context**: 
We would like to access the doc from UI.

**Summary**:
- Add the documentation entry point from the Navbar 
- Add the link in the volume creation page
- Change the icon in clusterMonistering page ( question icon => infomation icon)
- Fix bugs for create volume list 

**Acceptance criteria**: 
Add the link in the volume creation page and add the documentation entry point from the Navbar:

![image](https://user-images.githubusercontent.com/18453133/71962977-f5952a00-31fa-11ea-95c7-8a83c72de495.png)

- should pass the cypress test:
`./node_modules/cypress/bin/cypress run -b chrome -s cypress/integration/AccessDocumentation.feature`

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2149 

The integration branch in 2.5 is:
 `w/2.5/improvement/2149-documentation-access-from-the-UI`
