### PR TITLE
salt/tests: Add unit tests for `metalk8s_package_manager_yum` salt module

### DIFF
--- a/salt/tests/unit/modules/files/test_metalk8s_package_manager_yum.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_package_manager_yum.yaml
@@ -1,0 +1,194 @@
+list_dependents:
+  # 3 dependents - all of them in allowed_versions
+  - repoquery_output: |
+      calico-cni-plugin 3.8.2-1.el7
+      kubelet 1.15.11-0
+      kubernetes-cni 0.7.5-0
+    allowed_versions:
+      kubelet: 1.15.11-0
+      kubernetes-cni: 0.7.5-0
+      calico-cni-plugin: 3.8.2-1.el7
+      kubectl: 1.15.11-0
+    fromrepo: "metalk8s-kubernetes"
+    result:
+      kubelet: 1.15.11-0
+      kubernetes-cni: 0.7.5-0
+      calico-cni-plugin: 3.8.2-1.el7
+
+  # 3 dependents - only one in allowed_versions
+  - repoquery_output: |
+      my_unknown_package 1.2.3
+      my_second_unknown_package 4.5.6
+      kubelet 1.15.11-0
+    allowed_versions:
+      kubelet: 1.15.11-0
+      kubernetes-cni: 0.7.5-0
+      calico-cni-plugin: 3.8.2-1.el7
+      kubectl: 1.15.11-0
+    result:
+      kubelet: 1.15.11-0
+
+  # 1 dependents - not in the allowed_versions
+  - repoquery_output: |
+      kubelet 1.15.10-0
+    allowed_versions:
+      kubelet: 1.15.11-0
+    result: {}
+
+  # 3 dependents - empty allowed_versions
+  - repoquery_output: |
+      calico-cni-plugin 3.8.2-1.el7
+      kubelet 1.15.11-0
+      kubernetes-cni 0.7.5-0
+    result: {}
+
+  # 0 dependents - empty allowed_versions
+  - repoquery_output: ""
+    result: {}
+
+  # 0 dependents - few allowed_versions
+  - repoquery_output: ""
+    allowed_versions:
+      kubelet: 1.15.11-0
+      kubernetes-cni: 0.7.5-0
+      calico-cni-plugin: 3.8.2-1.el7
+      kubectl: 1.15.11-0
+    result: {}
+
+  # Error when retrieving dependents
+  - repoquery_output: null
+    result: null
+
+list_pkg_dependents:
+  # No version specified
+  - result:
+      my_package: null
+
+  # version specified - no dependents
+  - version: "3.11.12"
+    result:
+      my_package: "3.11.12"
+
+  # version specified - no dependents - in pkgs_info
+  - version: "3.11.12"
+    pkgs_info:
+      my_package:
+        version: "3.11.12"
+    result:
+      my_package: "3.11.12"
+
+  # version specified - no dependents - version not in pkgs_info
+  - version: "3.11.13"
+    pkgs_info:
+      my_package:
+        version: "3.11.12"
+    result: null
+
+  # version specified - no dependents - package not in pkgs_info
+  - name: "my_unknown_package"
+    version: "3.11.12"
+    pkgs_info:
+      my_package:
+        version: "3.11.12"
+    result: null
+
+  # version specified - 2 dependents not installed
+  - version: "3.11.12"
+    list_dependents:
+      my_second_package: "1.11.12"
+      my_third_package: "2.14.15"
+    result:
+      my_package: "3.11.12"
+
+  # version specified - 2 dependents 1 installed in another version
+  - version: "3.11.12"
+    list_dependents:
+      my_second_package: "1.11.12"
+      package_not_yet_installed: "2.14.15"
+    rpm_qa_outputs:
+      my_package: |
+        my_package-3.11.10.el7
+      my_second_package: |
+        my_second_package-1.11.12.el7
+      package_not_yet_installed: ""
+    result:
+      my_package: "3.11.12"
+      my_second_package: "1.11.12"
+
+  # version specified - error when checking if package installed
+  - version: "3.11.12"
+    rpm_qa_outputs:
+      my_package: null
+    result: null
+
+  # Salt special case (check issue #2523)
+  - name: "salt-minion"
+    version: "3000.3"
+    rpm_qa_outputs:
+      salt-minion: |
+        salt-minion-2018.3.4-1.el7.noarch
+      salt: |
+        salt-2018.3.4-1.el7.noarch
+    result:
+      salt-minion: "3000.3"
+      salt: "3000.3"
+
+check_pkg_availability:
+  # check 0 package
+  - pkgs_info: {}
+
+  # check 1 package availabe
+  - pkgs_info:
+      my_package:
+        version: "3.11.12"
+
+  # check 3 package available
+  - pkgs_info:
+      my_first_package:
+        version: "3.11.12"
+      my_second_package:
+        version: null
+      my_third_package:
+        version: "3.10.5-0.el7"
+
+  # check 1 package not available - error when retrieving it
+  - pkgs_info:
+      nonexistent_pkg: {}
+    ybase_installs: False
+    raise_msg: "No candidate found for package: nonexistent_pkg"
+
+  # check 1 package not available with version - error when retrieving it
+  - pkgs_info:
+      nonexistent_pkg:
+        version: "3.11.12"
+    ybase_installs: False
+    raise_msg: "No candidate found for package: nonexistent_pkg-3.11.12"
+
+  # check 1 package available - error when checking dependencies
+  - pkgs_info:
+      missing_deps_pkg:
+        version: "3.11.12"
+    ybase_process_trans: False
+    raise_msg: "Some package dependencies are missing: .*"
+
+  # check 3 package (2 available, 1 not available) - error when retrieving it
+  - pkgs_info:
+      my_first_package:
+        version: "3.11.12"
+      nonexistent_pkg: {}
+      my_second_package:
+        version: null
+    ybase_installs:
+      nonexistent_pkg: False
+    raise_msg: "No candidate found for package: nonexistent_pkg"
+
+  # check 3 package available - error when checking dependencies
+  - pkgs_info:
+      my_first_package:
+        version: "3.11.12"
+      my_second_package:
+        version: null
+      my_third_package:
+        version: "3.10.5-0.el7"
+    ybase_process_trans: False
+    raise_msg: "Some package dependencies are missing: .*"

--- a/salt/tests/unit/modules/test_metalk8s_package_manager_yum.py
+++ b/salt/tests/unit/modules/test_metalk8s_package_manager_yum.py
@@ -1,0 +1,199 @@
+import os.path
+import yaml
+
+from parameterized import param, parameterized
+
+from salt.exceptions import CommandExecutionError
+
+from salttesting.mixins import LoaderModuleMockMixin
+from salttesting.unit import TestCase
+from salttesting.mock import MagicMock, patch
+from salttesting.helpers import ForceImportErrorOn
+
+from tests.unit import utils
+
+import metalk8s_package_manager_yum
+
+
+YAML_TESTS_FILE = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "files", "test_metalk8s_package_manager_yum.yaml"
+)
+with open(YAML_TESTS_FILE) as fd:
+    YAML_TESTS_CASES = yaml.safe_load(fd)
+
+
+class Metalk8sPackageManagerYumTestCase(TestCase, LoaderModuleMockMixin):
+    """
+    TestCase for `metalk8s_package_manager_yum` module
+    """
+    loader_module = metalk8s_package_manager_yum
+    loader_module_globals = {
+        "__grains__": {
+            "os_family": "RedHat"
+        }
+    }
+
+    def test_virtual_success(self):
+        """
+        Tests the return of `__virtual__` function, success
+        """
+        with patch.dict("sys.modules", yum=MagicMock()):
+            reload(metalk8s_package_manager_yum)
+            self.assertEqual(
+                metalk8s_package_manager_yum.__virtual__(),
+                'metalk8s_package_manager'
+            )
+
+    def test_virtual_fail_import(self):
+        """
+        Tests the return of `__virtual__` function, unable to import yum
+        """
+        with ForceImportErrorOn("yum"):
+            reload(metalk8s_package_manager_yum)
+            self.assertEqual(
+                metalk8s_package_manager_yum.__virtual__(),
+                False
+            )
+
+    @parameterized.expand(
+        param.explicit(kwargs=test_case)
+        for test_case in YAML_TESTS_CASES["list_dependents"]
+    )
+    def test_list_dependents(self, repoquery_output, result, **kwargs):
+        """
+        Tests the return of `_list_dependents` function
+        """
+        if repoquery_output is None:
+            repoquery_cmd_kwargs = {
+                'retcode': 1,
+                'stderr': 'An error has occured'
+            }
+        else:
+            repoquery_cmd_kwargs = {
+                'stdout': repoquery_output
+            }
+
+        repoquery_cmd_mock = MagicMock(
+            return_value=utils.cmd_output(**repoquery_cmd_kwargs)
+        )
+
+        with patch.dict(metalk8s_package_manager_yum.__salt__,
+                        {'cmd.run_all': repoquery_cmd_mock}):
+            self.assertEqual(
+                metalk8s_package_manager_yum._list_dependents(
+                    "my_package",
+                    "1.2.3",
+                    **kwargs
+                ),
+                result
+            )
+            repoquery_cmd_mock.assert_called_once()
+            self.assertEqual(
+                repoquery_cmd_mock.call_args[0][0][0],
+                "repoquery"
+            )
+            if "fromrepo" in kwargs:
+                self.assertIn(
+                    kwargs["fromrepo"],
+                    repoquery_cmd_mock.call_args[0][0]
+                )
+
+    @parameterized.expand(
+        param.explicit(kwargs=test_case)
+        for test_case in YAML_TESTS_CASES["list_pkg_dependents"]
+    )
+    def test_list_pkg_dependents(self, result,
+                                 list_dependents=None, rpm_qa_outputs=None,
+                                 **kwargs):
+        """
+        Tests the return of `list_pkg_dependents` function
+        """
+        def _rpm_qa_cmd(command):
+            out_kwargs = {}
+            if command[0] == 'rpm' and command[1] == '-qa':
+                # rpm_qa_outputs == None means nothings installed so
+                # `rpm -qa <package>` return "" and retcode 0
+                if rpm_qa_outputs is not None:
+                    if isinstance(rpm_qa_outputs, dict):
+                        if rpm_qa_outputs.get(command[2]) is None:
+                            out_kwargs['retcode'] = 1
+                            out_kwargs['stderr'] = 'An error has occured'
+                        else:
+                            out_kwargs['stdout'] = rpm_qa_outputs[command[2]]
+                    else:
+                        out_kwargs['stdout'] = rpm_qa_outputs
+                return utils.cmd_output(**out_kwargs)
+            return None
+
+        salt_dict = {
+            'cmd.run_all': MagicMock(side_effect=_rpm_qa_cmd)
+        }
+        list_dependents_mock = MagicMock(
+            return_value={} if list_dependents is None else list_dependents
+        )
+
+        with patch.dict(metalk8s_package_manager_yum.__salt__, salt_dict), \
+                patch("metalk8s_package_manager_yum._list_dependents",
+                      list_dependents_mock):
+            self.assertEqual(
+                metalk8s_package_manager_yum.list_pkg_dependents(
+                    kwargs.pop("name", "my_package"),
+                    **kwargs
+                ),
+                result
+            )
+
+    @parameterized.expand(
+        param.explicit(kwargs=test_case)
+        for test_case in YAML_TESTS_CASES["check_pkg_availability"]
+    )
+    def test_check_pkg_availability(self, pkgs_info, raise_msg=None,
+                                    ybase_installs=True,
+                                    ybase_process_trans=True):
+        """
+        Tests the return of `check_pkg_availability` function
+        """
+        def _ybase_install(name, *_args, **_kwargs):
+            success = True
+
+            if ybase_installs is False:
+                success = False
+            elif isinstance(ybase_installs, dict):
+                success = ybase_installs.get(name, True)
+            else:
+                return ybase_installs
+
+            if success:
+                return True
+            raise Exception("An error has occurred")
+
+        ybase_mock = MagicMock()
+
+        install_mock = ybase_mock.return_value.install
+        install_mock.side_effect = _ybase_install
+        process_trans_mock = ybase_mock.return_value.processTransaction
+        if ybase_process_trans:
+            process_trans_mock.return_value = True
+        else:
+            process_trans_mock.side_effect = Exception("An error has occurred")
+
+        with patch.dict("sys.modules", {"yum": MagicMock()}):
+            reload(metalk8s_package_manager_yum)
+            with patch("yum.YumBase", ybase_mock), \
+                    patch("yum.Errors.InstallError", Exception), \
+                    patch("yum.Errors.YumDownloadError", Exception), \
+                    patch("yum.Errors.YumRPMCheckError", Exception), \
+                    patch("logging.getLogger", MagicMock()):
+                if raise_msg:
+                    self.assertRaisesRegexp(
+                        CommandExecutionError,
+                        raise_msg,
+                        metalk8s_package_manager_yum.check_pkg_availability,
+                        pkgs_info
+                    )
+                else:
+                    # This function does not return anything
+                    metalk8s_package_manager_yum.check_pkg_availability(
+                        pkgs_info
+                    )


### PR DESCRIPTION
**Component**:

'salt', 'tests'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

#2266 

**Summary**:

Add unit tests for `metalk8s_package_manager_yum` salt custom module,
use a dedicated yaml file containing input, arguments and expected
result for some functions

NOTE: This PR does not test `metalk8s_package_manager_apt` as right now it does not work as expected and it's not used

---

Refs: #2266
