### PR TITLE
Fix doit clean

### DIFF
--- a/buildchain/buildchain/builder.py
+++ b/buildchain/buildchain/builder.py
@@ -34,7 +34,7 @@ def _builder_image(
         They are passed to `LocalImage` init method.
     """
     img_name = '{}-{}-builder'.format(config.PROJECT_NAME.lower(), name)
-    kwargs.setdefault('task_dep', ['_build_root'])
+    kwargs.setdefault('task_dep', []).append('_build_root')
 
     return LocalImage(
         name=img_name,

--- a/buildchain/buildchain/docs.py
+++ b/buildchain/buildchain/docs.py
@@ -70,9 +70,14 @@ def task__doc_mkdir_iso_root() -> types.TaskDict:
 
 def task__doc_mkdir_build_root() -> types.TaskDict:
     """Create the documentation build root directory."""
-    return targets.Mkdir(
+    def clean_doctrees() -> None:
+        coreutils.rm_rf(constants.DOCS_BUILD_ROOT/'doctrees')
+
+    task = targets.Mkdir(
         directory=constants.DOCS_BUILD_ROOT, task_dep=['_build_root']
     ).task
+    task['clean'] = [clean_doctrees, doit.task.clean_targets]
+    return task
 
 
 def task__doc_deploy() -> types.TaskDict:

--- a/buildchain/buildchain/image.py
+++ b/buildchain/buildchain/image.py
@@ -109,7 +109,7 @@ def _remote_image(
     constants to add some arguments.
     """
     overrides.setdefault('destination', constants.ISO_IMAGE_ROOT)
-    overrides.setdefault('task_dep', ['_image_mkdir_root'])
+    overrides.setdefault('task_dep', []).append('_image_mkdir_root')
 
     image_info = _get_image_info(name)
     kwargs = dict(image_info._asdict(), repository=repository,
@@ -131,7 +131,7 @@ def _local_image(name: str, **kwargs: Any) -> targets.LocalImage:
     kwargs.setdefault('destination', constants.ISO_IMAGE_ROOT)
     kwargs.setdefault('dockerfile', constants.ROOT/'images'/name/'Dockerfile')
     kwargs.setdefault('save_on_disk', True)
-    kwargs.setdefault('task_dep', ['_image_mkdir_root'])
+    kwargs.setdefault('task_dep', []).append('_image_mkdir_root')
 
     return targets.LocalImage(
         name=name,
@@ -144,7 +144,7 @@ def _operator_image(name: str, **kwargs: Any) -> targets.OperatorImage:
     image_info = _get_image_info(name)
 
     kwargs.setdefault('destination', constants.ISO_IMAGE_ROOT)
-    kwargs.setdefault('task_dep', ['_image_mkdir_root'])
+    kwargs.setdefault('task_dep', []).append('_image_mkdir_root')
 
     return targets.OperatorImage(
         name=name,

--- a/buildchain/buildchain/packaging.py
+++ b/buildchain/buildchain/packaging.py
@@ -178,7 +178,6 @@ def task__download_deb_packages() -> types.TaskDict:
                 continue
             coreutils.rm_rf(repository.pkgdir)
         utils.unlink_if_exist(witness)
-        constants.REPO_DEB_ROOT.rmdir()
 
     def mkdirs() -> None:
         """Create directories for the repositories."""

--- a/buildchain/buildchain/targets/directory.py
+++ b/buildchain/buildchain/targets/directory.py
@@ -4,9 +4,8 @@
 """Provides operations on directories."""
 
 
-from os import umask
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 from buildchain import types
 from buildchain import utils
@@ -17,19 +16,16 @@ from . import base
 class Mkdir(base.AtomicTarget):
     """Create a directory."""
 
-    def __init__(self, directory: Path, user_mask: Optional[int] = None,
-                 **kwargs: Any):
+    def __init__(self, directory: Path, **kwargs: Any):
         """Initialize with the target directory.
 
         Arguments:
             directory: path to the directory to create
-            user_mask: user mask to apply for directory mode
 
         Keyword Arguments:
             They are passed to `Target` init method.
         """
         kwargs['targets'] = [directory]
-        self._umask = user_mask
         super().__init__(**kwargs)
 
     @property
@@ -37,15 +33,11 @@ class Mkdir(base.AtomicTarget):
         task = self.basic_task
         task.update({
             'title': utils.title_with_target1('MKDIR'),
-            'actions': [(self._run, [task['targets'][0], self._umask])],
+            'actions': [(self._run, [task['targets'][0]])],
             'uptodate': [True],
         })
         return task
 
     @staticmethod
-    def _run(directory: Path, user_mask: Optional[int] = None) -> None:
-        if user_mask is not None:
-            prev_umask = umask(user_mask)
+    def _run(directory: Path) -> None:
         directory.mkdir(exist_ok=True)
-        if user_mask is not None:
-            umask(prev_umask)

--- a/buildchain/buildchain/targets/local_image.py
+++ b/buildchain/buildchain/targets/local_image.py
@@ -188,7 +188,8 @@ class LocalImage(image.ContainerImage):
         """Build a container image locally."""
         actions: List[types.Action] = [self.check_dockerfile_dependencies]
         actions.extend(self._do_build())
-        actions.extend(self._do_save())
+        if self.save_on_disk:
+            actions.extend(self._do_save())
         return actions
 
     def _do_build(self) -> List[types.Action]:
@@ -197,10 +198,6 @@ class LocalImage(image.ContainerImage):
 
     def _do_save(self) -> List[types.Action]:
         """Return the actions used to save the image."""
-        if not self.save_on_disk:
-            # If we don't save the image, at least we touch a file
-            # (to keep track of the build).
-            return [(coreutils.touch, [self.dest_dir/self.tag], {})]
         # If a destination is defined, let's save the image there.
         cmd = [
             config.ExtCommand.SKOPEO.value, '--override-os', 'linux',

--- a/buildchain/buildchain/ui.py
+++ b/buildchain/buildchain/ui.py
@@ -67,6 +67,7 @@ def task__ui_build() -> types.TaskDict:
         'title': utils.title_with_target1('NPM BUILD'),
         'task_dep': [
             '_build_builder:{}'.format(builder.UI_BUILDER.name),
+            '_ui_mkdir_build_root',
         ],
         'file_dep': list(utils.git_ls('ui')),
         'targets': [constants.UI_BUILD_ROOT/'index.html'],

--- a/buildchain/buildchain/ui.py
+++ b/buildchain/buildchain/ui.py
@@ -36,11 +36,12 @@ def task_ui() -> types.TaskDict:
 
 def task__ui_mkdir_build_root() -> types.TaskDict:
     """Create the MetalK8s UI build root directory."""
-    return targets.Mkdir(
-        directory=constants.UI_BUILD_ROOT,
-        user_mask=0o000,  # node user needs to be able to write in this folder
-        task_dep=['_build_root'],
+    task = targets.Mkdir(
+        directory=constants.UI_BUILD_ROOT, task_dep=['_build_root'],
     ).task
+    # `node` user in the container needs to be able to write in this folder.
+    task['actions'].append(lambda: constants.UI_BUILD_ROOT.chmod(0o777))
+    return task
 
 
 def task__ui_build() -> types.TaskDict:

--- a/buildchain/buildchain/ui.py
+++ b/buildchain/buildchain/ui.py
@@ -46,24 +46,10 @@ def task__ui_mkdir_build_root() -> types.TaskDict:
 def task__ui_build() -> types.TaskDict:
     """Build the MetalK8s UI NodeJS code."""
     def clean() -> None:
-        coreutils.rm_rf(constants.UI_BUILD_ROOT)
-
-    build_ui = docker_command.DockerRun(
-        builder=builder.UI_BUILDER,
-        command=['/entrypoint.sh'],
-        run_config=docker_command.default_run_config(
-            constants.ROOT/'ui'/'entrypoint.sh'
-        ),
-        mounts=[
-            utils.bind_mount(
-                target=Path('/home/node/build'),
-                source=constants.UI_BUILD_ROOT,
-            ),
-        ],
-    )
+        run_ui_builder('clean')()
 
     return {
-        'actions': [build_ui],
+        'actions': [run_ui_builder('build')],
         'title': utils.title_with_target1('NPM BUILD'),
         'task_dep': [
             '_build_builder:{}'.format(builder.UI_BUILDER.name),
@@ -88,6 +74,23 @@ def task__ui_config() -> types.TaskDict:
         'file_dep': [source],
         'clean': True,
     }
+
+
+def run_ui_builder(cmd: str) -> docker_command.DockerRun:
+    """Return a DockerRun instance of the UI builder for the given command."""
+    return docker_command.DockerRun(
+        builder=builder.UI_BUILDER,
+        command=['/entrypoint.sh', cmd],
+        run_config=docker_command.default_run_config(
+            constants.ROOT/'ui'/'entrypoint.sh'
+        ),
+        mounts=[
+            utils.bind_mount(
+                target=Path('/home/node/build'),
+                source=constants.UI_BUILD_ROOT,
+            ),
+        ],
+    )
 
 
 __all__ = utils.export_only_tasks(__name__)

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -463,6 +463,13 @@ stages:
             <<: *_env_final_status_artifact_success
             STEP_NAME: build
       - Upload: *upload_final_status_artifact
+      - ShellCommand:
+          name: Cleanup build tree
+          env:
+            PYTHON_SYS: python3.6
+          command: ./doit.sh clean && test ! -d _build
+          usePTY: true
+          haltOnFailure: true
 
   buildprev:
     worker: *build_worker

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -13,3 +13,4 @@ COPY src /home/node/src
 COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
+CMD ["build"]

--- a/ui/entrypoint.sh
+++ b/ui/entrypoint.sh
@@ -2,6 +2,26 @@
 
 set -eu
 
-npm ci
+build() {
+    npm ci
+    npm run build
+}
 
-npm run build
+clean() {
+    rm -rf /home/node/build
+}
+
+case ${1:- } in
+    build)
+        build
+        ;;
+    clean)
+        clean
+        ;;
+    '')
+        exec /bin/bash
+        ;;
+    *)
+        exec "$@"
+        ;;
+esac


### PR DESCRIPTION
**Component**:

buildchain

**Context**: 

`./doit.sh clean` doesn't work (i.e. the `_build` directory still exists and isn't empty).

**Summary**:

- fix task to build local images (don't `touch` a file on disk)
- fix race conditions due to missing dependencies
- fix doc task cleanup (handle garbage from Sphinx)
- fix wrong usage of `setdefault` for `task_dep` (this one could be backported to 2.0 I believe)
- fix "double-delete" of a directory
- fix `_ui_build` cleanup (was tricky because of the `node` user…)
- bonus: simplify code of `Mkdir` task
- add check for `./doit.sh clean` in the CI

**Acceptance criteria**: 

Green build in CI (we now ensure that `./doit.sh clean` works in the CI)

---

Closes: #2223 