### PR TITLE
salt: Fix invalid check in downgrade precheck

### DIFF
--- a/salt/metalk8s/orchestrate/downgrade/precheck.sls
+++ b/salt/metalk8s/orchestrate/downgrade/precheck.sls
@@ -4,7 +4,7 @@
 {%- set nodes_versions = pillar.metalk8s.nodes.values() | map(attribute='version') | list %}
 {%- do nodes_versions.sort(cmp=salt.pkg.version_cmp, reverse=True) %}
 {%- set expected = nodes_versions | first %}
-{%- if salt.pkg.version_cmp(saltenv | replace('metalk8s-', ''), expected) >= 0 %}
+{%- if salt.pkg.version_cmp(saltenv | replace('metalk8s-', ''), expected) < 0 %}
 
 Invalid saltenv "{{ saltenv }}" consider using "metalk8s-{{ expected }}":
   test.fail_without_changes


### PR DESCRIPTION
**Component**:

'salt', 'lifecycle'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->


**Summary**:

In 41a3583a we added a check to allow `saltenv` to be superior or equal
to higher node version but we did the oposite.
It's fix now in this commit

---

Fixes: #2551
