### PR TITLE
Improvement/gh 2267 generate simple junit for eve steps

### DIFF
--- a/eve/generate_junit_result.sh
+++ b/eve/generate_junit_result.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Simple ugly bash script to generate really really simple junit file
+# with just the result of the build step, waiting for something integrated
+# directly in `eve`
+
+FAILURE=0
+ERROR=0
+TYPE=""
+
+case "$FINAL_STATUS" in
+    "SUCCESSFUL")
+        ;;
+    "FAILED")
+        FAILURE=1
+        TYPE="failure"
+        ;;
+    *)
+        ERROR=1
+        TYPE="error"
+        ;;
+esac
+
+
+cat << EOF
+<?xml version="1.0" ?>
+<testsuites disabled="0" errors="$ERROR" failures="$FAILURE" \
+tests="1" time="0.0">
+    <testsuite disabled="0" errors="$ERROR" failures="$FAILURE" \
+name="$TEST_SUITE" skipped="0" tests="1" time="0">
+EOF
+
+if [ "$TYPE" ]; then
+
+    cat << EOF
+        <testcase name="$TEST_NAME" classname="$CLASS_NAME">
+            <$TYPE type="$TYPE" message="$FINAL_STATUS"/>
+        </testcase>
+EOF
+
+else
+    cat << EOF
+        <testcase name="$TEST_NAME" classname="$CLASS_NAME"/>
+EOF
+fi
+
+cat << EOF
+    </testsuite>
+</testsuites>
+EOF

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -444,7 +444,7 @@ stages:
           name: Run all linting targets
           command: ./doit.sh lint
           usePTY: true
-          haltOnFailure: false
+          haltOnFailure: true
       - ShellCommand:
           <<: *add_final_status_artifact_success
           env:

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -290,6 +290,12 @@ models:
           [[ ${STEP_NAME:-} ]] && BUILD_STATUS_DIR+="/build_status/$STEP_NAME"
           mkdir -p "$BUILD_STATUS_DIR"
           echo -n "$FINAL_STATUS" > "$BUILD_STATUS_DIR/.final_status"
+          TEST_NAME="${TEST_NAME:-$STEP_NAME}"
+          if [[ ${TEST_NAME:-} && ${TEST_SUITE:-} ]]; then
+              git checkout "%(prop:branch)s" && \
+              eve/generate_junit_result.sh \
+                  > "$BUILD_STATUS_DIR/junit_status.xml"
+          fi
         '
       env: &_env_final_status_artifact
         STEP_NAME: ''
@@ -335,6 +341,10 @@ stages:
       - Upload: *upload_final_status_artifact
 
   build:
+    _metalk8s_internal_info:
+      junit_info: &_build_metalk8s_junit_info
+        TEST_SUITE: build
+        TEST_NAME: metalk8s
     worker: &build_worker
       type: kube_pod
       path: eve/workers/pod-builder/pod.yaml
@@ -347,6 +357,7 @@ stages:
           <<: *add_final_status_artifact_failed
           env:
             <<: *_env_final_status_artifact_failed
+            <<: *_build_metalk8s_junit_info
             STEP_NAME: build
       - ShellCommand: *setup_cache
       - ShellCommand: *build_all
@@ -364,10 +375,15 @@ stages:
           <<: *add_final_status_artifact_success
           env:
             <<: *_env_final_status_artifact_success
+            <<: *_build_metalk8s_junit_info
             STEP_NAME: build
       - Upload: *upload_final_status_artifact
 
   docs:
+    _metalk8s_internal_info:
+      junit_info: &_build_docs_junit_info
+        TEST_SUITE: build
+        TEST_NAME: docs
     worker:
       type: kube_pod
       path: eve/workers/pod-docs-builder/pod.yaml
@@ -381,6 +397,7 @@ stages:
           <<: *add_final_status_artifact_failed
           env:
             <<: *_env_final_status_artifact_failed
+            <<: *_build_docs_junit_info
             STEP_NAME: docs
       - ShellCommand: *setup_cache
       - ShellCommand:
@@ -399,10 +416,16 @@ stages:
           <<: *add_final_status_artifact_success
           env:
             <<: *_env_final_status_artifact_success
+            <<: *_build_docs_junit_info
             STEP_NAME: docs
       - Upload: *upload_final_status_artifact
 
   lint:
+    _metalk8s_internal_info:
+      junit_info: &_lint_junit_info
+        TEST_SUITE: lint
+        # This one should be split in different test case for each linting
+        TEST_NAME: full
     worker:
       type: kube_pod
       path: eve/workers/pod-linter/pod.yaml
@@ -414,6 +437,7 @@ stages:
           <<: *add_final_status_artifact_failed
           env:
             <<: *_env_final_status_artifact_failed
+            <<: *_lint_junit_info
             STEP_NAME: lint
       - ShellCommand: *setup_cache
       - ShellCommand:
@@ -425,10 +449,16 @@ stages:
           <<: *add_final_status_artifact_success
           env:
             <<: *_env_final_status_artifact_success
+            <<: *_lint_junit_info
             STEP_NAME: lint
       - Upload: *upload_final_status_artifact
 
   single-node:
+    _metalk8s_internal_info:
+      junit_info: &_install_single-node_junit_info
+        TEST_SUITE: install
+        CLASS_NAME: single-node.centos7
+        TEST_NAME: simple environment
     worker: &single_node_worker
       type: openstack
       image: CentOS-7-x86_64-GenericCloud-1809.qcow2
@@ -440,6 +470,7 @@ stages:
           <<: *add_final_status_artifact_failed
           env:
             <<: *_env_final_status_artifact_failed
+            <<: *_install_single-node_junit_info
             STEP_NAME: single-node
       - ShellCommand: *setup_cache
       - ShellCommand: *ssh_ip_setup
@@ -479,6 +510,7 @@ stages:
           <<: *add_final_status_artifact_success
           env:
             <<: *_env_final_status_artifact_success
+            <<: *_install_single-node_junit_info
             STEP_NAME: single-node
       - Upload: *upload_final_status_artifact
       - ShellCommand:
@@ -487,6 +519,11 @@ stages:
             STEP_NAME: single-node
 
   multiple-nodes:
+    _metalk8s_internal_info:
+      junit_info: &_install_multi-node_junit_info
+        TEST_SUITE: install
+        CLASS_NAME: multi-node.centos7
+        TEST_NAME: 1 bootstrap 1 master,etcd
     worker:
       <<: *single_node_worker
       flavor: m1.medium
@@ -497,6 +534,7 @@ stages:
           <<: *add_final_status_artifact_failed
           env:
             <<: *_env_final_status_artifact_failed
+            <<: *_install_multi-node_junit_info
             STEP_NAME: multiple-nodes
       - ShellCommand: *setup_cache
       - ShellCommand: *ssh_ip_setup
@@ -709,6 +747,7 @@ stages:
           <<: *add_final_status_artifact_success
           env:
             <<: *_env_final_status_artifact_success
+            <<: *_install_multi-node_junit_info
             STEP_NAME: multiple-nodes
       - Upload: *upload_final_status_artifact
       - ShellCommand:


### PR DESCRIPTION
**Component**:

'build'

**Context**: 

Currently we do not have any report for build status.

**Summary**:

This commit add a very very simple script to generate really simple junit for each steps
of the build. 1 junit with 1 test suite and 1 test case per step.
A better junit reporting should be done directly by eve in the futur,
this junit just allow us to have a report giving use the result of each
build steps

Junit example:

Success:
```
<?xml version="1.0" ?>
<testsuites disabled="0" errors="0" failures="0" tests="1" time="0.0">
	<testsuite disabled="0" errors="0" failures="0" name="upgrade" skipped="0" tests="1" time="0">
		<testcase name="simple environment" classname="single-node.centos7"/>
	</testsuite>
</testsuites>
```

Fail:
```
<?xml version="1.0" ?>
<testsuites disabled="0" errors="0" failures="1" tests="1" time="0.0">
	<testsuite disabled="0" errors="0" failures="1" name="upgrade" skipped="0" tests="1" time="0">
		<testcase name="simple environment" classname="single-node.centos7">
			<failure type="failure" message="FAILED"/>
		</testcase>
	</testsuite>
</testsuites>
```

---

Fixes: #2267 