### PR TITLE
charts: Update Log dashboard filter to really filter on system and pod logs

### DIFF
--- a/charts/logs-dashboard.json
+++ b/charts/logs-dashboard.json
@@ -991,7 +991,7 @@
         "useTags": false
       },
       {
-        "allValue": ".*",
+        "allValue": ".+",
         "datasource": "$metrics",
         "definition": "label_values(kube_pod_info{cluster=\"$cluster\"}, node)",
         "hide": 0,
@@ -1117,7 +1117,7 @@
         "useTags": false
       },
       {
-        "allValue": ".*",
+        "allValue": ".+",
         "datasource": "$logs",
         "definition": "label_values({cluster=\"$cluster\"}, hostname)",
         "hide": 0,


### PR DESCRIPTION
**Component**:

'charts', 'log'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

In log grafana dashboard we have 2 queries for logs (one for pod logs and another for system logs), before this PR if no filter were set each query match other logs.
E.g:
I filter only on namespace="metalk8s-ui":
- query for Pod logs will only retrieve logs from pod in namespace "metalk8s-ui" (expected)
- query for system logs will retrieve all system logs (expected) **+ all pod logs (no matter the namespace) (NOT expected)**

**Summary**:

Update Log dashboard so that:
- system log query expect hostname non-empty (so never match pod logs)
- pod log query expect node non-empty (so never match system logs)

---

Refs: #2721 
