### PR TITLE
Add link to build requirements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ An opinionated Kubernetes distribution with a focus on long-term on-prem deploym
 
 ## Building
 
+Prerequisites are listed [here](docs/developer/building/requirements.rst).
+
 To build a MetalK8s ISO, simply type `./doit.sh`.
 
 For more information, please refers to developer documentation.


### PR DESCRIPTION
**Component**:

documentation

**Context**: 

With the current README people will try to build an ISO by running doit right away (as we suggest) and it will likely fail because of some missing requirement and people will have no clue on what to do next because there is no mention nor link of those build requirements here.

**Summary**:

In the README, add a link to the part of the documentation that lists the build requirements.