### PR TITLE
Add content in post-installation procedure

### DIFF
--- a/docs/developer/running/cluster.rst
+++ b/docs/developer/running/cluster.rst
@@ -20,6 +20,8 @@ This command will start a virtual machine (using VirtualBox) and:
 - import a private SSH key (automatically generated in ``.vagrant``)
 - generate a boostrap configuration
 - execute the bootstrap script to make this machine a bootstrap node
+- provision sparse-file Volumes for Prometheus and Alertmanager to run on this
+  bootstrap node
 
 After executing this command, you have a MetalK8s bootstrap node up and running
 and you can connect to it by using ``vagrant ssh bootstrap``.

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -58,7 +58,15 @@ Glossary
      The kubelet is the primary "node agent" that runs on each cluster node.
 
      |see K8s docs|
-     `https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/`
+     `kubelet <https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/>`_.
+
+   Namespace
+     A Namespace is a Kubernetes abstraction to support multiple virtual
+     clusters backed by the same physical cluster, providing a scope for
+     resource names.
+
+     |see K8s docs|
+     `namespaces <https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/>`_.
 
    Node
      A Node is a Kubernetes worker machine - either virtual or physical.

--- a/docs/installation/post-install.rst
+++ b/docs/installation/post-install.rst
@@ -10,19 +10,14 @@ to monitor the system will not be running (the respective :term:`Pods <Pod>`
 will remain in *Pending* state), because they require persistent storage to be
 available.
 
-You can either provision these storage volumes on the bootstrap
-node, or later on other nodes joining the cluster. Templates for the required
+You can either provision these storage volumes on the :term:`Bootstrap
+node`, or later on other nodes joining the cluster. Templates for the required
 volumes are available in :download:`examples/prometheus-sparse.yaml
 <../../examples/prometheus-sparse.yaml>`.
 
 Note, however, these templates use the `sparseLoopDevice` *Volume* type, which
 is not suitable for production installations. Refer to :ref:`volume-management`
 for more information on how to provision persistent storage.
-
-.. note::
-
-   When deploying using Vagrant, persistent volumes for Prometheus and
-   AlertManager are already provisioned.
 
 .. todo::
 

--- a/docs/installation/post-install.rst
+++ b/docs/installation/post-install.rst
@@ -84,3 +84,95 @@ such, for :ref:`MetalK8s GUI <installation-services-admin-ui>` and
 To change Grafana user credentials, follow :ref:`this procedure
 <ops-grafana-admin>`.
 
+
+Validating the deployment
+^^^^^^^^^^^^^^^^^^^^^^^^^
+To ensure the Kubernetes cluster is properly running before scheduling
+applications, perform the following sanity checks:
+
+#. Check that all desired Nodes are in a **Ready** state and show the expected
+   :ref:`roles <node-roles>`:
+
+   .. code-block:: shell
+
+      root@bootstrap $ kubectl --kubeconfig /etc/kubernetes/admin.conf \
+                         get nodes
+      NAME         STATUS   ROLES                         AGE   VERSION
+      bootstrap    Ready    bootstrap,etcd,infra,master   42m   v1.15.5
+      node-1       Ready    etcd,infra,master             26m   v1.15.5
+      node-2       Ready    etcd,infra,master             25m   v1.15.5
+
+   Use the ``kubectl describe node <node_name>`` to get more details about a
+   Node (for instance, to check the right :ref:`taints <node-taints>` are
+   applied).
+
+#. Check that :term:`Pods <Pod>` are in their expected state (most of the time,
+   **Running**, except for Prometheus and AlertManager if the required storage
+   was not provisioned yet - see :ref:`the procedure above <Provision
+   Prometheus Storage>`).
+
+   To look for all Pods at once, use the
+   ``--all-namespaces`` flag. On the other hand, use the ``-n`` or
+   ``--namespace`` option to select Pods in a given :term:`Namespace`.
+
+   For instance, to check all Pods making up the cluster-critical services:
+
+   .. code-block:: shell
+
+      root@bootstrap $ kubectl --kubeconfig /etc/kubernetes/admin.conf \
+                         get pods --namespace kube-system
+      NAME                                       READY   STATUS    RESTARTS   AGE
+      apiserver-proxy-bootstrap                  1/1     Running   0          43m
+      apiserver-proxy-node-1                     1/1     Running   0          2m28s
+      apiserver-proxy-node-2                     1/1     Running   0          9m
+      calico-kube-controllers-6d8db9bcf5-w5w94   1/1     Running   0          43m
+      calico-node-4vxpp                          1/1     Running   0          43m
+      calico-node-hvlkx                          1/1     Running   7          23m
+      calico-node-jhj4r                          1/1     Running   0          8m59s
+      coredns-8576b4bf99-lfjfc                   1/1     Running   0          43m
+      coredns-8576b4bf99-tnt6b                   1/1     Running   0          43m
+      etcd-bootstrap                             1/1     Running   0          43m
+      etcd-node-1                                1/1     Running   0          3m47s
+      etcd-node-2                                1/1     Running   3          8m58s
+      kube-apiserver-bootstrap                   1/1     Running   0          43m
+      kube-apiserver-node-1                      1/1     Running   0          2m45s
+      kube-apiserver-node-2                      1/1     Running   0          7m31s
+      kube-controller-manager-bootstrap          1/1     Running   3          44m
+      kube-controller-manager-node-1             1/1     Running   1          2m39s
+      kube-controller-manager-node-2             1/1     Running   2          7m25s
+      kube-proxy-gnxtp                           1/1     Running   0          28m
+      kube-proxy-kvtjm                           1/1     Running   0          43m
+      kube-proxy-vggzg                           1/1     Running   0          27m
+      kube-scheduler-bootstrap                   1/1     Running   1          44m
+      kube-scheduler-node-1                      1/1     Running   0          2m39s
+      kube-scheduler-node-2                      1/1     Running   0          7m25s
+      repositories-bootstrap                     1/1     Running   0          44m
+      salt-master-bootstrap                      2/2     Running   0          44m
+      storage-operator-756b87c78f-mjqc5          1/1     Running   1          43m
+
+#. Using the result of the above command, obtain a shell in a running ``etcd``
+   Pod (replacing ``<etcd_pod_name>`` with the appropriate value):
+
+   .. code-block:: shell
+
+      root@bootstrap $ kubectl --kubeconfig /etc/kubernetes/admin.conf \
+                         exec --namespace kube-system -it <etcd_pod_name> sh
+
+   Once in this shell, use the following to obtain health information for the
+   ``etcd`` cluster:
+
+   .. code-block:: shell
+
+      root@etcd-bootstrap $ etcdctl --endpoints=https://[127.0.0.1]:2379 \
+                              --ca-file=/etc/kubernetes/pki/etcd/ca.crt \
+                              --cert-file=/etc/kubernetes/pki/etcd/healthcheck-client.crt \
+                              --key-file=/etc/kubernetes/pki/etcd/healthcheck-client.key \
+                              cluster-health
+
+      member 46af28ca4af6c465 is healthy: got healthy result from https://<first-node-ip>:2379
+      member 81de403db853107e is healthy: got healthy result from https://<second-node-ip>:2379
+      member 8878627efe0f46be is healthy: got healthy result from https://<third-node-ip>:2379
+      cluster is healthy
+
+#. Finally, check that the exposed services are accessible, using the
+   information from :doc:`this document <./services>`.

--- a/docs/installation/post-install.rst
+++ b/docs/installation/post-install.rst
@@ -69,3 +69,18 @@ For more details on the available options for storage management, see
 
    - Sanity check
    - Troubleshooting if needed
+
+
+Changing credentials
+^^^^^^^^^^^^^^^^^^^^
+After a fresh installation, an administrator account is created with default
+credentials. For production deployments, make sure to change those credentials
+and use safer values.
+
+To change user credentials and groups for :term:`K8s API <API Server>` (and as
+such, for :ref:`MetalK8s GUI <installation-services-admin-ui>` and
+:term:`SaltAPI`), follow :ref:`this procedure <ops-k8s-admin>`.
+
+To change Grafana user credentials, follow :ref:`this procedure
+<ops-grafana-admin>`.
+

--- a/docs/operation/account_administration.rst
+++ b/docs/operation/account_administration.rst
@@ -6,6 +6,8 @@ This section highlights **MetalK8s Account Administration** which covers
 changing the default username and password for some MetalK8s services.
 
 
+.. _ops-grafana-admin:
+
 Administering Grafana
 *********************
 
@@ -48,10 +50,10 @@ perform the following procedures:
      username and password will be overwritten with default credentials
      ``admin`` / ``admin``.
 
+.. _ops-k8s-admin:
+
 Administering MetalK8s GUI, Kubernetes API and Salt API
 *******************************************************
-
-.. _Administering-MetalK8s-GUI-Kubernetes-API-and-Salt-API:
 
 During installation, MetalK8s configures the Kubernetes API to accept Basic
 authentication, with default credentials ``admin`` / ``admin``.

--- a/docs/operation/troubleshooting.rst
+++ b/docs/operation/troubleshooting.rst
@@ -59,9 +59,7 @@ Account Administration Errors
 Forgot the MetalK8s GUI password
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 If you forget the MetalK8s GUI username and/or password combination,
-follow
-:ref:`this procedure <Administering-MetalK8s-GUI-Kubernetes-API-and-Salt-API>`
-to reset or change it.
+follow :ref:`this procedure <ops-k8s-admin>` to reset or change it.
 
 General Kubernetes Resource Errors
 ++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
**Component**: docs

**Context**: 2.4.2 release

**Summary**:

- change Prom/AM storage example to use `rawBlockDevice` instead of `sparseLoopDevice`
- add section linking to Ops guide for changing credentials
- add some sanity checks with `kubectl` / `etcdctl` (nodes list, pods list, etcd cluster health)

**Acceptance criteria**:

- content is valid and understandable
- no obvious topic is missing from this procedure (sanity checks in particular)


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2117

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
