### PR TITLE
build/docker: do not stack `task_error` decorator

### DIFF
--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -156,7 +156,7 @@ CONTAINER_IMAGES : Tuple[Image, ...] = (
     Image(
         name='nginx',
         version=NGINX_IMAGE_VERSION,
-        digest='sha256:dd2d0ac3fff2f007d99e033b64854be0941e19a2ad51f174d9240dda20d9f534',
+        digest='sha256:f09fe80eb0e75e97b04b9dfb065ac3fda37a8fac0161f42fca1e6fe4d0977c80',
     ),
     Image(
         name='nginx-ingress-controller',
@@ -176,7 +176,7 @@ CONTAINER_IMAGES : Tuple[Image, ...] = (
     Image(
         name='pause',
         version='3.1',
-        digest='sha256:f78411e19d84a252e53bff71a4407a5686c46983a2c2eeed83929b888179acea',
+        digest='sha256:da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e',
     ),
     Image(
         name='prometheus',


### PR DESCRIPTION
**Component**:

buildchain

**Context**: 

When we have an error in the Dockerfile of one of the builder, the task that build the image swallow the error and return a successful status.
Then build moves forward and fails at a later steps with an unrelated error.

The problems come from our use of the `task_error` decorator.
We stack multiple calls of it to handle different error, but this isn't supported and some errors ends up swallowed.

**Summary**:

Change the implementation of `task_error` so that we can specify a list of errors and their handler in a single call.

**Acceptance criteria**: 

- Delete the builder image: `docker rmi metalk8s-build`
- Delete the on-disk witness: `rm _build/metalk8s-build:latest`
- Insert an error in your Dockerfile, like:

```diff
diff --git a/packages/redhat/Dockerfile b/packages/redhat/Dockerfile
index a48a7aff..c4b13a58 100644
--- a/packages/redhat/Dockerfile
+++ b/packages/redhat/Dockerfile
@@ -11,7 +11,7 @@ RUN sed -i s/@SALT_VERSION@/$SALT_VERSION/ /etc/yum.repos.d/saltstack.repo
 RUN yum install -y \
         createrepo \
         epel-release \
-        rpm-build \
+        rpm-build
         rpmdevtools \
         rpmlint \
         yum-utils \
```

- run `./doit.sh _build_container` and you should see something like:

```
-- MKDIR        _build
.  CHECK CMD    skopeo
.  IMG BUILD    metalk8s-build:latest
TaskError - taskid:_build_container
400 Client Error: Bad Request ("Dockerfile parse error line 15: unknown instruction: RPMDEVTOOLS")

########################################
_build_container <stdout>:
```
---

Closes: #2395