### PR TITLE
Fix the metalk8s.volumes state when running for more than one volume.

### DIFF
--- a/salt/metalk8s/volumes/prepared/init.sls
+++ b/salt/metalk8s/volumes/prepared/init.sls
@@ -48,12 +48,21 @@ Provision backing storage for {{ volume }}:
     - name: {{ volume }}
     - require:
       - metalk8s_volumes: Prepare backing storage for {{ volume }}
+    - require_in:
+      - module: Update pillar after volume provisioning
 
-Update pillar after volume provisionning:
+{%- endfor %}
+
+{%- if volumes_to_create %}
+
+Update pillar after volume provisioning:
   module.run:
     - saltutil.refresh_pillar:
       - wait: True
-    - require:
-      - metalk8s_volumes: Provision backing storage for {{ volume }}
 
-{%- endfor %}
+{%- else %}
+
+No volume to create:
+  test.succeed_without_changes: []
+
+{%- endif %}


### PR DESCRIPTION
**Component**:

salt

**Context**: 

Calling the `metalk8s.volumes` states with several volumes fails.

**Summary**:

- Move the "Update pillar after volume provisioning" step should be outside of
the for loop
- fix the typo in "provisioning"

**Acceptance criteria**: 

- Spawn a Vagrant VM (we will have 2 volumes already)
- Run `salt-call state.sls metalk8s.volumes saltenv=metalk8s-2.5.2-dev`
=> No error

---

Refs: #2726
Closes: #2729