### PR TITLE
test: refactor Requests retry helper and make it generic

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -255,6 +255,14 @@ def ssh_config(request):
     return request.config.getoption('--ssh-config')
 
 
+@pytest.fixture(scope="function")
+def request_retry_session(request):
+    # Callers can inject arguments using `pytest.mark.parametrize`
+    params = getattr(request, 'param', {})
+
+    return utils.requests_retry_session(**params)
+
+
 def count_running_pods(
         request, k8s_client, pods_count, label, namespace, node):
     ssh_config = request.config.getoption('--ssh-config')

--- a/tests/post/steps/test_authentication.py
+++ b/tests/post/steps/test_authentication.py
@@ -3,8 +3,6 @@ import re
 
 import requests
 import requests.exceptions
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
 
 import pytest
 from pytest_bdd import scenario, given, then, when, parsers
@@ -132,7 +130,7 @@ def check_cp_ingress_pod_and_container(
     "we perform a request on '{path}' with port '{port}' on control-plane IP"))
 def perform_request(host, context, control_plane_ip, path, port):
     try:
-        context['response'] = requests_retry_session().get(
+        context['response'] = utils.requests_retry_session().get(
             'https://{ip}:{port}{path}'.format(
                 ip=control_plane_ip, port=port, path=path
             ),
@@ -162,7 +160,7 @@ def dex_login(host, control_plane_ip, username, password, context):
 def reach_openid_config(host, control_plane_ip):
     def _get_openID_config():
         try:
-            response = requests_retry_session().get(
+            response = utils.requests_retry_session().get(
                 'https://{}:{}/oidc/.well-known/openid-configuration'.format(
                     control_plane_ip, INGRESS_PORT
                 ),
@@ -226,7 +224,7 @@ def successful_login(host, context, status_code):
 
 def _dex_auth_request(control_plane_ip, username, password):
     try:
-        response = requests_retry_session().post(
+        response = utils.requests_retry_session().post(
             'https://{}:{}/oidc/auth?'.format(control_plane_ip, INGRESS_PORT),
             data={
                 'response_type': 'id_token',
@@ -271,32 +269,6 @@ def _dex_auth_request(control_plane_ip, username, password):
         pytest.fail("Unable to login with error: {}".format(exc))
 
     return result
-
-
-# a retry helper that performs 3 retries with an exponential sleep interval
-# between each request.
-# Only retry internal server errors and service unavailable errors
-# Source: https://www.peterbe.com/plog/best-practice-with-retries-with-requests
-
-def requests_retry_session(
-    retries=3,
-    backoff_factor=0.3,
-    status_forcelist=(500, 503),
-    method_whitelist=frozenset(['GET', 'POST']),
-    session=None
-):
-    session = session or requests.Session()
-    retry = Retry(
-        total=retries,
-        read=retries,
-        connect=retries,
-        backoff_factor=backoff_factor,
-        status_forcelist=status_forcelist,
-    )
-    adapter = HTTPAdapter(max_retries=retry)
-    session.mount("http://", adapter)
-    session.mount("https://", adapter)
-    return session
 
 
 # }}}


### PR DESCRIPTION

**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
'test'

**Context**: 

See: https://github.com/scality/metalk8s/pull/2249#discussion_r381489467

**Summary**:

Made the requests retry helper generic by declaring it in `tests/utils.py` before importing it into the authentication test.

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
