### PR TITLE
ci: fix empty sosreport

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -439,7 +439,7 @@ models:
         mkdir -p "sosreport/sosreport/$STEP_NAME" &&
         for host in $HOSTS_LIST; do
           scp -F "$SSH_CONFIG" \
-          $host:/var/tmp/sosreport-* \
+          "$host:/var/tmp/sosreport-*.tar.xz" \
           "sosreport/sosreport/$STEP_NAME/$host-sosreport.tar.xz"
         done
       alwaysRun: true


### PR DESCRIPTION
**Component**: ci

**Context**: 
we were copying and renaming all files matching a specific pattern `/var/tmp/sosreport-*`, thus
overwriting the archive with its checksum file:
/var/tmp/sosreport-[...].tar.xz
/var/tmp/sosreport-[...].tar.xz.md5

**Summary**:
we are now more precise on the pattern we use, so that we don't overwrite the archive with its checksum.

**Acceptance criteria**: green build and sosreport content is there. :)
