### PR TITLE
docs: pin `six` version and update `tox` version in Docker build

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -28,7 +28,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 # NOTE: the tox package available is too old; we want tox >= 3.4, for the
 # `commands_pre` syntax
-RUN python3.6 -m pip install tox==3.9.0 && \
+RUN python3.6 -m pip install six==1.14.0 tox==3.14.3 && \
     rm -rf ~/.cache/pip
 
 WORKDIR /usr/src/metalk8s


### PR DESCRIPTION
The `virtualenv` version pulled in by `tox` isn't happy with the
old(ish) version of `six` as pulled into the container, breaking all
builds.

Pinning `six` and bumping `tox` instead.

(cherry picked from commit d473479134bdee90317be5c04f5ba8a1ae40d6a4)