### PR TITLE
Bugfix/gh 2408 fix saltenv for lifecycle scripts

### DIFF
--- a/scripts/downgrade.sh.in
+++ b/scripts/downgrade.sh.in
@@ -6,7 +6,7 @@ set -o pipefail
 VERBOSE=${VERBOSE:-0}
 LOGFILE=/var/log/metalk8s/downgrade.log
 DRY_RUN=0
-SALTENV=""
+SALTENV=${SALTENV:-}
 DESTINATION_VERSION=""
 SALT_CALL=${SALT_CALL:-salt-call}
 CRICTL=${CRICTL:-crictl}
@@ -133,14 +133,6 @@ die() {
     return 1
 }
 
-_set_env() {
-    if [ -z "$SALTENV" ]; then
-        SALTENV="metalk8s-$($SALT_CALL --out txt slsutil.renderer \
-            string="{{ pillar.metalk8s.nodes[grains.id].version }}" \
-            | cut -c 8-)"
-    fi
-}
-
 get_salt_container() {
     local -r max_retries=10
     local salt_container='' attempts=0
@@ -159,10 +151,6 @@ get_salt_container() {
     fi
 
     echo "$salt_container"
-}
-
-_init () {
-    _set_env
 }
 
 precheck_downgrade () {
@@ -208,7 +196,7 @@ patch_kubesystem_namespace() {
     SALT_MASTER_CALL=(crictl exec -i "$(get_salt_container)")
 
     "${SALT_MASTER_CALL[@]}" salt-run saltutil.sync_all \
-        saltenv="metalk8s-@@VERSION"
+        saltenv="$SALTENV"
 
     #update the annotation with the new destination value
     "${SALT_MASTER_CALL[@]}" salt-run state.orchestrate_single \
@@ -225,10 +213,16 @@ get_cluster_version() {
 }
 
 # Main
-_init
 if [ -z "$DESTINATION_VERSION" ]; then
     get_cluster_version
     run "Getting cluster version $DESTINATION_VERSION"
+fi
+
+# SALTENV should be equal to script version and equal to the higher node
+# version of the cluster
+# (checked by the precheck orchestrate)
+if [ -z "$SALTENV" ]; then
+    SALTENV="metalk8s-@@VERSION"
 fi
 
 run "Performing Pre-Downgrade checks" precheck_downgrade

--- a/scripts/upgrade.sh.in
+++ b/scripts/upgrade.sh.in
@@ -6,6 +6,7 @@ set -o pipefail
 VERBOSE=${VERBOSE:-0}
 LOGFILE=/var/log/metalk8s/upgrade.log
 DRY_RUN=0
+SALTENV=${SALTENV:-}
 DESTINATION_VERSION=""
 SALT_CALL=${SALT_CALL:-salt-call}
 
@@ -168,23 +169,23 @@ upgrade_bootstrap () {
 launch_upgrade () {
     SALT_MASTER_CALL=(crictl exec -i "$(get_salt_container)")
     "${SALT_MASTER_CALL[@]}" salt-run saltutil.sync_all \
-        saltenv="metalk8s-$DESTINATION_VERSION"
+        saltenv="$SALTENV"
 
     "${SALT_MASTER_CALL[@]}" salt-run metalk8s_saltutil.sync_auth  \
-        saltenv="metalk8s-$DESTINATION_VERSION"
+        saltenv="$SALTENV"
 
     "${SALT_MASTER_CALL[@]}" salt-run saltutil.sync_roster  \
-        saltenv="metalk8s-$DESTINATION_VERSION"
+        saltenv="$SALTENV"
 
     "${SALT_MASTER_CALL[@]}" salt-run state.orchestrate \
-        metalk8s.orchestrate.upgrade saltenv="metalk8s-$DESTINATION_VERSION"
+        metalk8s.orchestrate.upgrade saltenv="$SALTENV"
 }
 
 precheck_upgrade() {
     SALT_MASTER_CALL=(crictl exec -i "$(get_salt_container)")
     "${SALT_MASTER_CALL[@]}" salt-run state.orchestrate \
         metalk8s.orchestrate.upgrade.precheck \
-        saltenv="metalk8s-$DESTINATION_VERSION" \
+        saltenv="$SALTENV" \
         pillar="{'metalk8s': {'cluster_version': '$DESTINATION_VERSION'}}"
 }
 
@@ -193,7 +194,7 @@ patch_kubesystem_namespace() {
     SALT_MASTER_CALL=(crictl exec -i "$(get_salt_container)")
 
     "${SALT_MASTER_CALL[@]}" salt-run saltutil.sync_all \
-        saltenv="metalk8s-@@VERSION"
+        saltenv="$SALTENV"
 
     #update the annotation with the new destination value
     "${SALT_MASTER_CALL[@]}" salt-run state.orchestrate_single \
@@ -212,6 +213,12 @@ get_cluster_version() {
 if [ -z "$DESTINATION_VERSION" ]; then
     get_cluster_version
     run "Getting cluster version $DESTINATION_VERSION"
+fi
+
+# SALTENV should be equal to script version and DESTINATION_VERSION
+# (checked by the precheck orchestrate)
+if [ -z "$SALTENV" ]; then
+    SALTENV="metalk8s-@@VERSION"
 fi
 
 run "Performing Pre-Upgrade checks" precheck_upgrade


### PR DESCRIPTION
**Component**:

'scripts', 'lifecycle'

**Context**: 

When downgrading if for whatever reason downgrade fails after bootstrap node downgrade the saltenv used when launching a new downgrade will use the bootstrap node version which is wrong and downgrade precheck state will fail.

**Summary**:

In upgrade and downgrade script use the MetalK8s version of the script as
saltenv to run each and every states with the ability to override it with
the `SALTENV` environment variable

---

Fixes: #2408 
