### PR TITLE
build/debian: Fix Saltstack repository URL

### DIFF
--- a/packages/debian/download_packages.py
+++ b/packages/debian/download_packages.py
@@ -98,8 +98,6 @@ def fetch_binary(
 
 def add_external_repositories(salt_version: str) -> None:
     """Register Salt and Kubernetes repository."""
-    # Only keep the major and minor version number.
-    salt_version = '.'.join(salt_version.split('.')[:2])
     # TODO: move these static info in `versions.py`.
     repositories = [
         {
@@ -110,13 +108,13 @@ def add_external_repositories(salt_version: str) -> None:
         }, {
             'name': 'saltstack',
             'key': urllib.parse.urljoin(
-                'https://repo.saltstack.com/',
-                'apt/ubuntu/18.04/amd64/{}/SALTSTACK-GPG-KEY.pub'.format(
+                'https://repo.saltstack.com/apt/ubuntu/',
+                '18.04/amd64/archive/{}/SALTSTACK-GPG-KEY.pub'.format(
                     salt_version
                 )
             ),
             'source': 'deb http://repo.saltstack.com/apt/ubuntu/'\
-                      '18.04/amd64/{} bionic main'.format(salt_version)
+                      '18.04/amd64/archive/{} bionic main'.format(salt_version)
         }
     ]
     for repo in repositories:


### PR DESCRIPTION
We pin an old version of Saltstack to use in our product. This version
is no longer available on the "main" repo domain, but instead under the
"archive" domain. URL thus need to change, though only for Debian (as we
already used the "archive" domain for RedHat).

---

**NB:** this currently prevents any CI run for 2.4 or 2.5 from passing the `build` stage.