### PR TITLE
workaround kubernetes yum repository bug

### DIFF
--- a/packages/redhat/entrypoint.sh
+++ b/packages/redhat/entrypoint.sh
@@ -97,6 +97,7 @@ download_packages() {
         "--downloadonly"
         "--releasever=$releasever"
         "--installroot=/install_root"
+        "--setopt=obsoletes=0"
     )
 
     get_rpm_gpg_keys


### PR DESCRIPTION

**Component**: buildchain, packages

**Context**:
We can no longer build development branch from 2.0 to 2.3 because of an error during packages download.

**Summary**:
Because of a change in Kubernetes Yum repository, kubernetes-cni is now obsoleted by kubelet-1.18.4, which prevents from resolving dependencies for previous kubelet versions because they depend on kubernetes-cni.

See https://github.com/kubernetes/kubernetes/issues/92242 for details.

The right thing to do would be to backport changes (related to how we fetch packages) done in development/2.4, because the way we handle it does not seem to be affected by this kind of bug.
But, there is some work to do as there is plenty of stuff to backport (at least some changes from 3 different PRs #1928, #1846 and #1714, didn't go further) in buildchain, so for now we do a quick workaround.

**Acceptance criteria**:
We can build all versions of MetalK8s