### PR TITLE
salt: Do not overwrite private key if they already exists

### DIFF
--- a/salt/metalk8s/kubernetes/apiserver/certs/etcd-client.sls
+++ b/salt/metalk8s/kubernetes/apiserver/certs/etcd-client.sls
@@ -1,11 +1,13 @@
 {%- from "metalk8s/map.jinja" import etcd with context %}
 
+{%- set private_key_path = "/etc/kubernetes/pki/apiserver-etcd-client.key" %}
+
 include:
   - metalk8s.internal.m2crypto
 
 Create apiserver etcd client private key:
   x509.private_key_managed:
-    - name: /etc/kubernetes/pki/apiserver-etcd-client.key
+    - name: {{ private_key_path }}
     - bits: 2048
     - verbose: False
     - user: root
@@ -15,11 +17,13 @@ Create apiserver etcd client private key:
     - dir_mode: 755
     - require:
       - metalk8s_package_manager: Install m2crypto
+    - unless:
+      - test -f "{{ private_key_path }}"
 
 Generate apiserver etcd client certificate:
   x509.certificate_managed:
     - name: /etc/kubernetes/pki/apiserver-etcd-client.crt
-    - public_key: /etc/kubernetes/pki/apiserver-etcd-client.key
+    - public_key: {{ private_key_path }}
     - ca_server: {{ pillar['metalk8s']['ca']['minion'] }}
     - signing_policy: {{ etcd.cert.apiserver_client_signing_policy }}
     - CN: kube-apiserver-etcd-client

--- a/salt/metalk8s/kubernetes/apiserver/certs/front-proxy-client.sls
+++ b/salt/metalk8s/kubernetes/apiserver/certs/front-proxy-client.sls
@@ -1,11 +1,13 @@
 {%- from "metalk8s/map.jinja" import front_proxy with context %}
 
+{%- set private_key_path = "/etc/kubernetes/pki/front-proxy-client.key" %}
+
 include:
   - metalk8s.internal.m2crypto
 
 Create front proxy client private key:
   x509.private_key_managed:
-    - name: /etc/kubernetes/pki/front-proxy-client.key
+    - name: {{ private_key_path }}
     - bits: 2048
     - verbose: False
     - user: root
@@ -15,11 +17,13 @@ Create front proxy client private key:
     - dir_mode: 755
     - require:
       - metalk8s_package_manager: Install m2crypto
+    - unless:
+      - test -f "{{ private_key_path }}"
 
 Generate front proxy client certificate:
   x509.certificate_managed:
     - name: /etc/kubernetes/pki/front-proxy-client.crt
-    - public_key: /etc/kubernetes/pki/front-proxy-client.key
+    - public_key: {{ private_key_path }}
     - ca_server: {{ pillar['metalk8s']['ca']['minion'] }}
     - signing_policy: {{ front_proxy.cert.client_signing_policy }}
     - CN: front-proxy-client

--- a/salt/metalk8s/kubernetes/apiserver/certs/kubelet-client.sls
+++ b/salt/metalk8s/kubernetes/apiserver/certs/kubelet-client.sls
@@ -1,11 +1,13 @@
 {%- from "metalk8s/map.jinja" import kube_api with context %}
 
+{%- set private_key_path = "/etc/kubernetes/pki/apiserver-kubelet-client.key" %}
+
 include:
   - metalk8s.internal.m2crypto
 
 Create kube-apiserver kubelet client private key:
   x509.private_key_managed:
-    - name: /etc/kubernetes/pki/apiserver-kubelet-client.key
+    - name: {{ private_key_path }}
     - bits: 2048
     - verbose: False
     - user: root
@@ -15,11 +17,13 @@ Create kube-apiserver kubelet client private key:
     - dir_mode: 755
     - require:
       - metalk8s_package_manager: Install m2crypto
+    - unless:
+      - test -f "{{ private_key_path }}"
 
 Generate kube-apiserver kubelet client certificate:
   x509.certificate_managed:
     - name: /etc/kubernetes/pki/apiserver-kubelet-client.crt
-    - public_key: /etc/kubernetes/pki/apiserver-kubelet-client.key
+    - public_key: {{ private_key_path }}
     - ca_server: {{ pillar['metalk8s']['ca']['minion'] }}
     - signing_policy: {{ kube_api.cert.client_signing_policy }}
     - CN: kube-apiserver-kubelet-client

--- a/salt/metalk8s/kubernetes/ca/etcd/installed.sls
+++ b/salt/metalk8s/kubernetes/ca/etcd/installed.sls
@@ -1,11 +1,13 @@
 {%- from "metalk8s/map.jinja" import etcd with context %}
 
+{%- set private_key_path = "/etc/kubernetes/pki/etcd/ca.key" %}
+
 include:
   - metalk8s.internal.m2crypto
 
 Create etcd CA private key:
   x509.private_key_managed:
-    - name: /etc/kubernetes/pki/etcd/ca.key
+    - name: {{ private_key_path }}
     - bits: 4096
     - verbose: False
     - user: root
@@ -15,11 +17,13 @@ Create etcd CA private key:
     - dir_mode: 755
     - require:
       - metalk8s_package_manager: Install m2crypto
+    - unless:
+      - test -f "{{ private_key_path }}"
 
 Generate etcd CA certificate:
   x509.certificate_managed:
     - name: /etc/kubernetes/pki/etcd/ca.crt
-    - signing_private_key: /etc/kubernetes/pki/etcd/ca.key
+    - signing_private_key: {{ private_key_path }}
     - CN: etcd-ca
     - keyUsage: "critical digitalSignature, keyEncipherment, keyCertSign"
     - basicConstraints: "critical CA:true"

--- a/salt/metalk8s/kubernetes/ca/front-proxy/installed.sls
+++ b/salt/metalk8s/kubernetes/ca/front-proxy/installed.sls
@@ -1,11 +1,13 @@
 {%- from "metalk8s/map.jinja" import front_proxy with context %}
 
+{%- set private_key_path = "/etc/kubernetes/pki/front-proxy-ca.key" %}
+
 include:
   - metalk8s.internal.m2crypto
 
 Create front proxy CA private key:
   x509.private_key_managed:
-    - name: /etc/kubernetes/pki/front-proxy-ca.key
+    - name: {{ private_key_path }}
     - bits: 4096
     - verbose: False
     - user: root
@@ -15,11 +17,13 @@ Create front proxy CA private key:
     - dir_mode: 755
     - require:
       - metalk8s_package_manager: Install m2crypto
+    - unless:
+      - test -f "{{ private_key_path }}"
 
 Generate front proxy CA certificate:
   x509.certificate_managed:
     - name: /etc/kubernetes/pki/front-proxy-ca.crt
-    - signing_private_key: /etc/kubernetes/pki/front-proxy-ca.key
+    - signing_private_key: {{ private_key_path }}
     - CN: front-proxy-ca
     - keyUsage: "critical digitalSignature, keyEncipherment, keyCertSign"
     - basicConstraints: "critical CA:true"

--- a/salt/metalk8s/kubernetes/ca/kubernetes/installed.sls
+++ b/salt/metalk8s/kubernetes/ca/kubernetes/installed.sls
@@ -1,11 +1,13 @@
 {%- from "metalk8s/map.jinja" import ca with context %}
 
+{%- set private_key_path = "/etc/kubernetes/pki/ca.key" %}
+
 include:
   - metalk8s.internal.m2crypto
 
 Create CA private key:
   x509.private_key_managed:
-    - name: /etc/kubernetes/pki/ca.key
+    - name: {{ private_key_path }}
     - bits: 4096
     - verbose: False
     - user: root
@@ -15,11 +17,13 @@ Create CA private key:
     - dir_mode: 755
     - require:
       - metalk8s_package_manager: Install m2crypto
+    - unless:
+      - test -f "{{ private_key_path }}"
 
 Generate CA certificate:
   x509.certificate_managed:
     - name: /etc/kubernetes/pki/ca.crt
-    - signing_private_key: /etc/kubernetes/pki/ca.key
+    - signing_private_key: {{ private_key_path }}
     - CN: kubernetes
     - keyUsage: "critical digitalSignature, keyEncipherment, keyCertSign"
     - basicConstraints: "critical CA:true"

--- a/salt/metalk8s/kubernetes/etcd/certs/healthcheck-client.sls
+++ b/salt/metalk8s/kubernetes/etcd/certs/healthcheck-client.sls
@@ -1,11 +1,13 @@
 {%- from "metalk8s/map.jinja" import etcd with context %}
 
+{%- set private_key_path = "/etc/kubernetes/pki/etcd/healthcheck-client.key" %}
+
 include:
   - metalk8s.internal.m2crypto
 
 Create etcd healthcheck client private key:
   x509.private_key_managed:
-    - name: /etc/kubernetes/pki/etcd/healthcheck-client.key
+    - name: {{ private_key_path }}
     - bits: 2048
     - verbose: False
     - user: root
@@ -15,11 +17,13 @@ Create etcd healthcheck client private key:
     - dir_mode: 755
     - require:
       - metalk8s_package_manager: Install m2crypto
+    - unless:
+      - test -f "{{ private_key_path }}"
 
 Generate etcd healthcheck client certificate:
   x509.certificate_managed:
     - name: /etc/kubernetes/pki/etcd/healthcheck-client.crt
-    - public_key: /etc/kubernetes/pki/etcd/healthcheck-client.key
+    - public_key: {{ private_key_path }}
     - ca_server: {{ pillar['metalk8s']['ca']['minion'] }}
     - signing_policy: {{ etcd.cert.healthcheck_client_signing_policy }}
     - CN: kube-etcd-healthcheck-client

--- a/salt/metalk8s/kubernetes/etcd/certs/peer.sls
+++ b/salt/metalk8s/kubernetes/etcd/certs/peer.sls
@@ -1,11 +1,13 @@
 {%- from "metalk8s/map.jinja" import etcd with context %}
 
+{%- set private_key_path = "/etc/kubernetes/pki/etcd/peer.key" %}
+
 include:
   - metalk8s.internal.m2crypto
 
 Create etcd peer private key:
   x509.private_key_managed:
-    - name: /etc/kubernetes/pki/etcd/peer.key
+    - name: {{ private_key_path }}
     - bits: 2048
     - verbose: False
     - user: root
@@ -15,11 +17,13 @@ Create etcd peer private key:
     - dir_mode: 755
     - require:
       - metalk8s_package_manager: Install m2crypto
+    - unless:
+      - test -f "{{ private_key_path }}"
 
 Generate etcd peer certificate:
   x509.certificate_managed:
     - name: /etc/kubernetes/pki/etcd/peer.crt
-    - public_key: /etc/kubernetes/pki/etcd/peer.key
+    - public_key: {{ private_key_path }}
     - ca_server: {{ pillar['metalk8s']['ca']['minion'] }}
     - signing_policy: {{ etcd.cert.peer_signing_policy }}
     - CN: "{{ grains['fqdn'] }}"

--- a/salt/metalk8s/kubernetes/etcd/certs/server.sls
+++ b/salt/metalk8s/kubernetes/etcd/certs/server.sls
@@ -1,11 +1,13 @@
 {%- from "metalk8s/map.jinja" import etcd with context %}
 
+{%- set private_key_path = "/etc/kubernetes/pki/etcd/server.key" %}
+
 include:
   - metalk8s.internal.m2crypto
 
 Create etcd server private key:
   x509.private_key_managed:
-    - name: /etc/kubernetes/pki/etcd/server.key
+    - name: {{ private_key_path }}
     - bits: 2048
     - verbose: False
     - user: root
@@ -15,11 +17,13 @@ Create etcd server private key:
     - dir_mode: 755
     - require:
       - metalk8s_package_manager: Install m2crypto
+    - unless:
+      - test -f "{{ private_key_path }}"
 
 Generate etcd server certificate:
   x509.certificate_managed:
     - name: /etc/kubernetes/pki/etcd/server.crt
-    - public_key: /etc/kubernetes/pki/etcd/server.key
+    - public_key: {{ private_key_path }}
     - ca_server: {{ pillar['metalk8s']['ca']['minion'] }}
     - signing_policy: {{ etcd.cert.server_signing_policy }}
     - CN: "{{ grains['fqdn'] }}"

--- a/salt/metalk8s/kubernetes/sa/installed.sls
+++ b/salt/metalk8s/kubernetes/sa/installed.sls
@@ -1,9 +1,11 @@
+{%- set private_key_path = "/etc/kubernetes/pki/sa.key" %}
+
 include:
   - metalk8s.internal.m2crypto
 
 Create SA private key:
   x509.private_key_managed:
-    - name: /etc/kubernetes/pki/sa.key
+    - name: {{ private_key_path }}
     - bits: 2048
     - verbose: False
     - user: root
@@ -13,11 +15,13 @@ Create SA private key:
     - dir_mode: 755
     - require:
       - metalk8s_package_manager: Install m2crypto
+    - unless:
+      - test -f "{{ private_key_path }}"
 
 Store SA public key:
   file.managed:
     - name: /etc/kubernetes/pki/sa.pub
-    - contents: __slot__:salt:x509.get_public_key("/etc/kubernetes/pki/sa.key")
+    - contents: __slot__:salt:x509.get_public_key("{{ private_key_path }}")
     - user: root
     - group: root
     - mode: 644

--- a/salt/metalk8s/salt/master/certs/etcd-client.sls
+++ b/salt/metalk8s/salt/master/certs/etcd-client.sls
@@ -1,11 +1,13 @@
 {%- from "metalk8s/map.jinja" import etcd with context %}
 
+{%- set private_key_path = "/etc/kubernetes/pki/etcd/salt-master-etcd-client.key" %}
+
 include:
   - metalk8s.internal.m2crypto
 
 Create salt master etcd client private key:
   x509.private_key_managed:
-    - name: /etc/kubernetes/pki/etcd/salt-master-etcd-client.key
+    - name: {{ private_key_path }}
     - bits: 2048
     - verbose: False
     - user: root
@@ -15,11 +17,13 @@ Create salt master etcd client private key:
     - dir_mode: 755
     - require:
       - metalk8s_package_manager: Install m2crypto
+    - unless:
+      - test -f "{{ private_key_path }}"
 
 Generate salt master etcd client certificate:
   x509.certificate_managed:
     - name: /etc/kubernetes/pki/etcd/salt-master-etcd-client.crt
-    - public_key: /etc/kubernetes/pki/etcd/salt-master-etcd-client.key
+    - public_key: {{ private_key_path }}
     - ca_server: {{ pillar['metalk8s']['ca']['minion'] }}
     - signing_policy: {{ etcd.cert.apiserver_client_signing_policy }}
     - CN: etcd-salt-master-client


### PR DESCRIPTION
**Component**:

'salt'

**Context**: 

In our salt states we generate a bunch of private key for certificates,
those private key are only needed to generate these certificates and we
do not really care about the length of the key, so if the key already
exists do not generate a new one and take this one even if it's not the
expected key length

**Summary**:

If the key already exists do not generate a new one and take this one even if it's not the
expected key length

---

