### PR TITLE
ci: Upload final_status at the artifacts root

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -258,7 +258,8 @@ models:
       name: Add final status to artifacts
       command: |-
         bash -c '
-          declare -r BUILD_STATUS_DIR=build_status/build_status/${STEP_NAME:-}
+          declare BUILD_STATUS_DIR=build_status
+          [[ ${STEP_NAME:-} ]] && BUILD_STATUS_DIR+="/build_status/$STEP_NAME"
           mkdir -p "$BUILD_STATUS_DIR"
           echo -n "$FINAL_STATUS" > "$BUILD_STATUS_DIR/.final_status"
         '


### PR DESCRIPTION
We used to upload all status files in a subdirectory. The "root" status
(for the whole build execution) should however be stored at the root of
the artifacts directory, to ensure artifacts promotion will work
properly.