### PR TITLE
[ui] Move the toggle from Navbar to Sidebar

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1812,8 +1812,8 @@
       "integrity": "sha512-afmTuJrylUU/0OtqzaRkbyYFFNgCF73Bvel/sw90pvGrWIZ+vyoIJqA6eMSoA6+nb443kTmulmBtC9NerXboNg=="
     },
     "@scality/core-ui": {
-      "version": "github:scality/core-ui#f1c819fac64ac9d2c8ebe772806867a7b766ac14",
-      "from": "github:scality/core-ui#v0.5.0"
+      "version": "github:scality/core-ui#1b4fff111aaa9b79eed823b0dd57cf7a9ae1d108",
+      "from": "github:scality/core-ui#1b4fff1"
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "4.2.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.7.2",
     "@kubernetes/client-node": "github:scality/kubernetes-client-javascript.git#browser-0.10.2-62-g61d8543",
-    "@scality/core-ui": "github:scality/core-ui.git#v0.5.0",
+    "@scality/core-ui": "github:scality/core-ui.git#1b4fff1",
     "axios": "^0.18.0",
     "formik": "1.5.1",
     "lodash.isempty": "^4.4.0",

--- a/ui/src/containers/Layout.js
+++ b/ui/src/containers/Layout.js
@@ -50,6 +50,7 @@ const Layout = (props) => {
   }, [dispatch]);
 
   const sidebarConfig = {
+    onToggleClick: toggleSidebar,
     expanded: sidebar.expanded,
     actions: [
       {
@@ -182,7 +183,6 @@ const Layout = (props) => {
   }
 
   const navbar = {
-    onToggleClick: toggleSidebar,
     productName: intl.translate('product_name'),
     logo: <img alt="logo" src={process.env.PUBLIC_URL + theme.logo_path} />,
   };


### PR DESCRIPTION
**Component**: ui

**Context**: 
Since the Navbar will be in the Shell in the future, We want to add the toggle in the sidebar to switch between the sidebar status of expand/minimum.

**Summary**:
- Add toggle in the sidebar
- Update the core-ui package

**Acceptance criteria**: 
Please find the screenshots: 
**Expanded sidebar:**
![image](https://user-images.githubusercontent.com/18453133/80407615-31492200-88c6-11ea-9c31-42f61ff4f496.png)

**Minimum sidebar**:
![image](https://user-images.githubusercontent.com/18453133/80407644-3d34e400-88c6-11ea-9184-4a24f4e0bc30.png)


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2486 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
