### PR TITLE
Add warning concerning the migration of customized admin credentials

### DIFF
--- a/docs/operation/downgrade.rst
+++ b/docs/operation/downgrade.rst
@@ -29,9 +29,15 @@ command.
 This will simulate the downgrade prechecks and provide an overview of the
 changes to be carried out in your MetalK8s cluster.
 
+.. important::
+
+    The version prefix metalk8s-**X.X.X** as used below during a MetalK8s
+    downgrade must be the currently-installed MetalKs8 version.
+
    .. code::
 
-     /srv/scality/metalk8s-X.X.X/downgrade.sh --destination-version <destination_version> --dry-run --verbose
+     /srv/scality/metalk8s-X.X.X/downgrade.sh --destination-version \
+       <destination_version> --dry-run --verbose
 
 Downgrade Steps
 ***************

--- a/docs/operation/downgrade.rst
+++ b/docs/operation/downgrade.rst
@@ -24,6 +24,8 @@ Downgrade Pre-requisites
 Before proceeding with the downgrade procedure, make sure to complete the
 pre-requisites listed in :doc:`/operation/preparation`.
 
+Run pre-check
+-------------
 You can test if your environment will successfully downgrade with the following
 command.
 This will simulate the downgrade prechecks and provide an overview of the

--- a/docs/operation/downgrade.rst
+++ b/docs/operation/downgrade.rst
@@ -26,7 +26,7 @@ pre-requisites listed in :doc:`/operation/preparation`.
 
 You can test if your environment will successfully downgrade with the following
 command.
-This will simulate the downgrade procedure and provide an overview of the
+This will simulate the downgrade prechecks and provide an overview of the
 changes to be carried out in your MetalK8s cluster.
 
    .. code::

--- a/docs/operation/upgrade.rst
+++ b/docs/operation/upgrade.rst
@@ -29,9 +29,16 @@ command.
 This will simulate the upgrade prechecks and provide an overview of the
 changes to be carried out in your MetalK8s cluster.
 
+.. important::
+
+    The version prefix metalk8s-**X.X.X** as used below during a MetalK8s
+    upgrade must be the new MetalK8s version you would like to upgrade
+    to.
+
    .. code::
 
-     /srv/scality/metalk8s-X.X.X/upgrade.sh --destination-version <destination_version> --dry-run --verbose
+     /srv/scality/metalk8s-X.X.X/upgrade.sh --destination-version \
+       <destination_version> --dry-run --verbose
 
 Upgrade Steps
 *************

--- a/docs/operation/upgrade.rst
+++ b/docs/operation/upgrade.rst
@@ -24,6 +24,8 @@ Upgrade Pre-requisites
 Before proceeding with the upgrade procedure, make sure to complete the
 pre-requisites listed in :doc:`/operation/preparation`.
 
+Run pre-check
+-------------
 You can test if your environment will successfully upgrade with the following
 command.
 This will simulate the upgrade prechecks and provide an overview of the
@@ -39,6 +41,26 @@ changes to be carried out in your MetalK8s cluster.
 
      /srv/scality/metalk8s-X.X.X/upgrade.sh --destination-version \
        <destination_version> --dry-run --verbose
+
+Backup old credentials
+----------------------
+Starting 2.5.0, MetalK8s will henceforth implement OpenID Connect (OIDC) based
+authentication. Both K8s and Grafana will be configured to make use of the same
+OIDC provider.
+
+.. warning::
+
+    Before running an upgrade from 2.4.x to 2.5.0 or higher, MetalK8s
+    administrators **must** ensure all static users defined in
+    ``/etc/kubernetes/htpasswd`` can be recreated, and if any, all users that
+    were defined in Grafana.
+    The upgrade procedure will result in all admin credentials being reset
+    to their default values, and any additional user being removed. MetalK8s
+    administrators need to remember and reconfigure these username/password
+    pairs.
+
+    After upgrade is complete, a procedure for configuring the OIDC provider
+    (Dex) user store will be provided in the next version.
 
 Upgrade Steps
 *************

--- a/docs/operation/upgrade.rst
+++ b/docs/operation/upgrade.rst
@@ -26,7 +26,7 @@ pre-requisites listed in :doc:`/operation/preparation`.
 
 You can test if your environment will successfully upgrade with the following
 command.
-This will simulate the upgrade procedure and provide an overview of the
+This will simulate the upgrade prechecks and provide an overview of the
 changes to be carried out in your MetalK8s cluster.
 
    .. code::


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
'docs'

**Context**: 

See #2125 

**Summary**:

MetalK8s administrators should be aware of the breaking changes in 2.5.0 regarding 
the new authentication mechanism and how to migrate their old creds.

Should land in 2.4.3!!

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2125 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
