### PR TITLE
salt: fix unsafe approach for etcd `initial-cluster-state

### DIFF
--- a/salt/metalk8s/orchestrate/bootstrap/init.sls
+++ b/salt/metalk8s/orchestrate/bootstrap/init.sls
@@ -30,6 +30,7 @@
 
 {%- set pillar_data = {
         'bootstrap_id': pillar.bootstrap_id,
+        'is_bootstrap': True,
         'metalk8s': {
             'nodes': {
                 pillar.bootstrap_id: {


### PR DESCRIPTION
**Component**:
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
'salt', 'bootstrap'

**Context**: 

See #2102 

**Summary**:

This PR ensures that we set the etcd initial cluster state to `existing` by default and then override this value only during a Bootstrap orchestration.

We also ensure to raise an error when the etcd member list is empty because If all nodes are unavailable we should never set the cluster state to `new`

**Acceptance criteria**: 

Etcd deployment should be resilient.
---
<!-- Declare one or more issues to close once this PR gets merged -->
Closes: #2102 
<!-- If you want to refer to an issue while not closing it, use:
See: #ISSUE_NUMBER
-->