### PR TITLE
tests: Pin virtualenv version for tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 skipsdist = true
 minversion = 3.18.0
+requires = virtualenv >= 20.0
 
 [testenv]
 whitelist_externals = bash


### PR DESCRIPTION
With a low version of virtualenv (e.g. 16.0), we had issues because the
default pip installed is not handling our requirements with hashes
enforced properly.
