### PR TITLE
build: upgrade pip version prior to install package

### DIFF
--- a/images/salt-master/Dockerfile
+++ b/images/salt-master/Dockerfile
@@ -26,6 +26,7 @@ gpgkey=https://repo.saltstack.com/yum/redhat/\$releasever/\$basearch/archive/%s/
  && yum install -y python2-kubernetes salt-master salt-api salt-ssh openssh-clients \
  && yum install -y python-pip \
  && yum clean all \
+ && pip install pip==20.0.2 \
  && pip install etcd3 \
  && chmod +x /tini
 


### PR DESCRIPTION
**Component**: build

**Context**: 
The pip version shipped in this dist is very old 8.1.2 (2016-05-10), which prevented us from using it to install etcd client and its dependencies.

**Summary**:
We now use the latest pip version available.

**Acceptance criteria**: we can build salt-master image 

---

Closes: #2220