### PR TITLE
docs: Read version details from buildchain

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,12 @@ import sys
 _lib_path = pathlib.Path(__file__).parent / '_lib'
 sys.path.insert(0, str(_lib_path.resolve()))
 
+# MetalK8s Buildchain
+_buildchain_path = pathlib.Path(__file__) / "../../buildchain"
+sys.path.insert(0, str(_buildchain_path.resolve()))
+from buildchain import constants
+from buildchain import versions
+
 # -- Environment toggles -----------------------------------------------------
 
 ON_RTD = os.environ.get('READTHEDOCS') == 'True'
@@ -27,11 +33,19 @@ project = 'MetalK8s'
 copyright = '2019, Scality'
 author = 'Scality'
 
-# The short version, {major}.{minor}
-version = '2.0'
-
 # The full version, including alpha/beta/rc tags
-release = '2.0.0-dev'
+version = versions.VERSION
+
+# The full git reference if this is a developemnt release (otherwise, same as
+# version)
+if versions.VERSION_SUFFIX == "-dev":
+    release = constants.GIT_REF
+
+    # NOTE: we use this tag to show a warning message with more details about
+    # a given release in `introduction.rst`
+    tags.add('unreleased')
+else:
+    release = versions.VERSION
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -1,3 +1,14 @@
+.. only:: unreleased
+
+   .. warning::
+
+      This is a development version and was not officialy released.
+
+      .. parsed-literal::
+
+         Version: |version|
+         Git Revision: |release|
+
 .. only:: latex
 
    Introduction

--- a/docs/quickstart/bootstrap.rst
+++ b/docs/quickstart/bootstrap.rst
@@ -11,8 +11,8 @@ Mount this ISO file at the specific following path:
 
 .. parsed-literal::
 
-   root@bootstrap $ mkdir -p /srv/scality/metalk8s-|release|
-   root@bootstrap $ mount <path-to-iso> /srv/scality/metalk8s-|release|
+   root@bootstrap $ mkdir -p /srv/scality/metalk8s-|version|
+   root@bootstrap $ mount <path-to-iso> /srv/scality/metalk8s-|version|
 
 
 .. _quickstart-bootstrap-config:
@@ -102,7 +102,7 @@ Bootstrap node.
 
 .. parsed-literal::
 
-   root@bootstrap $ /srv/scality/metalk8s-|release|/bootstrap.sh
+   root@bootstrap $ /srv/scality/metalk8s-|version|/bootstrap.sh
 
 Validate the install
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/quickstart/expansion.rst
+++ b/docs/quickstart/expansion.rst
@@ -52,7 +52,7 @@ following the template below:
        metalk8s.scality.com/ssh-host: <node control-plane IP>
        metalk8s.scality.com/ssh-sudo: 'false'
      labels:
-       metalk8s.scality.com/version: '|release|'
+       metalk8s.scality.com/version: '|version|'
        <role labels>
    spec:
      taints: <taints>
@@ -136,7 +136,7 @@ Start the node deployment.
 .. parsed-literal::
 
    root@salt-master-bootstrap $ salt-run state.orchestrate metalk8s.orchestrate.deploy_node \\
-                                saltenv=metalk8s-|release| \\
+                                saltenv=metalk8s-|version| \\
                                 pillar='{"orchestrate": {"node_name": "<node-name>"}}'
 
    ... lots of output ...


### PR DESCRIPTION
We used to hardcode the `version` and `release` variables (and with
improper values, as we want `version` to hold the full version, not just
the {major}.{minor}).

Now, we read this information using the buildchain helpers, and extend
this with a full Git reference and a warning to display on unreleased
builds.

Fixes: #1703