### PR TITLE
salt: Fix invalid custom object Listing in Salt

### DIFF
--- a/salt/_utils/kubernetes_utils.py
+++ b/salt/_utils/kubernetes_utils.py
@@ -446,13 +446,6 @@ class CustomApiClient(ApiClient):
 
             result = base_method(*args, **kwargs)
 
-            if verb == 'list':
-                return CustomObject({
-                    'kind': '{}List'.format(self.kind),
-                    'apiVersion': '{s.group}/{s.version}'.format(s=self),
-                    'items': [CustomObject(obj) for obj in result],
-                })
-
             # TODO: do we have a result for `delete` methods?
             return CustomObject(result)
 


### PR DESCRIPTION
**Component**:

**Context**: 

Listing for custom object do not work in our Salt k8s module

**Summary**:

We do not need any special case to List custom objects as python
kubernetes output the right output (same as the one from "classic
objects")

---

Fixes: #2592
