### PR TITLE
Fix device name resolution when the device doesn't exist

### DIFF
--- a/salt/_modules/metalk8s_volumes.py
+++ b/salt/_modules/metalk8s_volumes.py
@@ -181,9 +181,9 @@ def device_name(path):
         # TOCTTOU, but `realpath` doesn't return error on non-existing path…
         if os.path.exists(path):
             realpath = os.path.realpath(path)
-            return os.path.basename(realpath)
+            return {'success': True, 'result': os.path.basename(realpath)}
         time.sleep(0.1)
-    raise Exception('device `{}` not found'.format(path))
+    return {'success': False, 'result': 'device `{}` not found'.format(path)}
 
 
 def device_info(name):

--- a/salt/tests/unit/modules/test_metalk8s_volumes.py
+++ b/salt/tests/unit/modules/test_metalk8s_volumes.py
@@ -438,13 +438,13 @@ class Metalk8sVolumesTestCase(TestCase, LoaderModuleMockMixin):
 
     @parameterized.expand([
         # Nominal case: device exists.
-        ([True], 'my-device'),
+        ('exists', [True], 'my-device'),
         # Error case: device doesn't exists.
-        ([False]*10, 'device `/dev/my-device` not found'),
+        ('missing', [False]*10, 'device `/dev/my-device` not found'),
         # Device is temporarily missing.
-        ([False, False, False, True], 'my-device'),
+        ('transient-missing', [False, False, False, True], 'my-device'),
     ])
-    def test_device_name(self, exist_values, result):
+    def test_device_name(self, _, exist_values, result):
         expected = {'success': any(exist_values), 'result': result}
         exists_mock = MagicMock(side_effect=exist_values)
         realpath_mock = MagicMock(side_effect=lambda path: path)
@@ -501,14 +501,14 @@ class Metalk8sVolumesTestCase(TestCase, LoaderModuleMockMixin):
 
 class RawBlockDeviceBlockTestCase(TestCase):
     @parameterized.expand([
-        ('/dev/sda', None),
-        ('/dev/sda1', '1'),
-        ('/dev/vdc', None),       # Virtual disk
-        ('/dev/vdc2', '2'),       # Partition on a virtual disk
-        ('/dev/nvme0n1', None),   # NVME disk
-        ('/dev/nvme0n1p3', '3'),  # Partition on a NVME disk
-        ('/dev/dm-0', None),      # LVM device
+        ('disk', '/dev/sda', None),
+        ('partition', '/dev/sda1', '1'),
+        ('virtual-disk', '/dev/vdc', None),
+        ('virtual-disk-part', '/dev/vdc2', '2'),
+        ('nvme', '/dev/nvme0n1', None),
+        ('nvme-part', '/dev/nvme0n1p3', '3'),
+        ('lvm', '/dev/dm-0', None),
     ])
-    def test_get_partition(self, name, expected):
+    def test_get_partition(self, _, name, expected):
         partition = metalk8s_volumes.RawBlockDeviceBlock._get_partition(name)
         self.assertEqual(partition, expected)

--- a/storage-operator/pkg/salt/client_test.go
+++ b/storage-operator/pkg/salt/client_test.go
@@ -322,15 +322,21 @@ func TestExtractDeviceName(t *testing.T) {
 		name string
 	}{
 		"ok": {
-			json: `{"return": [{"bootstrap": "loop0"}]}`,
+			json: `{"return": [{"bootstrap": {"success": true, "result": "loop0"}}]}`,
 			name: "loop0",
 		},
-		"empty":         {json: `{}`, name: ""},
-		"missingReturn": {json: `{"name": "foobar"}`, name: ""},
-		"invalidReturn": {json: `{"return": "foo"}`, name: ""},
-		"noResult":      {json: `{"return": []}`, name: ""},
-		"missingNone":   {json: `{"return": [{"node1": "loop0"}]}`, name: ""},
-		"invalidJID":    {json: `{"return": [{"bootstrap": 42}]}`, name: ""},
+		"error": {
+			json: `{"return": [{"bootstrap": {"success": false, "result": "ERROR"}}]}`,
+			name: "",
+		},
+		"empty":          {json: `{}`, name: ""},
+		"missingReturn":  {json: `{"name": "foobar"}`, name: ""},
+		"invalidReturn":  {json: `{"return": "foo"}`, name: ""},
+		"noResult":       {json: `{"return": []}`, name: ""},
+		"missingNode":    {json: `{"return": [{"node1": "loop0"}]}`, name: ""},
+		"invalidResult":  {json: `{"return": [{"bootstrap": 42}]}`, name: ""},
+		"invalidSuccess": {json: `{"return": [{"bootstrap": {"success": 0, "result": ""}}]}`, name: ""},
+		"invalidOutput":  {json: `{"return": [{"bootstrap": {"success": true, "result": 42}}]}`, name: ""},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
**Component**:

salt, operator

**Context**: 

When the device name resolution fails because the given device doesn't exists, we wrongly interpret it as a success, thanks to the ambiguous Salt response.

**Summary**:

Instead of returning a plain string, return a dict with a success field and a result field.
See the commit message for more info on the different solutions that have been tested.

**Acceptance criteria**: 

- Delete the device symlink of the target volume `vol1`: `rm /dev/disk/by-uuid/<vol1-ID>`
- Edit the volume (e.g. change its size or path) to trigger a reconciliation: `kubectl edit volume <vol1-name>`
- Observe in the storage-operator logs that ① we have an error, ② we reschedule a reconciliation
- Recreate the device symlink: `ln -s <pv-devicepath> /dev/disk/by-uuid/<vol1-ID>`
- Observe that the reconciliation is a success on the next retry.

---

Closes: #2728