### PR TITLE
Add digest for dex config

### DIFF
--- a/charts/dex.yaml
+++ b/charts/dex.yaml
@@ -40,6 +40,10 @@ extraVolumeMounts:
   - name: dex-login
     mountPath: /web/themes/scality
 
+podAnnotations:
+  # Override default checksum as we want to manage it with salt
+  checksum/config: '__slot__:salt:metalk8s_kubernetes.get_object_digest(kind="Secret", apiVersion="v1", namespace="metalk8s-auth", name="dex", path="data:config.yaml")'
+
 certs:
   web:
     create: false

--- a/docs/operation/cluster_and_service_configuration.rst
+++ b/docs/operation/cluster_and_service_configuration.rst
@@ -143,13 +143,6 @@ To add a new static user, perform the following operations:
                        salt-master-bootstrap -- salt-run \\
                        state.sls metalk8s.addons.dex.deployed saltenv=metalk8s-|version|
 
-#. From the Bootstrap node, restart the Dex deployments.
-
-   .. code-block:: shell
-
-      root@bootstrap $ kubectl --kubeconfig /etc/kubernetes/admin.conf \
-                         rollout restart deployment dex -n metalk8s-auth
-
 #. Finally, create and apply the required :file:`ClusterRoleBinding.yaml` file
    that ensures that the newly added static user is bound to a Cluster Role.
 
@@ -265,13 +258,6 @@ To change the password of an existing user, perform the following operations:
                        --kubeconfig /etc/kubernetes/admin.conf \\
                        salt-master-bootstrap -- salt-run \\
                        state.sls metalk8s.addons.dex.deployed saltenv=metalk8s-|version|
-
-#. From the Bootstrap node, restart the Dex deployments.
-
-   .. code-block:: shell
-
-      root@bootstrap $ kubectl --kubeconfig /etc/kubernetes/admin.conf \
-                         rollout restart deployment dex -n metalk8s-auth
 
 #. Verify that the password has been changed and you can log in to the MetalK8s
    UI using the new password

--- a/salt/_modules/metalk8s_kubernetes.py
+++ b/salt/_modules/metalk8s_kubernetes.py
@@ -133,6 +133,9 @@ def _object_manipulation_function(action):
                 )
             )
 
+        # Format slots on the manifest
+        manifest = __salt__.metalk8s.format_slots(manifest)
+
         # Adding label containing metalk8s version (retrieved from saltenv)
         if action in ['create', 'replace']:
             match = re.search(r'^metalk8s-(?P<version>.+)$', saltenv)

--- a/salt/metalk8s/addons/dex/config/dex.yaml
+++ b/salt/metalk8s/addons/dex/config/dex.yaml
@@ -6,11 +6,4 @@ spec:
   # Configure the Dex Deployment
   deployment:
     replicas: 2
-  localuserstore:
-    enabled: true
-    userlist:
-      - email: "admin@metalk8s.invalid"
-        hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
-        username: "admin"
-        userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
   connectors: []

--- a/salt/metalk8s/addons/dex/deployed/chart.sls
+++ b/salt/metalk8s/addons/dex/deployed/chart.sls
@@ -187,7 +187,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d58a2489f8f7fd4df3f78cad5ea6ac51e7eda9ca076c41689ce853539ff2a15b
+        checksum/config: __slot__:salt:metalk8s_kubernetes.get_object_digest(kind="Secret",
+          apiVersion="v1", namespace="metalk8s-auth", name="dex", path="data:config.yaml")
       labels:
         app.kubernetes.io/component: dex
         app.kubernetes.io/instance: dex

--- a/salt/metalk8s/addons/dex/deployed/service-configuration.sls
+++ b/salt/metalk8s/addons/dex/deployed/service-configuration.sls
@@ -23,7 +23,14 @@ Create dex-config ConfigMap:
           config.yaml: |-
             apiVersion: addons.metalk8s.scality.com
             kind: DexConfig
-            spec: {}
+            spec:
+              localuserstore:
+                enabled: true
+                userlist:
+                  - email: "admin@metalk8s.invalid"
+                    hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+                    username: "admin"
+                    userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
 
  {%- else %}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,7 @@ def version(request, host):
             'source %s && echo $VERSION', str(product_path)
         )
 
+
 @pytest.fixture(scope="module")
 def hostname(host):
     """Return the result of `hostname` on the `host` fixture.
@@ -52,10 +53,14 @@ def nodename(host):
     Node name need to be equal to the salt minion id so just retrieve the
     salt minion id
     """
-    with host.sudo():
-        return host.check_output(
-            'salt-call --local --out txt grains.get id | cut -c 8-'
-        )
+    return utils.get_grain(host, 'id')
+
+
+@pytest.fixture(scope="module")
+def control_plane_ip(host):
+    """Return the Kubernetes control plane IP based on the salt grain
+    """
+    return utils.get_grain(host, 'metalk8s:control_plane_ip')
 
 
 @pytest.fixture(scope="module")

--- a/tests/post/features/authentication.feature
+++ b/tests/post/features/authentication.feature
@@ -26,12 +26,10 @@ Feature: Authentication is up and running
         Given the Kubernetes API is available
         And the control-plane Ingress path '/oidc' is available
         And pods with label 'app.kubernetes.io/name=dex' are 'Ready'
-        When we login to Dex as 'admin@metalk8s.com' using password 'password'
-        Then authentication fails with login error
+        Then we are not able to login to Dex as 'admin@metalk8s.com' using password 'password'
 
     Scenario: Login to Dex using correct email and password
         Given the Kubernetes API is available
         And the control-plane Ingress path '/oidc' is available
         And pods with label 'app.kubernetes.io/name=dex' are 'Ready'
-        When we login to Dex as 'admin@metalk8s.invalid' using password 'password'
-        Then the server returns '303' with an ID token
+        Then we are able to login to Dex as 'admin@metalk8s.invalid' using password 'password'

--- a/tests/post/features/service_configuration.feature
+++ b/tests/post/features/service_configuration.feature
@@ -7,3 +7,13 @@ Feature: Cluster and Services Configurations
         And we have a 'metalk8s-dex-config' CSC in namespace 'metalk8s-auth'
         When we update the CSC 'spec.deployment.replicas' to '3'
         Then we have '3' at 'status.available_replicas' for 'dex' Deployment in namespace 'metalk8s-auth'
+
+    Scenario: Update Admin static user password
+        Given the Kubernetes API is available
+        And we have a 'metalk8s-dex-config' CSC in namespace 'metalk8s-auth'
+        # NOTE: Consider that admin user is the first of the userlist
+        # Update password to "new-password"
+        When we update the CSC 'spec.localuserstore.userlist.0.hash' to '$2y$14$pDe0vj917rR3XJQ5iEZvhuSGoWkZg2/qBN/mMLqwFSz9S7EYcbIpO'
+        Then we have 2 running pod labeled 'app.kubernetes.io/name=dex' in namespace 'metalk8s-auth'
+        And we are not able to login to Dex as 'admin@metalk8s.invalid' using password 'password'
+        And we are able to login to Dex as 'admin@metalk8s.invalid' using password 'new-password'

--- a/tests/post/steps/test_authentication.py
+++ b/tests/post/steps/test_authentication.py
@@ -18,9 +18,8 @@ from tests import utils
 INGRESS_PORT = 8443
 
 # }}}
-
-
 # Scenarios {{{
+
 
 @scenario('../features/authentication.feature', 'List Pods')
 def test_list_pods(host):
@@ -55,8 +54,6 @@ def test_login(host):
 
 
 # }}}
-
-
 # Fixtures {{{
 
 @pytest.fixture(scope='function')
@@ -65,8 +62,6 @@ def context():
 
 
 # }}}
-
-
 # Given {{{
 
 
@@ -109,8 +104,6 @@ def check_cp_ingress_pod_and_container(
 
 
 # }}}
-
-
 # When {{{
 
 
@@ -137,24 +130,7 @@ def perform_request(
         )
 
 
-@when(parsers.parse(
-    "we login to Dex as '{username}' using password '{password}'"))
-def dex_login(
-    host,
-    control_plane_ip,
-    username,
-    password,
-    context,
-    request_retry_session
-):
-    context['login_response'] = _dex_auth_request(
-        control_plane_ip, username, password, request_retry_session
-    )
-
-
 # }}}
-
-
 # Then {{{
 
 
@@ -198,84 +174,4 @@ def server_returns(host, context, status_code, status_message):
     assert response.status_code == int(status_code)
     assert response.text.rstrip('\n') == status_message
 
-
-@then(parsers.parse("authentication fails with login error"))
-def failed_login(host, context):
-    auth_response = context.get('login_response')
-    assert auth_response.text is not None
-    assert auth_response.status_code == 200
-    # 'Invalid Email Address and password' is found in auth_response.text
-    assert 'Invalid Email Address and password' in auth_response.text
-    assert auth_response.headers.get('location') is None
-
-
-@then(parsers.parse("the server returns '{status_code}' with an ID token"))
-def successful_login(host, context, status_code):
-    auth_response = context.get('login_response')
-    if auth_response.text is None:
-        assert False
-    assert auth_response.status_code == int(status_code)
-    assert auth_response.headers.get('location') is not None
-
-
 #  }}}
-
-
-# Helper {{{
-
-
-def _dex_auth_request(
-    control_plane_ip,
-    username,
-    password,
-    request_retry_session
-):
-    try:
-        response = request_retry_session.post(
-            'https://{}:{}/oidc/auth?'.format(control_plane_ip, INGRESS_PORT),
-            data={
-                'response_type': 'id_token',
-                'client_id': 'metalk8s-ui',
-                'scope': 'openid audience:server:client_id:oidc-auth-client',
-                'redirect_uri': 'https://{}:{}/oauth2/callback'.format(
-                    control_plane_ip, INGRESS_PORT
-                ),
-                'nonce': 'nonce'
-            },
-            verify=False,
-        )
-    except requests.exceptions.ConnectionError as exc:
-        pytest.fail("Dex authentication request failed with error: {}".format(
-            exc
-            )
-        )
-
-    auth_request = response.text  # response is an html form
-    # form action looks like:
-    # <a href="/oidc/auth/local?req=ovc5qdll5zznlubewjok266rl" target="_self">
-    try:
-        reqpath = re.search(
-            r'href=[\'"](?P<reqpath>/oidc/\S+)[\'"] ', auth_request
-        ).group('reqpath')
-
-    except AttributeError as exc:
-        raise AttributeError(exc)
-
-    try:
-        result = requests.post(
-            "https://{}:{}{}".format(
-                control_plane_ip, INGRESS_PORT, reqpath
-            ),
-            data={
-                'login': username,
-                'password': password
-            },
-            verify=False, allow_redirects=False,
-        )
-    except requests.exceptions.ConnectionError as exc:
-        pytest.fail("Unable to login with error: {}".format(exc))
-
-    return result
-
-
-# }}}

--- a/tests/post/steps/test_authentication.py
+++ b/tests/post/steps/test_authentication.py
@@ -1,4 +1,3 @@
-import json
 import re
 
 import requests
@@ -63,17 +62,6 @@ def test_login(host):
 @pytest.fixture(scope='function')
 def context():
     return {}
-
-
-@pytest.fixture(scope='function')
-def control_plane_ip(host):
-    with host.sudo():
-        output = host.check_output(' '.join([
-            'salt-call', '--local', '--out=json',
-            'grains.get', 'metalk8s:control_plane_ip',
-        ]))
-        ip = json.loads(output)['local']
-    return ip
 
 
 # }}}

--- a/tests/post/steps/test_ingress.py
+++ b/tests/post/steps/test_ingress.py
@@ -1,10 +1,10 @@
-import json
-
 import requests
 import requests.exceptions
 
 import pytest
 from pytest_bdd import given, parsers, scenario, then, when
+
+from tests import utils
 
 
 @scenario('../features/ingress.feature', 'Access HTTP services')
@@ -30,14 +30,7 @@ def context():
 
 @given('the node control-plane IP is not equal to its workload-plane IP')
 def node_control_plane_ip_is_not_equal_to_its_workload_plane_ip(host):
-    with host.sudo():
-        output = host.check_output(' '.join([
-            'salt-call --local',
-            'grains.get metalk8s',
-            '--out json',
-        ]))
-
-    data = json.loads(output)['local']
+    data = utils.get_grain(host, 'metalk8s')
 
     assert 'control_plane_ip' in data
     assert 'workload_plane_ip' in data
@@ -65,13 +58,7 @@ def perform_request(host, context, protocol, port, plane):
     if plane not in grains:
         raise NotImplementedError
 
-    with host.sudo():
-        ip_output = host.check_output(' '.join([
-            'salt-call --local',
-            'grains.get {grain}'.format(grain=grains[plane]),
-            '--out json',
-        ]))
-    ip = json.loads(ip_output)['local']
+    ip = utils.get_grain(host, grains[plane])
 
     try:
         context['response'] = requests.get(

--- a/tests/post/steps/test_service_configuration.py
+++ b/tests/post/steps/test_service_configuration.py
@@ -18,6 +18,12 @@ def test_service_config_propagation(host):
     pass
 
 
+@scenario('../features/service_configuration.feature',
+          'Update Admin static user password')
+def test_static_user_change(host):
+    pass
+
+
 # }}}
 # Given {{{
 

--- a/tests/post/steps/test_ui.py
+++ b/tests/post/steps/test_ui.py
@@ -4,6 +4,7 @@ import pytest
 from pytest_bdd import scenario, then
 import requests
 
+from tests import utils
 
 # Scenarios
 @scenario('../features/ui_alive.feature', 'Reach the UI')
@@ -13,12 +14,7 @@ def test_ui(host):
 
 @then("we can reach the UI")
 def reach_UI(host):
-    with host.sudo():
-        output = host.check_output(' '.join([
-            'salt-call', '--local', '--out=json',
-            'grains.get', 'metalk8s:control_plane_ip',
-        ]))
-        ip = json.loads(output)['local']
+    ip = utils.get_grain(host, 'metalk8s:control_plane_ip')
 
     response = requests.get(
         'https://{ip}:8443'.format(ip=ip),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -167,7 +167,11 @@ def get_dict_element(data, path, delimiter='.'):
     Traverse a dict using a 'delimiter' on a target string.
     getitem(a, b) returns the value of a at index b
     """
-    return functools.reduce(operator.getitem, path.split(delimiter), data)
+    return functools.reduce(
+        operator.getitem,
+        (int(k) if k.isdigit() else k for k in path.split(delimiter)),
+        data
+    )
 
 
 def set_dict_element(data, path, value, delimiter='.'):
@@ -176,9 +180,12 @@ def set_dict_element(data, path, value, delimiter='.'):
     and replace the value of a key
     """
     current = data
-    elements = path.split(delimiter)
+    elements = [int(k) if k.isdigit() else k for k in path.split(delimiter)]
     for element in elements[:-1]:
-        current = current.setdefault(element, {})
+        if isinstance(element, int):
+            current = current[element] if len(current) > element else []
+        else:
+            current = current.setdefault(element, {})
     current[elements[-1]] = value
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -68,10 +68,7 @@ def get_node_name(nodename, ssh_config=None):
     """Get a node name (from SSH config)."""
     if ssh_config is not None:
         node = testinfra.get_host(nodename, ssh_config=ssh_config)
-        with node.sudo():
-            return node.check_output(
-                'salt-call --local --out txt grains.get id | cut -c 8-'
-            )
+        return get_grain(node, 'id')
     return nodename
 
 


### PR DESCRIPTION
**Component**:

'salt', 'authentication'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

#2569 

**Summary**:

- Add simple "salt slots" handling in Kubernetes manifest when using `metalk8s_kubernetes` module
- Add digest of secret to `checksum/config` annotation for Dex pods
- Remove `kubectl rollout restart` command from doc
- Add test for Dex static user password change

---

Fixes: #2569 
