### PR TITLE
salt: Downgrade pre-check allow saltenv >= higher node

### DIFF
--- a/salt/metalk8s/orchestrate/downgrade/precheck.sls
+++ b/salt/metalk8s/orchestrate/downgrade/precheck.sls
@@ -4,7 +4,7 @@
 {%- set nodes_versions = pillar.metalk8s.nodes.values() | map(attribute='version') | list %}
 {%- do nodes_versions.sort(cmp=salt.pkg.version_cmp, reverse=True) %}
 {%- set expected = nodes_versions | first %}
-{%- if saltenv != 'metalk8s-' ~  expected %}
+{%- if salt.pkg.version_cmp(saltenv | replace('metalk8s-', ''), expected) >= 0 %}
 
 Invalid saltenv "{{ saltenv }}" consider using "metalk8s-{{ expected }}":
   test.fail_without_changes


### PR DESCRIPTION
**Component**:

'salt', 'lifecycle'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Summary**:

Node version represent the version desired on a specific node and not
the actual deployed version so if for any reason a downgrade failed
after all node version being set to the destination one, we want to be
able to run the downgrade again so the saltenv specified may be higher
that all the node versions

---

Fixes: #2551 
