### PR TITLE
salt/tests: Add unit tests for `metalk8s_kubernetes` salt module

### DIFF
--- a/salt/tests/requirements.in
+++ b/salt/tests/requirements.in
@@ -4,3 +4,4 @@ salttesting == 2018.9.21
 mock == 3.0.5
 parameterized == 0.7.4
 etcd3 != 0.11.0
+kubernetes

--- a/salt/tests/requirements.txt
+++ b/salt/tests/requirements.txt
@@ -16,10 +16,14 @@ backports-abc==0.5 \
     --hash=sha256:033be54514a03e255df75c5aee8f9e672f663f93abb723444caec8fe43437bde \
     --hash=sha256:52089f97fe7a9aa0d3277b220c1d730a85aefd64e1b2664696fe35317c5470a7 \
     # via salt
+cachetools==3.1.1 \
+    --hash=sha256:428266a1c0d36dc5aca63a2d7c5942e88c2c898d72139fca0e97fdd2380517ae \
+    --hash=sha256:8ea2d3ce97850f31e4a08b0e2b5e6c34997d7216a9d2c98e0f3978630d4da69a \
+    # via google-auth
 certifi==2020.6.20 \
     --hash=sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3 \
     --hash=sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41 \
-    # via requests
+    # via kubernetes, requests
 chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
@@ -47,6 +51,10 @@ futures==3.3.0 \
     --hash=sha256:49b3f5b064b6e3afc3316421a3f25f66c137ae88f068abbf72830170033c5e16 \
     --hash=sha256:7e033af76a5e35f58e56da7a91e687706faf4e7bdfb2cbc3f2cca6b9bcda9794 \
     # via grpcio, salt, tenacity
+google-auth==1.19.2 \
+    --hash=sha256:15b42d57d6c3d868d318e8273c06b2692fc5aad1bc45989a4f68f1fee05d41b2 \
+    --hash=sha256:f404448f3d3c91944b1d907427d4a0c48f465898e9dbacf1bdebf95c5fe03273 \
+    # via kubernetes
 grpcio==1.30.0 \
     --hash=sha256:08362b8b09562179b14db6ffce4b88e1a6a6edac8bccb85dd35f7b214fa5a0f5 \
     --hash=sha256:09bea7902adc33620d68462671942e163ab12214073ffb613d2fef3df94254f6 \
@@ -88,10 +96,17 @@ importlib-metadata==1.7.0 \
     --hash=sha256:90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83 \
     --hash=sha256:dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070 \
     # via pluggy
+ipaddress==1.0.23 \
+    --hash=sha256:6e0f4a39e66cb5bb9a137b00276a2eff74f93b71dcbdad6f10ff7df9d3557fcc \
+    --hash=sha256:b7f8e0369580bb4a24d5ba1d7cc29660a4a6987763faf1d8a8046830e020e7e2 \
+    # via kubernetes
 jinja2==2.11.2 \
     --hash=sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0 \
     --hash=sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035 \
     # via salt
+kubernetes==11.0.0 \
+    --hash=sha256:1a2472f8b01bc6aa87e3a34781f859bded5a5c8ff791a53d889a8bd6cc550430 \
+    --hash=sha256:4af81201520977139a143f96123fb789fa351879df37f122916b9b6ed050bbaf
 markupsafe==1.1.1 \
     --hash=sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473 \
     --hash=sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161 \
@@ -162,6 +177,10 @@ msgpack==0.6.2 \
     --hash=sha256:ea3c2f859346fcd55fc46e96885301d9c2f7a36d453f5d8f2967840efa1e1830 \
     --hash=sha256:f0f47bafe9c9b8ed03e19a100a743662dd8c6d0135e684feea720a0d0046d116 \
     # via salt
+oauthlib==3.1.0 \
+    --hash=sha256:bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889 \
+    --hash=sha256:df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea \
+    # via requests-oauthlib
 parameterized==0.7.4 \
     --hash=sha256:190f8cc7230eee0b56b30d7f074fd4d165f7c45e6077582d0813c8557e738490 \
     --hash=sha256:59ab908e31c01505a987a2be78854e19cb1630c047bbab7848169c371d614d56
@@ -193,29 +212,41 @@ protobuf==3.12.2 \
     --hash=sha256:eafe9fa19fcefef424ee089fb01ac7177ff3691af7cc2ae8791ae523eb6ca907 \
     --hash=sha256:f4b73736108a416c76c17a8a09bc73af3d91edaa26c682aaa460ef91a47168d3 \
     # via etcd3
-psutil==5.7.0 \
-    --hash=sha256:1413f4158eb50e110777c4f15d7c759521703bd6beb58926f1d562da40180058 \
-    --hash=sha256:298af2f14b635c3c7118fd9183843f4e73e681bb6f01e12284d4d70d48a60953 \
-    --hash=sha256:60b86f327c198561f101a92be1995f9ae0399736b6eced8f24af41ec64fb88d4 \
-    --hash=sha256:685ec16ca14d079455892f25bd124df26ff9137664af445563c1bd36629b5e0e \
-    --hash=sha256:73f35ab66c6c7a9ce82ba44b1e9b1050be2a80cd4dcc3352cc108656b115c74f \
-    --hash=sha256:75e22717d4dbc7ca529ec5063000b2b294fc9a367f9c9ede1f65846c7955fd38 \
-    --hash=sha256:a02f4ac50d4a23253b68233b07e7cdb567bd025b982d5cf0ee78296990c22d9e \
-    --hash=sha256:d008ddc00c6906ec80040d26dc2d3e3962109e40ad07fd8a12d0284ce5e0e4f8 \
-    --hash=sha256:d84029b190c8a66a946e28b4d3934d2ca1528ec94764b180f7d6ea57b0e75e26 \
-    --hash=sha256:e2d0c5b07c6fe5a87fa27b7855017edb0d52ee73b71e6ee368fae268605cc3f5 \
-    --hash=sha256:f344ca230dd8e8d5eee16827596f1c22ec0876127c28e800d7ae20ed44c4b310 \
+psutil==5.7.2 \
+    --hash=sha256:0ee3c36428f160d2d8fce3c583a0353e848abb7de9732c50cf3356dd49ad63f8 \
+    --hash=sha256:10512b46c95b02842c225f58fa00385c08fa00c68bac7da2d9a58ebe2c517498 \
+    --hash=sha256:4080869ed93cce662905b029a1770fe89c98787e543fa7347f075ade761b19d6 \
+    --hash=sha256:5e9d0f26d4194479a13d5f4b3798260c20cecf9ac9a461e718eb59ea520a360c \
+    --hash=sha256:66c18ca7680a31bf16ee22b1d21b6397869dda8059dbdb57d9f27efa6615f195 \
+    --hash=sha256:68d36986ded5dac7c2dcd42f2682af1db80d4bce3faa126a6145c1637e1b559f \
+    --hash=sha256:90990af1c3c67195c44c9a889184f84f5b2320dce3ee3acbd054e3ba0b4a7beb \
+    --hash=sha256:a5b120bb3c0c71dfe27551f9da2f3209a8257a178ed6c628a819037a8df487f1 \
+    --hash=sha256:d8a82162f23c53b8525cf5f14a355f5d1eea86fa8edde27287dd3a98399e4fdf \
+    --hash=sha256:f2018461733b23f308c298653c8903d32aaad7873d25e1d228765e91ae42c3f2 \
+    --hash=sha256:ff1977ba1a5f71f89166d5145c3da1cea89a0fdb044075a12c720ee9123ec818 \
     # via salttesting
 py==1.9.0 \
     --hash=sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2 \
     --hash=sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342 \
     # via pytest
+pyasn1-modules==0.2.8 \
+    --hash=sha256:905f84c712230b2c592c19470d3ca8d552de726050d1d1716282a1f6146be65e \
+    --hash=sha256:a50b808ffeb97cb3601dd25981f6b016cbb3d31fbf57a8b8a87428e6158d0c74 \
+    # via google-auth
+pyasn1==0.4.8 \
+    --hash=sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d \
+    --hash=sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba \
+    # via pyasn1-modules, rsa
 pycrypto==2.6.1 \
     --hash=sha256:f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c \
     # via salt
 pytest==4.3.1 \
     --hash=sha256:592eaa2c33fae68c7d75aacf042efc9f77b27c08a6224a4f59beab8d9a420523 \
     --hash=sha256:ad3ad5c450284819ecde191a654c09b0ec72257a2c711b9633d677c71c9850c4
+python-dateutil==2.8.1 \
+    --hash=sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c \
+    --hash=sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a \
+    # via kubernetes
 pyyaml==5.3.1 \
     --hash=sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97 \
     --hash=sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76 \
@@ -228,7 +259,7 @@ pyyaml==5.3.1 \
     --hash=sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d \
     --hash=sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c \
     --hash=sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a \
-    # via salt
+    # via kubernetes, salt
 pyzmq==19.0.1 \
     --hash=sha256:07fb8fe6826a229dada876956590135871de60dbc7de5a18c3bcce2ed1f03c98 \
     --hash=sha256:13a5638ab24d628a6ade8f794195e1a1acd573496c3b85af2f1183603b7bf5e0 \
@@ -259,10 +290,18 @@ pyzmq==19.0.1 \
     --hash=sha256:f9d7e742fb0196992477415bb34366c12e9bb9a0699b8b3f221ff93b213d7bec \
     --hash=sha256:faee2604f279d31312bc455f3d024f160b6168b9c1dde22bf62d8c88a4deca8e \
     # via salt
+requests-oauthlib==1.3.0 \
+    --hash=sha256:7f71572defaecd16372f9006f33c2ec8c077c3cfa6f5911a9a90202beb513f3d \
+    --hash=sha256:b4261601a71fd721a8bd6d7aa1cc1d6a8a93b4a9f5e96626f8e4d91e8beeaa6a \
+    # via kubernetes
 requests==2.24.0 \
     --hash=sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b \
     --hash=sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898 \
-    # via salt
+    # via kubernetes, requests-oauthlib, salt
+rsa==4.0 \
+    --hash=sha256:14ba45700ff1ec9eeb206a2ce76b32814958a98e372006c8fb76ba820211be66 \
+    --hash=sha256:1a836406405730121ae9823e19c6e806c62bbad73f890574fff50efa4122c487 \
+    # via google-auth
 salt==3000.3 \
     --hash=sha256:fcca49985e697d914e5a7f34b2fd8bbd833bcf7779d30174a279a4de2294cea7
 salttesting==2018.9.21 \
@@ -287,20 +326,23 @@ singledispatch==3.4.0.3 \
 six==1.15.0 \
     --hash=sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259 \
     --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced \
-    # via etcd3, grpcio, mock, more-itertools, pathlib2, protobuf, pytest, salttesting, singledispatch, tenacity
+    # via etcd3, google-auth, grpcio, kubernetes, mock, more-itertools, pathlib2, protobuf, pytest, python-dateutil, salttesting, singledispatch, tenacity, websocket-client
 tenacity==6.2.0 \
     --hash=sha256:29ae90e7faf488a8628432154bb34ace1cca58244c6ea399fd33f066ac71339a \
     --hash=sha256:5a5d3dcd46381abe8b4f82b5736b8726fd3160c6c7161f53f8af7f1eb9b82173 \
     # via etcd3
-typing==3.7.4.1 \
-    --hash=sha256:91dfe6f3f706ee8cc32d38edbbf304e9b7583fb37108fef38229617f8b3eba23 \
-    --hash=sha256:c8cabb5ab8945cd2f54917be357d134db9cc1eb039e59d1606dc1e60cb1d9d36 \
-    --hash=sha256:f38d83c5a7a7086543a0f649564d661859c5146a85775ab90c0d2f93ffaa9714 \
+typing==3.7.4.3 \
+    --hash=sha256:1187fb9c82fd670d10aa07bbb6cfcfe4bdda42d6fab8d5134f04e8c4d0b71cc9 \
+    --hash=sha256:283d868f5071ab9ad873e5e52268d611e851c870a2ba354193026f2dfb29d8b5 \
     # via tenacity
 urllib3==1.25.9 \
     --hash=sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527 \
     --hash=sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115 \
-    # via requests
+    # via kubernetes, requests
+websocket-client==0.57.0 \
+    --hash=sha256:0fc45c961324d79c781bab301359d5a1b00b13ad1b10415a4780229ef71a5549 \
+    --hash=sha256:d735b91d6d1692a6a181f2a8c9e0238e5f6373356f561bb9dc4c7af36f452010 \
+    # via kubernetes
 zipp==1.2.0 \
     --hash=sha256:c70410551488251b0fee67b460fb9a536af8d6f9f008ad10ac51f615b6a521b1 \
     --hash=sha256:e0d9e63797e483a30d27e09fffd308c59a700d365ec34e93cc100844168bf921 \

--- a/salt/tests/unit/modules/files/test_metalk8s_kubernetes.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_kubernetes.yaml
@@ -1,0 +1,519 @@
+# Tests that can be run by different `metalk8s_kubernetes` functions
+common_tests:
+  # Error missing args
+  - raises: True
+    result: 'Must provide one of .* to .* object'
+
+  # Error invalid manifest
+  - manifest:
+      invalid: manifest
+      content: wrong
+      a: b
+    info_scope: null
+    raises: True
+    result: "Invalid manifest: An error has occurred"
+
+  # Error giving manifest and name (manifest file path)
+  - name: /path/to/my/manifest.yaml
+    manifest:
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: my_node
+    raises: True
+    result: 'Cannot use both "manifest" and "name".'
+
+  # Error reading manifest file
+  - name: /invalid/path/manifest.yaml
+    manifest_file_content: null
+    raises: True
+    result: 'Failed to read file "/invalid/path/manifest.yaml": An error has occurred'
+
+  # Invalid YAML manifest file
+  - name: /path/to/my/invalid-manifest.yaml
+    manifest_file_content: False
+    raises: True
+    result: 'Invalid YAML in file "/path/to/my/invalid-manifest.yaml": An error has occurred'
+
+create_object:
+  # Simple manifest without labels
+  - manifest:
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: my_node
+    result: &simple_node_create_result
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: my_node
+        labels:
+          metalk8s.scality.com/version: unknown
+          app.kubernetes.io/managed-by: salt
+          heritage: salt
+
+  # Simple manifest with labels
+  - manifest:
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: my_node
+        labels:
+          my.first.label: First
+          my.second.label: Second
+    result:
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: my_node
+        labels:
+          my.first.label: First
+          my.second.label: Second
+          metalk8s.scality.com/version: unknown
+          app.kubernetes.io/managed-by: salt
+          heritage: salt
+
+  # Simple manifest with saltenv (matching version)
+  - manifest:
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: my_node
+    saltenv: metalk8s-2.5.0
+    result:
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: my_node
+        labels:
+          metalk8s.scality.com/version: 2.5.0
+          app.kubernetes.io/managed-by: salt
+          heritage: salt
+
+  # Simple manifest with saltenv (NOT matching version)
+  - manifest:
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: my_node
+    saltenv: my-custom-salt-env
+    result: *simple_node_create_result
+
+  # Simple manifest using manifest file
+  - name: /path/to/my/manifest.yaml
+    manifest_file_content:
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: my_node
+    result: *simple_node_create_result
+
+  # Error when creating object
+  - manifest:
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: my_node
+    api_status_code: 0
+    raises: True
+    result: |
+      Failed to create object: \(0\)
+      Reason: An error has occurred
+
+delete_object:
+  # Simple Pod deletion (using manifest) - No namespace
+  - manifest:
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: my_pod
+    called_with:
+      name: my_pod
+      namespace: null
+    result: "<my_pod deleted object dict>"
+
+  # Simple Pod deletion (using manifest)
+  - manifest:
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: my_pod
+        namespace: my-custom-namespace
+    called_with:
+      name: my_pod
+      namespace: my-custom-namespace
+    result: "<my_pod deleted object dict>"
+
+  # Simple Pod deletion (no manifest) - No namespace
+  - apiVersion: v1
+    kind: Pod
+    name: my_pod
+    called_with:
+      name: my_pod
+      namespace: default
+    result: "<my_pod deleted object dict>"
+
+  # Simple Pod deletion (no manifest)
+  - apiVersion: v1
+    kind: Pod
+    name: my_pod
+    namespace: my-custom-namespace
+    called_with:
+      name: my_pod
+      namespace: my-custom-namespace
+    result: "<my_pod deleted object dict>"
+
+  # Simple already deleted Pod deletion (raise 404, expected)
+  - apiVersion: v1
+    kind: Pod
+    name: my_already_deleted_pod
+    api_status_code: 404
+    called_with:
+      name: my_already_deleted_pod
+      namespace: default
+    result: null
+
+  # Error when deleting object
+  - apiVersion: v1
+    kind: Pod
+    name: my_pod
+    api_status_code: 0
+    raises: True
+    result: |
+      Failed to delete object: \(0\)
+      Reason: An error has occurred
+
+replace_object:
+  # Simple replace object (same behavior as create)
+  - manifest:
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: my_node
+    called_with:
+      name: my_node
+    result: *simple_node_create_result
+
+  # Simple replace object - with old_object
+  - manifest:
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: my_node
+    old_object: &simple_old_node_object
+      # Old object is considered as k8s object so snake case
+      api_version: v1
+      kind: Node
+      metadata:
+        name: my_node
+        resource_version: "123456"
+    result: &simple_node_replace_result
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: my_node
+        labels:
+          metalk8s.scality.com/version: unknown
+          app.kubernetes.io/managed-by: salt
+          heritage: salt
+        resourceVersion: "123456"
+
+  # Simple replace object - with old_object (resourceVersion overrided)
+  - manifest:
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: my_node
+        resourceVersion: "987654"
+    old_object: *simple_old_node_object
+    result: *simple_node_replace_result
+
+  # Replace custom object - with old_object
+  - manifest:
+      apiVersion: custom/v1
+      kind: MyCustomObject
+      metadata:
+        name: my_object
+    old_object:
+      # For custom object we keep YAML style as k8s object do not exists in
+      # python-kubernetes
+      apiVersion: custom/v1
+      kind: MyCustomObject
+      metadata:
+        name: my_object
+        resourceVersion: "123456"
+    result:
+      apiVersion: custom/v1
+      kind: MyCustomObject
+      metadata:
+        name: my_object
+        labels:
+          metalk8s.scality.com/version: unknown
+          app.kubernetes.io/managed-by: salt
+          heritage: salt
+        resourceVersion: "123456"
+
+    # Replace service object (special case we need to keep cluster_ip)
+  - manifest:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: my_service
+    old_object:
+      # Old object is considered as k8s object so snake case
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: my_service
+        resource_version: "123456"
+      spec:
+        cluster_ip: "10.11.12.13"
+    result:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: my_service
+        labels:
+          metalk8s.scality.com/version: unknown
+          app.kubernetes.io/managed-by: salt
+          heritage: salt
+        resourceVersion: "123456"
+      spec:
+        clusterIP: "10.11.12.13"
+
+  # Error when replacing object
+  - manifest:
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: my_node
+    api_status_code: 0
+    raises: True
+    result: |
+      Failed to replace object: \(0\)
+      Reason: An error has occurred
+
+get_object:
+  # Simple Get Pod (using manifest) - No namespace
+  - manifest:
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: my_node
+    called_with:
+      name: my_node
+      namespace: null
+    result: "<my_node object dict>"
+
+  # Simple Get Pod (using manifest)
+  - manifest:
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: my_pod
+        namespace: my-custom-namespace
+    called_with:
+      name: my_pod
+      namespace: my-custom-namespace
+    result: "<my_pod object dict>"
+
+  # Simple Get Pod  (no manifest) - No namespace
+  - apiVersion: v1
+    kind: Pod
+    name: my_pod
+    called_with:
+      name: my_pod
+      namespace: default
+    result: "<my_pod object dict>"
+
+  # Simple Pod deletion (no manifest)
+  - apiVersion: v1
+    kind: Pod
+    name: my_pod
+    namespace: my-custom-namespace
+    called_with:
+      name: my_pod
+      namespace: my-custom-namespace
+    result: "<my_pod object dict>"
+
+  # Simple Get unexisting Pod (raise 404, expected)
+  - apiVersion: v1
+    kind: Pod
+    name: my_absent_pod
+    api_status_code: 404
+    called_with:
+      name: my_absent_pod
+      namespace: default
+    result: null
+
+  # Error when retrieving object
+  - apiVersion: v1
+    kind: Pod
+    name: my_pod
+    api_status_code: 0
+    raises: True
+    result: |
+      Failed to retrieve object: \(0\)
+      Reason: An error has occurred
+
+update_object:
+  # Simple Node update (using manifest)
+  - manifest:
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: my_node
+        labels:
+          my.new.label: my-new-label
+    initial_obj:
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: my_node
+    called_with: &simple_node_update_called_with
+      name: my_node
+      body:
+        metadata:
+          labels:
+            my.new.label: my-new-label
+    result: &simple_node_update_result
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: my_node
+        labels:
+          my.new.label: my-new-label
+
+  # Simple Node update
+  - apiVersion: v1
+    kind: Node
+    name: my_node
+    patch:
+      metadata:
+        labels:
+          my.new.label: my-new-label
+    initial_obj:
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: my_node
+    called_with: *simple_node_update_called_with
+    result: *simple_node_update_result
+
+  # Error patch arg missing
+  - apiVersion: v1
+    kind: Node
+    name: my_node
+    raises: True
+    result: 'Must provide one of "manifest" or "name" \(path to a file\) or "name" and "kind" and "apiVersion" and "patch" to update object.'
+
+  # Error when updating object
+  - apiVersion: v1
+    kind: Node
+    name: my_node
+    patch:
+      metadata:
+        labels:
+          my.new.label: my-new-label
+    raises: True
+    result: |
+      Failed to update object: \(0\)
+      Reason: An error has occurred
+
+list_objects:
+  # Simple list Pod
+  - apiVersion: v1
+    kind: Pod
+    called_with:
+      namespace: default
+    result: &list_object_result
+      - "<my first object dict>"
+      - "<my second object dict>"
+
+  # Simple list Node
+  - apiVersion: v1
+    kind: Node
+    info_scope: cluster
+    result: *list_object_result
+
+  # List Pod for a specific namespace
+  - apiVersion: v1
+    kind: Pod
+    namespace: my-custom-namespace
+    called_with:
+      namespace: my-custom-namespace
+    result: *list_object_result
+
+  # List Pod for all namespace
+  - apiVersion: v1
+    kind: Pod
+    all_namespaces: True
+    called_with:
+      all_namespaces: True
+    result: *list_object_result
+
+  # List with field_selector
+  - apiVersion: v1
+    kind: Pod
+    namespace: my-custom-namespace
+    field_selector: "spec.nodeName=my_node"
+    called_with:
+      namespace: my-custom-namespace
+      field_selector: "spec.nodeName=my_node"
+    result: *list_object_result
+
+  # List with label_selector
+  - apiVersion: v1
+    kind: Pod
+    label_selector: "my.simple.label=abcd"
+    called_with:
+      label_selector: "my.simple.label=abcd"
+    result: *list_object_result
+
+  # List all_namespace with field_selector and label_selector
+  - apiVersion: v1
+    kind: Pod
+    all_namespaces: True
+    field_selector: "spec.nodeName=my_node"
+    label_selector: "my.simple.label=abcd"
+    called_with:
+      all_namespaces: True
+      field_selector: "spec.nodeName=my_node"
+      label_selector: "my.simple.label=abcd"
+    result: *list_object_result
+
+  # Invalid object listing
+  - apiVersion: v1
+    kind: MyInvalidKind
+    info_scope: null
+    raises: True
+    result: 'Unsupported resource "v1/MyInvalidKind": An error has occurred'
+
+  # Error when listing namespaced resource (default namespace)
+  - apiVersion: v1
+    kind: Pod
+    api_status_code: 0
+    raises: True
+    result: |-
+      Failed to list resources "v1/Pod" in namespace "default": \(0\)
+      Reason: An error has occurred
+
+  # Error when listing namespaced resource (specified namespace)
+  - apiVersion: v1
+    kind: Pod
+    namespace: my-custom-namespace
+    api_status_code: 0
+    raises: True
+    result: |-
+      Failed to list resources "v1/Pod" in namespace "my-custom-namespace": \(0\)
+      Reason: An error has occurred
+
+  # Error when listing cluster resource
+  - apiVersion: v1
+    kind: Node
+    info_scope: cluster
+    api_status_code: 0
+    raises: True
+    result: |-
+      Failed to list resources "v1/Node": \(0\)
+      Reason: An error has occurred

--- a/salt/tests/unit/modules/test_metalk8s_kubernetes.py
+++ b/salt/tests/unit/modules/test_metalk8s_kubernetes.py
@@ -1,0 +1,560 @@
+import os.path
+import yaml
+
+from parameterized import param, parameterized
+
+from kubernetes.client.rest import ApiException
+from salt.utils import dictupdate
+from salt.exceptions import CommandExecutionError
+
+from salttesting.mixins import LoaderModuleMockMixin
+from salttesting.unit import TestCase
+from salttesting.mock import MagicMock, patch
+from salttesting.helpers import ForceImportErrorOn
+
+import metalk8s_kubernetes
+
+
+YAML_TESTS_FILE = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "files", "test_metalk8s_kubernetes.yaml"
+)
+with open(YAML_TESTS_FILE) as fd:
+    YAML_TESTS_CASES = yaml.safe_load(fd)
+
+
+class Metalk8sKubernetesTestCase(TestCase, LoaderModuleMockMixin):
+    """
+    TestCase for `metalk8s_kubernetes` module
+    """
+    loader_module = metalk8s_kubernetes
+
+    @staticmethod
+    def loader_module_globals():
+        def _manifest_to_object_mock(manifest, **_):
+            # Simulate k8s object for key used in the module
+            # It's not really robust but here we only test the
+            # `metalk8s_kubernetes` module
+            obj = MagicMock()
+
+            obj.api_version = manifest.get('apiVersion')
+            obj.kind = manifest.get('kind')
+
+            meta = manifest.get('metadata', {})
+            obj.metadata.name = meta.get('name')
+            obj.metadata.namespace = meta.get('namespace')
+            obj.metadata.resourceVersion = meta.get('resourceVersion')
+            obj.metadata.resource_version = meta.get('resource_version')
+
+            obj.spec.cluster_ip = manifest.get('spec', {}).get('cluster_ip')
+
+            def _to_dict():
+                if obj.metadata.resourceVersion:
+                    meta['resourceVersion'] = obj.metadata.resourceVersion
+                if obj.metadata.resource_version:
+                    meta['resourceVersion'] = obj.metadata.resource_version
+                if obj.spec.cluster_ip:
+                    manifest.setdefault('spec', {})['clusterIP'] = \
+                        obj.spec.cluster_ip
+
+                return manifest
+
+            obj.to_dict.side_effect = _to_dict
+
+            return obj
+
+        return {
+            '__utils__': {
+                'metalk8s_kubernetes.get_kind_info': MagicMock(),
+                'metalk8s_kubernetes.convert_manifest_to_object': MagicMock(
+                    side_effect=_manifest_to_object_mock
+                ),
+            },
+            '__salt__': {
+                'metalk8s_kubernetes.get_kubeconfig': MagicMock(
+                    return_value=('/my/kube/config', 'my-context')
+                )
+            }
+        }
+
+    def test_virtual_success(self):
+        """
+        Tests the return of `__virtual__` function, success
+        """
+        reload(metalk8s_kubernetes)
+        self.assertEqual(
+            metalk8s_kubernetes.__virtual__(),
+            'metalk8s_kubernetes'
+        )
+
+    @parameterized.expand([
+        'kubernetes.client',
+        ('urllib3.exceptions', 'urllib3')
+    ])
+    def test_virtual_fail_import(self, import_error_on, dep_error=None):
+        """
+        Tests the return of `__virtual__` function, fail import
+        """
+        with ForceImportErrorOn(import_error_on):
+            reload(metalk8s_kubernetes)
+            self.assertEqual(
+                metalk8s_kubernetes.__virtual__(),
+                (False, 'Missing dependencies: {}'.format(
+                    dep_error or import_error_on
+                ))
+            )
+
+    def test_virtual_no_utils(self):
+        """
+        Tests the return of `__virtual__` function, missing kubernetes utils
+        """
+        with patch.dict(metalk8s_kubernetes.__utils__):
+            metalk8s_kubernetes.__utils__.pop(
+                'metalk8s_kubernetes.get_kind_info'
+            )
+            reload(metalk8s_kubernetes)
+            self.assertEqual(
+                metalk8s_kubernetes.__virtual__(),
+                (False, 'Missing `metalk8s_kubernetes` utils module')
+            )
+
+    @parameterized.expand(
+        param.explicit(kwargs=test_case)
+        for test_case in YAML_TESTS_CASES['create_object'] + YAML_TESTS_CASES['common_tests']
+    )
+    def test_create_object(self, result, raises=False, api_status_code=None,
+                           info_scope="cluster", manifest_file_content=None,
+                           called_with=None, **kwargs):
+        """
+        Tests the return of `create_object` function
+        """
+        def _create_mock(body, **_):
+            if api_status_code is not None:
+                raise ApiException(
+                    status=api_status_code,
+                    reason='An error has occurred'
+                )
+
+            # body == object
+            return body
+
+        get_kind_info_mock = MagicMock()
+        if not info_scope:
+            get_kind_info_mock.side_effect = ValueError(
+                'An error has occurred'
+            )
+        get_kind_info_mock.return_value.scope = info_scope
+
+        create_mock = get_kind_info_mock.return_value.client.create
+        create_mock.side_effect = _create_mock
+
+        manifest_read_mock = MagicMock()
+        # None = IOError
+        # False = YAMLError
+        if manifest_file_content is None:
+            manifest_read_mock.side_effect = IOError(
+                'An error has occurred'
+            )
+        elif manifest_file_content is False:
+            manifest_read_mock.side_effect = yaml.YAMLError(
+                'An error has occurred'
+            )
+        else:
+            manifest_read_mock.return_value = manifest_file_content
+
+        utils_dict = {
+            'metalk8s_kubernetes.get_kind_info': get_kind_info_mock
+        }
+        salt_dict = {
+            'metalk8s_kubernetes.read_and_render_yaml_file': manifest_read_mock
+        }
+        with patch.dict(metalk8s_kubernetes.__utils__, utils_dict), \
+                patch.dict(metalk8s_kubernetes.__salt__, salt_dict):
+            if raises:
+                self.assertRaisesRegexp(
+                    Exception,
+                    result,
+                    metalk8s_kubernetes.create_object,
+                    **kwargs
+                )
+            else:
+                self.assertEqual(
+                    metalk8s_kubernetes.create_object(**kwargs),
+                    result
+                )
+                create_mock.assert_called_once()
+                if called_with:
+                    self.assertDictContainsSubset(
+                        called_with,
+                        create_mock.call_args.kwargs
+                    )
+
+    @parameterized.expand(
+        param.explicit(kwargs=test_case)
+        for test_case in YAML_TESTS_CASES['delete_object'] + YAML_TESTS_CASES['common_tests']
+    )
+    def test_delete_object(self, result, raises=False, api_status_code=None,
+                           info_scope="namespaced", manifest_file_content=None,
+                           called_with=None, **kwargs):
+        """
+        Tests the return of `delete_object` function
+        """
+        def _delete_mock(name, **_):
+            if api_status_code is not None:
+                raise ApiException(
+                    status=api_status_code,
+                    reason='An error has occurred'
+                )
+
+            res = MagicMock()
+            # Do not return a real object as it does not bring any value in
+            # this test
+            res.to_dict.return_value = "<{} deleted object dict>".format(name)
+            return res
+
+        get_kind_info_mock = MagicMock()
+        if not info_scope:
+            get_kind_info_mock.side_effect = ValueError(
+                'An error has occurred'
+            )
+        get_kind_info_mock.return_value.scope = info_scope
+
+        delete_mock = get_kind_info_mock.return_value.client.delete
+        delete_mock.side_effect = _delete_mock
+
+        manifest_read_mock = MagicMock()
+        # None = IOError
+        # False = YAMLError
+        if manifest_file_content is None:
+            manifest_read_mock.side_effect = IOError(
+                'An error has occurred'
+            )
+        elif manifest_file_content is False:
+            manifest_read_mock.side_effect = yaml.YAMLError(
+                'An error has occurred'
+            )
+        else:
+            manifest_read_mock.return_value = manifest_file_content
+
+        utils_dict = {
+            'metalk8s_kubernetes.get_kind_info': get_kind_info_mock
+        }
+        salt_dict = {
+            'metalk8s_kubernetes.read_and_render_yaml_file': manifest_read_mock
+        }
+        with patch.dict(metalk8s_kubernetes.__utils__, utils_dict), \
+                patch.dict(metalk8s_kubernetes.__salt__, salt_dict):
+            if raises:
+                self.assertRaisesRegexp(
+                    Exception,
+                    result,
+                    metalk8s_kubernetes.delete_object,
+                    **kwargs
+                )
+            else:
+                self.assertEqual(
+                    metalk8s_kubernetes.delete_object(**kwargs),
+                    result
+                )
+                delete_mock.assert_called_once()
+                if called_with:
+                    self.assertDictContainsSubset(
+                        called_with,
+                        delete_mock.call_args.kwargs
+                    )
+
+    @parameterized.expand(
+        param.explicit(kwargs=test_case)
+        for test_case in YAML_TESTS_CASES['replace_object'] + YAML_TESTS_CASES['common_tests']
+    )
+    def test_replace_object(self, result, raises=False, api_status_code=None,
+                            info_scope="cluster", manifest_file_content=None,
+                            called_with=None, **kwargs):
+        """
+        Tests the return of `repace_object` function
+        """
+        def _replace_mock(body, **_):
+            if api_status_code is not None:
+                raise ApiException(
+                    status=api_status_code,
+                    reason='An error has occurred'
+                )
+
+            # body == object
+            return body
+
+        get_kind_info_mock = MagicMock()
+        if not info_scope:
+            get_kind_info_mock.side_effect = ValueError(
+                'An error has occurred'
+            )
+        get_kind_info_mock.return_value.scope = info_scope
+
+        replace_mock = get_kind_info_mock.return_value.client.replace
+        replace_mock.side_effect = _replace_mock
+
+        manifest_read_mock = MagicMock()
+        # None = IOError
+        # False = YAMLError
+        if manifest_file_content is None:
+            manifest_read_mock.side_effect = IOError(
+                'An error has occurred'
+            )
+        elif manifest_file_content is False:
+            manifest_read_mock.side_effect = yaml.YAMLError(
+                'An error has occurred'
+            )
+        else:
+            manifest_read_mock.return_value = manifest_file_content
+
+        utils_dict = {
+            'metalk8s_kubernetes.get_kind_info': get_kind_info_mock
+        }
+        salt_dict = {
+            'metalk8s_kubernetes.read_and_render_yaml_file': manifest_read_mock
+        }
+        with patch.dict(metalk8s_kubernetes.__utils__, utils_dict), \
+                patch.dict(metalk8s_kubernetes.__salt__, salt_dict):
+            if raises:
+                self.assertRaisesRegexp(
+                    Exception,
+                    result,
+                    metalk8s_kubernetes.replace_object,
+                    **kwargs
+                )
+            else:
+                self.assertEqual(
+                    metalk8s_kubernetes.replace_object(**kwargs),
+                    result
+                )
+                replace_mock.assert_called_once()
+                if called_with:
+                    self.assertDictContainsSubset(
+                        called_with,
+                        replace_mock.call_args.kwargs
+                    )
+
+    @parameterized.expand(
+        param.explicit(kwargs=test_case)
+        for test_case in YAML_TESTS_CASES['get_object'] + YAML_TESTS_CASES['common_tests']
+    )
+    def test_get_object(self, result, raises=False, api_status_code=None,
+                        info_scope="namespaced", manifest_file_content=None,
+                        called_with=None, **kwargs):
+        """
+        Tests the return of `get_object` function
+        """
+        def _retrieve_mock(name, **_):
+            if api_status_code is not None:
+                raise ApiException(
+                    status=api_status_code,
+                    reason='An error has occurred'
+                )
+
+            res = MagicMock()
+            # Do not return a real object as it does not bring any value in
+            # this test
+            res.to_dict.return_value = "<{} object dict>".format(name)
+            return res
+
+        get_kind_info_mock = MagicMock()
+        if not info_scope:
+            get_kind_info_mock.side_effect = ValueError(
+                'An error has occurred'
+            )
+        get_kind_info_mock.return_value.scope = info_scope
+
+        retrieve_mock = get_kind_info_mock.return_value.client.retrieve
+        retrieve_mock.side_effect = _retrieve_mock
+
+        manifest_read_mock = MagicMock()
+        # None = IOError
+        # False = YAMLError
+        if manifest_file_content is None:
+            manifest_read_mock.side_effect = IOError(
+                'An error has occurred'
+            )
+        elif manifest_file_content is False:
+            manifest_read_mock.side_effect = yaml.YAMLError(
+                'An error has occurred'
+            )
+        else:
+            manifest_read_mock.return_value = manifest_file_content
+
+        utils_dict = {
+            'metalk8s_kubernetes.get_kind_info': get_kind_info_mock
+        }
+        salt_dict = {
+            'metalk8s_kubernetes.read_and_render_yaml_file': manifest_read_mock
+        }
+        with patch.dict(metalk8s_kubernetes.__utils__, utils_dict), \
+                patch.dict(metalk8s_kubernetes.__salt__, salt_dict):
+            if raises:
+                self.assertRaisesRegexp(
+                    Exception,
+                    result,
+                    metalk8s_kubernetes.get_object,
+                    **kwargs
+                )
+            else:
+                self.assertEqual(
+                    metalk8s_kubernetes.get_object(**kwargs),
+                    result
+                )
+                retrieve_mock.assert_called_once()
+                if called_with:
+                    self.assertDictContainsSubset(
+                        called_with,
+                        retrieve_mock.call_args.kwargs
+                    )
+
+    @parameterized.expand(
+        param.explicit(kwargs=test_case)
+        for test_case in YAML_TESTS_CASES['update_object'] + YAML_TESTS_CASES['common_tests']
+    )
+    def test_update_object(self, result, raises=False, initial_obj=None,
+                           info_scope="cluster", manifest_file_content=None,
+                           called_with=None, **kwargs):
+        """
+        Tests the return of `update_object` function
+        """
+        def _update_mock(body, **_):
+            if not initial_obj:
+                raise ApiException(status=0, reason='An error has occurred')
+
+            res = MagicMock()
+            # body == patch
+            res.to_dict.return_value = dictupdate.update(initial_obj, body)
+            return res
+
+        get_kind_info_mock = MagicMock()
+        if not info_scope:
+            get_kind_info_mock.side_effect = ValueError(
+                'An error has occurred'
+            )
+        get_kind_info_mock.return_value.scope = info_scope
+
+        update_mock = get_kind_info_mock.return_value.client.update
+        update_mock.side_effect = _update_mock
+
+        manifest_read_mock = MagicMock()
+        # None = IOError
+        # False = YAMLError
+        if manifest_file_content is None:
+            manifest_read_mock.side_effect = IOError(
+                'An error has occurred'
+            )
+        elif manifest_file_content is False:
+            manifest_read_mock.side_effect = yaml.YAMLError(
+                'An error has occurred'
+            )
+        else:
+            manifest_read_mock.return_value = manifest_file_content
+
+        utils_dict = {
+            'metalk8s_kubernetes.get_kind_info': get_kind_info_mock
+        }
+        salt_dict = {
+            'metalk8s_kubernetes.read_and_render_yaml_file': manifest_read_mock
+        }
+        with patch.dict(metalk8s_kubernetes.__utils__, utils_dict), \
+                patch.dict(metalk8s_kubernetes.__salt__, salt_dict):
+            if raises:
+                self.assertRaisesRegexp(
+                    Exception,
+                    result,
+                    metalk8s_kubernetes.update_object,
+                    **kwargs
+                )
+            else:
+                self.assertEqual(
+                    metalk8s_kubernetes.update_object(**kwargs),
+                    result
+                )
+                update_mock.assert_called_once()
+                if called_with:
+                    self.assertDictContainsSubset(
+                        called_with,
+                        update_mock.call_args.kwargs
+                    )
+
+    @parameterized.expand([
+        ({'kind': 'Pod', 'apiVersion': 'v1', 'metadata': {'name': 'my_node'}}, True),
+        (None, False)
+    ])
+    def test_object_exists(self, get_object_return, result):
+        """
+        Tests the return of `object_exists` function
+        """
+        get_object_mock = MagicMock(return_value=get_object_return)
+        # Mock `get_object` as we do not want to test this function again here
+        with patch("metalk8s_kubernetes.get_object", get_object_mock):
+            self.assertEqual(
+                metalk8s_kubernetes.object_exists(
+                    kind="Node",
+                    apiVersion="v1",
+                    name="my_node"
+                ),
+                result
+            )
+            get_object_mock.assert_called_once()
+
+    @parameterized.expand(
+        param.explicit(kwargs=test_case)
+        for test_case in YAML_TESTS_CASES['list_objects']
+    )
+    def test_list_objects(self, result, raises=False, api_status_code=None,
+                          info_scope="namespaced", called_with=None, **kwargs):
+        """
+        Tests the return of `list_objects` function
+        """
+        def _list_mock(**_):
+            if api_status_code is not None:
+                raise ApiException(
+                    status=api_status_code,
+                    reason='An error has occurred'
+                )
+
+            res = MagicMock()
+            # Do not return a real list object as it does not bring any value
+            # in this test
+            obj1 = MagicMock()
+            obj1.to_dict.return_value = '<my first object dict>'
+            obj2 = MagicMock()
+            obj2.to_dict.return_value = '<my second object dict>'
+
+            res.items = [obj1, obj2]
+            return res
+
+        get_kind_info_mock = MagicMock()
+        if not info_scope:
+            get_kind_info_mock.side_effect = ValueError(
+                'An error has occurred'
+            )
+        get_kind_info_mock.return_value.scope = info_scope
+
+        list_mock = get_kind_info_mock.return_value.client.list
+        list_mock.side_effect = _list_mock
+
+        utils_dict = {
+            'metalk8s_kubernetes.get_kind_info': get_kind_info_mock
+        }
+        with patch.dict(metalk8s_kubernetes.__utils__, utils_dict):
+            if raises:
+                self.assertRaisesRegexp(
+                    Exception,
+                    result,
+                    metalk8s_kubernetes.list_objects,
+                    **kwargs
+                )
+            else:
+                self.assertEqual(
+                    metalk8s_kubernetes.list_objects(**kwargs),
+                    result
+                )
+                list_mock.assert_called_once()
+                if called_with:
+                    self.assertDictContainsSubset(
+                        called_with,
+                        list_mock.call_args.kwargs
+                    )


### PR DESCRIPTION
**Component**:

'salt', 'tests'

**Context**: 

#2041 
#2266 

**Summary**:

Add unit tests for `metalk8s_kubernetes` salt custom module, use a
dedicated yaml file containing input, arguments
and expected result for some functions

```
---------- coverage: platform linux2, python 2.7.18-final-0 ----------
Name                                   Stmts   Miss  Cover   Missing
--------------------------------------------------------------------
salt/_modules/metalk8s_kubernetes.py     136      0   100%
```

NOTE: This PR only add unit tests for salt `metalk8s_kubernetes` custom module and not for `kubernetes_utils` so we do not test interaction with `python-kubernetes` here

---

Refs: #2266, #2041
