### PR TITLE
salt/tests: Add unit tests for `metalk8s_drain`

### DIFF
--- a/salt/_modules/metalk8s_drain.py
+++ b/salt/_modules/metalk8s_drain.py
@@ -64,7 +64,8 @@ def _mirrorpod_filter(pod):
 
     Args:
       - pod: kubernetes pod object
-    Returns: True if the pod has the mirror annotation, False if not
+    Returns: (False, "") if the pod has the mirror annotation,
+             (True, "") if not
     '''
     mirror_annotation = "kubernetes.io/config.mirror"
 
@@ -248,8 +249,11 @@ class Drain(object):
             pod['metadata']['namespace'], controller_ref
         )
         if not response:
+            meta = pod['metadata']
             raise DrainException(
-                "Missing pod controller for '{0}'".format(controller_ref.name)
+                "Missing controller for pod '{}/{}'".format(
+                    meta['namespace'], meta['name']
+                )
             )
         return controller_ref
 
@@ -284,7 +288,9 @@ class Drain(object):
                 )
 
             raise DrainException(
-                "Missing pod controller for '{0}'".format(controller_ref.name)
+                "Missing controller for pod '{}/{}'".format(
+                    pod['metadata']['namespace'], pod['metadata']['name']
+                )
             )
 
         if not self.ignore_daemonset:
@@ -324,6 +330,7 @@ class Drain(object):
                     warnings.setdefault(
                         warning, []).append(pod['metadata']['name'])
                 is_deletable &= filter_deletable
+
             if is_deletable:
                 pods.append(pod)
 

--- a/salt/tests/unit/log_utils.py
+++ b/salt/tests/unit/log_utils.py
@@ -1,0 +1,73 @@
+"""Copied and inspired from `unittest._log`, added in Python 3.4+"""
+import collections
+import contextlib
+from io import StringIO
+import logging
+
+
+LoggingWatcher = collections.namedtuple(
+    "LoggingWatcher", ["records", "output"]
+)
+
+
+class CapturingHandler(logging.Handler):
+    def __init__(self):
+        super(CapturingHandler, self).__init__()
+        self.watcher = LoggingWatcher([], [])
+
+    def flush(self):
+        pass
+
+    def emit(self, record):
+        self.watcher.records.append(record)
+        msg = self.format(record)
+        self.watcher.output.append(msg)
+
+
+LOGGING_FORMAT = "%(levelname)s | %(message)s"
+
+
+@contextlib.contextmanager
+def capture_logs(logger, level=logging.DEBUG, fmt=LOGGING_FORMAT):
+    formatter = logging.Formatter(fmt=fmt)
+    handler = CapturingHandler()
+    handler.setFormatter(formatter)
+
+    old_handlers = logger.handlers[:]
+    old_level = logger.level
+    old_propagate = logger.propagate
+    logger.handlers = [handler]
+    logger.setLevel(level)
+    logger.propagate = False
+
+    try:
+        yield handler.watcher
+    finally:
+        logger.handlers = old_handlers
+        logger.setLevel(old_level)
+        logger.propagate = old_propagate
+
+
+def check_captured_logs(watcher, expected_records):
+    if not expected_records:
+        assert watcher.records == [], \
+            "Expected no logs, got:\n{}".format(
+                '\n'.join(msg for msg in watcher.output)
+            )
+    else:
+        assert len(watcher.records) == len(expected_records), \
+            "Expected {} log lines, got {}. Received:\n{}".format(
+                len(expected_records),
+                len(watcher.records),
+                '\n'.join(msg for msg in watcher.output)
+            )
+
+        for expected, actual in zip(expected_records, watcher.records):
+            assert expected['level'] == actual.levelname, \
+                "Invalid log level, got '{}', expected '{}'\n{}".format(
+                    actual.levelname, expected['level'], actual.message
+                )
+            assert expected['contains'] in actual.message, \
+                "Log message '{}' does not contain '{}'".format(
+                    actual.message, expected['contains']
+                )

--- a/salt/tests/unit/mocks/kubernetes.py
+++ b/salt/tests/unit/mocks/kubernetes.py
@@ -1,0 +1,242 @@
+"""Mocked implementations of Kubernetes API for use in unit tests.
+
+Aims to provide a simple yet configurable implementation of CRUD methods,
+allowing to keep track of actions in an in-memory "database" or trigger
+arbitrary problems for specific test needs.
+"""
+import contextlib
+import copy
+
+from salt.utils import dictupdate
+from salttesting.mock import MagicMock, patch
+
+from tests.unit import utils
+
+
+class ResourceFilter:
+    """Helper object for filtering a list of resource instances."""
+
+    NAMED_FILTERS = {
+        'name': lambda i, v: i['metadata']['name'] == v,
+        'namespace': lambda i, v: i['metadata']['namespace'] == v,
+    }
+
+    def __init__(self, instances):
+        self.instances = instances
+
+    def filter(self, name, value):
+        if name in ResourceFilter.NAMED_FILTERS:
+            return [
+                i for i in self.instances
+                if ResourceFilter.NAMED_FILTERS[name](i, value)
+            ]
+
+        if callable(value):
+            return [i for i in self.instances if value(i)]
+
+        return [
+            i for i in self.instances
+            if utils.get_dict_element(i, name) == value
+        ]
+
+    def filter_update(self, name, value):
+        self.instances = self.filter(name, value)
+
+
+class APIMock:
+    """Mock a K8s-style REST API over a set of resources stored in a dict."""
+
+    def __init__(self, database=None):
+        self.database = database or {}
+
+    @property
+    def api_resources(self):
+        return list(self.database.keys())
+
+    def filter(self, instances, filters):
+        filtered = ResourceFilter(instances)
+
+        for name, value in filters.items():
+            filtered.filter_update(name, value)
+
+        return filtered.instances
+
+    def retrieve(self, resource, **filters):
+        instances = self.database.get(resource, None)
+
+        assert instances is not None, \
+            "Resource '{}' unknown (available: {})".format(
+                resource, ', '.join(self.api_resources)
+            )
+
+        return self.filter(instances, filters)
+
+    def get_instance(self, resource, instance):
+        filters = {
+            'name': instance['metadata']['name'],
+        }
+        namespace = instance['metadata'].get('namespace')
+        if namespace is not None:
+            filters['namespace'] = namespace
+
+        candidates = self.retrieve(resource, **filters)
+        return candidates[0] if candidates else None
+
+    def create(self, resource, instance):
+        existing = self.get_instance(resource, instance)
+        assert existing is None, \
+            "Cannot create '{}/{}': already exists.".format(
+                resource, instance['metadata']['name']
+            )
+
+        self.database.setdefault(resource, []).append(instance)
+
+    def update(self, resource, instance):
+        existing = self.get_instance(resource, instance)
+        assert existing is not None, \
+            "Cannot update '{}/{}': not found.".format(
+                resource, instance['metadata']['name']
+            )
+
+        self.database[resource].remove(existing)
+        self.database[resource].append(instance)
+
+    def delete(self, resource, **filters):
+        for to_remove in self.retrieve(resource, **filters):
+            self.database[resource].remove(to_remove)
+
+    def patch(self, resource, name, patch, **filters):
+        candidates = self.retrieve(resource, name=name, **filters)
+        assert len(candidates) == 1, \
+            "Found more than one instance of '{}/{}' to patch".format(
+                resource, name
+            )
+
+        updated = dictupdate.update(candidates[0], patch)
+        self.update(resource, updated)
+
+
+class KubernetesAPIMock:
+    """Add simple helpers to mock `metalk8s_kubernetes` methods in tests.
+
+    Manages a set of resources (e.g. "pods") and the corresponding instances,
+    and provides mocked equivalents for `metalk8s_kubernetes` methods relying
+    on the managed resources.
+
+    TODO:
+    - add mock implementation for all methods from metalk8s_kubernetes
+    - add helpers for manipulating the database
+    - add helpers for populating the database
+    """
+
+    def __init__(self, database=None, resources=None):
+        self.api = APIMock(database or {})
+
+        # resources contains the mapping between short resource names, used as
+        # keys in the DATABASE, and (kind / apiVersion) pairs used when
+        # interacting with the real K8s API
+        self.resources = resources or {}
+
+    def seed(self, database=None):
+        self.api.database = copy.deepcopy(database or {})
+
+    def time_mock_from_events(self, events):
+        return TimedEventsMock(self.api, events)
+
+    def get_resource(self, kind, apiVersion):
+        resource = self.resources.get((apiVersion, kind), None)
+        assert resource is not None, \
+            "'{}/{}' is not a known resource ({})".format(
+                apiVersion, kind,
+                ', '.join(
+                    '{vk[0]}/{vk[1]}: {r}'.format(r=resource, vk=versionkind)
+                    for versionkind, resource in self.resources.items()
+                )
+            )
+        return resource
+
+    def get_object(self, name, kind, apiVersion, **kwargs):
+        resource = self.get_resource(kind, apiVersion)
+        objects = self.api.retrieve(resource, name=name, **kwargs)
+        res = objects[0] if objects else None
+        print("Called get_object %s/%s name=%s kwargs=%r - %r" % (
+            apiVersion, kind, name, kwargs, res
+        ))
+        return res
+
+    def list_objects(self, kind, apiVersion, all_namespaces=False,
+                     field_selector=None, **kwargs):
+        resource = self.get_resource(kind, apiVersion)
+
+        # If namespace isn't in kwargs, then all members of the matching
+        # resource (after other filters were applied) will get returned
+        assert all_namespaces or 'namespace' in kwargs, \
+            "Must either enable `all_namespaces` or pass a `namespace` kwarg"
+
+        if field_selector is not None:
+            # Naive re-implem
+            key, _, value = field_selector.partition('=')
+            if value is None:
+                value = ''
+            kwargs[key] = value
+
+        res = self.api.retrieve(resource, **kwargs)
+        print("Called get_object %s/%s kwargs=%r - %r" % (
+            apiVersion, kind, kwargs, res
+        ))
+        return res
+
+
+class TimedEventsMock:
+    """Store timed events to affect an APIMock and mock the `time` module."""
+
+    def __init__(self, api, events):
+        self.api = api
+        self.events = events
+        self._timer = 0
+        self._time_mock = MagicMock(side_effect=self.get_time)
+        self._sleep_mock = MagicMock(side_effect=self.fake_sleep)
+        self._initialized = False
+
+    @property
+    def time(self):
+        return self._time_mock
+
+    @property
+    def sleep(self):
+        return self._sleep_mock
+
+    def get_time(self, *_a, **_k):
+        if not self._initialized:
+            eventlist = self.events.get(0, [])
+            for event in eventlist:
+                self.handle_event(event)
+            self._initialized = True
+
+        return self._timer
+
+    def fake_sleep(self, duration, *_a, **_k):
+        print("Called time.sleep(%d) - now at %d" % (duration, self._timer))
+        self.process_events(duration)
+        self._timer += duration
+
+    def process_events(self, duration):
+        for timestep, eventlist in self.events.items():
+            if self._timer < timestep <= self._timer + duration:
+                for event in eventlist:
+                    self.handle_event(event)
+
+    def handle_event(self, event):
+        print("Processing event %r" % event)
+        kwargs = copy.deepcopy(event)
+        resource = kwargs.pop('resource')
+        verb = kwargs.pop('verb')
+
+        method = getattr(self.api, verb)
+        method(resource, **kwargs)
+        print("Done")
+
+    @contextlib.contextmanager
+    def patch(self):
+        with patch('time.time', self.time), patch('time.sleep', self.sleep):
+            yield

--- a/salt/tests/unit/modules/files/test_metalk8s_drain.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_drain.yaml
@@ -1,0 +1,558 @@
+evict_pod:
+  ## NOMINAL CASES
+
+  # Nominal (successful eviction)
+  - name: my-pod
+    result: True
+
+  # Custom parameters
+  - name: my-pod
+    namespace: my-ns
+    grace_period: 0
+    result: True
+
+  # Pod not found (no need to evict)
+  - name: not-found-pod
+    create_raises: ApiException
+    create_error_status: 404
+    result: True
+    log_lines:
+    - level: DEBUG
+      contains: >-
+        Received '404 Not Found' when creating Eviction for not-found-pod,
+        ignoring
+
+  # Temporary failure (eviction rejected because of forbidden disruption)
+  - name: busy-pod
+    create_raises: ApiException
+    create_error_status: 429
+    create_error_body:
+      message: this pod is meditating
+    result: False
+    log_lines:
+    - level: INFO
+      contains: "Cannot evict busy-pod at the moment: this pod is meditating"
+
+  ## ERROR CASES
+
+  # Unknown API error
+  - name: my-pod
+    create_raises: ApiException
+    create_error_status: 500
+    result: 'Failed to evict pod "my-pod" in namespace "default"'
+    raises: True
+
+  # Unknown HTTP error
+  - name: my-pod
+    create_raises: HTTPError
+    result: 'Failed to evict pod "my-pod" in namespace "default"'
+    raises: True
+
+
+drain:
+  ## NOMINAL
+  nominal:
+    # No pod at all
+    - node_name: my-node
+      dataset: empty
+      pods_to_evict: []
+      log_lines:
+      - level: DEBUG
+        contains: Beginning drain of Node my-node
+      - level: DEBUG
+        contains: "Starting eviction of pods: no pods to evict."
+
+    # One pod with a standard controller
+    - node_name: my-node
+      dataset: single-replicaset
+      pods_to_evict:
+      - my-replicaset-pod
+      events:
+        # Evicted after a single tick
+        1:
+          - resource: pods
+            verb: delete
+            name: my-replicaset-pod
+      log_lines:
+      - level: DEBUG
+        contains: Beginning drain of Node my-node
+      - level: DEBUG
+        contains: "Starting eviction of pods: my-replicaset-pod"
+      - level: DEBUG
+        contains: >-
+          Waiting for eviction of Pod my-replicaset-pod
+          (current status: Running)
+      - level: INFO
+        contains: my-replicaset-pod evicted
+
+    # Multiple pods
+    - node_name: my-node
+      dataset: multiple-pods
+      pods_to_evict:
+        - my-pod-1
+        - my-pod-2
+        - my-pod-3
+      events:
+        # All evicted after one tick
+        1:
+          - resource: pods
+            verb: delete
+            name: my-pod-1
+          - resource: pods
+            verb: delete
+            name: my-pod-2
+          - resource: pods
+            verb: delete
+            name: my-pod-3
+      log_lines:
+      - level: DEBUG
+        contains: Beginning drain of Node my-node
+      - level: DEBUG
+        contains: "Starting eviction of pods: my-pod-1, my-pod-2, my-pod-3"
+      - level: DEBUG
+        contains: >-
+          Waiting for eviction of Pod my-pod-1 (current status: Running)
+      - level: DEBUG
+        contains: >-
+          Waiting for eviction of Pod my-pod-2 (current status: Running)
+      - level: DEBUG
+        contains: >-
+          Waiting for eviction of Pod my-pod-3 (current status: Running)
+      - level: INFO
+        contains: my-pod-1 evicted
+      - level: INFO
+        contains: my-pod-2 evicted
+      - level: INFO
+        contains: my-pod-3 evicted
+
+  dry-run:
+    # No pod
+    - node_name: my-node
+      dataset: empty
+      pods_to_evict: []
+
+    # Single pod with a RS controller
+    - node_name: my-node
+      dataset: single-replicaset
+      pods_to_evict:
+        - my-replicaset-pod
+
+    # No pod matching this node
+    - node_name: unknown-node
+      dataset: single-pod
+      pods_to_evict: []
+
+    # Finished pod
+    - node_name: my-node
+      dataset: finished-pod
+      pods_to_evict:
+        - my-finished-pod
+
+    # Finished orphan pod
+    - node_name: my-node
+      dataset: finished-orphaned-pod
+      pods_to_evict:
+        - my-finished-pod
+
+    # All possible pods (ReplicaSet, DaemonSet, unmanaged, with local storage)
+    - node_name: my-node
+      dataset: full
+      # Add some args to evict the special pods
+      force: true
+      delete_local_data: true
+      ignore_daemonset: true
+      # DaemonSet-managed and static pods are ignored
+      pods_to_evict:
+        - my-pod
+        - my-replicaset-pod
+        - my-pod-with-local-storage
+
+  # Filters are applied before attempting the actual eviction, so the test
+  # will run in dry-run mode
+  # Logs captured in this test are only above WARNING level
+  eviction-filters:
+    ## NOMINAL
+    # Static pods (ignored, silently)
+    # FIXME: all filters are executed, and we see some incorrect warnings
+    - node_name: my-node
+      dataset: single-static-pod
+      pods_to_evict: []
+      log_lines:
+        - level: WARNING
+          contains: >-
+            Deleting pods not managed by ReplicationController, ReplicaSet,
+            Job, DaemonSet or StatefulSet: my-static-pod
+
+    # DaemonSet-managed pods (ignored, with a warning)
+    - node_name: my-node
+      dataset: single-daemonset
+      pods_to_evict: []
+      ignore_daemonset: true
+      log_lines:
+        - level: WARNING
+          contains: "Ignoring DaemonSet-managed pods: my-daemonset-pod"
+
+    # Orphaned DaemonSet-managed pods (evicted, with a warning)
+    - node_name: my-node
+      dataset: orphaned-daemonset-pod
+      pods_to_evict:
+        - my-daemonset-pod
+      force: true
+      log_lines:
+        - level: WARNING
+          contains: >-
+            Deleting pods not managed by ReplicationController, ReplicaSet,
+            Job, DaemonSet or StatefulSet: my-daemonset-pod
+
+    # Unmanaged pods (evicted, with a warning)
+    - node_name: my-node
+      dataset: single-pod
+      pods_to_evict:
+        - my-pod
+      force: true
+      log_lines:
+      - level: WARNING
+        contains: >-
+          Deleting pods not managed by ReplicationController, ReplicaSet,
+          Job, DaemonSet or StatefulSet: my-pod
+
+    # Orphaned pods (evicted, with a warning)
+    - node_name: my-node
+      dataset: orphaned-replicaset-pod
+      pods_to_evict:
+        - my-replicaset-pod
+      force: true
+      log_lines:
+      - level: WARNING
+        contains: >-
+          Deleting pods not managed by ReplicationController, ReplicaSet,
+          Job, DaemonSet or StatefulSet: my-replicaset-pod
+
+    # Local storage (evicted, with a warning)
+    - node_name: my-node
+      dataset: single-local-storage
+      pods_to_evict:
+        - my-pod-with-local-storage
+      delete_local_data: true
+      log_lines:
+      - level: WARNING
+        contains: "Deleting pods with local storage: my-pod-with-local-storage"
+
+    ## ERROR
+    # Daemonset-managed pods
+    - node_name: my-node
+      dataset: single-daemonset
+      pods_to_evict: []
+      raises: true
+      raise_msg: "DaemonSet-managed pods: my-daemonset-pod."
+
+    # Orphaned Daemonset-managed pods
+    - node_name: my-node
+      dataset: orphaned-daemonset-pod
+      pods_to_evict: []
+      raises: true
+      # FIXME: weird error
+      raise_msg: >-
+        Missing controller for pod 'my-namespace/my-daemonset-pod':
+        my-daemonset-pod, my-daemonset-pod.
+
+    # Other orphaned pods
+    - node_name: my-node
+      dataset: orphaned-replicaset-pod
+      pods_to_evict: []
+      raises: true
+      raise_msg: >-
+        Missing controller for pod 'my-namespace/my-replicaset-pod':
+        my-replicaset-pod.
+
+    # Local storage (evicted, with a warning)
+    - node_name: my-node
+      dataset: single-local-storage
+      pods_to_evict:
+        - my-pod-with-local-storage
+      raises: true
+      raise_msg: "pods with local storage: my-pod-with-local-storage."
+
+  # Check how eviction is retried on temporary failure
+  eviction-retry:
+    # No retry
+    - node_name: my-node
+      dataset: single-replicaset
+      events:
+        1:
+          - resource: pods
+            verb: delete
+            name: my-replicaset-pod
+      eviction_attempts: 1
+
+    # Retry until eviction isn't locked
+    - node_name: my-node
+      dataset: blocked-eviction
+      events:
+        # evict_pods sleeps 5 seconds between each eviction attempt, so we will
+        # try to evict twice with an error, and third attempt will work
+        8:
+          - resource: evictionmocks
+            verb: delete
+            pod: my-namespace/my-replicaset-pod
+        # we delete the pod 2 second after success when creating the eviction
+        10:
+          - resource: pods
+            verb: delete
+            name: my-replicaset-pod
+            namespace: my-namespace
+      eviction_attempts: 3
+
+  waiting-for-eviction:
+    # Instantaneous
+    - node_name: my-node
+      dataset: single-replicaset
+      events:
+        0:
+          - resource: pods
+            verb: delete
+            name: my-replicaset-pod
+      sleep_time: 0
+
+    # One pod waits 5 seconds
+    - node_name: my-node
+      dataset: single-replicaset
+      events:
+        5:
+          - resource: pods
+            verb: delete
+            name: my-replicaset-pod
+      sleep_time: 5
+
+    # One pod waits 10 seconds, the others wait 2 seconds
+    - node_name: my-node
+      dataset: multiple-pods
+      events:
+        2:
+          - resource: pods
+            verb: delete
+            name: my-pod-1
+          - resource: pods
+            verb: delete
+            name: my-pod-2
+        10:
+          - resource: pods
+            verb: delete
+            name: my-pod-3
+      sleep_time: 10
+
+  ## ERROR
+  timeout:
+    # Eviction creation is retried but never succeeds
+    - node_name: my-node
+      dataset: blocked-eviction
+
+    # Eviction creation succeeds, but the pod is never removed
+    - node_name: my-node
+      dataset: single-replicaset
+
+  eviction-error:
+    - node_name: my-node
+      dataset: broken-eviction
+
+
+datasets:
+  __common:
+    base-pod: &base_pod
+      api_version: v1
+      kind: Pod
+      metadata: &base_pod_meta
+        name: my-pod
+        namespace: my-namespace
+        owner_references: null
+        annotations: {}
+        uid: ede4ed1b-9a5e-4168-961c-b1bdad691ec7
+      spec: &base_pod_spec
+        containers: []
+        volumes: []
+        # NOTE: this should be `node_name` from our PoV, but we use this
+        # key for filtering server-side so we keep it as-is in our mock
+        nodeName: my-node
+      status: &base_pod_status
+        phase: Running
+
+    pod-with-local-storage: &local_storage_pod
+      <<: *base_pod
+      metadata:
+        <<: *base_pod_meta
+        name: my-pod-with-local-storage
+      spec:
+        <<: *base_pod_spec
+        volumes:
+        - name: tmp-volume
+          empty_dir: {}
+
+    static-pod: &static_pod
+      <<: *base_pod
+      metadata:
+        <<: *base_pod_meta
+        name: my-static-pod
+        annotations:
+          kubernetes.io/config.hash: be5260b5b984bb8a9b56204adf9d3a46
+          kubernetes.io/config.mirror: be5260b5b984bb8a9b56204adf9d3a46
+          kubernetes.io/config.source: file
+
+    finished-pod: &finished_pod
+      <<: *base_pod
+      metadata:
+        <<: *base_pod_meta
+        name: my-finished-pod
+        owner_references:
+        - api_version: batch/v1
+          kind: Job
+          controller: true
+          name: my-job
+      status:
+        <<: *base_pod_status
+        phase: Succeeded
+
+    replicaset-pod: &replicaset_pod
+      <<: *base_pod
+      metadata: &replicaset_pod_meta
+        <<: *base_pod_meta
+        name: my-replicaset-pod
+        owner_references:
+        - api_version: apps/v1
+          kind: ReplicaSet
+          controller: true
+          name: my-replicaset
+
+    daemonset-pod: &daemonset_pod
+      <<: *base_pod
+      metadata:
+        <<: *base_pod_meta
+        name: my-daemonset-pod
+        owner_references:
+        - api_version: apps/v1
+          kind: DaemonSet
+          controller: true
+          name: my-daemonset
+
+    common-replicaset: &common_replicaset
+      api_version: apps/v1
+      kind: ReplicaSet
+      metadata:
+        name: my-replicaset
+        namespace: my-namespace
+
+    common-daemonset: &common_daemonset
+      api_version: apps/v1
+      kind: DaemonSet
+      metadata:
+        name: my-daemonset
+        namespace: my-namespace
+
+    common-job: &common_job
+      api_version: batch/v1
+      kind: Job
+      metadata:
+        name: my-job
+        namespace: my-namespace
+
+  empty: &empty_dataset
+    # Real K8s resources
+    pods: []
+    replicasets: []
+    daemonsets: []
+    jobs: []
+
+    # Test utility resources
+    evictionmocks: []
+
+  single-pod:
+    <<: *empty_dataset
+    pods:
+      - *base_pod
+
+  single-static-pod:
+    <<: *empty_dataset
+    pods:
+      - *static_pod
+
+  finished-pod: &finished_pod_dataset
+    <<: *empty_dataset
+    pods:
+      - *finished_pod
+    jobs:
+      - *common_job
+
+  finished-orphaned-pod:
+    <<: *finished_pod_dataset
+    jobs: []
+
+  single-local-storage:
+    <<: *empty_dataset
+    pods:
+      - *local_storage_pod
+
+  single-replicaset: &single_replicaset_dataset
+    <<: *empty_dataset
+    pods:
+      - *replicaset_pod
+    replicasets:
+      - *common_replicaset
+
+  orphaned-replicaset-pod:
+    <<: *single_replicaset_dataset
+    replicasets: []
+
+  single-daemonset: &single_daemonset_dataset
+    <<: *empty_dataset
+    pods:
+      - *daemonset_pod
+    daemonsets:
+      - *common_daemonset
+
+  orphaned-daemonset-pod:
+    <<: *single_daemonset_dataset
+    daemonsets: []
+
+  multiple-pods:
+    <<: *single_replicaset_dataset
+    pods:
+      - <<: *replicaset_pod
+        metadata:
+          <<: *replicaset_pod_meta
+          name: my-pod-1
+      - <<: *replicaset_pod
+        metadata:
+          <<: *replicaset_pod_meta
+          name: my-pod-2
+      - <<: *replicaset_pod
+        metadata:
+          <<: *replicaset_pod_meta
+          name: my-pod-3
+
+  full:
+    <<: *empty_dataset
+    pods:
+      - *base_pod
+      - *replicaset_pod
+      - *static_pod
+      - *local_storage_pod
+      - *daemonset_pod
+    replicasets:
+      - *common_replicaset
+    daemonsets:
+      - *common_daemonset
+
+  blocked-eviction:
+    <<: *single_replicaset_dataset
+    evictionmocks:
+      - kind: EvictionMock
+        api_version: __tests__
+        pod: my-namespace/my-replicaset-pod
+        locked: true
+
+  broken-eviction:
+    <<: *single_replicaset_dataset
+    evictionmocks:
+      - kind: EvictionMock
+        api_version: __tests__
+        pod: my-namespace/my-replicaset-pod
+        raises: true

--- a/salt/tests/unit/modules/test_metalk8s.py
+++ b/salt/tests/unit/modules/test_metalk8s.py
@@ -18,6 +18,9 @@ YAML_TESTS_FILE = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
     "files", "test_metalk8s.yaml"
 )
+with open(YAML_TESTS_FILE) as fd:
+    YAML_TESTS_CASES = yaml.safe_load(fd)
+
 
 PRODUCT_TXT = '''
 NAME=MetalK8s
@@ -194,10 +197,7 @@ class Metalk8sTestCase(TestCase, LoaderModuleMockMixin):
 
             iso_info_cmd_mock.assert_called_once()
 
-    @parameterized.expand([
-        param.explicit(kwargs=test_case)
-        for test_case in yaml.safe_load(open(YAML_TESTS_FILE))["get_archives"]
-    ])
+    @utils.parameterized_from_cases(YAML_TESTS_CASES["get_archives"])
     def test_get_archives(self, archives, infos, result,
                           is_dirs=False, is_files=False,
                           raises=False, pillar_archives=None):
@@ -240,10 +240,7 @@ class Metalk8sTestCase(TestCase, LoaderModuleMockMixin):
                     result
                 )
 
-    @parameterized.expand([
-        param.explicit(kwargs=test_case)
-        for test_case in yaml.safe_load(open(YAML_TESTS_FILE))["check_pillar_keys"]
-    ])
+    @utils.parameterized_from_cases(YAML_TESTS_CASES["check_pillar_keys"])
     def test_check_pillar_keys(self, keys, result, raises=False,
                                pillar_content=None, refresh_called=False,
                                **kwargs):

--- a/salt/tests/unit/modules/test_metalk8s_drain.py
+++ b/salt/tests/unit/modules/test_metalk8s_drain.py
@@ -1,0 +1,343 @@
+# Standard library
+import json
+import logging
+import os.path
+
+# Runtime dependencies
+from kubernetes.client.rest import ApiException
+from salt.exceptions import CommandExecutionError
+from urllib3.exceptions import HTTPError
+
+# Test dependencies
+from parameterized import parameterized
+from salttesting.mixins import LoaderModuleMockMixin
+from salttesting.unit import TestCase
+from salttesting.mock import MagicMock, patch
+from salttesting.helpers import ForceImportErrorOn
+import yaml
+
+# Runtime modules
+import metalk8s_drain
+
+# Test modules
+from tests.unit.log_utils import capture_logs, check_captured_logs
+from tests.unit.utils import parameterized_from_cases
+from tests.unit.mocks import kubernetes as mock_kubernetes
+
+
+YAML_TESTS_FILE = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "files", "test_metalk8s_drain.yaml"
+)
+with open(YAML_TESTS_FILE) as fd:
+    YAML_TESTS_CASES = yaml.safe_load(fd)
+
+
+class Metalk8sDrainTestCase(TestCase, LoaderModuleMockMixin):
+    """Tests for `metalk8s_drain` execution module."""
+
+    loader_module = metalk8s_drain
+
+    loader_module_globals = {
+        '__salt__': {
+            'metalk8s_kubernetes.get_kubeconfig': MagicMock(
+                return_value=('/my/kube/config', 'my-context'),
+            ),
+        }
+    }
+
+    module_log_level = logging.DEBUG
+
+    def test_virtual_nominal(self):
+        """Nominal behaviour for `__virtual__`."""
+        reload(metalk8s_drain)
+        self.assertEqual(metalk8s_drain.__virtual__(), 'metalk8s_kubernetes')
+
+    @parameterized.expand([
+        ("missing kubernetes", "kubernetes.client.rest"),
+        ("missing urllib3", "urllib3.exceptions"),
+    ])
+    def test_virtual_fail_import(self, _, package):
+        """Behaviour for `__virtual__` on failed imports."""
+        with ForceImportErrorOn(package):
+            reload(metalk8s_drain)
+            self.assertTupleEqual(
+                metalk8s_drain.__virtual__(),
+                (False, "python kubernetes library not found")
+            )
+
+    def test_exception_formatting(self):
+        """Check that exceptions can be formatted as strings.
+
+        FIXME: this isn't used, nor well formatted.
+        """
+        exc = metalk8s_drain.DrainException("something broke")
+        self.assertEqual(
+            str(exc),
+            "<<class 'metalk8s_drain.DrainException'>> something broke"
+        )
+
+        exc = metalk8s_drain.DrainTimeoutException("too slow!")
+        self.assertEqual(
+            str(exc),
+            "<<class 'metalk8s_drain.DrainTimeoutException'>> too slow!"
+        )
+
+    @parameterized_from_cases(YAML_TESTS_CASES['evict_pod'])
+    def test_evict_pod(self, result, raises=False, create_raises=False,
+                       create_error_status=None, create_error_body=None,
+                       log_lines=None, **kwargs):
+        """Tests for `metalk8s_drain.evict_pod`."""
+        def _create_mock(*args, **kwargs):
+            if create_raises == 'ApiException':
+                if create_error_body is None:
+                    raise ApiException(status=create_error_status)
+                else:
+                    http_resp = MagicMock(
+                        status=create_error_status,
+                        data=json.dumps(create_error_body).encode('utf-8'),
+                    )
+                    raise ApiException(http_resp=http_resp)
+
+            elif create_raises == 'HTTPError':
+                raise HTTPError()
+
+        get_kind_info_mock = MagicMock()
+        create_mock = get_kind_info_mock.return_value.client.create
+        create_mock.side_effect = _create_mock
+
+        utils_dict = {
+            'metalk8s_kubernetes.get_kind_info': get_kind_info_mock,
+        }
+        with patch.dict(metalk8s_drain.__utils__, utils_dict), \
+                capture_logs(metalk8s_drain.log, logging.DEBUG) as captured:
+            if raises:
+                self.assertRaisesRegexp(
+                    CommandExecutionError,
+                    result,
+                    metalk8s_drain.evict_pod,
+                    **kwargs
+                )
+            else:
+                self.assertEqual(metalk8s_drain.evict_pod(**kwargs), result)
+                # TODO(gd): check that parameters match expected API call
+                create_mock.assert_called_once()
+
+            check_captured_logs(captured, log_lines)
+
+    @parameterized.expand([
+        ("cordon successful", False),
+        ("cordon failure", True),
+    ])
+    def test_node_drain(self, _, cordon_raises):
+        """Minimal tests for `metalk8s_drain.node_drain`.
+
+        See `DrainTestCase` below for advanced behaviour tests.
+        """
+        call_kwargs = {'node_name': 'example-node'}
+
+        drain_cls_mock = MagicMock()
+        run_drain_mock = drain_cls_mock.return_value.run_drain
+
+        cordon_mock = MagicMock()
+        if cordon_raises:
+            result = "Some error occured when cordoning"
+            cordon_mock.side_effect = CommandExecutionError(result)
+        else:
+            result = "Some result from drain"
+            run_drain_mock.return_value = result
+
+        salt_dict = {
+            'metalk8s_kubernetes.cordon_node': cordon_mock,
+        }
+        with patch.dict(metalk8s_drain.__salt__, salt_dict), \
+                patch("metalk8s_drain.Drain", drain_cls_mock):
+            if cordon_raises:
+                self.assertRaisesRegexp(
+                    CommandExecutionError,
+                    result,
+                    metalk8s_drain.node_drain,
+                    **call_kwargs
+                )
+                run_drain_mock.assert_not_called()
+            else:
+                self.assertEqual(
+                    metalk8s_drain.node_drain(**call_kwargs), result
+                )
+                run_drain_mock.assert_called_once()
+
+
+class DrainTestCase(TestCase, LoaderModuleMockMixin):
+    """Tests for the `Drain` interface used by the `metalk8s_drain` module.
+
+    These are split from the main execution module tests, as we can consider
+    this "drain" interface as a utility object.
+    The `Drain` class will be tested from its `run_drain` method to avoid going
+    too deep into unit-level tests of each available method, which wouldn't
+    bring much value otherwise, since not used anywhere else in the code.
+    """
+
+    loader_module = metalk8s_drain
+
+    def loader_module_globals(self):
+        # This method is called on each `setUp` invocation, which will reset
+        # the initial database for each test function
+        self.api_mock = mock_kubernetes.KubernetesAPIMock(
+            database={},
+            resources={
+                ('v1', 'Pod'): 'pods',
+                ('apps/v1', 'ReplicaSet'): 'replicasets',
+                ('apps/v1', 'DaemonSet'): 'daemonsets',
+                ('__tests__', 'EvictionMock'): 'evictionmocks',
+            },
+        )
+
+        def evict_pod_side_effect(name, namespace, **kwargs):
+            existing_pod = self.api_mock.get_object(
+                apiVersion='v1', kind='Pod', name=name, namespace=namespace
+            )
+            if existing_pod is None:
+                return True
+
+            eviction_mocks = self.api_mock.api.retrieve("evictionmocks")
+            eviction_mock = next((
+                mock for mock in eviction_mocks
+                if mock['pod'] == '{}/{}'.format(namespace, name)
+            ), None)
+            if eviction_mock is not None:
+                if eviction_mock.get('raises', False):
+                    raise CommandExecutionError('Failed to evict pod')
+
+                return not eviction_mock.get('locked', False)
+
+            return True
+
+        self.evict_pod_mock = MagicMock(side_effect=evict_pod_side_effect)
+
+        return {
+            '__salt__': {
+                'metalk8s_kubernetes.get_object': self.api_mock.get_object,
+                'metalk8s_kubernetes.list_objects': self.api_mock.list_objects,
+            },
+            'evict_pod': self.evict_pod_mock,
+        }
+
+    def seed_api_mock(self, dataset=None, events=None):
+        self.api_mock.seed(YAML_TESTS_CASES['datasets'][dataset])
+        self.time_mock = self.api_mock.time_mock_from_events(events or {})
+
+    @parameterized_from_cases(YAML_TESTS_CASES['drain']['nominal'])
+    def test_nominal(self, node_name, dataset, pods_to_evict, events=None,
+                     log_lines=None, **kwargs):
+        self.seed_api_mock(dataset, events)
+        drainer = metalk8s_drain.Drain(node_name, timeout=30, **kwargs)
+
+        with capture_logs(metalk8s_drain.log, logging.DEBUG) as captured, \
+                self.time_mock.patch():
+            result = drainer.run_drain()
+
+        self.assertEqual(result, "Eviction complete.")
+        check_captured_logs(captured, log_lines)
+        self.assertEqual(self.evict_pod_mock.call_count, len(pods_to_evict))
+        self.assertEqual(
+            set(call[1]['name'] for call in self.evict_pod_mock.call_args_list),
+            set(pods_to_evict)
+        )
+
+    @parameterized_from_cases(YAML_TESTS_CASES['drain']['dry-run'])
+    def test_dry_run(self, node_name, dataset, pods_to_evict, **kwargs):
+        self.seed_api_mock(dataset)
+        drainer = metalk8s_drain.Drain(node_name, **kwargs)
+
+        # Run in dry-run mode
+        result = drainer.run_drain(dry_run=True)
+
+        expected_result = "Prepared for eviction of pods: "
+        if pods_to_evict:
+            expected_result += ', '.join(pods_to_evict)
+        else:
+            expected_result += "no pods to evict."
+
+        self.assertEqual(result, expected_result)
+        self.evict_pod_mock.assert_not_called()
+
+    @parameterized_from_cases(YAML_TESTS_CASES['drain']['eviction-filters'])
+    def test_eviction_filters(self, node_name, dataset, pods_to_evict,
+                              log_lines=None, raises=False, raise_msg=None,
+                              **kwargs):
+        self.seed_api_mock(dataset)
+        drainer = metalk8s_drain.Drain(node_name, **kwargs)
+
+        with capture_logs(metalk8s_drain.log, logging.WARNING) as captured:
+            if raises:
+                self.assertRaisesRegexp(
+                    CommandExecutionError,
+                    "The following are not deletable: {}".format(raise_msg),
+                    drainer.run_drain,
+                    dry_run=True
+                )
+            else:
+                result = drainer.run_drain(dry_run=True)
+                expected_result = "Prepared for eviction of pods: "
+                if pods_to_evict:
+                    expected_result += ', '.join(pods_to_evict)
+                else:
+                    expected_result += "no pods to evict."
+                self.assertEqual(result, expected_result)
+
+        check_captured_logs(captured, log_lines)
+
+    @parameterized_from_cases(YAML_TESTS_CASES['drain']['eviction-retry'])
+    def test_eviction_retry(self, node_name, dataset, eviction_attempts,
+                            events=None, **kwargs):
+        """Check that eviction temporary failures (429) will be retried."""
+        self.seed_api_mock(dataset, events)
+        drainer = metalk8s_drain.Drain(node_name, **kwargs)
+
+        with self.time_mock.patch():
+            result = drainer.run_drain()
+
+        self.assertEqual(result, "Eviction complete.")
+        self.assertEqual(self.evict_pod_mock.call_count, eviction_attempts)
+
+    @parameterized_from_cases(
+        YAML_TESTS_CASES['drain']['waiting-for-eviction']
+    )
+    def test_waiting_for_eviction(self, node_name, dataset, sleep_time,
+                                  events=None, **kwargs):
+        """Check that the drain waits for pods to become evicted."""
+        self.seed_api_mock(dataset, events)
+        drainer = metalk8s_drain.Drain(node_name, **kwargs)
+
+        with self.time_mock.patch():
+            result = drainer.run_drain()
+
+        self.assertEqual(result, "Eviction complete.")
+        self.assertEqual(self.time_mock.time(), sleep_time)
+
+    @parameterized_from_cases(YAML_TESTS_CASES['drain']['timeout'])
+    def test_timeout(self, node_name, dataset, **kwargs):
+        """Check different sources of timeout."""
+        self.seed_api_mock(dataset)
+        drainer = metalk8s_drain.Drain(node_name, timeout=10, **kwargs)
+
+        with self.time_mock.patch():
+            self.assertRaisesRegexp(
+                CommandExecutionError,
+                "Drain did not complete within 10 seconds",
+                drainer.run_drain,
+            )
+
+    @parameterized_from_cases(YAML_TESTS_CASES['drain']['eviction-error'])
+    def test_eviction_error(self, node_name, dataset, **kwargs):
+        """Check that errors when evicting are stopping the drain process."""
+        self.seed_api_mock(dataset)
+        drainer = metalk8s_drain.Drain(node_name, **kwargs)
+
+        with self.time_mock.patch():
+            self.assertRaisesRegexp(
+                CommandExecutionError,
+                "Failed to evict pod",
+                drainer.run_drain,
+            )
+

--- a/salt/tests/unit/modules/test_metalk8s_grafana.py
+++ b/salt/tests/unit/modules/test_metalk8s_grafana.py
@@ -10,11 +10,14 @@ from salttesting.mock import MagicMock, patch
 
 import metalk8s_grafana
 
+from tests.unit import utils
 
 YAML_TESTS_FILE = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
     "files", "test_metalk8s_grafana.yaml"
 )
+with open(YAML_TESTS_FILE) as fd:
+    YAML_TESTS_CASES = yaml.safe_load(fd)
 
 
 class Metalk8sGrafanaTestCase(TestCase, LoaderModuleMockMixin):
@@ -29,10 +32,7 @@ class Metalk8sGrafanaTestCase(TestCase, LoaderModuleMockMixin):
         """
         self.assertEqual(metalk8s_grafana.__virtual__(), 'metalk8s_grafana')
 
-    @parameterized.expand(
-        param.explicit(kwargs=test_case)
-        for test_case in yaml.safe_load(open(YAML_TESTS_FILE))
-    )
+    @utils.parameterized_from_cases(YAML_TESTS_CASES)
     def test_load_dashboard(self, dashboard, result, raises=False, **kwargs):
         """
         Tests the return of `load_dashboard` function

--- a/salt/tests/unit/modules/test_metalk8s_kubernetes.py
+++ b/salt/tests/unit/modules/test_metalk8s_kubernetes.py
@@ -14,6 +14,8 @@ from salttesting.helpers import ForceImportErrorOn
 
 import metalk8s_kubernetes
 
+from tests.unit import utils
+
 
 YAML_TESTS_FILE = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
@@ -118,9 +120,8 @@ class Metalk8sKubernetesTestCase(TestCase, LoaderModuleMockMixin):
                 (False, 'Missing `metalk8s_kubernetes` utils module')
             )
 
-    @parameterized.expand(
-        param.explicit(kwargs=test_case)
-        for test_case in YAML_TESTS_CASES['create_object'] + YAML_TESTS_CASES['common_tests']
+    @utils.parameterized_from_cases(
+        YAML_TESTS_CASES['create_object'] + YAML_TESTS_CASES['common_tests']
     )
     def test_create_object(self, result, raises=False, api_status_code=None,
                            info_scope="cluster", manifest_file_content=None,
@@ -189,9 +190,8 @@ class Metalk8sKubernetesTestCase(TestCase, LoaderModuleMockMixin):
                         create_mock.call_args.kwargs
                     )
 
-    @parameterized.expand(
-        param.explicit(kwargs=test_case)
-        for test_case in YAML_TESTS_CASES['delete_object'] + YAML_TESTS_CASES['common_tests']
+    @utils.parameterized_from_cases(
+        YAML_TESTS_CASES['delete_object'] + YAML_TESTS_CASES['common_tests']
     )
     def test_delete_object(self, result, raises=False, api_status_code=None,
                            info_scope="namespaced", manifest_file_content=None,
@@ -263,9 +263,8 @@ class Metalk8sKubernetesTestCase(TestCase, LoaderModuleMockMixin):
                         delete_mock.call_args.kwargs
                     )
 
-    @parameterized.expand(
-        param.explicit(kwargs=test_case)
-        for test_case in YAML_TESTS_CASES['replace_object'] + YAML_TESTS_CASES['common_tests']
+    @utils.parameterized_from_cases(
+        YAML_TESTS_CASES['replace_object'] + YAML_TESTS_CASES['common_tests']
     )
     def test_replace_object(self, result, raises=False, api_status_code=None,
                             info_scope="cluster", manifest_file_content=None,
@@ -334,9 +333,8 @@ class Metalk8sKubernetesTestCase(TestCase, LoaderModuleMockMixin):
                         replace_mock.call_args.kwargs
                     )
 
-    @parameterized.expand(
-        param.explicit(kwargs=test_case)
-        for test_case in YAML_TESTS_CASES['get_object'] + YAML_TESTS_CASES['common_tests']
+    @utils.parameterized_from_cases(
+        YAML_TESTS_CASES['get_object'] + YAML_TESTS_CASES['common_tests']
     )
     def test_get_object(self, result, raises=False, api_status_code=None,
                         info_scope="namespaced", manifest_file_content=None,
@@ -408,9 +406,8 @@ class Metalk8sKubernetesTestCase(TestCase, LoaderModuleMockMixin):
                         retrieve_mock.call_args.kwargs
                     )
 
-    @parameterized.expand(
-        param.explicit(kwargs=test_case)
-        for test_case in YAML_TESTS_CASES['update_object'] + YAML_TESTS_CASES['common_tests']
+    @utils.parameterized_from_cases(
+        YAML_TESTS_CASES['update_object'] + YAML_TESTS_CASES['common_tests']
     )
     def test_update_object(self, result, raises=False, initial_obj=None,
                            info_scope="cluster", manifest_file_content=None,
@@ -499,9 +496,8 @@ class Metalk8sKubernetesTestCase(TestCase, LoaderModuleMockMixin):
             )
             get_object_mock.assert_called_once()
 
-    @parameterized.expand(
-        param.explicit(kwargs=test_case)
-        for test_case in YAML_TESTS_CASES['list_objects']
+    @utils.parameterized_from_cases(
+        YAML_TESTS_CASES['list_objects']
     )
     def test_list_objects(self, result, raises=False, api_status_code=None,
                           info_scope="namespaced", called_with=None, **kwargs):

--- a/salt/tests/unit/modules/test_metalk8s_kubernetes_utils.py
+++ b/salt/tests/unit/modules/test_metalk8s_kubernetes_utils.py
@@ -14,6 +14,8 @@ from salttesting.helpers import ForceImportErrorOn
 
 import metalk8s_kubernetes_utils
 
+from tests.unit import utils
+
 
 YAML_TESTS_FILE = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
@@ -57,10 +59,7 @@ class Metalk8sKubernetesUtilsTestCase(TestCase, LoaderModuleMockMixin):
                 ))
             )
 
-    @parameterized.expand([
-        param.explicit(kwargs=test_case)
-        for test_case in YAML_TESTS_CASES["get_kubeconfig"]
-    ])
+    @utils.parameterized_from_cases(YAML_TESTS_CASES["get_kubeconfig"])
     def test_get_kubeconfig(
         self,
         result,
@@ -158,10 +157,9 @@ class Metalk8sKubernetesUtilsTestCase(TestCase, LoaderModuleMockMixin):
                 metalk8s_kubernetes_utils.ping(),
             )
 
-    @parameterized.expand([
-        param.explicit(kwargs=test_case)
-        for test_case in YAML_TESTS_CASES["read_and_render_yaml_file"]
-    ])
+    @utils.parameterized_from_cases(
+        YAML_TESTS_CASES["read_and_render_yaml_file"]
+    )
     def test_read_and_render_yaml_file(
         self,
         source,

--- a/salt/tests/unit/modules/test_metalk8s_package_manager_yum.py
+++ b/salt/tests/unit/modules/test_metalk8s_package_manager_yum.py
@@ -56,10 +56,7 @@ class Metalk8sPackageManagerYumTestCase(TestCase, LoaderModuleMockMixin):
                 False
             )
 
-    @parameterized.expand(
-        param.explicit(kwargs=test_case)
-        for test_case in YAML_TESTS_CASES["list_dependents"]
-    )
+    @utils.parameterized_from_cases(YAML_TESTS_CASES["list_dependents"])
     def test_list_dependents(self, repoquery_output, result, **kwargs):
         """
         Tests the return of `_list_dependents` function
@@ -99,10 +96,7 @@ class Metalk8sPackageManagerYumTestCase(TestCase, LoaderModuleMockMixin):
                     repoquery_cmd_mock.call_args[0][0]
                 )
 
-    @parameterized.expand(
-        param.explicit(kwargs=test_case)
-        for test_case in YAML_TESTS_CASES["list_pkg_dependents"]
-    )
+    @utils.parameterized_from_cases(YAML_TESTS_CASES["list_pkg_dependents"])
     def test_list_pkg_dependents(self, result,
                                  list_dependents=None, rpm_qa_outputs=None,
                                  **kwargs):
@@ -144,10 +138,7 @@ class Metalk8sPackageManagerYumTestCase(TestCase, LoaderModuleMockMixin):
                 result
             )
 
-    @parameterized.expand(
-        param.explicit(kwargs=test_case)
-        for test_case in YAML_TESTS_CASES["check_pkg_availability"]
-    )
+    @utils.parameterized_from_cases(YAML_TESTS_CASES["check_pkg_availability"])
     def test_check_pkg_availability(self, pkgs_info, raise_msg=None,
                                     ybase_installs=True,
                                     ybase_process_trans=True):

--- a/salt/tests/unit/modules/test_metalk8s_solutions.py
+++ b/salt/tests/unit/modules/test_metalk8s_solutions.py
@@ -12,6 +12,8 @@ from salttesting.mock import MagicMock, mock_open, patch
 
 import metalk8s_solutions
 
+from tests.unit import utils
+
 
 YAML_TESTS_FILE = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
@@ -47,10 +49,7 @@ class Metalk8sSolutionsTestCase(TestCase, LoaderModuleMockMixin):
             (False, "Failed to load 'metalk8s' module.")
         )
 
-    @parameterized.expand([
-        param.explicit(kwargs=test_case)
-        for test_case in YAML_TESTS_CASES["read_config"]
-    ])
+    @utils.parameterized_from_cases(YAML_TESTS_CASES["read_config"])
     def test_read_config(self, create=False, config=None, result=None,
                          raises=False):
         """
@@ -82,10 +81,7 @@ class Metalk8sSolutionsTestCase(TestCase, LoaderModuleMockMixin):
                         result
                     )
 
-    @parameterized.expand([
-        param.explicit(kwargs=test_case)
-        for test_case in YAML_TESTS_CASES["configure_archive"]
-    ])
+    @utils.parameterized_from_cases(YAML_TESTS_CASES["configure_archive"])
     def test_configure_archive(self, archive, removed=None, config=None,
                                result=None, raises=False):
         """
@@ -120,10 +116,7 @@ class Metalk8sSolutionsTestCase(TestCase, LoaderModuleMockMixin):
                 )
                 self.assertEqual(config, result)
 
-    @parameterized.expand([
-        param.explicit(kwargs=test_case)
-        for test_case in YAML_TESTS_CASES["activate_solution"]
-    ])
+    @utils.parameterized_from_cases(YAML_TESTS_CASES["activate_solution"])
     def test_activate_solution(self, solution, version=None, config=None,
                                result=None, available=None, raises=False):
         """
@@ -166,10 +159,7 @@ class Metalk8sSolutionsTestCase(TestCase, LoaderModuleMockMixin):
 
                 self.assertEqual(config, result)
 
-    @parameterized.expand([
-        param.explicit(kwargs=test_case)
-        for test_case in YAML_TESTS_CASES["deactivate_solution"]
-    ])
+    @utils.parameterized_from_cases(YAML_TESTS_CASES["deactivate_solution"])
     def test_deactivate_solution(self, solution, config=None, raises=False,
                                  result=None):
         """
@@ -200,10 +190,7 @@ class Metalk8sSolutionsTestCase(TestCase, LoaderModuleMockMixin):
                 )
                 self.assertEqual(config, result)
 
-    @parameterized.expand([
-        param.explicit(kwargs=test_case)
-        for test_case in YAML_TESTS_CASES["list_solution_images"]
-    ])
+    @utils.parameterized_from_cases(YAML_TESTS_CASES["list_solution_images"])
     def test_list_solution_images(self, images=None, result=None,
                                   raises=False):
         """
@@ -253,10 +240,7 @@ class Metalk8sSolutionsTestCase(TestCase, LoaderModuleMockMixin):
                     result
                 )
 
-    @parameterized.expand([
-        param.explicit(kwargs=test_case)
-        for test_case in YAML_TESTS_CASES["read_solution_config"]
-    ])
+    @utils.parameterized_from_cases(YAML_TESTS_CASES["read_solution_config"])
     def test_read_solution_config(self, config=None, result=None,
                                   raises=False):
         """
@@ -288,10 +272,7 @@ class Metalk8sSolutionsTestCase(TestCase, LoaderModuleMockMixin):
                     result
                 )
 
-    @parameterized.expand(
-        param.explicit(kwargs=test_case)
-        for test_case in YAML_TESTS_CASES["list_available"]
-    )
+    @utils.parameterized_from_cases(YAML_TESTS_CASES["list_available"])
     def test_list_available(self, mountpoints=None, archive_infos=None,
                             result=None, raises=False):
         """

--- a/salt/tests/unit/modules/test_metalk8s_solutions_k8s.py
+++ b/salt/tests/unit/modules/test_metalk8s_solutions_k8s.py
@@ -9,6 +9,8 @@ from salttesting.mock import MagicMock, patch
 
 import metalk8s_solutions_k8s
 
+from tests.unit import utils
+
 
 YAML_TESTS_FILE = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
@@ -32,10 +34,7 @@ class Metalk8sSolutionsK8sTestCase(TestCase, LoaderModuleMockMixin):
             metalk8s_solutions_k8s.__virtual__(), 'metalk8s_solutions'
         )
 
-    @parameterized.expand([
-        param.explicit(kwargs=test_case)
-        for test_case in YAML_TESTS_CASES["list_active"]
-    ])
+    @utils.parameterized_from_cases(YAML_TESTS_CASES["list_active"])
     def test_list_active(self, configmap, result):
         """
         Tests the return of `list_active` function
@@ -47,10 +46,7 @@ class Metalk8sSolutionsK8sTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(metalk8s_solutions_k8s.__salt__, patch_dict):
             self.assertEqual(metalk8s_solutions_k8s.list_active(), result)
 
-    @parameterized.expand([
-        param.explicit(kwargs=test_case)
-        for test_case in YAML_TESTS_CASES["list_environments"]
-    ])
+    @utils.parameterized_from_cases(YAML_TESTS_CASES["list_environments"])
     def test_list_environments(self, namespaces, result, configmaps=None):
         """
         Tests the return of `list_environments` function

--- a/salt/tests/unit/modules/test_metalk8s_volumes.py
+++ b/salt/tests/unit/modules/test_metalk8s_volumes.py
@@ -1,8 +1,6 @@
 import os.path
 import yaml
 
-from parameterized import param, parameterized
-
 from salt.exceptions import CommandExecutionError
 
 from salttesting.mixins import LoaderModuleMockMixin
@@ -34,10 +32,7 @@ class Metalk8sVolumesTestCase(TestCase, LoaderModuleMockMixin):
         """
         self.assertEqual(metalk8s_volumes.__virtual__(), 'metalk8s_volumes')
 
-    @parameterized.expand(
-        param.explicit(kwargs=test_case)
-        for test_case in YAML_TESTS_CASES["exists"]
-    )
+    @utils.parameterized_from_cases(YAML_TESTS_CASES["exists"])
     def test_exists(self, name, result, raises=False, pillar_volumes=None,
                     is_file=True, get_size=1073741824, is_blkdev=True):
         """
@@ -73,10 +68,7 @@ class Metalk8sVolumesTestCase(TestCase, LoaderModuleMockMixin):
                     result
                 )
 
-    @parameterized.expand(
-        param.explicit(kwargs=test_case)
-        for test_case in YAML_TESTS_CASES["create"]
-    )
+    @utils.parameterized_from_cases(YAML_TESTS_CASES["create"])
     def test_create(self, name, raise_msg=None, pillar_volumes=None,
                     ftruncate=True):
         """
@@ -107,10 +99,7 @@ class Metalk8sVolumesTestCase(TestCase, LoaderModuleMockMixin):
                 # This function does not return anything
                 metalk8s_volumes.create(name)
 
-    @parameterized.expand(
-        param.explicit(kwargs=test_case)
-        for test_case in YAML_TESTS_CASES["is_provisioned"]
-    )
+    @utils.parameterized_from_cases(YAML_TESTS_CASES["is_provisioned"])
     def test_is_provisioned(self, name, result, raises=False,
                             pillar_volumes=None, losetup_output=None):
         """
@@ -153,10 +142,7 @@ class Metalk8sVolumesTestCase(TestCase, LoaderModuleMockMixin):
                     result
                 )
 
-    @parameterized.expand(
-        param.explicit(kwargs=test_case)
-        for test_case in YAML_TESTS_CASES["provision"]
-    )
+    @utils.parameterized_from_cases(YAML_TESTS_CASES["provision"])
     def test_provision(self, name, raise_msg=False,
                        pillar_volumes=None, losetup_output=None):
         """
@@ -197,10 +183,7 @@ class Metalk8sVolumesTestCase(TestCase, LoaderModuleMockMixin):
                 # This function does not return anything
                 metalk8s_volumes.provision(name)
 
-    @parameterized.expand(
-        param.explicit(kwargs=test_case)
-        for test_case in YAML_TESTS_CASES["is_formatted"]
-    )
+    @utils.parameterized_from_cases(YAML_TESTS_CASES["is_formatted"])
     def test_is_formatted(self, name, result, raises=False,
                           uuid_return=None, pillar_volumes=None):
         """
@@ -236,10 +219,7 @@ class Metalk8sVolumesTestCase(TestCase, LoaderModuleMockMixin):
                     result
                 )
 
-    @parameterized.expand(
-        param.explicit(kwargs=test_case)
-        for test_case in YAML_TESTS_CASES["format"]
-    )
+    @utils.parameterized_from_cases(YAML_TESTS_CASES["format"])
     def test_format(self, name, raise_msg=False,
                     current_fstype=None, has_partition=False,
                     pillar_volumes=None, mkfs_output=None):
@@ -292,10 +272,7 @@ class Metalk8sVolumesTestCase(TestCase, LoaderModuleMockMixin):
                 # This function does not return anything
                 metalk8s_volumes.format(name)
 
-    @parameterized.expand(
-        param.explicit(kwargs=test_case)
-        for test_case in YAML_TESTS_CASES["is_cleaned_up"]
-    )
+    @utils.parameterized_from_cases(YAML_TESTS_CASES["is_cleaned_up"])
     def test_is_cleaned_up(self, name, result, raises=False,
                            is_provisioned=False, exists=False,
                            pillar_volumes=None):
@@ -328,10 +305,7 @@ class Metalk8sVolumesTestCase(TestCase, LoaderModuleMockMixin):
                     result
                 )
 
-    @parameterized.expand(
-        param.explicit(kwargs=test_case)
-        for test_case in YAML_TESTS_CASES["clean_up"]
-    )
+    @utils.parameterized_from_cases(YAML_TESTS_CASES["clean_up"])
     def test_clean_up(self, name, raise_msg=False, pillar_volumes=None,
                       remove_error=None, ioctl_error=None):
         """

--- a/salt/tests/unit/utils.py
+++ b/salt/tests/unit/utils.py
@@ -2,6 +2,8 @@
 Utils, helpers for testing
 """
 
+from parameterized import param, parameterized
+
 
 def cmd_output(retcode=0, stdout=None, stderr=None, pid=12345):
     """
@@ -13,3 +15,10 @@ def cmd_output(retcode=0, stdout=None, stderr=None, pid=12345):
         'stdout': stdout or '',
         'stderr': stderr or ''
     }
+
+
+def parameterized_from_cases(test_cases):
+    return parameterized.expand(
+        param.explicit(kwargs=test_case) for test_case in test_cases
+    )
+

--- a/salt/tests/unit/utils.py
+++ b/salt/tests/unit/utils.py
@@ -1,6 +1,8 @@
 """
 Utils, helpers for testing
 """
+import functools
+import operator
 
 from parameterized import param, parameterized
 
@@ -22,3 +24,15 @@ def parameterized_from_cases(test_cases):
         param.explicit(kwargs=test_case) for test_case in test_cases
     )
 
+
+def split_path(path, delimiter="."):
+    return (
+        int(key) if key.isdigit() else key for key in path.split(delimiter)
+    )
+
+
+def get_dict_element(data, path, delimiter="."):
+    """Traverse a nested dict with a compound path."""
+    return functools.reduce(
+        operator.getitem, split_path(path, delimiter), data
+    )


### PR DESCRIPTION
This PR adds unit tests providing 100% coverage on the `metalk8s_drain` module.

To do so, it introduces:
- some utilities for capturing and checking logs
- an API mock which allows the tester to manage responses and objects
directly, while the tested code can interact with it through
`metalk8s_kubernetes` methods
- a mock for the `time` module, which allows the drain process to run
faster than real time, and also controls the API mock through timed
events
- a mock for the eviction API

See: #2266