### PR TITLE
salt: Fix `delete` for CustomObject in `metalk8s_kubernetes`

### DIFF
--- a/salt/_utils/kubernetes_utils.py
+++ b/salt/_utils/kubernetes_utils.py
@@ -452,6 +452,18 @@ class CustomApiClient(ApiClient):
 
         return method
 
+    def _method_name(self, verb):
+        # Override super(_method_name) for `delete` as two different functions
+        # exist to delete a custom object, one that take a `name` argument
+        # and another one that does not
+        # In our case we want to use the one with `name`
+        # See: https://github.com/scality/metalk8s/issues/2621
+        # NOTE: This may need to be removed once we will change the
+        # python-kubernetes version installed in salt-master
+        if verb == "delete":
+            return "{}_{}_0".format(verb, self.name)
+        return super(CustomApiClient, self)._method_name(verb)
+
 
 class CRKindInfo(object):
     """Equivalent of `KindInfo` for custom objects.


### PR DESCRIPTION
**Component**:

'salt', 'kubernetes'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

`delete` of CustomObject in our custom Salt module `metalk8s_kubernetes`
does not work as we use `delete_namespaced_custom_object` function that
does not take `name` argument instead of
`delete_namespaced_custom_object_0` that take `name`.

**Summary**:

This commit change the function used to delete a CustomObject

---

Fixes: #2621
