### PR TITLE
chart: template and store Dex backend config in a ConfigMap

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -229,6 +229,7 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/addons/dex/deployed/chart.sls'),
     Path('salt/metalk8s/addons/dex/deployed/init.sls'),
     Path('salt/metalk8s/addons/dex/deployed/namespace.sls'),
+    Path('salt/metalk8s/addons/dex/deployed/service-configuration.sls'),
     Path('salt/metalk8s/addons/dex/deployed/tls-secret.sls'),
     Path('salt/metalk8s/addons/dex/deployed/clusterrolebinding.sls'),
     targets.SerializedData(

--- a/charts/dex.yaml
+++ b/charts/dex.yaml
@@ -1,4 +1,4 @@
-image: '{% endraw %}{{ build_image_name(\"dex\", False) }}{% raw %}'
+image: '__image__(dex)'
 
 nodeSelector:
   node-role.kubernetes.io/infra: ''
@@ -11,7 +11,7 @@ tolerations:
     operator: "Exists"
     effect: "NoSchedule"
 
-replicas: 2
+replicas: '__var__(dex.spec.deployment.replicas)'
 
 # grpc support
 grpc: false
@@ -20,7 +20,7 @@ grpc: false
 https: true
 
 service:
-  clusterIP: '{% endraw %}{{ salt.metalk8s_network.get_oidc_service_ip() }}{% raw %}'
+  clusterIP: '__var__(salt.metalk8s_network.get_oidc_service_ip())'
 
 ingress:
   enabled: true
@@ -47,7 +47,7 @@ certs:
     create: false
 
 config:
-  issuer: '{% endraw %}https://{{ grains.metalk8s.control_plane_ip }}:8443/oidc{% raw %}'
+  issuer: '__url__(https://{{ grains.metalk8s.control_plane_ip }}:8443/oidc)'
   web:
     tlsCert: /etc/dex/tls/https/server/tls.crt
     tlsKey: /etc/dex/tls/https/server/tls.key
@@ -55,7 +55,7 @@ config:
     theme: "scality"
     issuer: "MetalK8s"
 
-  connectors: {}
+  connectors: '__var_tojson__(dex.spec.connectors)'
 
   oauth2:
     alwaysShowLoginScreen: true
@@ -77,18 +77,15 @@ config:
     - grafana-ui
   - id: metalk8s-ui
     redirectURIs:
-    - '{% endraw %}https://{{ grains.metalk8s.control_plane_ip }}:8443/oauth2/callback{% raw %}'
+    - '__url__(https://{{ grains.metalk8s.control_plane_ip }}:8443/oauth2/callback)'
     name: 'MetalK8s UI'
     secret: "ybrMJpVMQxsiZw26MhJzCjA2ut"
   - id: grafana-ui
     name: 'Grafana UI'
     redirectURIs:
-    - '{% endraw %}https://{{ grains.metalk8s.control_plane_ip }}:8443/grafana/login/generic_oauth{% raw %}'
+    - '__url__(https://{{ grains.metalk8s.control_plane_ip }}:8443/grafana/login/generic_oauth)'
     secret: "4lqK98NcsWG5qBRHJUqYM1"
 
-  staticPasswords:
-    - email: "admin@metalk8s.invalid"
-      # bcrypt hash of the string "password"
-      hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
-      username: "admin"
-      userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
+  enablePasswordDB: '__var__(dex.spec.localuserstore.enabled)'
+
+  staticPasswords: '__var_tojson__(dex.spec.localuserstore.userlist)'

--- a/charts/render.py
+++ b/charts/render.py
@@ -129,9 +129,23 @@ def keep_doc(doc):
 def replace_magic_strings(rendered_yaml):
     # Handle __var__
     result = re.sub(
-        r'__var__\((?P<varname>[\w\-_]+(?:\.[\w\-_]+)*)\)',
+        r'__var__\((?P<varname>[\w\-_]+(?:\.[\w\-_()]+)*)\)',
         r'{% endraw -%}{{ \g<varname> }}{%- raw %}',
         rendered_yaml,
+    )
+
+    # Handle __var_tojson__
+    result = re.sub(
+        r'__var_tojson__\((?P<varname>[\w\-_]+(?:\.[\w\-_()|]+)*)\)',
+        r'  {% endraw -%}{{ \g<varname> | tojson }}{%- raw %}',
+        result,
+    )
+
+    # Handle __url__
+    result = re.sub(
+        r'__url__\((?P<varname>.*)\)',
+        r'"{% endraw -%}\g<varname>{%- raw %}"',
+        result,
     )
 
     # Handle __image__

--- a/salt/metalk8s/addons/dex/deployed/init.sls
+++ b/salt/metalk8s/addons/dex/deployed/init.sls
@@ -13,5 +13,6 @@ include:
 - .namespace
 - .tls-secret
 - .theme-configmap
+- .service-configuration
 - .chart
 - .clusterrolebinding

--- a/salt/metalk8s/addons/dex/deployed/service-configuration.sls
+++ b/salt/metalk8s/addons/dex/deployed/service-configuration.sls
@@ -1,0 +1,44 @@
+include:
+  - .namespace
+
+{%- set dex_config = salt.metalk8s_kubernetes.get_object(
+        kind='ConfigMap',
+        apiVersion='v1',
+        namespace='metalk8s-auth',
+        name='metalk8s-dex-config'
+  )
+%}
+
+{%- if dex_config is none %}
+
+Create dex-config ConfigMap:
+  metalk8s_kubernetes.object_present:
+    - manifest:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: metalk8s-dex-config
+          namespace: metalk8s-auth
+        data:
+          config.yaml: |-
+            apiVersion: addons.metalk8s.scality.com
+            kind: DexConfig
+            spec:
+              deployment:
+                replicas: 2
+              localuserstore:
+                enabled: true
+                userlist:
+                  - email: "admin@metalk8s.invalid"
+                    hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+                    username: "admin"
+                    userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
+              connectors: []
+
+
+ {%- else %}
+
+metalk8s-dex-config ConfigMap already exist:
+  test.succeed_without_changes: []
+
+{%- endif %}

--- a/salt/metalk8s/service-configuration/deployed/init.sls
+++ b/salt/metalk8s/service-configuration/deployed/init.sls
@@ -7,3 +7,4 @@
 # default configurations to startup
 include:
   - metalk8s.addons.prometheus-operator.deployed.service-configuration
+  - metalk8s.addons.dex.deployed.service-configuration


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
'salt', 'kubernetes', 'chart'

**Context**: 

See #2261 

**Summary**:

- Have Dex configurations stored and persisted in a ConfigMap.
- For Dex/external IDP config, please reference this doc: https://github.com/dexidp/dex/blob/master/Documentation/connectors/ldap.md#configuration

**Acceptance criteria**: 

- Working cluster


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2261

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
