### PR TITLE
ci: stop using OpenStack server groups in terraform

### DIFF
--- a/eve/workers/openstack-multiple-nodes/terraform/nodes.tf
+++ b/eve/workers/openstack-multiple-nodes/terraform/nodes.tf
@@ -1,17 +1,8 @@
-resource "openstack_compute_servergroup_v2" "all" {
-  name     = "${local.prefix}-servergroup"
-  policies = []
-}
-
 resource "openstack_compute_instance_v2" "bastion" {
   name        = "${local.prefix}-bastion"
   image_name  = var.openstack_image_name
   flavor_name = var.openstack_flavour_name
   key_pair    = openstack_compute_keypair_v2.local_ssh_key.name
-
-  scheduler_hints {
-    group = openstack_compute_servergroup_v2.all.id
-  }
 
   security_groups = [
     openstack_networking_secgroup_v2.nodes.name,
@@ -68,10 +59,6 @@ resource "openstack_compute_instance_v2" "bootstrap" {
   flavor_name = var.openstack_flavour_name
   key_pair    = openstack_compute_keypair_v2.local_ssh_key.name
 
-  scheduler_hints {
-    group = openstack_compute_servergroup_v2.all.id
-  }
-
   security_groups = [
     openstack_networking_secgroup_v2.nodes.name,
   ]
@@ -119,10 +106,6 @@ resource "openstack_compute_instance_v2" "nodes" {
   image_name  = var.openstack_image_name
   flavor_name = var.openstack_flavour_name
   key_pair    = openstack_compute_keypair_v2.local_ssh_key.name
-
-  scheduler_hints {
-    group = openstack_compute_servergroup_v2.all.id
-  }
 
   security_groups = [
     openstack_networking_secgroup_v2.nodes.name,


### PR DESCRIPTION
**Component**: ci, tf

**Context**: 

**Summary**: removal of server groups in terraform

**Acceptance criteria**:  builds using terraform still work :)