### PR TITLE
Fix unclear error reported from bootstrap.sh

### DIFF
--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -9,6 +9,7 @@ if test -z "$(type -p)"; then set -o pipefail; fi
 
 VERBOSE=${VERBOSE:-0}
 LOGFILE=/var/log/metalk8s/bootstrap.log
+CONFIG_FILEPATH=/etc/metalk8s/bootstrap.yaml
 
 if ! options=$(getopt --options v --long verbose,log-file: -- "$@"); then
     echo 1>&2 "Incorrect arguments provided"
@@ -150,8 +151,19 @@ orchestrate_bootstrap() {
         "$SALT_CALL" mine.update
 }
 
+
+bootstrap_file_is_present() {
+    if [ ! -f "$CONFIG_FILEPATH" ]; then
+        die "You need to create a BootstrapConfiguration file, at $CONFIG_FILEPATH." \
+            "Please refer to the configuration section of the MetalK8s Installation Guide"
+        return 1
+    fi
+}
+
+
 main() {
     run "Determine the OS" determine_os
+    run "Checking that BootstrapConfiguration is present" bootstrap_file_is_present
     run "Pre-minion system tests" pre_minion_checks
     run "Configure internal repositories" configure_repositories
     run "Check mandatory packages presence" check_packages_presence


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
'Bootstrap', 'Bash'

**Context**: 

See #2150 

**Summary**:

Initially, running the bootstrap script without the Bootstrap.yaml
configuration file results to unclear errors(Exception caught loading ext_pillar).

Also if we run the bootstrap script when the bootstrap.yaml file does not have appropriate configurations we also notice this unclear situation.


**Acceptance criteria**: 

We should end up with usable errors like below


```
local:
    Data failed to compile:
----------
    Pillar failed to render with the following messages:
----------
    Expected value 'BootstrapConfiguration' for key 'kind', got 'None'
<< END >>

This script will now exit


```

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2150

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
