### PR TITLE
salt: Fix apiVersion of StorageClass to remove

### DIFF
--- a/salt/metalk8s/addons/prometheus-operator/post-upgrade.sls
+++ b/salt/metalk8s/addons/prometheus-operator/post-upgrade.sls
@@ -5,6 +5,6 @@ include:
 
 Delete old metalk8s-prometheus StorageClass:
   metalk8s_kubernetes.object_absent:
-    - apiVersion: v1
+    - apiVersion: storage.k8s.io/v1
     - kind: StorageClass
     - name: metalk8s-prometheus


### PR DESCRIPTION
Changes introduced by 13bc5a0 took the wrong apiVersion (v1) for
StorageClass, which live under storage.k8s.io/v1

See: 13bc5a0

