### PR TITLE
Fix deletion on pending volume

### DIFF
--- a/tests/post/features/volume.feature
+++ b/tests/post/features/volume.feature
@@ -148,3 +148,20 @@ Feature: Volume management
         And I delete the Volume 'test-volume10'
         Then the Volume 'test-volume10' does not exist
         And the PersistentVolume 'test-volume10' does not exist
+
+    Scenario: Test deletion while creation is in progress
+        Given the Kubernetes API is available
+        When I create the following Volume:
+            apiVersion: storage.metalk8s.scality.com/v1alpha1
+            kind: Volume
+            metadata:
+              name: test-volume11
+            spec:
+              nodeName: bootstrap
+              storageClassName: metalk8s-prometheus
+              sparseLoopDevice:
+                size: 10Gi
+        Then the Volume 'test-volume11' is 'Pending'
+        When I delete the Volume 'test-volume11'
+        Then the Volume 'test-volume11' does not exist
+        And the PersistentVolume 'test-volume11' does not exist

--- a/tests/post/steps/test_volume.py
+++ b/tests/post/steps/test_volume.py
@@ -180,6 +180,11 @@ def test_volume_invalid_storage_class(host, teardown):
 def test_volume_invalid_storage_class(host, teardown):
     pass
 
+@scenario('../features/volume.feature',
+          'Test deletion while creation is in progress')
+def test_volume_delete_while_pending(host, teardown):
+    pass
+
 # }}}
 # Given {{{
 


### PR DESCRIPTION
**Component**:

operator

**Context**: 

When trying to delete a volume whose creation was in progress, the volume stay stuck in Pending state forever.

**Summary**:

Don't exit the reconciliation loop too early, to let `deployVolume` move the creation process forward.

**Acceptance criteria**: 

A new test was added, so the CI should be green.
Otherwise, you can test with `kubectl apply -f volume.yaml && sleep 1 && kubectl delete -f volume.yaml` => it should work.

---

Closes: #2409 