### PR TITLE
salt: Ensure node exists before marking it as bootstrap

### DIFF
--- a/salt/_modules/metalk8s_kubernetes.py
+++ b/salt/_modules/metalk8s_kubernetes.py
@@ -299,6 +299,22 @@ get_object = _object_manipulation_function('retrieve')
 update_object = _object_manipulation_function('update')
 
 
+# Check if a specific object exists
+def object_exists(kind, apiVersion, name, **kwargs):
+    """
+    Simple helper to check if an object exists or not
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt-call metalk8s_kubernetes.object_exists kind="Node" apiVersion="v1" name="MyNode"
+    """
+    return get_object(
+        kind=kind, apiVersion=apiVersion, name=name, **kwargs
+    ) is not None
+
+
 # Listing resources can benefit from a simpler signature
 def list_objects(kind, apiVersion, namespace='default', all_namespaces=False,
                  field_selector=None, label_selector=None, **kwargs):

--- a/salt/metalk8s/kubernetes/mark-control-plane/deployed.sls.in
+++ b/salt/metalk8s/kubernetes/mark-control-plane/deployed.sls.in
@@ -3,6 +3,15 @@
 {%- set node_name = pillar.bootstrap_id %}
 {%- set cri_socket = kubelet.service.options['container-runtime-endpoint'] %}
 
+Ensure node {{ node_name }} exists:
+  test.configurable_test_state:
+    - changes: False
+    - result: __slot__:salt:metalk8s_kubernetes.object_exists(
+                  kind="Node", apiVersion="v1", name="{{ node_name }}")
+    # Retry as kubelet may take time to register
+    - retry:
+        attempts: 5
+
 Mark control plane node:
   metalk8s_kubernetes.object_updated:
     - name: {{ node_name }}
@@ -24,3 +33,5 @@ Mark control plane node:
             effect: "NoSchedule"
           - key: "node-role.kubernetes.io/infra"
             effect: "NoSchedule"
+    - require:
+      - test: Ensure node {{ node_name }} exists


### PR DESCRIPTION
**Component**:

'salt'

**Context**: 

#2601 

**Summary**:

In restore script, we configure a new bootstrap node according to a
backup file and just after kubelet installation we try to mark the node
as bootstrap node but kubelet may take some time to register so the
salt state may fail.
This commit adds a state to check that the node exists with a retry logic
in case kubelet not register yet when calling the salt state

---

Fixes: #2601 
