### PR TITLE
CI: Retry RHSM registration when it fails

### DIFF
--- a/eve/workers/openstack-single-node-rhel/terraform/bootstrap.tf
+++ b/eve/workers/openstack-single-node-rhel/terraform/bootstrap.tf
@@ -36,6 +36,11 @@ resource "openstack_compute_instance_v2" "bootstrap" {
   provisioner "remote-exec" {
     inline = [
       "sudo bash scripts/rhsm-register.sh '${var.rhsm_username}' '${var.rhsm_password}'",
+    ]
+  }
+
+  provisioner "remote-exec" {
+    inline = [
       "sudo bash scripts/bootstrap-config.sh",
     ]
   }

--- a/eve/workers/openstack-single-node-rhel/terraform/scripts/rhsm-register.sh
+++ b/eve/workers/openstack-single-node-rhel/terraform/scripts/rhsm-register.sh
@@ -2,8 +2,28 @@
 
 declare -r RHSM_USERNAME=$1
            RHSM_PASSWORD=$2
+           RETRIES=${3:-5}
+           WAIT=${4:-2}
 
-subscription-manager register --username "$RHSM_USERNAME" \
-    --password "$RHSM_PASSWORD" --auto-attach
-subscription-manager repos --enable=rhel-7-server-extras-rpms \
-    --enable=rhel-7-server-optional-rpms
+# We retry $RETRIES times in case of transient network issues.
+for (( try=0; try <= RETRIES; ++try )); do
+    if subscription-manager register --username "$RHSM_USERNAME" \
+            --password "$RHSM_PASSWORD" --auto-attach; then
+        echo "Successfully registered to RHSM"
+        if subscription-manager repos --enable=rhel-7-server-extras-rpms \
+                --enable=rhel-7-server-optional-rpms; then
+            echo "Yum repositories successfully enabled"
+            break
+        fi
+    fi
+    echo "Subscription failed, retrying in $WAIT seconds" 1>&2
+    subscription-manager unregister
+    sleep "$WAIT"
+done
+
+if ! subscription-manager status; then
+    echo "Unable to register this host to RHSM after $RETRIES retries." \
+         "Here is the content of /var/log/rhsm.log:" 1>&2
+    cat /var/log/rhsm/rhsm.log 1>&2
+    exit 1
+fi


### PR DESCRIPTION
**Component**: ci

**Context**:
Sometimes RHSM registration is failing in the CI, this leads to error during the bootstrap script.

**Summary**:
We now retry multiple times to register to RHSM before failing.
In case of failure, we exit terraform in error and display the rhsm log file to ease investigations.

**Acceptance criteria**: green build