### PR TITLE
Upgrade to Salt 3000.2 python2

### DIFF
--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -20,7 +20,7 @@ Image = namedtuple('Image', ('name', 'version', 'digest'))
 CALICO_VERSION     : str = '3.8.2'
 K8S_VERSION        : str = '1.11.10'
 KEEPALIVED_VERSION : str = '1.3.5-16.el7'
-SALT_VERSION       : str = '2018.3.4'
+SALT_VERSION       : str = '3000.2'
 
 def load_version_information() -> None:
     """Load version information from `VERSION`."""

--- a/images/salt-master/Dockerfile
+++ b/images/salt-master/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7.6.1810
 MAINTAINER moonshot-platform <moonshot-platform@scality.com>
 
 # Versions to use
-ARG SALT_VERSION=2018.3.4
+ARG SALT_VERSION=3000.2
 ARG TINI_VERSION=v0.18.0
 
 # Install and check tini

--- a/pillar/metalk8s/roles/ca.sls
+++ b/pillar/metalk8s/roles/ca.sls
@@ -1,19 +1,19 @@
 mine_functions:
   kubernetes_root_ca_b64:
-    mine_function: hashutil.base64_encodefile
-    fname: /etc/kubernetes/pki/ca.crt
+    - mine_function: hashutil.base64_encodefile
+    - /etc/kubernetes/pki/ca.crt
 
   kubernetes_etcd_ca_b64:
-    mine_function: hashutil.base64_encodefile
-    fname: /etc/kubernetes/pki/etcd/ca.crt
+    - mine_function: hashutil.base64_encodefile
+    - /etc/kubernetes/pki/etcd/ca.crt
 
   kubernetes_front_proxy_ca_b64:
-    mine_function: hashutil.base64_encodefile
-    fname: /etc/kubernetes/pki/front-proxy-ca.crt
+    - mine_function: hashutil.base64_encodefile
+    - /etc/kubernetes/pki/front-proxy-ca.crt
 
   kubernetes_sa_pub_key_b64:
-    mine_function: hashutil.base64_encodefile
-    fname: /etc/kubernetes/pki/sa.pub
+    - mine_function: hashutil.base64_encodefile
+    - /etc/kubernetes/pki/sa.pub
 
 x509_signing_policies:
   kube_apiserver_client_policy:

--- a/pillar/metalk8s/roles/minion.sls
+++ b/pillar/metalk8s/roles/minion.sls
@@ -1,7 +1,7 @@
 mine_functions:
   control_plane_ip:
-    mine_function: grains.get
-    key: metalk8s:control_plane_ip
+    - mine_function: grains.get
+    - metalk8s:control_plane_ip
   workload_plane_ip:
-    mine_function: grains.get
-    key: metalk8s:workload_plane_ip
+    - mine_function: grains.get
+    - metalk8s:workload_plane_ip

--- a/salt/_auth/kubernetes_rbac.py
+++ b/salt/_auth/kubernetes_rbac.py
@@ -147,20 +147,39 @@ def _load_kubeconfig(opts):
     return kubeconfig
 
 
-def auth(username, token, token_type, **kwargs):
+def auth(username, password=None, token=None, **kwargs):
     log.info('Authentication request for "%s"', username)
 
-    handler = AUTH_HANDLERS.get(token_type.lower(), None)
-    if not handler:
-        log.warning('Unknown auth token_type: %s', token_type)
+    if token and password:
+        log.warning(
+            'Invalid authentication request cannot provide "token" and '
+            '"password" at the same time'
+        )
         return False
+    if not token and (not password or not username):
+        log.warning(
+            'Invalid authentication request need a "token" or '
+            'a "username" and "password"'
+        )
+        return False
+
+    # Token authentication request not supported yet
+    if token:
+        log.warning('Authentication request with "token" is not supported yet')
+        return False
+
+    handler = AUTH_HANDLERS['basic']
 
     kubeconfig = _load_kubeconfig(__opts__)
     if kubeconfig is None:
         log.info('Failed to load Kubernetes API client configuration')
         return False
 
-    result = handler.get('auth', lambda _c, _u, _t: False)(kubeconfig, username, token)
+    result = handler.get('auth', lambda _c, _u, _t: False)(
+        kubeconfig,
+        username,
+        token or password
+    )
     if result:
         log.info('Authentication request for "%s" succeeded', username)
     else:
@@ -169,20 +188,39 @@ def auth(username, token, token_type, **kwargs):
     return result
 
 
-def groups(username, token, token_type, **kwargs):
+def groups(username, password=None, token=None, **kwargs):
     log.info('Groups request for "%s"', username)
 
-    handler = AUTH_HANDLERS.get(token_type.lower(), None)
-    if not handler:
-        log.debug('Unknown groups token_type: %s', token_type)
+    if token and password:
+        log.warning(
+            'Invalid groups request cannot provide "token" and "password" '
+            'at the same time'
+        )
         return []
+    if not token and (not password or not username):
+        log.warning(
+            'Invalid groups request need a "token" or '
+            'a "username" and "password"'
+        )
+        return []
+
+    # Token groups requests not supported yet
+    if token:
+        log.warning('Groups request with "token" is not supported yet')
+        return []
+
+    handler = AUTH_HANDLERS['basic']
 
     kubeconfig = _load_kubeconfig(__opts__)
     if kubeconfig is None:
         log.info('Failed to load Kubernetes API client configuration')
         return []
 
-    result = handler.get('groups', lambda _c, _u, _t: [])(kubeconfig, username, token)
+    result = handler.get('groups', lambda _c, _u, _t: [])(
+        kubeconfig,
+        username,
+        token or password
+    )
     log.debug('Groups for "%s": %r', username, result)
 
     return result

--- a/salt/_modules/metalk8s_package_manager.py
+++ b/salt/_modules/metalk8s_package_manager.py
@@ -105,7 +105,7 @@ def list_pkg_dependents(
     if not version:
         return all_pkgs
 
-    if pkgs_info and versions_dict[name] != version:
+    if pkgs_info and str(versions_dict[name]) != str(version):
         log.error(
             'Trying to list dependents for "%s" with version "%s", '
             'while version configured is "%s"',

--- a/salt/metalk8s/kubernetes/ca/etcd/advertised.sls
+++ b/salt/metalk8s/kubernetes/ca/etcd/advertised.sls
@@ -13,7 +13,7 @@ Ensure etcd CA cert is present:
     - mode: 644
     - makedirs: True
     - dir_mode: 755
-    - contents: {{ etcd_ca.splitlines() }}
+    - contents: {{ etcd_ca.splitlines() | tojson }}
 
 {%- else %}
 

--- a/salt/metalk8s/kubernetes/ca/etcd/installed.sls
+++ b/salt/metalk8s/kubernetes/ca/etcd/installed.sls
@@ -35,7 +35,7 @@ Generate etcd CA certificate:
 Advertise etcd CA certificate in the mine:
   module.wait:
     - mine.send:
-      - func: kubernetes_etcd_ca_b64
+      - kubernetes_etcd_ca_b64
       - mine_function: hashutil.base64_encodefile
       - /etc/kubernetes/pki/etcd/ca.crt
     - watch:

--- a/salt/metalk8s/kubernetes/ca/front-proxy/advertised.sls
+++ b/salt/metalk8s/kubernetes/ca/front-proxy/advertised.sls
@@ -13,7 +13,7 @@ Ensure front-proxy CA cert is present:
     - mode: 644
     - makedirs: True
     - dir_mode: 755
-    - contents: {{ ca_cert.splitlines() }}
+    - contents: {{ ca_cert.splitlines() | tojson }}
 
 {%- else %}
 

--- a/salt/metalk8s/kubernetes/ca/front-proxy/installed.sls
+++ b/salt/metalk8s/kubernetes/ca/front-proxy/installed.sls
@@ -35,7 +35,7 @@ Generate front proxy CA certificate:
 Advertise front proxy CA certificate in the mine:
   module.wait:
     - mine.send:
-      - func: kubernetes_front_proxy_ca_b64
+      - kubernetes_front_proxy_ca_b64
       - mine_function: hashutil.base64_encodefile
       - /etc/kubernetes/pki/front-proxy-ca.crt
     - watch:

--- a/salt/metalk8s/kubernetes/ca/kubernetes/advertised.sls
+++ b/salt/metalk8s/kubernetes/ca/kubernetes/advertised.sls
@@ -13,7 +13,7 @@ Ensure kubernetes CA cert is present:
     - mode: 644
     - makedirs: True
     - dir_mode: 755
-    - contents: {{ ca_cert.splitlines() }}
+    - contents: {{ ca_cert.splitlines() | tojson }}
 
 {%- else %}
 

--- a/salt/metalk8s/kubernetes/ca/kubernetes/exported.sls
+++ b/salt/metalk8s/kubernetes/ca/kubernetes/exported.sls
@@ -4,7 +4,7 @@ include:
 Advertise CA certificate in the mine:
   module.wait:
     - mine.send:
-      - func: 'kubernetes_root_ca_b64'
+      - kubernetes_root_ca_b64
       - mine_function: hashutil.base64_encodefile
       - /etc/kubernetes/pki/ca.crt
     - watch:

--- a/salt/metalk8s/kubernetes/sa/advertised.sls
+++ b/salt/metalk8s/kubernetes/sa/advertised.sls
@@ -13,7 +13,7 @@ Ensure SA pub key is present:
     - mode: 644
     - makedirs: True
     - dir_mode: 755
-    - contents: {{ sa_pub_key.splitlines() }}
+    - contents: {{ sa_pub_key.splitlines() | tojson }}
 
 {%- else %}
 
@@ -39,7 +39,7 @@ Ensure SA private key is present:
     - mode: 644
     - makedirs: True
     - dir_mode: 755
-    - contents: {{ sa_priv_key.splitlines() }}
+    - contents: {{ sa_priv_key.splitlines() | tojson }}
 
 {%- else %}
 

--- a/salt/metalk8s/kubernetes/sa/installed.sls
+++ b/salt/metalk8s/kubernetes/sa/installed.sls
@@ -29,7 +29,7 @@ Store SA public key:
 Advertise SA pub key in the mine:
   module.wait:
     - mine.send:
-      - func: kubernetes_sa_pub_key_b64
+      - kubernetes_sa_pub_key_b64
       - mine_function: hashutil.base64_encodefile
       - /etc/kubernetes/pki/sa.pub
     - watch:

--- a/salt/metalk8s/macro.sls
+++ b/salt/metalk8s/macro.sls
@@ -6,7 +6,7 @@
   metalk8s_package_manager.installed:
     - name: {{ name }}
     - fromrepo: {{ repo.repositories.keys() | join(',') }}
-    - pkgs_info: {{ repo.packages }}
+    - pkgs_info: {{ repo.packages | tojson }}
     {%- if package.version | default(None) %}
     - version: {{ package.version }}
     - hold: True

--- a/salt/metalk8s/repo/installed.sls
+++ b/salt/metalk8s/repo/installed.sls
@@ -43,7 +43,7 @@ Install repositories manifest:
         image: {{ image_fullname }}
         name: {{ repositories_name }}
         version: {{ repositories_version }}
-        archives: {{ archives }}
+        archives: {{ archives | tojson }}
         package_path: /{{ repo.relative_path }}
         image_path: '/images/'
         nginx_confd_path: {{ repo.config.directory }}

--- a/salt/metalk8s/salt/master/installed.sls
+++ b/salt/metalk8s/salt/master/installed.sls
@@ -31,7 +31,7 @@ Install and start salt master manifest:
     - context:
         image: {{ image_name }}
         version: {{ image_version }}
-        archives: {{ salt.metalk8s.get_archives() }}
+        archives: {{ salt.metalk8s.get_archives() | tojson }}
         salt_ip: "{{ salt_ip }}"
     - require:
       - file: Create salt master directories

--- a/tests/post/steps/test_salt_api.py
+++ b/tests/post/steps/test_salt_api.py
@@ -59,8 +59,7 @@ def login_salt_api(host, username, password, version, context, request):
         data={
             'eauth': 'kubernetes_rbac',
             'username': username,
-            'token': token,
-            'token_type': 'Basic',
+            'password': token
         },
         verify=False,
     )


### PR DESCRIPTION
**Component**:

'salt'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

Two CVE were found on the Salt side that has a huge security impact, Salt version 3000.2 include these fixes.

https://docs.saltstack.com/en/latest/topics/releases/3000.2.html#salt-3000-2-release-notes
https://labs.f-secure.com/advisories/saltstack-authorization-bypass

**Summary**:

In order to fix this CVE ASAP do not wait to have a full python3 solution for MetalK8s and use the python2 version of Salt 3000.2.

To support Salt 3000.2:
- Handle "non-string" version in our custom package manager Salt module
- Apply `tojson` filter when dumping certs from Salt mine to avoid unicode invalid certificate
- Changes mine send and mine functions in pillar to do not use kwargs as it does not work in Salt 3000.2 (https://github.com/saltstack/salt/issues/56584)
- backport https://github.com/scality/metalk8s/commit/0dbcbd18b5668d5a833107f43c6e8e8105c91df8 in 2.0
- Remove `token_type` from `kubernetes_rbac` salt Auth as we cannot provide additional kwargs for auth in Salt 3000.2 (https://github.com/saltstack/salt/commit/3dbe8dc8bed169ca35edee64c421f585f6263dad)

---

Fixes: #650 
