### PR TITLE
Use async call for disk.dump

### DIFF
--- a/storage-operator/pkg/salt/client.go
+++ b/storage-operator/pkg/salt/client.go
@@ -189,12 +189,12 @@ func (self *Client) PollJob(
 	nodeResult := result[nodeName].(map[string]interface{})
 
 	// The job is done: check if it has succeeded.
-	retcode := result[nodeName].(map[string]interface{})["retcode"].(float64)
+	retcode := nodeResult["retcode"].(float64)
 
 	switch int(retcode) {
 	case 0:
 		jobLogger.Info("Salt job succeeded")
-		return nodeResult, nil
+		return nodeResult["return"].(map[string]interface{}), nil
 	case 1: // Concurrent state execution.
 		return nil, fmt.Errorf("Salt job %s failed to run", job.ID)
 	default:

--- a/storage-operator/pkg/salt/job.go
+++ b/storage-operator/pkg/salt/job.go
@@ -1,0 +1,40 @@
+package salt
+
+import (
+	"fmt"
+	"strings"
+)
+
+// A Salt job handle.
+type JobHandle struct {
+	Name   string
+	ID     string
+	Result string
+}
+
+func newJob(name string, id string) *JobHandle {
+	return &JobHandle{Name: name, ID: id, Result: ""}
+}
+
+func JobFromString(s string) (*JobHandle, error) {
+	if len(s) == 0 {
+		return &JobHandle{"", "", ""}, nil
+	}
+
+	parts := strings.SplitN(s, "/", 3)
+	if len(parts) == 2 {
+		return &JobHandle{parts[0], parts[1], ""}, nil
+	} else if len(parts) == 3 {
+		return &JobHandle{parts[0], parts[1], parts[2]}, nil
+	} else {
+		return nil, fmt.Errorf("invalid job format: %s", s)
+	}
+}
+
+// Get the string representation of a job handle.
+func (job *JobHandle) String() string {
+	if job.Result == "" {
+		return fmt.Sprintf("%s/%s", job.Name, job.ID)
+	}
+	return fmt.Sprintf("%s/%s/%s", job.Name, job.ID, job.Result)
+}

--- a/storage-operator/pkg/salt/job_test.go
+++ b/storage-operator/pkg/salt/job_test.go
@@ -1,0 +1,43 @@
+package salt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	assert := assert.New(t)
+	job := newJob("ping", "deadbeef")
+
+	assert.NotNil(job)
+	assert.Equal("ping", job.Name)
+	assert.Equal("deadbeef", job.ID)
+	assert.Equal("", job.Result)
+	assert.Equal("ping/deadbeef", job.String())
+}
+
+func TestFromString(t *testing.T) {
+	assert := assert.New(t)
+	tests := map[string]struct {
+		input    string
+		success  bool
+		expected *JobHandle
+	}{
+		"empty":   {input: "", success: true, expected: &JobHandle{"", "", ""}},
+		"valid":   {input: "ping/pong", success: true, expected: &JobHandle{"ping", "pong", ""}},
+		"invalid": {input: "ping:pong", success: false, expected: nil},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			job, err := JobFromString(tc.input)
+
+			if tc.success {
+				assert.Equal(tc.expected, job)
+			} else {
+				assert.Error(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Component**:

operator

**Context**: 

Sometimes the call to `disk.dump` fails because we have another state running concurrent and this permanently put the volume in a failed state.

**Summary**:

Given the lack of details in Salt-API response (the server return an error 500 with a generic message, not much you can infer from that…) the simplest solution is to make the call to `disk.dump` an async one (that way we leverage the existing handling of concurrent states).
As a side bonus, we also no longer need a timeout (which wasn't handled properly in our case…).

The biggest change is the enrichment of the job ID (which becomes a Job Handle).

**Acceptance criteria**: 

No regression (existing tests still pass)
Cannot reproduce the described issue.

---

Closes: #2493 