### PR TITLE
salt: make `salt.minion.running` idempotent

### DIFF
--- a/salt/metalk8s/salt/minion/running.sls
+++ b/salt/metalk8s/salt/minion/running.sls
@@ -16,7 +16,9 @@ Ensure salt-minion running:
     - enable: True
     - require:
       - module: Wait until salt-minion restarted
-  module.run:
-    - test.ping: []
+  test.configurable_test_state:
+    - changes: False
+    - result: __slot__:salt:test.ping()
+    - comment: Ran 'test.ping'
     - require:
       - service: Ensure salt-minion running


### PR DESCRIPTION
Until now, we use `module.run` to execute `test.ping` after restarting
`salt-minion`. The `module.run` state has `changes` though,
unconditionally. As such, when re-running any state including
`salt.minion.running` (e.g., all highstates), this causes changes to be
reported.

Currently, when bringing a cluster to highstate, only these `module.run`
'states' cause any 'changes' to be reported, giving the impression our
states are not idempotent. The `test.ping` call is inherently
idempotent though...

As such, changing the approach slightly and instead of using
`module.run`, running `test.ping` from a `__slot__` call whose result is
set as the `result` of a `test.configurable_test_state` state, wich
`changes` set to `False`. As such, this state will now properly fail
when `test.ping` returns `False`, but no `changes` will be reported when
this state is applied.