### PR TITLE
build: Add custom grafana build image with plugins installed

### DIFF
--- a/buildchain/buildchain/image.py
+++ b/buildchain/buildchain/image.py
@@ -180,9 +180,6 @@ IMGS_PER_REPOSITORY : Dict[str, List[str]] = {
         'kube-scheduler',
         'nginx-ingress-defaultbackend-amd64',
     ],
-    constants.GRAFANA_REPOSITORY: [
-        'grafana',
-    ],
     constants.INGRESS_REPOSITORY: [
         'nginx-ingress-controller',
     ],
@@ -217,6 +214,10 @@ for repo, images in IMGS_PER_REPOSITORY.items():
 # }}}
 # Container images to build {{{
 TO_BUILD : Tuple[targets.LocalImage, ...] = (
+    _local_image(
+        name='grafana',
+        build_args={'GRAFANA_IMAGE_VERSION': versions.GRAFANA_IMAGE_VERSION},
+    ),
     _local_image(
         name='salt-master',
         build_args={'SALT_VERSION': versions.SALT_VERSION},

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -57,8 +57,9 @@ CENTOS_BASE_IMAGE : str = 'docker.io/centos'
 CENTOS_BASE_IMAGE_SHA256 : str = \
     '6ae4cddb2b37f889afd576a17a5286b311dcbf10a904409670827f6f9b50065e'
 
-NGINX_IMAGE_VERSION  : str = '1.15.8'
-NODEJS_IMAGE_VERSION : str = '10.16.0'
+GRAFANA_IMAGE_VERSION : str = '6.4.2'
+NGINX_IMAGE_VERSION   : str = '1.15.8'
+NODEJS_IMAGE_VERSION  : str = '10.16.0'
 
 # Current build IDs, to be augmented whenever we rebuild the corresponding
 # image, e.g. because the `Dockerfile` is changed, or one of the dependencies
@@ -105,11 +106,6 @@ CONTAINER_IMAGES : Tuple[Image, ...] = (
         name='etcd',
         version='3.3.10',
         digest='sha256:17da501f5d2a675be46040422a27b7cc21b8a43895ac998b171db1c346f361f7',
-    ),
-    Image(
-        name='grafana',
-        version='6.4.2',
-        digest='sha256:8c2238eea9d3d39aeb6174db2e30b233fd2546128ec1fa1bc64f8058afd51e68',
     ),
     Image(
         name='k8s-sidecar',
@@ -187,6 +183,11 @@ CONTAINER_IMAGES : Tuple[Image, ...] = (
         digest='sha256:ed3ec0597c2d5b7102a7f62c661a23d8e4b34d910693fc23fd40bfb1d9404dcf',
     ),
     # Local images
+    Image(
+        name='grafana',
+        version=GRAFANA_IMAGE_VERSION,
+        digest=None,
+    ),
     Image(
         name='metalk8s-ui',
         version=VERSION,

--- a/images/grafana/Dockerfile
+++ b/images/grafana/Dockerfile
@@ -1,0 +1,12 @@
+ARG GRAFANA_IMAGE_VERSION=6.4.2
+
+FROM grafana/grafana:${GRAFANA_IMAGE_VERSION}
+
+# cannot install plugin to /var/lib/grafana since it will be overwritten
+# For more about this see https://community.grafana.com/t/install-plugin-from-dockerfile/2603/5
+RUN mkdir -p /home/grafana/plugin && chown -R grafana:grafana /home/grafana/plugin
+
+# set new plugin path
+ENV GF_PATHS_PLUGINS=/home/grafana/plugin
+
+RUN grafana-cli --pluginsDir /home/grafana/plugin plugins install grafana-piechart-panel

--- a/images/grafana/README.md
+++ b/images/grafana/README.md
@@ -1,0 +1,23 @@
+Build grafana image
+===================
+
+WHY?
+====
+
+After updating prometheus-operator charts to version 8.1.2, the
+grafana-piechart-panel is not packaged with the upstream Grafana image and
+hence Kubernetes Networking  dashboards cannot display stats.
+
+The best alternative was to contribute upstream, but it seems future releases
+of the charts will come with Grafana 6.5.0 with the plugin issue already
+solved.
+
+In our best interest to release Metalk8s-2.4.2 with working dashboards,
+we resolve to building our own custom Grafana 6.4.2 with the plugin already
+installed.
+
+Note:
+=====
+
+This custom build will be reverted once the Prometheus-operator charts is
+updated some time in future.


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
'build', 'grafana'

**Context**: 

See #2175 

**Summary**:

Chart upgrade for prometheus-operator version 8.1.2 breaks the kubernetes-networking-workload dashboard due to a missing plugin.
Currently, the issue exist upstream and one is optimistic that future chart releases will fix the issue since Grafana will be upgraded from 6.4.2 to 6.5.0.

**Note:** This fix is put in place to have full working Grafana dashboards prior to Metalk8s-2.4.2 release. This commit should be reverted once a new prometheus-operator chart is released.

**Acceptance criteria**: 

- Working grafana-piechart-panel plugin
- The kubernetes-networking-workload  dashboard should display stats

![piechart_with_plugin_installed](https://user-images.githubusercontent.com/10956602/71917430-59c6d800-3180-11ea-8a3e-58bd75287fec.png)

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2175

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
