### PR TITLE
docs: fix Docker build dependencies

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -18,6 +18,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         python3.6 \
         python3-buildbot-worker \
         python3-pip \
+        python3-setuptools \
         texlive-fonts-extra \
         texlive-fonts-recommended \
         texlive-latex-extra \


### PR DESCRIPTION
Looks like now something upstream of either `six` or `tox` implicitly
requires `setuptools`, so installing the version as shipped by Ubuntu.

Guess at some point we'll need to freeze `tox` and all of its
dependencies...