### PR TITLE
CI: Split post-merge in two stages

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -512,6 +512,34 @@ stages:
           haltOnFailure: True
       - SetPropertyFromCommand: *set_version_prop
       - SetPropertyFromCommand: *set_short_version_prop
+      - TriggerStages:
+          name: Trigger post-merge lifecycle and solutions stages simultaneously
+          stage_names:
+            - post-merge-lifecycle
+            - post-merge-solutions
+          haltOnFailure: true
+      - ShellCommand: *add_final_status_artifact_success
+      - Upload: *upload_final_status_artifact
+      - TriggerStages:
+          name: Trigger TestRail objects creation and results upload
+          stage_names:
+            - create-upload-testrail-objects
+          alwaysRun: True
+
+  post-merge-solutions:
+    worker:
+      type: local
+    steps:
+      - TriggerStages:
+          name: Trigger build of Example Solution archive
+          stage_names:
+            - build-example-solution
+          haltOnFailure: true
+
+  post-merge-lifecycle:
+    worker:
+      type: local
+    steps:
       - SetPropertyFromCommand:
           name: Set previous version to upgrade from and downgrade to
           property: product_version_prev
@@ -520,10 +548,9 @@ stages:
               minor=$(echo "%(prop:product_version)s" | cut -d'.' -f2) &&
               echo "$major.$(( $minor-1 ))"
       - TriggerStages:
-          name: Trigger build of previous version and example solution simultaneously
+          name: Trigger build of previous version
           stage_names:
             - buildprev
-            - build-example-solution
           haltOnFailure: true
       - SetPropertyFromCommand:
           <<: *set_version_prop
@@ -532,20 +559,13 @@ stages:
           env:
             BASE_URL: "%(prop:artifacts_private_url)s/pre"
       - TriggerStages:
-          name: Trigger Post-merge test stages simultaneously
+          name: Trigger upgrade, downgrade and restore test stages simultaneously
           stage_names:
             - single-node-upgrade-centos
             - single-node-downgrade-centos
             - single-node-patch-version
             - bootstrap-restore
           waitForFinish: True
-      - ShellCommand: *add_final_status_artifact_success
-      - Upload: *upload_final_status_artifact
-      - TriggerStages:
-          name: Trigger TestRail objects creation and results upload
-          stage_names:
-            - create-upload-testrail-objects
-          alwaysRun: True
 
   create-upload-testrail-objects:
     worker:


### PR DESCRIPTION
**Component**: ci (post-merge)

**Context**: 
We were building previous version and example-solution in a first step, then
triggering tests on solutions and upgrade/downgrade of the platform as a second step.
If, for example, the building of example solution failed, we weren't doing the upgrade/downgrade tests, while they're not related.

**Summary**:
We now split the post-merge in two distinct parts, one for lifecycle (build previous version, upgrade, downgrade, restore) and one for solution (build solution and deploy it).
So, if one of the two builds fails, the tests for the other are still run.

This has been done to avoid losing all the benefits of the post-merge when a single component is failing.

It also reduces time needed for the post-merge tests as the Example Solution build can take ages.

**Acceptance criteria**: post-merge succeed