### PR TITLE
Make calico MTU configurable in bootstrap config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Enable `seccomp` support in `containerd`
   (Issue [#2259](https://github.com/scality/metalk8s/issues/2259),
   PR [#2369](https://github.com/scality/metalk8s/pull/2369))
+- [#1095](https://github.com/scality/metalk8s/issues/1095) - Ability to use
+  multiple CIDRs for control plane and workload plane networks and to specify
+  the workload plane MTU to compute the MTU used by Calico
+  (PR [#2677](https://github.com/scality/metalk8s/pull/2677))
 
 ### Enhancements
 - [#2674](https://github.com/scality/metalk8s/issues/2674) - Bump K8S version

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -128,11 +128,13 @@ fi
 
 echo "Creating bootstrap configuration"
 cat > /etc/metalk8s/bootstrap.yaml << EOF
-apiVersion: metalk8s.scality.com/v1alpha2
+apiVersion: metalk8s.scality.com/v1alpha3
 kind: BootstrapConfiguration
 networks:
-  controlPlane: #{CONTROL_PLANE_IP}/#{prefixlen(CONTROL_PLANE_NETMASK)}
-  workloadPlane: #{WORKLOAD_PLANE_IP}/#{prefixlen(WORKLOAD_PLANE_NETMASK)}
+  controlPlane:
+    cidr: #{CONTROL_PLANE_IP}/#{prefixlen(CONTROL_PLANE_NETMASK)}
+  workloadPlane:
+    cidr: #{WORKLOAD_PLANE_IP}/#{prefixlen(WORKLOAD_PLANE_NETMASK)}
 ca:
   minion: bootstrap
 archives:

--- a/docs/installation/advanced-guide.rst
+++ b/docs/installation/advanced-guide.rst
@@ -1,0 +1,36 @@
+Advanced guide
+==============
+
+.. _multiple CIDR network:
+
+Multiple CIDRs network
+----------------------
+
+In the Bootstrap Configuration it's possible to provide several CIDRs for a
+single network, it's needed when several nodes does not sit in the same
+network.
+
+.. code-block:: yaml
+
+     networks:
+       controlPlane:
+         cidr:
+           - 10.100.1.0/28
+           - 10.200.1.0/28
+       workloadPlane:
+         cidr:
+           - 10.100.2.0/28
+           - 10.200.2.0/28
+
+This kind of deployment needs good knowledge about networking, as each workload
+node needs to be able to communicate with all others, even those in a different
+workload CIDR.
+
+In this case :ref:`IP-in-IP encapsulation<enable IP-in-IP>` is likely needed.
+
+Some explanation can be found about this subject in
+`Calico documentation <https://docs.projectcalico.org/networking/vxlan-ipip>`_.
+
+.. todo::
+
+  - Explain more what is needed to not need IP-in-IP in that kind of scenario

--- a/docs/installation/bootstrap.rst
+++ b/docs/installation/bootstrap.rst
@@ -35,11 +35,13 @@ Configuration
 
    .. code-block:: yaml
 
-      apiVersion: metalk8s.scality.com/v1alpha2
+      apiVersion: metalk8s.scality.com/v1alpha3
       kind: BootstrapConfiguration
       networks:
-        controlPlane: <CIDR-notation>
-        workloadPlane: <CIDR-notation>
+        controlPlane:
+          cidr: <CIDR-notation>
+        workloadPlane:
+          cidr: <CIDR-notation>
         pods: <CIDR-notation>
         services: <CIDR-notation>
       proxies:
@@ -60,11 +62,20 @@ notation for it's various subfields.
       These values specify the range of IP addresses that will be used at the
       host level for each member of the cluster.
 
+
+      .. info::
+
+        Several CIDRs can be provided if all nodes do not sit in the same
+        network. This is an :ref:`advanced configuration<multiple CIDR network>`
+        which we do not recommend for non-experts.
+
       .. code-block:: yaml
 
             networks:
-              controlPlane: 10.200.1.0/28
-              workloadPlane: 10.200.1.0/28
+              controlPlane:
+                cidr: 10.200.1.0/28
+              workloadPlane:
+                cidr: 10.200.1.0/28
 
       All nodes within the cluster **must** connect to both the control plane
       and workload plane networks. If the same network range is chosen for both

--- a/docs/installation/bootstrap.rst
+++ b/docs/installation/bootstrap.rst
@@ -42,6 +42,7 @@ Configuration
           cidr: <CIDR-notation>
         workloadPlane:
           cidr: <CIDR-notation>
+          mtu: <network-MTU>
         pods: <CIDR-notation>
         services: <CIDR-notation>
       proxies:
@@ -69,6 +70,11 @@ notation for it's various subfields.
         network. This is an :ref:`advanced configuration<multiple CIDR network>`
         which we do not recommend for non-experts.
 
+      For ``workloadPlane`` entry an
+      `MTU <https://en.wikipedia.org/wiki/Maximum_transmission_unit>`_ can
+      also be provided, this MTU value should be the lowest MTU value accross
+      all the workload plane network. The default value for this MTU is 1460.
+
       .. code-block:: yaml
 
             networks:
@@ -76,6 +82,7 @@ notation for it's various subfields.
                 cidr: 10.200.1.0/28
               workloadPlane:
                 cidr: 10.200.1.0/28
+                mtu: 1500
 
       All nodes within the cluster **must** connect to both the control plane
       and workload plane networks. If the same network range is chosen for both

--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -17,3 +17,4 @@ and shows how to access various services after completing the setup.
    expansion
    post-install
    services
+   advanced-guide

--- a/eve/workers/openstack-multiple-nodes/terraform/scripts/bootstrap-config.sh
+++ b/eve/workers/openstack-multiple-nodes/terraform/scripts/bootstrap-config.sh
@@ -10,11 +10,14 @@ mkdir -p /etc/salt
 echo "bootstrap-node" > /etc/salt/minion_id
 
 cat > "$OUTPUT_FILE" << EOF
-apiVersion: metalk8s.scality.com/v1alpha2
+apiVersion: metalk8s.scality.com/v1alpha3
 kind: BootstrapConfiguration
 networks:
-  controlPlane: 10.100.0.0/16
-  workloadPlane: 10.100.0.0/16
+  controlPlane:
+    cidr:
+      - 10.100.0.0/16
+  workloadPlane:
+    cidr: 10.100.0.0/16
 ca:
   minion: $(cat /etc/salt/minion_id)
 archives:

--- a/eve/workers/openstack-single-node-rhel/terraform/scripts/bootstrap-config.sh
+++ b/eve/workers/openstack-single-node-rhel/terraform/scripts/bootstrap-config.sh
@@ -10,11 +10,14 @@ mkdir -p /etc/salt
 echo "bootstrap-rhel" > /etc/salt/minion_id
 
 cat > "$OUTPUT_FILE" << EOF
-apiVersion: metalk8s.scality.com/v1alpha2
+apiVersion: metalk8s.scality.com/v1alpha3
 kind: BootstrapConfiguration
 networks:
-  controlPlane: 10.100.0.0/16
-  workloadPlane: 10.100.0.0/16
+  controlPlane:
+    cidr: 10.100.0.0/16
+  workloadPlane:
+    cidr:
+      - 10.100.0.0/16
 ca:
   minion: $(cat /etc/salt/minion_id)
 archives:

--- a/salt/_modules/metalk8s_network.py
+++ b/salt/_modules/metalk8s_network.py
@@ -79,3 +79,30 @@ def get_oidc_service_ip():
     range.
     '''
     return _pick_nth_service_ip(OIDC_ADDRESS_NUMBER)
+
+
+def get_ip_from_cidrs(cidrs, current_ip=None):
+    '''
+    Return the first IP available
+
+    A current_ip can be given so that if the current_ip is already part of
+    one cidr we keep this IP (otherwise we return the first one)
+    '''
+    first_ip = None
+
+    for cidr in cidrs:
+        ip_addrs = __salt__["network.ip_addrs"](cidr=cidr)
+        if current_ip and current_ip in ip_addrs:
+            # Current IP still valid, return it
+            return current_ip
+
+        if ip_addrs and first_ip is None:
+            first_ip = ip_addrs[0]
+
+    if not first_ip:
+        raise CommandExecutionError(
+            "Unable to find an IP on this host in one of this cidr: {}"
+            .format(', '.join(cidrs))
+        )
+
+    return first_ip

--- a/salt/_modules/metalk8s_network.py
+++ b/salt/_modules/metalk8s_network.py
@@ -106,3 +106,26 @@ def get_ip_from_cidrs(cidrs, current_ip=None):
         )
 
     return first_ip
+
+
+def get_mtu_from_ip(ip):
+    '''
+    Return the MTU of the first interface with the specified IP
+    '''
+    ifaces = __salt__['network.ifacestartswith'](ip)
+
+    if not ifaces:
+        raise CommandExecutionError(
+            'Unable to get interface for "{}"'.format(ip)
+        )
+
+    iface = ifaces[0]
+
+    if len(ifaces) > 1:
+        log.warning(
+            'Several interfaces match the IP "%s", %s will be used: %s',
+            ip,
+            iface, ', '.join(ifaces)
+        )
+
+    return int(__salt__['file.read']('/sys/class/net/{}/mtu'.format(iface)))

--- a/salt/_pillar/metalk8s.py
+++ b/salt/_pillar/metalk8s.py
@@ -15,6 +15,7 @@ EXPECTED_APIVERSIONS = [
 
 DEFAULT_POD_NETWORK = '10.233.0.0/16'
 DEFAULT_SERVICE_NETWORK = '10.96.0.0/12'
+DEFAULT_MTU = 1460
 
 
 def _load_config(path):
@@ -100,6 +101,9 @@ def _load_networks(config_data):
 
     if errors:
         return __utils__['pillar_utils.errors_to_dict'](errors)
+
+    if 'mtu' not in networks_data['workloadPlane']:
+        networks_data['workloadPlane']['mtu'] = DEFAULT_MTU
 
     return {
         'control_plane': networks_data['controlPlane'],

--- a/salt/metalk8s/container-engine/containerd/installed.sls
+++ b/salt/metalk8s/container-engine/containerd/installed.sls
@@ -53,7 +53,11 @@ Create containerd service drop-in:
           - {{ "debug" if metalk8s.debug else "info" }}
         environment:
         {%- if proxies %}
-          {%- set no_proxy = ["localhost", "127.0.0.1"] + networks.values() %}
+          {%- set no_proxy = ["localhost", "127.0.0.1"] %}
+          {%- do no_proxy.extend(networks.control_plane.cidr) %}
+          {%- do no_proxy.extend(networks.workload_plane.cidr) %}
+          {%- do no_proxy.append(networks.pod) %}
+          {%- do no_proxy.append(networks.service) %}
           {%- if proxies.no_proxy | default %}
             {%- do no_proxy.extend(proxies.no_proxy) %}
           {%- endif %}

--- a/salt/metalk8s/kubernetes/cni/calico/deployed.sls
+++ b/salt/metalk8s/kubernetes/cni/calico/deployed.sls
@@ -634,7 +634,9 @@ spec:
             - name: IP
               value: "autodetect"
             - name: IP_AUTODETECTION_METHOD
-              value: can-reach={{ networks.workload_plane.split('/')[0] }}
+              # NOTE: Use first CIDR as all calico node should have route to
+              #       all workload CIDR
+              value: can-reach={{ networks.workload_plane.cidr[0].split('/')[0] }}
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
               value: "CrossSubnet"

--- a/salt/metalk8s/kubernetes/cni/calico/deployed.sls
+++ b/salt/metalk8s/kubernetes/cni/calico/deployed.sls
@@ -23,7 +23,8 @@ data:
   calico_backend: "bird"
 
   # Configure the MTU to use
-  veth_mtu: "1440"
+  # NOTE: MTU for calico = workload MTU - 20 (for IPinIP header)
+  veth_mtu: "{{ networks.workload_plane.mtu - 20 }}"
 
   # The CNI network configuration to install on each node.  The special
   # values in this config will be automatically populated.

--- a/salt/metalk8s/kubernetes/kube-proxy/deployed.sls
+++ b/salt/metalk8s/kubernetes/kube-proxy/deployed.sls
@@ -77,8 +77,7 @@ Deploy kube-proxy (ConfigMap):
             kind: KubeProxyConfiguration
             metricsBindAddress: 0.0.0.0:10249
             mode: ""
-            nodePortAddresses:
-            - {{ networks.workload_plane }}
+            nodePortAddresses: {{ networks.workload_plane.cidr | tojson }}
             oomScoreAdj: -999
             portRange: ""
             resourceContainer: /kube-proxy

--- a/salt/metalk8s/node/grains.sls
+++ b/salt/metalk8s/node/grains.sls
@@ -1,36 +1,41 @@
-{% set control_plane_ips = salt['network.ip_addrs'](cidr=salt['pillar.get']('networks:control_plane')) %}
+{%- if '_errors' in pillar.networks %}
+  {{ raise('Errors in networks pillar: ' ~ pillar.networks._errors) }}
+{%- endif %}
 
-{% if control_plane_ips %}
-{%   if 'metalk8s' not in grains
-        or 'control_plane_ip' not in grains['metalk8s']
-        or grains['metalk8s']['control_plane_ip'] not in control_plane_ips %}
+{%- set control_plane_ip = salt['metalk8s_network.get_ip_from_cidrs'](
+          pillar.networks.control_plane.cidr,
+          current_ip=grains.get('metalk8s', {}).get('control_plane_ip')
+) %}
+
+{%- if control_plane_ip %}
+
 Set control_plane_ip grain:
   grains.present:
     - name: metalk8s:control_plane_ip
-    - value: {{ control_plane_ips[0] }}
-{%   else %}
-control_plane_ip grain already set and valid:
-  test.succeed_without_changes
-{%   endif %}
-{% else %}
+    - value: {{ control_plane_ip }}
+
+{%- else %}
+
 No control-plane network interface present on the host:
   test.fail_without_changes
-{% endif %}
 
-{% set workload_plane_ips = salt['network.ip_addrs'](cidr=salt['pillar.get']('networks:workload_plane')) %}
-{% if workload_plane_ips %}
-{%   if 'metalk8s' not in grains
-        or 'workload_plane_ip' not in grains['metalk8s']
-        or grains['metalk8s']['workload_plane_ip'] not in workload_plane_ips %}
+{%- endif %}
+
+{%- set workload_plane_ip = salt['metalk8s_network.get_ip_from_cidrs'](
+          pillar.networks.workload_plane.cidr,
+          current_ip=grains.get('metalk8s', {}).get('workload_plane_ip')
+) %}
+
+{%- if workload_plane_ip %}
+
 Set workload_plane_ip grain:
   grains.present:
     - name: metalk8s:workload_plane_ip
-    - value: {{ workload_plane_ips[0] }}
-{%   else %}
-workload_plane_ip grain already set and valid:
-  test.succeed_without_changes
-{%   endif %}
-{% else %}
+    - value: {{ workload_plane_ip }}
+
+{%- else %}
+
 No workload-plane network interface present on the host:
   test.fail_without_changes
-{% endif %}
+
+{%- endif %}

--- a/salt/metalk8s/orchestrate/deploy_node.sls
+++ b/salt/metalk8s/orchestrate/deploy_node.sls
@@ -35,12 +35,21 @@ Wait minion available:
       - salt: Cordon the node
 {%- endif %}
 
+Sync module on the node:
+  salt.function:
+    - name: saltutil.sync_all
+    - tgt: {{ node_name }}
+    - kwarg:
+        saltenv: metalk8s-{{ version }}
+
 Set grains:
   salt.state:
     - tgt: {{ node_name }}
     - saltenv: metalk8s-{{ version }}
     - sls:
       - metalk8s.node.grains
+    - require:
+      - salt: Sync module on the node
 
 Refresh the mine:
   salt.function:
@@ -65,13 +74,6 @@ Drain the node:
       - salt: Run the highstate
 
 {%- endif %}
-
-Sync module on the node:
-  salt.function:
-    - name: saltutil.sync_all
-    - tgt: {{ node_name }}
-    - kwarg:
-        saltenv: {{ saltenv }}
 
 {%- if node_name in salt.saltutil.runner('manage.up') %}
 

--- a/salt/tests/unit/modules/test_metalk8s_network.py
+++ b/salt/tests/unit/modules/test_metalk8s_network.py
@@ -82,3 +82,51 @@ class Metalk8sNetworkTestCase(TestCase, LoaderModuleMockMixin):
                 error_msg,
                 metalk8s_network.get_cluster_dns_ip
             )
+
+    @parameterized.expand([
+        # 1 CIDR, 2 IP, take the first one
+        (['10.200.0.0/16'], ['10.200.0.1', '10.200.0.42'], '10.200.0.1'),
+        # 1 CIDR, 2 IP, current_ip set to the second one, take the second one
+        (['10.200.0.0/16'], ['10.200.0.1', '10.200.0.42'], '10.200.0.42', '10.200.0.42'),
+        # 1 CIDR, no IP, errors
+        (['10.200.0.0/16'], [], 'Unable to find an IP on this host in one of this cidr: 10.200.0.0/16', None, True),
+        # 2 CIDR, multiple IPs, take the first one of first CIDR
+        (['10.200.0.0/16', '10.100.0.0/16'], {'10.200.0.0/16': ['10.200.0.1', '10.200.0.42'], '10.100.0.0/16': ['10.100.0.12', '10.100.0.52']}, '10.200.0.1'),
+        # 2 CIDR, multiple IPs, with current_ip present
+        (['10.200.0.0/16', '10.100.0.0/16'], {'10.200.0.0/16': ['10.200.0.1', '10.200.0.42'], '10.100.0.0/16': ['10.100.0.12', '10.100.0.52']}, '10.100.0.52', '10.100.0.52'),
+        # 2 CIDR, multiple IPs, with current_ip absent
+        (['10.200.0.0/16', '10.100.0.0/16'], {'10.200.0.0/16': ['10.200.0.1', '10.200.0.42'], '10.100.0.0/16': ['10.100.0.12', '10.100.0.52']}, '10.200.0.1', '10.100.0.87'),
+        # 2 CIDR, first CIDR no IP
+        (['10.200.0.0/16', '10.100.0.0/16'], {'10.100.0.0/16': ['10.100.0.12', '10.100.0.52']}, '10.100.0.12'),
+        # 2 CIDR, no IP, with current_ip, errors
+        (['10.200.0.0/16', '10.100.0.0/16'], [], 'Unable to find an IP on this host in one of this cidr: 10.200.0.0/16, 10.100.0.0/16', '10.200.0.1', True),
+    ])
+    def test_get_ip_from_cidrs(self, cidrs, ip_addrs, result,
+                               current_ip=None, raises=False):
+        """
+        Tests the return of `get_ip_from_cidrs` function
+        """
+        def _get_ip_addrs(cidr):
+            if isinstance(ip_addrs, dict):
+                return ip_addrs.get(cidr)
+            return ip_addrs
+
+        salt_dict = {
+            'network.ip_addrs': MagicMock(side_effect=_get_ip_addrs)
+        }
+
+        with patch.dict(metalk8s_network.__salt__, salt_dict):
+            if raises:
+                self.assertRaisesRegexp(
+                    CommandExecutionError,
+                    result,
+                    metalk8s_network.get_ip_from_cidrs,
+                    cidrs=cidrs, current_ip=current_ip
+                )
+            else:
+                self.assertEqual(
+                    result,
+                    metalk8s_network.get_ip_from_cidrs(
+                        cidrs=cidrs, current_ip=current_ip
+                    )
+                )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -199,6 +199,17 @@ def get_grain(host, key):
     return grain
 
 
+def get_pillar(host, key, local=False):
+    with host.sudo():
+        output = host.check_output(
+            'salt-call {} --out=json pillar.get "{}"'.format(
+                '--local' if local else '',
+                key
+            )
+        )
+        return json.loads(output)['local']
+
+
 class PrometheusApiError(Exception):
     pass
 


### PR DESCRIPTION
**Component**:

'salt', 'kubernetes'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

#1095 

**Summary**:

- Allow multiple CIDRs for workload plane and control plane networks
- Make calico MTU configurable through bootstrap config
- Check MTU defined is smaller than the one on the local workload network interface

New bootstrap config network layout (still backward compatible with old style)

```
apiVersion: metalk8s.scality.com/v1alpha3
networks:
  workloadPlane:
    cidr:
      - 10.200.10.0/24
      - 10.200.20.0/24
    mtu: 4242
  controlPlane:
    cidr: 10.200.30.0/24
```

---
TODO:

- [x] Add unit test for `get_mtu_from_ip`
- [x] Add unit test for `get_ip_from_cidrs`
- [x] Update documentation for BootstrapConfig changes
- [x] Update tests (and vagrant) to use the new BootstrapConfig style
- [x] Add documentation about MTU configuration in bootstrap config
- [x] Add changelog entry 
 
---

Fixes: #1095 