### PR TITLE
[Solutions] Add e2e test for solutions upgrade downgrade

### DIFF
--- a/ui/cypress/integration/common/solutions.js
+++ b/ui/cypress/integration/common/solutions.js
@@ -72,6 +72,8 @@ Then(
       requestTimeout: 60000,
       responseTimeout: 60000,
     };
+    // To make sure the prepare environment is ready, because something we maybe update the env during the preparation
+    cy.wait('@getSolutionOperatorDeployment', timeOut);
     cy.wait('@getSolutionOperatorDeployment', timeOut);
 
     cy.get('.sc-table-column-cell-container-solutions').should(

--- a/ui/cypress/integration/common/solutions.js
+++ b/ui/cypress/integration/common/solutions.js
@@ -148,3 +148,22 @@ Then('I click on upgrade button and check the solution is upgraded', () => {
     upgradeSolutionVersion,
   );
 });
+
+Then(
+  'I click on the downgrade button and check the solution is downgraded',
+  () => {
+    cy.get('[data-cy="downgrade"]').click();
+    cy.get('.sc-modal .sc-select').eq(0).click();
+    cy.get(`[data-cy="${solutionVersion}"]`).click();
+    cy.get('[data-cy="upgrade_downgrade_button"]').click();
+    const timeOut = {
+      requestTimeout: 60000,
+      responseTimeout: 60000,
+    };
+
+    cy.wait('@getSolutionOperatorDeployment', timeOut);
+    cy.wait('@getSolutionOperatorDeployment', timeOut);
+
+    cy.get('.sc-table-column-cell-version').should('contain', solutionVersion);
+  },
+);

--- a/ui/cypress/integration/solutions/DowngradeSolution.feature
+++ b/ui/cypress/integration/solutions/DowngradeSolution.feature
@@ -1,0 +1,12 @@
+Feature: DowngradeSolution
+   Scenario: Downgrade a Solution
+     Given I log in
+     When I go to the solutions list by clicking the solution icon in the sidebar
+     And I go to the Create Environment page by clicking the Create a New Environment button
+     And I fill out the Create Environment form and check if the environment I created is displayed on the Environments list
+     When I click on the Add Solution button to add a solution to the environment
+     And I fill out the Add Solution form in the modal and I check if the solution is added the environment
+     When I go to the Environment Detail page by clicking the environment list
+     And I click on upgrade button and check the solution is upgraded
+     Then I click on the downgrade button and check the solution is downgraded
+

--- a/ui/cypress/integration/solutions/UpgradeSolution.feature
+++ b/ui/cypress/integration/solutions/UpgradeSolution.feature
@@ -1,0 +1,10 @@
+Feature: UpgradeSolution
+   Scenario: Upgrade a Solution
+     Given I log in
+     When I go to the solutions list by clicking the solution icon in the sidebar
+     And I go to the Create Environment page by clicking the Create a New Environment button
+     And I fill out the Create Environment form and check if the environment I created is displayed on the Environments list
+     When I click on the Add Solution button to add a solution to the environment
+     And I fill out the Add Solution form in the modal and I check if the solution is added the environment
+     When I go to the Environment Detail page by clicking the environment list
+     Then I click on upgrade button and check the solution is upgraded

--- a/ui/src/containers/SolutionDetail.js
+++ b/ui/src/containers/SolutionDetail.js
@@ -116,6 +116,7 @@ const SolutionDetail = () => {
                   setSelectedSolName(solName);
                   setIsUpgradeDowngradeSolutionModalOpen(true);
                 }}
+                data-cy="upgrade"
               />
             )}{' '}
             {solution?.availableDowngradeVersion?.length > 0 && (
@@ -128,6 +129,7 @@ const SolutionDetail = () => {
                   setSelectedSolName(solName);
                   setIsUpgradeDowngradeSolutionModalOpen(true);
                 }}
+                data-cy="downgrade"
               />
             )}
             {solution?.availableUpgradeVersion?.length === 0 &&
@@ -236,6 +238,7 @@ const SolutionDetail = () => {
                 (avaUpgradeVersion) => ({
                   label: avaUpgradeVersion.version,
                   value: avaUpgradeVersion.version,
+                  'data-cy': avaUpgradeVersion.version,
                 }),
               );
             } else {
@@ -243,6 +246,7 @@ const SolutionDetail = () => {
                 (avaDowngradeVersion) => ({
                   label: avaDowngradeVersion.version,
                   value: avaDowngradeVersion.version,
+                  'data-cy': avaDowngradeVersion.version,
                 }),
               );
             }
@@ -284,6 +288,7 @@ const SolutionDetail = () => {
                             : intl.translate('downgrade')
                         }
                         type="submit"
+                        data-cy="upgrade_downgrade_button"
                       />
                     </ActionContainer>
                   </FormStyle>

--- a/ui/src/containers/SolutionList.js
+++ b/ui/src/containers/SolutionList.js
@@ -125,6 +125,9 @@ const SolutionsList = (props) => {
     {
       label: intl.translate('name'),
       dataKey: 'name',
+      renderer: (_, environment) => {
+        return <span data-cy={`${environment.name}`}>{environment.name}</span>;
+      },
     },
     {
       label: intl.translate('description'),


### PR DESCRIPTION
**Component**: ui, solutions

**Context**: 
We need to test two scenario:
- upgrade 
`./node_modules/cypress/bin/cypress run -b chrome -s cypress/integration/solutions/UpgradeSolution.feature --no-exit`

- downgrade
`./node_modules/cypress/bin/cypress run -b chrome -s cypress/integration/solutions/DowngradeSolution.feature --no-exit`

**Summary**:

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2370 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
