### PR TITLE
salt: exclude PrometheusRule cleanup under certain conditions

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -220,6 +220,8 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/addons/prometheus-adapter/deployed/init.sls'),
 
     Path('salt/metalk8s/addons/prometheus-operator/post-cleanup.sls'),
+    Path('salt/metalk8s/addons/prometheus-operator/post-downgrade.sls'),
+    Path('salt/metalk8s/addons/prometheus-operator/post-upgrade.sls'),
     Path('salt/metalk8s/addons/prometheus-operator/deployed/chart.sls'),
     Path('salt/metalk8s/addons/prometheus-operator/deployed/cleanup.sls'),
     Path('salt/metalk8s/addons/prometheus-operator/deployed/dashboards.sls'),

--- a/salt/metalk8s/addons/prometheus-operator/post-downgrade.sls
+++ b/salt/metalk8s/addons/prometheus-operator/post-downgrade.sls
@@ -1,0 +1,23 @@
+# Include here all states that should be called after downgrading
+
+{%- set version = pillar.metalk8s.cluster_version %}
+
+{#- The Metalk8s python-kubernetes module for listing objects is bugged for
+    already released versions, The following release versions are affected:
+    2.4.0, 2.4.1, 2.4.2, 2.4.3 and 2.5.0
+    This issue as reported here:
+    https://github.com/scality/metalk8s/issues/2592 has been fixed. We need to
+    skip the PrometheusRule cleanup state for the versions mentioned above. #}
+
+{%- set affected_versions = ['2.4.0', '2.4.1', '2.4.2', '2.4.3', '2.5.0'] %}
+
+{%- if version not in affected_versions %}
+include:
+  - .post-cleanup
+
+{%- else %}
+
+Skipping PrometheusRule cleanup for affected version {{ version }}:
+  test.succeed_without_changes: []
+
+{%- endif %}

--- a/salt/metalk8s/addons/prometheus-operator/post-upgrade.sls
+++ b/salt/metalk8s/addons/prometheus-operator/post-upgrade.sls
@@ -1,4 +1,4 @@
 # Include here all states that should be called after upgrading
 
 include:
-  - metalk8s.addons.prometheus-operator.post-upgrade
+  - .post-cleanup

--- a/salt/metalk8s/orchestrate/downgrade/post.sls
+++ b/salt/metalk8s/orchestrate/downgrade/post.sls
@@ -1,4 +1,4 @@
 # Include here all states that should be called after downgrading
 
 include:
-  - metalk8s.addons.prometheus-operator.post-cleanup
+  - metalk8s.addons.prometheus-operator.post-downgrade


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
'salt', 'prometheus-operator'

**Context**: 

See #2606 

- MetalK8s python-kubernetes module for listing objects is bugged for released versions: (2.4.0, 2.4.1, 2.4.2, 2.4.3 and 2.5.0) & has been patched here: https://github.com/scality/metalk8s/pull/2593. For released versions mentioned above, we need to skip the post-upgrade cleanup state during a downgrade to this versions.

So, we have added the following:
- Add a mechanism to skip the post-upgrade PrometheusRule cleanup state once we encounter an affected version.

**Summary**:
```
[root@bootstrap /]# salt-run state.sls metalk8s.orchestrate.downgrade.post saltenv=metalk8s-2.4.4-dev
[WARNING ] org.freedesktop.DBus.Error.FileNotFound: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
bootstrap_master:
----------
          ID: Skipping PrometheusRule cleanup for affected version 2.4.3
    Function: test.succeed_without_changes
      Result: True
     Comment: Success!
     Started: 08:15:19.374903
    Duration: 0.343 ms
     Changes:   

Summary for bootstrap_master
------------
Succeeded: 1
Failed:    0
------------
Total states run:     1
Total run time:   0.343 ms
```

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2606

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
