### PR TITLE
Limit simultaneous install stages to 20

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -459,6 +459,7 @@ stages:
         TEST_SUITE: install
         CLASS_NAME: single-node.centos7
         TEST_NAME: simple environment
+    simultaneous_builds: 20
     worker: &single_node_worker
       type: openstack
       image: CentOS-7-x86_64-GenericCloud-1809.qcow2
@@ -524,6 +525,7 @@ stages:
         TEST_SUITE: install
         CLASS_NAME: multi-node.centos7
         TEST_NAME: 1 bootstrap 1 master,etcd
+    simultaneous_builds: 20
     worker:
       <<: *single_node_worker
       flavor: m1.medium

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -336,7 +336,7 @@ stages:
           name: Trigger single-node and multiple-nodes steps with built ISO
           stage_names:
             - single-node
-            - multiple-nodes
+            - multiple-nodes-centos
       - ShellCommand: *add_final_status_artifact_success
       - Upload: *upload_final_status_artifact
 
@@ -518,7 +518,7 @@ stages:
           env:
             STEP_NAME: single-node
 
-  multiple-nodes:
+  multiple-nodes-centos:
     _metalk8s_internal_info:
       junit_info: &_install_multi-node_junit_info
         TEST_SUITE: install
@@ -535,7 +535,7 @@ stages:
           env:
             <<: *_env_final_status_artifact_failed
             <<: *_install_multi-node_junit_info
-            STEP_NAME: multiple-nodes
+            STEP_NAME: multiple-nodes-centos
       - ShellCommand: *setup_cache
       - ShellCommand: *ssh_ip_setup
       - ShellCommand: *retrieve_iso
@@ -748,13 +748,13 @@ stages:
           env:
             <<: *_env_final_status_artifact_success
             <<: *_install_multi-node_junit_info
-            STEP_NAME: multiple-nodes
+            STEP_NAME: multiple-nodes-centos
       - Upload: *upload_final_status_artifact
       - ShellCommand:
           <<: *wait_debug
           timeout: 14400
           env:
-            STEP_NAME: multiple-nodes
+            STEP_NAME: multiple-nodes-centos
             DURATION: "14400"
       - ShellCommand:
           name: Destroy openstack virtual infra


### PR DESCRIPTION
**Component**:

'build'

**Context**: 

Do not consume too much CI resources during build.

**Summary**:

Limits the number of simultaneous "install stages" in parallel to 20.

**Acceptance criteria**: 


---
