### PR TITLE
ci: does not rely on worker_uuid anymore (backport)

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -602,7 +602,7 @@ stages:
             OS_USERNAME: "%(secret:scality_cloud_username)s"
             OS_PASSWORD: "%(secret:scality_cloud_password)s"
             OS_TENANT_NAME: "%(secret:scality_cloud_tenant_name)s"
-            TF_VAR_worker_uuid: "%(prop:worker_uuid)s"
+            TF_VAR_prefix: "%(prop:buildnumber)s-%(prop:stage_name)s"
             TF_VAR_nodes_count: "1"
           haltOnFailure: true
       - ShellCommand:

--- a/eve/workers/openstack-multiple-nodes/terraform/common.tf
+++ b/eve/workers/openstack-multiple-nodes/terraform/common.tf
@@ -1,4 +1,4 @@
-variable "worker_uuid" {
+variable "prefix" {
   type    = string
   default = ""
 }
@@ -10,6 +10,6 @@ resource "random_string" "current" {
 
 locals {
   prefix = "metalk8s-${
-    var.worker_uuid != "" ? var.worker_uuid : random_string.current.result
+    var.prefix != "" ? var.prefix : random_string.current.result
   }"
 }


### PR DESCRIPTION
This PR is a backport of changes already in v2.5+

**Component**: ci

**Context**:
In the CI context we were using worker_uuid property as a unique identifier prefix to all terraform resources we created, to avoid collision between these resources.
It happens that this UUID is not really unique and sometimes we have uncleaned resources on the MetalK8s scality.cloud CI tenant, so we end up having collision between old resources and new ones, this causes builds to fail.

**Summary**:
We now use the build number + the stage name as a prefix.
The build number should be unique accross any build and the stage name will be used to easily retrieve the resources of a specific stage of a build.


**Acceptance criteria**: green build