### PR TITLE
INTEGRATION [PR#2691 > development/2.5] salt/tests: Add unit tests for `metalk8s_solutions` salt module

### DIFF
--- a/salt/tests/unit/modules/files/test_metalk8s_solutions.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_solutions.yaml
@@ -1,0 +1,298 @@
+read_config:
+  # Ok - no solutions configuration file, create set to True
+  - create: True
+    result:
+      kind: SolutionsConfiguration
+      apiVersion: solutions.metalk8s.scality.com/v1alpha1
+      archives: []
+      active: {}
+  # Ok - existing configuration file
+  - config: |-
+      kind: SolutionsConfiguration
+      apiVersion: solutions.metalk8s.scality.com/v1alpha1
+      archives:
+        - /tmp/my-solution.iso
+      active:
+        my-solution: 1.0.0
+    result:
+      kind: SolutionsConfiguration
+      apiVersion: solutions.metalk8s.scality.com/v1alpha1
+      archives:
+        - /tmp/my-solution.iso
+      active:
+        my-solution: 1.0.0
+  # Nok - no solutions configuration file, create left to default (False)
+  - raises: True
+    result: 'Failed to load ".*": .*'
+  # Nok - no solutions configuration kind
+  - raises: True
+    config: |-
+      apiVersion: solutions.metalk8s.scality.com/v1alpha1
+    result: >-
+      Invalid `kind` in configuration \(None\), must be
+      "SolutionsConfiguration"
+  # Nok - invalid solutions configuration kind
+  - raises: True
+    config: |-
+      kind: InvalidSolutionsConfiguration
+      apiVersion: solutions.metalk8s.scality.com/v1alpha1
+    result: >-
+      Invalid `kind` in configuration \(InvalidSolutionsConfiguration\),
+      must be "SolutionsConfiguration"
+  # Nok - no solutions configuration apiVersion
+  - raises: True
+    config: |-
+      kind: SolutionsConfiguration
+    result: >-
+      Invalid `apiVersion` in configuration \(None\), must be one of: .*
+  # Nok - invalid solutions configuration apiVersion
+  - raises: True
+    config: |-
+      kind: SolutionsConfiguration
+      apiVersion: invalid.metalk8s.scality.com/v1alpha1
+    result: >-
+      Invalid `apiVersion` in configuration
+      \(invalid.metalk8s.scality.com/v1alpha1\), must be one of: .*
+
+configure_archive:
+  # Ok - add a solution archive
+  - archive: /tmp/my-solution.iso
+    config:
+      archives: []
+    result:
+      archives:
+         - /tmp/my-solution.iso
+  # Ok - remove a solution archive
+  - archive: /tmp/my-solution.iso
+    removed: True
+    config:
+      archives:
+        - /tmp/my-solution.iso
+        - /tmp/my-other-solution.iso
+    result:
+      archives:
+        - /tmp/my-other-solution.iso
+  # Ok - remove a non-existing archive
+  - archive: /tmp/my-solution.iso
+    removed: True
+    config:
+      archives:
+        - /tmp/my-other-solution.iso
+    result:
+      archives:
+        - /tmp/my-other-solution.iso
+  # Nok - solution config is not writable
+  - archive: /tmp/my-solution.iso
+    raises: True
+    config:
+      archives: []
+
+activate_solution:
+  # Ok - solution with specific version
+  - solution: my-solution
+    version: 1.0.0
+    available:
+      my-solution:
+        - version: 1.0.0
+        - version: 2.0.0
+      another-solution:
+        - version: 1.1.1
+    config:
+      active:
+        another-solution: 1.1.1
+    result:
+      active:
+        my-solution: 1.0.0
+        another-solution: 1.1.1
+  # Ok - solution with no version provided (default to latest)
+  - solution: my-solution
+    available:
+      my-solution:
+        - version: 1.0.0
+    config:
+      active: {}
+    result:
+      active:
+        my-solution: latest
+  # Ok - activate another version of a solution
+  - solution: my-solution
+    version: 1.0.0
+    available:
+      my-solution:
+        - version: 1.0.0
+        - version: 2.0.0
+    config:
+      active:
+        my-solution: 2.0.0
+    result:
+      active:
+        my-solution: 1.0.0
+  # Nok - solution version is not available
+  - solution: my-solution
+    version: 1.1.0
+    available:
+      my-solution:
+        - version: 1.0.0
+    result: >-
+      Cannot activate version "1.1.0" for Solution "my-solution": not available
+    raises: True
+  # Nok - solution is not available
+  - solution: my-solution
+    version: 1.1.0
+    result: 'Cannot activate Solution "my-solution": not available'
+    raises: True
+  # Nok - solution config is not writable
+  - solution: my-solution
+    version: 1.0.0
+    available:
+      my-solution:
+        - version: 1.0.0
+    config:
+      active: {}
+    result: Failed to write Solutions config file
+    raises: True
+
+deactivate_solution:
+  # Ok - deactivate an active solution
+  - solution: my-solution
+    config:
+      active:
+        my-solution: ''
+        my-other-solution: ''
+    result:
+      active:
+        my-other-solution: ''
+  # Ok - deactivate a non-active solution
+  - solution: my-solution
+    config:
+      active:
+        my-other-solution: ''
+    result:
+      active:
+        my-other-solution: ''
+  # Nok - solution config file is not writable
+  - solution: my-solution
+    config:
+      active: {}
+    raises: True
+
+list_solution_images:
+  # Ok - images directories with some extra files.
+  - images:
+      some-extra-file: False
+      my-solution-ui:
+        1.1.0: True
+        another-extra-file: False
+      my-solution-operator:
+        1.0.0: True
+    result:
+      - my-solution-ui:1.1.0
+      - my-solution-operator:1.0.0
+  # Nok - no images directory at solution root
+  - raises: True
+    result: .* does not exist or is not a directory
+
+read_solution_config:
+  # Ok - with config.yaml file
+  - config: |-
+      kind: SolutionConfig
+      apiVersion: solutions.metalk8s.scality.com/v1alpha1
+      operator:
+        image:
+          name: my-custom-operator
+          tag: 1.1.0
+      images:
+        - my-extra-image:1.1.0
+    result:
+      kind: SolutionConfig
+      apiVersion: solutions.metalk8s.scality.com/v1alpha1
+      operator:
+        image:
+          name: my-custom-operator
+          tag: 1.1.0
+      ui:
+        image:
+          name: my-solution-ui
+          tag: 1.0.0
+      images:
+        - my-extra-image:1.1.0
+      customApiGroups: []
+  # Ok - with empty config.yaml file (except kind and apiVersion)
+  - config: |-
+      kind: SolutionConfig
+      apiVersion: solutions.metalk8s.scality.com/v1alpha1
+    result:
+      kind: SolutionConfig
+      apiVersion: solutions.metalk8s.scality.com/v1alpha1
+      operator:
+        image:
+          name: my-solution-operator
+          tag: 1.0.0
+      ui:
+        image:
+          name: my-solution-ui
+          tag: 1.0.0
+      images: []
+      customApiGroups: []
+  # Ok - without config.yaml file
+  - result:
+      kind: SolutionConfig
+      apiVersion: solutions.metalk8s.scality.com/v1alpha1
+      operator:
+        image:
+          name: my-solution-operator
+          tag: 1.0.0
+      ui:
+        image:
+          name: my-solution-ui
+          tag: 1.0.0
+      images: []
+      customApiGroups: []
+  # Nok - bad or no solution config kind
+  - config: |-
+      kind: InvalidSolutionConfigKind
+      apiVersion: solutions.metalk8s.scality.com/v1alpha1
+    result: Wrong apiVersion/kind for .*
+    raises: True
+  # Nok - solution config apiVersion not provided
+  - config: |-
+      kind: SolutionConfig
+    result: Wrong apiVersion/kind for .*
+    raises: True
+
+list_available:
+  # Ok - 1 Solution
+  - mountpoints:
+      /: {}
+      /srv/scality/metalk8s-x.y.z: {}
+      /srv/scality/my-solution:
+        alt_device: /tmp/my-solution-1.0.0.iso
+        fstype: iso9660
+    archive_infos:
+      name: My Solution
+      version: 1.0.0
+    result:
+      my-solution:
+        - name: My Solution
+          id: my-solution-1.0.0
+          mountpoint: /srv/scality/my-solution
+          archive: /tmp/my-solution-1.0.0.iso
+          version: 1.0.0
+          config: null
+  # Nok - 1 Solution - fstype not iso9660
+  - mountpoints:
+      /srv/scality/my-solution:
+        alt_device: /tmp/my-solution-1.0.0.iso
+        fstype: xfs
+  # Nok - 1 Solution - no product.txt
+  - mountpoints:
+      /srv/scality/my-solution:
+        alt_device: /tmp/my-solution-1.0.0.iso
+        fstype: iso9660
+    raises: True
+  # Ok - No Solution mountpoint
+  - mountpoints:
+      /: {}
+      /srv/scality/metalk8s-x.y.z: {}
+  # Ok - No mountpoint
+  - {}

--- a/salt/tests/unit/modules/test_metalk8s_solutions.py
+++ b/salt/tests/unit/modules/test_metalk8s_solutions.py
@@ -1,0 +1,333 @@
+import errno
+import os.path
+import yaml
+
+from parameterized import param, parameterized
+
+from salt.exceptions import CommandExecutionError
+
+from salttesting.mixins import LoaderModuleMockMixin
+from salttesting.unit import TestCase
+from salttesting.mock import MagicMock, mock_open, patch
+
+import metalk8s_solutions
+
+
+YAML_TESTS_FILE = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "files", "test_metalk8s_solutions.yaml"
+)
+with open(YAML_TESTS_FILE) as fd:
+    YAML_TESTS_CASES = yaml.safe_load(fd)
+
+
+class Metalk8sSolutionsTestCase(TestCase, LoaderModuleMockMixin):
+    """
+    TestCase for `metalk8s_solutions` module
+    """
+    loader_module = metalk8s_solutions
+
+    def test_virtual_success(self):
+        """
+        Tests the return of `__virtual__` function, success
+        """
+        dict_patch = {'metalk8s.archive_info_from_iso': MagicMock()}
+        with patch.dict(metalk8s_solutions.__salt__, dict_patch):
+            self.assertEqual(
+                metalk8s_solutions.__virtual__(), 'metalk8s_solutions'
+            )
+
+    def test_virtual_missing_metalk8s_module(self):
+        """
+        Tests the return of `__virtual__` function,
+        when metalk8s module is missing
+        """
+        self.assertEqual(
+            metalk8s_solutions.__virtual__(),
+            (False, "Failed to load 'metalk8s' module.")
+        )
+
+    @parameterized.expand([
+        param.explicit(kwargs=test_case)
+        for test_case in YAML_TESTS_CASES["read_config"]
+    ])
+    def test_read_config(self, create=False, config=None, result=None,
+                         raises=False):
+        """
+        Tests the return of `read_config` function
+        """
+        open_mock = mock_open(read_data=config)
+        if not config:
+            open_mock.side_effect = IOError(
+                errno.ENOENT, "No such file or directory"
+            )
+
+        with patch("metalk8s_solutions.open", open_mock), \
+                patch("metalk8s_solutions._write_config_file", MagicMock()):
+            if raises:
+                self.assertRaisesRegexp(
+                    CommandExecutionError,
+                    result,
+                    metalk8s_solutions.read_config
+                )
+            else:
+                if create:
+                    self.assertEqual(
+                        metalk8s_solutions.read_config(create),
+                        result
+                    )
+                else:
+                    self.assertEqual(
+                        metalk8s_solutions.read_config(),
+                        result
+                    )
+
+    @parameterized.expand([
+        param.explicit(kwargs=test_case)
+        for test_case in YAML_TESTS_CASES["configure_archive"]
+    ])
+    def test_configure_archive(self, archive, removed=None, config=None,
+                               result=None, raises=False):
+        """
+        Tests the return of `configure_archive` function
+        """
+        def _write_config_file_mock(new_config):
+            if raises:
+                raise CommandExecutionError(
+                    "Failed to write Solutions config file"
+                )
+            config = new_config
+
+        read_config_mock = MagicMock(return_value=config)
+        write_config_file_mock = MagicMock(side_effect=_write_config_file_mock)
+
+        with patch("metalk8s_solutions.read_config", read_config_mock), \
+                patch("metalk8s_solutions._write_config_file",
+                      write_config_file_mock):
+            if raises:
+                self.assertRaisesRegexp(
+                    CommandExecutionError,
+                    "Failed to write Solutions config file",
+                    metalk8s_solutions.configure_archive,
+                    archive
+                )
+            else:
+                self.assertEqual(
+                    metalk8s_solutions.configure_archive(
+                        archive, removed=removed
+                    ),
+                    True
+                )
+                self.assertEqual(config, result)
+
+    @parameterized.expand([
+        param.explicit(kwargs=test_case)
+        for test_case in YAML_TESTS_CASES["activate_solution"]
+    ])
+    def test_activate_solution(self, solution, version=None, config=None,
+                               result=None, available=None, raises=False):
+        """
+        Tests the return of `activate_solution` function
+        """
+        def _yaml_safe_dump_mock(data, _):
+            if raises:
+                raise Exception("Something bad happened! :/")
+            config = data
+
+        list_available_mock = MagicMock(return_value=available or {})
+        read_config_mock = MagicMock(return_value=config)
+        yaml_safe_dump_mock = MagicMock(side_effect=_yaml_safe_dump_mock)
+
+        with patch("metalk8s_solutions.list_available", list_available_mock), \
+                patch("metalk8s_solutions.read_config", read_config_mock), \
+                patch("__builtin__.open", mock_open()), \
+                patch("yaml.safe_dump", yaml_safe_dump_mock):
+            if raises:
+                self.assertRaisesRegexp(
+                    CommandExecutionError,
+                    result,
+                    metalk8s_solutions.activate_solution,
+                    solution,
+                    version
+                )
+            else:
+                if version:
+                    self.assertEqual(
+                        metalk8s_solutions.activate_solution(
+                            solution, version
+                        ),
+                        True
+                    )
+                else:
+                    self.assertEqual(
+                        metalk8s_solutions.activate_solution(solution),
+                        True
+                    )
+
+                self.assertEqual(config, result)
+
+    @parameterized.expand([
+        param.explicit(kwargs=test_case)
+        for test_case in YAML_TESTS_CASES["deactivate_solution"]
+    ])
+    def test_deactivate_solution(self, solution, config=None, raises=False,
+                                 result=None):
+        """
+        Tests the return of `deactivate_solution` function
+        """
+        def _yaml_safe_dump_mock(data, _):
+            if raises:
+                raise Exception("Something bad happened! :/")
+            config = data
+
+        read_config_mock = MagicMock(return_value=config)
+        yaml_safe_dump_mock = MagicMock(side_effect=_yaml_safe_dump_mock)
+
+        with patch("metalk8s_solutions.read_config", read_config_mock), \
+                patch("yaml.safe_dump", yaml_safe_dump_mock), \
+                patch("metalk8s_solutions.open", mock_open()):
+            if raises:
+                self.assertRaisesRegexp(
+                    CommandExecutionError,
+                    "Failed to write Solutions config file",
+                    metalk8s_solutions.deactivate_solution,
+                    solution
+                )
+            else:
+                self.assertEqual(
+                    metalk8s_solutions.deactivate_solution(solution),
+                    True
+                )
+                self.assertEqual(config, result)
+
+    @parameterized.expand([
+        param.explicit(kwargs=test_case)
+        for test_case in YAML_TESTS_CASES["list_solution_images"]
+    ])
+    def test_list_solution_images(self, images=None, result=None,
+                                  raises=False):
+        """
+        Tests the return of `list_solution_images` function
+        """
+        mountpoint = '/srv/scality/my-solution/'
+        image_dir_prefix_len = len(os.path.join(mountpoint, 'images'))
+
+        if not images:
+            images = {}
+
+        def _get_image_name_and_version(path):
+            version = None
+            basename = path[image_dir_prefix_len:].lstrip('/')
+            try:
+                name, version = basename.split('/')
+            except ValueError:
+                name = basename
+            return name, version
+
+        def _path_isdir_mock(path):
+            name, version = _get_image_name_and_version(path)
+            return images and (not name or images[name]) and \
+                (not version or images[name][version])
+
+        def _listdir_mock(path):
+            name, version = _get_image_name_and_version(path)
+            if not name:
+                return images.keys()
+            return images[name].keys()
+
+        path_isdir_mock = MagicMock(side_effect=_path_isdir_mock)
+        listdir_mock = MagicMock(side_effect=_listdir_mock)
+
+        with patch("os.path.isdir", path_isdir_mock), \
+                patch("os.listdir", listdir_mock):
+            if raises:
+                self.assertRaisesRegexp(
+                    CommandExecutionError,
+                    result,
+                    metalk8s_solutions.list_solution_images,
+                    mountpoint
+                )
+            else:
+                self.assertItemsEqual(
+                    metalk8s_solutions.list_solution_images(mountpoint),
+                    result
+                )
+
+    @parameterized.expand([
+        param.explicit(kwargs=test_case)
+        for test_case in YAML_TESTS_CASES["read_solution_config"]
+    ])
+    def test_read_solution_config(self, config=None, result=None,
+                                  raises=False):
+        """
+        Tests the return of `read_solution_config` function
+        """
+        path_isfile_mock = MagicMock(return_value=config is not None)
+        list_solution_images_mock = MagicMock(return_value=[])
+        fopen_mock = mock_open(read_data=config)
+
+        read_solution_config_args = [
+            '/srv/scality/my-solution', 'my-solution', '1.0.0'
+        ]
+        with patch("os.path.isfile", path_isfile_mock), \
+                patch("salt.utils.files.fopen", fopen_mock), \
+                patch("metalk8s_solutions.list_solution_images",
+                      list_solution_images_mock):
+            if raises:
+                self.assertRaisesRegexp(
+                    CommandExecutionError,
+                    result,
+                    metalk8s_solutions.read_solution_config,
+                    *read_solution_config_args
+                )
+            else:
+                self.assertEqual(
+                    metalk8s_solutions.read_solution_config(
+                        *read_solution_config_args
+                    ),
+                    result
+                )
+
+    @parameterized.expand(
+        param.explicit(kwargs=test_case)
+        for test_case in YAML_TESTS_CASES["list_available"]
+    )
+    def test_list_available(self, mountpoints=None, archive_infos=None,
+                            result=None, raises=False):
+        """
+        Tests the return of `list_available` function
+        """
+        def _archive_info_from_tree(path):
+            if archive_infos:
+                return archive_infos
+            raise Exception('Path has no "product.txt"')
+
+        if not mountpoints:
+            mountpoints = {}
+        if not result:
+            result = {}
+
+        mount_active_mock = MagicMock(return_value=mountpoints)
+        archive_info_from_tree_mock = MagicMock(
+            side_effect=_archive_info_from_tree
+        )
+        read_solution_config_mock = MagicMock(return_value=None)
+
+        salt_dict_patch = {
+            'mount.active': mount_active_mock,
+            'metalk8s.archive_info_from_tree': archive_info_from_tree_mock,
+        }
+        with patch.dict(metalk8s_solutions.__salt__, salt_dict_patch), \
+                patch("metalk8s_solutions.read_solution_config",
+                      read_solution_config_mock):
+            if raises:
+                self.assertRaisesRegexp(
+                    Exception,
+                    'Path has no "product.txt"',
+                    metalk8s_solutions.list_available
+                )
+            else:
+                self.assertEqual(
+                    metalk8s_solutions.list_available(),
+                    result
+                )


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #2691.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/2.5/improvement/2266-test-salt-custom-module-solutions`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/2.5/improvement/2266-test-salt-custom-module-solutions
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/2.5/improvement/2266-test-salt-custom-module-solutions
```

Please always comment pull request #2691 instead of this one.