### PR TITLE
salt: Fix python invalid `time.sleep` argument

### DIFF
--- a/salt/_modules/metalk8s.py
+++ b/salt/_modules/metalk8s.py
@@ -237,7 +237,7 @@ def check_pillar_keys(keys, refresh=True, pillar=None, raise_error=True):
         # In salt 2018.3 we can not do synchronous pillar refresh, so add a
         # sleep
         # See https://github.com/saltstack/salt/issues/20590
-        time.sleep('10')
+        time.sleep(10)
 
     if not pillar:
         pillar = __pillar__


### PR DESCRIPTION
**Component**:

'salt'

**Context**: 

Typo in our `metalk8s` python salt module where we put a `time.sleep`
with quoted int which is totaly wrong

---
