### PR TITLE
ui/oidc: Add 'groups' scope when requesting an id_token from Dex

### DIFF
--- a/ui/src/ducks/config.js
+++ b/ui/src/ducks/config.js
@@ -136,8 +136,8 @@ export function setThemesAction(themes) {
 }
 
 // Selectors
-export const languageSelector = state => state.config.language;
-export const apiConfigSelector = state => state.config.api;
+export const languageSelector = (state) => state.config.language;
+export const apiConfigSelector = (state) => state.config.api;
 
 // Sagas
 export function* fetchTheme() {
@@ -169,17 +169,17 @@ export function* fetchConfig() {
       }),
     );
     const userManagerConfig = yield select(
-      state => state.config.userManagerConfig,
+      (state) => state.config.userManagerConfig,
     );
     yield put(setUserManagerAction(createUserManager(userManagerConfig)));
-    const userManager = yield select(state => state.config.userManager);
+    const userManager = yield select((state) => state.config.userManager);
     yield call(loadUser, store, userManager);
     yield put(setUserLoadedAction(true));
   }
 }
 
 export function* updateApiServerConfig({ payload }) {
-  const api = yield select(state => state.config.api);
+  const api = yield select((state) => state.config.api);
   if (api) {
     yield call(
       ApiK8s.updateApiServerConfig,
@@ -213,7 +213,7 @@ export function* updateLanguage(action) {
 }
 
 export function* logout() {
-  const userManager = yield select(state => state.config.userManager);
+  const userManager = yield select((state) => state.config.userManager);
   if (userManager) {
     userManager.removeUser(); // removes the user data from sessionStorage
   }

--- a/ui/src/ducks/config.js
+++ b/ui/src/ducks/config.js
@@ -37,8 +37,14 @@ const defaultState = {
     client_id: 'metalk8s-ui',
     redirect_uri: 'http://localhost:3000/callback',
     response_type: 'id_token',
-    scope:
-      'openid profile email offline_access audience:server:client_id:oidc-auth-client',
+    scope: [
+      'openid',
+      'profile',
+      'email',
+      'groups',
+      'offline_access', // For refresh tokens, not sure if that's useful
+      'audience:server:client_id:oidc-auth-client', // A token for apiserver
+    ].join(' '),
     authority: '',
     loadUserInfo: false,
     post_logout_redirect_uri: '/',


### PR DESCRIPTION
**Component**: ui

**Context**: 

In the scopes we request from Dex when retrieving and id_token to then
authenticate to K8s API, we didn't include the 'groups' optional scope.
This meant that apiserver couldn't retrieve the 'groups' claim from the
generated token, hence the authenticated user wouldn't be able to assume
roles based on Group-based (Cluster)RoleBindings.

**Summary**:

We add this scope to the `redux-oidc` manager configuration, and this
resolves the issue.

**Acceptance criteria**: 

See #2526 reproducing steps - group-based RBAC should be functional

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2526

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
