### PR TITLE
tests: Add tests to validate Prometheus (deployed alerting rules == default alerting rules)

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -1585,7 +1585,7 @@ stages:
             SSH_CONFIG: >-
               eve/workers/openstack-multiple-nodes/terraform/ssh_config
           command: >
-            tar cfp - tox.ini VERSION tests/ buildchain/buildchain/versions.py
+            tar cfp - tox.ini VERSION tests/ buildchain/buildchain/versions.py tools/
             | ssh -F $SSH_CONFIG bastion '(mkdir metalk8s; cd "$_"; tar xf -)'
       - ShellCommand:
           <<: *wait_pods_running_ssh

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,9 @@ from tests import kube_utils
 from tests import utils
 
 
+CONTROL_PLANE_INGRESS_PORT = 8443
+
+
 # Pytest command-line options
 def pytest_addoption(parser):
     parser.addoption(
@@ -261,6 +264,14 @@ def request_retry_session(request):
     params = getattr(request, 'param', {})
 
     return utils.requests_retry_session(**params)
+
+
+@pytest.fixture
+def prometheus_api(host):
+    return utils.PrometheusApi(
+        utils.get_grain(host, 'metalk8s:control_plane_ip'),
+        CONTROL_PLANE_INGRESS_PORT
+    )
 
 
 def count_running_pods(

--- a/tests/post/features/monitoring.feature
+++ b/tests/post/features/monitoring.feature
@@ -38,3 +38,8 @@ Feature: Monitoring is up and running
     Scenario: Node metrics can be retrieved using metrics.k8s.io/v1beta1
         Given the Kubernetes API is available
         Then a node with label 'node-role.kubernetes.io/bootstrap=' has metrics
+
+    Scenario: Ensure deployed Prometheus rules match the default
+        Given the Kubernetes API is available
+        And we have 1 running pod labeled 'prometheus=prometheus-operator-prometheus' in namespace 'metalk8s-monitoring'
+        Then the deployed Prometheus alert rules are the same as the default alert rules

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,6 @@
 import functools
 import ipaddress
+import json
 import logging
 import re
 import operator
@@ -180,3 +181,72 @@ def set_dict_element(data, path, value, delimiter='.'):
     path, _, key = path.rpartition(delimiter)
     (get_dict_element(data, path) if path else data)[key] = value
     return data
+
+
+def get_grain(host, key):
+    with host.sudo():
+        output = host.check_output(
+            'salt-call --local --out=json grains.get "{}"'.format(key)
+        )
+        grain = json.loads(output)['local']
+
+    return grain
+
+
+class PrometheusApiError(Exception):
+    pass
+
+
+class PrometheusApi:
+    def __init__(self, host, port=9090):
+        self.host = host
+        self.port = port
+        self.session = requests_retry_session()
+
+    def query(self, method, route, **kwargs):
+        try:
+            kwargs.setdefault('verify', False)
+            response = self.session.request(
+                method,
+                "https://{}:{}/api/prometheus/api/v1/{}".format(
+                    self.host, self.port, route
+                ),
+                **kwargs
+            )
+            response.raise_for_status()
+        except requests.exceptions.RequestException as exc:
+            raise PrometheusApiError(exc)
+
+        try:
+            result = response.json()
+        except ValueError as exc:
+            raise PrometheusApiError(exc)
+
+        return result
+
+    def get_alerts(self, **kwargs):
+        return self.query('GET', 'alerts', **kwargs)
+
+    def get_rules(self, **kwargs):
+        return self.query('GET', 'rules', **kwargs)
+
+    def find_rules(self, name=None, group=None, labels=None, **kwargs):
+        if not labels:
+            labels = {}
+        rules = []
+
+        response = self.get_rules(**kwargs)
+
+        for rule_group in response.get('data', {}).get('groups', []):
+            group_name = rule_group.get('name')
+            if group in (group_name, None):
+                for rule in rule_group.get('rules', []):
+                    if name in (rule.get('name'), None):
+                        if labels.items() <= rule.get('labels', {}).items():
+                            rule['group'] = group_name
+                            rules.append(rule)
+
+        return rules
+
+    def get_targets(self, **kwargs):
+        return self.query('GET', 'targets', **kwargs)


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
'tests', 'basic alerting', 'tooling'

**Context**: 

The following test is added to ensure that we can rightfully validate the deployed Prometheus alerting rules against the defaults at all times. 

See the issue here: #2538 

**Summary**:

Follow suit of PR #2542 as promised.
The guard (Heimdall the Gatekeeper) to catch Prometheus-operator chart upgrades that bring new 
undocumented alerting rules is in place.

**Acceptance criteria**: 

- Rightfully tested!
- Green build

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
