### PR TITLE
eve: replace old uis repository in example-solution builder

### DIFF
--- a/eve/workers/docker-centos7/Dockerfile
+++ b/eve/workers/docker-centos7/Dockerfile
@@ -6,8 +6,10 @@ ENV LANG=en_US.utf8
 
 WORKDIR /home/eve/workspace
 
-RUN yum install -y epel-release \
-    && yum install -y gcc \
+RUN yum install -y --setopt=skip_missing_names_on_install=False \
+    epel-release \
+    && yum install -y --setopt=skip_missing_names_on_install=False \
+    gcc \
     sudo \
     python-devel \
     python-pip \

--- a/eve/workers/pod-builder/Dockerfile
+++ b/eve/workers/pod-builder/Dockerfile
@@ -4,11 +4,11 @@ ARG BUILDBOT_VERSION=0.9.12
 
 WORKDIR /home/eve/workspace
 
-RUN yum install -y epel-release \
-    && yum-config-manager \
-    --add-repo \
+RUN yum install -y --setopt=skip_missing_names_on_install=False \
+    epel-release \
+    && yum-config-manager --add-repo \
     https://download.docker.com/linux/centos/docker-ce.repo \
-    && yum install -y \
+    && yum install -y --setopt=skip_missing_names_on_install=False \
     sudo \
     gcc \
     hardlinks \

--- a/eve/workers/pod-builder/Dockerfile
+++ b/eve/workers/pod-builder/Dockerfile
@@ -11,7 +11,7 @@ RUN yum install -y --setopt=skip_missing_names_on_install=False \
     && yum install -y --setopt=skip_missing_names_on_install=False \
     sudo \
     gcc \
-    hardlinks \
+    hardlink \
     make \
     python-devel \
     python-pip \

--- a/eve/workers/pod-example-solution-builder/Dockerfile
+++ b/eve/workers/pod-example-solution-builder/Dockerfile
@@ -5,12 +5,12 @@ ARG OPERATOR_SDK_VERSION=v0.16.0
 
 WORKDIR /home/eve/workspace
 
-RUN yum install -y \
+RUN yum install -y --setopt=skip_missing_names_on_install=False \
     epel-release \
     https://repo.ius.io/ius-release-el7.rpm \
     && yum-config-manager --add-repo \
     https://download.docker.com/linux/centos/docker-ce.repo \
-    && yum install -y \
+    && yum install -y --setopt=skip_missing_names_on_install=False \
     sudo \
     gcc \
     hardlinks \

--- a/eve/workers/pod-example-solution-builder/Dockerfile
+++ b/eve/workers/pod-example-solution-builder/Dockerfile
@@ -13,7 +13,7 @@ RUN yum install -y --setopt=skip_missing_names_on_install=False \
     && yum install -y --setopt=skip_missing_names_on_install=False \
     sudo \
     gcc \
-    hardlinks \
+    hardlink \
     make \
     genisoimage \
     golang \

--- a/eve/workers/pod-example-solution-builder/Dockerfile
+++ b/eve/workers/pod-example-solution-builder/Dockerfile
@@ -7,9 +7,8 @@ WORKDIR /home/eve/workspace
 
 RUN yum install -y \
     epel-release \
-    https://centos7.iuscommunity.org/ius-release.rpm \
-    && yum-config-manager \
-    --add-repo \
+    https://repo.ius.io/ius-release-el7.rpm \
+    && yum-config-manager --add-repo \
     https://download.docker.com/linux/centos/docker-ce.repo \
     && yum install -y \
     sudo \
@@ -17,13 +16,13 @@ RUN yum install -y \
     hardlinks \
     make \
     genisoimage \
-    git2u \
     golang \
     python-devel \
     python-pip \
     skopeo \
     yum-utils \
     docker-ce-cli-18.09.6 \
+    git224 \
     && curl -LO https://github.com/operator-framework/operator-sdk/releases/download/$OPERATOR_SDK_VERSION/operator-sdk-$OPERATOR_SDK_VERSION-x86_64-linux-gnu \
     && chmod +x operator-sdk-$OPERATOR_SDK_VERSION-x86_64-linux-gnu \
     && mkdir -p /usr/local/bin/ \

--- a/eve/workers/pod-unit-tests/Dockerfile
+++ b/eve/workers/pod-unit-tests/Dockerfile
@@ -9,8 +9,10 @@ ENV LANG=en_US.utf8
 WORKDIR /home/eve/workspace
 
 RUN curl -sL https://rpm.nodesource.com/setup_10.x | bash -
-RUN yum install -y epel-release \
-    && yum install -y gcc \
+RUN yum install -y --setopt=skip_missing_names_on_install=False \
+    epel-release \
+    && yum install -y --setopt=skip_missing_names_on_install=False \
+    gcc \
     sudo \
     make \
     python-devel \


### PR DESCRIPTION
**Component**: eve

**Context**:
Solution example cannot be built anymore in the CI

**Summary**:
UIS repository is used to install git2 on CentOS7 because otherwise the latest version available is 1.8.3.1 which is not compatible with the operator-sdk.

The repository has recently changed its URL, so we update it accordingly.
Plus, the package name has changed from git2u to git224.

We also add an option to yum install for it to fail when it cannot find a requested package, avoiding
ourselves to lost time on searching why the build is not working anymore (just because git was not in the good version).

**Acceptance criteria**:
We can build the Solution Example from the CI (in post-merge)