### PR TITLE
Tooling to extract deployed Prometheus alert rules + Cluster monitoring doc

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -58,6 +58,12 @@ Glossary
 
      For more information, see `etcd.io <https://etcd.io>`_.
 
+   Grafana
+     Grafana is a service for analysing and visualizing metrics scraped by
+     Prometheus.
+
+     For more information, see `Grafana <https://grafana.com/docs/grafana/latest/>`_.
+
    Kubeconfig
      A configuration file for :term:`kubectl`, which includes authentication
      through embedded certificates.
@@ -70,6 +76,13 @@ Glossary
 
      |see K8s docs|
      `kubelet <https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/>`_.
+
+   Kube-state-metrics
+     The kube-state-metrics service listens to the Kubernetes API server and
+     generates metrics about the state of the objects.
+
+     |see K8s docs|
+     `kube-state-metrics <https://github.com/kubernetes/kube-state-metrics/tree/master/docs/>`_.
 
    Namespace
      A Namespace is a Kubernetes abstraction to support multiple virtual
@@ -105,6 +118,13 @@ Glossary
      provided by the cluster or installed afterwards.
 
      For more details, see `prometheus.io <https://prometheus.io>`_.
+
+   Prometheus Node-exporter
+     The Prometheus node-exporter is an exporter for exposing hardware and
+     OS metrics read from the Linux Kernel. Users can typically obtain the
+     following metrics; cpu, memory, filesystem for each Kubernetes node.
+
+    For more details, see `prometheus node-exporter <https://prometheus.io/docs/guides/node-exporter>`_.
 
    SaltAPI
      SaltAPI is an HTTP service for exposing operations to perform with a

--- a/docs/operation/cluster_monitoring.rst
+++ b/docs/operation/cluster_monitoring.rst
@@ -1,0 +1,60 @@
+Cluster Monitoring
+==================
+
+This section contains information describing the MetalK8s monitoring and
+alerting stack, metric resources that are automatically monitored once MetalK8s
+is deployed, a list of alerting and recording rules which are pre-configured
+and much more.
+
+Monitoring stack
+****************
+
+MetalK8s ships with a monitoring stack that provides a cluster-wide
+view of cluster health, pod status, node status, network traffic status and
+much more. These view points are usually represented as charts,
+counts and graphs. For a closer look, access the
+:ref:`Grafana Service<installation-services-grafana>` to get more insights on
+monitoring stats provided once MetalK8s is deployed.
+
+The MetalK8s monitoring stack consist of the following main components;
+
+  - :term:`Alertmanager`
+  - :term:`Grafana`
+  - :term:`Kube-state-metrics`
+  - :term:`Prometheus`
+  - :term:`Prometheus Node-exporter`
+
+.. todo::
+
+   - For each of the components list above, provide a detail description of
+     its role within the Monitoring stack.
+   - How to customize default alerting & recording rules
+   - Default alerting & recording rules are available as a json file, we should
+     use the json to generate a corresponding rst table as below
+
+Prometheus
+^^^^^^^^^^
+In a MetalK8s cluster, the Prometheus service is responsible for recording
+real-time metrics in a time series database. Prometheus is capable of querying
+a list of datasources called `exporters` at specific polling frequency and then
+aggregating this data across the various sources.
+Prometheus makes use of a special language Prometheus Query Language - PromQL
+for writing alerting and recording rules which we will later see.
+
+Default Alerting rules
+""""""""""""""""""""""
+
+Alerting rules enable a user to specify a condition that must occur before an
+external system like slack is notified. For example, MetalK8s administrators
+could want to raise an alert for any node that is unreachable for a duration
+>1 minutes.
+
+Out-of-the-box, MetalK8s ships with preconfigured alerting rules. These
+alerting rules are typically written as PromQL queries.
+The table below outlines some of the preconfigured alerting rules exposed from
+a newly deployed MetalK8s cluster.
+
+.. csv-table:: Default Prometheus Alerting rules
+   :file: ../../tools/rule_extractor/alerting_rules.csv
+   :header: "Name", "Severity", "Description"
+

--- a/docs/operation/index.rst
+++ b/docs/operation/index.rst
@@ -20,4 +20,5 @@ do not have a working MetalK8s_ setup.
    volume_management/index
    account_administration
    cluster_and_service_configuration
+   cluster_monitoring
    troubleshooting

--- a/tools/rule_extractor/alerting_rules.csv
+++ b/tools/rule_extractor/alerting_rules.csv
@@ -1,0 +1,102 @@
+AlertmanagerConfigInconsistent,critical,The configuration of the instances of the Alertmanager cluster `{{$labels.service}}` are out of sync.
+AlertmanagerFailedReload,warning,Reloading Alertmanager's configuration has failed for {{ $labels.namespace }}/{{ $labels.pod}}.
+AlertmanagerMembersInconsistent,critical,Alertmanager has not found all other members of the cluster.
+etcdInsufficientMembers,critical,"etcd cluster ""{{ $labels.job }}"": insufficient members ({{ $value }})."
+etcdNoLeader,critical,"etcd cluster ""{{ $labels.job }}"": member {{ $labels.instance }} has no leader."
+etcdHighNumberOfLeaderChanges,warning,"etcd cluster ""{{ $labels.job }}"": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour."
+etcdHighNumberOfFailedGRPCRequests,warning,"etcd cluster ""{{ $labels.job }}"": {{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}."
+etcdHighNumberOfFailedGRPCRequests,critical,"etcd cluster ""{{ $labels.job }}"": {{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}."
+etcdGRPCRequestsSlow,critical,"etcd cluster ""{{ $labels.job }}"": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}."
+etcdMemberCommunicationSlow,warning,"etcd cluster ""{{ $labels.job }}"": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}."
+etcdHighNumberOfFailedProposals,warning,"etcd cluster ""{{ $labels.job }}"": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}."
+etcdHighFsyncDurations,warning,"etcd cluster ""{{ $labels.job }}"": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}."
+etcdHighCommitDurations,warning,"etcd cluster ""{{ $labels.job }}"": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}."
+etcdHighNumberOfFailedHTTPRequests,warning,{{ $value }}% of requests for {{ $labels.method }} failed on etcd instance {{ $labels.instance }}
+etcdHighNumberOfFailedHTTPRequests,critical,{{ $value }}% of requests for {{ $labels.method }} failed on etcd instance {{ $labels.instance }}.
+etcdHTTPRequestsSlow,warning,etcd instance {{ $labels.instance }} HTTP requests to {{ $labels.method }} are slow.
+TargetDown,warning,"{{ printf ""%.4g"" $value }}% of the {{ $labels.job }} targets in {{ $labels.namespace }} namespace are down."
+Watchdog,none,"This is an alert meant to ensure that the entire alerting pipeline is functional.
+This alert is always firing, therefore it should always be firing in Alertmanager
+and always fire against a receiver. There are integrations with various notification
+mechanisms that send a notification when this alert is not firing. For example the
+""DeadMansSnitch"" integration in PagerDuty."
+AlertmanagerDown,critical,Alertmanager has disappeared from Prometheus target discovery.
+KubeAPIDown,critical,KubeAPI has disappeared from Prometheus target discovery.
+KubeControllerManagerDown,critical,KubeControllerManager has disappeared from Prometheus target discovery.
+KubeSchedulerDown,critical,KubeScheduler has disappeared from Prometheus target discovery.
+KubeStateMetricsDown,critical,KubeStateMetrics has disappeared from Prometheus target discovery.
+KubeletDown,critical,Kubelet has disappeared from Prometheus target discovery.
+NodeExporterDown,critical,NodeExporter has disappeared from Prometheus target discovery.
+PrometheusDown,critical,Prometheus has disappeared from Prometheus target discovery.
+PrometheusOperatorDown,critical,PrometheusOperator has disappeared from Prometheus target discovery.
+KubePodCrashLooping,critical,"Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf ""%.2f"" $value }} times / 5 minutes."
+KubePodNotReady,critical,Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for longer than 15 minutes.
+KubeDeploymentGenerationMismatch,critical,"Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment }} does not match, this indicates that the Deployment has failed but has not been rolled back."
+KubeDeploymentReplicasMismatch,critical,Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not matched the expected number of replicas for longer than 15 minutes.
+KubeStatefulSetReplicasMismatch,critical,StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has not matched the expected number of replicas for longer than 15 minutes.
+KubeStatefulSetGenerationMismatch,critical,"StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset }} does not match, this indicates that the StatefulSet has failed but has not been rolled back."
+KubeStatefulSetUpdateNotRolledOut,critical,StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} update has not been rolled out.
+KubeDaemonSetRolloutStuck,critical,Only {{ $value | humanizePercentage }} of the desired Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} are scheduled and ready.
+KubeContainerWaiting,warning,Pod {{ $labels.namespace }}/{{ $labels.pod }} container {{ $labels.container}} has been in waiting state for longer than 1 hour.
+KubeDaemonSetNotScheduled,warning,{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} are not scheduled.
+KubeDaemonSetMisScheduled,warning,{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} are running where they are not supposed to run.
+KubeCronJobRunning,warning,CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more than 1h to complete.
+KubeJobCompletion,warning,Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more than one hour to complete.
+KubeJobFailed,warning,Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.
+KubeHpaReplicasMismatch,warning,HPA {{ $labels.namespace }}/{{ $labels.hpa }} has not matched the desired number of replicas for longer than 15 minutes.
+KubeHpaMaxedOut,warning,HPA {{ $labels.namespace }}/{{ $labels.hpa }} has been running at max replicas for longer than 15 minutes.
+KubeCPUOvercommit,warning,Cluster has overcommitted CPU resource requests for Pods and cannot tolerate node failure.
+KubeMemOvercommit,warning,Cluster has overcommitted memory resource requests for Pods and cannot tolerate node failure.
+KubeCPUOvercommit,warning,Cluster has overcommitted CPU resource requests for Namespaces.
+KubeMemOvercommit,warning,Cluster has overcommitted memory resource requests for Namespaces.
+KubeQuotaExceeded,warning,Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage }} of its {{ $labels.resource }} quota.
+CPUThrottlingHigh,warning,{{ $value | humanizePercentage }} throttling of CPU in namespace {{ $labels.namespace }} for container {{ $labels.container }} in pod {{ $labels.pod }}.
+KubePersistentVolumeUsageCritical,critical,The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is only {{ $value | humanizePercentage }} free.
+KubePersistentVolumeFullInFourDays,critical,"Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is expected to fill up within four days. Currently {{ $value | humanizePercentage }} is available."
+KubePersistentVolumeErrors,critical,The persistent volume {{ $labels.persistentvolume }} has status {{ $labels.phase }}.
+KubeAPILatencyHigh,warning,The API server has a 99th percentile latency of {{ $value }} seconds for {{ $labels.verb }} {{ $labels.resource }}.
+KubeAPILatencyHigh,critical,The API server has a 99th percentile latency of {{ $value }} seconds for {{ $labels.verb }} {{ $labels.resource }}.
+KubeAPIErrorsHigh,critical,API server is returning errors for {{ $value | humanizePercentage }} of requests.
+KubeAPIErrorsHigh,warning,API server is returning errors for {{ $value | humanizePercentage }} of requests.
+KubeAPIErrorsHigh,critical,API server is returning errors for {{ $value | humanizePercentage }} of requests for {{ $labels.verb }} {{ $labels.resource }} {{ $labels.subresource }}.
+KubeAPIErrorsHigh,warning,API server is returning errors for {{ $value | humanizePercentage }} of requests for {{ $labels.verb }} {{ $labels.resource }} {{ $labels.subresource }}.
+KubeClientCertificateExpiration,warning,A client certificate used to authenticate to the apiserver is expiring in less than 7.0 days.
+KubeClientCertificateExpiration,critical,A client certificate used to authenticate to the apiserver is expiring in less than 24.0 hours.
+KubeAPIDown,critical,KubeAPI has disappeared from Prometheus target discovery.
+KubeControllerManagerDown,critical,KubeControllerManager has disappeared from Prometheus target discovery.
+KubeNodeNotReady,warning,{{ $labels.node }} has been unready for more than 15 minutes.
+KubeNodeUnreachable,warning,{{ $labels.node }} is unreachable and some workloads may be rescheduled.
+KubeletTooManyPods,warning,Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage }} of its Pod capacity.
+KubeletDown,critical,Kubelet has disappeared from Prometheus target discovery.
+KubeSchedulerDown,critical,KubeScheduler has disappeared from Prometheus target discovery.
+KubeVersionMismatch,warning,There are {{ $value }} different semantic versions of Kubernetes components running.
+KubeClientErrors,warning,Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance }}' is experiencing {{ $value | humanizePercentage }} errors.'
+NodeFilesystemSpaceFillingUp,warning,Filesystem is predicted to run out of space within the next 24 hours.
+NodeFilesystemSpaceFillingUp,critical,Filesystem is predicted to run out of space within the next 4 hours.
+NodeFilesystemAlmostOutOfSpace,warning,Filesystem has less than 5% space left.
+NodeFilesystemAlmostOutOfSpace,critical,Filesystem has less than 3% space left.
+NodeFilesystemFilesFillingUp,warning,Filesystem is predicted to run out of inodes within the next 24 hours.
+NodeFilesystemFilesFillingUp,critical,Filesystem is predicted to run out of inodes within the next 4 hours.
+NodeFilesystemAlmostOutOfFiles,warning,Filesystem has less than 5% inodes left.
+NodeFilesystemAlmostOutOfFiles,critical,Filesystem has less than 3% inodes left.
+NodeNetworkReceiveErrs,warning,Network interface is reporting many receive errors.
+NodeNetworkTransmitErrs,warning,Network interface is reporting many transmit errors.
+NodeNetworkInterfaceFlapping,warning,"Network interface ""{{ $labels.device }}"" changing it's up status often on node-exporter {{ $labels.namespace }}/{{ $labels.pod }}"""
+ClockSkewDetected,warning,Clock skew detected on node-exporter {{ $labels.namespace }}/{{ $labels.pod }}. Ensure NTP is configured correctly on this host.
+PrometheusOperatorReconcileErrors,warning,Errors while reconciling {{ $labels.controller }} in {{ $labels.namespace }} Namespace.
+PrometheusOperatorNodeLookupErrors,warning,Errors while reconciling Prometheus in {{ $labels.namespace }} Namespace.
+PrometheusBadConfig,critical,Failed Prometheus configuration reload.
+PrometheusNotificationQueueRunningFull,warning,Prometheus alert notification queue predicted to run full in less than 30m.
+PrometheusErrorSendingAlertsToSomeAlertmanagers,warning,Prometheus has encountered more than 1% errors sending alerts to a specific Alertmanager.
+PrometheusErrorSendingAlertsToAnyAlertmanager,critical,Prometheus encounters more than 3% errors sending alerts to any Alertmanager.
+PrometheusNotConnectedToAlertmanagers,warning,Prometheus is not connected to any Alertmanagers.
+PrometheusTSDBReloadsFailing,warning,Prometheus has issues reloading blocks from disk.
+PrometheusTSDBCompactionsFailing,warning,Prometheus has issues compacting blocks.
+PrometheusNotIngestingSamples,warning,Prometheus is not ingesting samples.
+PrometheusDuplicateTimestamps,warning,Prometheus is dropping samples with duplicate timestamps.
+PrometheusOutOfOrderTimestamps,warning,Prometheus drops samples with out-of-order timestamps.
+PrometheusRemoteStorageFailures,critical,Prometheus fails to send samples to remote storage.
+PrometheusRemoteWriteBehind,critical,Prometheus remote write is behind.
+PrometheusRemoteWriteDesiredShards,warning,Prometheus remote write desired shards calculation wants to run more than configured max shards.
+PrometheusRuleFailures,critical,Prometheus is failing rule evaluations.
+PrometheusMissingRuleEvaluations,warning,Prometheus is missing rule evaluations due to slow rule group evaluation.

--- a/tools/rule_extractor/alerting_rules.json
+++ b/tools/rule_extractor/alerting_rules.json
@@ -1,0 +1,590 @@
+[
+    {
+        "message": "The configuration of the instances of the Alertmanager cluster `{{$labels.service}}` are out of sync.",
+        "name": "AlertmanagerConfigInconsistent",
+        "query": "count_values by(service) (\"config_hash\", alertmanager_config_hash{job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"}) / on(service) group_left() label_replace(max by(name, job, namespace, controller) (prometheus_operator_spec_replicas{controller=\"alertmanager\",job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"}), \"service\", \"$1\", \"name\", \"(.*)\") != 1",
+        "severity": "critical"
+    },
+    {
+        "message": "Reloading Alertmanager's configuration has failed for {{ $labels.namespace }}/{{ $labels.pod}}.",
+        "name": "AlertmanagerFailedReload",
+        "query": "alertmanager_config_last_reload_successful{job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"} == 0",
+        "severity": "warning"
+    },
+    {
+        "message": "Alertmanager has not found all other members of the cluster.",
+        "name": "AlertmanagerMembersInconsistent",
+        "query": "alertmanager_cluster_members{job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"} != on(service) group_left() count by(service) (alertmanager_cluster_members{job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"})",
+        "severity": "critical"
+    },
+    {
+        "message": "etcd cluster \"{{ $labels.job }}\": insufficient members ({{ $value }}).",
+        "name": "etcdInsufficientMembers",
+        "query": "sum by(job) (up{job=~\".*etcd.*\"} == bool 1) < ((count by(job) (up{job=~\".*etcd.*\"}) + 1) / 2)",
+        "severity": "critical"
+    },
+    {
+        "message": "etcd cluster \"{{ $labels.job }}\": member {{ $labels.instance }} has no leader.",
+        "name": "etcdNoLeader",
+        "query": "etcd_server_has_leader{job=~\".*etcd.*\"} == 0",
+        "severity": "critical"
+    },
+    {
+        "message": "etcd cluster \"{{ $labels.job }}\": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.",
+        "name": "etcdHighNumberOfLeaderChanges",
+        "query": "rate(etcd_server_leader_changes_seen_total{job=~\".*etcd.*\"}[15m]) > 3",
+        "severity": "warning"
+    },
+    {
+        "message": "etcd cluster \"{{ $labels.job }}\": {{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}.",
+        "name": "etcdHighNumberOfFailedGRPCRequests",
+        "query": "100 * sum by(job, instance, grpc_service, grpc_method) (rate(grpc_server_handled_total{grpc_code!=\"OK\",job=~\".*etcd.*\"}[5m])) / sum by(job, instance, grpc_service, grpc_method) (rate(grpc_server_handled_total{job=~\".*etcd.*\"}[5m])) > 1",
+        "severity": "warning"
+    },
+    {
+        "message": "etcd cluster \"{{ $labels.job }}\": {{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}.",
+        "name": "etcdHighNumberOfFailedGRPCRequests",
+        "query": "100 * sum by(job, instance, grpc_service, grpc_method) (rate(grpc_server_handled_total{grpc_code!=\"OK\",job=~\".*etcd.*\"}[5m])) / sum by(job, instance, grpc_service, grpc_method) (rate(grpc_server_handled_total{job=~\".*etcd.*\"}[5m])) > 5",
+        "severity": "critical"
+    },
+    {
+        "message": "etcd cluster \"{{ $labels.job }}\": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.",
+        "name": "etcdGRPCRequestsSlow",
+        "query": "histogram_quantile(0.99, sum by(job, instance, grpc_service, grpc_method, le) (rate(grpc_server_handling_seconds_bucket{grpc_type=\"unary\",job=~\".*etcd.*\"}[5m]))) > 0.15",
+        "severity": "critical"
+    },
+    {
+        "message": "etcd cluster \"{{ $labels.job }}\": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.",
+        "name": "etcdMemberCommunicationSlow",
+        "query": "histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job=~\".*etcd.*\"}[5m])) > 0.15",
+        "severity": "warning"
+    },
+    {
+        "message": "etcd cluster \"{{ $labels.job }}\": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.",
+        "name": "etcdHighNumberOfFailedProposals",
+        "query": "rate(etcd_server_proposals_failed_total{job=~\".*etcd.*\"}[15m]) > 5",
+        "severity": "warning"
+    },
+    {
+        "message": "etcd cluster \"{{ $labels.job }}\": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.",
+        "name": "etcdHighFsyncDurations",
+        "query": "histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job=~\".*etcd.*\"}[5m])) > 0.5",
+        "severity": "warning"
+    },
+    {
+        "message": "etcd cluster \"{{ $labels.job }}\": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.",
+        "name": "etcdHighCommitDurations",
+        "query": "histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job=~\".*etcd.*\"}[5m])) > 0.25",
+        "severity": "warning"
+    },
+    {
+        "message": "{{ $value }}% of requests for {{ $labels.method }} failed on etcd instance {{ $labels.instance }}",
+        "name": "etcdHighNumberOfFailedHTTPRequests",
+        "query": "sum by(method) (rate(etcd_http_failed_total{code!=\"404\",job=~\".*etcd.*\"}[5m])) / sum by(method) (rate(etcd_http_received_total{job=~\".*etcd.*\"}[5m])) > 0.01",
+        "severity": "warning"
+    },
+    {
+        "message": "{{ $value }}% of requests for {{ $labels.method }} failed on etcd instance {{ $labels.instance }}.",
+        "name": "etcdHighNumberOfFailedHTTPRequests",
+        "query": "sum by(method) (rate(etcd_http_failed_total{code!=\"404\",job=~\".*etcd.*\"}[5m])) / sum by(method) (rate(etcd_http_received_total{job=~\".*etcd.*\"}[5m])) > 0.05",
+        "severity": "critical"
+    },
+    {
+        "message": "etcd instance {{ $labels.instance }} HTTP requests to {{ $labels.method }} are slow.",
+        "name": "etcdHTTPRequestsSlow",
+        "query": "histogram_quantile(0.99, rate(etcd_http_successful_duration_seconds_bucket[5m])) > 0.15",
+        "severity": "warning"
+    },
+    {
+        "message": "{{ printf \"%.4g\" $value }}% of the {{ $labels.job }} targets in {{ $labels.namespace }} namespace are down.",
+        "name": "TargetDown",
+        "query": "100 * (count by(job, namespace, service) (up == 0) / count by(job, namespace, service) (up)) > 10",
+        "severity": "warning"
+    },
+    {
+        "message": "This is an alert meant to ensure that the entire alerting pipeline is functional.\nThis alert is always firing, therefore it should always be firing in Alertmanager\nand always fire against a receiver. There are integrations with various notification\nmechanisms that send a notification when this alert is not firing. For example the\n\"DeadMansSnitch\" integration in PagerDuty.",
+        "name": "Watchdog",
+        "query": "vector(1)",
+        "severity": "none"
+    },
+    {
+        "message": "Alertmanager has disappeared from Prometheus target discovery.",
+        "name": "AlertmanagerDown",
+        "query": "absent(up{job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"} == 1)",
+        "severity": "critical"
+    },
+    {
+        "message": "KubeAPI has disappeared from Prometheus target discovery.",
+        "name": "KubeAPIDown",
+        "query": "absent(up{job=\"apiserver\"} == 1)",
+        "severity": "critical"
+    },
+    {
+        "message": "KubeControllerManager has disappeared from Prometheus target discovery.",
+        "name": "KubeControllerManagerDown",
+        "query": "absent(up{job=\"kube-controller-manager\"} == 1)",
+        "severity": "critical"
+    },
+    {
+        "message": "KubeScheduler has disappeared from Prometheus target discovery.",
+        "name": "KubeSchedulerDown",
+        "query": "absent(up{job=\"kube-scheduler\"} == 1)",
+        "severity": "critical"
+    },
+    {
+        "message": "KubeStateMetrics has disappeared from Prometheus target discovery.",
+        "name": "KubeStateMetricsDown",
+        "query": "absent(up{job=\"kube-state-metrics\"} == 1)",
+        "severity": "critical"
+    },
+    {
+        "message": "Kubelet has disappeared from Prometheus target discovery.",
+        "name": "KubeletDown",
+        "query": "absent(up{job=\"kubelet\"} == 1)",
+        "severity": "critical"
+    },
+    {
+        "message": "NodeExporter has disappeared from Prometheus target discovery.",
+        "name": "NodeExporterDown",
+        "query": "absent(up{job=\"node-exporter\"} == 1)",
+        "severity": "critical"
+    },
+    {
+        "message": "Prometheus has disappeared from Prometheus target discovery.",
+        "name": "PrometheusDown",
+        "query": "absent(up{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"} == 1)",
+        "severity": "critical"
+    },
+    {
+        "message": "PrometheusOperator has disappeared from Prometheus target discovery.",
+        "name": "PrometheusOperatorDown",
+        "query": "absent(up{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"} == 1)",
+        "severity": "critical"
+    },
+    {
+        "message": "Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf \"%.2f\" $value }} times / 5 minutes.",
+        "name": "KubePodCrashLooping",
+        "query": "rate(kube_pod_container_status_restarts_total{job=\"kube-state-metrics\"}[15m]) * 60 * 5 > 0",
+        "severity": "critical"
+    },
+    {
+        "message": "Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for longer than 15 minutes.",
+        "name": "KubePodNotReady",
+        "query": "sum by(namespace, pod) (kube_pod_status_phase{job=\"kube-state-metrics\",phase=~\"Failed|Pending|Unknown\"} * on(namespace, pod) group_left(owner_kind) kube_pod_owner{owner_kind!=\"Job\"}) > 0",
+        "severity": "critical"
+    },
+    {
+        "message": "Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment }} does not match, this indicates that the Deployment has failed but has not been rolled back.",
+        "name": "KubeDeploymentGenerationMismatch",
+        "query": "kube_deployment_status_observed_generation{job=\"kube-state-metrics\"} != kube_deployment_metadata_generation{job=\"kube-state-metrics\"}",
+        "severity": "critical"
+    },
+    {
+        "message": "Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not matched the expected number of replicas for longer than 15 minutes.",
+        "name": "KubeDeploymentReplicasMismatch",
+        "query": "kube_deployment_spec_replicas{job=\"kube-state-metrics\"} != kube_deployment_status_replicas_available{job=\"kube-state-metrics\"}",
+        "severity": "critical"
+    },
+    {
+        "message": "StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has not matched the expected number of replicas for longer than 15 minutes.",
+        "name": "KubeStatefulSetReplicasMismatch",
+        "query": "kube_statefulset_status_replicas_ready{job=\"kube-state-metrics\"} != kube_statefulset_status_replicas{job=\"kube-state-metrics\"}",
+        "severity": "critical"
+    },
+    {
+        "message": "StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset }} does not match, this indicates that the StatefulSet has failed but has not been rolled back.",
+        "name": "KubeStatefulSetGenerationMismatch",
+        "query": "kube_statefulset_status_observed_generation{job=\"kube-state-metrics\"} != kube_statefulset_metadata_generation{job=\"kube-state-metrics\"}",
+        "severity": "critical"
+    },
+    {
+        "message": "StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} update has not been rolled out.",
+        "name": "KubeStatefulSetUpdateNotRolledOut",
+        "query": "max without(revision) (kube_statefulset_status_current_revision{job=\"kube-state-metrics\"} unless kube_statefulset_status_update_revision{job=\"kube-state-metrics\"}) * (kube_statefulset_replicas{job=\"kube-state-metrics\"} != kube_statefulset_status_replicas_updated{job=\"kube-state-metrics\"})",
+        "severity": "critical"
+    },
+    {
+        "message": "Only {{ $value | humanizePercentage }} of the desired Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} are scheduled and ready.",
+        "name": "KubeDaemonSetRolloutStuck",
+        "query": "kube_daemonset_status_number_ready{job=\"kube-state-metrics\"} / kube_daemonset_status_desired_number_scheduled{job=\"kube-state-metrics\"} < 1",
+        "severity": "critical"
+    },
+    {
+        "message": "Pod {{ $labels.namespace }}/{{ $labels.pod }} container {{ $labels.container}} has been in waiting state for longer than 1 hour.",
+        "name": "KubeContainerWaiting",
+        "query": "sum by(namespace, pod, container) (kube_pod_container_status_waiting_reason{job=\"kube-state-metrics\"}) > 0",
+        "severity": "warning"
+    },
+    {
+        "message": "{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} are not scheduled.",
+        "name": "KubeDaemonSetNotScheduled",
+        "query": "kube_daemonset_status_desired_number_scheduled{job=\"kube-state-metrics\"} - kube_daemonset_status_current_number_scheduled{job=\"kube-state-metrics\"} > 0",
+        "severity": "warning"
+    },
+    {
+        "message": "{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} are running where they are not supposed to run.",
+        "name": "KubeDaemonSetMisScheduled",
+        "query": "kube_daemonset_status_number_misscheduled{job=\"kube-state-metrics\"} > 0",
+        "severity": "warning"
+    },
+    {
+        "message": "CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more than 1h to complete.",
+        "name": "KubeCronJobRunning",
+        "query": "time() - kube_cronjob_next_schedule_time{job=\"kube-state-metrics\"} > 3600",
+        "severity": "warning"
+    },
+    {
+        "message": "Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more than one hour to complete.",
+        "name": "KubeJobCompletion",
+        "query": "kube_job_spec_completions{job=\"kube-state-metrics\"} - kube_job_status_succeeded{job=\"kube-state-metrics\"} > 0",
+        "severity": "warning"
+    },
+    {
+        "message": "Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.",
+        "name": "KubeJobFailed",
+        "query": "kube_job_failed{job=\"kube-state-metrics\"} > 0",
+        "severity": "warning"
+    },
+    {
+        "message": "HPA {{ $labels.namespace }}/{{ $labels.hpa }} has not matched the desired number of replicas for longer than 15 minutes.",
+        "name": "KubeHpaReplicasMismatch",
+        "query": "(kube_hpa_status_desired_replicas{job=\"kube-state-metrics\"} != kube_hpa_status_current_replicas{job=\"kube-state-metrics\"}) and changes(kube_hpa_status_current_replicas[15m]) == 0",
+        "severity": "warning"
+    },
+    {
+        "message": "HPA {{ $labels.namespace }}/{{ $labels.hpa }} has been running at max replicas for longer than 15 minutes.",
+        "name": "KubeHpaMaxedOut",
+        "query": "kube_hpa_status_current_replicas{job=\"kube-state-metrics\"} == kube_hpa_spec_max_replicas{job=\"kube-state-metrics\"}",
+        "severity": "warning"
+    },
+    {
+        "message": "Cluster has overcommitted CPU resource requests for Pods and cannot tolerate node failure.",
+        "name": "KubeCPUOvercommit",
+        "query": "sum(namespace:kube_pod_container_resource_requests_cpu_cores:sum) / sum(kube_node_status_allocatable_cpu_cores) > (count(kube_node_status_allocatable_cpu_cores) - 1) / count(kube_node_status_allocatable_cpu_cores)",
+        "severity": "warning"
+    },
+    {
+        "message": "Cluster has overcommitted memory resource requests for Pods and cannot tolerate node failure.",
+        "name": "KubeMemOvercommit",
+        "query": "sum(namespace:kube_pod_container_resource_requests_memory_bytes:sum) / sum(kube_node_status_allocatable_memory_bytes) > (count(kube_node_status_allocatable_memory_bytes) - 1) / count(kube_node_status_allocatable_memory_bytes)",
+        "severity": "warning"
+    },
+    {
+        "message": "Cluster has overcommitted CPU resource requests for Namespaces.",
+        "name": "KubeCPUOvercommit",
+        "query": "sum(kube_resourcequota{job=\"kube-state-metrics\",resource=\"cpu\",type=\"hard\"}) / sum(kube_node_status_allocatable_cpu_cores) > 1.5",
+        "severity": "warning"
+    },
+    {
+        "message": "Cluster has overcommitted memory resource requests for Namespaces.",
+        "name": "KubeMemOvercommit",
+        "query": "sum(kube_resourcequota{job=\"kube-state-metrics\",resource=\"memory\",type=\"hard\"}) / sum(kube_node_status_allocatable_memory_bytes{job=\"node-exporter\"}) > 1.5",
+        "severity": "warning"
+    },
+    {
+        "message": "Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage }} of its {{ $labels.resource }} quota.",
+        "name": "KubeQuotaExceeded",
+        "query": "kube_resourcequota{job=\"kube-state-metrics\",type=\"used\"} / ignoring(instance, job, type) (kube_resourcequota{job=\"kube-state-metrics\",type=\"hard\"} > 0) > 0.9",
+        "severity": "warning"
+    },
+    {
+        "message": "{{ $value | humanizePercentage }} throttling of CPU in namespace {{ $labels.namespace }} for container {{ $labels.container }} in pod {{ $labels.pod }}.",
+        "name": "CPUThrottlingHigh",
+        "query": "sum by(container, pod, namespace) (increase(container_cpu_cfs_throttled_periods_total{container!=\"\"}[5m])) / sum by(container, pod, namespace) (increase(container_cpu_cfs_periods_total[5m])) > (25 / 100)",
+        "severity": "warning"
+    },
+    {
+        "message": "The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is only {{ $value | humanizePercentage }} free.",
+        "name": "KubePersistentVolumeUsageCritical",
+        "query": "kubelet_volume_stats_available_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"} < 0.03",
+        "severity": "critical"
+    },
+    {
+        "message": "Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is expected to fill up within four days. Currently {{ $value | humanizePercentage }} is available.",
+        "name": "KubePersistentVolumeFullInFourDays",
+        "query": "(kubelet_volume_stats_available_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) < 0.15 and predict_linear(kubelet_volume_stats_available_bytes{job=\"kubelet\"}[6h], 4 * 24 * 3600) < 0",
+        "severity": "critical"
+    },
+    {
+        "message": "The persistent volume {{ $labels.persistentvolume }} has status {{ $labels.phase }}.",
+        "name": "KubePersistentVolumeErrors",
+        "query": "kube_persistentvolume_status_phase{job=\"kube-state-metrics\",phase=~\"Failed|Pending\"} > 0",
+        "severity": "critical"
+    },
+    {
+        "message": "The API server has a 99th percentile latency of {{ $value }} seconds for {{ $labels.verb }} {{ $labels.resource }}.",
+        "name": "KubeAPILatencyHigh",
+        "query": "cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{job=\"apiserver\",quantile=\"0.99\",subresource!=\"log\",verb!~\"LIST|WATCH|WATCHLIST|PROXY|CONNECT\"} > 1",
+        "severity": "warning"
+    },
+    {
+        "message": "The API server has a 99th percentile latency of {{ $value }} seconds for {{ $labels.verb }} {{ $labels.resource }}.",
+        "name": "KubeAPILatencyHigh",
+        "query": "cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{job=\"apiserver\",quantile=\"0.99\",subresource!=\"log\",verb!~\"LIST|WATCH|WATCHLIST|PROXY|CONNECT\"} > 4",
+        "severity": "critical"
+    },
+    {
+        "message": "API server is returning errors for {{ $value | humanizePercentage }} of requests.",
+        "name": "KubeAPIErrorsHigh",
+        "query": "sum(rate(apiserver_request_total{code=~\"5..\",job=\"apiserver\"}[5m])) / sum(rate(apiserver_request_total{job=\"apiserver\"}[5m])) > 0.03",
+        "severity": "critical"
+    },
+    {
+        "message": "API server is returning errors for {{ $value | humanizePercentage }} of requests.",
+        "name": "KubeAPIErrorsHigh",
+        "query": "sum(rate(apiserver_request_total{code=~\"5..\",job=\"apiserver\"}[5m])) / sum(rate(apiserver_request_total{job=\"apiserver\"}[5m])) > 0.01",
+        "severity": "warning"
+    },
+    {
+        "message": "API server is returning errors for {{ $value | humanizePercentage }} of requests for {{ $labels.verb }} {{ $labels.resource }} {{ $labels.subresource }}.",
+        "name": "KubeAPIErrorsHigh",
+        "query": "sum by(resource, subresource, verb) (rate(apiserver_request_total{code=~\"5..\",job=\"apiserver\"}[5m])) / sum by(resource, subresource, verb) (rate(apiserver_request_total{job=\"apiserver\"}[5m])) > 0.1",
+        "severity": "critical"
+    },
+    {
+        "message": "API server is returning errors for {{ $value | humanizePercentage }} of requests for {{ $labels.verb }} {{ $labels.resource }} {{ $labels.subresource }}.",
+        "name": "KubeAPIErrorsHigh",
+        "query": "sum by(resource, subresource, verb) (rate(apiserver_request_total{code=~\"5..\",job=\"apiserver\"}[5m])) / sum by(resource, subresource, verb) (rate(apiserver_request_total{job=\"apiserver\"}[5m])) > 0.05",
+        "severity": "warning"
+    },
+    {
+        "message": "A client certificate used to authenticate to the apiserver is expiring in less than 7.0 days.",
+        "name": "KubeClientCertificateExpiration",
+        "query": "apiserver_client_certificate_expiration_seconds_count{job=\"apiserver\"} > 0 and histogram_quantile(0.01, sum by(job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job=\"apiserver\"}[5m]))) < 604800",
+        "severity": "warning"
+    },
+    {
+        "message": "A client certificate used to authenticate to the apiserver is expiring in less than 24.0 hours.",
+        "name": "KubeClientCertificateExpiration",
+        "query": "apiserver_client_certificate_expiration_seconds_count{job=\"apiserver\"} > 0 and histogram_quantile(0.01, sum by(job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job=\"apiserver\"}[5m]))) < 86400",
+        "severity": "critical"
+    },
+    {
+        "message": "KubeAPI has disappeared from Prometheus target discovery.",
+        "name": "KubeAPIDown",
+        "query": "absent(up{job=\"apiserver\"} == 1)",
+        "severity": "critical"
+    },
+    {
+        "message": "KubeControllerManager has disappeared from Prometheus target discovery.",
+        "name": "KubeControllerManagerDown",
+        "query": "absent(up{job=\"kube-controller-manager\"} == 1)",
+        "severity": "critical"
+    },
+    {
+        "message": "{{ $labels.node }} has been unready for more than 15 minutes.",
+        "name": "KubeNodeNotReady",
+        "query": "kube_node_status_condition{condition=\"Ready\",job=\"kube-state-metrics\",status=\"true\"} == 0",
+        "severity": "warning"
+    },
+    {
+        "message": "{{ $labels.node }} is unreachable and some workloads may be rescheduled.",
+        "name": "KubeNodeUnreachable",
+        "query": "kube_node_spec_taint{effect=\"NoSchedule\",job=\"kube-state-metrics\",key=\"node.kubernetes.io/unreachable\"} == 1",
+        "severity": "warning"
+    },
+    {
+        "message": "Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage }} of its Pod capacity.",
+        "name": "KubeletTooManyPods",
+        "query": "max by(node) (max by(instance) (kubelet_running_pod_count{job=\"kubelet\"}) * on(instance) group_left(node) kubelet_node_name{job=\"kubelet\"}) / max by(node) (kube_node_status_capacity_pods{job=\"kube-state-metrics\"}) > 0.95",
+        "severity": "warning"
+    },
+    {
+        "message": "Kubelet has disappeared from Prometheus target discovery.",
+        "name": "KubeletDown",
+        "query": "absent(up{job=\"kubelet\"} == 1)",
+        "severity": "critical"
+    },
+    {
+        "message": "KubeScheduler has disappeared from Prometheus target discovery.",
+        "name": "KubeSchedulerDown",
+        "query": "absent(up{job=\"kube-scheduler\"} == 1)",
+        "severity": "critical"
+    },
+    {
+        "message": "There are {{ $value }} different semantic versions of Kubernetes components running.",
+        "name": "KubeVersionMismatch",
+        "query": "count(count by(gitVersion) (label_replace(kubernetes_build_info{job!~\"kube-dns|coredns\"}, \"gitVersion\", \"$1\", \"gitVersion\", \"(v[0-9]*.[0-9]*.[0-9]*).*\"))) > 1",
+        "severity": "warning"
+    },
+    {
+        "message": "Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance }}' is experiencing {{ $value | humanizePercentage }} errors.'",
+        "name": "KubeClientErrors",
+        "query": "(sum by(instance, job) (rate(rest_client_requests_total{code=~\"5..\"}[5m])) / sum by(instance, job) (rate(rest_client_requests_total[5m]))) > 0.01",
+        "severity": "warning"
+    },
+    {
+        "message": "Filesystem is predicted to run out of space within the next 24 hours.",
+        "name": "NodeFilesystemSpaceFillingUp",
+        "query": "(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_size_bytes{fstype!=\"\",job=\"node-exporter\"} * 100 < 40 and predict_linear(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\"}[6h], 24 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
+        "severity": "warning"
+    },
+    {
+        "message": "Filesystem is predicted to run out of space within the next 4 hours.",
+        "name": "NodeFilesystemSpaceFillingUp",
+        "query": "(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_size_bytes{fstype!=\"\",job=\"node-exporter\"} * 100 < 20 and predict_linear(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\"}[6h], 4 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
+        "severity": "critical"
+    },
+    {
+        "message": "Filesystem has less than 5% space left.",
+        "name": "NodeFilesystemAlmostOutOfSpace",
+        "query": "(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_size_bytes{fstype!=\"\",job=\"node-exporter\"} * 100 < 5 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
+        "severity": "warning"
+    },
+    {
+        "message": "Filesystem has less than 3% space left.",
+        "name": "NodeFilesystemAlmostOutOfSpace",
+        "query": "(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_size_bytes{fstype!=\"\",job=\"node-exporter\"} * 100 < 3 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
+        "severity": "critical"
+    },
+    {
+        "message": "Filesystem is predicted to run out of inodes within the next 24 hours.",
+        "name": "NodeFilesystemFilesFillingUp",
+        "query": "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100 < 40 and predict_linear(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"}[6h], 24 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
+        "severity": "warning"
+    },
+    {
+        "message": "Filesystem is predicted to run out of inodes within the next 4 hours.",
+        "name": "NodeFilesystemFilesFillingUp",
+        "query": "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100 < 20 and predict_linear(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"}[6h], 4 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
+        "severity": "critical"
+    },
+    {
+        "message": "Filesystem has less than 5% inodes left.",
+        "name": "NodeFilesystemAlmostOutOfFiles",
+        "query": "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100 < 5 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
+        "severity": "warning"
+    },
+    {
+        "message": "Filesystem has less than 3% inodes left.",
+        "name": "NodeFilesystemAlmostOutOfFiles",
+        "query": "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100 < 3 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
+        "severity": "critical"
+    },
+    {
+        "message": "Network interface is reporting many receive errors.",
+        "name": "NodeNetworkReceiveErrs",
+        "query": "increase(node_network_receive_errs_total[2m]) > 10",
+        "severity": "warning"
+    },
+    {
+        "message": "Network interface is reporting many transmit errors.",
+        "name": "NodeNetworkTransmitErrs",
+        "query": "increase(node_network_transmit_errs_total[2m]) > 10",
+        "severity": "warning"
+    },
+    {
+        "message": "Network interface \"{{ $labels.device }}\" changing it's up status often on node-exporter {{ $labels.namespace }}/{{ $labels.pod }}\"",
+        "name": "NodeNetworkInterfaceFlapping",
+        "query": "changes(node_network_up{device!~\"veth.+\",job=\"node-exporter\"}[2m]) > 2",
+        "severity": "warning"
+    },
+    {
+        "message": "Clock skew detected on node-exporter {{ $labels.namespace }}/{{ $labels.pod }}. Ensure NTP is configured correctly on this host.",
+        "name": "ClockSkewDetected",
+        "query": "abs(node_timex_offset_seconds{job=\"node-exporter\"}) > 0.05",
+        "severity": "warning"
+    },
+    {
+        "message": "Errors while reconciling {{ $labels.controller }} in {{ $labels.namespace }} Namespace.",
+        "name": "PrometheusOperatorReconcileErrors",
+        "query": "rate(prometheus_operator_reconcile_errors_total{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"}[5m]) > 0.1",
+        "severity": "warning"
+    },
+    {
+        "message": "Errors while reconciling Prometheus in {{ $labels.namespace }} Namespace.",
+        "name": "PrometheusOperatorNodeLookupErrors",
+        "query": "rate(prometheus_operator_node_address_lookup_errors_total{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"}[5m]) > 0.1",
+        "severity": "warning"
+    },
+    {
+        "message": "Failed Prometheus configuration reload.",
+        "name": "PrometheusBadConfig",
+        "query": "max_over_time(prometheus_config_last_reload_successful{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) == 0",
+        "severity": "critical"
+    },
+    {
+        "message": "Prometheus alert notification queue predicted to run full in less than 30m.",
+        "name": "PrometheusNotificationQueueRunningFull",
+        "query": "(predict_linear(prometheus_notifications_queue_length{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m], 60 * 30) > min_over_time(prometheus_notifications_queue_capacity{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]))",
+        "severity": "warning"
+    },
+    {
+        "message": "Prometheus has encountered more than 1% errors sending alerts to a specific Alertmanager.",
+        "name": "PrometheusErrorSendingAlertsToSomeAlertmanagers",
+        "query": "(rate(prometheus_notifications_errors_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) / rate(prometheus_notifications_sent_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m])) * 100 > 1",
+        "severity": "warning"
+    },
+    {
+        "message": "Prometheus encounters more than 3% errors sending alerts to any Alertmanager.",
+        "name": "PrometheusErrorSendingAlertsToAnyAlertmanager",
+        "query": "min without(alertmanager) (rate(prometheus_notifications_errors_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) / rate(prometheus_notifications_sent_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m])) * 100 > 3",
+        "severity": "critical"
+    },
+    {
+        "message": "Prometheus is not connected to any Alertmanagers.",
+        "name": "PrometheusNotConnectedToAlertmanagers",
+        "query": "max_over_time(prometheus_notifications_alertmanagers_discovered{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) < 1",
+        "severity": "warning"
+    },
+    {
+        "message": "Prometheus has issues reloading blocks from disk.",
+        "name": "PrometheusTSDBReloadsFailing",
+        "query": "increase(prometheus_tsdb_reloads_failures_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[3h]) > 0",
+        "severity": "warning"
+    },
+    {
+        "message": "Prometheus has issues compacting blocks.",
+        "name": "PrometheusTSDBCompactionsFailing",
+        "query": "increase(prometheus_tsdb_compactions_failed_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[3h]) > 0",
+        "severity": "warning"
+    },
+    {
+        "message": "Prometheus is not ingesting samples.",
+        "name": "PrometheusNotIngestingSamples",
+        "query": "rate(prometheus_tsdb_head_samples_appended_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) <= 0",
+        "severity": "warning"
+    },
+    {
+        "message": "Prometheus is dropping samples with duplicate timestamps.",
+        "name": "PrometheusDuplicateTimestamps",
+        "query": "rate(prometheus_target_scrapes_sample_duplicate_timestamp_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) > 0",
+        "severity": "warning"
+    },
+    {
+        "message": "Prometheus drops samples with out-of-order timestamps.",
+        "name": "PrometheusOutOfOrderTimestamps",
+        "query": "rate(prometheus_target_scrapes_sample_out_of_order_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) > 0",
+        "severity": "warning"
+    },
+    {
+        "message": "Prometheus fails to send samples to remote storage.",
+        "name": "PrometheusRemoteStorageFailures",
+        "query": "(rate(prometheus_remote_storage_failed_samples_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) / (rate(prometheus_remote_storage_failed_samples_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) + rate(prometheus_remote_storage_succeeded_samples_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]))) * 100 > 1",
+        "severity": "critical"
+    },
+    {
+        "message": "Prometheus remote write is behind.",
+        "name": "PrometheusRemoteWriteBehind",
+        "query": "(max_over_time(prometheus_remote_storage_highest_timestamp_in_seconds{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) - on(job, instance) group_right() max_over_time(prometheus_remote_storage_queue_highest_sent_timestamp_seconds{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m])) > 120",
+        "severity": "critical"
+    },
+    {
+        "message": "Prometheus remote write desired shards calculation wants to run more than configured max shards.",
+        "name": "PrometheusRemoteWriteDesiredShards",
+        "query": "(max_over_time(prometheus_remote_storage_shards_desired{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) > max_over_time(prometheus_remote_storage_shards_max{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]))",
+        "severity": "warning"
+    },
+    {
+        "message": "Prometheus is failing rule evaluations.",
+        "name": "PrometheusRuleFailures",
+        "query": "increase(prometheus_rule_evaluation_failures_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) > 0",
+        "severity": "critical"
+    },
+    {
+        "message": "Prometheus is missing rule evaluations due to slow rule group evaluation.",
+        "name": "PrometheusMissingRuleEvaluations",
+        "query": "increase(prometheus_rule_group_iterations_missed_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) > 0",
+        "severity": "warning"
+    }
+]

--- a/tools/rule_extractor/rule_extractor.py
+++ b/tools/rule_extractor/rule_extractor.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+
+'''
+Utility script to read and write Prometheus Alert rules to file.
+Ensures we can test the Alert rules deployed and for documentation
+purposes.
+'''
+
+import argparse
+import csv
+import ipaddress
+import json
+import pathlib
+import requests
+import subprocess
+import sys
+
+
+def query_prometheus_api(ip, port, route):
+    """Read the Prometheus route contents into memory."""
+    if not route:
+        sys.stderr.write("Expected endpoint route but got {}".format(route))
+        sys.exit(1)
+
+    endpoint = "https://{}:{}/api/prometheus/api/v1/{}".format(ip, port, route)
+    try:
+        response = requests.get(url=endpoint, verify=False)
+    except requests.exceptions.ConnectionError as exc:
+        sys.stderr.write(
+            "Failed to reach endpoint {}: {!s}".format(route, exc)
+        )
+        sys.exit(1)
+
+    if response.status_code != 200:
+        sys.stderr.write(
+            "Expected status code <200> got {}".format(response.status_code)
+        )
+        sys.exit(1)
+
+    return response.json()
+
+
+def write_json_to_file(content, rule_name):
+    filename = '{}.json'.format(rule_name)
+    filepath = pathlib.Path(__file__).parent/filename
+    try:
+        with open('{}'.format(filepath), 'w', encoding='utf-8') as f:
+            json.dump(content, f, indent=4, sort_keys=True)
+    except IOError as exc:
+        sys.stderr.write("Failed to write json file: {!s}".format(exc))
+        sys.exit(1)
+
+
+def write_csv_to_file(content, rule_name):
+    filename = '{}.csv'.format(rule_name)
+    filepath = pathlib.Path(__file__).parent/filename
+    csv_columns = ['name', 'severity', 'message']
+    try:
+        with open('{}'.format(filepath), 'w') as csvfile:
+            writer = csv.DictWriter(
+                csvfile, fieldnames=csv_columns, extrasaction='ignore'
+            )
+            writer.writerows(content)
+    except IOError as exc:
+        sys.stderr.write("Failed to write csv file: {!s}".format(exc))
+        sys.exit(1)
+
+
+def main():
+    """
+        python rule_extractor --ip 127.0.0.1 --port 9090 -t rules
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-i',
+        '--ip',
+        dest='ip',
+        help='Specify the target control-plane ingress IP address'
+    )
+    parser.add_argument(
+        '-p',
+        '--port',
+        dest='port',
+        default='8443',
+        help='Specify the target control-plane ingress port',
+        type=int
+    )
+    parser.add_argument(
+        '-t',
+        required=True,
+        dest='object_type',
+        help='Specify the type of objects to fetch',
+        choices=['rules']
+    )
+
+    args = parser.parse_args()
+    if args.ip:
+        ip = args.ip
+    else:
+        # Obtain VM ip by connecting to it and running a command
+        # Requires that the VM is up and running.
+        ip = subprocess.check_output(
+            [
+                "vagrant",
+                "ssh",
+                "--command",
+                "hostname -I | cut -d' ' -f1"
+            ]
+        ).decode(sys.stdout.encoding).strip()
+    # Validate that we got a real ipv4 address
+    try:
+        ipaddress.IPv4Address(ip)
+    except ValueError:
+        sys.stderr.write("Ip address: {} is invalid".format(ip))
+        sys.exit(1)
+
+    if args.object_type == "rules":
+        result = query_prometheus_api(ip=ip, port=args.port, route="rules")
+        write_json_to_file(result, "rules")
+        rule_group = result.get('data', {}).get('groups', [])
+        recording_rules = []
+        alerting_rules = []
+        for item in rule_group:
+            for rule in item.get('rules', []):
+                # rule type can be alerting or recording
+                # For now, we only need alerting rules
+                if rule['type'] == "alerting":
+                    message = rule['annotations'].get('message') or \
+                        rule['annotations'].get('summary')
+                    fixup_alerting_rule = {
+                        'name': rule['name'],
+                        'severity': rule['labels']['severity'],
+                        'message': message,
+                        'query': rule['query']
+                    }
+                    alerting_rules.append(fixup_alerting_rule)
+
+                elif rule['type'] == "recording":
+                    fixup_record_rules = {
+                        'name': rule['name'],
+                        'query': rule['query']
+                    }
+                    recording_rules.append(fixup_record_rules)
+
+        write_json_to_file(alerting_rules, "alerting_rules")
+        write_csv_to_file(alerting_rules, "alerting_rules")
+    else:
+        sys.stderr.write("Input argument {} is unsupported".format(
+            args.object_type)
+        )
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/rule_extractor/rules.json
+++ b/tools/rule_extractor/rules.json
@@ -1,0 +1,2042 @@
+{
+    "data": {
+        "groups": [
+            {
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-alertmanager.rules.yaml",
+                "interval": 30,
+                "name": "alertmanager.rules",
+                "rules": [
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "The configuration of the instances of the Alertmanager cluster `{{$labels.service}}` are out of sync."
+                        },
+                        "duration": 300,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "AlertmanagerConfigInconsistent",
+                        "query": "count_values by(service) (\"config_hash\", alertmanager_config_hash{job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"}) / on(service) group_left() label_replace(max by(name, job, namespace, controller) (prometheus_operator_spec_replicas{controller=\"alertmanager\",job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"}), \"service\", \"$1\", \"name\", \"(.*)\") != 1",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "Reloading Alertmanager's configuration has failed for {{ $labels.namespace }}/{{ $labels.pod}}."
+                        },
+                        "duration": 600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "AlertmanagerFailedReload",
+                        "query": "alertmanager_config_last_reload_successful{job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"} == 0",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "Alertmanager has not found all other members of the cluster."
+                        },
+                        "duration": 300,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "AlertmanagerMembersInconsistent",
+                        "query": "alertmanager_cluster_members{job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"} != on(service) group_left() count by(service) (alertmanager_cluster_members{job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"})",
+                        "type": "alerting"
+                    }
+                ]
+            },
+            {
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-etcd.yaml",
+                "interval": 30,
+                "name": "etcd",
+                "rules": [
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "etcd cluster \"{{ $labels.job }}\": insufficient members ({{ $value }})."
+                        },
+                        "duration": 180,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "etcdInsufficientMembers",
+                        "query": "sum by(job) (up{job=~\".*etcd.*\"} == bool 1) < ((count by(job) (up{job=~\".*etcd.*\"}) + 1) / 2)",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "etcd cluster \"{{ $labels.job }}\": member {{ $labels.instance }} has no leader."
+                        },
+                        "duration": 60,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "etcdNoLeader",
+                        "query": "etcd_server_has_leader{job=~\".*etcd.*\"} == 0",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "etcd cluster \"{{ $labels.job }}\": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour."
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "etcdHighNumberOfLeaderChanges",
+                        "query": "rate(etcd_server_leader_changes_seen_total{job=~\".*etcd.*\"}[15m]) > 3",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [
+                            {
+                                "activeAt": "2020-05-20T08:11:45.279979961Z",
+                                "annotations": {
+                                    "message": "etcd cluster \"kube-etcd\": 100% of requests for Watch failed on etcd instance 172.21.254.3:2381."
+                                },
+                                "labels": {
+                                    "alertname": "etcdHighNumberOfFailedGRPCRequests",
+                                    "grpc_method": "Watch",
+                                    "grpc_service": "etcdserverpb.Watch",
+                                    "instance": "172.21.254.3:2381",
+                                    "job": "kube-etcd",
+                                    "severity": "warning"
+                                },
+                                "state": "pending",
+                                "value": "1e+02"
+                            }
+                        ],
+                        "annotations": {
+                            "message": "etcd cluster \"{{ $labels.job }}\": {{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}."
+                        },
+                        "duration": 600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "etcdHighNumberOfFailedGRPCRequests",
+                        "query": "100 * sum by(job, instance, grpc_service, grpc_method) (rate(grpc_server_handled_total{grpc_code!=\"OK\",job=~\".*etcd.*\"}[5m])) / sum by(job, instance, grpc_service, grpc_method) (rate(grpc_server_handled_total{job=~\".*etcd.*\"}[5m])) > 1",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [
+                            {
+                                "activeAt": "2020-05-20T08:11:45.279979961Z",
+                                "annotations": {
+                                    "message": "etcd cluster \"kube-etcd\": 100% of requests for Watch failed on etcd instance 172.21.254.3:2381."
+                                },
+                                "labels": {
+                                    "alertname": "etcdHighNumberOfFailedGRPCRequests",
+                                    "grpc_method": "Watch",
+                                    "grpc_service": "etcdserverpb.Watch",
+                                    "instance": "172.21.254.3:2381",
+                                    "job": "kube-etcd",
+                                    "severity": "critical"
+                                },
+                                "state": "pending",
+                                "value": "1e+02"
+                            }
+                        ],
+                        "annotations": {
+                            "message": "etcd cluster \"{{ $labels.job }}\": {{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}."
+                        },
+                        "duration": 300,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "etcdHighNumberOfFailedGRPCRequests",
+                        "query": "100 * sum by(job, instance, grpc_service, grpc_method) (rate(grpc_server_handled_total{grpc_code!=\"OK\",job=~\".*etcd.*\"}[5m])) / sum by(job, instance, grpc_service, grpc_method) (rate(grpc_server_handled_total{job=~\".*etcd.*\"}[5m])) > 5",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "etcd cluster \"{{ $labels.job }}\": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}."
+                        },
+                        "duration": 600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "etcdGRPCRequestsSlow",
+                        "query": "histogram_quantile(0.99, sum by(job, instance, grpc_service, grpc_method, le) (rate(grpc_server_handling_seconds_bucket{grpc_type=\"unary\",job=~\".*etcd.*\"}[5m]))) > 0.15",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "etcd cluster \"{{ $labels.job }}\": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}."
+                        },
+                        "duration": 600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "etcdMemberCommunicationSlow",
+                        "query": "histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job=~\".*etcd.*\"}[5m])) > 0.15",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "etcd cluster \"{{ $labels.job }}\": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}."
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "etcdHighNumberOfFailedProposals",
+                        "query": "rate(etcd_server_proposals_failed_total{job=~\".*etcd.*\"}[15m]) > 5",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "etcd cluster \"{{ $labels.job }}\": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}."
+                        },
+                        "duration": 600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "etcdHighFsyncDurations",
+                        "query": "histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job=~\".*etcd.*\"}[5m])) > 0.5",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "etcd cluster \"{{ $labels.job }}\": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}."
+                        },
+                        "duration": 600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "etcdHighCommitDurations",
+                        "query": "histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job=~\".*etcd.*\"}[5m])) > 0.25",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "{{ $value }}% of requests for {{ $labels.method }} failed on etcd instance {{ $labels.instance }}"
+                        },
+                        "duration": 600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "etcdHighNumberOfFailedHTTPRequests",
+                        "query": "sum by(method) (rate(etcd_http_failed_total{code!=\"404\",job=~\".*etcd.*\"}[5m])) / sum by(method) (rate(etcd_http_received_total{job=~\".*etcd.*\"}[5m])) > 0.01",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "{{ $value }}% of requests for {{ $labels.method }} failed on etcd instance {{ $labels.instance }}."
+                        },
+                        "duration": 600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "etcdHighNumberOfFailedHTTPRequests",
+                        "query": "sum by(method) (rate(etcd_http_failed_total{code!=\"404\",job=~\".*etcd.*\"}[5m])) / sum by(method) (rate(etcd_http_received_total{job=~\".*etcd.*\"}[5m])) > 0.05",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "etcd instance {{ $labels.instance }} HTTP requests to {{ $labels.method }} are slow."
+                        },
+                        "duration": 600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "etcdHTTPRequestsSlow",
+                        "query": "histogram_quantile(0.99, rate(etcd_http_successful_duration_seconds_bucket[5m])) > 0.15",
+                        "type": "alerting"
+                    }
+                ]
+            },
+            {
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-general.rules.yaml",
+                "interval": 30,
+                "name": "general.rules",
+                "rules": [
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "{{ printf \"%.4g\" $value }}% of the {{ $labels.job }} targets in {{ $labels.namespace }} namespace are down."
+                        },
+                        "duration": 600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "TargetDown",
+                        "query": "100 * (count by(job, namespace, service) (up == 0) / count by(job, namespace, service) (up)) > 10",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [
+                            {
+                                "activeAt": "2020-05-20T01:07:25.520605063Z",
+                                "annotations": {
+                                    "message": "This is an alert meant to ensure that the entire alerting pipeline is functional.\nThis alert is always firing, therefore it should always be firing in Alertmanager\nand always fire against a receiver. There are integrations with various notification\nmechanisms that send a notification when this alert is not firing. For example the\n\"DeadMansSnitch\" integration in PagerDuty."
+                                },
+                                "labels": {
+                                    "alertname": "Watchdog",
+                                    "severity": "none"
+                                },
+                                "state": "firing",
+                                "value": "1e+00"
+                            }
+                        ],
+                        "annotations": {
+                            "message": "This is an alert meant to ensure that the entire alerting pipeline is functional.\nThis alert is always firing, therefore it should always be firing in Alertmanager\nand always fire against a receiver. There are integrations with various notification\nmechanisms that send a notification when this alert is not firing. For example the\n\"DeadMansSnitch\" integration in PagerDuty."
+                        },
+                        "duration": 0,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "none"
+                        },
+                        "name": "Watchdog",
+                        "query": "vector(1)",
+                        "type": "alerting"
+                    }
+                ]
+            },
+            {
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-k8s.rules.yaml",
+                "interval": 30,
+                "name": "k8s.rules",
+                "rules": [
+                    {
+                        "health": "ok",
+                        "name": "namespace:container_cpu_usage_seconds_total:sum_rate",
+                        "query": "sum by(namespace) (rate(container_cpu_usage_seconds_total{container!=\"POD\",image!=\"\",job=\"kubelet\"}[5m]))",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "name": "node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate",
+                        "query": "sum by(namespace, pod, container) (rate(container_cpu_usage_seconds_total{container!=\"POD\",image!=\"\",job=\"kubelet\"}[5m])) * on(namespace, pod) group_left(node) max by(namespace, pod, node) (kube_pod_info)",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "name": "node_namespace_pod_container:container_memory_working_set_bytes",
+                        "query": "container_memory_working_set_bytes{image!=\"\",job=\"kubelet\"} * on(namespace, pod) group_left(node) max by(namespace, pod, node) (kube_pod_info)",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "name": "node_namespace_pod_container:container_memory_rss",
+                        "query": "container_memory_rss{image!=\"\",job=\"kubelet\"} * on(namespace, pod) group_left(node) max by(namespace, pod, node) (kube_pod_info)",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "name": "node_namespace_pod_container:container_memory_cache",
+                        "query": "container_memory_cache{image!=\"\",job=\"kubelet\"} * on(namespace, pod) group_left(node) max by(namespace, pod, node) (kube_pod_info)",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "name": "node_namespace_pod_container:container_memory_swap",
+                        "query": "container_memory_swap{image!=\"\",job=\"kubelet\"} * on(namespace, pod) group_left(node) max by(namespace, pod, node) (kube_pod_info)",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "name": "namespace:container_memory_usage_bytes:sum",
+                        "query": "sum by(namespace) (container_memory_usage_bytes{container!=\"POD\",image!=\"\",job=\"kubelet\"})",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "name": "namespace:kube_pod_container_resource_requests_memory_bytes:sum",
+                        "query": "sum by(namespace, label_name) (sum by(namespace, pod) (kube_pod_container_resource_requests_memory_bytes{job=\"kube-state-metrics\"} * on(endpoint, instance, job, namespace, pod, service) group_left(phase) (kube_pod_status_phase{phase=~\"Pending|Running\"} == 1)) * on(namespace, pod) group_left(label_name) kube_pod_labels{job=\"kube-state-metrics\"})",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "name": "namespace:kube_pod_container_resource_requests_cpu_cores:sum",
+                        "query": "sum by(namespace, label_name) (sum by(namespace, pod) (kube_pod_container_resource_requests_cpu_cores{job=\"kube-state-metrics\"} * on(endpoint, instance, job, namespace, pod, service) group_left(phase) (kube_pod_status_phase{phase=~\"Pending|Running\"} == 1)) * on(namespace, pod) group_left(label_name) kube_pod_labels{job=\"kube-state-metrics\"})",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "labels": {
+                            "workload_type": "deployment"
+                        },
+                        "name": "mixin_pod_workload",
+                        "query": "sum by(namespace, workload, pod) (label_replace(label_replace(kube_pod_owner{job=\"kube-state-metrics\",owner_kind=\"ReplicaSet\"}, \"replicaset\", \"$1\", \"owner_name\", \"(.*)\") * on(replicaset, namespace) group_left(owner_name) kube_replicaset_owner{job=\"kube-state-metrics\"}, \"workload\", \"$1\", \"owner_name\", \"(.*)\"))",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "labels": {
+                            "workload_type": "daemonset"
+                        },
+                        "name": "mixin_pod_workload",
+                        "query": "sum by(namespace, workload, pod) (label_replace(kube_pod_owner{job=\"kube-state-metrics\",owner_kind=\"DaemonSet\"}, \"workload\", \"$1\", \"owner_name\", \"(.*)\"))",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "labels": {
+                            "workload_type": "statefulset"
+                        },
+                        "name": "mixin_pod_workload",
+                        "query": "sum by(namespace, workload, pod) (label_replace(kube_pod_owner{job=\"kube-state-metrics\",owner_kind=\"StatefulSet\"}, \"workload\", \"$1\", \"owner_name\", \"(.*)\"))",
+                        "type": "recording"
+                    }
+                ]
+            },
+            {
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kube-apiserver.rules.yaml",
+                "interval": 30,
+                "name": "kube-apiserver.rules",
+                "rules": [
+                    {
+                        "health": "ok",
+                        "labels": {
+                            "quantile": "0.99"
+                        },
+                        "name": "cluster_quantile:apiserver_request_duration_seconds:histogram_quantile",
+                        "query": "histogram_quantile(0.99, sum without(instance, pod) (rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\"}[5m])))",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "labels": {
+                            "quantile": "0.9"
+                        },
+                        "name": "cluster_quantile:apiserver_request_duration_seconds:histogram_quantile",
+                        "query": "histogram_quantile(0.9, sum without(instance, pod) (rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\"}[5m])))",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "labels": {
+                            "quantile": "0.5"
+                        },
+                        "name": "cluster_quantile:apiserver_request_duration_seconds:histogram_quantile",
+                        "query": "histogram_quantile(0.5, sum without(instance, pod) (rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\"}[5m])))",
+                        "type": "recording"
+                    }
+                ]
+            },
+            {
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kube-prometheus-node-recording.rules.yaml",
+                "interval": 30,
+                "name": "kube-prometheus-node-recording.rules",
+                "rules": [
+                    {
+                        "health": "ok",
+                        "name": "instance:node_cpu:rate:sum",
+                        "query": "sum by(instance) (rate(node_cpu_seconds_total{mode!=\"idle\",mode!=\"iowait\"}[3m]))",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "name": "instance:node_filesystem_usage:sum",
+                        "query": "sum by(instance) ((node_filesystem_size_bytes{mountpoint=\"/\"} - node_filesystem_free_bytes{mountpoint=\"/\"}))",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "name": "instance:node_network_receive_bytes:rate:sum",
+                        "query": "sum by(instance) (rate(node_network_receive_bytes_total[3m]))",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "name": "instance:node_network_transmit_bytes:rate:sum",
+                        "query": "sum by(instance) (rate(node_network_transmit_bytes_total[3m]))",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "name": "instance:node_cpu:ratio",
+                        "query": "sum without(cpu, mode) (rate(node_cpu_seconds_total{mode!=\"idle\",mode!=\"iowait\"}[5m])) / on(instance) group_left() count by(instance) (sum by(instance, cpu) (node_cpu_seconds_total))",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "name": "cluster:node_cpu:sum_rate5m",
+                        "query": "sum(rate(node_cpu_seconds_total{mode!=\"idle\",mode!=\"iowait\"}[5m]))",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "name": "cluster:node_cpu:ratio",
+                        "query": "cluster:node_cpu_seconds_total:rate5m / count(sum by(instance, cpu) (node_cpu_seconds_total))",
+                        "type": "recording"
+                    }
+                ]
+            },
+            {
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kube-scheduler.rules.yaml",
+                "interval": 30,
+                "name": "kube-scheduler.rules",
+                "rules": [
+                    {
+                        "health": "ok",
+                        "labels": {
+                            "quantile": "0.99"
+                        },
+                        "name": "cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile",
+                        "query": "histogram_quantile(0.99, sum without(instance, pod) (rate(scheduler_e2e_scheduling_duration_seconds_bucket{job=\"kube-scheduler\"}[5m])))",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "labels": {
+                            "quantile": "0.99"
+                        },
+                        "name": "cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile",
+                        "query": "histogram_quantile(0.99, sum without(instance, pod) (rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job=\"kube-scheduler\"}[5m])))",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "labels": {
+                            "quantile": "0.99"
+                        },
+                        "name": "cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile",
+                        "query": "histogram_quantile(0.99, sum without(instance, pod) (rate(scheduler_binding_duration_seconds_bucket{job=\"kube-scheduler\"}[5m])))",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "labels": {
+                            "quantile": "0.9"
+                        },
+                        "name": "cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile",
+                        "query": "histogram_quantile(0.9, sum without(instance, pod) (rate(scheduler_e2e_scheduling_duration_seconds_bucket{job=\"kube-scheduler\"}[5m])))",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "labels": {
+                            "quantile": "0.9"
+                        },
+                        "name": "cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile",
+                        "query": "histogram_quantile(0.9, sum without(instance, pod) (rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job=\"kube-scheduler\"}[5m])))",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "labels": {
+                            "quantile": "0.9"
+                        },
+                        "name": "cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile",
+                        "query": "histogram_quantile(0.9, sum without(instance, pod) (rate(scheduler_binding_duration_seconds_bucket{job=\"kube-scheduler\"}[5m])))",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "labels": {
+                            "quantile": "0.5"
+                        },
+                        "name": "cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile",
+                        "query": "histogram_quantile(0.5, sum without(instance, pod) (rate(scheduler_e2e_scheduling_duration_seconds_bucket{job=\"kube-scheduler\"}[5m])))",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "labels": {
+                            "quantile": "0.5"
+                        },
+                        "name": "cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile",
+                        "query": "histogram_quantile(0.5, sum without(instance, pod) (rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job=\"kube-scheduler\"}[5m])))",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "labels": {
+                            "quantile": "0.5"
+                        },
+                        "name": "cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile",
+                        "query": "histogram_quantile(0.5, sum without(instance, pod) (rate(scheduler_binding_duration_seconds_bucket{job=\"kube-scheduler\"}[5m])))",
+                        "type": "recording"
+                    }
+                ]
+            },
+            {
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kubernetes-absent.yaml",
+                "interval": 30,
+                "name": "kubernetes-absent",
+                "rules": [
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "Alertmanager has disappeared from Prometheus target discovery.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-alertmanagerdown"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "AlertmanagerDown",
+                        "query": "absent(up{job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"} == 1)",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "KubeAPI has disappeared from Prometheus target discovery.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapidown"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "KubeAPIDown",
+                        "query": "absent(up{job=\"apiserver\"} == 1)",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "KubeControllerManager has disappeared from Prometheus target discovery.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecontrollermanagerdown"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "KubeControllerManagerDown",
+                        "query": "absent(up{job=\"kube-controller-manager\"} == 1)",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "KubeScheduler has disappeared from Prometheus target discovery.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeschedulerdown"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "KubeSchedulerDown",
+                        "query": "absent(up{job=\"kube-scheduler\"} == 1)",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "KubeStateMetrics has disappeared from Prometheus target discovery.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatemetricsdown"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "KubeStateMetricsDown",
+                        "query": "absent(up{job=\"kube-state-metrics\"} == 1)",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "Kubelet has disappeared from Prometheus target discovery.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletdown"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "KubeletDown",
+                        "query": "absent(up{job=\"kubelet\"} == 1)",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "NodeExporter has disappeared from Prometheus target discovery.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodeexporterdown"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "NodeExporterDown",
+                        "query": "absent(up{job=\"node-exporter\"} == 1)",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "Prometheus has disappeared from Prometheus target discovery.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheusdown"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "PrometheusDown",
+                        "query": "absent(up{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"} == 1)",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "PrometheusOperator has disappeared from Prometheus target discovery.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheusoperatordown"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "PrometheusOperatorDown",
+                        "query": "absent(up{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"} == 1)",
+                        "type": "alerting"
+                    }
+                ]
+            },
+            {
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kubernetes-apps.yaml",
+                "interval": 30,
+                "name": "kubernetes-apps",
+                "rules": [
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf \"%.2f\" $value }} times / 5 minutes.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "KubePodCrashLooping",
+                        "query": "rate(kube_pod_container_status_restarts_total{job=\"kube-state-metrics\"}[15m]) * 60 * 5 > 0",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for longer than 15 minutes.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "KubePodNotReady",
+                        "query": "sum by(namespace, pod) (kube_pod_status_phase{job=\"kube-state-metrics\",phase=~\"Failed|Pending|Unknown\"} * on(namespace, pod) group_left(owner_kind) kube_pod_owner{owner_kind!=\"Job\"}) > 0",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment }} does not match, this indicates that the Deployment has failed but has not been rolled back.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentgenerationmismatch"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "KubeDeploymentGenerationMismatch",
+                        "query": "kube_deployment_status_observed_generation{job=\"kube-state-metrics\"} != kube_deployment_metadata_generation{job=\"kube-state-metrics\"}",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not matched the expected number of replicas for longer than 15 minutes.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentreplicasmismatch"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "KubeDeploymentReplicasMismatch",
+                        "query": "kube_deployment_spec_replicas{job=\"kube-state-metrics\"} != kube_deployment_status_replicas_available{job=\"kube-state-metrics\"}",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has not matched the expected number of replicas for longer than 15 minutes.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetreplicasmismatch"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "KubeStatefulSetReplicasMismatch",
+                        "query": "kube_statefulset_status_replicas_ready{job=\"kube-state-metrics\"} != kube_statefulset_status_replicas{job=\"kube-state-metrics\"}",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset }} does not match, this indicates that the StatefulSet has failed but has not been rolled back.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetgenerationmismatch"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "KubeStatefulSetGenerationMismatch",
+                        "query": "kube_statefulset_status_observed_generation{job=\"kube-state-metrics\"} != kube_statefulset_metadata_generation{job=\"kube-state-metrics\"}",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} update has not been rolled out.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetupdatenotrolledout"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "KubeStatefulSetUpdateNotRolledOut",
+                        "query": "max without(revision) (kube_statefulset_status_current_revision{job=\"kube-state-metrics\"} unless kube_statefulset_status_update_revision{job=\"kube-state-metrics\"}) * (kube_statefulset_replicas{job=\"kube-state-metrics\"} != kube_statefulset_status_replicas_updated{job=\"kube-state-metrics\"})",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "Only {{ $value | humanizePercentage }} of the desired Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} are scheduled and ready.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetrolloutstuck"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "KubeDaemonSetRolloutStuck",
+                        "query": "kube_daemonset_status_number_ready{job=\"kube-state-metrics\"} / kube_daemonset_status_desired_number_scheduled{job=\"kube-state-metrics\"} < 1",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "Pod {{ $labels.namespace }}/{{ $labels.pod }} container {{ $labels.container}} has been in waiting state for longer than 1 hour.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecontainerwaiting"
+                        },
+                        "duration": 3600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "KubeContainerWaiting",
+                        "query": "sum by(namespace, pod, container) (kube_pod_container_status_waiting_reason{job=\"kube-state-metrics\"}) > 0",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} are not scheduled.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetnotscheduled"
+                        },
+                        "duration": 600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "KubeDaemonSetNotScheduled",
+                        "query": "kube_daemonset_status_desired_number_scheduled{job=\"kube-state-metrics\"} - kube_daemonset_status_current_number_scheduled{job=\"kube-state-metrics\"} > 0",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} are running where they are not supposed to run.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetmisscheduled"
+                        },
+                        "duration": 600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "KubeDaemonSetMisScheduled",
+                        "query": "kube_daemonset_status_number_misscheduled{job=\"kube-state-metrics\"} > 0",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more than 1h to complete.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecronjobrunning"
+                        },
+                        "duration": 3600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "KubeCronJobRunning",
+                        "query": "time() - kube_cronjob_next_schedule_time{job=\"kube-state-metrics\"} > 3600",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more than one hour to complete.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobcompletion"
+                        },
+                        "duration": 3600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "KubeJobCompletion",
+                        "query": "kube_job_spec_completions{job=\"kube-state-metrics\"} - kube_job_status_succeeded{job=\"kube-state-metrics\"} > 0",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "KubeJobFailed",
+                        "query": "kube_job_failed{job=\"kube-state-metrics\"} > 0",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "HPA {{ $labels.namespace }}/{{ $labels.hpa }} has not matched the desired number of replicas for longer than 15 minutes.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpareplicasmismatch"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "KubeHpaReplicasMismatch",
+                        "query": "(kube_hpa_status_desired_replicas{job=\"kube-state-metrics\"} != kube_hpa_status_current_replicas{job=\"kube-state-metrics\"}) and changes(kube_hpa_status_current_replicas[15m]) == 0",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "HPA {{ $labels.namespace }}/{{ $labels.hpa }} has been running at max replicas for longer than 15 minutes.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpamaxedout"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "KubeHpaMaxedOut",
+                        "query": "kube_hpa_status_current_replicas{job=\"kube-state-metrics\"} == kube_hpa_spec_max_replicas{job=\"kube-state-metrics\"}",
+                        "type": "alerting"
+                    }
+                ]
+            },
+            {
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kubernetes-resources.yaml",
+                "interval": 30,
+                "name": "kubernetes-resources",
+                "rules": [
+                    {
+                        "alerts": [
+                            {
+                                "activeAt": "2020-05-20T08:11:32.940582493Z",
+                                "annotations": {
+                                    "message": "Cluster has overcommitted CPU resource requests for Pods and cannot tolerate node failure.",
+                                    "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuovercommit"
+                                },
+                                "labels": {
+                                    "alertname": "KubeCPUOvercommit",
+                                    "severity": "warning"
+                                },
+                                "state": "pending",
+                                "value": "7.125e-01"
+                            }
+                        ],
+                        "annotations": {
+                            "message": "Cluster has overcommitted CPU resource requests for Pods and cannot tolerate node failure.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuovercommit"
+                        },
+                        "duration": 300,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "KubeCPUOvercommit",
+                        "query": "sum(namespace:kube_pod_container_resource_requests_cpu_cores:sum) / sum(kube_node_status_allocatable_cpu_cores) > (count(kube_node_status_allocatable_cpu_cores) - 1) / count(kube_node_status_allocatable_cpu_cores)",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [
+                            {
+                                "activeAt": "2020-05-20T08:11:32.940582493Z",
+                                "annotations": {
+                                    "message": "Cluster has overcommitted memory resource requests for Pods and cannot tolerate node failure.",
+                                    "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememovercommit"
+                                },
+                                "labels": {
+                                    "alertname": "KubeMemOvercommit",
+                                    "severity": "warning"
+                                },
+                                "state": "pending",
+                                "value": "1.401801903236394e-01"
+                            }
+                        ],
+                        "annotations": {
+                            "message": "Cluster has overcommitted memory resource requests for Pods and cannot tolerate node failure.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememovercommit"
+                        },
+                        "duration": 300,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "KubeMemOvercommit",
+                        "query": "sum(namespace:kube_pod_container_resource_requests_memory_bytes:sum) / sum(kube_node_status_allocatable_memory_bytes) > (count(kube_node_status_allocatable_memory_bytes) - 1) / count(kube_node_status_allocatable_memory_bytes)",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "Cluster has overcommitted CPU resource requests for Namespaces.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuovercommit"
+                        },
+                        "duration": 300,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "KubeCPUOvercommit",
+                        "query": "sum(kube_resourcequota{job=\"kube-state-metrics\",resource=\"cpu\",type=\"hard\"}) / sum(kube_node_status_allocatable_cpu_cores) > 1.5",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "Cluster has overcommitted memory resource requests for Namespaces.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememovercommit"
+                        },
+                        "duration": 300,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "KubeMemOvercommit",
+                        "query": "sum(kube_resourcequota{job=\"kube-state-metrics\",resource=\"memory\",type=\"hard\"}) / sum(kube_node_status_allocatable_memory_bytes{job=\"node-exporter\"}) > 1.5",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage }} of its {{ $labels.resource }} quota.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "KubeQuotaExceeded",
+                        "query": "kube_resourcequota{job=\"kube-state-metrics\",type=\"used\"} / ignoring(instance, job, type) (kube_resourcequota{job=\"kube-state-metrics\",type=\"hard\"} > 0) > 0.9",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "{{ $value | humanizePercentage }} throttling of CPU in namespace {{ $labels.namespace }} for container {{ $labels.container }} in pod {{ $labels.pod }}.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-cputhrottlinghigh"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "CPUThrottlingHigh",
+                        "query": "sum by(container, pod, namespace) (increase(container_cpu_cfs_throttled_periods_total{container!=\"\"}[5m])) / sum by(container, pod, namespace) (increase(container_cpu_cfs_periods_total[5m])) > (25 / 100)",
+                        "type": "alerting"
+                    }
+                ]
+            },
+            {
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kubernetes-storage.yaml",
+                "interval": 30,
+                "name": "kubernetes-storage",
+                "rules": [
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is only {{ $value | humanizePercentage }} free.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeusagecritical"
+                        },
+                        "duration": 60,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "KubePersistentVolumeUsageCritical",
+                        "query": "kubelet_volume_stats_available_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"} < 0.03",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is expected to fill up within four days. Currently {{ $value | humanizePercentage }} is available.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefullinfourdays"
+                        },
+                        "duration": 3600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "KubePersistentVolumeFullInFourDays",
+                        "query": "(kubelet_volume_stats_available_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) < 0.15 and predict_linear(kubelet_volume_stats_available_bytes{job=\"kubelet\"}[6h], 4 * 24 * 3600) < 0",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "The persistent volume {{ $labels.persistentvolume }} has status {{ $labels.phase }}.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeerrors"
+                        },
+                        "duration": 300,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "KubePersistentVolumeErrors",
+                        "query": "kube_persistentvolume_status_phase{job=\"kube-state-metrics\",phase=~\"Failed|Pending\"} > 0",
+                        "type": "alerting"
+                    }
+                ]
+            },
+            {
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kubernetes-system-apiserver.yaml",
+                "interval": 30,
+                "name": "kubernetes-system-apiserver",
+                "rules": [
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "The API server has a 99th percentile latency of {{ $value }} seconds for {{ $labels.verb }} {{ $labels.resource }}.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapilatencyhigh"
+                        },
+                        "duration": 600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "KubeAPILatencyHigh",
+                        "query": "cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{job=\"apiserver\",quantile=\"0.99\",subresource!=\"log\",verb!~\"LIST|WATCH|WATCHLIST|PROXY|CONNECT\"} > 1",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "The API server has a 99th percentile latency of {{ $value }} seconds for {{ $labels.verb }} {{ $labels.resource }}.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapilatencyhigh"
+                        },
+                        "duration": 600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "KubeAPILatencyHigh",
+                        "query": "cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{job=\"apiserver\",quantile=\"0.99\",subresource!=\"log\",verb!~\"LIST|WATCH|WATCHLIST|PROXY|CONNECT\"} > 4",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "API server is returning errors for {{ $value | humanizePercentage }} of requests.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorshigh"
+                        },
+                        "duration": 600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "KubeAPIErrorsHigh",
+                        "query": "sum(rate(apiserver_request_total{code=~\"5..\",job=\"apiserver\"}[5m])) / sum(rate(apiserver_request_total{job=\"apiserver\"}[5m])) > 0.03",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "API server is returning errors for {{ $value | humanizePercentage }} of requests.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorshigh"
+                        },
+                        "duration": 600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "KubeAPIErrorsHigh",
+                        "query": "sum(rate(apiserver_request_total{code=~\"5..\",job=\"apiserver\"}[5m])) / sum(rate(apiserver_request_total{job=\"apiserver\"}[5m])) > 0.01",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "API server is returning errors for {{ $value | humanizePercentage }} of requests for {{ $labels.verb }} {{ $labels.resource }} {{ $labels.subresource }}.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorshigh"
+                        },
+                        "duration": 600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "KubeAPIErrorsHigh",
+                        "query": "sum by(resource, subresource, verb) (rate(apiserver_request_total{code=~\"5..\",job=\"apiserver\"}[5m])) / sum by(resource, subresource, verb) (rate(apiserver_request_total{job=\"apiserver\"}[5m])) > 0.1",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "API server is returning errors for {{ $value | humanizePercentage }} of requests for {{ $labels.verb }} {{ $labels.resource }} {{ $labels.subresource }}.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorshigh"
+                        },
+                        "duration": 600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "KubeAPIErrorsHigh",
+                        "query": "sum by(resource, subresource, verb) (rate(apiserver_request_total{code=~\"5..\",job=\"apiserver\"}[5m])) / sum by(resource, subresource, verb) (rate(apiserver_request_total{job=\"apiserver\"}[5m])) > 0.05",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "A client certificate used to authenticate to the apiserver is expiring in less than 7.0 days.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeclientcertificateexpiration"
+                        },
+                        "duration": 0,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "KubeClientCertificateExpiration",
+                        "query": "apiserver_client_certificate_expiration_seconds_count{job=\"apiserver\"} > 0 and histogram_quantile(0.01, sum by(job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job=\"apiserver\"}[5m]))) < 604800",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "A client certificate used to authenticate to the apiserver is expiring in less than 24.0 hours.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeclientcertificateexpiration"
+                        },
+                        "duration": 0,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "KubeClientCertificateExpiration",
+                        "query": "apiserver_client_certificate_expiration_seconds_count{job=\"apiserver\"} > 0 and histogram_quantile(0.01, sum by(job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job=\"apiserver\"}[5m]))) < 86400",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "KubeAPI has disappeared from Prometheus target discovery.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapidown"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "KubeAPIDown",
+                        "query": "absent(up{job=\"apiserver\"} == 1)",
+                        "type": "alerting"
+                    }
+                ]
+            },
+            {
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kubernetes-system-controller-manager.yaml",
+                "interval": 30,
+                "name": "kubernetes-system-controller-manager",
+                "rules": [
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "KubeControllerManager has disappeared from Prometheus target discovery.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecontrollermanagerdown"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "KubeControllerManagerDown",
+                        "query": "absent(up{job=\"kube-controller-manager\"} == 1)",
+                        "type": "alerting"
+                    }
+                ]
+            },
+            {
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kubernetes-system-kubelet.yaml",
+                "interval": 30,
+                "name": "kubernetes-system-kubelet",
+                "rules": [
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "{{ $labels.node }} has been unready for more than 15 minutes.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodenotready"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "KubeNodeNotReady",
+                        "query": "kube_node_status_condition{condition=\"Ready\",job=\"kube-state-metrics\",status=\"true\"} == 0",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "{{ $labels.node }} is unreachable and some workloads may be rescheduled.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodeunreachable"
+                        },
+                        "duration": 0,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "KubeNodeUnreachable",
+                        "query": "kube_node_spec_taint{effect=\"NoSchedule\",job=\"kube-state-metrics\",key=\"node.kubernetes.io/unreachable\"} == 1",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage }} of its Pod capacity.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubelettoomanypods"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "KubeletTooManyPods",
+                        "query": "max by(node) (max by(instance) (kubelet_running_pod_count{job=\"kubelet\"}) * on(instance) group_left(node) kubelet_node_name{job=\"kubelet\"}) / max by(node) (kube_node_status_capacity_pods{job=\"kube-state-metrics\"}) > 0.95",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "Kubelet has disappeared from Prometheus target discovery.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletdown"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "KubeletDown",
+                        "query": "absent(up{job=\"kubelet\"} == 1)",
+                        "type": "alerting"
+                    }
+                ]
+            },
+            {
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kubernetes-system-scheduler.yaml",
+                "interval": 30,
+                "name": "kubernetes-system-scheduler",
+                "rules": [
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "KubeScheduler has disappeared from Prometheus target discovery.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeschedulerdown"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "KubeSchedulerDown",
+                        "query": "absent(up{job=\"kube-scheduler\"} == 1)",
+                        "type": "alerting"
+                    }
+                ]
+            },
+            {
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kubernetes-system.yaml",
+                "interval": 30,
+                "name": "kubernetes-system",
+                "rules": [
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "There are {{ $value }} different semantic versions of Kubernetes components running.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeversionmismatch"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "KubeVersionMismatch",
+                        "query": "count(count by(gitVersion) (label_replace(kubernetes_build_info{job!~\"kube-dns|coredns\"}, \"gitVersion\", \"$1\", \"gitVersion\", \"(v[0-9]*.[0-9]*.[0-9]*).*\"))) > 1",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance }}' is experiencing {{ $value | humanizePercentage }} errors.'",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeclienterrors"
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "KubeClientErrors",
+                        "query": "(sum by(instance, job) (rate(rest_client_requests_total{code=~\"5..\"}[5m])) / sum by(instance, job) (rate(rest_client_requests_total[5m]))) > 0.01",
+                        "type": "alerting"
+                    }
+                ]
+            },
+            {
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-node-exporter.rules.yaml",
+                "interval": 30,
+                "name": "node-exporter.rules",
+                "rules": [
+                    {
+                        "health": "ok",
+                        "name": "instance:node_num_cpu:sum",
+                        "query": "count without(cpu) (count without(mode) (node_cpu_seconds_total{job=\"node-exporter\"}))",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "name": "instance:node_cpu_utilisation:rate1m",
+                        "query": "1 - avg without(cpu, mode) (rate(node_cpu_seconds_total{job=\"node-exporter\",mode=\"idle\"}[1m]))",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "name": "instance:node_load1_per_cpu:ratio",
+                        "query": "(node_load1{job=\"node-exporter\"} / instance:node_num_cpu:sum{job=\"node-exporter\"})",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "name": "instance:node_memory_utilisation:ratio",
+                        "query": "1 - (node_memory_MemAvailable_bytes{job=\"node-exporter\"} / node_memory_MemTotal_bytes{job=\"node-exporter\"})",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "name": "instance:node_vmstat_pgmajfault:rate1m",
+                        "query": "rate(node_vmstat_pgmajfault{job=\"node-exporter\"}[1m])",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "name": "instance_device:node_disk_io_time_seconds:rate1m",
+                        "query": "rate(node_disk_io_time_seconds_total{device=~\"nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+\",job=\"node-exporter\"}[1m])",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "name": "instance_device:node_disk_io_time_weighted_seconds:rate1m",
+                        "query": "rate(node_disk_io_time_weighted_seconds_total{device=~\"nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+\",job=\"node-exporter\"}[1m])",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "name": "instance:node_network_receive_bytes_excluding_lo:rate1m",
+                        "query": "sum without(device) (rate(node_network_receive_bytes_total{device!=\"lo\",job=\"node-exporter\"}[1m]))",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "name": "instance:node_network_transmit_bytes_excluding_lo:rate1m",
+                        "query": "sum without(device) (rate(node_network_transmit_bytes_total{device!=\"lo\",job=\"node-exporter\"}[1m]))",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "name": "instance:node_network_receive_drop_excluding_lo:rate1m",
+                        "query": "sum without(device) (rate(node_network_receive_drop_total{device!=\"lo\",job=\"node-exporter\"}[1m]))",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "name": "instance:node_network_transmit_drop_excluding_lo:rate1m",
+                        "query": "sum without(device) (rate(node_network_transmit_drop_total{device!=\"lo\",job=\"node-exporter\"}[1m]))",
+                        "type": "recording"
+                    }
+                ]
+            },
+            {
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-node-exporter.yaml",
+                "interval": 30,
+                "name": "node-exporter",
+                "rules": [
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "description": "Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf \"%.2f\" $value }}% available space left and is filling up.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodefilesystemspacefillingup",
+                            "summary": "Filesystem is predicted to run out of space within the next 24 hours."
+                        },
+                        "duration": 3600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "NodeFilesystemSpaceFillingUp",
+                        "query": "(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_size_bytes{fstype!=\"\",job=\"node-exporter\"} * 100 < 40 and predict_linear(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\"}[6h], 24 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "description": "Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf \"%.2f\" $value }}% available space left and is filling up fast.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodefilesystemspacefillingup",
+                            "summary": "Filesystem is predicted to run out of space within the next 4 hours."
+                        },
+                        "duration": 3600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "NodeFilesystemSpaceFillingUp",
+                        "query": "(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_size_bytes{fstype!=\"\",job=\"node-exporter\"} * 100 < 20 and predict_linear(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\"}[6h], 4 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "description": "Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf \"%.2f\" $value }}% available space left.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodefilesystemalmostoutofspace",
+                            "summary": "Filesystem has less than 5% space left."
+                        },
+                        "duration": 3600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "NodeFilesystemAlmostOutOfSpace",
+                        "query": "(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_size_bytes{fstype!=\"\",job=\"node-exporter\"} * 100 < 5 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "description": "Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf \"%.2f\" $value }}% available space left.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodefilesystemalmostoutofspace",
+                            "summary": "Filesystem has less than 3% space left."
+                        },
+                        "duration": 3600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "NodeFilesystemAlmostOutOfSpace",
+                        "query": "(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_size_bytes{fstype!=\"\",job=\"node-exporter\"} * 100 < 3 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "description": "Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf \"%.2f\" $value }}% available inodes left and is filling up.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodefilesystemfilesfillingup",
+                            "summary": "Filesystem is predicted to run out of inodes within the next 24 hours."
+                        },
+                        "duration": 3600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "NodeFilesystemFilesFillingUp",
+                        "query": "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100 < 40 and predict_linear(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"}[6h], 24 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "description": "Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf \"%.2f\" $value }}% available inodes left and is filling up fast.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodefilesystemfilesfillingup",
+                            "summary": "Filesystem is predicted to run out of inodes within the next 4 hours."
+                        },
+                        "duration": 3600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "NodeFilesystemFilesFillingUp",
+                        "query": "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100 < 20 and predict_linear(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"}[6h], 4 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "description": "Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf \"%.2f\" $value }}% available inodes left.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodefilesystemalmostoutoffiles",
+                            "summary": "Filesystem has less than 5% inodes left."
+                        },
+                        "duration": 3600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "NodeFilesystemAlmostOutOfFiles",
+                        "query": "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100 < 5 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "description": "Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf \"%.2f\" $value }}% available inodes left.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodefilesystemalmostoutoffiles",
+                            "summary": "Filesystem has less than 3% inodes left."
+                        },
+                        "duration": 3600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "NodeFilesystemAlmostOutOfFiles",
+                        "query": "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100 < 3 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "description": "{{ $labels.instance }} interface {{ $labels.device }} has encountered {{ printf \"%.0f\" $value }} receive errors in the last two minutes.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodenetworkreceiveerrs",
+                            "summary": "Network interface is reporting many receive errors."
+                        },
+                        "duration": 3600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "NodeNetworkReceiveErrs",
+                        "query": "increase(node_network_receive_errs_total[2m]) > 10",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "description": "{{ $labels.instance }} interface {{ $labels.device }} has encountered {{ printf \"%.0f\" $value }} transmit errors in the last two minutes.",
+                            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodenetworktransmiterrs",
+                            "summary": "Network interface is reporting many transmit errors."
+                        },
+                        "duration": 3600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "NodeNetworkTransmitErrs",
+                        "query": "increase(node_network_transmit_errs_total[2m]) > 10",
+                        "type": "alerting"
+                    }
+                ]
+            },
+            {
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-node-network.yaml",
+                "interval": 30,
+                "name": "node-network",
+                "rules": [
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "Network interface \"{{ $labels.device }}\" changing it's up status often on node-exporter {{ $labels.namespace }}/{{ $labels.pod }}\""
+                        },
+                        "duration": 120,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "NodeNetworkInterfaceFlapping",
+                        "query": "changes(node_network_up{device!~\"veth.+\",job=\"node-exporter\"}[2m]) > 2",
+                        "type": "alerting"
+                    }
+                ]
+            },
+            {
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-node-time.yaml",
+                "interval": 30,
+                "name": "node-time",
+                "rules": [
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "Clock skew detected on node-exporter {{ $labels.namespace }}/{{ $labels.pod }}. Ensure NTP is configured correctly on this host."
+                        },
+                        "duration": 120,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "ClockSkewDetected",
+                        "query": "abs(node_timex_offset_seconds{job=\"node-exporter\"}) > 0.05",
+                        "type": "alerting"
+                    }
+                ]
+            },
+            {
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-node.rules.yaml",
+                "interval": 30,
+                "name": "node.rules",
+                "rules": [
+                    {
+                        "health": "ok",
+                        "name": ":kube_pod_info_node_count:",
+                        "query": "sum(min by(node) (kube_pod_info))",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "name": "node_namespace_pod:kube_pod_info:",
+                        "query": "max by(node, namespace, pod) (label_replace(kube_pod_info{job=\"kube-state-metrics\"}, \"pod\", \"$1\", \"pod\", \"(.*)\"))",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "name": "node:node_num_cpu:sum",
+                        "query": "count by(node) (sum by(node, cpu) (node_cpu_seconds_total{job=\"node-exporter\"} * on(namespace, pod) group_left(node) node_namespace_pod:kube_pod_info:))",
+                        "type": "recording"
+                    },
+                    {
+                        "health": "ok",
+                        "name": ":node_memory_MemAvailable_bytes:sum",
+                        "query": "sum(node_memory_MemAvailable_bytes{job=\"node-exporter\"} or (node_memory_Buffers_bytes{job=\"node-exporter\"} + node_memory_Cached_bytes{job=\"node-exporter\"} + node_memory_MemFree_bytes{job=\"node-exporter\"} + node_memory_Slab_bytes{job=\"node-exporter\"}))",
+                        "type": "recording"
+                    }
+                ]
+            },
+            {
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-prometheus-operator.yaml",
+                "interval": 30,
+                "name": "prometheus-operator",
+                "rules": [
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "Errors while reconciling {{ $labels.controller }} in {{ $labels.namespace }} Namespace."
+                        },
+                        "duration": 600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "PrometheusOperatorReconcileErrors",
+                        "query": "rate(prometheus_operator_reconcile_errors_total{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"}[5m]) > 0.1",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "Errors while reconciling Prometheus in {{ $labels.namespace }} Namespace."
+                        },
+                        "duration": 600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "PrometheusOperatorNodeLookupErrors",
+                        "query": "rate(prometheus_operator_node_address_lookup_errors_total{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"}[5m]) > 0.1",
+                        "type": "alerting"
+                    }
+                ]
+            },
+            {
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-prometheus.yaml",
+                "interval": 30,
+                "name": "prometheus",
+                "rules": [
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "description": "Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed to reload its configuration.",
+                            "summary": "Failed Prometheus configuration reload."
+                        },
+                        "duration": 600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "PrometheusBadConfig",
+                        "query": "max_over_time(prometheus_config_last_reload_successful{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) == 0",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "description": "Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}} is running full.",
+                            "summary": "Prometheus alert notification queue predicted to run full in less than 30m."
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "PrometheusNotificationQueueRunningFull",
+                        "query": "(predict_linear(prometheus_notifications_queue_length{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m], 60 * 30) > min_over_time(prometheus_notifications_queue_capacity{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]))",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "description": "{{ printf \"%.1f\" $value }}% errors while sending alerts from Prometheus {{$labels.namespace}}/{{$labels.pod}} to Alertmanager {{$labels.alertmanager}}.",
+                            "summary": "Prometheus has encountered more than 1% errors sending alerts to a specific Alertmanager."
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "PrometheusErrorSendingAlertsToSomeAlertmanagers",
+                        "query": "(rate(prometheus_notifications_errors_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) / rate(prometheus_notifications_sent_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m])) * 100 > 1",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "description": "{{ printf \"%.1f\" $value }}% minimum errors while sending alerts from Prometheus {{$labels.namespace}}/{{$labels.pod}} to any Alertmanager.",
+                            "summary": "Prometheus encounters more than 3% errors sending alerts to any Alertmanager."
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "PrometheusErrorSendingAlertsToAnyAlertmanager",
+                        "query": "min without(alertmanager) (rate(prometheus_notifications_errors_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) / rate(prometheus_notifications_sent_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m])) * 100 > 3",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "description": "Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected to any Alertmanagers.",
+                            "summary": "Prometheus is not connected to any Alertmanagers."
+                        },
+                        "duration": 600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "PrometheusNotConnectedToAlertmanagers",
+                        "query": "max_over_time(prometheus_notifications_alertmanagers_discovered{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) < 1",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "description": "Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected {{$value | humanize}} reload failures over the last 3h.",
+                            "summary": "Prometheus has issues reloading blocks from disk."
+                        },
+                        "duration": 14400,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "PrometheusTSDBReloadsFailing",
+                        "query": "increase(prometheus_tsdb_reloads_failures_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[3h]) > 0",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "description": "Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected {{$value | humanize}} compaction failures over the last 3h.",
+                            "summary": "Prometheus has issues compacting blocks."
+                        },
+                        "duration": 14400,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "PrometheusTSDBCompactionsFailing",
+                        "query": "increase(prometheus_tsdb_compactions_failed_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[3h]) > 0",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "description": "Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting samples.",
+                            "summary": "Prometheus is not ingesting samples."
+                        },
+                        "duration": 600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "PrometheusNotIngestingSamples",
+                        "query": "rate(prometheus_tsdb_head_samples_appended_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) <= 0",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "description": "Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping {{ printf \"%.4g\" $value  }} samples/s with different values but duplicated timestamp.",
+                            "summary": "Prometheus is dropping samples with duplicate timestamps."
+                        },
+                        "duration": 600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "PrometheusDuplicateTimestamps",
+                        "query": "rate(prometheus_target_scrapes_sample_duplicate_timestamp_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) > 0",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "description": "Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping {{ printf \"%.4g\" $value  }} samples/s with timestamps arriving out of order.",
+                            "summary": "Prometheus drops samples with out-of-order timestamps."
+                        },
+                        "duration": 600,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "PrometheusOutOfOrderTimestamps",
+                        "query": "rate(prometheus_target_scrapes_sample_out_of_order_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) > 0",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "description": "Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to send {{ printf \"%.1f\" $value }}% of the samples to queue {{$labels.queue}}.",
+                            "summary": "Prometheus fails to send samples to remote storage."
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "PrometheusRemoteStorageFailures",
+                        "query": "(rate(prometheus_remote_storage_failed_samples_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) / (rate(prometheus_remote_storage_failed_samples_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) + rate(prometheus_remote_storage_succeeded_samples_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]))) * 100 > 1",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "description": "Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write is {{ printf \"%.1f\" $value }}s behind for queue {{$labels.queue}}.",
+                            "summary": "Prometheus remote write is behind."
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "PrometheusRemoteWriteBehind",
+                        "query": "(max_over_time(prometheus_remote_storage_highest_timestamp_in_seconds{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) - on(job, instance) group_right() max_over_time(prometheus_remote_storage_queue_highest_sent_timestamp_seconds{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m])) > 120",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "description": "Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write desired shards calculation wants to run {{ printf $value }} shards, which is more than the max of {{ printf `prometheus_remote_storage_shards_max{instance=\"%s\",job=\"{{ $prometheusJob }}\",namespace=\"{{ $namespace }}\"}` $labels.instance | query | first | value }}.",
+                            "summary": "Prometheus remote write desired shards calculation wants to run more than configured max shards."
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "PrometheusRemoteWriteDesiredShards",
+                        "query": "(max_over_time(prometheus_remote_storage_shards_desired{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) > max_over_time(prometheus_remote_storage_shards_max{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]))",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "description": "Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed to evaluate {{ printf \"%.0f\" $value }} rules in the last 5m.",
+                            "summary": "Prometheus is failing rule evaluations."
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "critical"
+                        },
+                        "name": "PrometheusRuleFailures",
+                        "query": "increase(prometheus_rule_evaluation_failures_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) > 0",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [
+                            {
+                                "activeAt": "2020-05-20T08:11:54.859562607Z",
+                                "annotations": {
+                                    "description": "Prometheus metalk8s-monitoring/prometheus-prometheus-operator-prometheus-0 has missed 3600 rule group evaluations in the last 5m.",
+                                    "summary": "Prometheus is missing rule evaluations due to slow rule group evaluation."
+                                },
+                                "labels": {
+                                    "alertname": "PrometheusMissingRuleEvaluations",
+                                    "endpoint": "web",
+                                    "instance": "10.233.132.79:9090",
+                                    "job": "prometheus-operator-prometheus",
+                                    "namespace": "metalk8s-monitoring",
+                                    "pod": "prometheus-prometheus-operator-prometheus-0",
+                                    "service": "prometheus-operator-prometheus",
+                                    "severity": "warning"
+                                },
+                                "state": "pending",
+                                "value": "3.6e+03"
+                            }
+                        ],
+                        "annotations": {
+                            "description": "Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed {{ printf \"%.0f\" $value }} rule group evaluations in the last 5m.",
+                            "summary": "Prometheus is missing rule evaluations due to slow rule group evaluation."
+                        },
+                        "duration": 900,
+                        "health": "ok",
+                        "labels": {
+                            "severity": "warning"
+                        },
+                        "name": "PrometheusMissingRuleEvaluations",
+                        "query": "increase(prometheus_rule_group_iterations_missed_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) > 0",
+                        "type": "alerting"
+                    }
+                ]
+            }
+        ]
+    },
+    "status": "success"
+}


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
''tooling', 'basic alerting'

**Context**: 

See #2538 

**Summary**:

This PR brings along the following changes:
- Tooling to read and dump deployed Prometheus alerting and recording rules to file. Dumped files will later be used during testing to assert that rules deployed match exactly what we know or raise so that Dev's can adjust and document new changes.
- Introduce a Cluster monitoring section in the Operation guide and then document default Alerting rules deployed by the Prometheus-operator.
- A PR for BDD testing the rules will follow subsequently

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2538 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
