### PR TITLE
Prometheus rules: Fix node filesystem files filling up Prometheus default alert rules

### DIFF
--- a/salt/metalk8s/addons/prometheus-operator/config/prometheus.yaml
+++ b/salt/metalk8s/addons/prometheus-operator/config/prometheus.yaml
@@ -25,7 +25,7 @@ spec:
           hours: 24  # Hours before there is no inode left
           threshold: 40  # Min space left to trigger prediction
         critical:
-          hours: 6
+          hours: 4
           threshold: 20
       node_filesystem_almost_out_of_files:
         warning:

--- a/tests/post/steps/test_service_configuration.py
+++ b/tests/post/steps/test_service_configuration.py
@@ -124,7 +124,7 @@ def check_prometheus_alert_rule(
 
     utils.retry(
         _wait_prometheus_config_reload,
-        times=10,
+        times=20,
         wait=5,
         name="wait for Prometheus configuration reload"
     )


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
'prometheus-operator', 'charts'

**Context**: 

Tests for Prometheus rules fail on integration branches for this PR : https://github.com/scality/metalk8s/pull/2546
Likely cause is due to a wrong default value specified for NodeFilesystemFilesFillingUp when severity is critical.

Note that the customization of Prometheus rules was only merged in 2.6.

**Summary**:

If we pick up the integration branch from https://github.com/scality/metalk8s/pull/2546, bootup a cluster  and run the rule_extractor script to compare the deployed rules with the defaults, we get the following output


```
ceban@ceban-ThinkPad-T470p:~/Desktop/scality_work/metalk8s$ git diff tools/rule_extractor/alerting_rules.json
diff --git a/tools/rule_extractor/alerting_rules.json b/tools/rule_extractor/alerting_rules.json
index 1418f673..9ad3d894 100644
--- a/tools/rule_extractor/alerting_rules.json
+++ b/tools/rule_extractor/alerting_rules.json
@@ -444,9 +444,9 @@
         "severity": "warning"
     },
     {
-        "message": "Filesystem is predicted to run out of inodes within the next 4 hours.",
+        "message": "Filesystem is predicted to run out of inodes within the next 6 hours.",
         "name": "NodeFilesystemFilesFillingUp",
-        "query": "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100 < 20 and predict_linear(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"}[6h], 4 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
+        "query": "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100 < 20 and predict_linear(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"}[6h], 6 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
         "severity": "critical"
     },
```

**Acceptance criteria**: 

PR https://github.com/scality/metalk8s/pull/2546 integration branch should pass normally.

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
