### PR TITLE
salt/solutions: Fix Operator Role rendering

### DIFF
--- a/salt/metalk8s/orchestrate/solutions/prepare-environment.sls
+++ b/salt/metalk8s/orchestrate/solutions/prepare-environment.sls
@@ -21,7 +21,7 @@ Apply Role for Operator of Solution {{ solution.name }}:
     - defaults:
         solution: {{ solution_id }}
         namespace: {{ namespace }}
-        custom_api_groups: {{ solution.config.customApiGroups }}
+        custom_api_groups: {{ solution.config.customApiGroups | tojson }}
         version: {{ solution.version }}
 
 Apply RoleBinding for Operator of Solution {{ solution.name }}:


### PR DESCRIPTION
With the introduction of Salt 3000, strings are converted to unicode by
default (hence, are not well rendered through Jinja without a `tojson`
filter).
This should not be needed once #2389 is done.

See: #650