### PR TITLE
build/deps: bump k8s version to 1.16.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - [#2572](https://github.com/scality/metalk8s/issues/2572) - Bump CoreDNS
 version to 1.6.2 (PR [#2575](https://github.com/scality/metalk8s/pull/2575))
 
+- [#2674](https://github.com/scality/metalk8s/issues/2674) - Bump K8S version
+to 1.16.13 (PR [#2363](https://github.com/scality/metalk8s/pull/2679))
+
 ## Release 2.5.1
 
 ### Breaking changes

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -18,7 +18,7 @@ Image = namedtuple('Image', ('name', 'version', 'digest'))
 # Project-wide versions {{{
 
 CALICO_VERSION     : str = '3.12.0'
-K8S_VERSION        : str = '1.16.10'
+K8S_VERSION        : str = '1.16.13'
 SALT_VERSION       : str = '3000.3'
 
 def load_version_information() -> None:
@@ -120,22 +120,22 @@ CONTAINER_IMAGES : Tuple[Image, ...] = (
     Image(
         name='kube-apiserver',
         version=_version_prefix(K8S_VERSION),
-        digest='sha256:63d6d14752a67865f0650fc0d7d982b758ce5fc8e9463c3535e91b16b86a6525',
+        digest='sha256:76434b2d8df2631f26a3ab88c2199d61868d4814ead1d617d816b37c3200cfea',
     ),
     Image(
         name='kube-controller-manager',
         version=_version_prefix(K8S_VERSION),
-        digest='sha256:2f162989247c7b6f3df63f98e139fec04058cd414063312564ced2e0500a3086',
+        digest='sha256:10310266d1a2c3d21276ec61005a67a78014cc2b71d5b3f503dbf4a6c3b7dadb',
     ),
     Image(
         name='kube-proxy',
         version=_version_prefix(K8S_VERSION),
-        digest='sha256:7fff91c637ac79a62da75c0511d990e5946d726b4a11b5942feb9719be9a56cc',
+        digest='sha256:527ed80e37c5f85b52dd686d08d5ae34d74efe60a0753bca0543abe9708788ad',
     ),
     Image(
         name='kube-scheduler',
         version=_version_prefix(K8S_VERSION),
-        digest='sha256:999aab546800f4fd5da282b11015909f845eccc1886ce348ce5d0c0410666ebc',
+        digest='sha256:1cbc899b82ae99535b61334a72865d08fb31ce3cf13f8dff7a1dc08d4b64d4de',
     ),
     Image(
         name='kube-state-metrics',


### PR DESCRIPTION


**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
'kubernetes', 'build', 'deps'

**Context**: 

See: #2674 

**Summary**:

- Bump k8s version to 1.16.13 to handle CVE-2020-8559, CVE-2020-8557 and CVE-2020-8558
- Deploys up to date versions for Kubelet, Kube-apiserver and Kube-proxy


**Acceptance criteria**: 

- No regression

---

<!-- Declare one or more issues to close once this PR gets merged -->

Refs: #2674

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
