### PR TITLE
Add state to cleanup old PrometheusRule CRs post upgrade/downgrade

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -219,6 +219,7 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/addons/prometheus-adapter/deployed/chart.sls'),
     Path('salt/metalk8s/addons/prometheus-adapter/deployed/init.sls'),
 
+    Path('salt/metalk8s/addons/prometheus-operator/post-cleanup.sls'),
     Path('salt/metalk8s/addons/prometheus-operator/deployed/chart.sls'),
     Path('salt/metalk8s/addons/prometheus-operator/deployed/cleanup.sls'),
     Path('salt/metalk8s/addons/prometheus-operator/deployed/dashboards.sls'),
@@ -424,10 +425,12 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/orchestrate/downgrade/init.sls'),
     Path('salt/metalk8s/orchestrate/downgrade/precheck.sls'),
     Path('salt/metalk8s/orchestrate/downgrade/pre.sls'),
+    Path('salt/metalk8s/orchestrate/downgrade/post.sls'),
 
     Path('salt/metalk8s/orchestrate/upgrade/init.sls'),
     Path('salt/metalk8s/orchestrate/upgrade/precheck.sls'),
     Path('salt/metalk8s/orchestrate/upgrade/pre.sls'),
+    Path('salt/metalk8s/orchestrate/upgrade/post.sls'),
 
     Path('salt/metalk8s/orchestrate/solutions/import-components.sls'),
     Path('salt/metalk8s/orchestrate/solutions/prepare-environment.sls'),

--- a/salt/metalk8s/addons/prometheus-operator/post-cleanup.sls
+++ b/salt/metalk8s/addons/prometheus-operator/post-cleanup.sls
@@ -1,0 +1,40 @@
+{#- For the Prometheus-operator chart, after a cluster upgrade/downgrade some
+    remnants of the old installation might remain such as PrometheusRules.
+    This state is meant to cleanup old PrometheusRules marked with labels of
+    an old Metalk8s version #}
+
+{%- set version = pillar.metalk8s.cluster_version %}
+
+{#- Todo: In future, we might need to provide a complete list of object kind
+    and apiversions that require cleanup. For now, we only handle
+    PrometheusRules #}
+
+{%- set prometheus_rules_to_remove = salt.metalk8s_kubernetes.list_objects(
+        kind="PrometheusRule",
+        apiVersion="monitoring.coreos.com/v1",
+        namespace="metalk8s-monitoring",
+        label_selector="app.kubernetes.io/part-of=metalk8s,metalk8s.scality.com/version!=" ~ version
+    ) %}
+
+{%- if prometheus_rules_to_remove %}
+
+{%- for prometheus_rule in prometheus_rules_to_remove %}
+
+Delete old PrometheusRule {{ prometheus_rule['metadata']['name'] }}:
+  metalk8s_kubernetes.object_absent:
+    - name: {{ prometheus_rule['metadata']['name'] }}
+    - namespace: {{ prometheus_rule['metadata']['namespace'] }}
+    - kind: {{ prometheus_rule['kind'] }}
+    - apiVersion: {{ prometheus_rule['apiVersion'] }}
+    - wait:
+        attempts: 10
+        sleep: 10
+
+{%- endfor %}
+
+{%- else %}
+
+No PrometheusRule to cleanup:
+  test.succeed_without_changes: []
+
+{%- endif %}

--- a/salt/metalk8s/orchestrate/downgrade/post.sls
+++ b/salt/metalk8s/orchestrate/downgrade/post.sls
@@ -1,0 +1,4 @@
+# Include here all states that should be called after downgrading
+
+include:
+  - metalk8s.addons.prometheus-operator.post-cleanup

--- a/salt/metalk8s/orchestrate/upgrade/post.sls
+++ b/salt/metalk8s/orchestrate/upgrade/post.sls
@@ -1,0 +1,4 @@
+# Include here all states that should be called after upgrading
+
+include:
+  - metalk8s.addons.prometheus-operator.post-cleanup

--- a/scripts/downgrade.sh.in
+++ b/scripts/downgrade.sh.in
@@ -92,6 +92,13 @@ launch_pre_downgrade () {
         saltenv="$SALTENV"
 }
 
+launch_post_downgrade () {
+    SALT_MASTER_CALL=(crictl exec -i "$(get_salt_container)")
+    "${SALT_MASTER_CALL[@]}" salt-run state.orchestrate \
+        metalk8s.orchestrate.downgrade.post \
+        saltenv="$SALTENV"
+}
+
 launch_downgrade () {
     SALT_MASTER_CALL=(crictl exec -i "$(get_salt_container)")
     "${SALT_MASTER_CALL[@]}" salt-run saltutil.sync_all \
@@ -172,3 +179,4 @@ run "Setting cluster version to $DESTINATION_VERSION" patch_kubesystem_namespace
 run "Launching the pre-downgrade" launch_pre_downgrade
 run "Downgrading bootstrap" downgrade_bootstrap
 run "Launching the downgrade" launch_downgrade
+run "Launching the post-downgrade" launch_post_downgrade

--- a/scripts/upgrade.sh.in
+++ b/scripts/upgrade.sh.in
@@ -107,6 +107,12 @@ launch_pre_upgrade () {
         saltenv="$SALTENV"
 }
 
+launch_post_upgrade () {
+    SALT_MASTER_CALL=(crictl exec -i "$(get_salt_container)")
+    "${SALT_MASTER_CALL[@]}" salt-run state.orchestrate \
+        metalk8s.orchestrate.upgrade.post \
+        saltenv="$SALTENV"
+}
 
 launch_upgrade () {
     SALT_MASTER_CALL=(crictl exec -i "$(get_salt_container)")
@@ -169,3 +175,4 @@ run "Upgrading bootstrap" upgrade_bootstrap
 run "Setting cluster version to $DESTINATION_VERSION" patch_kubesystem_namespace
 run "Launching the pre-upgrade" launch_pre_upgrade
 run "Launching the upgrade" launch_upgrade
+run "Launching the post-upgrade" launch_post_upgrade


### PR DESCRIPTION

**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
'salt', 'prometheus-operator'

**Context**: 

See: #2585 

**Summary**:

- Ensures we are able to clean up remnants of old PrometheusRule CR's post upgrade/downgrade
- Tested upgrade locally from 2.4.4-dev to 2.5.1-dev (output below 👇)
```
bootstrap_master:
----------
          ID: Delete old prometheus-operator-objects prometheus-operator-kubernetes-absent
    Function: metalk8s_kubernetes.object_absent
        Name: prometheus-operator-kubernetes-absent
      Result: True
     Comment: The object was deleted and not present after 4 check attempts
     Started: 06:50:30.580050
    Duration: 32276.439 ms
     Changes:   
              ----------
              new:
                  absent
              old:
                  present
----------
          ID: Delete old prometheus-operator-objects prometheus-operator-node-time
    Function: metalk8s_kubernetes.object_absent
        Name: prometheus-operator-node-time
      Result: True
     Comment: The object was deleted and not present after 2 check attempts
     Started: 06:51:02.864299
    Duration: 10454.147 ms
     Changes:   
              ----------
              new:
                  absent
              old:
                  present

Summary for bootstrap_master
------------
Succeeded: 2 (changed=2)
Failed:    0
------------
Total states run:     2
Total run time:  42.731 s

```

**Acceptance criteria**: 

- Monitoring tests in post-merge should pass!!

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2585

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
