### PR TITLE
build,scripts,salt: Pin salt version in bootstrap and restore and set repo priority to 1

### DIFF
--- a/buildchain/buildchain/iso.py
+++ b/buildchain/buildchain/iso.py
@@ -85,7 +85,10 @@ FILE_TREES : Tuple[helper.FileTree, ...] = (
                 task_name='bootstrap.sh',
                 source=constants.ROOT/'scripts'/'bootstrap.sh.in',
                 destination=constants.ISO_ROOT/'bootstrap.sh',
-                context={'VERSION': versions.VERSION},
+                context={
+                    'VERSION': versions.VERSION,
+                    'SALT_VERSION': versions.SALT_VERSION
+                },
                 file_dep=[versions.VERSION_FILE],
                 task_dep=['_iso_mkdir_root'],
             ),
@@ -101,7 +104,10 @@ FILE_TREES : Tuple[helper.FileTree, ...] = (
                 task_name='restore.sh',
                 source=constants.ROOT/'scripts'/'restore.sh.in',
                 destination=constants.ISO_ROOT/'restore.sh',
-                context={'VERSION': versions.VERSION},
+                context={
+                    'VERSION': versions.VERSION,
+                    'SALT_VERSION': versions.SALT_VERSION
+                },
                 file_dep=[versions.VERSION_FILE],
                 task_dep=['_iso_mkdir_root'],
             ),

--- a/salt/metalk8s/repo/redhat.sls
+++ b/salt/metalk8s/repo/redhat.sls
@@ -65,6 +65,9 @@ Configure {{ repo_name }} repository:
   {%- endif %}
     - repo_gpg_check: {{ repo_config.repo_gpg_check }}
     - enabled: {{ repo_config.enabled }}
+    # Set priority to 1, even if the `yum-plugin-priorities` is not installed,
+    # so that our repos has priority over others
+    - priority: 1
     # URL to the proxy server for this repository.
     # Set to '_none_' to disable the global proxy setting
     # for this repository.

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -56,7 +56,7 @@ BASE_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 SALT_CALL=${SALT_CALL:-salt-call}
 
 declare -a PACKAGES=(
-    salt-minion
+    salt-minion-@@SALT_VERSION
     genisoimage
 )
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -95,6 +95,7 @@ configure_yum_local_repository() {
 name=$repo_name
 baseurl=file://$repo_path
 enabled=1
+priority=1
 gpgcheck=$gpgcheck
 ${gpg_keys:+gpgkey=${gpg_keys%?}}
 EOF

--- a/scripts/restore.sh.in
+++ b/scripts/restore.sh.in
@@ -70,7 +70,7 @@ BASE_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 SALT_CALL=${SALT_CALL:-salt-call}
 
 declare -a PACKAGES=(
-    salt-minion
+    salt-minion-@@SALT_VERSION
     genisoimage
 )
 


### PR DESCRIPTION
**Component**:

'salt', 'build', 'scripts'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

#2704 

**Summary**:

In bootstrap and restore we install salt-minion on the node so we need
to pin the salt version we want to install and not just install the one
yum will find depending on various things (like available versions,
priority on repos, ...).
Also set the priority to 1 on all our repos so that our repositories has
priority over others if the `yum-plugin-priorities` package is
installed.
NOTE: If `yum-plugin-priorities` is installed and priority is set on one
repos then other repos with the same package will just be ignored
(e.g.: epel installed with priority=98 we cannot install `salt-3000.3`
as salt-3000.3 is excluded because a repo with some priority has the
package in a different version)

**Test**:

Tested manually with
```
[epel]
name=Extra Packages for Enterprise Linux 7 - $basearch
#baseurl=http://download.fedoraproject.org/pub/epel/7/$basearch
metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch
failovermethod=priority
enabled=1
gpgcheck=1
gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
priority=9
```
And `yum-plugin-priorities` installed and it works well (even if salt-2015 is already installed before bootstrapping)

---

Fixes: #2704
