### PR TITLE
Reconfigure MetalK8s authn to support external backends(Keycloak)

### DIFF
--- a/charts/dex.yaml
+++ b/charts/dex.yaml
@@ -79,6 +79,7 @@ config:
     trustedPeers:
     - metalk8s-ui
     - grafana-ui
+    - external-oidc-ui
   - id: metalk8s-ui
     redirectURIs:
     - '__escape__(https://{{ grains.metalk8s.control_plane_ip }}:8443/oauth2/callback)'
@@ -89,6 +90,10 @@ config:
     redirectURIs:
     - '__escape__(https://{{ grains.metalk8s.control_plane_ip }}:8443/grafana/login/generic_oauth)'
     secret: "4lqK98NcsWG5qBRHJUqYM1"
+  - id: external-oidc-ui
+    name: '__var__(dex.spec.externalIDP.staticClient.name)'
+    redirectURIs: '__var_tojson_nospace__(dex.spec.externalIDP.staticClient.redirectURIs)'
+    secret: "ZXhhbXBsZS1hcHAtc2VjcmV0" #Secret cannot be put in a CSC ConfigMap
 
   enablePasswordDB: '__var__(dex.spec.localuserstore.enabled)'
 

--- a/charts/render.py
+++ b/charts/render.py
@@ -152,6 +152,12 @@ def replace_magic_strings(rendered_yaml):
         result,
     )
 
+    result = re.sub(
+        r'__var_tojson_nospace__\((?P<varname>[\w\-_]+(?:\.[\w\-_()|]+)*)\)',
+        r'{% endraw -%}{{ \g<varname> | tojson }}{%- raw %}',
+        result,
+    )
+
     # Handle __escape__
     result = re.sub(
         r'__escape__\((?P<varname>.*)\)',

--- a/docs/operation/account_administration.rst
+++ b/docs/operation/account_administration.rst
@@ -72,3 +72,12 @@ refer to :ref:`this procedure <Change-dex-static-user-password>`
    - Dex connectors
 
    - How to add a new connector (LDAP, AD, SAML)
+
+Adding an External Identity Provider
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+MetalK8s is capable of federating (delegating) it's OIDC provider capabilities
+to an external full-fledge Identity and Access Management (IAM) system like
+Keycloak.
+
+To add a new external Identity Provider to MetalK8s, refer to
+:ref:`this procedure <Add-new-external-identity-provider>`

--- a/docs/operation/cluster_and_service_configuration.rst
+++ b/docs/operation/cluster_and_service_configuration.rst
@@ -510,6 +510,55 @@ To change the password of an existing user, perform the following operations:
       - Configuring LDAP
       - Configuring Active Directory(AD)
 
+.. _Add-new-external-identity-provider:
+
+Add new external Identity Provider
+""""""""""""""""""""""""""""""""""
+
+#. From the Bootstrap node, edit the ConfigMap ``metalk8s-dex-config`` as
+   follows
+
+   .. code-block:: shell
+
+      root@bootstrap $ kubectl --kubeconfig /etc/kubernetes/admin.conf \
+                         edit configmaps metalk8s-dex-config -n metalk8s-auth
+
+   - Add the following mandatory fields where:
+
+      - <oidc-client-name> refers to any chosen alphanumeric e.g Keycloak-UI
+      - <redirectURIs> refers to an HTTP endpoint where the authorization code
+        or tokens are sent to. It must match a registered and valid callback
+        URI available on your external Identity Provider.
+
+   .. code-block:: yaml
+
+      [...]
+      data:
+         config.yaml: |-
+            spec:
+              externalIDP:
+                staticClient:
+                  name: "<oidc-client-name>"
+                  redirectURIs:
+                    - "<redirectURIs_1>"
+                    - "<redirectURIs_2>"
+      [...]
+
+#. Save the ConfigMap changes.
+
+#. From the Bootstrap node, run the following to propagate the
+   changes.
+
+   .. parsed-literal::
+
+      root\@bootstrap $ kubectl exec -n kube-system -c salt-master \\
+                         --kubeconfig /etc/kubernetes/admin.conf \\
+                         salt-master-bootstrap -- salt-run \\
+                         state.sls metalk8s.addons.dex.deployed saltenv=metalk8s-|version|
+
+#. Verify that your configured external Identity Provider correctly redirects
+   when a login request is initiated.
+
 Loki Configuration Customization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/salt/metalk8s/addons/dex/deployed/chart.sls
+++ b/salt/metalk8s/addons/dex/deployed/chart.sls
@@ -50,6 +50,7 @@ stringData:
       trustedPeers:
       - metalk8s-ui
       - grafana-ui
+      - external-oidc-ui
     - id: metalk8s-ui
       name: MetalK8s UI
       redirectURIs:
@@ -60,6 +61,10 @@ stringData:
       redirectURIs:
       - "{% endraw -%}https://{{ grains.metalk8s.control_plane_ip }}:8443/grafana/login/generic_oauth{%- raw %}"
       secret: 4lqK98NcsWG5qBRHJUqYM1
+    - id: external-oidc-ui
+      name: {% endraw -%}{{ dex.spec.externalIDP.staticClient.name }}{%- raw %}
+      redirectURIs: {% endraw -%}{{ dex.spec.externalIDP.staticClient.redirectURIs | tojson }}{%- raw %}
+      secret: ZXhhbXBsZS1hcHAtc2VjcmV0
     enablePasswordDB: {% endraw -%}{{ dex.spec.localuserstore.enabled }}{%- raw %}
     staticPasswords:
       {% endraw -%}{{ dex.spec.localuserstore.userlist | tojson }}{%- raw %}

--- a/salt/metalk8s/addons/dex/deployed/service-configuration.sls
+++ b/salt/metalk8s/addons/dex/deployed/service-configuration.sls
@@ -31,6 +31,11 @@ Create dex-config ConfigMap:
                     hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
                     username: "admin"
                     userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
+              externalIDP:
+                staticClient:
+                  name: ""
+                  redirectURIs: []
+
 
  {%- else %}
 


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->
'salt', 'dex', 'charts', 'oidc'

**Context**: 

See: [ticket](https://scality.atlassian.net/browse/RINGX-18)

**Summary**:

- Reconfigure Dex to add support for any external Identity Provider
- Add documentation on how to edit the CSC that handles authn config params

**Acceptance criteria**: 

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
