### PR TITLE
salt/volume: use a better regexp to recognize partitions

### DIFF
--- a/salt/_modules/metalk8s_volumes.py
+++ b/salt/_modules/metalk8s_volumes.py
@@ -448,7 +448,9 @@ class RawBlockDeviceBlock(RawBlockDevice):
         # Detect which kind of device we have: a real disk, only a partition or
         # an LVM volume.
         name = device_name(self.path)
-        match = re.search('(?P<partition>\d+)$', name)
+        match = re.search(
+            '(?:(?:h|s|v|xv)d[a-z]|nvme\d+n\d+p)(?P<partition>\d+)$', name
+        )
         self._partition = None
         if self._get_lvm_path() is not None:
             self._kind = DeviceType.LVM

--- a/salt/tests/unit/modules/test_metalk8s_volumes.py
+++ b/salt/tests/unit/modules/test_metalk8s_volumes.py
@@ -510,3 +510,18 @@ class Metalk8sVolumesTestCase(TestCase, LoaderModuleMockMixin):
                     result,
                     metalk8s_volumes.device_info(name)
                 )
+
+
+class RawBlockDeviceBlockTestCase(TestCase):
+    @parameterized.expand([
+        ('/dev/sda', None),
+        ('/dev/sda1', '1'),
+        ('/dev/vdc', None),       # Virtual disk
+        ('/dev/vdc2', '2'),       # Partition on a virtual disk
+        ('/dev/nvme0n1', None),   # NVME disk
+        ('/dev/nvme0n1p3', '3'),  # Partition on a NVME disk
+        ('/dev/dm-0', None),      # LVM device
+    ])
+    def test_get_partition(self, name, expected):
+        partition = metalk8s_volumes.RawBlockDeviceBlock._get_partition(name)
+        self.assertEqual(partition, expected)


### PR DESCRIPTION
**Component**:

salt

**Context**: 

The current regexp to recognize partitions was too simple and was treating all NVME devices as partitions.

**Summary**:

We replace use a new regexp inspired by the one used for `ignored-devices` in `node-exporter`.

**Acceptance criteria**: 

You can create Block volume on NVME devices.

---

Closes: #2724