### PR TITLE
salt: Fix missing import in `metalk8s_cordon` salt module

### DIFF
--- a/salt/_modules/metalk8s_cordon.py
+++ b/salt/_modules/metalk8s_cordon.py
@@ -4,6 +4,8 @@ Module for cordoning and uncordoning a Kubernetes node.
 This module's functions are merged into the `metalk8s_kubernetes`
 module when called by salt by virtue of its `__virtualname__` attribute.
 '''
+from salt.exceptions import CommandExecutionError
+
 
 __virtualname__ = 'metalk8s_kubernetes'
 


### PR DESCRIPTION
**Component**:

'salt'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

In `_check_deps` function in `metalk8s_cordon.py` salt module we raise a
`CommandExecutionError` but this one is not imported at all.

**Summary**:

This PR fixes this.


---
