### PR TITLE
docs: Add step to downgrade Salt if needed

### DIFF
--- a/docs/operation/downgrade.rst
+++ b/docs/operation/downgrade.rst
@@ -46,6 +46,72 @@ Downgrade Steps
 Ensure that the downgrade pre-requisites above have been met before you make
 any step further.
 
+Saltstack downgrade (only needed for 2.4.0, 2.4.1, 2.4.2, 2.4.3, or 2.5.0)
+--------------------------------------------------------------------------
+
+When downgrading MetalK8s to ``2.4.0``, ``2.4.1``, ``2.4.2``, ``2.4.3``, or
+``2.5.0`` you first need to downgrade Salt minions manually, if you downgrade
+to another version then you can skip this section.
+
+.. warning::
+
+  MetalK8s ``2.4.0``, ``2.4.1``, ``2.4.2``, ``2.4.3``, and ``2.5.0`` use Salt
+  version 2018.3.4 that has two known dangerous CVE
+  (`CVE-2020-11651 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-11651>`_,
+  `CVE-2020-11652 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-11652>`_)
+  , downgrade to these versions only if it's mandatory.
+
+#. Go inside the Salt-master container
+
+   .. code::
+
+     kubectl --kubeconfig=/etc/kubernetes/admin.conf exec -it \
+         $(kubectl --kubeconfig=/etc/kubernetes/admin.conf get pods \
+             --namespace kube-system \
+             --selector "app.kubernetes.io/name=salt-master" \
+             --field-selector=status.phase=Running \
+             --output jsonpath='{.items[*].metadata.name}') \
+         --namespace kube-system -c salt-master -- bash
+
+#. Sync all Salt modules to MetalK8s destination version
+
+   .. code::
+
+     salt '*' saltutil.sync_all saltenv=metalk8s-<version>
+
+#. Configure repositories to make packages available
+
+   .. code::
+
+     salt '*' state.sls metalk8s.repo saltenv=metalk8s-<version>
+
+#. Downgrade Salt minions
+
+   .. code::
+
+     salt '*' state.single pkg.installed salt \
+         pkgs="[{'salt-minion': '2018.3.4'}, {'salt': '2018.3.4'}]" \
+         hold=True update_holds=True --timeout=200
+
+#. Check that every Salt minions run with `2018.3.4`
+
+   .. note::
+
+     Master downgrade is handled by the utility script in the next section
+
+   .. code::
+
+     salt-run manage.versions
+
+#. Leave the Salt-master container
+
+   .. code::
+
+     exit
+
+MetalK8s downgrade
+------------------
+
 To downgrade a MetalK8s cluster, run the utility script shipped
 with the **current** installation providing it with the destination version:
 


### PR DESCRIPTION
**Component**:

'docs'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

`deploy_node` orchestrate of 2.4.0, 2.4.1, 2.4.2, 2.4.3, and 2.5.0 does
not handle Salt downgrade so to downgrade to these versions we first
need to downgrade all Salt minions manually

**Summary**:

Add a procedure in the documentation to downgrade Salt minions manually

---

Sees: e3916c899a229da101e6cc890ca09f57166e745f
Refs: #2525 
