### PR TITLE
Collect I/O metrics from disk partitions and loop devices

### DIFF
--- a/charts/prometheus-operator/values.yaml
+++ b/charts/prometheus-operator/values.yaml
@@ -1059,6 +1059,7 @@ prometheus-node-exporter:
     ##
     jobLabel: node-exporter
   extraArgs:
+    - --collector.diskstats.ignored-devices=^(ram|fd)\\d+$
     - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
     - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
 

--- a/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
@@ -51162,6 +51162,7 @@ spec:
         - --path.procfs=/host/proc
         - --path.sysfs=/host/sys
         - --web.listen-address=$(HOST_IP):9100
+        - --collector.diskstats.ignored-devices=^(ram|fd)\\d+$
         - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
         - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
         env:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -274,11 +274,8 @@ def request_retry_session(request):
 
 
 @pytest.fixture
-def prometheus_api(host):
-    return utils.PrometheusApi(
-        utils.get_grain(host, 'metalk8s:control_plane_ip'),
-        CONTROL_PLANE_INGRESS_PORT
-    )
+def prometheus_api(control_plane_ip):
+    return utils.PrometheusApi(control_plane_ip, CONTROL_PLANE_INGRESS_PORT)
 
 
 def count_running_pods(

--- a/tests/kube_utils.py
+++ b/tests/kube_utils.py
@@ -1,6 +1,86 @@
+import abc
+import ast
+import json
+from urllib3.exceptions import HTTPError
+
+import kubernetes.client
 from kubernetes.client.rest import ApiException
+import yaml
 
 from tests import utils
+
+# Constants {{{
+
+DEFAULT_SC = """
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {name}
+provisioner: kubernetes.io/no-provisioner
+reclaimPolicy: Retain
+volumeBindingMode: WaitForFirstConsumer
+mountOptions:
+  - rw
+parameters:
+  fsType: ext4
+  mkfsOptions: '["-m", "0"]'
+"""
+
+DEFAULT_VOLUME = """
+apiVersion: storage.metalk8s.scality.com/v1alpha1
+kind: Volume
+metadata:
+  name: {name}
+spec:
+  nodeName: bootstrap
+  storageClassName: metalk8s
+  sparseLoopDevice:
+    size: 10Gi
+"""
+
+POD_TEMPLATE = """
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {volume_name}-pod
+spec:
+  volumes:
+    - name: {volume_name}-pod-storage
+      persistentVolumeClaim:
+        claimName: {volume_name}-pvc
+  containers:
+    - name: {volume_name}-pod-container
+      image: {image_name}
+      command: [{command}]
+      args: {args}
+      volumeMounts:
+        - mountPath: "/mnt/"
+          name: {volume_name}-pod-storage
+  tolerations:
+  - key: "node-role.kubernetes.io/bootstrap"
+    operator: "Exists"
+    effect: "NoSchedule"
+  - key: "node-role.kubernetes.io/infra"
+    operator: "Exists"
+    effect: "NoSchedule"
+  terminationGracePeriodSeconds: 0
+"""
+
+PVC_TEMPLATE = """
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {volume_name}-pvc
+spec:
+  storageClassName: {storage_class}
+  accessModes:
+      - {access}
+  resources:
+      requests:
+        storage: {size}
+"""
+
+# }}}
 
 # See https://kubernetes.io/docs/concepts/architecture/nodes/#condition
 # And https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions
@@ -61,3 +141,306 @@ def check_pod_status(k8s_client, name, namespace="default", state="Running"):
         return pod
 
     return _check_pod_status
+
+
+# Client {{{
+
+class Client(abc.ABC):
+    """Helper class for manipulation of K8s resources in tests."""
+
+    def __init__(self, k8s_client, kind, retry_count, retry_delay):
+        self._client = k8s_client
+        self._kind   = kind
+        self._count  = retry_count
+        self._delay  = retry_delay
+
+    def create_from_yaml(self, manifest):
+        """Create a new object from the given YAML manifest."""
+        self._create(yaml.safe_load(manifest))
+
+    def get(self, name):
+        """Return the object identified by `name`, or None if not found."""
+        try:
+            return self._get(name)
+        except (ApiException, HTTPError) as exc:
+            if isinstance(exc, ApiException) and exc.status == 404:
+                return None
+            raise
+
+    def delete(self, name, sync=False):
+        """Delete the object identified by `name`.
+
+        If `sync` is True, don't return until the object is actually deleted.
+        """
+        self._delete(name)
+        if sync:
+            self.wait_for_deletion(name)
+
+    def delete_all(self, prefix=None, sync=False):
+        """Delete all the existing objects.
+
+        If `prefix` is given, only the objects whose name starts with the prefix
+        are deleted.
+        If `sync` is True, don't return until the object is actually deleted.
+        """
+        for obj in self.list():
+            if isinstance(obj, dict):
+                name = obj['metadata']['name']
+            else:
+                name = obj.metadata.name
+            if prefix is None or name.startswith(prefix):
+                self.delete(name, sync=sync)
+
+    def wait_for_deletion(self, name):
+        """Wait for the object to disappear."""
+        def _check_absence():
+            assert self.get(name) is None,\
+                '{} {} still exist'.format(self._kind, name)
+
+        utils.retry(
+            _check_absence, times=self._count, wait=self._delay,
+            name='checking the absence of {} {}'.format(self._kind, name)
+        )
+
+    def check_deletion_marker(self, name):
+        def _check_deletion_marker():
+            obj = self.get(name)
+            assert obj is not None, '{} {} not found'.format(self._kind, name)
+            if isinstance(obj, dict):
+                tstamp = obj['metadata'].get('deletionTimestamp')
+            else:
+                tstamp = obj.metadata.deletion_timestamp
+            assert tstamp is not None,\
+                '{} {} is not marked for deletion'.format(self._kind, name)
+
+        utils.retry(
+            _check_deletion_marker, times=self._count, wait=self._delay,
+            name='checking that {} {} is marked for deletion'.format(
+                self._kind, name
+            )
+        )
+
+
+    @abc.abstractmethod
+    def list(self):
+        """Return a list of existing objects."""
+        pass
+
+    @abc.abstractmethod
+    def _create(self, body):
+        """Create a new object using the given body."""
+        pass
+
+    @abc.abstractmethod
+    def _get(self, name):
+        """Return the object identified by `name`, raise if not found."""
+        pass
+
+    @abc.abstractmethod
+    def _delete(self, name):
+        """Delete the object identified by `name`.
+
+        The object may be simply marked for deletion and stay around for a
+        while.
+        """
+        pass
+
+# }}}
+# VolumeClient {{{
+
+class VolumeClient(Client):
+    def __init__(self, k8s_client, ssh_config):
+        super().__init__(
+            k8s_client, kind='Volume', retry_count=30, retry_delay=2
+        )
+        self._ssh_config = ssh_config
+        self._group="storage.metalk8s.scality.com"
+        self._version="v1alpha1"
+        self._plural="volumes"
+
+    def list(self):
+        return self._client.list_cluster_custom_object(
+            group=self._group, version=self._version, plural=self._plural
+        )['items']
+
+    def _create(self, body):
+        # Fixup the node name.
+        body['spec']['nodeName'] = utils.get_node_name(
+            body['spec']['nodeName'], self._ssh_config
+        )
+        self._client.create_cluster_custom_object(
+            group=self._group, version=self._version, plural=self._plural,
+            body=body
+        )
+
+    def _get(self, name):
+        return self._client.get_cluster_custom_object(
+            group=self._group, version=self._version, plural=self._plural,
+            name=name
+        )
+
+    def _delete(self, name):
+        body = kubernetes.client.V1DeleteOptions()
+        self._client.delete_cluster_custom_object(
+            group=self._group, version=self._version, plural=self._plural,
+            name=name, body=body, grace_period_seconds=0
+        )
+
+    @staticmethod
+    def compute_phase(volume_status):
+        for condition in volume_status.get('conditions', []):
+            if condition['type'] != 'Ready':
+                continue
+            if condition['status'] == 'True':
+                return 'Available'
+            elif condition['status'] == 'False':
+                return 'Failed'
+            elif condition['status'] == 'Unknown':
+                return condition['reason']
+            else:
+                assert False, 'invalid condition status: {}'.format(
+                    condition['status']
+                )
+        return ''
+
+    @staticmethod
+    def get_error(volume_status):
+        for condition in volume_status.get('conditions', []):
+            if condition['type'] != 'Ready':
+                continue
+            return condition.get('reason', ''), condition.get('message', '')
+        return '', ''
+
+
+# }}}
+# PersistentVolumeClient {{{
+
+class PersistentVolumeClient(Client):
+    def __init__(self, k8s_client):
+        super().__init__(
+            k8s_client, kind='PersistentVolume',
+            retry_count=10, retry_delay=2
+        )
+
+    def list(self):
+        return self._client.list_persistent_volume().items
+
+    def _create(self, body):
+        self._client.create_persistent_volume(body=body)
+
+    def _get(self, name):
+        return self._client.read_persistent_volume(name)
+
+    def _delete(self, name):
+        body = kubernetes.client.V1DeleteOptions()
+        self._client.delete_persistent_volume(
+            name=name, body=body, grace_period_seconds=0
+        )
+
+# }}}
+# PersistentVolumeClaimClient {{{
+
+class PersistentVolumeClaimClient(Client):
+    def __init__(self, k8s_client, namespace='default'):
+        super().__init__(
+            k8s_client, kind='PersistentVolumeClaim',
+            retry_count=10, retry_delay=2
+        )
+        self._namespace = namespace
+
+    def create_for_volume(self, volume, pv):
+        """Create a PVC matching the given volume."""
+        assert pv is not None, 'PersistentVolume {} not found'.format(volume)
+        body = PVC_TEMPLATE.format(
+            volume_name=volume,
+            storage_class=pv.spec.storage_class_name,
+            access=pv.spec.access_modes[0],
+            size=pv.spec.capacity['storage']
+        )
+        self.create_from_yaml(body)
+
+    def list(self):
+        return self._client.list_namespaced_persistent_volume_claim(
+            namespace=self._namespace
+        ).items
+
+    def _create(self, body):
+        self._client.create_namespaced_persistent_volume_claim(
+            namespace=self._namespace, body=body
+        )
+
+    def _get(self, name):
+        return self._client.read_namespaced_persistent_volume_claim(
+            name=name, namespace=self._namespace
+        )
+
+    def _delete(self, name):
+        self._client.delete_namespaced_persistent_volume_claim(
+            name=name, namespace=self._namespace, grace_period_seconds=0
+        )
+
+# }}}
+# PodClient {{{
+
+class PodClient(Client):
+    def __init__(self, k8s_client, image, namespace='default'):
+        super().__init__(
+            k8s_client, kind='Pod', retry_count=30, retry_delay=2
+        )
+        self._image = image
+        self._namespace = namespace
+
+    def create_with_volume(self, volume_name, command):
+        """Create a pod using the specified volume."""
+        binary, *args = ast.literal_eval(command)
+        body = POD_TEMPLATE.format(
+            volume_name=volume_name, image_name=self._image,
+            command=json.dumps(binary), args=json.dumps(args)
+        )
+        self.create_from_yaml(body)
+        # Wait for the Pod to be up and running.
+        pod_name = '{}-pod'.format(volume_name)
+        utils.retry(
+            check_pod_status(self._client, pod_name),
+            times=self._count, wait=self._delay,
+            name="wait for pod {}".format(pod_name)
+        )
+
+    def list(self):
+        return self._client.list_namespaced_pod(namespace=self._namespace).items
+
+    def _create(self, body):
+        self._client.create_namespaced_pod(namespace=self._namespace, body=body)
+
+    def _get(self, name):
+        return self._client.read_namespaced_pod(
+            name=name, namespace=self._namespace
+        )
+
+    def _delete(self, name):
+        self._client.delete_namespaced_pod(
+            name=name, namespace=self._namespace, grace_period_seconds=0
+        )
+
+# }}}
+# StorageClassClient {{{
+
+class StorageClassClient(Client):
+    def __init__(self, k8s_client):
+        super().__init__(
+            k8s_client, kind='StorageClass', retry_count=10, retry_delay=2
+        )
+
+    def list(self):
+        return self._client.list_storage_class().items
+
+    def _create(self, body):
+        self._client.create_storage_class(body=body)
+
+    def _get(self, name):
+        return self._client.read_storage_class(name=name)
+
+    def _delete(self, name):
+        self._client.delete_storage_class(name=name, grace_period_seconds=0)
+
+# }}}

--- a/tests/post/features/monitoring.feature
+++ b/tests/post/features/monitoring.feature
@@ -43,3 +43,9 @@ Feature: Monitoring is up and running
         Given the Kubernetes API is available
         And we have 1 running pod labeled 'prometheus=prometheus-operator-prometheus' in namespace 'metalk8s-monitoring'
         Then the deployed Prometheus alert rules are the same as the default alert rules
+
+    Scenario: Volume metrics can be found based on device name
+        Given the Kubernetes API is available
+        And I have created a test Volume
+        And the Prometheus API is available
+        Then I can get I/O stats for this test Volume's device

--- a/tests/post/features/monitoring.feature
+++ b/tests/post/features/monitoring.feature
@@ -46,6 +46,6 @@ Feature: Monitoring is up and running
 
     Scenario: Volume metrics can be found based on device name
         Given the Kubernetes API is available
-        And I have created a test Volume
         And the Prometheus API is available
+        And a test Volume 'test-monitoring1' exists
         Then I can get I/O stats for this test Volume's device

--- a/tests/post/steps/conftest.py
+++ b/tests/post/steps/conftest.py
@@ -1,9 +1,40 @@
 # coding: utf-8
+
+from kubernetes.client import CustomObjectsApi
+from kubernetes.client import StorageV1Api
+import pytest
 from pytest_bdd import given, parsers
 
 from tests import kube_utils, utils
 
 
+# Fixtures {{{
+
+@pytest.fixture
+def volume_client(k8s_apiclient, ssh_config):
+    return kube_utils.VolumeClient(
+        CustomObjectsApi(api_client=k8s_apiclient), ssh_config
+    )
+
+@pytest.fixture
+def pv_client(k8s_client):
+    return kube_utils.PersistentVolumeClient(k8s_client)
+
+@pytest.fixture
+def pvc_client(k8s_client):
+    return kube_utils.PersistentVolumeClaimClient(k8s_client)
+
+@pytest.fixture
+def pod_client(k8s_client, utils_image):
+    return kube_utils.PodClient(k8s_client, utils_image)
+
+@pytest.fixture
+def sc_client(k8s_apiclient):
+    return kube_utils.StorageClassClient(
+        StorageV1Api(api_client=k8s_apiclient)
+    )
+
+# }}}
 # Helpers {{{
 
 def _check_pods_status(k8s_client, expected_status, ssh_config,

--- a/tests/post/steps/conftest.py
+++ b/tests/post/steps/conftest.py
@@ -96,4 +96,23 @@ def check_all_pods_status(request, host, k8s_client, expected_status):
     _check_pods_status(
         k8s_client, expected_status, ssh_config
     )
+
+@given(parsers.parse("a test Volume '{name}' exists"))
+def test_volume(volume_client, name):
+    """Get or create a Volume by name and return it as a fixture.
+
+    Volume will be deleted after execution of the test.
+    """
+    if volume_client.get(name) is None:
+        volume_client.create_from_yaml(
+            kube_utils.DEFAULT_VOLUME.format(name=name)
+        )
+
+    try:
+        yield volume_client.wait_for_status(
+            name, 'Available', wait_for_device_name=True
+        )
+    finally:
+        volume_client.delete(name, sync=True)
+
 # }}}

--- a/tests/post/steps/test_volume.py
+++ b/tests/post/steps/test_volume.py
@@ -1,13 +1,6 @@
-import abc
-import ast
-import json
 import re
-from urllib3.exceptions import HTTPError
 
 import kubernetes as k8s
-import kubernetes.client
-from kubernetes.client import CustomObjectsApi
-from kubernetes.client import StorageV1Api
 from kubernetes.client.rest import ApiException
 import pytest
 from pytest_bdd import given, when, scenario, then, parsers
@@ -16,100 +9,7 @@ import yaml
 from tests import utils
 from tests import kube_utils
 
-
-# Constants {{{
-
-DEFAULT_VOLUME = """
-apiVersion: storage.metalk8s.scality.com/v1alpha1
-kind: Volume
-metadata:
-  name: {name}
-spec:
-  nodeName: bootstrap
-  storageClassName: metalk8s
-  sparseLoopDevice:
-    size: 10Gi
-"""
-
-PVC_TEMPLATE = """
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: {volume_name}-pvc
-spec:
-  storageClassName: {storage_class}
-  accessModes:
-      - {access}
-  resources:
-      requests:
-        storage: {size}
-"""
-
-POD_TEMPLATE = """
-apiVersion: v1
-kind: Pod
-metadata:
-  name: {volume_name}-pod
-spec:
-  volumes:
-    - name: {volume_name}-pod-storage
-      persistentVolumeClaim:
-        claimName: {volume_name}-pvc
-  containers:
-    - name: {volume_name}-pod-container
-      image: {image_name}
-      command: [{command}]
-      args: {args}
-      volumeMounts:
-        - mountPath: "/mnt/"
-          name: {volume_name}-pod-storage
-  tolerations:
-  - key: "node-role.kubernetes.io/bootstrap"
-    operator: "Exists"
-    effect: "NoSchedule"
-  - key: "node-role.kubernetes.io/infra"
-    operator: "Exists"
-    effect: "NoSchedule"
-  terminationGracePeriodSeconds: 0
-"""
-
-DEFAULT_SC = """
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: {name}
-provisioner: kubernetes.io/no-provisioner
-reclaimPolicy: Retain
-volumeBindingMode: WaitForFirstConsumer
-mountOptions:
-  - rw
-parameters:
-  fsType: ext4
-  mkfsOptions: '["-m", "0"]'
-"""
-
-# }}}
 # Fixture {{{
-
-@pytest.fixture
-def volume_client(k8s_apiclient, ssh_config):
-    return VolumeClient(CustomObjectsApi(api_client=k8s_apiclient), ssh_config)
-
-@pytest.fixture
-def pv_client(k8s_client):
-    return PersistentVolumeClient(k8s_client)
-
-@pytest.fixture
-def pvc_client(k8s_client):
-    return PersistentVolumeClaimClient(k8s_client)
-
-@pytest.fixture
-def pod_client(k8s_client, utils_image):
-    return PodClient(k8s_client, utils_image)
-
-@pytest.fixture
-def sc_client(k8s_apiclient):
-    return StorageClassClient(StorageV1Api(api_client=k8s_apiclient))
 
 @pytest.fixture
 def teardown(pod_client, pvc_client, volume_client, sc_client):
@@ -191,7 +91,9 @@ def test_volume_delete_while_pending(host, teardown):
 @given(parsers.parse("a Volume '{name}' exist"))
 def volume_exist(context, name, volume_client):
     if volume_client.get(name) is None:
-        volume_client.create_from_yaml(DEFAULT_VOLUME.format(name=name))
+        volume_client.create_from_yaml(
+            kube_utils.DEFAULT_VOLUME.format(name=name)
+        )
         check_volume_status(context, name, 'Available', volume_client)
 
 
@@ -219,7 +121,7 @@ def storage_class_does_not_exist(name, sc_client):
 @given(parsers.parse("a StorageClass '{name}' exist"))
 def storage_class_exist(name, sc_client):
     if sc_client.get(name) is None:
-        sc_client.create_from_yaml(DEFAULT_SC.format(name=name))
+        sc_client.create_from_yaml(kube_utils.DEFAULT_SC.format(name=name))
 
 # }}}
 # When {{{
@@ -281,7 +183,7 @@ def check_volume_status(context, name, status, volume_client):
         assert volume is not None, 'Volume {} not found'.format(name)
         context[name] = volume
         try:
-            phase = VolumeClient.compute_phase(volume['status'])
+            phase = kube_utils.VolumeClient.compute_phase(volume['status'])
             assert phase == status,\
                 'Unexpected status: expected {}, got {}'.format(status, phase)
         except KeyError:
@@ -375,8 +277,8 @@ def check_volume_error(context, name, code, pattern, volume_client):
         context[name] = volume
         status = volume.get('status')
         assert status is not None, 'no status for volume {}'.format(name)
-        phase = VolumeClient.compute_phase(status)
-        errcode, errmsg = VolumeClient.get_error(status)
+        phase = kube_utils.VolumeClient.compute_phase(status)
+        errcode, errmsg = kube_utils.VolumeClient.get_error(status)
         assert phase == 'Failed',\
             'Unexpected status: expected Failed, got {}'.format(status, phase)
         assert errcode == code,\
@@ -455,306 +357,6 @@ def check_storage_is_deleted(context, host, name):
 
 # }}}
 # Helpers {{{
-# Client {{{
-
-class Client(abc.ABC):
-    def __init__(self, k8s_client, kind, retry_count, retry_delay):
-        self._client = k8s_client
-        self._kind   = kind
-        self._count  = retry_count
-        self._delay  = retry_delay
-
-    def create_from_yaml(self, manifest):
-        """Create a new object from the given YAML manifest."""
-        self._create(yaml.safe_load(manifest))
-
-    def get(self, name):
-        """Return the object identified by `name`, or None if not found."""
-        try:
-            return self._get(name)
-        except (ApiException, HTTPError) as exc:
-            if isinstance(exc, ApiException) and exc.status == 404:
-                return None
-            raise
-
-    def delete(self, name, sync=False):
-        """Delete the object identified by `name`.
-
-        If `sync` is True, don't return until the object is actually deleted.
-        """
-        self._delete(name)
-        if sync:
-            self.wait_for_deletion(name)
-
-    def delete_all(self, prefix=None, sync=False):
-        """Delete all the existing objects.
-
-        If `prefix` is given, only the objects whose name starts with the prefix
-        are deleted.
-        If `sync` is True, don't return until the object is actually deleted.
-        """
-        for obj in self.list():
-            if isinstance(obj, dict):
-                name = obj['metadata']['name']
-            else:
-                name = obj.metadata.name
-            if prefix is None or name.startswith(prefix):
-                self.delete(name, sync=sync)
-
-    def wait_for_deletion(self, name):
-        """Wait for the object to disappear."""
-        def _check_absence():
-            assert self.get(name) is None,\
-                '{} {} still exist'.format(self._kind, name)
-
-        utils.retry(
-            _check_absence, times=self._count, wait=self._delay,
-            name='checking the absence of {} {}'.format(self._kind, name)
-        )
-
-    def check_deletion_marker(self, name):
-        def _check_deletion_marker():
-            obj = self.get(name)
-            assert obj is not None, '{} {} not found'.format(self._kind, name)
-            if isinstance(obj, dict):
-                tstamp = obj['metadata'].get('deletionTimestamp')
-            else:
-                tstamp = obj.metadata.deletion_timestamp
-            assert tstamp is not None,\
-                '{} {} is not marked for deletion'.format(self._kind, name)
-
-        utils.retry(
-            _check_deletion_marker, times=self._count, wait=self._delay,
-            name='checking that {} {} is marked for deletion'.format(
-                self._kind, name
-            )
-        )
-
-
-    @abc.abstractmethod
-    def list(self):
-        """Return a list of existing objects."""
-        pass
-
-    @abc.abstractmethod
-    def _create(self, body):
-        """Create a new object using the given body."""
-        pass
-
-    @abc.abstractmethod
-    def _get(self, name):
-        """Return the object identified by `name`, raise if not found."""
-        pass
-
-    @abc.abstractmethod
-    def _delete(self, name):
-        """Delete the object identified by `name`.
-
-        The object may be simply marked for deletion and stay around for a
-        while.
-        """
-        pass
-
-# }}}
-# VolumeClient {{{
-
-class VolumeClient(Client):
-    def __init__(self, k8s_client, ssh_config):
-        super().__init__(
-            k8s_client, kind='Volume', retry_count=30, retry_delay=2
-        )
-        self._ssh_config = ssh_config
-        self._group="storage.metalk8s.scality.com"
-        self._version="v1alpha1"
-        self._plural="volumes"
-
-    def list(self):
-        return self._client.list_cluster_custom_object(
-            group=self._group, version=self._version, plural=self._plural
-        )['items']
-
-    def _create(self, body):
-        # Fixup the node name.
-        body['spec']['nodeName'] = utils.get_node_name(
-            body['spec']['nodeName'], self._ssh_config
-        )
-        self._client.create_cluster_custom_object(
-            group=self._group, version=self._version, plural=self._plural,
-            body=body
-        )
-
-    def _get(self, name):
-        return self._client.get_cluster_custom_object(
-            group=self._group, version=self._version, plural=self._plural,
-            name=name
-        )
-
-    def _delete(self, name):
-        body = kubernetes.client.V1DeleteOptions()
-        self._client.delete_cluster_custom_object(
-            group=self._group, version=self._version, plural=self._plural,
-            name=name, body=body, grace_period_seconds=0
-        )
-
-    @staticmethod
-    def compute_phase(volume_status):
-        for condition in volume_status.get('conditions', []):
-            if condition['type'] != 'Ready':
-                continue
-            if condition['status'] == 'True':
-                return 'Available'
-            elif condition['status'] == 'False':
-                return 'Failed'
-            elif condition['status'] == 'Unknown':
-                return condition['reason']
-            else:
-                assert False, 'invalid condition status: {}'.format(
-                    condition['status']
-                )
-        return ''
-
-    @staticmethod
-    def get_error(volume_status):
-        for condition in volume_status.get('conditions', []):
-            if condition['type'] != 'Ready':
-                continue
-            return condition.get('reason', ''), condition.get('message', '')
-        return '', ''
-
-
-# }}}
-# PersistentVolumeClient {{{
-
-class PersistentVolumeClient(Client):
-    def __init__(self, k8s_client):
-        super().__init__(
-            k8s_client, kind='PersistentVolume',
-            retry_count=10, retry_delay=2
-        )
-
-    def list(self):
-        return self._client.list_persistent_volume().items
-
-    def _create(self, body):
-        self._client.create_persistent_volume(body=body)
-
-    def _get(self, name):
-        return self._client.read_persistent_volume(name)
-
-    def _delete(self, name):
-        body = kubernetes.client.V1DeleteOptions()
-        self._client.delete_persistent_volume(
-            name=name, body=body, grace_period_seconds=0
-        )
-
-# }}}
-# PersistentVolumeClaimClient {{{
-
-class PersistentVolumeClaimClient(Client):
-    def __init__(self, k8s_client, namespace='default'):
-        super().__init__(
-            k8s_client, kind='PersistentVolumeClaim',
-            retry_count=10, retry_delay=2
-        )
-        self._namespace = namespace
-
-    def create_for_volume(self, volume, pv):
-        """Create a PVC matching the given volume."""
-        assert pv is not None, 'PersistentVolume {} not found'.format(volume)
-        body = PVC_TEMPLATE.format(
-            volume_name=volume,
-            storage_class=pv.spec.storage_class_name,
-            access=pv.spec.access_modes[0],
-            size=pv.spec.capacity['storage']
-        )
-        self.create_from_yaml(body)
-
-    def list(self):
-        return self._client.list_namespaced_persistent_volume_claim(
-            namespace=self._namespace
-        ).items
-
-    def _create(self, body):
-        self._client.create_namespaced_persistent_volume_claim(
-            namespace=self._namespace, body=body
-        )
-
-    def _get(self, name):
-        return self._client.read_namespaced_persistent_volume_claim(
-            name=name, namespace=self._namespace
-        )
-
-    def _delete(self, name):
-        self._client.delete_namespaced_persistent_volume_claim(
-            name=name, namespace=self._namespace, grace_period_seconds=0
-        )
-
-# }}}
-# PodClient {{{
-
-class PodClient(Client):
-    def __init__(self, k8s_client, image, namespace='default'):
-        super().__init__(
-            k8s_client, kind='Pod', retry_count=30, retry_delay=2
-        )
-        self._image = image
-        self._namespace = namespace
-
-    def create_with_volume(self, volume_name, command):
-        """Create a pod using the specified volume."""
-        binary, *args = ast.literal_eval(command)
-        body = POD_TEMPLATE.format(
-            volume_name=volume_name, image_name=self._image,
-            command=json.dumps(binary), args=json.dumps(args)
-        )
-        self.create_from_yaml(body)
-        # Wait for the Pod to be up and running.
-        pod_name = '{}-pod'.format(volume_name)
-        utils.retry(
-            kube_utils.check_pod_status(self._client, pod_name),
-            times=self._count, wait=self._delay,
-            name="wait for pod {}".format(pod_name)
-        )
-
-    def list(self):
-        return self._client.list_namespaced_pod(namespace=self._namespace).items
-
-    def _create(self, body):
-        self._client.create_namespaced_pod(namespace=self._namespace, body=body)
-
-    def _get(self, name):
-        return self._client.read_namespaced_pod(
-            name=name, namespace=self._namespace
-        )
-
-    def _delete(self, name):
-        self._client.delete_namespaced_pod(
-            name=name, namespace=self._namespace, grace_period_seconds=0
-        )
-
-# }}}
-# StorageClassClient {{{
-
-class StorageClassClient(Client):
-    def __init__(self, k8s_client):
-        super().__init__(
-            k8s_client, kind='StorageClass', retry_count=10, retry_delay=2
-        )
-
-    def list(self):
-        return self._client.list_storage_class().items
-
-    def _create(self, body):
-        self._client.create_storage_class(body=body)
-
-    def _get(self, name):
-        return self._client.read_storage_class(name=name)
-
-    def _delete(self, name):
-        self._client.delete_storage_class(name=name, grace_period_seconds=0)
-
-# }}}
-
 def _quantity_to_bytes(quantity):
     """Return a quantity with a unit converted into a number of bytes.
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -155,11 +155,13 @@ def run_salt_command(host, command, ssh_config):
     )
 
     assert output.exit_status == 0, \
-        'command {} failed with: \nout: {}\nerr:'.format(
+        'command {} failed with: \nout: {}\nerr: {}'.format(
             command,
             output.stdout,
             output.stderr
         )
+
+    return output
 
 
 def get_dict_element(data, path, delimiter='.'):


### PR DESCRIPTION
**Component**: node-exporter, tests

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: See #2631 (we need metrics for all kinds of devices that can be used in Volumes)

**Summary**:

- Adapt `node-exporter`'s `collector.diskstats.ignored-devices` to only ignore RAM disks and floppy disks
- Add a test to ensure we can actually get metrics for a `SparseLoopDevice` Volume

**Acceptance criteria**: 

- tests pass
- metrics can be retrieved for all kinds of devices allowed in Volumes

_Note that those metrics are always 0 for loop devices on old kernels such as what comes with CentOS 7_

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2631 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
