### PR TITLE
Add Alertmanager conf as a customizable service configuration

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -269,6 +269,8 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/addons/prometheus-adapter/deployed/chart.sls'),
     Path('salt/metalk8s/addons/prometheus-adapter/deployed/init.sls'),
 
+    Path('salt/metalk8s/addons/prometheus-operator/deployed/'
+         'alertmanager-configuration-secret.sls'),
     Path('salt/metalk8s/addons/prometheus-operator/deployed/chart.sls'),
     Path('salt/metalk8s/addons/prometheus-operator/deployed/cleanup.sls'),
     Path('salt/metalk8s/addons/prometheus-operator/deployed/dashboards.sls'),

--- a/charts/prometheus-operator.yaml
+++ b/charts/prometheus-operator.yaml
@@ -38,6 +38,18 @@ alertmanager:
             matchLabels:
               app.kubernetes.io/name: prometheus-operator-alertmanager
 
+  ## Passing the below configuration directives through the helm template
+  ## engine leads to no substitution since the variables passed will be base64
+  ## encoded directly hence we end up with `alertmanager.yaml` being invalid
+
+  ## So let us disable the creation of this secret from the default charts
+  ## and then create a new secret that replaces the
+  ## alertmanager-prometheus-operator-alertmanager secret with new config
+  ## read from a ConfigMap (metalk8s-alertmanager-config)
+
+  # config: '__var_tojson__(alertmanager.spec.notification.config)'
+
+    useExistingSecret: true
 
 prometheusOperator:
   tlsProxy:

--- a/salt/metalk8s/addons/prometheus-operator/deployed/alertmanager-configuration-secret.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/alertmanager-configuration-secret.sls
@@ -1,0 +1,23 @@
+{%- set alertmanager = salt.metalk8s_service_configuration.get_service_conf(
+        'metalk8s-monitoring', 'metalk8s-alertmanager-config'
+  )
+%}
+
+Create Alertmanager Configuration Secret:
+  metalk8s_kubernetes.object_present:
+    - manifest:
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          labels:
+            app: prometheus-operator-alertmanager
+            app.kubernetes.io/managed-by: salt
+            app.kubernetes.io/name: prometheus-operator-alertmanager
+            app.kubernetes.io/part-of: metalk8s
+            heritage: metalk8s
+            release: prometheus-operator
+          name: alertmanager-prometheus-operator-alertmanager
+          namespace: metalk8s-monitoring
+        stringData:
+          alertmanager.yaml: |-
+            {{ alertmanager.spec.notification.config | tojson }}

--- a/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
@@ -286,22 +286,6 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  alertmanager.yaml: Z2xvYmFsOgogIHJlc29sdmVfdGltZW91dDogNW0KcmVjZWl2ZXJzOgotIG5hbWU6ICJudWxsIgpyb3V0ZToKICBncm91cF9ieToKICAtIGpvYgogIGdyb3VwX2ludGVydmFsOiA1bQogIGdyb3VwX3dhaXQ6IDMwcwogIHJlY2VpdmVyOiAibnVsbCIKICByZXBlYXRfaW50ZXJ2YWw6IDEyaAogIHJvdXRlczoKICAtIG1hdGNoOgogICAgICBhbGVydG5hbWU6IFdhdGNoZG9nCiAgICByZWNlaXZlcjogIm51bGwiCg==
-kind: Secret
-metadata:
-  labels:
-    app: prometheus-operator-alertmanager
-    app.kubernetes.io/managed-by: salt
-    app.kubernetes.io/name: prometheus-operator-alertmanager
-    app.kubernetes.io/part-of: metalk8s
-    chart: prometheus-operator-8.1.2
-    heritage: metalk8s
-    release: prometheus-operator
-  name: alertmanager-prometheus-operator-alertmanager
-  namespace: metalk8s-monitoring
----
-apiVersion: v1
-data:
   provider.yaml: |-
     apiVersion: 1
     providers:

--- a/salt/metalk8s/addons/prometheus-operator/deployed/init.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/init.sls
@@ -3,5 +3,6 @@ include:
   - .storageclass
   - .cleanup
   - .chart
+  - .alertmanager-configuration-secret
   - .dashboards
   - .service-configuration

--- a/salt/metalk8s/addons/prometheus-operator/deployed/service-configuration.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/service-configuration.sls
@@ -90,6 +90,25 @@ Create alertmanager-config ConfigMap:
             spec:
               deployment:
                 replicas: 1
+              notification:
+                config:
+                  global:
+                    resolve_timeout: 5m
+                  templates: []
+                  route:
+                    group_by: ['job']
+                    group_wait: 30s
+                    group_interval: 5m
+                    repeat_interval: 12h
+                    receiver: 'null'
+                    routes:
+                    - match:
+                        alertname: Watchdog
+                      receiver: 'null'
+                  receivers:
+                    - name: 'null'
+                  inhibit_rules: []
+
 {%- else %}
 
 metalk8s-alertmanager-config ConfigMap already exist:


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
'salt', 'charts', 'prometheus-operator'

**Context**: 

See #2262 

**Summary**:

Template and store `alertmanager.yaml` as a service configuration in a MetalK8s cluster making it possible that users can customize and add new alert channels.

**Acceptance criteria**: 

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2262 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
