### PR TITLE
salt/tests: Add unit tests for `metalk8s_grafana` salt module

### DIFF
--- a/salt/tests/unit/modules/files/test_metalk8s_grafana.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_grafana.yaml
@@ -1,0 +1,141 @@
+- dashboard: null
+  raises: True
+  result: 'Unable to load file contents'
+- dashboard: {
+    "editable": true,
+    "title": "my dashboard",
+    "tags": ["my tag"]
+  }
+  result: {
+    "editable": false,
+    "title": "my dashboard",
+    "tags": ["my tag"]
+  }
+- dashboard: {
+    "title": "my dashboard",
+    "tags": []
+  }
+  title: "my new dashboard"
+  result: {
+    "title": "my new dashboard"
+  }
+- dashboard: {
+    "title": "my dashboard",
+    "tags": []
+  }
+  tags: ["my new tag"]
+  result: {
+    "tags": ["my new tag"]
+  }
+- dashboard: {
+    "title": "my dashboard",
+    "tags": ["my tag"]
+  }
+  tags: ["my new tag"]
+  result: {
+    "tags": ["my new tag"]
+  }
+- dashboard: {
+    "title": "my dashboard",
+    "tags": []
+  }
+  datasource_variable: "my datasource"
+  result: {
+    "templating": {
+      "list": [
+        {
+          "current": {
+            "text": "Prometheus",
+            "value": "Prometheus"
+          },
+          "hide": 2,
+          "name": "my datasource",
+          "query": "prometheus",
+          "type": "datasource"
+        }
+      ]
+    }
+  }
+- dashboard: {
+    "title": "my dashboard",
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "current": {},
+          "hide": 0,
+          "name": "my first datasource",
+          "query": "prom",
+          "type": "datasource"
+        }
+      ]
+    }
+  }
+  datasource_variable: "my new datasource"
+  result: {
+    "templating": {
+      "list": [
+        {
+          "current": {
+            "text": "Prometheus",
+            "value": "Prometheus"
+          },
+          "hide": 2,
+          "name": "my new datasource",
+          "query": "prometheus",
+          "type": "datasource"
+        },
+        {
+          "current": {},
+          "hide": 0,
+          "name": "my first datasource",
+          "query": "prom",
+          "type": "datasource"
+        }
+      ]
+    }
+  }
+- dashboard: {
+    "title": "my dashboard",
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "current": {},
+          "hide": 0,
+          "name": "my first datasource",
+          "query": "prom",
+          "type": "datasource"
+        }
+      ]
+    }
+  }
+  title: "my new dashboard title"
+  tags: ["my new tag 1", "my new tag 2"]
+  datasource_variable: "my new datasource"
+  result: {
+    "editable": False,
+    "title": "my new dashboard title",
+    "tags": ["my new tag 1", "my new tag 2"],
+    "templating": {
+      "list": [
+        {
+          "current": {
+            "text": "Prometheus",
+            "value": "Prometheus"
+          },
+          "hide": 2,
+          "name": "my new datasource",
+          "query": "prometheus",
+          "type": "datasource"
+        },
+        {
+          "current": {},
+          "hide": 0,
+          "name": "my first datasource",
+          "query": "prom",
+          "type": "datasource"
+        }
+      ]
+    }
+  }  

--- a/salt/tests/unit/modules/test_metalk8s_grafana.py
+++ b/salt/tests/unit/modules/test_metalk8s_grafana.py
@@ -1,0 +1,63 @@
+import json
+import os.path
+import yaml
+
+from parameterized import param, parameterized
+
+from salttesting.mixins import LoaderModuleMockMixin
+from salttesting.unit import TestCase
+from salttesting.mock import MagicMock, patch
+
+import metalk8s_grafana
+
+
+YAML_TESTS_FILE = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "files", "test_metalk8s_grafana.yaml"
+)
+
+
+class Metalk8sGrafanaTestCase(TestCase, LoaderModuleMockMixin):
+    """
+    TestCase for `metalk8s_grafana` module
+    """
+    loader_module = metalk8s_grafana
+
+    def test_virtual(self):
+        """
+        Tests the return of `__virtual__` function
+        """
+        self.assertEqual(metalk8s_grafana.__virtual__(), 'metalk8s_grafana')
+
+    @parameterized.expand(
+        param.explicit(kwargs=test_case)
+        for test_case in yaml.safe_load(open(YAML_TESTS_FILE))
+    )
+    def test_load_dashboard(self, dashboard, result, raises=False, **kwargs):
+        """
+        Tests the return of `load_dashboard` function
+        """
+        get_file_str_mock = MagicMock(
+            return_value=json.dumps(dashboard, indent=4) if dashboard else ""
+        )
+        patch_dict = {
+            'cp.get_file_str': get_file_str_mock
+        }
+        with patch.dict(metalk8s_grafana.__salt__, patch_dict):
+            if raises:
+                self.assertRaisesRegexp(
+                    AssertionError,
+                    result,
+                    metalk8s_grafana.load_dashboard,
+                    path="my_dashboard.json",
+                    **kwargs
+                )
+            else:
+                self.assertDictContainsSubset(
+                    result,
+                    metalk8s_grafana.load_dashboard(
+                        path="my_dashboard.json",
+                        **kwargs
+                    )
+                )
+


### PR DESCRIPTION
**Component**:

'salt', 'tests'

**Context**: 

#2266 

**Summary**:

Add unit tests for `metalk8s_grafana` salt custom module, use a
dedicated yaml file containing input dashboard json and arguments
and expected result for `load_dashboard` function

---

Refs: #2266