### PR TITLE
tests: Use nodename instead of hostname to compute pod name

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,19 @@ def hostname(host):
 
 
 @pytest.fixture(scope="module")
+def nodename(host):
+    """Return the kubernetes node name of the `host`
+
+    Node name need to be equal to the salt minion id so just retrieve the
+    salt minion id
+    """
+    with host.sudo():
+        return host.check_output(
+            'salt-call --local --out txt grains.get id | cut -c 8-'
+        )
+
+
+@pytest.fixture(scope="module")
 def kubeconfig_data(request, host):
     """Fixture to generate a kubeconfig file for remote usage."""
     with host.sudo():

--- a/tests/kube_utils.py
+++ b/tests/kube_utils.py
@@ -20,7 +20,7 @@ def get_pods(
         field_selector.append('status.phase={}'.format(state))
 
     if node:
-        nodename = utils.resolve_hostname(node, ssh_config)
+        nodename = utils.get_node_name(node, ssh_config)
         field_selector.append('spec.nodeName={}'.format(nodename))
 
     kwargs = {}

--- a/tests/post/steps/test_static_pods.py
+++ b/tests/post/steps/test_static_pods.py
@@ -48,7 +48,7 @@ def test_static_pods_restart(host, transient_files):
 
 @given("I have set up a static pod", target_fixture="static_pod_id")
 def set_up_static_pod(
-    host, hostname, k8s_client, utils_image, transient_files
+    host, nodename, k8s_client, utils_image, transient_files
 ):
     manifest_path = str(MANIFESTS_PATH / "{}.yaml".format(DEFAULT_POD_NAME))
 
@@ -102,7 +102,7 @@ def set_up_static_pod(
     # See: https://github.com/kubernetes/kubernetes/issues/65825
     transient_files.insert(0, manifest_path)
 
-    fullname = "{}-{}".format(DEFAULT_POD_NAME, hostname)
+    fullname = "{}-{}".format(DEFAULT_POD_NAME, nodename)
 
     utils.retry(
         kube_utils.wait_for_pod(k8s_client, fullname),
@@ -137,8 +137,8 @@ def manage_static_pod(host):
 
 
 @then("the static pod was changed")
-def check_static_pod_changed(host, hostname, k8s_client, static_pod_id):
-    fullname = "{}-{}".format(DEFAULT_POD_NAME, hostname)
+def check_static_pod_changed(host, nodename, k8s_client, static_pod_id):
+    fullname = "{}-{}".format(DEFAULT_POD_NAME, nodename)
 
     wait_for_pod = kube_utils.wait_for_pod(
         k8s_client,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -52,11 +52,12 @@ def get_ip_from_cidr(host, cidr):
     return None
 
 
-def resolve_hostname(nodename, ssh_config):
-    """Resolve a node name (from SSH config) to a real hostname."""
+def get_node_name(nodename, ssh_config=None):
+    """Get a node name (from SSH config)."""
     if ssh_config is not None:
         node = testinfra.get_host(nodename, ssh_config=ssh_config)
-        nodename = node.check_output('hostname')
-    else:
-        assert nodename == 'bootstrap'
+        with node.sudo():
+            return node.check_output(
+                'salt-call --local --out txt grains.get id | cut -c 8-'
+            )
     return nodename


### PR DESCRIPTION
**Component**:

'tests'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

We still use hostname in our test which is wrong

**Summary**:

Since we can deploy nodes using a node name different from the hostname,
pod deployed can have a name that does no contain the hostname

**Acceptance criteria**: 

Green build

---
