### PR TITLE
tox/tests: Bump tox minversion to 3.18.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = true
-minversion = 3.4.0
+minversion = 3.18.0
 
 [testenv]
 whitelist_externals = bash


### PR DESCRIPTION
The previous minversion (3.4.0) was not sufficient for running the
newly-added `unit-tests` environment. We thus bump it to the latest
available tox version at this time, which should be sufficient to make
using tox seamless for new users.

See: #2266