### PR TITLE
build: escape "+" char in package URL

### DIFF
--- a/packages/debian/download_packages.py
+++ b/packages/debian/download_packages.py
@@ -78,7 +78,9 @@ def fetch_binary(
     filename = pathlib.Path(package.filename).name
     destfile = destdir/filename
     print('Downloading package {}'.format(filename))
-    with urllib.request.urlopen(package.uri) as response:
+    pkg_uri = urllib.parse.urlparse(package.uri)
+    pkg_uri = pkg_uri._replace(path=urllib.parse.quote(pkg_uri.path))
+    with urllib.request.urlopen(urllib.parse.urlunparse(pkg_uri)) as response:
         destfile.write_bytes(response.read())
     # Check package size.
     if destfile.stat().st_size != package.size:


### PR DESCRIPTION
**Component**: build

**Context**: 

**Summary**:

**Acceptance criteria**:
We can download Ubuntu packages and the build is green.
Basically, `./doit.sh packaging` must work

---

Closes: #2286