### PR TITLE
[ui] Bugfix: monitoring page cannot display all the alerts

### DIFF
--- a/ui/src/containers/ClusterMonitoring.js
+++ b/ui/src/containers/ClusterMonitoring.js
@@ -33,14 +33,13 @@ const PageContainer = styled.div`
   flex-direction: column;
   height: 100%;
   padding: ${padding.larger};
-
   .sc-loader {
     padding: 0 ${padding.smaller};
   }
 `;
 
 const TableContainer = styled.div`
-  height: 100%;
+  height: 80%;
   flex-grow: 1;
 
   .sc-table-column-cell-container-severity {

--- a/ui/src/containers/ClusterMonitoring.js
+++ b/ui/src/containers/ClusterMonitoring.js
@@ -48,7 +48,7 @@ const TableContainer = styled.div`
 `;
 
 const PageSubtitle = styled.h3`
-  color: ${props => props.theme.brand.text};
+  color: ${(props) => props.theme.brand.text};
   margin: ${padding.small} 0;
   display: flex;
   align-items: center;
@@ -76,7 +76,7 @@ const RightClusterStatusContainer = styled.div`
 const ClusterStatusValue = styled.span`
   margin: 0 ${padding.small};
   font-weight: bold;
-  color: ${props => {
+  color: ${(props) => {
     switch (props.value) {
       case CLUSTER_STATUS_UNKNOWN:
         return props.theme.brand.warning;
@@ -89,11 +89,11 @@ const ClusterStatusValue = styled.span`
 `;
 
 const InformationMarkIcon = styled.i`
-  color: ${props => props.theme.brand.primary};
+  color: ${(props) => props.theme.brand.primary};
 `;
 
 const TooltipContent = styled.div`
-  color: ${props => props.theme.brand.primary};
+  color: ${(props) => props.theme.brand.primary};
   font-weight: ${fontWeight.bold};
 `;
 
@@ -101,12 +101,12 @@ const ControlPlaneStatusLabel = styled.span`
   margin-left: ${padding.smaller};
 `;
 
-const ClusterMonitoring = props => {
+const ClusterMonitoring = (props) => {
   const dispatch = useDispatch();
-  const alerts = useSelector(state => state.app.monitoring.alert);
-  const clusterStatus = useSelector(state => makeClusterStatus(state, props));
-  const cluster = useSelector(state => state.app.monitoring.cluster);
-  const config = useSelector(state => state.config);
+  const alerts = useSelector((state) => state.app.monitoring.alert);
+  const clusterStatus = useSelector((state) => makeClusterStatus(state, props));
+  const cluster = useSelector((state) => state.app.monitoring.cluster);
+  const config = useSelector((state) => state.config);
 
   useEffect(() => {
     dispatch(refreshAlertsAction());
@@ -136,7 +136,7 @@ const ClusterMonitoring = props => {
       label: intl.translate('severity'),
       dataKey: 'severity',
       width: 100,
-      renderer: data => {
+      renderer: (data) => {
         return <CircleStatus className="fas fa-circle" status={data} />;
       },
     },
@@ -149,7 +149,7 @@ const ClusterMonitoring = props => {
       label: intl.translate('active_at'),
       dataKey: 'activeAt',
       width: 200,
-      renderer: data => (
+      renderer: (data) => (
         <span>
           <FormattedDate value={data} />{' '}
           <FormattedTime
@@ -164,8 +164,8 @@ const ClusterMonitoring = props => {
   ];
 
   const alertsList = alerts.list
-    .filter(alert => alert.state !== 'pending')
-    .map(alert => {
+    .filter((alert) => alert.state !== 'pending')
+    .map((alert) => {
       return {
         name: alert.labels.alertname,
         severity: alert.labels.severity,
@@ -174,7 +174,7 @@ const ClusterMonitoring = props => {
       };
     });
 
-  const checkControlPlaneStatus = jobCount =>
+  const checkControlPlaneStatus = (jobCount) =>
     jobCount > 0 ? STATUS_SUCCESS : STATUS_CRITICAL;
 
   const apiServerStatus = checkControlPlaneStatus(cluster.apiServerStatus);

--- a/ui/src/containers/NodeList.js
+++ b/ui/src/containers/NodeList.js
@@ -66,10 +66,10 @@ const TableContainer = styled.div`
 `;
 
 const NodeList = () => {
-  const nodes = useSelector(state => state.app.nodes);
-  const theme = useSelector(state => state.config.theme);
+  const nodes = useSelector((state) => state.app.nodes);
+  const theme = useSelector((state) => state.config.theme);
   const dispatch = useDispatch();
-  const deployNode = payload => dispatch(deployNodeAction(payload));
+  const deployNode = (payload) => dispatch(deployNodeAction(payload));
 
   useRefreshEffect(refreshNodesAction, stopRefreshNodesAction);
 
@@ -85,7 +85,7 @@ const NodeList = () => {
     {
       label: intl.translate('status'),
       dataKey: 'status',
-      renderer: data => <span> {intl.translate(data) || data}</span>,
+      renderer: (data) => <span> {intl.translate(data) || data}</span>,
     },
     {
       label: intl.translate('deployment'),
@@ -99,7 +99,7 @@ const NodeList = () => {
             <span className="status">
               <Button
                 text={intl.translate('deploy')}
-                onClick={event => {
+                onClick={(event) => {
                   event.stopPropagation();
                   deployNode(rowData);
                 }}
@@ -113,7 +113,7 @@ const NodeList = () => {
             <span className="status">
               <Button
                 text={intl.translate('deploying')}
-                onClick={event => {
+                onClick={(event) => {
                   event.stopPropagation();
                   history.push(`/nodes/${rowData.name}/deploy`);
                 }}
@@ -142,7 +142,7 @@ const NodeList = () => {
     setSortDirection(sortDirection);
   };
 
-  const onRowClick = row => {
+  const onRowClick = (row) => {
     if (row.rowData && row.rowData.name) {
       history.push(`/nodes/${row.rowData.name}`);
     }
@@ -176,7 +176,7 @@ const NodeList = () => {
           sortBy={sortBy}
           sortDirection={sortDirection}
           onSort={onSort}
-          onRowClick={item => {
+          onRowClick={(item) => {
             // FIXME we will change that behavior later
             // We want let the user click on the item only it's deployed.
             if (

--- a/ui/src/containers/NodeList.js
+++ b/ui/src/containers/NodeList.js
@@ -36,6 +36,7 @@ const ActionContainer = styled.div`
 `;
 
 const TableContainer = styled.div`
+  height: 80%;
   flex-grow: 1;
   .status {
     display: flex;


### PR DESCRIPTION
**Component**: ui

**Context**: 
When the number of alerts is more than the capacity of the table, we can't scroll down to check the last few alerts.

**Summary**:
Change the height of the table from 100% to 80%

**Acceptance criteria**: 
We can scroll down until the end of the table.
![image](https://user-images.githubusercontent.com/18453133/80695884-da666700-8ad6-11ea-9606-68f2f41584c2.png)

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2495 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
