### PR TITLE
Support python-kubernetes client v11

### DIFF
--- a/salt/_utils/kubernetes_utils.py
+++ b/salt/_utils/kubernetes_utils.py
@@ -14,7 +14,7 @@ from salt.utils.dictdiffer import recursive_diff
 try:
     import kubernetes.config
     import kubernetes.client as k8s_client
-    import kubernetes.client.apis as k8s_apis
+    import kubernetes.client.api as k8s_apis
 
     # Workaround for https://github.com/kubernetes-client/python/issues/376
     def set_conditions(self, conditions):
@@ -88,7 +88,7 @@ class ApiClient(object):
                  method_names=None, all_namespaces_name=None):
         if api_cls not in ALL_APIS:
             raise ValueError(
-                '`api_cls` must be an API from `kubernetes.client.apis`'
+                '`api_cls` must be an API from `kubernetes.client.api`'
             )
         methods = self.CRUD_METHODS
         if isinstance(method_names, six.string_types):

--- a/salt/_utils/kubernetes_utils.py
+++ b/salt/_utils/kubernetes_utils.py
@@ -440,7 +440,7 @@ class CustomApiClient(ApiClient):
 
             # Convert body to_dict if it's a CustomObject as
             # `python-kubernetes` want a dict or a specific objects with
-            # some attributes like `swagger_types`, `attributes_map`, ...
+            # some attributes like `openapi_types`, `attributes_map`, ...
             if isinstance(kwargs.get('body'), CustomObject):
                 kwargs['body'] = kwargs['body'].to_dict()
 
@@ -669,7 +669,7 @@ def _build_standard_object(model, manifest):
     """Construct an instance of `model` based on its `manifest`.
 
     This method assumes `model` to be a member of `kubernetes.client.models`,
-    so that it can use its `attribute_map` and `swagger_types` attributes.
+    so that it can use its `attribute_map` and `openapi_types` attributes.
     """
     # `model.attribute_map` contain all attribute correspondance between
     # snake case and YAML style (camel case) so we need to reverse it
@@ -684,7 +684,7 @@ def _build_standard_object(model, manifest):
     kwargs = {}
     for src_key, src_value in manifest.items():
         key = reverse_attr_map.get(src_key, src_key)
-        type_str = model.swagger_types.get(key)
+        type_str = model.openapi_types.get(key)
 
         if type_str is None:
             raise ValueError(
@@ -715,7 +715,7 @@ def _cast_value(value, type_string):
     """Attempt to cast a value given a type declaration as a string.
 
     Used exclusively by `_build_standard_object`, relying on the models
-    `swagger_types` declarations for converting manifests into Python objects.
+    `openapi_types` declarations for converting manifests into Python objects.
     """
     # Special case for None used for exemple when patching to remove key
     if value is None:


### PR DESCRIPTION
**Component**: salt, kubernetes

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**:

`python2-kubernetes` has been updated from v10 to v11 in `epel` - our Salt states/modules are now broken and no pre-merge will pass until we support it

**Summary**:

Cherry-picked commits from @Ebaneck's PR: #2449

**Acceptance criteria**: 

Both pre-merge and post-merge should work
