### PR TITLE
salt: Fix apiserver-proxy upstreams

### DIFF
--- a/salt/_modules/metalk8s.py
+++ b/salt/_modules/metalk8s.py
@@ -87,6 +87,12 @@ def minions_by_role(role, nodes=None):
             Defaults to `pillar.metalk8s.nodes`.
     '''
     nodes = nodes or __pillar__['metalk8s']['nodes']
+    pillar_errors = nodes.pop('_errors', None)
+    if pillar_errors:
+        raise CommandExecutionError(
+            "Can't retrieve minions by role because of errors in pillar "
+            "'metalk8s:nodes': {}".format(', '.join(pillar_errors))
+        )
 
     return [
         node

--- a/salt/metalk8s/kubernetes/apiserver-proxy/files/apiserver-proxy.conf.j2
+++ b/salt/metalk8s/kubernetes/apiserver-proxy/files/apiserver-proxy.conf.j2
@@ -13,10 +13,11 @@ events {
 {%- if pillar.get('apiserver_ip') %}
 {%-     set masters_request = {'ip': pillar.apiserver_ip} %}
 {%- else %}
+{%-     set master_minions = salt['metalk8s.minions_by_role']('master') %}
 {%-     set masters_request = salt['mine.get'](
-            tgt='I@metalk8s:nodes:*:roles:master',
+            tgt=master_minions | join(','),
             fun='control_plane_ip',
-            tgt_type='compound',
+            tgt_type='list',
         )
 %}
 {%- endif %}

--- a/salt/metalk8s/kubernetes/apiserver-proxy/files/apiserver-proxy.conf.j2
+++ b/salt/metalk8s/kubernetes/apiserver-proxy/files/apiserver-proxy.conf.j2
@@ -11,21 +11,26 @@ events {
 }
 
 {%- if pillar.get('apiserver_ip') %}
-{%-     set masters_request = {'ip': pillar.apiserver_ip} %}
+{%-     set apiservers = [pillar.apiserver_ip] %}
 {%- else %}
-{%-     set master_minions = salt['metalk8s.minions_by_role']('master') %}
-{%-     set masters_request = salt['mine.get'](
-            tgt=master_minions | join(','),
-            fun='control_plane_ip',
-            tgt_type='list',
-        )
+{%-     set masters = salt['metalk8s.minions_by_role']('master') %}
+{%-     if not masters %}
+            {{ raise("No master nodes in pillar 'metalk8s:nodes', "
+                     ~ "can't deploy apiserver-proxy") }}
+{%-     else %}
+{%-         set master_ips = salt['mine.get'](
+                tgt=masters | join(','),
+                fun='control_plane_ip',
+                tgt_type='list',
+            )
 %}
-{%- endif %}
-{%- if not masters_request %}
-{# In this case, we're (likely) bootstrapping #}
-{%-   set apiservers = ['127.0.0.1'] %}
-{%- else %}
-{%-   set apiservers = masters_request.values() | sort %}
+{%-         if not master_ips and grains.id in masters %}
+{# In case we're bootstrapping, the Mine wouldn't be available #}
+{%-             set apiservers = ["127.0.0.1"] %}
+{%-         else %}
+{%-             set apiservers = master_ips.values() | sort %}
+{%-         endif %}
+{%-     endif %}
 {%- endif %}
 
 stream {

--- a/salt/metalk8s/orchestrate/bootstrap/init.sls
+++ b/salt/metalk8s/orchestrate/bootstrap/init.sls
@@ -33,6 +33,7 @@
         'is_bootstrap': True,
         'metalk8s': {
             'nodes': {
+                '_errors': None,
                 pillar.bootstrap_id: {
                     'roles': ['bootstrap', 'master', 'etcd', 'ca', 'infra'],
                     'version': version,


### PR DESCRIPTION
The previous approached relied on the pillar target
`metalk8s:nodes:*:roles:master`, which will always match all minions
since they all have access to the full `metalk8s:nodes` pillar value.
Instead, we use the `metalk8s.minions_by_role` execution method to
define the right target when retrieving control plane IPs from the mine.

We also change the `metalk8s.minions_by_role` method to handle
pillar errors gracefully, and let clients handle an empty list as they wish
(which was already the approach taken in the apiserver-proxy
configuration template, considering an empty result implies we are
bootstrapping).