### PR TITLE
Enforce the usage of --kubeconfig flag in Solutions script

### DIFF
--- a/scripts/solutions.sh
+++ b/scripts/solutions.sh
@@ -20,6 +20,8 @@ SOLUTION=''
 VERBOSE=${VERBOSE:-0}
 VERSION=''
 
+export KUBECONFIG
+
 declare -A COMMANDS=(
     [import]=import_solution
     [unimport]=unimport_solution


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
'kubernetes'

**Context**: 

While using Solutions.sh script to provision new solutions, users fall into the following situations:
The connection to the server localhost:8080 was refused - did you specify the right host or port?

This is likely because we didn't specify the `--kubeconfig` flag while executing kubectl commands

**Summary**:

Most Devs will have an environment with the exported KUBECONFIG env but this is not the case in the CI. And since we need to test the example-solution in the CI, we require to explicitly set the `--kubeconfig` flag.

**Acceptance criteria**: 

- Working Solutions.sh script

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
