### PR TITLE
salt: enable Loki table manager purge

### DIFF
--- a/salt/metalk8s/addons/logging/loki/config/loki.yaml
+++ b/salt/metalk8s/addons/logging/loki/config/loki.yaml
@@ -40,5 +40,5 @@ spec:
       filesystem:
         directory: /data/loki/chunks
     table_manager:
-      retention_deletes_enabled: false
-      retention_period: 0s
+      retention_deletes_enabled: true
+      retention_period: 336h


### PR DESCRIPTION
**Component**: log, salt

**Context**: 

**Summary**:
set to 2 weeks which means we can have 3 weeks of retention at most.

**Acceptance criteria**: 


---

See: #2682
