### PR TITLE
scripts: update solutions configmap at archive import

### DIFF
--- a/scripts/solutions.sh
+++ b/scripts/solutions.sh
@@ -283,6 +283,10 @@ import_solution() {
     run "Importing Solutions" \
         salt_minion_exec state.sls metalk8s.solutions.available \
         saltenv="$SALTENV"
+    run "Updating Solutions ConfigMap" \
+        salt_master_exec salt-run state.orchestrate \
+        metalk8s.orchestrate.solutions.deploy-components \
+        pillar="{'bootstrap_id': '$(get_salt_minion_id)'}"
     run "Configuring Metalk8s registry" \
         salt_minion_exec state.sls metalk8s.repo.installed \
         saltenv="$SALTENV"
@@ -295,6 +299,10 @@ unimport_solution() {
     run "Unimporting Solutions" \
         salt_minion_exec state.sls metalk8s.solutions.available \
         saltenv="$SALTENV"
+    run "Updating Solutions ConfigMap" \
+        salt_master_exec salt-run state.orchestrate \
+        metalk8s.orchestrate.solutions.deploy-components \
+        pillar="{'bootstrap_id': '$(get_salt_minion_id)'}"
     run "Configuring Metalk8s registry" \
         salt_minion_exec state.sls metalk8s.repo.installed \
         saltenv="$SALTENV"


### PR DESCRIPTION
**Component**: scripts, solutions

**Context**: 

**Summary**:
Update automatically the metalk8s-solutions configmap when importing or removing a Solution from the cluster, so the configmap always reflects what solutions are available.

**Acceptance criteria**:
When we import a Solution, the metalk8s-solutions must be updated accordingly:
```
# ./solutions.sh import --archive /vagrant/_build/hyperdrive.iso
> Updating Solutions configuration file... done [7s]
> Importing Solutions... done [11s]
> Updating Solutions ConfigMap... done [18s]
> Configuring Metalk8s registry... done [18s]

# kubectl get cm -n metalk8s-solutions metalk8s-solutions -o yaml
apiVersion: v1
data:
  hyperdrive: '[{"name": "HyperDrive", "archive": "/vagrant/_build/hyperdrive.iso",
    "version": "0.2.0", "active": false, "mountpoint": "/srv/scality/hyperdrive-0.2.0",
    "config": {"kind": "SolutionConfig", "apiVersion": "solutions.metalk8s.scality.com/v1alpha1",
    "operator": {"image": {"tag": "0.2.0", "name": "hyperdrive-operator"}}, "ui":
    {"image": {"tag": "0.2.0", "name": "hyperdrive-ui"}}, "images": ["hdcontroller:0.2.0",
    "hdoperator:0.2.0", "hyperiod:0.2.0"], "customApiGroups": []}, "id": "hyperdrive-0.2.0"}] '
kind: ConfigMap
metadata:
  creationTimestamp: "2020-03-31T14:02:54Z"
  labels:
    metalk8s.scality.com/version: 2.4.3-dev
  name: metalk8s-solutions
  namespace: metalk8s-solutions
  resourceVersion: "75265"
  selfLink: /api/v1/namespaces/metalk8s-solutions/configmaps/metalk8s-solutions
  uid: 659c627f-d252-483c-bc72-6ce0e4521095
```
