### PR TITLE
[ui]Adapt create volume E2E test for new volume page

### DIFF
--- a/ui/cypress/integration/common/CreateVolume.feature
+++ b/ui/cypress/integration/common/CreateVolume.feature
@@ -1,0 +1,6 @@
+Feature: CreateVolume
+ Scenario: CreateVolume with SparseLoopDevice
+     Given I log in
+     When I go to the volume page by click the volume icon in the sidebar
+     And I go to create volume page by click on Create a New Volume button
+     Then I fill out the create volume form with SparseLoopDevice volume type and check if the status is Ready

--- a/ui/src/components/VolumeDetailCard.js
+++ b/ui/src/components/VolumeDetailCard.js
@@ -194,7 +194,9 @@ const VolumeDetailCard = (props) => {
   return (
     <VolumeDetailCardContainer>
       <VolumeInformation>
-        <VolumeNameTitle>{name}</VolumeNameTitle>
+        <VolumeNameTitle data-cy="volume_detail_card_name">
+          {name}
+        </VolumeNameTitle>
         <InformationSpan>
           <InformationLabel>{intl.translate('node')}</InformationLabel>
           <InformationValue>{nodeName}</InformationValue>
@@ -205,7 +207,9 @@ const VolumeDetailCard = (props) => {
         </InformationSpan>
         <InformationSpan>
           <InformationLabel>{intl.translate('status')}</InformationLabel>
-          <InformationValue>{status}</InformationValue>
+          <InformationValue data-cy="volume_status_value">
+            {status}
+          </InformationValue>
         </InformationSpan>
         <InformationSpan>
           <InformationLabel>{intl.translate('storageClass')}</InformationLabel>
@@ -250,8 +254,12 @@ const VolumeDetailCard = (props) => {
             {labels?.map((label) => {
               return (
                 <div key={label.name}>
-                  <LabelName>{label.name}</LabelName>
-                  <LabelValue>{label.value}</LabelValue>
+                  <LabelName data-cy="volume_label_name">
+                    {label.name}
+                  </LabelName>
+                  <LabelValue data-cy="volume_label_value">
+                    {label.value}
+                  </LabelValue>
                 </div>
               );
             })}

--- a/ui/src/components/VolumeListTable.js
+++ b/ui/src/components/VolumeListTable.js
@@ -180,6 +180,7 @@ function GlobalFilter({
             history.push('/volumes/createVolume');
           }
         }}
+        data-cy="create-volume-button"
       />
     </ActionContainer>
   );


### PR DESCRIPTION
**Component**: ui, tests

**Context**: I removed the Create volume E2E when merged the New Volume Page, so we should enable it again based on the changes of New Volume Page

**Summary**:
For the moment, we only test create volume with sparseloop device. Since the CI is not ready for rawBlockdevice.

Note that:
storage class should be `metalk8s` instead of the previous `metalk8s-prometheus`


**Acceptance criteria**: 
`./node_modules/cypress/bin/cypress run -b chrome -s cypress/integration/common/CreateVolume.feature`

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2696 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
