### PR TITLE
salt: Add datasource in grafana for Loki

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -273,6 +273,7 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/addons/logging/deployed/namespace.sls'),
     Path('salt/metalk8s/addons/logging/loki/config/loki.yaml'),
     Path('salt/metalk8s/addons/logging/loki/deployed/chart.sls'),
+    Path('salt/metalk8s/addons/logging/loki/deployed/datasource.sls'),
     Path('salt/metalk8s/addons/logging/loki/deployed/init.sls'),
     Path('salt/metalk8s/addons/logging/loki/deployed/',
          'loki-configuration-secret.sls'),

--- a/salt/metalk8s/addons/logging/loki/deployed/datasource.sls
+++ b/salt/metalk8s/addons/logging/loki/deployed/datasource.sls
@@ -1,0 +1,25 @@
+include:
+  - metalk8s.addons.prometheus-operator.deployed.namespace
+
+Deploy ConfigMap for Loki datasource:
+  metalk8s_kubernetes.object_present:
+    - manifest:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: loki-grafana-datasource
+          namespace: metalk8s-monitoring
+          labels:
+            grafana_datasource: "1"
+            app.kubernetes.io/managed-by: metalk8s
+            app.kubernetes.io/part-of: metalk8s
+            heritage: metalk8s
+        data:
+          loki-datasource.yaml: |-
+            apiVersion: 1
+            datasources:
+            - name: Loki
+              type: loki
+              access: proxy
+              url: http://loki.metalk8s-logging.svc.cluster.local:3100/
+              version: 1

--- a/salt/metalk8s/addons/logging/loki/deployed/init.sls
+++ b/salt/metalk8s/addons/logging/loki/deployed/init.sls
@@ -3,3 +3,4 @@ include:
   - .loki-configuration-secret
   - .chart
   - .storageclass
+  - .datasource


### PR DESCRIPTION
**Component**:

'salt', 'logging'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

#2683

**Summary**:

Add a new datasource in grafana for Loki

NOTE: Wait for #2722 to be merged first

---

Fixes: #2683
