### PR TITLE
Bugfix/2334 install yum utils

### DIFF
--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -332,6 +332,7 @@ PACKAGES: Dict[str, Tuple[PackageVersion, ...]] = {
             release='1.el7'
         ),
         PackageVersion(name='yum-plugin-versionlock'),
+        PackageVersion(name='yum-utils'),
     ),
     'debian': (
         PackageVersion(

--- a/salt/metalk8s/repo/redhat.sls
+++ b/salt/metalk8s/repo/redhat.sls
@@ -9,6 +9,10 @@ Set metalk8s_osmajorrelease in yum vars:
     - name: /etc/yum/vars/metalk8s_osmajorrelease
     - contents: {{ grains['osmajorrelease'] }}
 
+Install yum-utils:
+  pkg.installed:
+    - name: yum-utils
+
 Install yum-plugin-versionlock:
   pkg.installed:
     - name: yum-plugin-versionlock


### PR DESCRIPTION
**Component**: build, salt

**Context**: yum-utils package may not be present on the hosts where we deploy metalk8s, thus breaking the installation or expansion, because we never install it.

**Summary**: we now ship the yum-utils package in the ISO and install it at the beginning of repositories setup.  

**Acceptance criteria**: be able to bootstrap a machine or do an expansion on a node without yum-utils installed prior to that.

---

Closes: #2334