### PR TITLE
images: enrich `metalk8s-utils` image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,6 @@
 
 ### Features Added
 - Upgrade Calico to 3.12.0 (PR [#2253](https://github.com/scality/metalk8s/pull/2253))
+- Extend the set of packages installed in the `metalk8s-utils` container image
+  (Partially resolves issue [#2156](https://github.com/scality/metalk8s/issues/2156),
+  PR [#2374](https://github.com/scality/metalk8s/pull/2374))

--- a/buildchain/buildchain/image.py
+++ b/buildchain/buildchain/image.py
@@ -39,6 +39,7 @@ from buildchain import targets
 from buildchain import types
 from buildchain import utils
 from buildchain import versions
+from buildchain import ROOT
 
 
 def task_images() -> types.TaskDict:
@@ -250,7 +251,12 @@ TO_BUILD : Tuple[targets.LocalImage, ...] = (
                             .isoformat(),
             'VCS_REF': constants.GIT_REF or '<unknown>',
             'METALK8S_VERSION': versions.VERSION,
+            'SALT_VERSION': versions.SALT_VERSION,
+            'KUBERNETES_VERSION': versions.K8S_VERSION,
         },
+        file_dep=[
+            ROOT/'images'/'metalk8s-utils'/'configure-repos.sh',
+        ],
     ),
     _operator_image(
         name='storage-operator',

--- a/images/metalk8s-utils/Dockerfile
+++ b/images/metalk8s-utils/Dockerfile
@@ -4,6 +4,14 @@ ARG BASE_IMAGE=docker.io/centos
 
 FROM $BASE_IMAGE@sha256:$BASE_IMAGE_SHA256
 
+# Kubernetes version
+ARG KUBERNETES_VERSION
+# Salt version
+ARG SALT_VERSION
+
+COPY configure-repos.sh /
+RUN /configure-repos.sh 7 $SALT_VERSION && rm /configure-repos.sh
+
 # Timestamp of the build, formatted as RFC3339
 ARG BUILD_DATE
 # Git revision o the tree at build time
@@ -12,8 +20,6 @@ ARG VCS_REF
 ARG VERSION
 # Version of the project, e.g. `git describe --always --long --dirty --broken`
 ARG METALK8S_VERSION
-
-ENTRYPOINT ["/bin/sh"]
 
 # These contain BUILD_DATE so should come 'late' for layer caching
 LABEL maintainer="moonshot-platform@scality.com" \
@@ -46,13 +52,58 @@ LABEL maintainer="moonshot-platform@scality.com" \
 
 # Final layers, installing tooling
 RUN yum install -y epel-release && \
-    yum install -y \
+    yum install -y --setopt=skip_missing_names_on_install=False \
+        bash-completion \
+        bash-completion-extras \
         bind-utils \
+        bzip2 \
+        conntrack-tools \
+        cri-tools \
         curl \
+        e2fsprogs \
+        ebtables \
+        etcd \
+        ethtool \
+        gdb \
+        git \
+        htop \
+        httpd-tools \
         httpie \
+        iotop \
         iperf \
+        iperf3 \
         iproute \
+        ipset \
+        iptables \
+        ipvsadm \
+        jnettop \
+        jq \
+        "kubectl-${KUBERNETES_VERSION}" \
+        less \
+        lsof \
+        ltrace \
+        lvm2 \
+        net-tools \
+        nethogs \
+        nmap \
+        nmap-ncat \
+        openssh-clients \
+        openssh-server \
+        openssl \
+        parted \
+        perf \
+        rsync \
+        salt-master \
+        salt-minion \
         socat \
+        strace \
+        sysstat \
+        tcpdump \
         telnet \
+        util-linux \
+        vim \
+        wget \
+        wireshark \
+        xfsprogs \
         && \
     yum clean all

--- a/images/metalk8s-utils/configure-repos.sh
+++ b/images/metalk8s-utils/configure-repos.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -xue -o pipefail
+
+CENTOS_VERSION=$1
+SALT_VERSION=$2
+
+cat > /etc/yum.repos.d/kubernetes.repo << EOF
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el$CENTOS_VERSION-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
+       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+EOF
+
+cat > /etc/yum.repos.d/saltstack.repo << EOF
+[saltstack]
+name=SaltStack repo for RHEL/CentOS \$releasever
+baseurl=https://repo.saltstack.com/yum/redhat/\$releasever/\$basearch/archive/$SALT_VERSION
+enabled=1
+gpgcheck=1
+gpgkey=https://repo.saltstack.com/yum/redhat/\$releasever/\$basearch/archive/$SALT_VERSION/SALTSTACK-GPG-KEY.pub
+       https://repo.saltstack.com/yum/redhat/\$releasever/\$basearch/archive/$SALT_VERSION/base/RPM-GPG-KEY-CentOS-$CENTOS_VERSION
+EOF


### PR DESCRIPTION
This patch extends the `metalk8s-utils` `Dockerfile` to add a bunch of
packages (and make some related changes):

- The Kubernetes and SaltStack repositories are enabled in the image
- No longer override the entrypoint
- Fail when a given package (name) doesn't exist
- Add the following packages to the image:

  * `bash-completion`
  * `bash-completion-extras`
  * `bzip2`
  * `conntrack-tools`
  * `cri-tools`, for `crictl`
  * `e2fsprogs`
  * `ebtables`
  * `etcd`, for `etcdctl`
  * `ethtool`
  * `gdb`
  * `git`
  * `htop`
  * `httpd-tools`, for `htpasswd` (see #2352)
  * `iotop`
  * `iperf3` (next to `iperf` which was already installed)
  * `ipset`
  * `iptables`
  * `ipvsadm`
  * `jnettop`
  * `jq`
  * `kubectl` (pinned to the version of Kubernetes this MetalK8s release ships with)
  * `less`
  * `lsof`
  * `ltrace`
  * `lvm2`
  * `net-tools`
  * `nethogs`
  * `nmap`
  * `nmap-ncat`, for `nc`
  * `openssh-clients`
  * `openssh-server`
  * `openssl`, for its CLI interface
  * `parted`
  * `perf`
  * `rsync`
  * `salt-master`, for `salt` and `salt-run`
  * `salt-minion`, for `salt-call`
  * `strace`
  * `sysstat`
  * `tcpdump`
  * `util-linux`, for `nsenter` and others
  * `vim`
  * `wget`
  * `wireshark`, for `tshark`
  * `xfsprogs`

This resolves #2156 to a great extent. However, documentation on how to
use the image is still lacking, as well as some of the tools referred to
in the ticket, for which no upstream packages are available.

See: https://github.com/scality/metalk8s/issues/2156
See: https://github.com/scality/metalk8s/issues/2352