### PR TITLE
Expose alertmanager API to the MetalK8s UI

### DIFF
--- a/salt/metalk8s/addons/ui/deployed/dependencies.sls
+++ b/salt/metalk8s/addons/ui/deployed/dependencies.sls
@@ -53,3 +53,21 @@ spec:
   ports:
     - name: http
       port: 9090
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: alertmanager-api
+  namespace: metalk8s-ui
+  labels:
+    app: metalk8s-ui
+    app.kubernetes.io/managed-by: salt
+    app.kubernetes.io/name: metalk8s-ui
+    app.kubernetes.io/part-of: metalk8s
+    heritage: metalk8s
+spec:
+  type: ExternalName
+  externalName: prometheus-operator-alertmanager.metalk8s-monitoring.svc.cluster.local
+  ports:
+    - name: http
+      port: 9093

--- a/salt/metalk8s/addons/ui/deployed/ingress.sls
+++ b/salt/metalk8s/addons/ui/deployed/ingress.sls
@@ -53,6 +53,10 @@ spec:
         backend:
           serviceName: prometheus-api
           servicePort: 9090
+      - path: /api/alertmanager(/|$)(.*)
+        backend:
+          serviceName: alertmanager-api
+          servicePort: 9093
 ---
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress


### PR DESCRIPTION
**Component**: salt, ui

**Context**: 
MetalK8s UI needs to access to Alertmanager API in order to retrieve alerts and show them. 

**Summary**:
Expose Alertmanager API through the already existing ingress `metalk8s-ui-proxies-http` in namespace `metalk8s-ui`.

**Acceptance criteria**: 
Build is green and Alertmanager is accessible through the control plane IPs of the nodes.

---

Closes: #2636
