### PR TITLE
ci: does not rely on worker_uuid anymore

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -392,7 +392,7 @@ models:
         OS_USERNAME: "%(secret:scality_cloud_username)s"
         OS_PASSWORD: "%(secret:scality_cloud_password)s"
         OS_TENANT_NAME: "%(secret:scality_cloud_tenant_name)s"
-        TF_VAR_worker_uuid: "%(prop:worker_uuid)s"
+        TF_VAR_prefix: "%(prop:buildnumber)s-%(prop:stage_name)s"
       haltOnFailure: true
   - ShellCommand: &terraform_destroy
       name: Destroy openstack virtual infra

--- a/eve/workers/openstack-multiple-nodes/terraform/common.tf
+++ b/eve/workers/openstack-multiple-nodes/terraform/common.tf
@@ -1,4 +1,4 @@
-variable "worker_uuid" {
+variable "prefix" {
   type    = string
   default = ""
 }
@@ -10,6 +10,6 @@ resource "random_string" "current" {
 
 locals {
   prefix = "metalk8s-${
-    var.worker_uuid != "" ? var.worker_uuid : random_string.current.result
+    var.prefix != "" ? var.prefix : random_string.current.result
   }"
 }

--- a/eve/workers/openstack-single-node-rhel/terraform/common.tf
+++ b/eve/workers/openstack-single-node-rhel/terraform/common.tf
@@ -1,10 +1,17 @@
+variable "prefix" {
+  type    = string
+  default = ""
+}
+
 resource "random_string" "current" {
   length  = 5
   special = false
 }
 
 locals {
-  prefix = "metalk8s-${random_string.current.result}"
+  prefix = "metalk8s-${
+    var.prefix != "" ? var.prefix : random_string.current.result
+  }"
 }
 
 variable "rhsm_username" {


### PR DESCRIPTION
**Component**: ci

**Context**: 
In the CI context we were using worker_uuid property as a unique identifier prefix to all terraform resources we created, to avoid collision between these resources.
It happens that this UUID is not really unique and sometimes we have uncleaned resources on the MetalK8s scality.cloud CI tenant, so we end up having collision between old resources and new ones, this causes builds to fail.

**Summary**:
We now use the build number + the stage name as a prefix.
The build number should be unique accross any build and the stage name will be used to easily retrieve the resources of a specific stage of a build.

**Acceptance criteria**: 
Resources should be spawned with the right prefix and everything should still work fine.
