### PR TITLE
Enable grain caching and only spawn 1 node for multi-node CI stage

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -532,7 +532,7 @@ stages:
             OS_PASSWORD: "%(secret:scality_cloud_password)s"
             OS_TENANT_NAME: "%(secret:scality_cloud_tenant_name)s"
             TF_VAR_worker_uuid: "%(prop:worker_uuid)s"
-            TF_VAR_nodes_count: "2"
+            TF_VAR_nodes_count: "1"
           haltOnFailure: true
       - ShellCommand:
           name: Check SSH config for bootstrap node

--- a/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
+++ b/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
@@ -4,6 +4,9 @@ peer:
   .*:
     - x509.sign_remote_certificate
 
+# Enable grains caching on salt-master
+grains_cache: True
+
 # We use information from the `metalk8s_node` ext_pillar to match in
 # `pillar/top.sls`, hence we need to load them first.
 ext_pillar_first: true


### PR DESCRIPTION
**Component**:

'build', 'salt'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

1. Grains compute may take time on salt-master and they are computed at each and every salt command
2. We spawn 2 extra node in the multi-node CI stage when we only expand to the first one

**Summary**:

1. Enable grains caching for salt-master
2. Only spawn 1 extra node in the multi-node CI stage

---
