### PR TITLE
docs: add `release` tag

### DIFF
--- a/buildchain/buildchain/docs.py
+++ b/buildchain/buildchain/docs.py
@@ -116,6 +116,9 @@ def task_doc() -> Iterator[types.TaskDict]:
             command=['/entrypoint.sh', target.command],
             builder=builder.DOC_BUILDER,
             run_config=run_config,
+            environment={
+                'O': '-t release',
+            },
             mounts=[
                 utils.bind_mount(
                     target=Path('/usr/src/metalk8s/docs/_build/'),

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -28,7 +28,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 # NOTE: the tox package available is too old; we want tox >= 3.4, for the
 # `commands_pre` syntax
-RUN python3.6 -m pip install tox==3.9.0 && \
+RUN python3.6 -m pip install six==1.14.0 tox==3.14.3 && \
     rm -rf ~/.cache/pip
 
 WORKDIR /usr/src/metalk8s

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -167,7 +167,7 @@ texinfo_documents = [
 # -- Options for todo extension ----------------------------------------------
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
-todo_include_todos = True
+todo_include_todos = not tags.has('release')
 
 # -- Options for sphinxcontrib-spelling --------------------------------------
 # See http://sphinxcontrib-spelling.readthedocs.io/en/latest/customize.html

--- a/tox.ini
+++ b/tox.ini
@@ -48,8 +48,8 @@ deps =
 commands =
     doc8 docs/
     {toxinidir}/docs/build.cmd {posargs:html}
+passenv = O
 setenv =
-    O=-j4 -n -W
     SPHINXOPTS=-j4 -n -W
 
 [doc8]


### PR DESCRIPTION
This commit adds a `release` tag to the Sphinx project. Currently, when
set, `todo` elements in the documentation will *not* be rendered. This
is, however, not the default.

A related change is made to pass the `O` environment variable from the
`tox` invocation all the way down to arguments to `sphinx-build`. As
such, one can now run

```
O="-t release" tox -e docs
```

to create 'release' builds of the documentation.