### PR TITLE
Various missing salt module unit tests for 2.5+

### DIFF
--- a/salt/_modules/metalk8s_kubernetes.py
+++ b/salt/_modules/metalk8s_kubernetes.py
@@ -9,6 +9,7 @@ module, while other methods can be found in `metalk8s_kubernetes_utils.py`,
 `metalk8s_drain.py` and `metalk8s_cordon.py`.
 """
 
+import json
 import logging
 import re
 
@@ -400,5 +401,8 @@ def get_object_digest(path=None, checksum='sha256', *args, **kwargs):
                     path
                 )
             )
+
+    if isinstance(obj, dict):
+        obj = json.dumps(obj, sort_keys=True)
 
     return __salt__.hashutil.digest(str(obj), checksum=checksum)

--- a/salt/tests/unit/modules/files/test_metalk8s.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s.yaml
@@ -260,3 +260,71 @@ check_pillar_keys:
     }
     raises: True
     result: "Unable to get my.third.key.does-not-exists:\n\tEmpty value for third.key"
+
+format_slots:
+  # Simple format slots (no slots)
+  - data:
+      my: simple
+      data:
+        - content
+        - without
+        - any: slots
+    result:
+      my: simple
+      data:
+        - content
+        - without
+        - any: slots
+
+  # Simple single slot returning string
+  - data: __slot__:salt:my_mod.my_fun()
+    slots_returns:
+      my_mod.my_fun: 'ABC123'
+    result: 'ABC123'
+
+  # Invalid slot ignored (malformed)
+  - data: __slot__:malformed_slot_call
+    result: __slot__:malformed_slot_call
+
+  # Invalid slot ignored (invalid caller)
+  - data: __slot__:my_invalid_caller:slot.call()
+    result: __slot__:my_invalid_caller:slot.call()
+
+  # Multiple slots nested (with some invalid call ignored)
+  - data:
+      mykey:
+        abc: __slot__:salt:my_mod.first_fun()
+        def:
+          - 123
+          - __slot__:salt:my_mod.second_fun(with, some, x=args)
+          - __slot:malformed_slot_call
+      otherkey: __slot__:invalid_caller:slot.call()
+    slots_returns:
+      my_mod.first_fun: 'First fun simple return'
+      my_mod.second_fun:
+        Dict: return
+        For:
+          - second
+          - funct: ion
+    result:
+      mykey:
+        abc: 'First fun simple return'
+        def:
+          - 123
+          - Dict: return
+            For:
+              - second
+              - funct: ion
+          - __slot:malformed_slot_call
+      otherkey: __slot__:invalid_caller:slot.call()
+
+    # Error during slot execution
+    data:
+      my_key:
+        abc:
+          - def
+          - __slot__:salt:my_mod.my_fun()
+    slots_returns:
+      my_mod.my_fun: null
+    raises: True
+    result: "Unable to compute slot '__slot__:salt:my_mod.my_fun\\(\\)': An error has occurred"

--- a/salt/tests/unit/modules/files/test_metalk8s_kubernetes.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_kubernetes.yaml
@@ -517,3 +517,46 @@ list_objects:
     result: |-
       Failed to list resources "v1/Node": \(0\)
       Reason: An error has occurred
+
+get_object_digest:
+  # Simple full object digest
+  - obj:
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: my_node
+    result: 134164353c059f0e1c55c5d4f40eb500997399f0f1fcbb8dd373baec3a9e8c39
+
+  # Object specific key digest
+  - obj:
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: my_node
+    path: 'metadata:name'
+    result: e74a1c5e32ef10c596001d2ba43bc94d6687919769e67e8b90386b77cc6f3a3a
+
+  # Object digest md5
+  - obj:
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: my_node
+    path: 'metadata:name'
+    checksum: 'md5'
+    result: d98adbe109489058e7a6ec9716acdadb
+
+  # Unable to get object
+  - obj: null
+    raises: True
+    result: 'Unable to find the object'
+
+  # Unable to find the key in the object
+  - obj:
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: my_node
+    path: 'metadata:invalid:path'
+    raises: True
+    result: 'Unable to find key "metadata:invalid:path" in the object'

--- a/salt/tests/unit/modules/test_metalk8s_network.py
+++ b/salt/tests/unit/modules/test_metalk8s_network.py
@@ -82,3 +82,29 @@ class Metalk8sNetworkTestCase(TestCase, LoaderModuleMockMixin):
                 error_msg,
                 metalk8s_network.get_cluster_dns_ip
             )
+
+    def test_get_oidc_service_ip_success(self):
+        """
+        Tests the return of `get_oidc_service_ip` function, success
+        """
+        self.assertEqual(metalk8s_network.get_oidc_service_ip(), "10.0.0.7")
+
+    @parameterized.expand([
+        (None, 'Pillar key "networks:service" must be set.'),
+        (
+            '10.0.0.0/32',
+            'Could not obtain an IP in the network range 10.0.0.0/32'
+        )
+    ])
+    def test_get_oidc_service_ip_raise(self, service_ip, error_msg):
+        """
+        Tests the return of `get_oidc_service_ip` function, when raising
+        """
+        with patch.dict(
+                metalk8s_network.__pillar__,
+                {'networks': {'service': service_ip}}):
+            self.assertRaisesRegexp(
+                CommandExecutionError,
+                error_msg,
+                metalk8s_network.get_oidc_service_ip
+            )


### PR DESCRIPTION
**Component**:

'salt', 'tests'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

#2266 

**Summary**:

- unit tests for `metalk8s.format_slots`
- Fix `metalk8s_kubernetes.get_object_digest` for dict
- unit tests for `metalk8s_kubernetes.get_object_digest`
- unit tests for `metalk8s_network.get_oidc_service_ip`

**Acceptance criteria**: 

```
---------- coverage: platform linux2, python 2.7.18-final-0 ----------
Name                                   Stmts   Miss  Cover   Missing
--------------------------------------------------------------------
salt/_modules/metalk8s.py                150      0   100%
salt/_modules/metalk8s_kubernetes.py     147      0   100%
salt/_modules/metalk8s_network.py         26      0   100%
--------------------------------------------------------------------
TOTAL                                    323      0   100%
```

---

Refs: #2266 
