### PR TITLE
Build a second example-solution ISO for upgrade/downgrade tests

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -704,19 +704,36 @@ stages:
           command: >
             . examples/metalk8s-solution-example/VERSION &&
             echo "$VERSION_MAJOR.$VERSION_MINOR.$VERSION_PATCH$VERSION_SUFFIX"
-      - ShellCommand:
+      - ShellCommand: &build_example_solution_iso
           name: Build Example Solution ISO
           command: >
             cd examples/metalk8s-solution-example &&
-            DOCKER_SOCKET=http://localhost:2375 make iso
+            DOCKER_SOCKET=http://localhost:2375 make iso &&
+            rm -rf examples/metalk8s-solution-example/_build/images
+            examples/metalk8s-solution-example/_build/root/images
           haltOnFailure: True
           timeout: 3600
+      - ShellCommand:
+          name: Increment Example Solution patch version
+          command: >
+            bash -c '
+            . examples/metalk8s-solution-example/VERSION &&
+            sed -i "s/^VERSION_PATCH=.*$/VERSION_PATCH=$(( ++VERSION_PATCH ))/"
+            examples/metalk8s-solution-example/VERSION
+            '
+          haltOnFailure: True
+      - SetPropertyFromCommand:
+          <<: *set_example_solution_version
+          name: Set Example Solution version next property
+          property: example_solution_version_next
+      - ShellCommand: *build_example_solution_iso
       - ShellCommand:
           <<: *copy_artifacts
           env:
             <<: *_env_copy_artifacts
             ARTIFACTS: >-
               examples/metalk8s-solution-example/_build/example-solution-%(prop:example_solution_version)s.iso
+              examples/metalk8s-solution-example/_build/example-solution-%(prop:example_solution_version_next)s.iso
       - Upload: *upload_artifacts
       - ShellCommand:
           <<: *add_final_status_artifact_success

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -1734,6 +1734,15 @@ stages:
             SSH_CONFIG: >-
               eve/workers/openstack-single-node-with-cypress/terraform/ssh_config
       - SetPropertyFromCommand: *set_example_solution_version
+      - SetPropertyFromCommand:
+          name: Set Example Solution version next property
+          property: example_solution_version_next
+          command: >
+            eval $(bash -c '
+            . examples/metalk8s-solution-example/VERSION &&
+            sed "s/^VERSION_PATCH=.*$/VERSION_PATCH=$(( ++VERSION_PATCH ))/"
+            examples/metalk8s-solution-example/VERSION') &&
+            echo "$VERSION_MAJOR.$VERSION_MINOR.$VERSION_PATCH$VERSION_SUFFIX"
       - ShellCommand:
           <<: *retrieve_iso
           name: Retrieve Solution example-solution ISO image
@@ -1744,9 +1753,21 @@ stages:
             FILE_DEST: example-solution.iso
             BASE_URL: "%(prop:artifacts_private_url)s"
       - ShellCommand:
-          name: Copy Solutions ISO to bootstrap node
+          <<: *retrieve_iso
+          name: Retrieve Solution next example-solution ISO image
+          env:
+            <<: *_env_retrieve_artifact_retry
+            FILE_SOURCE: >-
+              example-solution-%(prop:example_solution_version_next)s.iso
+            FILE_DEST: example-solution-next.iso
+            BASE_URL: "%(prop:artifacts_private_url)s"
+      - ShellCommand:
+          name: Copy Solutions ISOs to bootstrap node
           command: >
-            scp -F ssh_config ../../../../example-solution.iso "bootstrap:/var/tmp"
+            scp -F ssh_config
+            ../../../../example-solution.iso
+            ../../../../example-solution-next.iso
+            "bootstrap:/var/tmp"
           workdir: build/eve/workers/openstack-single-node-with-cypress/terraform/
           haltOnFailure: true
       - ShellCommand:
@@ -1777,14 +1798,21 @@ stages:
               eve/workers/openstack-single-node-with-cypress/terraform/ssh_config
           command: scp -r -F "$SSH_CONFIG" ui "cypress:"
           haltOnFailure: true
-      - ShellCommand:
+      - ShellCommand: &import_solution_archive_ssh
           name: Import Solution example-solution archive
+          env:
+            SOLUTION_ARCHIVE: /var/tmp/example-solution.iso
           command: >
             ssh -F ssh_config bootstrap
             sudo /var/tmp/metalk8s/solutions.sh
-            import --archive /var/tmp/example-solution.iso
+            import --archive "$SOLUTION_ARCHIVE"
           workdir: build/eve/workers/openstack-single-node-with-cypress/terraform/
           haltOnFailure: true
+      - ShellCommand:
+          <<: *import_solution_archive_ssh
+          name: Import Solution next example-solution archive
+          env:
+            SOLUTION_ARCHIVE: /var/tmp/example-solution-next.iso
       - ShellCommand:
           name: Run Solutions UI tests
           command: >


### PR DESCRIPTION
**Component**: ci

**Context**:
In order to be able to tests upgrade/downgrade of Solutions, we need to have at least 2 different version of the example-solution.

**Summary**:
Build a second example-solution ISO with the patch version bumped by 1.

**Acceptance criteria**:
- [x] A second archive is well generated and uploaded to artifacts.
- [x] The import of the Solution archive works.

---

Closes: #2390