### PR TITLE
[UI] Fill the node information for node list table

### DIFF
--- a/salt/metalk8s/addons/ui/deployed/ui.sls
+++ b/salt/metalk8s/addons/ui/deployed/ui.sls
@@ -46,7 +46,8 @@ Create metalk8s-ui ConfigMap:
               "url_grafana": "/grafana",
               "url_oidc_provider": "/oidc",
               "url_redirect": "https://{{ ingress_control_plane }}/oauth2/callback",
-              "url_doc": "/docs"
+              "url_doc": "/docs",
+              "url_alertmanager": "/api/alertmanager"
             }
 
 Create ui-branding ConfigMap:

--- a/ui/src/components/CommonLayoutStyle.js
+++ b/ui/src/components/CommonLayoutStyle.js
@@ -1,0 +1,47 @@
+import styled from 'styled-components';
+import { padding } from '@scality/core-ui/dist/style/theme';
+
+export const PageContainer = styled.div`
+  display: flex;
+  box-sizing: border-box;
+  height: 100%;
+  flex-wrap: wrap;
+  padding: ${padding.small};
+`;
+
+export const LeftSideInstanceList = styled.div`
+  flex-direction: column;
+  min-height: 696px;
+  width: 45%;
+`;
+
+export const RightSidePanel = styled.div`
+  flex-direction: column;
+  width: 55%;
+  /* Make it scrollable for the small laptop screen */
+  overflow-y: scroll;
+  margin: ${padding.small} ${padding.small} ${padding.small} 0;
+`;
+
+export const NoInstanceSelectedContainer = styled.div`
+  margin: ${padding.small} ${padding.small} ${padding.small} 0;
+  width: 55%;
+  min-height: 700px;
+  background-color: ${(props) => props.theme.brand.primaryDark1};
+`;
+
+export const NoInstanceSelected = styled.div`
+  position: relative;
+  top: 50%;
+  transform: translateY(-50%);
+  color: ${(props) => props.theme.brand.textPrimary};
+  text-align: center;
+`;
+
+export const PageContentContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  height: 100%;
+  width: 100%;
+  background-color: ${(props) => props.theme.brand.primary};
+`;

--- a/ui/src/components/NodeListTable.js
+++ b/ui/src/components/NodeListTable.js
@@ -1,0 +1,322 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { useHistory } from 'react-router';
+import { useLocation } from 'react-router-dom';
+import styled from 'styled-components';
+import {
+  useTable,
+  useFilters,
+  useGlobalFilter,
+  useAsyncDebounce,
+} from 'react-table';
+import { useQuery } from '../services/utils';
+import { fontSize, padding } from '@scality/core-ui/dist/style/theme';
+import CircleStatus from './CircleStatus';
+import { Button } from '@scality/core-ui';
+import { intl } from '../translations/IntlGlobalProvider';
+
+const NodeListContainer = styled.div`
+  color: ${(props) => props.theme.brand.textPrimary};
+  padding: ${padding.base};
+  font-family: 'Lato';
+  font-size: ${fontSize.base};
+  border-color: ${(props) => props.theme.brand.borderLight};
+  .sc-progressbarcontainer {
+    width: 100%;
+  }
+  .ReactTable .rt-thead {
+    overflow-y: scroll;
+  }
+  table {
+    border-spacing: 0;
+    .sc-select-container {
+      width: 120px;
+      height: 10px;
+    }
+    tr {
+      :last-child {
+        td {
+          border-bottom: 0;
+          font-weight: normal;
+        }
+      }
+    }
+
+    th {
+      font-weight: bold;
+      height: 56px;
+      text-align: left;
+      padding: ${padding.smaller};
+    }
+
+    td {
+      margin: 0;
+      padding: 0.5rem;
+      border-bottom: 1px solid black;
+      text-align: left;
+      padding: 5px;
+
+      :last-child {
+        border-right: 0;
+      }
+    }
+  }
+`;
+
+const HeadRow = styled.tr`
+  width: 100%;
+  /* To display scroll bar on the table */
+  display: table;
+  table-layout: fixed;
+`;
+
+const CreateNodeButton = styled(Button)`
+  margin-left: ${padding.larger};
+`;
+
+const TableRow = styled(HeadRow)`
+  &:hover,
+  &:focus {
+    background-color: ${(props) => props.theme.brand.backgroundBluer};
+    border-top: 1px solid ${(props) => props.theme.brand.secondary};
+    border-bottom: 1px solid ${(props) => props.theme.brand.secondary};
+    outline: none;
+    cursor: pointer;
+  }
+`;
+
+// * table body
+const Body = styled.tbody`
+  /* To display scroll bar on the table */
+  display: block;
+  height: calc(100vh - 250px);
+  overflow: auto;
+  overflow-y: scroll;
+`;
+
+const Cell = styled.td`
+  overflow-wrap: break-word;
+  border-top: 1px solid #424242;
+`;
+
+const ActionContainer = styled.span`
+  display: flex;
+`;
+
+function GlobalFilter({
+  preGlobalFilteredRows,
+  globalFilter,
+  setGlobalFilter,
+  theme,
+}) {
+  const [value, setValue] = React.useState(globalFilter);
+  const history = useHistory();
+  const location = useLocation();
+  const onChange = useAsyncDebounce((value) => {
+    setGlobalFilter(value || undefined);
+
+    // update the URL with the content of search
+    const searchParams = new URLSearchParams(location.search);
+    const isSearch = searchParams.has('search');
+    if (!isSearch) {
+      searchParams.append('search', value);
+    } else {
+      searchParams.set('search', value);
+    }
+    history.push(`?${searchParams.toString()}`);
+  }, 500);
+
+  return (
+    <ActionContainer>
+      <input
+        value={value || undefined}
+        onChange={(e) => {
+          setValue(e.target.value);
+          onChange(e.target.value);
+        }}
+        placeholder={`Search`}
+        style={{
+          fontSize: '1.1rem',
+          color: theme.brand.textPrimary,
+          border: 'solid 1px #3b4045',
+          width: '223px',
+          height: '27px',
+          borderRadius: '4px',
+          backgroundColor: theme.brand.primaryDark2,
+          fontFamily: 'Lato',
+          fontStyle: 'italic',
+          opacity: '0.6',
+          lineHeight: '1.43',
+          letterSpacing: 'normal',
+          paddingLeft: '10px',
+        }}
+      />
+      <CreateNodeButton
+        size="small"
+        variant="secondary"
+        text={intl.translate('create_new_node')}
+        icon={<i className="fas fa-plus-circle"></i>}
+        onClick={() => {
+          history.push('/nodes/create');
+        }}
+        data-cy="create-node-button"
+      />
+    </ActionContainer>
+  );
+}
+
+function Table({ columns, data, rowClicked, theme }) {
+  const query = useQuery();
+  const querySearch = query.get('search');
+
+  // Use the state and functions returned from useTable to build your UI
+  const defaultColumn = React.useMemo(
+    () => ({
+      Filter: GlobalFilter,
+    }),
+    [],
+  );
+
+  const {
+    getTableProps,
+    getTableBodyProps,
+    headerGroups,
+    rows,
+    prepareRow,
+    state,
+    visibleColumns,
+    preGlobalFilteredRows,
+    setGlobalFilter,
+  } = useTable(
+    {
+      columns,
+      data,
+      defaultColumn,
+      initialState: { globalFilter: querySearch },
+    },
+    useFilters,
+    useGlobalFilter,
+  );
+
+  return (
+    <>
+      <table {...getTableProps()}>
+        <thead>
+          {/* The first row should be the search bar */}
+          <tr>
+            <th
+              colSpan={visibleColumns.length}
+              style={{
+                textAlign: 'left',
+              }}
+            >
+              <GlobalFilter
+                preGlobalFilteredRows={preGlobalFilteredRows}
+                globalFilter={state.globalFilter}
+                setGlobalFilter={setGlobalFilter}
+                theme={theme}
+              />
+            </th>
+          </tr>
+          {headerGroups.map((headerGroup) => {
+            return (
+              <HeadRow {...headerGroup.getHeaderGroupProps()}>
+                {headerGroup.headers.map((column) => {
+                  const headerStyleProps = column.getHeaderProps({
+                    style: column.cellStyle,
+                  });
+                  return (
+                    <th {...headerStyleProps}>{column.render('Header')}</th>
+                  );
+                })}
+              </HeadRow>
+            );
+          })}
+        </thead>
+        <Body {...getTableBodyProps()}>
+          {rows.map((row, i) => {
+            prepareRow(row);
+            return (
+              <TableRow
+                {...row.getRowProps({ onClick: () => rowClicked(row) })}
+                row={row}
+              >
+                {row.cells.map((cell) => {
+                  let cellProps = cell.getCellProps({
+                    style: {
+                      ...cell.column.cellStyle,
+                    },
+                  });
+                  if (
+                    cell.column.Header !== 'Name' &&
+                    cell.value === intl.translate('unknown')
+                  ) {
+                    return (
+                      <Cell {...cellProps}>
+                        <div>{intl.translate('unknown')}</div>
+                      </Cell>
+                    );
+                  } else {
+                    return <Cell {...cellProps}>{cell.render('Cell')}</Cell>;
+                  }
+                })}
+              </TableRow>
+            );
+          })}
+        </Body>
+      </table>
+    </>
+  );
+}
+
+const NodeListTable = (props) => {
+  const theme = useSelector((state) => state.config.theme);
+
+  const columns = React.useMemo(
+    () => [
+      {
+        Header: 'Name',
+        accessor: 'name',
+        width: 200,
+      },
+      {
+        Header: 'Role',
+        accessor: 'role',
+        width: 100,
+      },
+      {
+        Header: 'Health',
+        accessor: 'health',
+        cellStyle: { textAlign: 'center', width: '50px' },
+        Cell: (cellProps) => {
+          return (
+            <CircleStatus className="fas fa-circle" status={cellProps.value} />
+          );
+        },
+      },
+      {
+        Header: 'Status',
+        accessor: 'status',
+        cellStyle: { textAlign: 'center', width: '100px' },
+      },
+    ],
+    [],
+  );
+
+  // handle the row selection by updating the URL
+  const onClickRow = (row) => {};
+
+  return (
+    <NodeListContainer>
+      <Table
+        columns={columns}
+        data={[]}
+        rowClicked={onClickRow}
+        theme={theme}
+        defaultPageSize={10}
+      />
+    </NodeListContainer>
+  );
+};
+
+export default NodeListTable;

--- a/ui/src/components/NodeListTable.js
+++ b/ui/src/components/NodeListTable.js
@@ -103,6 +103,32 @@ const ActionContainer = styled.span`
   display: flex;
 `;
 
+const NodeNameText = styled.div`
+  font-size: ${fontSize.large};
+`;
+
+const IPText = styled.span`
+  font-size: ${fontSize.smaller};
+  padding-right: ${padding.small};
+  color: ${(props) => props.theme.brand.textSecondary};
+`;
+
+// the color of the status depends on the `Status` and `Condition` of the Node
+const StatusText = styled.div`
+  color: ${(props) => {
+    switch (props.textColor) {
+      case 'green':
+        return props.theme.brand.healthy;
+      case 'yellow':
+        return props.theme.brand.warning;
+      case 'red':
+        return props.theme.brand.critical;
+      default:
+        return props.theme.brand.textSecondary;
+    }
+  }};
+`;
+
 function GlobalFilter({
   preGlobalFilteredRows,
   globalFilter,
@@ -247,10 +273,17 @@ function Table({ columns, data, rowClicked, theme }) {
                       ...cell.column.cellStyle,
                     },
                   });
-                  if (
-                    cell.column.Header !== 'Name' &&
-                    cell.value === intl.translate('unknown')
-                  ) {
+                  if (cell.column.Header === 'Name') {
+                    return (
+                      <Cell {...cellProps}>
+                        <NodeNameText>{cell.value.name}</NodeNameText>
+                        <div>
+                          <IPText>CP: {cell.value.control_plane_ip}</IPText>
+                          <IPText>WP: {cell.value.workload_plane_ip}</IPText>
+                        </div>
+                      </Cell>
+                    );
+                  } else if (cell.value === intl.translate('unknown')) {
                     return (
                       <Cell {...cellProps}>
                         <div>{intl.translate('unknown')}</div>
@@ -270,19 +303,34 @@ function Table({ columns, data, rowClicked, theme }) {
 }
 
 const NodeListTable = (props) => {
+  const { nodeListData } = props;
+
   const theme = useSelector((state) => state.config.theme);
 
   const columns = React.useMemo(
     () => [
       {
-        Header: 'Name',
-        accessor: 'name',
-        width: 200,
+        Header: 'Health',
+        accessor: 'health',
+        cellStyle: { textAlign: 'center', width: '50px' },
+        Cell: (cellProps) => {
+          return (
+            <CircleStatus
+              className="fa fa-circle fa-2x"
+              status={cellProps.value}
+            />
+          );
+        },
       },
       {
-        Header: 'Role',
-        accessor: 'role',
-        width: 100,
+        Header: 'Name',
+        accessor: 'name',
+        cellStyle: { width: '180px' },
+      },
+      {
+        Header: 'Roles',
+        accessor: 'roles',
+        cellStyle: { width: '200px' },
       },
       {
         Header: 'Health',
@@ -298,6 +346,39 @@ const NodeListTable = (props) => {
         Header: 'Status',
         accessor: 'status',
         cellStyle: { textAlign: 'center', width: '100px' },
+        Cell: (cellProps) => {
+          const { status, conditions } = cellProps.value;
+          // green for status.conditions['Ready'] == True and all other conditions are false
+          // yellow for status.conditions['Ready'] == True and some other conditions are true
+          // red for status.conditions['Ready'] == False
+          // grey when there is no status.conditions
+          const otherConditions = conditions?.filter(
+            (cond) => cond !== 'ready',
+          );
+          if (status === 'ready' && otherConditions.length === 0) {
+            return (
+              <StatusText textColor="green">
+                {intl.translate('ready')}
+              </StatusText>
+            );
+          } else if (status === 'ready' && otherConditions.length !== 0) {
+            otherConditions.map((cond) => {
+              return <StatusText textColor="yellow">{cond}</StatusText>;
+            });
+          } else if (status !== 'ready') {
+            return (
+              <StatusText textColor="red">
+                {intl.translate('not_ready')}
+              </StatusText>
+            );
+          } else if (!otherConditions) {
+            return (
+              <StatusText textColor="gray">
+                {intl.translate('unknown')}
+              </StatusText>
+            );
+          }
+        },
       },
     ],
     [],
@@ -310,7 +391,7 @@ const NodeListTable = (props) => {
     <NodeListContainer>
       <Table
         columns={columns}
-        data={[]}
+        data={nodeListData}
         rowClicked={onClickRow}
         theme={theme}
         defaultPageSize={10}

--- a/ui/src/components/NodeListTable.js
+++ b/ui/src/components/NodeListTable.js
@@ -310,19 +310,6 @@ const NodeListTable = (props) => {
   const columns = React.useMemo(
     () => [
       {
-        Header: 'Health',
-        accessor: 'health',
-        cellStyle: { textAlign: 'center', width: '50px' },
-        Cell: (cellProps) => {
-          return (
-            <CircleStatus
-              className="fa fa-circle fa-2x"
-              status={cellProps.value}
-            />
-          );
-        },
-      },
-      {
         Header: 'Name',
         accessor: 'name',
         cellStyle: { width: '180px' },
@@ -338,7 +325,10 @@ const NodeListTable = (props) => {
         cellStyle: { textAlign: 'center', width: '50px' },
         Cell: (cellProps) => {
           return (
-            <CircleStatus className="fas fa-circle" status={cellProps.value} />
+            <CircleStatus
+              className="fa fa-circle fa-2x"
+              status={cellProps.value}
+            />
           );
         },
       },

--- a/ui/src/containers/Layout.js
+++ b/ui/src/containers/Layout.js
@@ -78,20 +78,6 @@ const Layout = (props) => {
           strict: true,
         }),
       },
-      // deactive the access to the global volumes page now, we can only access the volume page through the node page
-      // {
-      //   label: intl.translate('volumes'),
-      //   icon: <i className="fas fa-database" />,
-      //   onClick: () => {
-      //     history.push('/volumes');
-      //   },
-      //   active: useRouteMatch({
-      //     path: '/volumes',
-      //     exact: false,
-      //     strict: true,
-      //   }),
-      // },
-      // need to remove the solutions since it's not working in 2.5 or should be backported
       {
         label: intl.translate('volumes'),
         icon: <i className="fas fa-database" />,

--- a/ui/src/containers/Layout.js
+++ b/ui/src/containers/Layout.js
@@ -8,6 +8,7 @@ import { Layout as CoreUILayout, Notifications } from '@scality/core-ui';
 import { intl } from '../translations/IntlGlobalProvider';
 import NodeCreateForm from './NodeCreateForm';
 import NodeList from './NodeList';
+import NodePage from './NodePage';
 import SolutionList from './SolutionList';
 import EnvironmentCreationForm from './EnvironmentCreationForm';
 import NodeInformation from './NodeInformation';
@@ -229,6 +230,7 @@ const Layout = (props) => {
           />
           <PrivateRoute path="/nodes/:id" component={NodeInformation} />
           <PrivateRoute exact path="/nodes" component={NodeList} />
+          <PrivateRoute exact path="/newNodes" component={NodePage} />
           <PrivateRoute exact path="/environments" component={SolutionList} />
           <PrivateRoute path="/volumes" component={VolumePage} />
           <PrivateRoute

--- a/ui/src/containers/NodeCreateForm.js
+++ b/ui/src/containers/NodeCreateForm.js
@@ -20,7 +20,7 @@ import { intl } from '../translations/IntlGlobalProvider';
 
 const CreateNodeContainter = styled.div`
   height: 100%;
-  padding-left: ${padding.base};
+  padding: ${padding.small};
   display: inline-block;
 `;
 
@@ -136,6 +136,7 @@ const NodeCreateForm = () => {
         <Breadcrumb
           activeColor={theme.brand.secondary}
           paths={[
+            <BreadcrumbLabel>{intl.translate('platform')}</BreadcrumbLabel>,
             <StyledLink to="/nodes">{intl.translate('nodes')}</StyledLink>,
             <BreadcrumbLabel>
               {intl.translate('create_new_node')}

--- a/ui/src/containers/NodePage.js
+++ b/ui/src/containers/NodePage.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { Breadcrumb } from '@scality/core-ui';
+import { refreshNodesAction, stopRefreshNodesAction } from '../ducks/app/nodes';
+import { useRefreshEffect } from '../services/utils';
+import {
+  BreadcrumbContainer,
+  BreadcrumbLabel,
+} from '../components/BreadcrumbStyle';
+import NodePageContent from './NodePageContent';
+import { PageContainer } from '../components/CommonLayoutStyle';
+import { intl } from '../translations/IntlGlobalProvider';
+
+const NodePage = (props) => {
+  useRefreshEffect(refreshNodesAction, stopRefreshNodesAction);
+  const theme = useSelector((state) => state.config.theme);
+
+  const nodes = useSelector((state) => state.app.nodes.list);
+
+  return (
+    <PageContainer>
+      <BreadcrumbContainer>
+        <Breadcrumb
+          activeColor={theme.brand.secondary}
+          paths={[
+            <BreadcrumbLabel title={intl.translate('platform')}>
+              {intl.translate('platform')}
+            </BreadcrumbLabel>,
+            <BreadcrumbLabel title={intl.translate('nodes')}>
+              {intl.translate('nodes')}
+            </BreadcrumbLabel>,
+          ]}
+        />
+      </BreadcrumbContainer>
+      <NodePageContent nodes={nodes}></NodePageContent>
+    </PageContainer>
+  );
+};
+
+export default NodePage;

--- a/ui/src/containers/NodePage.js
+++ b/ui/src/containers/NodePage.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import { useSelector } from 'react-redux';
+import React, { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import { Breadcrumb } from '@scality/core-ui';
 import { refreshNodesAction, stopRefreshNodesAction } from '../ducks/app/nodes';
 import { useRefreshEffect } from '../services/utils';
@@ -9,13 +9,22 @@ import {
 } from '../components/BreadcrumbStyle';
 import NodePageContent from './NodePageContent';
 import { PageContainer } from '../components/CommonLayoutStyle';
+import { fetchNodesIPsInterfaceAction } from '../ducks/app/nodes';
+import { fetchAlertsAlertmanagerAction } from '../ducks/app/alerts';
+import { getNodeListData } from '../services/NodeUtils';
 import { intl } from '../translations/IntlGlobalProvider';
 
 const NodePage = (props) => {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(fetchNodesIPsInterfaceAction());
+    dispatch(fetchAlertsAlertmanagerAction());
+  }, [dispatch]);
   useRefreshEffect(refreshNodesAction, stopRefreshNodesAction);
-  const theme = useSelector((state) => state.config.theme);
 
+  const theme = useSelector((state) => state.config.theme);
   const nodes = useSelector((state) => state.app.nodes.list);
+  const nodeListData = useSelector((state) => getNodeListData(state, props));
 
   return (
     <PageContainer>
@@ -32,7 +41,10 @@ const NodePage = (props) => {
           ]}
         />
       </BreadcrumbContainer>
-      <NodePageContent nodes={nodes}></NodePageContent>
+      <NodePageContent
+        nodes={nodes}
+        nodeListData={nodeListData}
+      ></NodePageContent>
     </PageContainer>
   );
 };

--- a/ui/src/containers/NodePageContent.js
+++ b/ui/src/containers/NodePageContent.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { useHistory } from 'react-router';
+import NodeListTable from '../components/NodeListTable';
+import {
+  LeftSideInstanceList,
+  RightSidePanel,
+  NoInstanceSelectedContainer,
+  NoInstanceSelected,
+  PageContentContainer,
+} from '../components/CommonLayoutStyle';
+import { intl } from '../translations/IntlGlobalProvider';
+
+const NodePageContent = (props) => {
+  const history = useHistory();
+  const currentNodeName =
+    history?.location?.pathname?.split('/')?.slice(2)[0] || '';
+  return (
+    <PageContentContainer>
+      <LeftSideInstanceList>
+        <NodeListTable />
+      </LeftSideInstanceList>
+      {currentNodeName ? (
+        <RightSidePanel></RightSidePanel>
+      ) : (
+        <NoInstanceSelectedContainer>
+          <NoInstanceSelected>
+            {intl.translate('no_node_selected')}
+          </NoInstanceSelected>
+        </NoInstanceSelectedContainer>
+      )}
+    </PageContentContainer>
+  );
+};
+
+export default NodePageContent;

--- a/ui/src/containers/NodePageContent.js
+++ b/ui/src/containers/NodePageContent.js
@@ -11,13 +11,16 @@ import {
 import { intl } from '../translations/IntlGlobalProvider';
 
 const NodePageContent = (props) => {
+  const { nodeListData } = props;
+
   const history = useHistory();
   const currentNodeName =
     history?.location?.pathname?.split('/')?.slice(2)[0] || '';
+
   return (
     <PageContentContainer>
       <LeftSideInstanceList>
-        <NodeListTable />
+        <NodeListTable nodeListData={nodeListData} />
       </LeftSideInstanceList>
       {currentNodeName ? (
         <RightSidePanel></RightSidePanel>

--- a/ui/src/containers/VolumePageContent.js
+++ b/ui/src/containers/VolumePageContent.js
@@ -1,7 +1,5 @@
 import React from 'react';
 import { useHistory } from 'react-router';
-import styled from 'styled-components';
-import { padding } from '@scality/core-ui/dist/style/theme';
 import { allSizeUnitsToBytes } from '../services/utils';
 import VolumeListTable from '../components/VolumeListTable';
 import VolumeDetailCard from '../components/VolumeDetailCard';
@@ -13,44 +11,14 @@ import {
   PORT_NUMBER_PROMETHEUS,
 } from '../constants';
 import { computeVolumeGlobalStatus } from '../services/NodeVolumesUtils';
+import {
+  LeftSideInstanceList,
+  RightSidePanel,
+  NoInstanceSelectedContainer,
+  NoInstanceSelected,
+  PageContentContainer,
+} from '../components/CommonLayoutStyle';
 import { intl } from '../translations/IntlGlobalProvider';
-
-const VolumePageContentContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  height: 100%;
-  width: 100%;
-  background-color: ${(props) => props.theme.brand.primary};
-`;
-
-const LeftSideVolumeList = styled.div`
-  flex-direction: column;
-  min-height: 696px;
-  width: 45%;
-`;
-
-const RightSidePanel = styled.div`
-  flex-direction: column;
-  width: 55%;
-  /* Make it scrollable for the small laptop screen */
-  overflow-y: scroll;
-  margin: ${padding.small} ${padding.small} ${padding.small} 0;
-`;
-
-const NoVolumeSelected = styled.div`
-  position: relative;
-  top: 50%;
-  transform: translateY(-50%);
-  color: ${(props) => props.theme.brand.textPrimary};
-  text-align: center;
-`;
-
-const NoVolumeSelectedContainer = styled.div`
-  margin: ${padding.small} ${padding.small} ${padding.small} 0;
-  width: 55%;
-  min-height: 700px;
-  background-color: ${(props) => props.theme.brand.primaryDark1};
-`;
 
 // <VolumePageContent> component extracts volume name from URL and holds the volume-specific data.
 // The three components in RightSidePanel (<VolumeDetailCard> / <ActiveAlertsCard> / <MetricGraphCard>) are dumb components,
@@ -149,14 +117,14 @@ const VolumePageContent = (props) => {
   };
 
   return (
-    <VolumePageContentContainer>
-      <LeftSideVolumeList>
+    <PageContentContainer>
+      <LeftSideInstanceList>
         <VolumeListTable
           volumeListData={volumeListData}
           nodeName={node?.name}
           volumeName={currentVolumeName}
         ></VolumeListTable>
-      </LeftSideVolumeList>
+      </LeftSideInstanceList>
 
       {currentVolumeName && volume ? (
         <RightSidePanel>
@@ -207,13 +175,13 @@ const VolumePageContent = (props) => {
           ></MetricGraphCard>
         </RightSidePanel>
       ) : (
-        <NoVolumeSelectedContainer>
-          <NoVolumeSelected>
+        <NoInstanceSelectedContainer>
+          <NoInstanceSelected>
             {intl.translate('no_volume_selected')}
-          </NoVolumeSelected>
-        </NoVolumeSelectedContainer>
+          </NoInstanceSelected>
+        </NoInstanceSelectedContainer>
       )}
-    </VolumePageContentContainer>
+    </PageContentContainer>
   );
 };
 

--- a/ui/src/containers/VolumePageContent.js
+++ b/ui/src/containers/VolumePageContent.js
@@ -36,8 +36,8 @@ const VolumePageContent = (props) => {
   } = props;
 
   const history = useHistory();
-  const currentVolumeName = history?.location?.pathname?.split('/').pop();
-
+  const currentVolumeName =
+    history?.location?.pathname?.split('/').slice(2)[0] || '';
   const volume = volumes?.find(
     (volume) => volume.metadata.name === currentVolumeName,
   );

--- a/ui/src/ducks/app/alerts.js
+++ b/ui/src/ducks/app/alerts.js
@@ -1,0 +1,42 @@
+import { takeEvery, call, put } from 'redux-saga/effects';
+import * as ApiAlertmanager from '../../services/alertmanager/api';
+
+// Actions
+const FETCH_ALERTS_ALERTMANAGER = 'FETCH_ALERTS_ALERTMANAGER';
+const UPDATE_ALERTS_ALERTMANAGER = 'UPDATE_ALERTS_ALERTMANAGER';
+
+// Reducer
+const defaultState = {
+  list: [],
+};
+
+export default function reducer(state = defaultState, action = {}) {
+  switch (action.type) {
+    case UPDATE_ALERTS_ALERTMANAGER:
+      return { ...state, ...action.payload };
+    default:
+      return state;
+  }
+}
+
+// Action Creators
+export const fetchAlertsAlertmanagerAction = () => {
+  return { type: FETCH_ALERTS_ALERTMANAGER };
+};
+
+export const updateAlertsAlertmanagerAction = (payload) => {
+  return { type: UPDATE_ALERTS_ALERTMANAGER, payload };
+};
+
+// Sagas
+export function* fetchAlertsAlertmanager() {
+  const result = yield call(ApiAlertmanager.getAlerts);
+
+  if (!result.error) {
+    yield put(updateAlertsAlertmanagerAction({ list: result }));
+  }
+}
+
+export function* alertsSaga() {
+  yield takeEvery(FETCH_ALERTS_ALERTMANAGER, fetchAlertsAlertmanager);
+}

--- a/ui/src/ducks/app/nodes.js
+++ b/ui/src/ducks/app/nodes.js
@@ -217,6 +217,9 @@ export const updateNodesIPsInterfacesAction = (payload) => {
 // Selectors
 export const clusterVersionSelector = (state) => state.app.nodes.clusterVersion;
 export const nodesRefreshingSelector = (state) => state.app.nodes.isRefreshing;
+export const nodesIPsInterfacesSelector = (state) =>
+  state.app.nodes.nodesIPsInterfaces;
+export const nodesSelector = (state) => state.app.nodes.list;
 
 // Sagas
 export function* fetchClusterVersion() {
@@ -252,6 +255,17 @@ export function* fetchNodes() {
             node.status.conditions.find(
               (conditon) => conditon.type === 'Ready',
             );
+
+          // Store the name of conditions which the status are True in the array
+          // given the avaiable conditions (Ready, DiskPressure, MemoryPressure, PIDPressure, Network Unavailable, Unschedulable)
+          let conditions = [];
+          const activeCondition = node.status.conditions.find(
+            (cond) => cond.status === 'True',
+          );
+          if (activeCondition && activeCondition.types) {
+            conditions.push(activeCondition.type);
+          }
+
           let status;
           if (statusType && statusType.status === 'True') {
             status = API_STATUS_READY;
@@ -260,7 +274,6 @@ export function* fetchNodes() {
           } else {
             status = API_STATUS_UNKNOWN;
           }
-
           const roleTaintMatched = roleTaintMap.find((item) => {
             const nodeRoles = Object.keys(node.metadata.labels).filter((role) =>
               role.includes(ROLE_PREFIX),
@@ -291,12 +304,12 @@ export function* fetchNodes() {
               rolesLabel.push(intl.translate('infra'));
             }
           }
-
           return {
             name: node.metadata.name,
             metalk8s_version:
               node.metadata.labels['metalk8s.scality.com/version'],
             status: status,
+            conditions: conditions,
             control_plane: roleTaintMatched && roleTaintMatched.control_plane,
             workload_plane: roleTaintMatched && roleTaintMatched.workload_plane,
             bootstrap: roleTaintMatched && roleTaintMatched.bootstrap,

--- a/ui/src/ducks/config.js
+++ b/ui/src/ducks/config.js
@@ -9,6 +9,7 @@ import * as Api from '../services/api';
 import * as ApiK8s from '../services/k8s/api';
 import * as ApiSalt from '../services/salt/api';
 import * as ApiPrometheus from '../services/prometheus/api';
+import * as ApiAlertmanager from '../services/alertmanager/api';
 import { EN_LANG, FR_LANG, LANGUAGE } from '../constants';
 
 import { authenticateSaltApi } from './login';
@@ -162,6 +163,8 @@ export function* fetchConfig() {
     yield put(setApiConfigAction(result));
     yield call(ApiSalt.initialize, result.url_salt);
     yield call(ApiPrometheus.initialize, result.url_prometheus);
+    yield call(ApiAlertmanager.initialize, result.url_alertmanager);
+
     yield put(
       setUserManagerConfigAction({
         authority: result.url_oidc_provider,

--- a/ui/src/ducks/reducer.js
+++ b/ui/src/ducks/reducer.js
@@ -11,7 +11,7 @@ import notifications from './app/notifications';
 import salt from './app/salt';
 import monitoring from './app/monitoring';
 import solutions from './app/solutions';
-
+import alerts from './app/alerts';
 const rootReducer = combineReducers({
   config,
   login,
@@ -24,6 +24,7 @@ const rootReducer = combineReducers({
     monitoring,
     volumes,
     solutions,
+    alerts,
   }),
   oidc: oidcReducer,
 });

--- a/ui/src/ducks/sagas.js
+++ b/ui/src/ducks/sagas.js
@@ -8,6 +8,7 @@ import { solutionsSaga } from './app/solutions';
 import { volumesSaga } from './app/volumes';
 import { authenticateSaga } from './login';
 import { configSaga } from './config';
+import { alertsSaga } from './app/alerts';
 
 export default function* rootSaga() {
   yield all([
@@ -20,5 +21,6 @@ export default function* rootSaga() {
     fork(saltSaga),
     fork(solutionsSaga),
     fork(volumesSaga),
+    fork(alertsSaga),
   ]);
 }

--- a/ui/src/services/NodeUtils.js
+++ b/ui/src/services/NodeUtils.js
@@ -1,0 +1,31 @@
+import { createSelector } from 'reselect';
+import { nodesSelector, nodesIPsInterfacesSelector } from '../ducks/app/nodes';
+
+const METALK8S_CONTROL_PLANE_IP = 'metalk8s:control_plane_ip';
+const METALK8S_WORKLOAD_PLANE_IP = 'metalk8s:workload_plane_ip';
+
+// Return the data used by the Node list table
+export const getNodeListData = createSelector(
+  nodesSelector,
+  nodesIPsInterfacesSelector,
+  (nodes, nodesIPsInterfaces) => {
+    return nodes?.map((node) => {
+      return {
+        // IPs of Control Plane and Workload Plane are in the same Cell with Name
+        name: {
+          name: node?.name,
+          control_plane_ip:
+            (nodesIPsInterfaces[node.name] &&
+              nodesIPsInterfaces[node.name][METALK8S_CONTROL_PLANE_IP]) ||
+            undefined,
+          workload_plane_ip:
+            (nodesIPsInterfaces[node.name] &&
+              nodesIPsInterfaces[node.name][METALK8S_WORKLOAD_PLANE_IP]) ||
+            undefined,
+        },
+        status: { status: node?.status, conditions: node?.conditions },
+        roles: node?.roles,
+      };
+    });
+  },
+);

--- a/ui/src/services/alertmanager/api.js
+++ b/ui/src/services/alertmanager/api.js
@@ -1,0 +1,11 @@
+import ApiClient from '../ApiClient';
+
+let alertmanagerApiClient = null;
+
+export function initialize(apiUrl) {
+  alertmanagerApiClient = new ApiClient({ apiUrl });
+}
+
+export function getAlerts() {
+  return alertmanagerApiClient.get('/api/v2/alerts');
+}

--- a/ui/src/services/salt/api.js
+++ b/ui/src/services/salt/api.js
@@ -50,3 +50,16 @@ export async function prepareEnvironment(environment, version) {
     },
   });
 }
+
+export async function getNodesIPsInterfaces() {
+  return saltApiClient.post('/', {
+    client: 'local',
+    tgt: '*',
+    fun: 'grains.item',
+    arg: [
+      'metalk8s:control_plane_ip',
+      'metalk8s:workload_plane_ip',
+      'ip_interfaces',
+    ],
+  });
+}

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -163,5 +163,6 @@
   "volume_is_not_bound": "The volume is not bound yet",
   "no_active_alerts": "No active alerts",
   "not_used": "Not used",
-  "no_volume_selected": "No Volume Selected"
+  "no_volume_selected": "No Volume Selected",
+  "no_node_selected": "No Node Selected"
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -163,5 +163,6 @@
   "volume_is_not_bound": "Le volume n'est pas encore lié",
   "no_active_alerts": "Aucune alerte active",
   "not_used": "Non utilisé",
-  "no_volume_selected": "Aucun volume sélectionné"
+  "no_volume_selected": "Aucun volume sélectionné",
+  "no_node_selected": "Aucun nœud sélectionné"
 }


### PR DESCRIPTION
**Component**: ui, nodes

**Context**: 
Fill the node list table

**Summary**:
- Add the Control Plane IP and Workload Plane IP under the Node Name
- Get the Roles by the labels `node-role.kubernetes.io/<role>`
- Be able to retrieve the alerts from alertmanager.
- But haven't implemented the filter to compute the health
- the color of the status depends on the condition and status
          // green for status.conditions['Ready'] == True and all other conditions are false
          // yellow for status.conditions['Ready'] == True and some other conditions are true
          // red for status.conditions['Ready'] == False
          // grey when there is no status.conditions

**Acceptance criteria**: 
![image](https://user-images.githubusercontent.com/18453133/92754611-4ca35e00-f38b-11ea-92e9-1cf5c1b16cb7.png)


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2772 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
