### PR TITLE
salt: Do not raise when `saltutil_cmd` failed in solutions ext_pillar

### DIFF
--- a/salt/_pillar/metalk8s_solutions.py
+++ b/salt/_pillar/metalk8s_solutions.py
@@ -29,10 +29,17 @@ def _load_solutions(bootstrap_id):
 
     errors = []
     try:
-        result['available'] = __salt__['saltutil.cmd'](
+        available_ret = __salt__['saltutil.cmd'](
             tgt=bootstrap_id,
             fun='metalk8s_solutions.list_available',
-        )[bootstrap_id]['ret']
+        )[bootstrap_id]
+        if available_ret['retcode'] != 0:
+            raise Exception('[{}] {}'.format(
+                available_ret['retcode'],
+                available_ret['ret']
+            ))
+
+        result['available'] = available_ret['ret']
     except Exception as exc:
         errors.append(
             "Error when listing available Solutions: {}".format(exc)


### PR DESCRIPTION
**Component**:

'salt'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

If for whatever reason `saltutil_cmd` command to list available
solutions in solution ext_pillar fail, the `ret` would be a string
containing the error message so `result['available'].items()` would
raise.

**Summary**:

Check `retcode` of `saltutil_cmd` and add the return in `errors` list if
`retcode` is not equal to `0`

---

Fixes: #2411 
