### PR TITLE
csc: Add ability to update CSC defaults during upgrade/downgrade

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -226,6 +226,7 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/addons/dex/ca/advertised.sls'),
     Path('salt/metalk8s/addons/dex/certs/init.sls'),
     Path('salt/metalk8s/addons/dex/certs/server.sls'),
+    Path('salt/metalk8s/addons/dex/config/dex.yaml'),
     Path('salt/metalk8s/addons/dex/deployed/chart.sls'),
     Path('salt/metalk8s/addons/dex/deployed/init.sls'),
     Path('salt/metalk8s/addons/dex/deployed/namespace.sls'),
@@ -269,6 +270,9 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/addons/prometheus-adapter/deployed/chart.sls'),
     Path('salt/metalk8s/addons/prometheus-adapter/deployed/init.sls'),
 
+    Path('salt/metalk8s/addons/prometheus-operator/config/alertmanager.yaml'),
+    Path('salt/metalk8s/addons/prometheus-operator/config/grafana.yaml'),
+    Path('salt/metalk8s/addons/prometheus-operator/config/prometheus.yaml'),
     Path('salt/metalk8s/addons/prometheus-operator/deployed/'
          'alertmanager-configuration-secret.sls'),
     Path('salt/metalk8s/addons/prometheus-operator/deployed/chart.sls'),

--- a/salt/metalk8s/addons/dex/config/dex.yaml
+++ b/salt/metalk8s/addons/dex/config/dex.yaml
@@ -1,0 +1,16 @@
+---
+# Configuration of the Dex (OIDC) service
+apiVersion: addons.metalk8s.scality.com
+kind: DexConfig
+spec:
+  # Configure the Dex Deployment
+  deployment:
+    replicas: 2
+  localuserstore:
+    enabled: true
+    userlist:
+      - email: "admin@metalk8s.invalid"
+        hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+        username: "admin"
+        userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
+  connectors: []

--- a/salt/metalk8s/addons/dex/deployed/chart.sls
+++ b/salt/metalk8s/addons/dex/deployed/chart.sls
@@ -1,7 +1,8 @@
 #!jinja | metalk8s_kubernetes
 
 {%- from "metalk8s/repo/macro.sls" import build_image_name with context %}
-{%- set dex = salt.metalk8s_service_configuration.get_service_conf('metalk8s-auth', 'metalk8s-dex-config') %}
+{% import_yaml 'metalk8s/addons/dex/config/dex.yaml' as dex_defaults with context %}
+{%- set dex = salt.metalk8s_service_configuration.get_service_conf('metalk8s-auth', 'metalk8s-dex-config', dex_defaults) %}
 
 {% raw %}
 

--- a/salt/metalk8s/addons/dex/deployed/service-configuration.sls
+++ b/salt/metalk8s/addons/dex/deployed/service-configuration.sls
@@ -23,18 +23,7 @@ Create dex-config ConfigMap:
           config.yaml: |-
             apiVersion: addons.metalk8s.scality.com
             kind: DexConfig
-            spec:
-              deployment:
-                replicas: 2
-              localuserstore:
-                enabled: true
-                userlist:
-                  - email: "admin@metalk8s.invalid"
-                    hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
-                    username: "admin"
-                    userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
-              connectors: []
-
+            spec: {}
 
  {%- else %}
 

--- a/salt/metalk8s/addons/prometheus-operator/config/alertmanager.yaml
+++ b/salt/metalk8s/addons/prometheus-operator/config/alertmanager.yaml
@@ -1,0 +1,26 @@
+---
+# Configuration of the Alertmanager service
+apiVersion: addons.metalk8s.scality.com
+kind: AlertmanagerConfig
+spec:
+  # Configure the Alertmanager Deployment
+  deployment:
+    replicas: 1
+  notification:
+    config:
+      global:
+        resolve_timeout: 5m
+      templates: []
+      route:
+        group_by: ['job']
+        group_wait: 30s
+        group_interval: 5m
+        repeat_interval: 12h
+        receiver: 'null'
+        routes:
+        - match:
+            alertname: Watchdog
+          receiver: 'null'
+      receivers:
+        - name: 'null'
+      inhibit_rules: []

--- a/salt/metalk8s/addons/prometheus-operator/config/grafana.yaml
+++ b/salt/metalk8s/addons/prometheus-operator/config/grafana.yaml
@@ -1,0 +1,8 @@
+---
+# Configuration of the Grafana service
+apiVersion: addons.metalk8s.scality.com
+kind: GrafanaConfig
+spec:
+  # Configure the Grafana Deployment
+  deployment:
+    replicas: 1

--- a/salt/metalk8s/addons/prometheus-operator/config/prometheus.yaml
+++ b/salt/metalk8s/addons/prometheus-operator/config/prometheus.yaml
@@ -1,0 +1,8 @@
+---
+# Configuration of the Prometheus service
+apiVersion: addons.metalk8s.scality.com
+kind: PrometheusConfig
+spec:
+  # Configure the Prometheus Deployment
+  deployment:
+    replicas: 1

--- a/salt/metalk8s/addons/prometheus-operator/deployed/alertmanager-configuration-secret.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/alertmanager-configuration-secret.sls
@@ -1,5 +1,7 @@
+{% import_yaml 'metalk8s/addons/prometheus-operator/config/alertmanager.yaml' as alertmanager_defaults with context %}
+
 {%- set alertmanager = salt.metalk8s_service_configuration.get_service_conf(
-        'metalk8s-monitoring', 'metalk8s-alertmanager-config'
+        'metalk8s-monitoring', 'metalk8s-alertmanager-config', alertmanager_defaults
   )
 %}
 

--- a/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
@@ -1,9 +1,12 @@
 #!jinja | metalk8s_kubernetes
 
 {%- from "metalk8s/repo/macro.sls" import build_image_name with context %}
-{%- set grafana = salt.metalk8s_service_configuration.get_service_conf('metalk8s-monitoring', 'metalk8s-grafana-config') %}
-{%- set prometheus = salt.metalk8s_service_configuration.get_service_conf('metalk8s-monitoring', 'metalk8s-prometheus-config') %}
-{%- set alertmanager = salt.metalk8s_service_configuration.get_service_conf('metalk8s-monitoring', 'metalk8s-alertmanager-config') %}
+{% import_yaml 'metalk8s/addons/prometheus-operator/config/grafana.yaml' as grafana_defaults with context %}
+{% import_yaml 'metalk8s/addons/prometheus-operator/config/prometheus.yaml' as prometheus_defaults with context %}
+{% import_yaml 'metalk8s/addons/prometheus-operator/config/alertmanager.yaml' as alertmanager_defaults with context %}
+{%- set grafana = salt.metalk8s_service_configuration.get_service_conf('metalk8s-monitoring', 'metalk8s-grafana-config', grafana_defaults) %}
+{%- set prometheus = salt.metalk8s_service_configuration.get_service_conf('metalk8s-monitoring', 'metalk8s-prometheus-config', prometheus_defaults) %}
+{%- set alertmanager = salt.metalk8s_service_configuration.get_service_conf('metalk8s-monitoring', 'metalk8s-alertmanager-config', alertmanager_defaults) %}
 
 {% raw %}
 
@@ -40382,7 +40385,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7bdc765fb193e66e7a094a5fb0ffe34218370368d820cffbaf93cae218ebe61f
+        checksum/config: 822028727d07edab6b024280685ef2510fcbae564ca11bea646dde763fd9559c
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/sc-dashboard-provider-config: 424200eb6040b7b1ec58add370935c65963d856f8ece2725caaa8390a3b54eee
         checksum/secret: 90b18138547156baaa1588680e3842aabcb31605c7f7fb8baa7eacc2b6d4822b

--- a/salt/metalk8s/addons/prometheus-operator/deployed/service-configuration.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/service-configuration.sls
@@ -39,9 +39,8 @@ Create grafana-config ConfigMap:
           config.yaml: |-
             apiVersion: addons.metalk8s.scality.com
             kind: GrafanaConfig
-            spec:
-              deployment:
-                replicas: 1
+            spec: {}
+
 {%- else %}
 
 metalk8s-grafana-config ConfigMap already exist:
@@ -63,9 +62,8 @@ Create prometheus-config ConfigMap:
           config.yaml: |-
             apiVersion: addons.metalk8s.scality.com
             kind: PrometheusConfig
-            spec:
-              deployment:
-                replicas: 1
+            spec: {}
+
 {%- else %}
 
 metalk8s-prometheus-config ConfigMap already exist:
@@ -87,27 +85,7 @@ Create alertmanager-config ConfigMap:
           config.yaml: |-
             apiVersion: addons.metalk8s.scality.com
             kind: AlertmanagerConfig
-            spec:
-              deployment:
-                replicas: 1
-              notification:
-                config:
-                  global:
-                    resolve_timeout: 5m
-                  templates: []
-                  route:
-                    group_by: ['job']
-                    group_wait: 30s
-                    group_interval: 5m
-                    repeat_interval: 12h
-                    receiver: 'null'
-                    routes:
-                    - match:
-                        alertname: Watchdog
-                      receiver: 'null'
-                  receivers:
-                    - name: 'null'
-                  inhibit_rules: []
+            spec: {}
 
 {%- else %}
 

--- a/tests/post/features/service_configuration.feature
+++ b/tests/post/features/service_configuration.feature
@@ -4,7 +4,7 @@ Feature: Cluster and Services Configurations
         Given the Kubernetes API is available
         And pods with label 'app.kubernetes.io/name=dex' are 'Ready'
         And we have 2 running pod labeled 'app.kubernetes.io/name=dex' in namespace 'metalk8s-auth'
-        And we have a 'metalk8s-dex-config' CSC in namespace 'metalk8s-auth' with 'spec.deployment.replicas' equal to '2'
+        And we have a 'metalk8s-dex-config' CSC in namespace 'metalk8s-auth'
         When we update 'metalk8s-dex-config' CSC in namespace 'metalk8s-auth' 'spec.deployment.replicas' to '3'
         And we apply the 'metalk8s.addons.dex.deployed' salt state
         Then we have '3' at 'status.available_replicas' for 'dex' Deployment in namespace 'metalk8s-auth'


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
'salt', 'kubernetes', 'csc'

**Context**: 

See #2488 

**Summary**:

- This PR adds the ability to update default CSC values during upgrade and downgrade while keeping the CSC Configmap intact. This works because we are able to merge the user customizations defined within Configmaps into the defaults packaged alongside each chart and then use the resulting dict object to render & deploy Metalk8s addons.

Flow:
1. Create CSC defaults for each Addon  e.g `alertmanager.yaml`
2. Import the CSC defaults within the charts using the `render.py` script
3. Call a salt module that takes arguments `csc ConfigMap name`, `namespace` and `default csc`
4. The module should merge the configs read in `csc ConfigMap` to those of `default CSC` and use  the resulting object to deploy the Addon


**Acceptance criteria**: 

no regression

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2488 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
