### PR TITLE
Documentation/apply official theme

### DIFF
--- a/buildchain/buildchain/docs.py
+++ b/buildchain/buildchain/docs.py
@@ -116,9 +116,6 @@ def task_doc() -> Iterator[types.TaskDict]:
             command=['/entrypoint.sh', target.command],
             builder=builder.DOC_BUILDER,
             run_config=run_config,
-            environment={
-                'O': '-t release',
-            },
             mounts=[
                 utils.bind_mount(
                     target=Path('/usr/src/metalk8s/docs/_build/'),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,6 +104,8 @@ master_doc = 'index'
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
+if RELEASE_BUILD:
+    exclude_patterns.append('developer/*')
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,6 +4,7 @@
 # list see the documentation:
 # http://www.sphinx-doc.org/en/master/config
 
+import datetime
 import os
 import pathlib
 import subprocess
@@ -32,7 +33,7 @@ ON_RTD = os.environ.get('READTHEDOCS') == 'True'
 # -- Project information -----------------------------------------------------
 
 project = 'MetalK8s'
-copyright = '2019, Scality'
+copyright = '{}, Scality'.format(datetime.datetime.now().year)
 author = 'Scality'
 
 # Used for finding the project logo and defining some links

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,5 +29,4 @@ Indices and tables
 ==================
 
 * :ref:`genindex`
-* :ref:`modindex`
 * :ref:`search`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,9 +24,8 @@ Welcome to MetalK8s's documentation!
    developer/index
    glossary
 
-
 Indices and tables
-==================
+------------------
 
 * :ref:`genindex`
 * :ref:`search`

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -8,5 +8,6 @@ sphinxcontrib_github_alt >= 1.0
 sphinxcontrib-plantuml >= 0.16.1
 sphinxcontrib-spelling >= 4.1
 sphinx-autobuild >= 0.7.1
+-e git+https://github.com/scality/sphinx-tools.git@v3.0#egg=sphinx_scality
 
 doc8 >= 0.8.0

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -2,6 +2,7 @@
 # Added here because `pip-compile` doesn't work cross-platform.
 colorama >= 0.3.9
 plantuml >= 0.2
+PyYAML >= 5.3.1
 Sphinx >= 3.0.4
 sphinx_rtd_theme >= 0.3
 sphinxcontrib_github_alt >= 1.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -26,6 +26,7 @@ pyenchant==3.1.1          # via sphinxcontrib-spelling
 pygments==2.7.2           # via doc8, sphinx
 pyparsing==2.4.7          # via packaging
 pytz==2020.4              # via babel
+pyyaml==5.3.1
 requests==2.25.0          # via sphinx
 restructuredtext-lint==1.3.2  # via doc8
 six==1.15.0               # via doc8, livereload, packaging

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,213 +4,45 @@
 #
 #    tox -e pip-compile
 #
-alabaster==0.7.12 \
-    --hash=sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359 \
-    --hash=sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02 \
-    # via sphinx
-argh==0.26.2 \
-    --hash=sha256:a9b3aaa1904eeb78e32394cd46c6f37ac0fb4af6dc488daa58971bdc7d7fcaf3 \
-    --hash=sha256:e9535b8c84dc9571a48999094fda7f33e63c3f1b74f3e5f3ac0105a58405bb65 \
-    # via sphinx-autobuild
-babel==2.8.0 \
-    --hash=sha256:1aac2ae2d0d8ea368fa90906567f5c08463d98ade155c0c4bfedd6a0f7160e38 \
-    --hash=sha256:d670ea0b10f8b723672d3a6abeb87b565b244da220d76b4dba1b66269ec152d4 \
-    # via sphinx
-certifi==2020.4.5.1 \
-    --hash=sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304 \
-    --hash=sha256:51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519 \
-    # via requests
-chardet==3.0.4 \
-    --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
-    --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
-    # via doc8, requests
-colorama==0.4.3 \
-    --hash=sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff \
-    --hash=sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1
-doc8==0.8.1 \
-    --hash=sha256:4d1df12598807cf08ffa9a1d5ef42d229ee0de42519da01b768ff27211082c12 \
-    --hash=sha256:4d58a5c8c56cedd2b2c9d6e3153be5d956cf72f6051128f0f2255c66227df721
-docutils==0.16 \
-    --hash=sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af \
-    --hash=sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc \
-    # via doc8, restructuredtext-lint, sphinx, sphinxcontrib-github-alt
-httplib2==0.18.1 \
-    --hash=sha256:8af66c1c52c7ffe1aa5dc4bcd7c769885254b0756e6e69f953c7f0ab49a70ba3 \
-    --hash=sha256:ca2914b015b6247791c4866782fa6042f495b94401a0f0bd3e1d6e0ba2236782 \
-    # via plantuml
-idna==2.9 \
-    --hash=sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb \
-    --hash=sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa \
-    # via requests
-imagesize==1.2.0 \
-    --hash=sha256:6965f19a6a2039c7d48bca7dba2473069ff854c36ae6f19d2cde309d998228a1 \
-    --hash=sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1 \
-    # via sphinx
-jinja2==2.11.2 \
-    --hash=sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0 \
-    --hash=sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035 \
-    # via sphinx
-livereload==2.6.1 \
-    --hash=sha256:78d55f2c268a8823ba499305dcac64e28ddeb9a92571e12d543cd304faf5817b \
-    --hash=sha256:89254f78d7529d7ea0a3417d224c34287ebfe266b05e67e51facaf82c27f0f66 \
-    # via sphinx-autobuild
-markupsafe==1.1.1 \
-    --hash=sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473 \
-    --hash=sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161 \
-    --hash=sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235 \
-    --hash=sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5 \
-    --hash=sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42 \
-    --hash=sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff \
-    --hash=sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b \
-    --hash=sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1 \
-    --hash=sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e \
-    --hash=sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183 \
-    --hash=sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66 \
-    --hash=sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b \
-    --hash=sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1 \
-    --hash=sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15 \
-    --hash=sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1 \
-    --hash=sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e \
-    --hash=sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b \
-    --hash=sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905 \
-    --hash=sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735 \
-    --hash=sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d \
-    --hash=sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e \
-    --hash=sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d \
-    --hash=sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c \
-    --hash=sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21 \
-    --hash=sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2 \
-    --hash=sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5 \
-    --hash=sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b \
-    --hash=sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6 \
-    --hash=sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f \
-    --hash=sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f \
-    --hash=sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2 \
-    --hash=sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7 \
-    --hash=sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be \
-    # via jinja2
-packaging==20.4 \
-    --hash=sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8 \
-    --hash=sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181 \
-    # via sphinx
-pathtools==0.1.2 \
-    --hash=sha256:7c35c5421a39bb82e58018febd90e3b6e5db34c5443aaaf742b3f33d4655f1c0 \
-    # via sphinx-autobuild, watchdog
-pbr==5.4.5 \
-    --hash=sha256:07f558fece33b05caf857474a366dfcc00562bca13dd8b47b2b3e22d9f9bf55c \
-    --hash=sha256:579170e23f8e0c2f24b0de612f71f648eccb79fb1322c814ae6b3c07b5ba23e8 \
-    # via stevedore
-plantuml==0.3.0 \
-    --hash=sha256:f21789bc4abc3e8888d23a8fa010e942989f1a73d6e50e10a54688cbee52aa1c
-port_for==0.3.1 \
-    --hash=sha256:b16a84bb29c2954db44c29be38b17c659c9c27e33918dec16b90d375cc596f1c \
-    # via sphinx-autobuild
-pyenchant==3.1.1 \
-    --hash=sha256:8ca419921e79022b344581ef7baf2e23af5c20b3e56b2f3d5a0448bd5bf2662e \
-    --hash=sha256:997465ab1f0dc9900b3bde0a1998c62ac08e64cc9a0870865d50de1e7d4b5afa \
-    --hash=sha256:ce0915d7acd771fde6e8c2dce8ad0cb0e6f7c4fa8430cc96e3e7134e99aeb12f \
-    --hash=sha256:fd490efd7ce46e461cbd905bf6e2fdd540d85f43973b296a743b4591bfbcca60 \
-    # via sphinxcontrib-spelling
-pygments==2.6.1 \
-    --hash=sha256:647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44 \
-    --hash=sha256:ff7a40b4860b727ab48fad6360eb351cc1b33cbf9b15a0f689ca5353e9463324 \
-    # via doc8, sphinx
-pyparsing==2.4.7 \
-    --hash=sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1 \
-    --hash=sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b \
-    # via packaging
-pytz==2020.1 \
-    --hash=sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed \
-    --hash=sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048 \
-    # via babel
-pyyaml==5.3.1 \
-    --hash=sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97 \
-    --hash=sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76 \
-    --hash=sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2 \
-    --hash=sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648 \
-    --hash=sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf \
-    --hash=sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f \
-    --hash=sha256:7739fc0fa8205b3ee8808aea45e968bc90082c10aef6ea95e855e10abf4a37b2 \
-    --hash=sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee \
-    --hash=sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d \
-    --hash=sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c \
-    --hash=sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a \
-    # via sphinx-autobuild
-requests==2.23.0 \
-    --hash=sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee \
-    --hash=sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6 \
-    # via sphinx
-restructuredtext-lint==1.3.1 \
-    --hash=sha256:470e53b64817211a42805c3a104d2216f6f5834b22fe7adb637d1de4d6501fb8 \
-    # via doc8
-six==1.15.0 \
-    --hash=sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259 \
-    --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced \
-    # via doc8, livereload, packaging, sphinxcontrib-spelling, stevedore
-snowballstemmer==2.0.0 \
-    --hash=sha256:209f257d7533fdb3cb73bdbd24f436239ca3b2fa67d56f6ff88e86be08cc5ef0 \
-    --hash=sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52 \
-    # via sphinx
-sphinx-autobuild==0.7.1 \
-    --hash=sha256:66388f81884666e3821edbe05dd53a0cfb68093873d17320d0610de8db28c74e \
-    --hash=sha256:e60aea0789cab02fa32ee63c7acae5ef41c06f1434d9fd0a74250a61f5994692
-sphinx-rtd-theme==0.4.3 \
-    --hash=sha256:00cf895504a7895ee433807c62094cf1e95f065843bf3acd17037c3e9a2becd4 \
-    --hash=sha256:728607e34d60456d736cc7991fd236afb828b21b82f956c5ea75f94c8414040a
-sphinx==3.0.4 \
-    --hash=sha256:779a519adbd3a70fc7c468af08c5e74829868b0a5b34587b33340e010291856c \
-    --hash=sha256:ea64df287958ee5aac46be7ac2b7277305b0381d213728c3a49d8bb9b8415807
-sphinxcontrib-applehelp==1.0.2 \
-    --hash=sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a \
-    --hash=sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58 \
-    # via sphinx
-sphinxcontrib-devhelp==1.0.2 \
-    --hash=sha256:8165223f9a335cc1af7ffe1ed31d2871f325254c0423bc0c4c7cd1c1e4734a2e \
-    --hash=sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4 \
-    # via sphinx
-sphinxcontrib-github-alt==1.2 \
-    --hash=sha256:cdd1f61090e9ca1f317283dc85b311d788864d7e41baa479882c9fc914b43641 \
-    --hash=sha256:cfd7584d559bb89a1dde3b418fea3b5b8e601e1f50459873635256b5d1712af5
-sphinxcontrib-htmlhelp==1.0.3 \
-    --hash=sha256:3c0bc24a2c41e340ac37c85ced6dafc879ab485c095b1d65d2461ac2f7cca86f \
-    --hash=sha256:e8f5bb7e31b2dbb25b9cc435c8ab7a79787ebf7f906155729338f3156d93659b \
-    # via sphinx
-sphinxcontrib-jsmath==1.0.1 \
-    --hash=sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178 \
-    --hash=sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8 \
-    # via sphinx
-sphinxcontrib-plantuml==0.18 \
-    --hash=sha256:accc8c57f953cc74e87d043e5599b46eb5e5e9c4e3291e8c7822dcdd6c2ba520
-sphinxcontrib-qthelp==1.0.3 \
-    --hash=sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72 \
-    --hash=sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6 \
-    # via sphinx
-sphinxcontrib-serializinghtml==1.1.4 \
-    --hash=sha256:eaa0eccc86e982a9b939b2b82d12cc5d013385ba5eadcc7e4fed23f4405f77bc \
-    --hash=sha256:f242a81d423f59617a8e5cf16f5d4d74e28ee9a66f9e5b637a18082991db5a9a \
-    # via sphinx
-sphinxcontrib-spelling==5.0.0 \
-    --hash=sha256:a1070b74d8509f4d02c74cb1c187bbde95b0178338aff88fedea3c672b099f4e \
-    --hash=sha256:a89abbd82443eb1159f334593c383438440b30d9d71676af6b1c2d9499152ce7
-stevedore==1.32.0 \
-    --hash=sha256:18afaf1d623af5950cc0f7e75e70f917784c73b652a34a12d90b309451b5500b \
-    --hash=sha256:a4e7dc759fb0f2e3e2f7d8ffe2358c19d45b9b8297f393ef1256858d82f69c9b \
-    # via doc8
-tornado==6.0.4 \
-    --hash=sha256:0fe2d45ba43b00a41cd73f8be321a44936dc1aba233dee979f17a042b83eb6dc \
-    --hash=sha256:22aed82c2ea340c3771e3babc5ef220272f6fd06b5108a53b4976d0d722bcd52 \
-    --hash=sha256:2c027eb2a393d964b22b5c154d1a23a5f8727db6fda837118a776b29e2b8ebc6 \
-    --hash=sha256:5217e601700f24e966ddab689f90b7ea4bd91ff3357c3600fa1045e26d68e55d \
-    --hash=sha256:5618f72e947533832cbc3dec54e1dffc1747a5cb17d1fd91577ed14fa0dc081b \
-    --hash=sha256:5f6a07e62e799be5d2330e68d808c8ac41d4a259b9cea61da4101b83cb5dc673 \
-    --hash=sha256:c58d56003daf1b616336781b26d184023ea4af13ae143d9dda65e31e534940b9 \
-    --hash=sha256:c952975c8ba74f546ae6de2e226ab3cc3cc11ae47baf607459a6728585bb542a \
-    --hash=sha256:c98232a3ac391f5faea6821b53db8db461157baa788f5d6222a193e9456e1740 \
-    # via livereload, sphinx-autobuild
-urllib3==1.25.9 \
-    --hash=sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527 \
-    --hash=sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115 \
-    # via requests
-watchdog==0.10.2 \
-    --hash=sha256:c560efb643faed5ef28784b2245cf8874f939569717a4a12826a173ac644456b \
-    # via sphinx-autobuild
+-e git+https://github.com/scality/sphinx-tools.git@v3.0#egg=sphinx_scality
+alabaster==0.7.12         # via sphinx
+babel==2.9.0              # via sphinx
+certifi==2020.11.8        # via requests
+chardet==3.0.4            # via doc8, requests
+colorama==0.4.4
+doc8==0.8.1
+docutils==0.16            # via doc8, restructuredtext-lint, sphinx, sphinxcontrib-github-alt
+httplib2==0.18.1          # via plantuml
+idna==2.10                # via requests
+imagesize==1.2.0          # via sphinx
+importlib-metadata==3.1.0  # via sphinxcontrib-spelling, stevedore
+jinja2==2.11.2            # via sphinx
+livereload==2.6.3         # via sphinx-autobuild
+markupsafe==1.1.1         # via jinja2
+packaging==20.4           # via sphinx
+pbr==5.5.1                # via stevedore
+plantuml==0.3.0
+pyenchant==3.1.1          # via sphinxcontrib-spelling
+pygments==2.7.2           # via doc8, sphinx
+pyparsing==2.4.7          # via packaging
+pytz==2020.4              # via babel
+requests==2.25.0          # via sphinx
+restructuredtext-lint==1.3.2  # via doc8
+six==1.15.0               # via doc8, livereload, packaging
+snowballstemmer==2.0.0    # via sphinx
+sphinx-autobuild==2020.9.1
+sphinx-rtd-theme==0.5.0
+sphinx==3.3.1
+sphinxcontrib-applehelp==1.0.2  # via sphinx
+sphinxcontrib-devhelp==1.0.2  # via sphinx
+sphinxcontrib-github-alt==1.2
+sphinxcontrib-htmlhelp==1.0.3  # via sphinx
+sphinxcontrib-jsmath==1.0.1  # via sphinx
+sphinxcontrib-plantuml==0.19
+sphinxcontrib-qthelp==1.0.3  # via sphinx
+sphinxcontrib-serializinghtml==1.1.4  # via sphinx
+sphinxcontrib-spelling==7.1.0
+stevedore==3.2.2          # via doc8
+tornado==6.1              # via livereload
+urllib3==1.26.2           # via requests
+zipp==3.4.0               # via importlib-metadata

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ commands =
         -o "{toxinidir}/buildchain/requirements-dev.txt" \
         "{toxinidir}/buildchain/requirements-dev.in"
     pip-compile \
-        --index --emit-trusted-host --annotate --generate-hashes \
+        --index --emit-trusted-host --annotate \
         {posargs:--upgrade} \
         -o "{toxinidir}/docs/requirements.txt" \
         "{toxinidir}/docs/requirements.in"

--- a/tox.ini
+++ b/tox.ini
@@ -66,7 +66,9 @@ deps =
 commands =
     doc8 docs/
     {toxinidir}/docs/build.cmd {posargs:html}
-passenv = O
+passenv =
+    O
+    READTHEDOCS
 setenv =
     SPHINXOPTS=-j4 -n -W
 


### PR DESCRIPTION
**Component**: docs, build

**Context**:

We want to use the official Scality theme for MetalK8s docs.

**Summary**:

Apply the official Scality documentation theme everywhere, with small specificities depending on the destination of the build:

- for ReadTheDocs, we make the "home link" (used for the header Scality logo) and the back arrow point to `https://metal-k8s.readthedocs.io`
- for Scality-hosted docs, we make these links respectively `https://documentation.scality.com` and `https://documentation.scality.com/metalk8s`
- for embedded docs, we disable these links (and hide the back arrow) for now

We also add:

- a `release` tag to simulate a build from the latest Git tag
- a `scality-product` tag, to generate docs to be hosted on `documentation.scality.com`

You can use `O='-t release -t scality-product' tox -e docs` to pass these tags to Sphinx.