### PR TITLE
buildchain: Pin `kubernetes-cni` version to `0.7.5`

### DIFF
--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -307,7 +307,8 @@ PACKAGE_LIST: Dict[str, Tuple[PackageVersion, ...]] = {
         PackageVersion(name='genisoimage'),
         PackageVersion(name='iproute'),
         PackageVersion(name='iptables'),
-        PackageVersion(name='kubernetes-cni'),
+        # NOTE: kubelet require `kubernetes-cni = 0.7.5`
+        PackageVersion(name='kubernetes-cni', version='0.7.5'),
         PackageVersion(name='m2crypto'),
         PackageVersion(name='runc'),
         PackageVersion(name='salt-minion', version=SALT_VERSION),


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

Unable to build `development/2.0` branch

**Summary**:

Kubelet 1.11.10 require a specific version of `kubernetes-cni` version
so we need to pin `kubernetes-cni` version we download to this specific
one which is `0.7.5`

NOTE: This PR only pin the version on `development/2.0` since `kubelet-1.12.10`+ require `kubernetes-cni >= 0.7.5`

---

Fixes: #2658

