### PR TITLE
eve: Rename `minor` section to `minor dev` in TestRail

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -653,7 +653,7 @@ stages:
     _metalk8s_internal_info:
       junit_info: &_downgrade_minor_single-node_junit_info
         TEST_SUITE: downgrade
-        CLASS_NAME: minor.single node.centos7
+        CLASS_NAME: minor dev.single node.centos7
         TEST_NAME: simple environment
     simultaneous_builds: 20
     worker: &single_node_worker
@@ -760,7 +760,7 @@ stages:
     _metalk8s_internal_info:
       junit_info: &_upgrade_minor_single-node_junit_info
         TEST_SUITE: upgrade
-        CLASS_NAME: minor.single node.centos7
+        CLASS_NAME: minor dev.single node.centos7
         TEST_NAME: simple environment
     simultaneous_builds: 20
     worker: *single_node_worker

--- a/eve/testrail_description_file.yaml
+++ b/eve/testrail_description_file.yaml
@@ -10,9 +10,10 @@ Upgrade:
   description: >-
     Upgrade tests
   sections: &lifecycle_sections
-    Minor:
+    Minor Dev:
       description: >-
         Previous minor version tests
+        (last commit of previous development branch)
       sub_sections:
         Single Node:
           description: >-


### PR DESCRIPTION
**Component**:

'tests', 'ci', 'testrail'

**Summary**:

Since we will need to test lifecycle with minor version (released one)
rename the current `minor` section (that only contains test from
development branch) to `minor dev` so that we have a section specific to
test about non-released version and a section for released ones

---

Sees: #2276 
