### PR TITLE
eve: Add build url to `text` in JUnit

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -324,6 +324,7 @@ models:
         STEP_NAME: ''
         FINAL_STATUS: ''
         TEXT: |-
+          Build Url: %(prop:buildurl)s
           Artifact Url: %(prop:artifacts_public_url)s
           Branch: %(prop:branch)s
           Commit: %(prop:revision)s


### PR DESCRIPTION
**Component**:

'build', 'tests'

**Context**: 

Currently we use JUnit file to upload test result to TestRail but we
only have artifacts URL, branch name and commit revision to investigate in
case of test fail.

**Summary**:

Add build url in the JUnit to upload this to TestRail.

---

Fixes: #2371