### PR TITLE
doc: update documentation with default login details for MetalK8s UI & Grafana service

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -549,6 +549,10 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/solutions/available.sls'),
     Path('salt/metalk8s/solutions/init.sls'),
 
+    Path('salt/metalk8s/utils/init.sls'),
+    Path('salt/metalk8s/utils/httpd-tools/init.sls'),
+    Path('salt/metalk8s/utils/httpd-tools/installed.sls'),
+
     Path('salt/metalk8s/volumes/init.sls'),
     Path('salt/metalk8s/volumes/prepared/init.sls'),
     Path('salt/metalk8s/volumes/prepared/installed.sls'),

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -331,6 +331,7 @@ PACKAGES: Dict[str, Tuple[PackageVersion, ...]] = {
             release='1.el7'
         ),
         PackageVersion(name='container-selinux'),  # TODO #1710
+        PackageVersion(name='httpd-tools'),
         PackageVersion(
             name='metalk8s-sosreport',
             version=SHORT_VERSION,

--- a/docs/installation/services.rst
+++ b/docs/installation/services.rst
@@ -30,7 +30,13 @@ The login page is loaded, and should resemble the following:
 
 .. image:: img/ui/login.png
 
-Log in with the default login / password (admin / admin).
+Log in with the default login / password
+(``admin@metalk8s.invalid`` / ``password``).
+
+  .. note::
+
+     To change the default password as provided above, refer to
+     :ref:`this procedure <Change-dex-user-password>`.
 
 The landing page should look like this:
 
@@ -48,7 +54,7 @@ This page displays two monitoring indicators:
 Grafana
 -------
 Grafana is available on the same host as the MetalK8s UI, under ``/grafana``.
-Log in with the default credentials: ``admin`` / ``admin``.
+Log in with the default credentials: ``admin@metalk8s.invalid`` / ``password``.
 
 .. _installation-services-salt:
 
@@ -69,7 +75,9 @@ To interact with the Salt Master with the usual CLIs, open a terminal in the
 
 .. code-block:: shell
 
-   root@bootstrap $ kubectl exec -it -n kube-system -c salt-master --kubeconfig /etc/kubernetes/admin.conf salt-master-bootstrap bash
+   root@bootstrap $ kubectl exec -it -n kube-system -c salt-master \
+                      --kubeconfig /etc/kubernetes/admin.conf \
+                      salt-master-bootstrap bash
 
 .. todo::
 

--- a/docs/operation/account_administration.rst
+++ b/docs/operation/account_administration.rst
@@ -3,66 +3,72 @@ Account Administration
 ======================
 
 This section highlights **MetalK8s Account Administration** which covers
-changing the default username and password for some MetalK8s services.
+user authentication, identity management and access control.
 
+User Authentication and Identity management
+-------------------------------------------
+
+Identity management and user authentication in MetalK8s is driven by the
+integration of `kube-apiserver` and Dex (an OIDC provider).
+
+Kubernetes API enables OpenID Connect (OIDC) as one authentication strategy
+(it also supports certificate-based authentication) by trusting Dex as an
+OIDC Provider.
+
+Dex can authenticate users against:
+
+   - a static user store (stored in configuration)
+   - a connector-based interface, allowing to plug in external such as LDAP,
+     SAML, GitHub, Active Directory and others.
+
+MetalK8s OIDC based Services
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+MetalK8s out of the box enables OpenID Connect (OIDC) based authentication for
+its UI and Grafana service.
 
 .. _ops-grafana-admin:
 
-Administering Grafana
-*********************
+Administering Grafana and MetalK8s UI
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A fresh install of MetalK8s has a Grafana service instance with default
-credentials: ``admin`` / ``admin``. For more information on how to access
-Grafana, please refer to :ref:`this procedure <installation-services-grafana>`
+A fresh installation of MetalK8s has its UI and Grafana service with default
+login credentials as: ``admin@metalk8s.invalid`` / ``password``.
 
-Changing Grafana username and password
---------------------------------------
+This default user is defined in Dex configuration as a static user, to
+allow MetalK8s administrators first time access to these services. It is
+recommended that MetalK8s administrators change the default password.
 
-To change the default username and password for Grafana on a MetalK8s cluster,
-perform the following procedures:
+.. note::
 
-#. Create a file named ``patch-secret.yaml`` that has the following content:
+   The MetalK8s UI and Grafana are both configured to use OIDC as
+   an authentication mechanism, and trust Dex as a Provider. Changing
+   the Dex configuration, including the default credentials, will impact
+   both UIs.
 
-   .. code-block:: yaml
+For information on how to access the MetalK8s UI, please refer to
+:ref:`this procedure <installation-services-admin-ui>`
 
-      stringData:
-        admin-user: <username-in-clear>
-        admin-password: <password-in-clear>
+For information on how to access the Grafana service, please refer to
+:ref:`this procedure <installation-services-grafana>`
 
-#. Apply the patch file by running:
 
-   .. code-block:: shell
+Add new static user
+^^^^^^^^^^^^^^^^^^^
 
-      $ kubectl --kubeconfig /etc/kubernetes/admin.conf patch secrets prometheus-operator-grafana --patch "$(cat patch-secret.yaml)" -n metalk8s-monitoring
+To add a new static user for either the MetalK8s UI and/or Grafana service,
+refer to :ref:`this procedure <Add-dex-static-user>`
 
-#. Now, roll out the new updates for Grafana:
+Change static user password
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-   .. code-block:: shell
-
-      $ kubectl --kubeconfig /etc/kubernetes/admin.conf rollout restart deploy prometheus-operator-grafana -n metalk8s-monitoring
-
-#. Access the Grafana instance and authenticate yourself using the new Account
-   credentials.
-
-  .. warning::
-
-     During an upgrade or downgrade of a MetalK8s cluster, customized Grafana
-     username and password will be overwritten with default credentials
-     ``admin`` / ``admin``.
-
-.. _ops-k8s-admin:
-
-Administering MetalK8s GUI, Kubernetes API and Salt API
-*******************************************************
-
-During installation, MetalK8s configures the Kubernetes API to accept Basic
-authentication, with default credentials ``admin`` / ``admin``.
-
-Services exposed by MetalK8s, such as
-:ref:`its GUI <installation-services-admin-ui>` or
-:ref:`Salt API <installation-services-salt>`, rely on the Kubernetes API for
-authenticating their users.
+To change the default password for the MetalK8s UI and/or Grafana service,
+refer to :ref:`this procedure <Change-dex-static-user-password>`
 
 .. todo::
 
-    - Define how to create and administer users.
+   Add documentation on the following
+
+   - Dex connectors
+
+   - How to add a new connector (LDAP, AD, SAML)

--- a/docs/operation/cluster_and_service_configuration.rst
+++ b/docs/operation/cluster_and_service_configuration.rst
@@ -15,6 +15,7 @@ documented procedure to the later.
 
 Managing Authentication
 ^^^^^^^^^^^^^^^^^^^^^^^
+   .. _Add-dex-static-user:
 
 Add a local static user
 """""""""""""""""""""""

--- a/docs/operation/cluster_and_service_configuration.rst
+++ b/docs/operation/cluster_and_service_configuration.rst
@@ -30,12 +30,18 @@ MetalK8s installation.
 
 To add a new static user, perform the following operations:
 
-#. Generate a password ``hash``. The command below requires **apache-utils**
-   package to be installed.
+   .. _Generate-password-hash:
+
+#. Generate a bcrypt hash of your new password.
+
+   - To generate the bcrypt hash, on the Bootstrap node, run the following.
 
    .. code-block:: shell
 
-      root@bootstrap $ htpasswd -bnBC 12 "" <replace-with-password> | tr -d ':\n'
+      root@bootstrap $ htpasswd -nBC 14 "" | tr -d ':'
+      New password:
+      Re-type new password:
+      <your hash here, starting with "$2y$14$">
 
 #. Generate a unique ``UserID`` by running the following command.
 
@@ -68,20 +74,17 @@ To add a new static user, perform the following operations:
                       userID: "<uuidv4>"
       [...]
 
-#. Save and apply the changes.
+#. Save the ConfigMap changes.
 
-#. From the Bootstrap node, execute the following command which connects to
-   the Salt master container and applies salt-states to propagate the new
-   changes down to the underlying services.
+#. From the Bootstrap node, run the following to propagate the
+   changes.
 
-   Make sure to replace the <version> prefix in the command below with the
-   currently installed MetalK8s version number e.g 2.5.0
+   .. parsed-literal::
 
-   .. code-block:: shell
-
-      root@bootstrap $ crictl exec -it \
-                         $(crictl ps -q --label io.kubernetes.container.name=salt-master) bash \
-                         -c "salt-run state.sls metalk8s.addons.dex.deployed saltenv=metalk8s-<version>"
+      root@bootstrap $ kubectl exec -n kube-system -c salt-master \\
+                       --kubeconfig /etc/kubernetes/admin.conf \\
+                       salt-master-bootstrap -- salt-run \\
+                       state.sls metalk8s.addons.dex.deployed saltenv=metalk8s-|release|
 
 #. Finally, create and apply the required :file:`ClusterRoleBinding.yaml` file
    that ensures that the newly added static user is bound to a Cluster Role.
@@ -146,6 +149,51 @@ To add a new static user, perform the following operations:
 
 #. Verify that the user has been successfully added and you can log in to the
    MetalK8s UI using the new email and password.
+
+.. _Change-dex-static-user-password:
+
+Change password for local static user
+"""""""""""""""""""""""""""""""""""""
+
+To change the password of an existing user, perform the following operations:
+
+#. Generate a bcrypt hash of the new password using
+   :ref:`this procedure<Generate-password-hash>` .
+
+#. From the Bootstrap node, edit the ConfigMap ``metalk8s-dex-config`` and then
+   change the ``hash`` for the selected user:
+
+   .. code-block:: shell
+
+      root@bootstrap $ kubectl --kubeconfig /etc/kubernetes/admin.conf \
+                         edit configmaps metalk8s-dex-config -n metalk8s-auth
+
+      [..]
+      config.yaml: |-
+         localuserstore:
+            enabled: true
+            userlist:
+               - email: "admin@metalk8s.invalid"
+                  hash: "<new-password-hash>"
+                  username: "admin"
+                  userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
+      [...]
+
+
+#. Save the ConfigMap changes.
+
+#. From the Bootstrap node, run the following to propagate the
+   changes.
+
+   .. parsed-literal::
+
+      root@bootstrap $ kubectl exec -n kube-system -c salt-master \\
+                       --kubeconfig /etc/kubernetes/admin.conf \\
+                       salt-master-bootstrap -- salt-run \\
+                       state.sls metalk8s.addons.dex.deployed saltenv=metalk8s-|release|
+
+#. Verify that the password has been changed and you can log in to the MetalK8s
+   UI using the new password
 
 .. todo::
 
@@ -216,15 +264,12 @@ perform the following operations:
                   replicas: <number-of-replicas>
       [...]
 
-#. Save and apply the changes.
+#. Save the ConfigMap changes.
 
 
 #. From the Bootstrap node, execute the following command which connects to
    the Salt master container and applies salt-states to propagate the new
    changes down to the underlying services.
-
-   Make sure to replace the <version> prefix in the command below with the
-   currently installed MetalK8s version number e.g 2.5.0
 
    .. note::
 
@@ -233,12 +278,13 @@ perform the following operations:
       normally. Refer to :ref:`this procedure <Provision Prometheus storage>`
       for more information.
 
-   .. code-block:: shell
 
-      root@bootstrap $ crictl exec -it \
-                         $(crictl ps -q --label io.kubernetes.container.name=salt-master) bash \
-                         -c "salt-run state.sls metalk8s.addons.prometheus-operator.deployed saltenv=metalk8s-<version>"
+   .. parsed-literal::
 
+      root@bootstrap $ kubectl exec -n kube-system -c salt-master \\
+                       --kubeconfig /etc/kubernetes/admin.conf \\
+                       salt-master-bootstrap -- salt-run state.sls \\
+                       metalk8s.addons.prometheus-operator.deployed saltenv=metalk8s-|release|
 
 .. todo::
 

--- a/salt/metalk8s/roles/bootstrap/init.sls
+++ b/salt/metalk8s/roles/bootstrap/init.sls
@@ -5,3 +5,4 @@ include:
   - metalk8s.repo.installed
   - metalk8s.salt.master
   - metalk8s.kubectl
+  - metalk8s.utils

--- a/salt/metalk8s/utils/httpd-tools/init.sls
+++ b/salt/metalk8s/utils/httpd-tools/init.sls
@@ -1,0 +1,12 @@
+#
+#
+# Available states
+# ================
+#
+# * installed   -> install the given utility
+#
+#
+#
+
+include:
+  - .installed

--- a/salt/metalk8s/utils/httpd-tools/installed.sls
+++ b/salt/metalk8s/utils/httpd-tools/installed.sls
@@ -1,0 +1,16 @@
+{%- from "metalk8s/macro.sls" import pkg_installed with context %}
+
+include:
+  - metalk8s.repo
+
+{%- if grains['os_family'].lower() == 'redhat' %}
+Install httpd-tools:
+  {{ pkg_installed('httpd-tools') }}
+    - require:
+      - test: Repositories configured
+{% else %}
+
+Os family is debian-based:
+  test.succeed_without_changes: []
+
+{%- endif %}

--- a/salt/metalk8s/utils/init.sls
+++ b/salt/metalk8s/utils/init.sls
@@ -1,0 +1,10 @@
+#
+# State to install utilities .
+#
+# Available states
+# ================
+#
+#
+
+include:
+  - .httpd-tools


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
'docs'

**Context**: 

See #2351 

**Summary**:

This PR adds the following changes:
- Adds and update the default login credentials for both the MetalK8s GUI and Grafana Service
- Introduces a new section in CSC that deals with changing passwords for local static user
- Removes outdated information in the Account administration page.

The following was not taken care of:
- Add a new landing page png image of the MetalK8s GUI login page(Todo in #2158 )

**Acceptance criteria**: 


---

Closes: #2351
Closes: #2352
