### PR TITLE
salt: add pre-upgrade & pre-downgrade states to cleanup Prometheus-operator-grafana Deployments

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -285,6 +285,8 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/addons/prometheus-operator/deployed/',
             'service-configuration.sls'),
     Path('salt/metalk8s/addons/prometheus-operator/deployed/storageclass.sls'),
+    Path('salt/metalk8s/addons/prometheus-operator/pre-downgrade.sls'),
+    Path('salt/metalk8s/addons/prometheus-operator/pre-upgrade.sls'),
 
     Path('salt/metalk8s/addons/ui/deployed/dependencies.sls'),
     Path('salt/metalk8s/addons/ui/deployed/ingress.sls'),

--- a/salt/metalk8s/addons/prometheus-operator/pre-downgrade.sls
+++ b/salt/metalk8s/addons/prometheus-operator/pre-downgrade.sls
@@ -1,0 +1,26 @@
+{%- set dest_version = pillar.metalk8s.cluster_version %}
+
+{#- In MetalK8s-2.5.1 the upstream Prometheus-operator chart changed the
+    MatchLabels selector for prometheus-operator-grafana Deployment
+    but `selector` are immutable field so, in this case, we cannot replace
+    the object we need to first remove the current one and then deploy the
+    desired one. #}
+{#- Only do it `if dest_version < 2.5.1` #}
+{%- if salt.pkg.version_cmp(dest_version, '2.5.1') == -1 %}
+
+Delete old prometheus-operator-grafana deployment:
+  metalk8s_kubernetes.object_absent:
+    - name: prometheus-operator-grafana
+    - namespace: metalk8s-monitoring
+    - kind: Deployment
+    - apiVersion: apps/v1
+    - wait:
+        attempts: 10
+        sleep: 10
+
+{%- else %}
+
+Prometheus-operator-grafana deployment already ready for downgrade:
+  test.succeed_without_changes: []
+
+{%- endif %}

--- a/salt/metalk8s/addons/prometheus-operator/pre-upgrade.sls
+++ b/salt/metalk8s/addons/prometheus-operator/pre-upgrade.sls
@@ -1,0 +1,42 @@
+{%- set dest_version = pillar.metalk8s.cluster_version %}
+
+{#- In MetalK8s-2.5.1 the upstream Prometheus-operator chart changed the
+    MatchLabels selector for prometheus-operator-grafana Deployment
+    but `selector` are immutable field so, in this case, we cannot replace
+    the object we need to first remove the current one and then deploy the
+    desired one. #}
+{%- set grafana_deployment = salt.metalk8s_kubernetes.get_object(
+        kind='Deployment',
+        apiVersion='apps/v1',
+        name='prometheus-operator-grafana',
+        namespace='metalk8s-monitoring'
+    ) %}
+
+{#- Only do it `if current_version < 2.5.1` #}
+{#- NOTE: If no version consider it's a 2.4.0 or 2.4.1 as version label was
+    added just after. #}
+
+{%- if grafana_deployment and
+       salt.pkg.version_cmp(
+          grafana_deployment.get('metadata', {}).get('labels', {}).get(
+            'metalk8s.scality.com/version', '2.4.1'
+          ),
+          '2.5.1'
+       ) == -1 %}
+
+Delete old prometheus-operator-grafana deployment:
+  metalk8s_kubernetes.object_absent:
+    - name: prometheus-operator-grafana
+    - namespace: metalk8s-monitoring
+    - kind: Deployment
+    - apiVersion: apps/v1
+    - wait:
+        attempts: 10
+        sleep: 10
+
+{%- else %}
+
+Prometheus-operator-grafana deployment already ready for upgrade:
+  test.succeed_without_changes: []
+
+{%- endif %}

--- a/salt/metalk8s/orchestrate/downgrade/pre.sls
+++ b/salt/metalk8s/orchestrate/downgrade/pre.sls
@@ -5,3 +5,4 @@
 include:
   - metalk8s.addons.nginx-ingress.pre-downgrade
   - metalk8s.addons.nginx-ingress-control-plane.pre-downgrade
+  - metalk8s.addons.prometheus-operator.pre-downgrade

--- a/salt/metalk8s/orchestrate/upgrade/pre.sls
+++ b/salt/metalk8s/orchestrate/upgrade/pre.sls
@@ -5,4 +5,5 @@
 include:
   - metalk8s.addons.nginx-ingress.pre-upgrade
   - metalk8s.addons.nginx-ingress-control-plane.pre-upgrade
+  - metalk8s.addons.prometheus-operator.pre-upgrade
   - metalk8s.kubernetes.apiserver.pre-upgrade


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

See #2579 

**Summary**:

Since we bump the Prometheus-operator charts to `8.13.0` in the 2.5 branches, the upstream changed the matching labels for Grafana Deployment and so we need to handle this during an upgrade or downgrade by adding salt states to clean up the Deployment.

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2579

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
