### PR TITLE
Feature/2615 annotate pv with device name

### DIFF
--- a/salt/_modules/metalk8s_volumes.py
+++ b/salt/_modules/metalk8s_volumes.py
@@ -158,6 +158,28 @@ def clean_up(name):
     _get_volume(name).clean_up()
 
 
+def device_name(path):
+    """Resolve the given device path into the "real" device name.
+
+    For instance, `/dev/disk/by-uuid/668efc89-be5b-4b13-b3d1-1294e829f33b` could
+    resolve to `sda`.
+
+    Args:
+        name (str): volume name
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '<NODE_NAME>' metalk8s_volumes.device_name /dev/disk/by-uuid/668efc89-be5b-4b13-b3d1-1294e829f33b
+    """
+    # TOCTTOU, but `realpath` doesn't return error on non-existing path…
+    if not os.path.exists(path):
+        raise Exception('device `{}` not found'.format(path))
+    realpath = os.path.realpath(path)
+    return os.path.basename(realpath)
+
+
 # Volume {{{
 
 

--- a/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
+++ b/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
@@ -45,6 +45,7 @@ external_auth:
     storage-operator:
       - '*':
         - 'disk.dump'
+        - 'metalk8s_volumes.device_name'
         - 'state.sls'
       - '@jobs'
 

--- a/storage-operator/deploy/crds/storage_v1alpha1_volume_crd.yaml
+++ b/storage-operator/deploy/crds/storage_v1alpha1_volume_crd.yaml
@@ -111,6 +111,9 @@ spec:
                 - status
                 type: object
               type: array
+            deviceName:
+              description: Name of the underlying block device.
+              type: string
             job:
               description: Job in progress
               type: string

--- a/storage-operator/pkg/apis/storage/v1alpha1/volume_types.go
+++ b/storage-operator/pkg/apis/storage/v1alpha1/volume_types.go
@@ -121,6 +121,8 @@ type VolumeStatus struct {
 
 	// Job in progress
 	Job string `json:"job,omitempty"`
+	// Name of the underlying block device.
+	DeviceName string `json:"deviceName,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/storage-operator/pkg/apis/storage/v1alpha1/zz_generated.openapi.go
+++ b/storage-operator/pkg/apis/storage/v1alpha1/zz_generated.openapi.go
@@ -158,6 +158,13 @@ func schema_pkg_apis_storage_v1alpha1_VolumeStatus(ref common.ReferenceCallback)
 							Format:      "",
 						},
 					},
+					"deviceName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name of the underlying block device.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/storage-operator/pkg/controller/volume/volume_controller.go
+++ b/storage-operator/pkg/controller/volume/volume_controller.go
@@ -719,11 +719,16 @@ func (self *ReconcileVolume) refreshDeviceName(
 	volume *storagev1alpha1.Volume,
 	pv *corev1.PersistentVolume,
 ) (reconcile.Result, error) {
-	path := pv.Spec.PersistentVolumeSource.Local.Path
 	nodeName := string(volume.Spec.NodeName)
 	reqLogger := log.WithValues(
 		"Volume.Name", volume.Name, "Volume.NodeName", nodeName,
 	)
+
+	if pv.Spec.PersistentVolumeSource.Local == nil {
+		reqLogger.Info("skipping volume: not a local storage")
+		return endReconciliation()
+	}
+	path := pv.Spec.PersistentVolumeSource.Local.Path
 
 	name, err := self.salt.GetDeviceName(ctx, nodeName, volume.Name, path)
 	if err != nil {

--- a/storage-operator/pkg/controller/volume/volume_controller.go
+++ b/storage-operator/pkg/controller/volume/volume_controller.go
@@ -201,7 +201,7 @@ reclaim its storage and remove the finalizers to let the object be deleted.
 
 }}} */
 
-const DEVICE_ANNOTATION = "storage.metalk8s.scality.com/device"
+const DEVICE_ANNOTATION = "storage.metalk8s.scality.com/device-name"
 const VOLUME_PROTECTION = "storage.metalk8s.scality.com/volume-protection"
 const JOB_DONE_MARKER = "DONE"
 

--- a/storage-operator/pkg/salt/client.go
+++ b/storage-operator/pkg/salt/client.go
@@ -75,6 +75,8 @@ func NewClient(creds *Credential, caCertData []byte) (*Client, error) {
 func (self *Client) PrepareVolume(
 	ctx context.Context, nodeName string, volumeName string, saltenv string,
 ) (*JobHandle, error) {
+	const jobName string = "PrepareVolume"
+
 	payload := map[string]interface{}{
 		"client": "local_async",
 		"tgt":    nodeName,
@@ -87,25 +89,25 @@ func (self *Client) PrepareVolume(
 	}
 
 	self.logger.Info(
-		"PrepareVolume", "Volume.NodeName", nodeName, "Volume.Name", volumeName,
+		jobName, "Volume.NodeName", nodeName, "Volume.Name", volumeName,
 	)
 
 	ans, err := self.authenticatedRequest(ctx, "POST", "/", payload)
 	if err != nil {
 		return nil, errors.Wrapf(
 			err,
-			"PrepareVolume failed (env=%s, target=%s, volume=%s)",
-			saltenv, nodeName, volumeName,
+			"%s failed (env=%s, target=%s, volume=%s)",
+			jobName, saltenv, nodeName, volumeName,
 		)
 	}
 	if jid, err := extractJID(ans); err != nil {
 		return nil, errors.Wrapf(
 			err,
-			"Cannot extract JID from PrepareVolume response for volume %s",
-			volumeName,
+			"Cannot extract JID from %s response for volume %s",
+			jobName, volumeName,
 		)
 	} else {
-		return newJob("PrepareVolume", jid), nil
+		return newJob(jobName, jid), nil
 	}
 }
 
@@ -122,6 +124,8 @@ func (self *Client) PrepareVolume(
 func (self *Client) UnprepareVolume(
 	ctx context.Context, nodeName string, volumeName string, saltenv string,
 ) (*JobHandle, error) {
+	const jobName string = "UnprepareVolume"
+
 	payload := map[string]interface{}{
 		"client": "local_async",
 		"tgt":    nodeName,
@@ -134,26 +138,25 @@ func (self *Client) UnprepareVolume(
 	}
 
 	self.logger.Info(
-		"UnprepareVolume",
-		"Volume.NodeName", nodeName, "Volume.Name", volumeName,
+		jobName, "Volume.NodeName", nodeName, "Volume.Name", volumeName,
 	)
 
 	ans, err := self.authenticatedRequest(ctx, "POST", "/", payload)
 	if err != nil {
 		return nil, errors.Wrapf(
 			err,
-			"UnrepareVolume failed (env=%s, target=%s, volume=%s)",
-			saltenv, nodeName, volumeName,
+			"%s failed (env=%s, target=%s, volume=%s)",
+			jobName, saltenv, nodeName, volumeName,
 		)
 	}
 	if jid, err := extractJID(ans); err != nil {
 		return nil, errors.Wrapf(
 			err,
-			"Cannot extract JID from UnprepareVolume response for volume %s",
-			volumeName,
+			"Cannot extract JID from %s response for volume %s",
+			jobName, volumeName,
 		)
 	} else {
-		return newJob("UnprepareVolume", jid), nil
+		return newJob(jobName, jid), nil
 	}
 }
 
@@ -223,6 +226,8 @@ func getStateFailureRootCause(output interface{}) string {
 func (self *Client) GetVolumeSize(
 	ctx context.Context, nodeName string, volumeName string, devicePath string,
 ) (*JobHandle, error) {
+	const jobName string = "GetVolumeSize"
+
 	payload := map[string]interface{}{
 		"client":  "local_async",
 		"tgt":     nodeName,
@@ -232,25 +237,25 @@ func (self *Client) GetVolumeSize(
 	}
 
 	self.logger.Info(
-		"GetVolumeSize", "Volume.NodeName", nodeName, "Volume.Name", volumeName,
+		jobName, "Volume.NodeName", nodeName, "Volume.Name", volumeName,
 	)
 
 	ans, err := self.authenticatedRequest(ctx, "POST", "/", payload)
 	if err != nil {
 		return nil, errors.Wrapf(
 			err,
-			"GetVolumeSize failed (target=%s, volume=%s, device=%s)",
-			nodeName, volumeName, devicePath,
+			"%s failed (target=%s, volume=%s, device=%s)",
+			jobName, nodeName, volumeName, devicePath,
 		)
 	}
 	if jid, err := extractJID(ans); err != nil {
 		return nil, errors.Wrapf(
 			err,
-			"Cannot extract JID from GetVolumeSize response for volume %s",
-			volumeName,
+			"Cannot extract JID from %s response for volume %s",
+			jobName, volumeName,
 		)
 	} else {
-		return newJob("GetVolumeSize", jid), nil
+		return newJob(jobName, jid), nil
 	}
 }
 

--- a/tests/post/features/salt_api.feature
+++ b/tests/post/features/salt_api.feature
@@ -17,6 +17,6 @@ Feature: SaltAPI
     Scenario: Login to SaltAPI using a ServiceAccount
         Given the Kubernetes API is available
         When we login to SaltAPI with the ServiceAccount 'storage-operator'
-        Then we can invoke '["disk.dump", "state.sls"]' on '*'
+        Then we can invoke '["disk.dump", "metalk8s_volumes.device_name", "state.sls"]' on '*'
         And we have '@jobs' perms
 

--- a/tests/post/features/volume.feature
+++ b/tests/post/features/volume.feature
@@ -28,7 +28,7 @@ Feature: Volume management
         Then the Volume 'test-volume1' is 'Available'
         And the PersistentVolume 'test-volume1' has size '10Gi'
         And the PersistentVolume 'test-volume1' has label 'random-key' with value 'random-value'
-        And the PersistentVolume 'test-volume1' has annotations 'storage.metalk8s.scality.com/device' with value 'loop\d+'
+        And the PersistentVolume 'test-volume1' has annotations 'storage.metalk8s.scality.com/device-name' with value 'loop\d+'
         And the backing storage for Volume 'test-volume1' is created
 
     Scenario: Test volume deletion (sparseLoopDevice)

--- a/tests/post/features/volume.feature
+++ b/tests/post/features/volume.feature
@@ -28,6 +28,7 @@ Feature: Volume management
         Then the Volume 'test-volume1' is 'Available'
         And the PersistentVolume 'test-volume1' has size '10Gi'
         And the PersistentVolume 'test-volume1' has label 'random-key' with value 'random-value'
+        And the PersistentVolume 'test-volume1' has annotations 'storage.metalk8s.scality.com/device' with value 'loop\d+'
         And the backing storage for Volume 'test-volume1' is created
 
     Scenario: Test volume deletion (sparseLoopDevice)

--- a/tests/post/features/volume.feature
+++ b/tests/post/features/volume.feature
@@ -28,7 +28,7 @@ Feature: Volume management
         Then the Volume 'test-volume1' is 'Available'
         And the PersistentVolume 'test-volume1' has size '10Gi'
         And the PersistentVolume 'test-volume1' has label 'random-key' with value 'random-value'
-        And the PersistentVolume 'test-volume1' has annotations 'storage.metalk8s.scality.com/device-name' with value 'loop\d+'
+        And the Volume 'test-volume1' has device name 'loop\d+'
         And the backing storage for Volume 'test-volume1' is created
 
     Scenario: Test volume deletion (sparseLoopDevice)

--- a/tests/post/steps/test_volume.py
+++ b/tests/post/steps/test_volume.py
@@ -330,6 +330,26 @@ def check_pv_label(name, key, value, pv_client):
     )
 
 
+@then(parsers.parse(
+    "the PersistentVolume '{name}' has annotations '{key}' with value '{value}'"
+))
+def check_pv_annotations(name, key, value, pv_client):
+    def _check_pv_annotations():
+        pv = pv_client.get(name)
+        assert pv is not None, 'PersistentVolume {} not found'.format(name)
+        annotations = pv.metadata.annotations or {}
+        assert key in annotations, 'Annotations {} is missing'.format(key)
+        assert re.match(value, annotations[key]) is not None,\
+            'Unexpected value for annotations {}: expected {}, got {}'.format(
+                key, value, annotations[key]
+            )
+
+    utils.retry(
+        _check_pv_annotations, times=10, wait=2,
+        name='checking annotations of PersistentVolume {}'.format(name)
+    )
+
+
 @then(parsers.parse("the Volume '{name}' does not exist"))
 def check_volume_absent(name, volume_client):
     volume_client.wait_for_deletion(name)

--- a/tests/post/steps/test_volume.py
+++ b/tests/post/steps/test_volume.py
@@ -331,22 +331,23 @@ def check_pv_label(name, key, value, pv_client):
 
 
 @then(parsers.parse(
-    "the PersistentVolume '{name}' has annotations '{key}' with value '{value}'"
+    "the Volume '{name}' has device name '{value}'"
 ))
-def check_pv_annotations(name, key, value, pv_client):
-    def _check_pv_annotations():
-        pv = pv_client.get(name)
-        assert pv is not None, 'PersistentVolume {} not found'.format(name)
-        annotations = pv.metadata.annotations or {}
-        assert key in annotations, 'Annotations {} is missing'.format(key)
-        assert re.match(value, annotations[key]) is not None,\
-            'Unexpected value for annotations {}: expected {}, got {}'.format(
-                key, value, annotations[key]
+def check_device_name(name, value, volume_client):
+    def _check_device_name():
+        volume = volume_client.get(name)
+        assert volume is not None, 'Volume {} not found'.format(name)
+        status = volume.get('status')
+        assert status is not None, 'no status for volume {}'.format(name)
+        deviceName = status.get('deviceName', '')
+        assert re.match(value, deviceName) is not None,\
+            'Unexpected value for deviceName: expected {}, got {}'.format(
+                value, deviceName
             )
 
     utils.retry(
-        _check_pv_annotations, times=10, wait=2,
-        name='checking annotations of PersistentVolume {}'.format(name)
+        _check_device_name, times=10, wait=2,
+        name='checking deviceName of Volume {}'.format(name)
     )
 
 


### PR DESCRIPTION
**Component**:

salt, operator

**Context**: 

In order to expose I/O metrics we need a way to link a PV/Volume (which is what we expose in our UI) to the underlying block device (which is the label used to export I/O metrics). 

**Summary**:

Add a new annotation on the PV created by our operator.
This annotation contains the name of the underlying block device and is refreshed at each reconciliation iteration (because it may change in some occasion, like a reboot).

**Acceptance criteria**: 

When you create a volume, the PV should have an annotation `storage.metalk8s.scality.com/device` providing the name of the underlying block device.
A test was added to check that and should pass.

---

Closes: #2615 