### PR TITLE
ui/volume: rephrase the volume status from Available to Ready

### DIFF
--- a/ui/cypress/integration/common/volume.js
+++ b/ui/cypress/integration/common/volume.js
@@ -99,16 +99,16 @@ Then(
       .find('.sc-table-column-cell-name')
       .should('contain', volumeNameSparseLoopDevice);
 
-    // Wait until the volume is available
+    // Wait until the volume is ready
     cy.waitUntil(
       () =>
         cy
           .get('.sc-table-row')
           .eq(1) //2 rows with the header included
           .find('.sc-table-column-cell-status')
-          .then($span => $span.text() === 'Available'),
+          .then($span => $span.text() === 'Ready'),
       {
-        errorMsg: `Volume ${volumeNameSparseLoopDevice} is not available`,
+        errorMsg: `Volume ${volumeNameSparseLoopDevice} is not ready`,
         timeout: 120000, // waits up to 120000 ms, default to 5000
         interval: 5000, // performs the check every 5000 ms, default to 200
       },

--- a/ui/src/constants.js
+++ b/ui/src/constants.js
@@ -23,6 +23,7 @@ export const STATUS_FAILED = 'Failed';
 export const STATUS_AVAILABLE = 'Available';
 export const STATUS_RELEASED = 'Released';
 export const STATUS_UNKNOWN = 'Unknown';
+export const STATUS_READY = 'Ready';
 
 export const SPARSE_LOOP_DEVICE = 'sparseLoopDevice';
 export const RAW_BLOCK_DEVICE = 'rawBlockDevice';

--- a/ui/src/containers/NodeVolumes.js
+++ b/ui/src/containers/NodeVolumes.js
@@ -32,8 +32,8 @@ import {
   STATUS_TERMINATING,
   STATUS_PENDING,
   STATUS_FAILED,
-  STATUS_AVAILABLE,
   STATUS_BOUND,
+  STATUS_READY,
 } from '../constants';
 
 const VolumeTable = styled.div`
@@ -172,7 +172,7 @@ const NodeVolumes = props => {
               hintMessage = intl.messages.volume_status_unknown_hint;
               break;
             case STATUS_FAILED:
-            case STATUS_AVAILABLE:
+            case STATUS_READY:
               const persistentVolume = persistentVolumes.find(
                 pv => pv?.metadata?.name === rowData.name,
               );

--- a/ui/src/services/NodeVolumesUtils.js
+++ b/ui/src/services/NodeVolumesUtils.js
@@ -55,7 +55,6 @@ export const isVolumeDeletable = (rowData, persistentVolumes) => {
   }
 };
 
-
 // Compute the global status of a volume from its conditions.
 //
 // Arguments
@@ -79,28 +78,28 @@ export const computeVolumeGlobalStatus = (name, status) => {
   const condStatus = condition?.status;
   const condReason = condition?.reason;
 
-  switch(condStatus) {
-  case 'True':
-    return STATUS_READY;
-  case 'False':
-    return STATUS_FAILED;
-  case 'Unknown':
-    switch(condReason) {
-    case 'Pending':
-      return STATUS_PENDING;
-    case 'Terminating':
-      return STATUS_TERMINATING;
+  switch (condStatus) {
+    case 'True':
+      return STATUS_READY;
+    case 'False':
+      return STATUS_FAILED;
+    case 'Unknown':
+      switch (condReason) {
+        case 'Pending':
+          return STATUS_PENDING;
+        case 'Terminating':
+          return STATUS_TERMINATING;
+        default:
+          console.error(
+            `Unexpected Ready reason for Volume ${name}: ${condReason}`,
+          );
+          return STATUS_UNKNOWN;
+      }
     default:
       console.error(
-        `Unexpected Ready reason for Volume ${name}: ${condReason}`,
+        `Unexpected Ready status for Volume ${name}: ${condStatus}`,
       );
       return STATUS_UNKNOWN;
-    }
-  default:
-    console.error(
-      `Unexpected Ready status for Volume ${name}: ${condStatus}`,
-    );
-    return STATUS_UNKNOWN;
   }
 };
 

--- a/ui/src/services/NodeVolumesUtils.js
+++ b/ui/src/services/NodeVolumesUtils.js
@@ -6,6 +6,7 @@ import {
   STATUS_AVAILABLE,
   STATUS_BOUND,
   STATUS_RELEASED,
+  STATUS_READY,
 } from '../constants';
 
 export const isVolumeDeletable = (rowData, persistentVolumes) => {
@@ -18,7 +19,7 @@ export const isVolumeDeletable = (rowData, persistentVolumes) => {
     case STATUS_TERMINATING:
       return false;
     case STATUS_FAILED:
-    case STATUS_AVAILABLE:
+    case STATUS_READY:
       if (persistentVolumes?.length === 0) {
         return true;
       } else {
@@ -80,7 +81,7 @@ export const computeVolumeGlobalStatus = (name, status) => {
 
   switch(condStatus) {
   case 'True':
-    return STATUS_AVAILABLE;
+    return STATUS_READY;
   case 'False':
     return STATUS_FAILED;
   case 'Unknown':

--- a/ui/src/services/NodeVolumesUtils.test.js
+++ b/ui/src/services/NodeVolumesUtils.test.js
@@ -278,7 +278,7 @@ it('should return false when volume is ready and there is no PV', () => {
 
 it('should return Unkown when called with wrong input', () => {
   const volume = {
-    'status': {'conditions': []}
+    status: { conditions: [] },
   };
   const result = computeVolumeGlobalStatus('test', volume);
   expect(result).toEqual(STATUS_UNKNOWN);
@@ -290,13 +290,13 @@ it('should return Unkown when volume has no status', () => {
 });
 
 it('should return Unkown when volume has no conditions', () => {
-  const volumeStatus = {'conditions': []};
+  const volumeStatus = { conditions: [] };
   const result = computeVolumeGlobalStatus('test', volumeStatus);
   expect(result).toEqual(STATUS_UNKNOWN);
 });
 
 it('should return Unkown when volume has no Ready condition', () => {
-  const volumeStatus = {'conditions': [{'type': 'nope'}]};
+  const volumeStatus = { conditions: [{ type: 'nope' }] };
   const result = computeVolumeGlobalStatus('test', volumeStatus);
   expect(result).toEqual(STATUS_UNKNOWN);
 });
@@ -308,25 +308,23 @@ it('should return Ready when Ready condition is True', () => {
 });
 
 it('should return Failed when Ready condition is False', () => {
-  const volumeStatus = {'conditions': [
-    {'type': 'Ready', 'status': 'False'}
-  ]};
+  const volumeStatus = { conditions: [{ type: 'Ready', status: 'False' }] };
   const result = computeVolumeGlobalStatus('test', volumeStatus);
   expect(result).toEqual(STATUS_FAILED);
 });
 
 it('should return Pending when Ready condition is Unknown/Pending', () => {
-  const volumeStatus = {'conditions': [
-    {'type': 'Ready', 'status': 'Unknown', 'reason': 'Pending'}
-  ]};
+  const volumeStatus = {
+    conditions: [{ type: 'Ready', status: 'Unknown', reason: 'Pending' }],
+  };
   const result = computeVolumeGlobalStatus('test', volumeStatus);
   expect(result).toEqual(STATUS_PENDING);
 });
 
 it('should return Pending when Ready condition is Unknown/Terminating', () => {
-  const volumeStatus = {'conditions': [
-    {'type': 'Ready', 'status': 'Unknown', 'reason': 'Terminating'}
-  ]};
+  const volumeStatus = {
+    conditions: [{ type: 'Ready', status: 'Unknown', reason: 'Terminating' }],
+  };
   const result = computeVolumeGlobalStatus('test', volumeStatus);
   expect(result).toEqual(STATUS_TERMINATING);
 });
@@ -334,11 +332,11 @@ it('should return Pending when Ready condition is Unknown/Terminating', () => {
 // }}}
 // volumeGetError {{{
 
-const NO_ERROR = ['', '']
+const NO_ERROR = ['', ''];
 
 it('should return no error when called with wrong input', () => {
   const volume = {
-    'status': {'conditions': []}
+    status: { conditions: [] },
   };
   const result = volumeGetError(volume);
   expect(result).toEqual(NO_ERROR);
@@ -350,42 +348,40 @@ it('should return no error when called with no status', () => {
 });
 
 it('should return no error when called with no conditions', () => {
-  const volumeStatus = {'conditions': []};
+  const volumeStatus = { conditions: [] };
   const result = volumeGetError(volumeStatus);
   expect(result).toEqual(NO_ERROR);
 });
 
 it('should return no error when called with no Ready conditions', () => {
-  const volumeStatus = {'conditions': [{'type': 'nope'}]};
+  const volumeStatus = { conditions: [{ type: 'nope' }] };
   const result = volumeGetError(volumeStatus);
   expect(result).toEqual(NO_ERROR);
 });
 
 it('should return no error when called with successful Ready condition', () => {
-  const volumeStatus = {'conditions': [
-    {'type': 'Ready', 'status': 'True'}
-  ]};
+  const volumeStatus = { conditions: [{ type: 'Ready', status: 'True' }] };
   const result = volumeGetError(volumeStatus);
   expect(result).toEqual(NO_ERROR);
 });
 
 it('should return no error when called with pending Ready condition', () => {
-  const volumeStatus = {'conditions': [
-    {'type': 'Ready', 'status': 'Unknown'}
-  ]};
+  const volumeStatus = { conditions: [{ type: 'Ready', status: 'Unknown' }] };
   const result = volumeGetError(volumeStatus);
   expect(result).toEqual(NO_ERROR);
 });
 
 it('should return error when called with failed Ready condition', () => {
-  const volumeStatus = {'conditions': [
-    {
-      'type': 'Ready',
-      'status': 'False',
-      'reason': 'CreationError',
-      'message': 'BOOM'
-    }
-  ]};
+  const volumeStatus = {
+    conditions: [
+      {
+        type: 'Ready',
+        status: 'False',
+        reason: 'CreationError',
+        message: 'BOOM',
+      },
+    ],
+  };
   const result = volumeGetError(volumeStatus);
   expect(result).toEqual(['CreationError', 'BOOM']);
 });

--- a/ui/src/services/NodeVolumesUtils.test.js
+++ b/ui/src/services/NodeVolumesUtils.test.js
@@ -3,7 +3,7 @@ import {
   STATUS_TERMINATING,
   STATUS_PENDING,
   STATUS_FAILED,
-  STATUS_AVAILABLE,
+  STATUS_READY,
 } from '../constants';
 import {
   computeVolumeGlobalStatus,
@@ -84,50 +84,50 @@ const testcaseVolumeFailedPvUnknown = {
   ],
 };
 
-const testcaseVolumeAvailablePvFailed = {
-  rowData: { status: 'Available', name: 'test' },
+const testcaseVolumeReadyPvFailed = {
+  rowData: { status: 'Ready', name: 'test' },
   persistentVolumes: [
     { metadata: { name: 'test' }, status: { phase: 'Failed' } },
   ],
 };
 
-const testcaseVolumeAvailablePvAvailable = {
-  rowData: { status: 'Available', name: 'test' },
+const testcaseVolumeReadyPvAvailable = {
+  rowData: { status: 'Ready', name: 'test' },
   persistentVolumes: [
     { metadata: { name: 'test' }, status: { phase: 'Available' } },
   ],
 };
 
-const testcaseVolumeAvailablePvReleased = {
-  rowData: { status: 'Available', name: 'test' },
+const testcaseVolumeReadyPvReleased = {
+  rowData: { status: 'Ready', name: 'test' },
   persistentVolumes: [
     { metadata: { name: 'test' }, status: { phase: 'Released' } },
   ],
 };
 
 const testcaseVolumeAvailablePvPending = {
-  rowData: { status: 'Available', name: 'test' },
+  rowData: { status: 'Ready', name: 'test' },
   persistentVolumes: [
     { metadata: { name: 'test' }, status: { phase: 'Pending' } },
   ],
 };
 
-const testcaseVolumeAvailablePvBound = {
-  rowData: { status: 'Available', name: 'test' },
+const testcaseVolumeReadyPvBound = {
+  rowData: { status: 'Ready', name: 'test' },
   persistentVolumes: [
     { metadata: { name: 'test' }, status: { phase: 'Bound' } },
   ],
 };
 
-const testcaseVolumeAvailablePvUnknown = {
-  rowData: { status: 'Available', name: 'test' },
+const testcaseVolumeReadyPvUnknown = {
+  rowData: { status: 'Ready', name: 'test' },
   persistentVolumes: [
     { metadata: { name: 'test' }, status: { phase: 'Unknown' } },
   ],
 };
 
-const testcaseVolumeAvailableWithoutPv = {
-  rowData: { status: 'Available', name: 'test' },
+const testcaseVolumeReadyWithoutPv = {
+  rowData: { status: 'Ready', name: 'test' },
   persistentVolumes: [
     { metadata: { name: 'testnoPV' }, status: { phase: 'Available' } },
   ],
@@ -216,31 +216,31 @@ it('should return false when volume is failed and PV is unknown', () => {
   expect(result).toEqual(false);
 });
 
-it('should return true when volume is available and PV is failed', () => {
+it('should return true when volume is ready and PV is failed', () => {
   const result = isVolumeDeletable(
-    testcaseVolumeAvailablePvFailed.rowData,
-    testcaseVolumeAvailablePvFailed.persistentVolumes,
+    testcaseVolumeReadyPvFailed.rowData,
+    testcaseVolumeReadyPvFailed.persistentVolumes,
   );
   expect(result).toEqual(true);
 });
 
-it('should return true when volume is available and PV is available', () => {
+it('should return true when volume is ready and PV is available', () => {
   const result = isVolumeDeletable(
-    testcaseVolumeAvailablePvAvailable.rowData,
-    testcaseVolumeAvailablePvAvailable.persistentVolumes,
+    testcaseVolumeReadyPvAvailable.rowData,
+    testcaseVolumeReadyPvAvailable.persistentVolumes,
   );
   expect(result).toEqual(true);
 });
 
-it('should return true when volume is available and PV is released', () => {
+it('should return true when volume is ready and PV is released', () => {
   const result = isVolumeDeletable(
-    testcaseVolumeAvailablePvReleased.rowData,
-    testcaseVolumeAvailablePvReleased.persistentVolumes,
+    testcaseVolumeReadyPvReleased.rowData,
+    testcaseVolumeReadyPvReleased.persistentVolumes,
   );
   expect(result).toEqual(true);
 });
 
-it('should return false when volume is available and PV is pending', () => {
+it('should return false when volume is ready and PV is pending', () => {
   const result = isVolumeDeletable(
     testcaseVolumeAvailablePvPending.rowData,
     testcaseVolumeAvailablePvPending.persistentVolumes,
@@ -248,26 +248,26 @@ it('should return false when volume is available and PV is pending', () => {
   expect(result).toEqual(false);
 });
 
-it('should return false when volume is available and PV is bound', () => {
+it('should return false when volume is ready and PV is bound', () => {
   const result = isVolumeDeletable(
-    testcaseVolumeAvailablePvBound.rowData,
-    testcaseVolumeAvailablePvBound.persistentVolumes,
+    testcaseVolumeReadyPvBound.rowData,
+    testcaseVolumeReadyPvBound.persistentVolumes,
   );
   expect(result).toEqual(false);
 });
 
-it('should return false when volume is available and PV is unknown', () => {
+it('should return false when volume is ready and PV is unknown', () => {
   const result = isVolumeDeletable(
-    testcaseVolumeAvailablePvUnknown.rowData,
-    testcaseVolumeAvailablePvUnknown.persistentVolumes,
+    testcaseVolumeReadyPvUnknown.rowData,
+    testcaseVolumeReadyPvUnknown.persistentVolumes,
   );
   expect(result).toEqual(false);
 });
 
-it('should return false when volume is available and there is no PV', () => {
+it('should return false when volume is ready and there is no PV', () => {
   const result = isVolumeDeletable(
-    testcaseVolumeAvailableWithoutPv.rowData,
-    testcaseVolumeAvailableWithoutPv.persistentVolumes,
+    testcaseVolumeReadyWithoutPv.rowData,
+    testcaseVolumeReadyWithoutPv.persistentVolumes,
   );
   expect(result).toEqual(true);
 });
@@ -301,12 +301,10 @@ it('should return Unkown when volume has no Ready condition', () => {
   expect(result).toEqual(STATUS_UNKNOWN);
 });
 
-it('should return Available when Ready condition is True', () => {
-  const volumeStatus = {'conditions': [
-    {'type': 'Ready', 'status': 'True'}
-  ]};
+it('should return Ready when Ready condition is True', () => {
+  const volumeStatus = { conditions: [{ type: 'Ready', status: 'True' }] };
   const result = computeVolumeGlobalStatus('test', volumeStatus);
-  expect(result).toEqual(STATUS_AVAILABLE);
+  expect(result).toEqual(STATUS_READY);
 });
 
 it('should return Failed when Ready condition is False', () => {


### PR DESCRIPTION
**Component**: ui, volume

**Context**: 
The volume status available is confusing. For example, when the PV is bound, we displayed `Available`.

**Summary**:
Rephrase the volume status from `Available` to `Ready`

**Acceptance criteria**: 
![image](https://user-images.githubusercontent.com/18453133/74762959-24350480-527f-11ea-8eba-9c7c9a048893.png)

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2245 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
