### PR TITLE
 build(deps): bump coredns from 1.3.1 to 1.6.5

### DIFF
--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -101,8 +101,8 @@ CONTAINER_IMAGES : Tuple[Image, ...] = (
     ),
     Image(
         name='coredns',
-        version='1.6.2',
-        digest='sha256:12eb885b8685b1b13a04ecf5c23bc809c2e57917252fd7b0be9e9c00644e8ee5',
+        version='1.6.5',
+        digest='sha256:7ec975f167d815311a7136c32e70735f0d00b73781365df1befd46ed35bd4fe7',
     ),
     Image(
         name='dex',

--- a/salt/metalk8s/kubernetes/coredns/deployed.sls
+++ b/salt/metalk8s/kubernetes/coredns/deployed.sls
@@ -15,7 +15,9 @@ Create coredns ConfigMap:
           Corefile: |
             .:53 {
                 errors
-                health
+                health {
+                  lameduck 5s
+                }
                 ready
                 kubernetes {{ coredns.cluster_domain }} {{ coredns.reverse_cidrs }} {
                   pods insecure


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
'deps', 'build'

**Context**:

See: #2572  

**Summary**:

A followup of  this PR: https://github.com/scality/metalk8s/pull/2575

- Since the target branch runs K8s 1.17 and following the kubeadm standards as specified in the issue, let us bump the version of coredns to `1.6.5`.

- The resource is gotten from here: https://github.com/kubernetes/kubernetes/blob/release-1.17/cmd/kubeadm/app/phases/addons/dns/manifests.go#L306.

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2572

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
