### PR TITLE
vagrant: add workaround for VirtualBox audio issue

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -161,7 +161,7 @@ Vagrant.configure("2") do |config|
     v.linked_clone = true
     v.memory = 2048
     v.cpus = 2
-    v.customize ["modifyvm", :id, "--chipset", "ich9"]
+    v.customize ["modifyvm", :id, "--chipset", "ich9", "--audio", "none"]
   end
 
   config.vm.network "private_network",
@@ -178,6 +178,7 @@ Vagrant.configure("2") do |config|
 
     bootstrap.vm.provider "virtualbox" do |v|
       v.memory = 4096
+      v.customize ["modifyvm", :id, "--audio", "none"]
       bootstrap.vm.synced_folder ".", "/vagrant", type: "virtualbox"
     end
 


### PR DESCRIPTION
This issue appears with VirtualBox version 5.2.8+ which seems to have an issue when trying to add
the audio to a VM.
We can either shorten the VM name to workaround this issue or disable the audio.
Since we don't need the audio on our boxes, we choose to deactivate the audio.

Without thix fix we end up with such errors:
```
There was an error while executing `VBoxManage`, a CLI used by Vagrant
for controlling VirtualBox. The command and stderr is shown below.

Command: ["startvm", "20b29baa-fc92-45e5-9ebd-e43d5f87228d", "--type", "headless"]

Stderr: VBoxManage: error: The specified string / bytes buffer was to small.
Specify a larger one and retry. (VERR_CFGM_NOT_ENOUGH_SPACE)
VBoxManage: error: Details: code NS_ERROR_FAILURE (0x80004005), component ConsoleWrap, interface IConsole
```

See hashicorp/vagrant#9524 for details.