### PR TITLE
calico: update to Calico 3.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
 # CHANGELOG
 
 ## Release 2.5.0 (in development)
+
+### Features Added
+- Upgrade Calico to 3.12.0 (PR [#2253](https://github.com/scality/metalk8s/pull/2253))

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -17,7 +17,7 @@ Image = namedtuple('Image', ('name', 'version', 'digest'))
 
 # Project-wide versions {{{
 
-CALICO_VERSION     : str = '3.10.2'
+CALICO_VERSION     : str = '3.12.0'
 K8S_VERSION        : str = '1.16.2'
 SALT_VERSION       : str = '2018.3.4'
 

--- a/packages/redhat/calico-cni-plugin.spec
+++ b/packages/redhat/calico-cni-plugin.spec
@@ -6,12 +6,12 @@
 
 %ifarch x86_64
 %global built_arch              amd64
-%global calico_sha256           fbc6588d6c83552403c5e75f108690f9f36fd65421552ae070dc1c93fa6f5139
-%global calico_ipam_sha256      522cc86264ae971625f68471c587fcecd9fbcfb362534b8fba03336702593e89
+%global calico_sha256           020b1387d903a8f9a8b68f727972ed319f8c9af16b5ca7059539d3480999a9a6
+%global calico_ipam_sha256      a5d6c71246cac61c41c22439f2890fbf4254bde2a02d1800a872d6c31b988b37
 %endif
 
 Name:           calico-cni-plugin
-Version:        3.10.2
+Version:        3.12.0
 Release:        1%{?dist}
 Summary:        Calico CNI plugin
 
@@ -49,6 +49,9 @@ install -p -m 755 %{SOURCE2} %{buildroot}/opt/cni/bin/calico-ipam
 %doc README.md
 
 %changelog
+* Thu Feb 20 2020 Nicolas Trangez <nicolas.trangez@scality.com> - 3.12.0-1
+- Version bump
+
 * Sat Dec 14 2019 Nicolas Trangez <nicolas.trangez@scality.com> - 3.10.2-1
 - Version bump
 

--- a/salt/metalk8s/kubernetes/cni/calico/configured.sls
+++ b/salt/metalk8s/kubernetes/cni/calico/configured.sls
@@ -48,5 +48,12 @@ Create CNI calico configuration file:
             capabilities:
               portMappings: true
             conditionsV4: ["-d", "{{ grains.metalk8s.workload_plane_ip }}/32"]
+          # Note: Calico upstream enables the `bandwidth` CNI plugin by default.
+          # However, this plugin (executable) is not available in the CNI RPM
+          # package we currently install. Hence, not enabling this functionality
+          # (for now).
+          #- type: "bandwidth"
+          #  capabilities:
+          #    bandwidth: true
     - require:
       - metalk8s_kubeconfig: Create kubeconf file for calico

--- a/salt/metalk8s/kubernetes/cni/calico/deployed.sls
+++ b/salt/metalk8s/kubernetes/cni/calico/deployed.sls
@@ -54,6 +54,10 @@ data:
   #        "type": "portmap",
   #        "snat": true,
   #        "capabilities": {"portMappings": true}
+  #      },
+  #      {
+  #        "type": "bandwidth",
+  #        "capabilities": {"bandwidth": true}
   #      }
   #    ]
   #  }
@@ -512,7 +516,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
         # Make sure calico-node gets scheduled on all nodes.
@@ -533,7 +537,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         #- name: upgrade-ipam
-        #  image: calico/cni:v3.10.2
+        #  image: calico/cni:v3.12.0
         #  command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
         #  env:
         #    - name: KUBERNETES_NODE_NAME
@@ -550,11 +554,13 @@ spec:
         #      name: host-local-net-dir
         #    - mountPath: /host/opt/cni/bin
         #      name: cni-bin-dir
+        #  securityContext:
+        #    privileged: true
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         # Note: In MetalK8s, we handle this in the Calico state
         #- name: install-cni
-        #  image: calico/cni:v3.10.2
+        #  image: calico/cni:v3.12.0
         #  command: ["/install-cni.sh"]
         #  env:
         #    # Name of the CNI config file to create.
@@ -585,14 +591,18 @@ spec:
         #      name: cni-bin-dir
         #    - mountPath: /host/etc/cni/net.d
         #      name: cni-net-dir
+        #  securityContext:
+        #    privileged: true
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         # Note: In MetalK8s, we have no support for Dikastes (yet).
         #- name: flexvol-driver
-        #  image: calico/pod2daemon-flexvol:v3.10.2
+        #  image: calico/pod2daemon-flexvol:v3.12.0
         #  volumeMounts:
         #  - name: flexvol-driver-host
         #    mountPath: /host/driver
+        #  securityContext:
+        #    privileged: true
       containers:
         # Runs calico-node container on each Kubernetes node.  This
         # container programs network policy and routes on each
@@ -770,7 +780,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       tolerations:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly


### PR DESCRIPTION
Deployment manifest updated based on upstream from
https://docs.projectcalico.org/v3.12/manifests/calico.yaml.

Note: Calico by default now deploys a CNI configuration which includes
the `bandwidth` plugin. Since this plugin executable is not part of the
`kubernetes-cni` package we deploy, this is not enabled in 'our'
configuration.

Once `kubernetes-cni` would include this binary (or, given where things
are going, `kubelet` includes it), we could enable it.

Another approach would be for our `calico-cni-plugin` to include the
required CNI plugins (as is done by the upstream install mechanism,
copying binaries out of a container), and no longer install
`kubernetes-cni`. However, this would introduce conflicts between
packages installing the same files.