### PR TITLE
eve: Use minion id by default instead of hostname for create volume

### DIFF
--- a/eve/create-volumes.sh
+++ b/eve/create-volumes.sh
@@ -37,7 +37,7 @@ check_pod_is_in_phase() {
     [[ $phase = "$expected_phase" ]]
 }
 
-BOOTSTRAP_NODE_NAME=${BOOTSTRAP_NODE_NAME:-$(hostname)}
+BOOTSTRAP_NODE_NAME=${BOOTSTRAP_NODE_NAME:-$(salt-call --local --out txt grains.get id | cut -c 8-)}
 PRODUCT_TXT=${PRODUCT_TXT:-/vagrant/_build/root/product.txt}
 MAX_TRIES=300
 


### PR DESCRIPTION
**Component**:

'build'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

Node name can be different from hostname

**Summary**:

In create-volume.sh we need to get the node name since we no longer use
hostname as nodename we need to always take salt minion id

---


