### PR TITLE
salt-api: Prevent impersonation of ServiceAccounts using Bearer tokens

### DIFF
--- a/salt/_auth/kubernetes_rbac.py
+++ b/salt/_auth/kubernetes_rbac.py
@@ -84,6 +84,11 @@ def _review_access(kubeconfig, resource, verb):
     client = kubernetes.client.ApiClient(configuration=kubeconfig)
     authz_api = kubernetes.client.AuthorizationV1Api(api_client=client)
 
+    # NOTE: any authenticated user can use this API.
+    # This comes from the fact that an authenticated user will always belong to
+    # the `system:authenticated` group, and this group is bound to the
+    # `system:basic-user` ClusterRole, which enables creating
+    # SelfSubjectAccessReviews and SelfSubjectRulesReviews.
     return authz_api.create_self_subject_access_review(
         body=kubernetes.client.V1SelfSubjectAccessReview(
             spec=kubernetes.client.V1SelfSubjectAccessReviewSpec(

--- a/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
+++ b/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
@@ -42,7 +42,7 @@ external_auth:
       - '@wheel'
       - '@runner'
       - '@jobs'
-    storage-operator:
+    'system:serviceaccount:kube-system:storage-operator':
       - '*':
         - 'disk.dump'
         - 'state.sls':

--- a/storage-operator/pkg/controller/volume/volume_controller.go
+++ b/storage-operator/pkg/controller/volume/volume_controller.go
@@ -975,16 +975,13 @@ func getAuthCredential(config *rest.Config) *salt.Credential {
 	if config.BearerToken != "" {
 		log.Info("using ServiceAccount bearer token")
 		return salt.NewCredential(
-			"storage-operator", config.BearerToken, salt.BearerToken,
+			"storage-operator", config.BearerToken, salt.Bearer,
 		)
 	} else if config.Username != "" && config.Password != "" {
 		log.Info("using Basic HTTP authentication")
-		creds := fmt.Sprintf("%s:%s", config.Username, config.Password)
-		token := b64.StdEncoding.EncodeToString([]byte(creds))
-		return salt.NewCredential(config.Username, token, salt.BasicToken)
+		return salt.NewCredential(config.Username, config.Password, salt.Basic)
 	} else {
 		log.Info("using default Basic HTTP authentication")
-		token := b64.StdEncoding.EncodeToString([]byte("admin:admin"))
-		return salt.NewCredential("admin", token, salt.BasicToken)
+		return salt.NewCredential("admin", "admin", salt.Basic)
 	}
 }

--- a/storage-operator/pkg/controller/volume/volume_controller.go
+++ b/storage-operator/pkg/controller/volume/volume_controller.go
@@ -2,7 +2,6 @@ package volume
 
 import (
 	"context"
-	b64 "encoding/base64"
 	"fmt"
 	"io/ioutil"
 	"time"
@@ -975,7 +974,10 @@ func getAuthCredential(config *rest.Config) *salt.Credential {
 	if config.BearerToken != "" {
 		log.Info("using ServiceAccount bearer token")
 		return salt.NewCredential(
-			"storage-operator", config.BearerToken, salt.Bearer,
+			// FIXME: this should depend on the actual SA used
+			"system:serviceaccount:kube-system:storage-operator",
+			config.BearerToken,
+			salt.Bearer,
 		)
 	} else if config.Username != "" && config.Password != "" {
 		log.Info("using Basic HTTP authentication")

--- a/storage-operator/pkg/controller/volume/volume_controller_test.go
+++ b/storage-operator/pkg/controller/volume/volume_controller_test.go
@@ -18,19 +18,19 @@ func TestGetAuthCredential(t *testing.T) {
 		"ServiceAccount": {
 			token: "foo", username: "", password: "",
 			expected: salt.NewCredential(
-				"storage-operator", "foo", salt.BearerToken,
+				"storage-operator", "foo", salt.Bearer,
 			),
 		},
 		"BasicAuth": {
 			token: "", username: "foo", password: "bar",
 			expected: salt.NewCredential(
-				"foo", "Zm9vOmJhcg==", salt.BasicToken,
+				"foo", "bar", salt.Basic,
 			),
 		},
 		"DefaultCreds": {
 			token: "", username: "", password: "",
 			expected: salt.NewCredential(
-				"admin", "YWRtaW46YWRtaW4=", salt.BasicToken,
+				"admin", "admin", salt.Basic,
 			),
 		},
 	}

--- a/storage-operator/pkg/controller/volume/volume_controller_test.go
+++ b/storage-operator/pkg/controller/volume/volume_controller_test.go
@@ -18,7 +18,9 @@ func TestGetAuthCredential(t *testing.T) {
 		"ServiceAccount": {
 			token: "foo", username: "", password: "",
 			expected: salt.NewCredential(
-				"storage-operator", "foo", salt.Bearer,
+				"system:serviceaccount:kube-system:storage-operator",
+				"foo",
+				salt.Bearer,
 			),
 		},
 		"BasicAuth": {

--- a/storage-operator/pkg/salt/client.go
+++ b/storage-operator/pkg/salt/client.go
@@ -325,10 +325,10 @@ func (self *Client) authenticate(ctx context.Context) error {
 		"username": self.creds.username,
 	}
 
-	if self.creds.kind == BearerToken {
-		payload["token"] = self.creds.token
+	if self.creds.kind == Bearer {
+		payload["token"] = self.creds.secret
 	} else {
-		payload["password"] = self.creds.token
+		payload["password"] = self.creds.secret
 	}
 
 	self.logger.Info(

--- a/storage-operator/pkg/salt/creds.go
+++ b/storage-operator/pkg/salt/creds.go
@@ -2,30 +2,30 @@ package salt
 
 import "fmt"
 
-type TokenType string
+type AuthType string
 
-// "Enum" representing the preparation steps of a volume.
+// Supported SaltAPI authentication methods.
 const (
-	BasicToken  TokenType = "Basic"
-	BearerToken TokenType = "Bearer"
+	Basic  AuthType = "Basic"
+	Bearer AuthType = "Bearer"
 )
 
 // Credentials for Salt API.
 type Credential struct {
-	username string    // User name.
-	token    string    // User token.
-	kind     TokenType // Token type: Basic or Bearer.
+	username string   // User name.
+	secret   string   // User secret (token or password).
+	kind     AuthType // Authentication method (can be Basic or Bearer).
 }
 
 // Create a new Salt API client.
 //
 // Arguments
 //     username: user name
-//     token:    user token
-//     kind:     token type (must be either Basic or Bearer)
-func NewCredential(username string, token string, kind TokenType) *Credential {
-	if kind != BasicToken && kind != BearerToken {
-		panic(fmt.Sprintf("invalid token type: %s", kind))
+//     secret:   user token or password (interpretation depends on authType)
+//     authType: authentication method
+func NewCredential(username string, secret string, authType AuthType) *Credential {
+	if authType != Basic && authType != Bearer {
+		panic(fmt.Sprintf("invalid authentication method: %s", authType))
 	}
-	return &Credential{username: username, token: token, kind: kind}
+	return &Credential{username: username, secret: secret, kind: authType}
 }

--- a/storage-operator/pkg/salt/creds_test.go
+++ b/storage-operator/pkg/salt/creds_test.go
@@ -9,19 +9,19 @@ import (
 func TestNewCredential(t *testing.T) {
 	tests := map[string]struct {
 		username string
-		token    string
+		secret   string
 	}{
-		"Basic":  {username: "foo", token: "bar"},
-		"Bearer": {username: "baz", token: "qux"},
+		"Basic":  {username: "foo", secret: "bar"},
+		"Bearer": {username: "baz", secret: "qux"},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			creds := NewCredential(tc.username, tc.token, TokenType(name))
+			creds := NewCredential(tc.username, tc.secret, AuthType(name))
 
 			assert.Equal(t, tc.username, creds.username)
-			assert.Equal(t, tc.token, creds.token)
-			assert.Equal(t, TokenType(name), creds.kind)
+			assert.Equal(t, tc.secret, creds.secret)
+			assert.Equal(t, AuthType(name), creds.kind)
 		})
 	}
 }

--- a/tests/post/features/salt_api.feature
+++ b/tests/post/features/salt_api.feature
@@ -9,13 +9,23 @@ Feature: SaltAPI
         And we have '@runner' perms
         And we have '@jobs' perms
 
-    Scenario: Login to SaltAPI using a ServiceAccount
+    Scenario: Login to SaltAPI using the storage-operator ServiceAccount
         Given the Kubernetes API is available
-        When we login to SaltAPI with the ServiceAccount 'storage-operator'
+        When we login to SaltAPI with the ServiceAccount 'kube-system/storage-operator'
         Then we can invoke '["disk.dump", {"state.sls": {"kwargs": {"mods": r"metalk8s\.volumes.*"}}}]' on '*'
         And we have '@jobs' perms
         And we can not ping all minions
         And we can not run state 'test.nop' on '*'
+
+    Scenario: Login to SaltAPI using any ServiceAccount
+        Given the Kubernetes API is available
+        When we login to SaltAPI with the ServiceAccount 'kube-system/default'
+        Then we have no permissions
+
+    Scenario: SaltAPI impersonation using a ServiceAccount
+        Given the Kubernetes API is available
+        When we impersonate user 'system:serviceaccount:kube-system:storage-operator' against SaltAPI using the ServiceAccount 'kube-system/default'
+        Then authentication fails
 
     Scenario: Login to SaltAPI using an incorrect password
         Given the Kubernetes API is available

--- a/tests/post/features/salt_api.feature
+++ b/tests/post/features/salt_api.feature
@@ -3,7 +3,8 @@ Feature: SaltAPI
     Scenario: Login to SaltAPI using Basic auth
         Given the Kubernetes API is available
         When we login to SaltAPI as 'admin' using password 'admin'
-        Then we can ping all minions
+        Then authentication succeeds
+        And we can ping all minions
         And we can invoke '[".*"]' on '*'
         And we have '@wheel' perms
         And we have '@runner' perms
@@ -12,7 +13,8 @@ Feature: SaltAPI
     Scenario: Login to SaltAPI using the storage-operator ServiceAccount
         Given the Kubernetes API is available
         When we login to SaltAPI with the ServiceAccount 'kube-system/storage-operator'
-        Then we can invoke '["disk.dump", {"state.sls": {"kwargs": {"mods": r"metalk8s\.volumes.*"}}}]' on '*'
+        Then authentication succeeds
+        And we can invoke '["disk.dump", {"state.sls": {"kwargs": {"mods": r"metalk8s\.volumes.*"}}}]' on '*'
         And we have '@jobs' perms
         And we can not ping all minions
         And we can not run state 'test.nop' on '*'
@@ -20,7 +22,8 @@ Feature: SaltAPI
     Scenario: Login to SaltAPI using any ServiceAccount
         Given the Kubernetes API is available
         When we login to SaltAPI with the ServiceAccount 'kube-system/default'
-        Then we have no permissions
+        Then authentication succeeds
+        And we have no permissions
 
     Scenario: SaltAPI impersonation using a ServiceAccount
         Given the Kubernetes API is available

--- a/tests/post/steps/test_salt_api.py
+++ b/tests/post/steps/test_salt_api.py
@@ -54,11 +54,8 @@ def context():
     "we login to SaltAPI as '{username}' using password '{password}'"))
 def login_salt_api_basic(host, username, password, version, context):
     address = _get_salt_api_address(host, version)
-    token = base64.encodebytes(
-        '{}:{}'.format(username, password).encode('utf-8')
-    ).rstrip()
     context['salt-api'] = _salt_api_login(
-        address, username=username, password=token
+        address, username=username, password=password
     )
 
 

--- a/tests/post/steps/test_salt_api.py
+++ b/tests/post/steps/test_salt_api.py
@@ -131,6 +131,12 @@ def run_state_on_targets(host, context, negated, module, targets):
 def authentication_fails(host, context):
     assert context['salt-api']['login-status-code'] == 401
 
+
+@then('authentication succeeds')
+def authentication_succeeds(host, context):
+    assert context['salt-api']['login-status-code'] == 200
+
+
 @then(parsers.parse("we can invoke '{modules}' on '{targets}'"))
 def invoke_module_on_target(host, context, modules, targets):
     assert {targets: ast.literal_eval(modules)} in context['salt-api']['perms']

--- a/ui/src/ducks/login.js
+++ b/ui/src/ducks/login.js
@@ -106,7 +106,6 @@ export function* authenticate({ payload }) {
       setAuthenticationSuccessAction({
         username,
         password,
-        token,
       }),
     );
     yield call(authenticateSaltApi, true);
@@ -156,7 +155,6 @@ export function* fetchUserInfo() {
       setAuthenticationSuccessAction({
         username,
         password,
-        token,
       }),
     );
     yield call(authenticateSaltApi);

--- a/ui/src/ducks/login.test.js
+++ b/ui/src/ducks/login.test.js
@@ -61,7 +61,6 @@ it('authentication success', () => {
       payload: {
         username: 'admin',
         password: 'admin',
-        token,
       },
     }),
   );
@@ -94,7 +93,6 @@ it('fetchUserInfo success', () => {
       payload: {
         username: 'test',
         password: 'test',
-        token: 'dGVzdDp0ZXN0',
       },
     }),
   );

--- a/ui/src/services/salt/api.js
+++ b/ui/src/services/salt/api.js
@@ -14,7 +14,7 @@ export function authenticate(user) {
   return saltApiClient.post('/login', {
     eauth: 'kubernetes_rbac',
     username: user.username,
-    password: user.token,
+    password: user.password,
   });
 }
 


### PR DESCRIPTION
**Note for reviewers**:

This PR adds some changes to Basic auth handling, and does so in different manners:

- in 2.4, Basic auth support in SaltAPI is maintained (through the `password` value for `POST /login`), but now uses plaintext password instead of the `user:password` base64-encoded token
- in 2.5 and upwards, Basic auth support in SaltAPI is entirely removed, and logic for having multiple handlers based on authentication method is removed - as such, we also remove this particular logic from our clients, namely `storage-operator` and `metalk8s-ui`


<details>
  <summary>Commits</summary>

### salt-api: Rework Basic auth handling

Instead of relying on the strange assumption that the /login 'password'
argument is actually the full 'user:password' base64-encoded token, we
adjust the storage-operator and metalk8s-ui to pass in this password in
cleartext.

This commit also updates the `_auth_basic` handler to rely on the same
SelfSubjectAccessReview API as the  `_groups_basic` handler did.

---

### salt-api: Prevent SA impersonation

When using ServiceAccount, we were not checking if the provided Bearer
`token` actually belonged to the claimed `username`. This is now done,
and we add tests to prevent regressions.

NOTE: storage-operator username, from SaltAPI PoV, is now
'system:serviceaccount:kube-system:storage-operator'.

Fixes: #2634

---

### tests: Add positive check for auth success

We only assessed if an authentication attempt failed, while tried to
check the actual permissions for an authn assumed successful.
To make errors more explicit, we add a `then` check that the
"authentication succeeds".

See: #2634

</details>