### PR TITLE
[UI] Layout of New Node Page

### DIFF
--- a/ui/src/components/CommonLayoutStyle.js
+++ b/ui/src/components/CommonLayoutStyle.js
@@ -1,0 +1,47 @@
+import styled from 'styled-components';
+import { padding } from '@scality/core-ui/dist/style/theme';
+
+export const PageContainer = styled.div`
+  display: flex;
+  box-sizing: border-box;
+  height: 100%;
+  flex-wrap: wrap;
+  padding: ${padding.small};
+`;
+
+export const LeftSideInstanceList = styled.div`
+  flex-direction: column;
+  min-height: 696px;
+  width: 45%;
+`;
+
+export const RightSidePanel = styled.div`
+  flex-direction: column;
+  width: 55%;
+  /* Make it scrollable for the small laptop screen */
+  overflow-y: scroll;
+  margin: ${padding.small} ${padding.small} ${padding.small} 0;
+`;
+
+export const NoInstanceSelectedContainer = styled.div`
+  margin: ${padding.small} ${padding.small} ${padding.small} 0;
+  width: 55%;
+  min-height: 700px;
+  background-color: ${(props) => props.theme.brand.primaryDark1};
+`;
+
+export const NoInstanceSelected = styled.div`
+  position: relative;
+  top: 50%;
+  transform: translateY(-50%);
+  color: ${(props) => props.theme.brand.textPrimary};
+  text-align: center;
+`;
+
+export const PageContentContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  height: 100%;
+  width: 100%;
+  background-color: ${(props) => props.theme.brand.primary};
+`;

--- a/ui/src/components/NodeListTable.js
+++ b/ui/src/components/NodeListTable.js
@@ -1,0 +1,322 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { useHistory } from 'react-router';
+import { useLocation } from 'react-router-dom';
+import styled from 'styled-components';
+import {
+  useTable,
+  useFilters,
+  useGlobalFilter,
+  useAsyncDebounce,
+} from 'react-table';
+import { useQuery } from '../services/utils';
+import { fontSize, padding } from '@scality/core-ui/dist/style/theme';
+import CircleStatus from './CircleStatus';
+import { Button } from '@scality/core-ui';
+import { intl } from '../translations/IntlGlobalProvider';
+
+const NodeListContainer = styled.div`
+  color: ${(props) => props.theme.brand.textPrimary};
+  padding: ${padding.base};
+  font-family: 'Lato';
+  font-size: ${fontSize.base};
+  border-color: ${(props) => props.theme.brand.borderLight};
+  .sc-progressbarcontainer {
+    width: 100%;
+  }
+  .ReactTable .rt-thead {
+    overflow-y: scroll;
+  }
+  table {
+    border-spacing: 0;
+    .sc-select-container {
+      width: 120px;
+      height: 10px;
+    }
+    tr {
+      :last-child {
+        td {
+          border-bottom: 0;
+          font-weight: normal;
+        }
+      }
+    }
+
+    th {
+      font-weight: bold;
+      height: 56px;
+      text-align: left;
+      padding: ${padding.smaller};
+    }
+
+    td {
+      margin: 0;
+      padding: 0.5rem;
+      border-bottom: 1px solid black;
+      text-align: left;
+      padding: 5px;
+
+      :last-child {
+        border-right: 0;
+      }
+    }
+  }
+`;
+
+const HeadRow = styled.tr`
+  width: 100%;
+  /* To display scroll bar on the table */
+  display: table;
+  table-layout: fixed;
+`;
+
+const CreateNodeButton = styled(Button)`
+  margin-left: ${padding.larger};
+`;
+
+const TableRow = styled(HeadRow)`
+  &:hover,
+  &:focus {
+    background-color: ${(props) => props.theme.brand.backgroundBluer};
+    border-top: 1px solid ${(props) => props.theme.brand.secondary};
+    border-bottom: 1px solid ${(props) => props.theme.brand.secondary};
+    outline: none;
+    cursor: pointer;
+  }
+`;
+
+// * table body
+const Body = styled.tbody`
+  /* To display scroll bar on the table */
+  display: block;
+  height: calc(100vh - 250px);
+  overflow: auto;
+  overflow-y: scroll;
+`;
+
+const Cell = styled.td`
+  overflow-wrap: break-word;
+  border-top: 1px solid #424242;
+`;
+
+const ActionContainer = styled.span`
+  display: flex;
+`;
+
+function GlobalFilter({
+  preGlobalFilteredRows,
+  globalFilter,
+  setGlobalFilter,
+  theme,
+}) {
+  const [value, setValue] = React.useState(globalFilter);
+  const history = useHistory();
+  const location = useLocation();
+  const onChange = useAsyncDebounce((value) => {
+    setGlobalFilter(value || undefined);
+
+    // update the URL with the content of search
+    const searchParams = new URLSearchParams(location.search);
+    const isSearch = searchParams.has('search');
+    if (!isSearch) {
+      searchParams.append('search', value);
+    } else {
+      searchParams.set('search', value);
+    }
+    history.push(`?${searchParams.toString()}`);
+  }, 500);
+
+  return (
+    <ActionContainer>
+      <input
+        value={value || undefined}
+        onChange={(e) => {
+          setValue(e.target.value);
+          onChange(e.target.value);
+        }}
+        placeholder={`Search`}
+        style={{
+          fontSize: '1.1rem',
+          color: theme.brand.textPrimary,
+          border: 'solid 1px #3b4045',
+          width: '223px',
+          height: '27px',
+          borderRadius: '4px',
+          backgroundColor: theme.brand.primaryDark2,
+          fontFamily: 'Lato',
+          fontStyle: 'italic',
+          opacity: '0.6',
+          lineHeight: '1.43',
+          letterSpacing: 'normal',
+          paddingLeft: '10px',
+        }}
+      />
+      <CreateNodeButton
+        size="small"
+        variant="secondary"
+        text={intl.translate('create_new_node')}
+        icon={<i className="fas fa-plus-circle"></i>}
+        onClick={() => {
+          history.push('/nodes/create');
+        }}
+        data-cy="create-node-button"
+      />
+    </ActionContainer>
+  );
+}
+
+function Table({ columns, data, rowClicked, theme }) {
+  const query = useQuery();
+  const querySearch = query.get('search');
+
+  // Use the state and functions returned from useTable to build your UI
+  const defaultColumn = React.useMemo(
+    () => ({
+      Filter: GlobalFilter,
+    }),
+    [],
+  );
+
+  const {
+    getTableProps,
+    getTableBodyProps,
+    headerGroups,
+    rows,
+    prepareRow,
+    state,
+    visibleColumns,
+    preGlobalFilteredRows,
+    setGlobalFilter,
+  } = useTable(
+    {
+      columns,
+      data,
+      defaultColumn,
+      initialState: { globalFilter: querySearch },
+    },
+    useFilters,
+    useGlobalFilter,
+  );
+
+  return (
+    <>
+      <table {...getTableProps()}>
+        <thead>
+          {/* The first row should be the search bar */}
+          <tr>
+            <th
+              colSpan={visibleColumns.length}
+              style={{
+                textAlign: 'left',
+              }}
+            >
+              <GlobalFilter
+                preGlobalFilteredRows={preGlobalFilteredRows}
+                globalFilter={state.globalFilter}
+                setGlobalFilter={setGlobalFilter}
+                theme={theme}
+              />
+            </th>
+          </tr>
+          {headerGroups.map((headerGroup) => {
+            return (
+              <HeadRow {...headerGroup.getHeaderGroupProps()}>
+                {headerGroup.headers.map((column) => {
+                  const headerStyleProps = column.getHeaderProps({
+                    style: column.cellStyle,
+                  });
+                  return (
+                    <th {...headerStyleProps}>{column.render('Header')}</th>
+                  );
+                })}
+              </HeadRow>
+            );
+          })}
+        </thead>
+        <Body {...getTableBodyProps()}>
+          {rows.map((row, i) => {
+            prepareRow(row);
+            return (
+              <TableRow
+                {...row.getRowProps({ onClick: () => rowClicked(row) })}
+                row={row}
+              >
+                {row.cells.map((cell) => {
+                  let cellProps = cell.getCellProps({
+                    style: {
+                      ...cell.column.cellStyle,
+                    },
+                  });
+                  if (
+                    cell.column.Header !== 'Name' &&
+                    cell.value === intl.translate('unknown')
+                  ) {
+                    return (
+                      <Cell {...cellProps}>
+                        <div>{intl.translate('unknown')}</div>
+                      </Cell>
+                    );
+                  } else {
+                    return <Cell {...cellProps}>{cell.render('Cell')}</Cell>;
+                  }
+                })}
+              </TableRow>
+            );
+          })}
+        </Body>
+      </table>
+    </>
+  );
+}
+
+const NodeListTable = (props) => {
+  const theme = useSelector((state) => state.config.theme);
+
+  const columns = React.useMemo(
+    () => [
+      {
+        Header: 'Name',
+        accessor: 'name',
+        width: 200,
+      },
+      {
+        Header: 'Role',
+        accessor: 'role',
+        width: 100,
+      },
+      {
+        Header: 'Health',
+        accessor: 'health',
+        cellStyle: { textAlign: 'center', width: '50px' },
+        Cell: (cellProps) => {
+          return (
+            <CircleStatus className="fas fa-circle" status={cellProps.value} />
+          );
+        },
+      },
+      {
+        Header: 'Status',
+        accessor: 'status',
+        cellStyle: { textAlign: 'center', width: '100px' },
+      },
+    ],
+    [],
+  );
+
+  // handle the row selection by updating the URL
+  const onClickRow = (row) => {};
+
+  return (
+    <NodeListContainer>
+      <Table
+        columns={columns}
+        data={[]}
+        rowClicked={onClickRow}
+        theme={theme}
+        defaultPageSize={10}
+      />
+    </NodeListContainer>
+  );
+};
+
+export default NodeListTable;

--- a/ui/src/containers/Layout.js
+++ b/ui/src/containers/Layout.js
@@ -78,20 +78,6 @@ const Layout = (props) => {
           strict: true,
         }),
       },
-      // deactive the access to the global volumes page now, we can only access the volume page through the node page
-      // {
-      //   label: intl.translate('volumes'),
-      //   icon: <i className="fas fa-database" />,
-      //   onClick: () => {
-      //     history.push('/volumes');
-      //   },
-      //   active: useRouteMatch({
-      //     path: '/volumes',
-      //     exact: false,
-      //     strict: true,
-      //   }),
-      // },
-      // need to remove the solutions since it's not working in 2.5 or should be backported
       {
         label: intl.translate('volumes'),
         icon: <i className="fas fa-database" />,

--- a/ui/src/containers/Layout.js
+++ b/ui/src/containers/Layout.js
@@ -8,6 +8,7 @@ import { Layout as CoreUILayout, Notifications } from '@scality/core-ui';
 import { intl } from '../translations/IntlGlobalProvider';
 import NodeCreateForm from './NodeCreateForm';
 import NodeList from './NodeList';
+import NodePage from './NodePage';
 import SolutionList from './SolutionList';
 import EnvironmentCreationForm from './EnvironmentCreationForm';
 import NodeInformation from './NodeInformation';
@@ -229,6 +230,7 @@ const Layout = (props) => {
           />
           <PrivateRoute path="/nodes/:id" component={NodeInformation} />
           <PrivateRoute exact path="/nodes" component={NodeList} />
+          <PrivateRoute exact path="/newNodes" component={NodePage} />
           <PrivateRoute exact path="/environments" component={SolutionList} />
           <PrivateRoute path="/volumes" component={VolumePage} />
           <PrivateRoute

--- a/ui/src/containers/NodeCreateForm.js
+++ b/ui/src/containers/NodeCreateForm.js
@@ -20,7 +20,7 @@ import { intl } from '../translations/IntlGlobalProvider';
 
 const CreateNodeContainter = styled.div`
   height: 100%;
-  padding-left: ${padding.base};
+  padding: ${padding.small};
   display: inline-block;
 `;
 
@@ -136,6 +136,7 @@ const NodeCreateForm = () => {
         <Breadcrumb
           activeColor={theme.brand.secondary}
           paths={[
+            <BreadcrumbLabel>{intl.translate('platform')}</BreadcrumbLabel>,
             <StyledLink to="/nodes">{intl.translate('nodes')}</StyledLink>,
             <BreadcrumbLabel>
               {intl.translate('create_new_node')}

--- a/ui/src/containers/NodePage.js
+++ b/ui/src/containers/NodePage.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { Breadcrumb } from '@scality/core-ui';
+import { refreshNodesAction, stopRefreshNodesAction } from '../ducks/app/nodes';
+import { useRefreshEffect } from '../services/utils';
+import {
+  BreadcrumbContainer,
+  BreadcrumbLabel,
+} from '../components/BreadcrumbStyle';
+import NodePageContent from './NodePageContent';
+import { PageContainer } from '../components/CommonLayoutStyle';
+import { intl } from '../translations/IntlGlobalProvider';
+
+const NodePage = (props) => {
+  useRefreshEffect(refreshNodesAction, stopRefreshNodesAction);
+  const theme = useSelector((state) => state.config.theme);
+
+  const nodes = useSelector((state) => state.app.nodes.list);
+
+  return (
+    <PageContainer>
+      <BreadcrumbContainer>
+        <Breadcrumb
+          activeColor={theme.brand.secondary}
+          paths={[
+            <BreadcrumbLabel title={intl.translate('platform')}>
+              {intl.translate('platform')}
+            </BreadcrumbLabel>,
+            <BreadcrumbLabel title={intl.translate('nodes')}>
+              {intl.translate('nodes')}
+            </BreadcrumbLabel>,
+          ]}
+        />
+      </BreadcrumbContainer>
+      <NodePageContent nodes={nodes}></NodePageContent>
+    </PageContainer>
+  );
+};
+
+export default NodePage;

--- a/ui/src/containers/NodePageContent.js
+++ b/ui/src/containers/NodePageContent.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { useHistory } from 'react-router';
+import NodeListTable from '../components/NodeListTable';
+import {
+  LeftSideInstanceList,
+  RightSidePanel,
+  NoInstanceSelectedContainer,
+  NoInstanceSelected,
+  PageContentContainer,
+} from '../components/CommonLayoutStyle';
+import { intl } from '../translations/IntlGlobalProvider';
+
+const NodePageContent = (props) => {
+  const history = useHistory();
+  const currentNodeName =
+    history?.location?.pathname?.split('/')?.slice(2)[0] || '';
+  return (
+    <PageContentContainer>
+      <LeftSideInstanceList>
+        <NodeListTable />
+      </LeftSideInstanceList>
+      {currentNodeName ? (
+        <RightSidePanel></RightSidePanel>
+      ) : (
+        <NoInstanceSelectedContainer>
+          <NoInstanceSelected>
+            {intl.translate('no_node_selected')}
+          </NoInstanceSelected>
+        </NoInstanceSelectedContainer>
+      )}
+    </PageContentContainer>
+  );
+};
+
+export default NodePageContent;

--- a/ui/src/containers/VolumePageContent.js
+++ b/ui/src/containers/VolumePageContent.js
@@ -35,8 +35,8 @@ const VolumePageContent = (props) => {
   } = props;
 
   const history = useHistory();
-  const currentVolumeName = history?.location?.pathname?.split('/').pop();
-
+  const currentVolumeName =
+    history?.location?.pathname?.split('/').slice(2)[0] || '';
   const volume = volumes?.find(
     (volume) => volume.metadata.name === currentVolumeName,
   );

--- a/ui/src/containers/VolumePageContent.js
+++ b/ui/src/containers/VolumePageContent.js
@@ -1,7 +1,5 @@
 import React from 'react';
 import { useHistory } from 'react-router';
-import styled from 'styled-components';
-import { padding } from '@scality/core-ui/dist/style/theme';
 import VolumeListTable from '../components/VolumeListTable';
 import VolumeDetailCard from '../components/VolumeDetailCard';
 import ActiveAlertsCard from '../components/VolumeActiveAlertsCard';
@@ -12,44 +10,14 @@ import {
   PORT_NUMBER_PROMETHEUS,
 } from '../constants';
 import { computeVolumeGlobalStatus } from '../services/NodeVolumesUtils';
+import {
+  LeftSideInstanceList,
+  RightSidePanel,
+  NoInstanceSelectedContainer,
+  NoInstanceSelected,
+  PageContentContainer,
+} from '../components/CommonLayoutStyle';
 import { intl } from '../translations/IntlGlobalProvider';
-
-const VolumePageContentContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  height: 100%;
-  width: 100%;
-  background-color: ${(props) => props.theme.brand.primary};
-`;
-
-const LeftSideVolumeList = styled.div`
-  flex-direction: column;
-  min-height: 696px;
-  width: 45%;
-`;
-
-const RightSidePanel = styled.div`
-  flex-direction: column;
-  width: 55%;
-  /* Make it scrollable for the small laptop screen */
-  overflow-y: scroll;
-  margin: ${padding.small} ${padding.small} ${padding.small} 0;
-`;
-
-const NoVolumeSelected = styled.div`
-  position: relative;
-  top: 50%;
-  transform: translateY(-50%);
-  color: ${(props) => props.theme.brand.textPrimary};
-  text-align: center;
-`;
-
-const NoVolumeSelectedContainer = styled.div`
-  margin: ${padding.small} ${padding.small} ${padding.small} 0;
-  width: 55%;
-  min-height: 700px;
-  background-color: ${(props) => props.theme.brand.primaryDark1};
-`;
 
 // <VolumePageContent> component extracts volume name from URL and holds the volume-specific data.
 // The three components in RightSidePanel (<VolumeDetailCard> / <ActiveAlertsCard> / <MetricGraphCard>) are dumb components,
@@ -152,14 +120,14 @@ const VolumePageContent = (props) => {
   };
 
   return (
-    <VolumePageContentContainer>
-      <LeftSideVolumeList>
+    <PageContentContainer>
+      <LeftSideInstanceList>
         <VolumeListTable
           volumeListData={volumeListData}
           nodeName={node?.name}
           volumeName={currentVolumeName}
         ></VolumeListTable>
-      </LeftSideVolumeList>
+      </LeftSideInstanceList>
 
       {currentVolumeName && volume ? (
         <RightSidePanel>
@@ -207,13 +175,13 @@ const VolumePageContent = (props) => {
           ></MetricGraphCard>
         </RightSidePanel>
       ) : (
-        <NoVolumeSelectedContainer>
-          <NoVolumeSelected>
+        <NoInstanceSelectedContainer>
+          <NoInstanceSelected>
             {intl.translate('no_volume_selected')}
-          </NoVolumeSelected>
-        </NoVolumeSelectedContainer>
+          </NoInstanceSelected>
+        </NoInstanceSelectedContainer>
       )}
-    </VolumePageContentContainer>
+    </PageContentContainer>
   );
 };
 

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -163,5 +163,6 @@
   "volume_is_not_bound": "The volume is not bound yet",
   "no_active_alerts": "No active alerts",
   "not_used": "Not used",
-  "no_volume_selected": "No Volume Selected"
+  "no_volume_selected": "No Volume Selected",
+  "no_node_selected": "No Node Selected"
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -163,5 +163,6 @@
   "volume_is_not_bound": "Le volume n'est pas encore lié",
   "no_active_alerts": "Aucune alerte active",
   "not_used": "Non utilisé",
-  "no_volume_selected": "Aucun volume sélectionné"
+  "no_volume_selected": "Aucun volume sélectionné",
+  "no_node_selected": "Aucun nœud sélectionné"
 }


### PR DESCRIPTION
**Component**: ui, nodes

**Context**: 
We want to set up the layout of empty node page, breadcrumb with empty node table only with Header (Health/Name/Role/Status), no node selected on the right side panel.

**Summary**:
Initialize the components for New Node Page:

`<NodePage>` fetch all the data needed for New Node Page and pass them to <NodePageContent/> component
`<NodePageContent>`
- Set up the layout of NodePage included Nodelist table and Right-side panel
- Retrieve the nodelist from <NodePage>
- Retrieve the current node from the URL to display the information in RSP
`<NodeListTable>`

**Acceptance criteria**: 
The **temporary URL** to access the New Node Page is: `/newNodes`
![image](https://user-images.githubusercontent.com/18453133/92460763-a1e34200-f1c8-11ea-8ecf-024f081df2cf.png)


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2771 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
