### PR TITLE
eve: `test_tools` repo get migrated to github

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -451,7 +451,7 @@ stages:
       - ShellCommand:
           name: Install test tools requirements
           command: >
-            git clone git@bitbucket.org:scality/test_tools.git &&
+            git clone git@github.com:scality/test_tools.git &&
             sudo yum install -y epel-release &&
             sudo yum install -y wget python3.6 python3-pip &&
             pip3 install --user -r test_tools/testrail/requirements.txt


### PR DESCRIPTION
**Component**:

'eve'

**Summary**:

`test_tools` repo get migrated from bitbucket to github, so update the
clone link in eve

---

