### PR TITLE
salt: raise if solution manifest does not exist

### DIFF
--- a/salt/_modules/metalk8s_solutions.py
+++ b/salt/_modules/metalk8s_solutions.py
@@ -315,6 +315,13 @@ def manifest_from_iso(path):
             )
         )
 
+    if not result['stdout']:
+        raise CommandExecutionError(
+            "Solution ISO at '{}' must contain a '{}' file".format(
+                path, SOLUTION_MANIFEST
+            )
+        )
+
     try:
         manifest = yaml.safe_load(result['stdout'])
     except yaml.YAMLError as exc:


### PR DESCRIPTION
**Component**: salt, solutions

**Context**:
When trying to deploy old Solution archive, without the manifest.yaml file, salt crashes with a not really clear error.

**Summary**:
We now have a clear error message when there is no manifest.yaml found at the root of the Solution archive.

**Acceptance criteria**: 
