### PR TITLE
ci: Fix previous ISO download

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -921,8 +921,8 @@ stages:
           <<: *retrieve_iso
           name: Retrieve previous ISO image
           env:
+            <<: *_env_retrieve_artifact_retry
             <<: *_env_previous_artifact
-            MAX_ATTEMPTS: "300"
       - ShellCommand: &check_prev_iso_checksum
           <<: *check_iso_checksum
           name: Check previous ISO image with checksum


### PR DESCRIPTION
**Component**:

'build'

**Context**: 

Since be6efe9c4ad2ffcbd50bea51bc5e6fb70cf9092e retrieving of previous
ISO is broken because the source file environment variable is empty.

**Summary**:

Just add default environment value to the retrieve previous ISO step

---
