### PR TITLE
containers: upgrade python kubernetes version deployed on salt master

### DIFF
--- a/images/salt-master/Dockerfile
+++ b/images/salt-master/Dockerfile
@@ -15,9 +15,18 @@ gpgkey=https://repo.saltstack.com/yum/redhat/\$releasever/\$basearch/archive/%s/
  && rpm --import https://repo.saltstack.com/yum/redhat/7/x86_64/archive/${SALT_VERSION}/SALTSTACK-GPG-KEY.pub \
  && yum clean expire-cache \
  && yum install -y epel-release \
- && yum install -y python2-kubernetes salt-master salt-api salt-ssh openssh-clients \
+ && yum install -y salt-master salt-api salt-ssh openssh-clients \
  && yum install -y python-pip \
  && pip install pip==20.0.2 \
+ # TODO: issue #2454
+ # Docker build will die here because we have PyYAML==3.11 installed
+ # ERROR: Cannot uninstall 'PyYAML'. It is a distutils installed project and
+ # thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall
+ # Since kubernetes-client requires PyYAML==3.12 ipaddress==1.0.17 we can ignore the installed versions using:
+ && pip install setuptools==40.3.0 \
+ && pip install --ignore-installed PyYAML==3.12 ipaddress==1.0.17 \
+ && pip install kubernetes==11.0.0 \
+ # End
  && pip install "etcd3 != 0.11.0" \
  && yum clean all
 

--- a/salt/_utils/kubernetes_utils.py
+++ b/salt/_utils/kubernetes_utils.py
@@ -427,7 +427,7 @@ class CustomApiClient(ApiClient):
 
             # Convert body to_dict if it's a CustomObject as
             # `python-kubernetes` want a dict or a specific objects with
-            # some attributes like `swagger_types`, `attributes_map`, ...
+            # some attributes like `openapi_types`, `attributes_map`, ...
             if isinstance(kwargs.get('body'), CustomObject):
                 kwargs['body'] = kwargs['body'].to_dict()
 
@@ -656,7 +656,7 @@ def _build_standard_object(model, manifest):
     """Construct an instance of `model` based on its `manifest`.
 
     This method assumes `model` to be a member of `kubernetes.client.models`,
-    so that it can use its `attribute_map` and `swagger_types` attributes.
+    so that it can use its `attribute_map` and `openapi_types` attributes.
     """
     # `model.attribute_map` contain all attribute correspondance between
     # snake case and YAML style (camel case) so we need to reverse it
@@ -671,7 +671,7 @@ def _build_standard_object(model, manifest):
     kwargs = {}
     for src_key, src_value in manifest.items():
         key = reverse_attr_map.get(src_key, src_key)
-        type_str = model.swagger_types.get(key)
+        type_str = model.openapi_types.get(key)
 
         if type_str is None:
             raise ValueError(
@@ -702,7 +702,7 @@ def _cast_value(value, type_string):
     """Attempt to cast a value given a type declaration as a string.
 
     Used exclusively by `_build_standard_object`, relying on the models
-    `swagger_types` declarations for converting manifests into Python objects.
+    `openapi_types` declarations for converting manifests into Python objects.
     """
     # Special case for None used for exemple when patching to remove key
     if value is None:

--- a/salt/_utils/kubernetes_utils.py
+++ b/salt/_utils/kubernetes_utils.py
@@ -14,7 +14,7 @@ from salt.utils.dictdiffer import recursive_diff
 try:
     import kubernetes.config
     import kubernetes.client as k8s_client
-    import kubernetes.client.apis as k8s_apis
+    import kubernetes.client.api as k8s_apis
 
     # Workaround for https://github.com/kubernetes-client/python/issues/376
     def set_conditions(self, conditions):
@@ -88,7 +88,7 @@ class ApiClient(object):
                  method_names=None, all_namespaces_name=None):
         if api_cls not in ALL_APIS:
             raise ValueError(
-                '`api_cls` must be an API from `kubernetes.client.apis`'
+                '`api_cls` must be an API from `kubernetes.client.api`'
             )
         methods = self.CRUD_METHODS
         if isinstance(method_names, six.string_types):


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
'containers', 'kubernetes'

**Context**: 

See #2029 

**Summary**:

`Use pip install one last time.`
Updating the Prometheus-operator charts to 8.13.0 requires at least v11 of python-kubernetes package see https://github.com/scality/metalk8s/issues/2430#issuecomment-617692984.

Let us add this package to the salt-master image at build time knowing that we might need to build and/or package it as an rpm package shortly after.

We are not going to close issue #2029 for now but this PR will ensure we can close issue #2430 at least for now.

**Acceptance criteria**: 

- Tested the Prometheus-operator 8.13.0 charts and upgrade seems to work
- From salt-master container, verify the package version installed
```
[root@bootstrap vagrant]# crictl exec -it a32b3c04fe529 bash
[root@bootstrap /]# python
Python 2.7.5 (default, Oct 30 2018, 23:45:53) 
[GCC 4.8.5 20150623 (Red Hat 4.8.5-36)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import kubernetes
>>> print kubernetes.__version__
11.0.0
>>> 

```


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
