### PR TITLE
salt: repositories listen on control plane IP

### DIFF
--- a/salt/metalk8s/repo/configured.sls
+++ b/salt/metalk8s/repo/configured.sls
@@ -13,6 +13,7 @@ Generate repositories nginx configuration:
     - makedirs: true
     - backup: false
     - defaults:
+        listening_address: {{ grains.metalk8s.control_plane_ip }}
         listening_port: {{ repo.port }}
 
 Deploy common container registry nginx configuration:

--- a/salt/metalk8s/repo/files/nginx.conf.j2
+++ b/salt/metalk8s/repo/files/nginx.conf.j2
@@ -1,5 +1,5 @@
 server {
-    listen       {{ listening_port }};
+    listen       {{ listening_address }}:{{ listening_port }};
     server_name  localhost;
 
     location / {

--- a/salt/metalk8s/repo/files/repositories-manifest.yaml.j2
+++ b/salt/metalk8s/repo/files/repositories-manifest.yaml.j2
@@ -33,12 +33,12 @@ spec:
           protocol: TCP
       livenessProbe:
         httpGet:
-          host: localhost
+          host: {{ probe_host }}
           port: http
           path: /
       readinessProbe:
         httpGet:
-          host: localhost
+          host: {{ probe_host }}
           port: http
           path: /
       volumeMounts:

--- a/salt/metalk8s/repo/installed.sls
+++ b/salt/metalk8s/repo/installed.sls
@@ -55,6 +55,7 @@ Install repositories manifest:
         package_path: /{{ repo.relative_path }}
         image_path: '/images/'
         nginx_confd_path: {{ repo.config.directory }}
+        probe_host: {{ grains.metalk8s.control_plane_ip }}
     - require:
       - containerd: Inject nginx image
       - file: Generate repositories nginx configuration
@@ -83,7 +84,8 @@ Ensure repositories container is up:
 
 Wait for Repositories container to answer:
   http.wait_for_successful_query:
-   - name: http://127.0.0.1:{{ repo.port }}/{{ saltenv }}/
+   - name: http://{{ grains.metalk8s.control_plane_ip }}:{{
+     repo.port }}/{{ saltenv }}/
    - status: 200
    - require:
      - module: Ensure repositories container is up


### PR DESCRIPTION
**Component**: salt

**Context**:
nginx used to serve repositories listens on 0.0.0.0

**Summary**:
In Nginx configuration we now listen only on control plane IP, rather than listening on all host addresses.
Also adapt readiness and liveness probes host of the container to reflect this change.

**Acceptance criteria**: Green build & after bootstrap, repositories listen only on control plane IP

---

Closes: #2165