### PR TITLE
Bind Dex static admin user to a Grafana Admin role automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@
 version to 1.6.2 (PR [#2575](https://github.com/scality/metalk8s/pull/2575))
 
 - [#2674](https://github.com/scality/metalk8s/issues/2674) - Bump K8S version
-to 1.16.13 (PR [#2363](https://github.com/scality/metalk8s/pull/2679))
+to 1.16.13 (PR [#2679](https://github.com/scality/metalk8s/pull/2679))
+
+### Bug fixes
+- [#2653](https://github.com/scality/metalk8s/issues/2653) - Bind MetalK8s
+OIDC static admin user to a Grafana Admin role
+(PR [#2742](https://github.com/scality/metalk8s/pull/2742))
 
 ## Release 2.5.1
 

--- a/charts/prometheus-operator.yaml
+++ b/charts/prometheus-operator.yaml
@@ -164,6 +164,7 @@ grafana:
       auth_url: '__escape__(https://{{ grains.metalk8s.control_plane_ip }}:8443/oidc/auth)'
       token_url:  '__escape__(https://{{ grains.metalk8s.control_plane_ip }}:8443/oidc/token)'
       api_url: '__escape__(https://{{ grains.metalk8s.control_plane_ip }}:8443/oidc/userinfo)'
+      role_attribute_path: contains(email, '{% endraw -%}{{ dex.spec.localuserstore.userlist[0]['email'] }}{%- raw %}') && 'Admin'
 
   testFramework:
     enabled: false

--- a/charts/render.py
+++ b/charts/render.py
@@ -179,9 +179,9 @@ def main():
 
     class ActionServiceConfigArgs(argparse.Action):
         def __call__(self, parser, args, values, option_string=None):
-            if len(values) > 3:
+            if len(values) > 4:
                 raise argparse.ArgumentTypeError(
-                    'Argument "{0}" requires between 1 and 3 arguments'
+                    'Argument "{0}" requires between 1 and 4 arguments'
                     .format(option_string)
                 )
 
@@ -196,21 +196,26 @@ def main():
                 path = 'metalk8s/addons/{0}/config/{1}.yaml'.format(
                     args.name, name
                 )
+            service_namespace = values.pop(0)
 
             option = getattr(args, self.dest)
             if option is None:
-                setattr(args, self.dest, [[name, configmap, path]])
+                setattr(
+                    args,
+                    self.dest,
+                    [[name, configmap, path, service_namespace]]
+                )
             else:
-                option.append([name, configmap, path])
+                option.append([name, configmap, path, service_namespace])
 
     '''
     To use this argument, follow the format below:
-        --service-config service_name service_configmap_name
+        --service-config service_name service_configmap_name service_namespace
     where service_name is actually the jinja variable which will hold
     ConfigMap contents.
     Note that you can specify multiple service config arguments using:
-        --service-config grafana metalk8s-grafana-config
-        --service-config prometheus metalk8s-prometheus-config
+        --service-config grafana metalk8s-grafana-config metalk8s-monitoring
+        --service-config dex metalk8s-dex-config metalk8s-auth
     '''
     # Todo: Add kind & apiVersion to the service-config nargs
     parser.add_argument(
@@ -220,7 +225,8 @@ def main():
         required=False,
         dest="service_configs",
         help="Example: --service-config grafana metalk8s-grafana-config "
-             "metalk8s/addons/prometheus-operator/config/grafana.yaml"
+             "metalk8s/addons/prometheus-operator/config/grafana.yaml "
+             "metalk8s-monitoring"
     )
     parser.add_argument('path', help="Path to the chart directory")
     args = parser.parse_args()
@@ -243,7 +249,7 @@ def main():
 
     import_csc_yaml = []
     config = []
-    for name, configmap, path in args.service_configs:
+    for name, configmap, path, service_namespace in args.service_configs:
         import_csc_yaml.append(
             "{{% import_yaml '{0}' as {1}_defaults with context %}}".format(
                 path, name
@@ -252,7 +258,7 @@ def main():
         config.append(
             "{{%- set {0} = salt.metalk8s_service_configuration"
             ".get_service_conf('{1}', '{2}', {0}_defaults) %}}".format(
-                name, args.namespace, configmap
+                name, service_namespace, configmap
             )
         )
 

--- a/charts/render.py
+++ b/charts/render.py
@@ -177,6 +177,32 @@ def main():
     )
     parser.add_argument('values', help="Our custom chart values")
 
+    class ActionServiceConfigArgs(argparse.Action):
+        def __call__(self, parser, args, values, option_string=None):
+            if len(values) > 3:
+                raise argparse.ArgumentTypeError(
+                    'Argument "{0}" requires between 1 and 3 arguments'
+                    .format(option_string)
+                )
+
+            name = values.pop(0)
+            try:
+                configmap = values.pop(0)
+            except IndexError:
+                configmap = 'metalk8s-{0}-config'.format(name)
+            try:
+                path = values.pop(0)
+            except IndexError:
+                path = 'metalk8s/addons/{0}/config/{1}.yaml'.format(
+                    args.name, name
+                )
+
+            option = getattr(args, self.dest)
+            if option is None:
+                setattr(args, self.dest, [[name, configmap, path]])
+            else:
+                option.append([name, configmap, path])
+
     '''
     To use this argument, follow the format below:
         --service-config service_name service_configmap_name
@@ -189,11 +215,12 @@ def main():
     # Todo: Add kind & apiVersion to the service-config nargs
     parser.add_argument(
         '--service-config',
-        action='append',
-        nargs=2,
+        action=ActionServiceConfigArgs,
+        nargs='+',
         required=False,
         dest="service_configs",
-        help="Example: --service-config grafana metalk8s-grafana-config"
+        help="Example: --service-config grafana metalk8s-grafana-config "
+             "metalk8s/addons/prometheus-operator/config/grafana.yaml"
     )
     parser.add_argument('path', help="Path to the chart directory")
     args = parser.parse_args()
@@ -212,27 +239,27 @@ def main():
             doc=fixup_doc(
                 doc=doc
             )
-        )
-    if args.service_configs:
-        import_csc_yaml = '\n'.join(
-            ("{{% import_yaml 'metalk8s/addons/{0}/config/{1}.yaml' as "
-                "{1}_defaults with context %}}").format(
-                args.name, service_config[0]
-            ) for service_config in args.service_configs
-        )
+        ) if doc else None
 
-        config = '\n'.join(
-            ("{{%- set {0} = salt.metalk8s_service_configuration"
-                ".get_service_conf('{1}', '{2}', {0}_defaults) %}}").format(
-                service_config[0], args.namespace, service_config[1]
-            ) for service_config in args.service_configs
+    import_csc_yaml = []
+    config = []
+    for name, configmap, path in args.service_configs:
+        import_csc_yaml.append(
+            "{{% import_yaml '{0}' as {1}_defaults with context %}}".format(
+                path, name
+            )
         )
-    else:
-        import_csc_yaml = ''
-        config = ''
+        config.append(
+            "{{%- set {0} = salt.metalk8s_service_configuration"
+            ".get_service_conf('{1}', '{2}', {0}_defaults) %}}".format(
+                name, args.namespace, configmap
+            )
+        )
 
     sys.stdout.write(START_BLOCK.format(
-        csc_defaults=import_csc_yaml, configlines=config).lstrip()
+            csc_defaults='\n'.join(import_csc_yaml),
+            configlines='\n'.join(config)
+        ).lstrip()
     )
     sys.stdout.write('\n')
 

--- a/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
@@ -4,9 +4,11 @@
 {% import_yaml 'metalk8s/addons/prometheus-operator/config/grafana.yaml' as grafana_defaults with context %}
 {% import_yaml 'metalk8s/addons/prometheus-operator/config/prometheus.yaml' as prometheus_defaults with context %}
 {% import_yaml 'metalk8s/addons/prometheus-operator/config/alertmanager.yaml' as alertmanager_defaults with context %}
+{% import_yaml 'metalk8s/addons/dex/config/dex.yaml' as dex_defaults with context %}
 {%- set grafana = salt.metalk8s_service_configuration.get_service_conf('metalk8s-monitoring', 'metalk8s-grafana-config', grafana_defaults) %}
 {%- set prometheus = salt.metalk8s_service_configuration.get_service_conf('metalk8s-monitoring', 'metalk8s-prometheus-config', prometheus_defaults) %}
 {%- set alertmanager = salt.metalk8s_service_configuration.get_service_conf('metalk8s-monitoring', 'metalk8s-alertmanager-config', alertmanager_defaults) %}
+{%- set dex = salt.metalk8s_service_configuration.get_service_conf('metalk8s-auth', 'metalk8s-dex-config', dex_defaults) %}
 
 {% raw %}
 
@@ -327,6 +329,7 @@ data:
     client_id = grafana-ui
     client_secret = 4lqK98NcsWG5qBRHJUqYM1
     enabled = true
+    role_attribute_path = contains(email, '{% endraw -%}{{ dex.spec.localuserstore.userlist[0]['email'] }}{%- raw %}') && 'Admin'
     scopes = openid profile email groups
     tls_skip_verify_insecure = true
     token_url = "{% endraw -%}https://{{ grains.metalk8s.control_plane_ip }}:8443/oidc/token{%- raw %}"
@@ -51232,7 +51235,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7b469c4cdb154cb1f2987d376bbd99cd9757f2aab45bc90ee521824e329c24d2
+        checksum/config: 99946dc6287166fccab96ec15282aa472c91e332872d5ad4a89dca37ff7f30ee
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/sc-dashboard-provider-config: d8d82dc736b65dc3ccf0e743a2f7a371fe340cf2874c76f164366f347b23b6b4
         checksum/secret: 0b5d0cba774f73eb434cecec5282d028eb34e57b1ff23bb3aa075519de6d1892


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
'salt', 'prometheus-operator', 'charts', 'grafana'

**Context**: 

See: #2653 

**Summary**:

When logging into Grafana, with the default admin@metalk8s.invalid Dex static user, we should automatically get full access permissions in Grafana. This is possible since we now make use of the Grafana role attribute to map the Dex user to a Grafana Admin role.

**Acceptance criteria**: 

- We should be able to log in to Grafana with `admin@metalk8s.invalid` user possessing Admin role attributes in Grafana.

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2653 
