### PR TITLE
salt/tests: Add unit tests for `metalk8s_service_configuration` salt module

### DIFF
--- a/salt/tests/unit/modules/files/test_metalk8s_service_configuration.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_service_configuration.yaml
@@ -1,0 +1,152 @@
+get_service_config:
+  #. Success: a retrieved Configmap object with `config.yaml` in the data section is merged with a `default_csc` correctly
+  - configmap_name: 'my_configmap'
+    default_csc:
+      apiVersion: my_apiVersion1
+      kind: my_kind1
+      spec:
+        deployment:
+          replicas: my_replicas
+          containers: my_containers
+    configmap_obj:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: my_configmap
+      data:
+        config.yaml: |-
+          kind: my_kind1
+          apiVersion: my_apiVersion1
+          spec:
+            deployment:
+              replicas: my_new_replicas
+    result:
+      apiVersion: my_apiVersion1
+      kind: my_kind1
+      spec:
+        deployment:
+          replicas: my_new_replicas
+          containers: my_containers
+
+  #. Success: a retrieved Configmap object with `config.yaml` in the data
+  #  section is merged with a `default_csc` correctly given the apiVersion and
+  #  kind from args matches the corresponding value in `config.yaml` section
+  - configmap_name: 'my_configmap'
+    apiVersion: my_apiVersion4
+    kind: my_kind4
+    default_csc:
+      apiVersion: my_apiVersion4
+      kind: my_kind4
+      spec:
+        deployment:
+          replicas: my_replicas
+          containers: null
+    configmap_obj:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: my_configmap
+      data:
+        config.yaml: |-
+          kind: my_kind4
+          apiVersion: my_apiVersion4
+          spec:
+            deployment:
+              replicas: my_new_replicas
+              containers:
+                - name: my_new_container
+    result:
+      apiVersion: my_apiVersion4
+      kind: my_kind4
+      spec:
+        deployment:
+          replicas: my_new_replicas
+          containers:
+            - name: my_new_container
+
+  #. Error: missing configmap_name
+  - configmap_name: null
+    result: "Expected a ConfigMap name but got None"
+    raises: True
+
+  #. Error: default_csc is not of type `dict`
+  - configmap_name: 'my_configmap'
+    default_csc: 'my_default_csc'
+    result: "Expected default CSC for ConfigMap my_configmap but got my_default_csc"
+    raises: True
+
+  #. Error: unable to retrieve a ConfigMap object
+  - configmap_name: 'my_configmap'
+    object_get: False
+    result: "Failed to read ConfigMap object my_configmap"
+    raises: True
+
+  #. Error: retrieved ConfigMap manifest is empty
+  - configmap_name: 'my_configmap'
+    configmap_obj: null
+    result: "Expected ConfigMap object but got None"
+    raises: True
+
+  #. Error: yaml error raised when reading config.yaml
+  - configmap_name: 'my_configmap'
+    configmap_obj:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: my_configmap
+      data:
+        config.yaml: |-
+          my: invalid: yaml
+    result: "Invalid YAML format in ConfigMap"
+    raises: True
+
+  #. Error: retrieved ConfigMap object has no `data` section with `config.yaml` as key
+  - configmap_name: 'my_configmap'
+    configmap_obj:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: my_configmap
+      data:
+    result: "Failed loading `config.yaml` from ConfigMap my_configmap"
+    raises: True
+
+  #. Error: retrieved Configmap object has an empty `config.yaml`
+  - configmap_name: 'my_configmap'
+    configmap_obj:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: my_configmap
+      data:
+        config.yaml: ''
+    result: "Expected `config.yaml` as yaml in the ConfigMap my_configmap but got {}"
+    raises: True
+
+  # Error: apiVersion provided as args does not match corresponding apiVersion found in the `config.yaml` section
+  - configmap_name: 'my_configmap'
+    apiVersion: "my_apiVersion"
+    configmap_obj:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: my_configmap
+      data:
+        config.yaml: |-
+          apiVersion: my_addon_apiVersion
+    result: "Expected value my_apiVersion for key apiVersion, got my_addon_apiVersion"
+    raises: True
+
+  # Error: `kind` provided as args does not match corresponding `kind` found in the `config.yaml` section
+  - configmap_name: 'my_configmap'
+    kind: "my_kind"
+    configmap_obj:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: my_configmap
+      data:
+        config.yaml: |-
+          kind: my_addon_kind
+    result: "Expected value my_kind for key kind, got my_addon_kind"
+    raises: True

--- a/salt/tests/unit/modules/test_metalk8s_service_configuration.py
+++ b/salt/tests/unit/modules/test_metalk8s_service_configuration.py
@@ -1,0 +1,89 @@
+import os.path
+import yaml
+
+from parameterized import param, parameterized
+
+from salt.exceptions import CommandExecutionError
+
+from salttesting.mixins import LoaderModuleMockMixin
+from salttesting.unit import TestCase
+from salttesting.mock import MagicMock, patch
+
+import metalk8s_service_configuration
+
+YAML_TESTS_FILE = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "files", "test_metalk8s_service_configuration.yaml"
+)
+with open(YAML_TESTS_FILE) as fd:
+    YAML_TESTS_CASES = yaml.safe_load(fd)
+
+
+class Metalk8sServiceConfigurationTestCase(TestCase, LoaderModuleMockMixin):
+    """
+    TestCase for `metalk8s_service_configuration` module
+    """
+    loader_module = metalk8s_service_configuration
+
+    def test_virtual(self):
+        """
+        Tests the return of `__virtual__` function
+        """
+        self.assertEqual(
+            metalk8s_service_configuration.__virtual__(),
+            'metalk8s_service_configuration'
+        )
+
+    @parameterized.expand([
+        param.explicit(kwargs=test_case)
+        for test_case in YAML_TESTS_CASES["get_service_config"]
+    ])
+    def test_get_service_conf(
+        self,
+        configmap_name,
+        result,
+        configmap_obj=None,
+        default_csc=None,
+        object_get=True,
+        raises=False,
+        **kwargs
+    ):
+        """
+        Tests the return of `get_service_conf` function
+        """
+        get_configmap_mock = MagicMock()
+
+        if default_csc is None:
+            default_csc = {}
+
+        if object_get:
+            get_configmap_mock.return_value = configmap_obj
+        else:
+            get_configmap_mock.side_effect = ValueError(
+                'Failed to read ConfigMap object my_configmap'
+            )
+
+        salt_dict = {
+            'metalk8s_kubernetes.get_object': get_configmap_mock
+        }
+
+        with patch.dict(metalk8s_service_configuration.__salt__, salt_dict):
+            if raises:
+                self.assertRaisesRegexp(
+                    CommandExecutionError,
+                    result,
+                    metalk8s_service_configuration.get_service_conf,
+                    namespace="my_namespace",
+                    configmap_name=configmap_name,
+                    default_csc=default_csc,
+                    **kwargs
+                )
+            else:
+                self.assertEqual(
+                    metalk8s_service_configuration.get_service_conf(
+                        namespace="my_namespace",
+                        configmap_name=configmap_name,
+                        default_csc=default_csc,
+                    ), result
+                )
+                get_configmap_mock.assert_called_once()


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
'salt', 'tests'

**Context**: 

See: #2266

**Summary**:

Add unit tests for metalk8s_service_configuration salt custom module, use a dedicated yaml file containing input, arguments and expected result.

```
---------- coverage: platform linux2, python 2.7.17-final-0 ----------
Name                                              Stmts   Miss  Cover   Missing
-------------------------------------------------------------------------------
salt/_modules/metalk8s_service_configuration.py      34      0   100%
```

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->
Refs: #2266

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
