### PR TITLE
[UI] Fill the node information for node list table

### DIFF
--- a/salt/metalk8s/addons/ui/deployed/ui.sls
+++ b/salt/metalk8s/addons/ui/deployed/ui.sls
@@ -46,7 +46,8 @@ Create metalk8s-ui ConfigMap:
               "url_grafana": "/grafana",
               "url_oidc_provider": "/oidc",
               "url_redirect": "https://{{ ingress_control_plane }}/oauth2/callback",
-              "url_doc": "/docs"
+              "url_doc": "/docs",
+              "url_alertmanager": "/api/alertmanager"
             }
 
 Create ui-branding ConfigMap:

--- a/ui/src/components/NodeListTable.js
+++ b/ui/src/components/NodeListTable.js
@@ -103,6 +103,32 @@ const ActionContainer = styled.span`
   display: flex;
 `;
 
+const NodeNameText = styled.div`
+  font-size: ${fontSize.large};
+`;
+
+const IPText = styled.span`
+  font-size: ${fontSize.smaller};
+  padding-right: ${padding.small};
+  color: ${(props) => props.theme.brand.textSecondary};
+`;
+
+// the color of the status depends on the `Status` and `Condition` of the Node
+const StatusText = styled.div`
+  color: ${(props) => {
+    switch (props.textColor) {
+      case 'green':
+        return props.theme.brand.healthy;
+      case 'yellow':
+        return props.theme.brand.warning;
+      case 'red':
+        return props.theme.brand.critical;
+      default:
+        return props.theme.brand.textSecondary;
+    }
+  }};
+`;
+
 function GlobalFilter({
   preGlobalFilteredRows,
   globalFilter,
@@ -247,10 +273,17 @@ function Table({ columns, data, rowClicked, theme }) {
                       ...cell.column.cellStyle,
                     },
                   });
-                  if (
-                    cell.column.Header !== 'Name' &&
-                    cell.value === intl.translate('unknown')
-                  ) {
+                  if (cell.column.Header === 'Name') {
+                    return (
+                      <Cell {...cellProps}>
+                        <NodeNameText>{cell.value.name}</NodeNameText>
+                        <div>
+                          <IPText>CP: {cell.value.control_plane_ip}</IPText>
+                          <IPText>WP: {cell.value.workload_plane_ip}</IPText>
+                        </div>
+                      </Cell>
+                    );
+                  } else if (cell.value === intl.translate('unknown')) {
                     return (
                       <Cell {...cellProps}>
                         <div>{intl.translate('unknown')}</div>
@@ -270,19 +303,34 @@ function Table({ columns, data, rowClicked, theme }) {
 }
 
 const NodeListTable = (props) => {
+  const { nodeListData } = props;
+
   const theme = useSelector((state) => state.config.theme);
 
   const columns = React.useMemo(
     () => [
       {
-        Header: 'Name',
-        accessor: 'name',
-        width: 200,
+        Header: 'Health',
+        accessor: 'health',
+        cellStyle: { textAlign: 'center', width: '50px' },
+        Cell: (cellProps) => {
+          return (
+            <CircleStatus
+              className="fa fa-circle fa-2x"
+              status={cellProps.value}
+            />
+          );
+        },
       },
       {
-        Header: 'Role',
-        accessor: 'role',
-        width: 100,
+        Header: 'Name',
+        accessor: 'name',
+        cellStyle: { width: '180px' },
+      },
+      {
+        Header: 'Roles',
+        accessor: 'roles',
+        cellStyle: { width: '200px' },
       },
       {
         Header: 'Health',
@@ -298,6 +346,39 @@ const NodeListTable = (props) => {
         Header: 'Status',
         accessor: 'status',
         cellStyle: { textAlign: 'center', width: '100px' },
+        Cell: (cellProps) => {
+          const { status, conditions } = cellProps.value;
+          // green for status.conditions['Ready'] == True and all other conditions are false
+          // yellow for status.conditions['Ready'] == True and some other conditions are true
+          // red for status.conditions['Ready'] == False
+          // grey when there is no status.conditions
+          const otherConditions = conditions?.filter(
+            (cond) => cond !== 'ready',
+          );
+          if (status === 'ready' && otherConditions.length === 0) {
+            return (
+              <StatusText textColor="green">
+                {intl.translate('ready')}
+              </StatusText>
+            );
+          } else if (status === 'ready' && otherConditions.length !== 0) {
+            otherConditions.map((cond) => {
+              return <StatusText textColor="yellow">{cond}</StatusText>;
+            });
+          } else if (status !== 'ready') {
+            return (
+              <StatusText textColor="red">
+                {intl.translate('not_ready')}
+              </StatusText>
+            );
+          } else if (!otherConditions) {
+            return (
+              <StatusText textColor="gray">
+                {intl.translate('unknown')}
+              </StatusText>
+            );
+          }
+        },
       },
     ],
     [],
@@ -310,7 +391,7 @@ const NodeListTable = (props) => {
     <NodeListContainer>
       <Table
         columns={columns}
-        data={[]}
+        data={nodeListData}
         rowClicked={onClickRow}
         theme={theme}
         defaultPageSize={10}

--- a/ui/src/components/NodeListTable.js
+++ b/ui/src/components/NodeListTable.js
@@ -342,9 +342,8 @@ const NodeListTable = (props) => {
           // yellow for status.conditions['Ready'] == True and some other conditions are true
           // red for status.conditions['Ready'] == False
           // grey when there is no status.conditions
-          const notReadyConditions = conditions?.filter(
-            (cond) => cond !== 'ready' ?? [],
-          );
+          const notReadyConditions =
+            conditions?.filter((cond) => cond !== 'Ready') ?? [];
           if (status === 'ready' && notReadyConditions.length === 0) {
             return (
               <StatusText textColor="green">

--- a/ui/src/components/NodeListTable.js
+++ b/ui/src/components/NodeListTable.js
@@ -303,7 +303,7 @@ function Table({ columns, data, rowClicked, theme }) {
 }
 
 const NodeListTable = (props) => {
-  const { nodeListData } = props;
+  const { nodeTableData } = props;
 
   const theme = useSelector((state) => state.config.theme);
 
@@ -380,7 +380,7 @@ const NodeListTable = (props) => {
     <NodeListContainer>
       <Table
         columns={columns}
-        data={nodeListData}
+        data={nodeTableData}
         rowClicked={onClickRow}
         theme={theme}
         defaultPageSize={10}

--- a/ui/src/components/NodeListTable.js
+++ b/ui/src/components/NodeListTable.js
@@ -338,20 +338,19 @@ const NodeListTable = (props) => {
         cellStyle: { textAlign: 'center', width: '100px' },
         Cell: (cellProps) => {
           const { status, conditions } = cellProps.value;
+          // the `conditions` include the other conditions that exclude "Ready".
           // green for status.conditions['Ready'] == True and all other conditions are false
           // yellow for status.conditions['Ready'] == True and some other conditions are true
           // red for status.conditions['Ready'] == False
           // grey when there is no status.conditions
-          const notReadyConditions =
-            conditions?.filter((cond) => cond !== 'Ready') ?? [];
-          if (status === 'ready' && notReadyConditions.length === 0) {
+          if (status === 'ready' && conditions.length === 0) {
             return (
               <StatusText textColor="green">
                 {intl.translate('ready')}
               </StatusText>
             );
-          } else if (status === 'ready' && notReadyConditions.length !== 0) {
-            notReadyConditions.map((cond) => {
+          } else if (status === 'ready' && conditions.length !== 0) {
+            conditions.map((cond) => {
               return <StatusText textColor="yellow">{cond}</StatusText>;
             });
           } else if (status !== 'ready') {
@@ -383,7 +382,6 @@ const NodeListTable = (props) => {
         data={nodeTableData}
         rowClicked={onClickRow}
         theme={theme}
-        defaultPageSize={10}
       />
     </NodeListContainer>
   );

--- a/ui/src/components/NodeListTable.js
+++ b/ui/src/components/NodeListTable.js
@@ -342,17 +342,17 @@ const NodeListTable = (props) => {
           // yellow for status.conditions['Ready'] == True and some other conditions are true
           // red for status.conditions['Ready'] == False
           // grey when there is no status.conditions
-          const otherConditions = conditions?.filter(
-            (cond) => cond !== 'ready',
+          const notReadyConditions = conditions?.filter(
+            (cond) => cond !== 'ready' ?? [],
           );
-          if (status === 'ready' && otherConditions.length === 0) {
+          if (status === 'ready' && notReadyConditions.length === 0) {
             return (
               <StatusText textColor="green">
                 {intl.translate('ready')}
               </StatusText>
             );
-          } else if (status === 'ready' && otherConditions.length !== 0) {
-            otherConditions.map((cond) => {
+          } else if (status === 'ready' && notReadyConditions.length !== 0) {
+            notReadyConditions.map((cond) => {
               return <StatusText textColor="yellow">{cond}</StatusText>;
             });
           } else if (status !== 'ready') {
@@ -361,7 +361,7 @@ const NodeListTable = (props) => {
                 {intl.translate('not_ready')}
               </StatusText>
             );
-          } else if (!otherConditions) {
+          } else {
             return (
               <StatusText textColor="gray">
                 {intl.translate('unknown')}

--- a/ui/src/components/NodeListTable.js
+++ b/ui/src/components/NodeListTable.js
@@ -310,19 +310,6 @@ const NodeListTable = (props) => {
   const columns = React.useMemo(
     () => [
       {
-        Header: 'Health',
-        accessor: 'health',
-        cellStyle: { textAlign: 'center', width: '50px' },
-        Cell: (cellProps) => {
-          return (
-            <CircleStatus
-              className="fa fa-circle fa-2x"
-              status={cellProps.value}
-            />
-          );
-        },
-      },
-      {
         Header: 'Name',
         accessor: 'name',
         cellStyle: { width: '180px' },
@@ -338,7 +325,10 @@ const NodeListTable = (props) => {
         cellStyle: { textAlign: 'center', width: '50px' },
         Cell: (cellProps) => {
           return (
-            <CircleStatus className="fas fa-circle" status={cellProps.value} />
+            <CircleStatus
+              className="fa fa-circle fa-2x"
+              status={cellProps.value}
+            />
           );
         },
       },

--- a/ui/src/components/NodeListTable.js
+++ b/ui/src/components/NodeListTable.js
@@ -278,8 +278,8 @@ function Table({ columns, data, rowClicked, theme }) {
                       <Cell {...cellProps}>
                         <NodeNameText>{cell.value.name}</NodeNameText>
                         <div>
-                          <IPText>CP: {cell.value.control_plane_ip}</IPText>
-                          <IPText>WP: {cell.value.workload_plane_ip}</IPText>
+                          <IPText>CP: {cell.value.controlPlaneIP}</IPText>
+                          <IPText>WP: {cell.value.workloadPlaneIP}</IPText>
                         </div>
                       </Cell>
                     );

--- a/ui/src/containers/NodePage.js
+++ b/ui/src/containers/NodePage.js
@@ -23,8 +23,7 @@ const NodePage = (props) => {
   useRefreshEffect(refreshNodesAction, stopRefreshNodesAction);
 
   const theme = useSelector((state) => state.config.theme);
-  const nodes = useSelector((state) => state.app.nodes.list);
-  const nodeListData = useSelector((state) => getNodeListData(state, props));
+  const nodeTableData = useSelector((state) => getNodeListData(state, props));
 
   return (
     <PageContainer>
@@ -41,10 +40,7 @@ const NodePage = (props) => {
           ]}
         />
       </BreadcrumbContainer>
-      <NodePageContent
-        nodes={nodes}
-        nodeListData={nodeListData}
-      ></NodePageContent>
+      <NodePageContent nodeTableData={nodeTableData}></NodePageContent>
     </PageContainer>
   );
 };

--- a/ui/src/containers/NodePage.js
+++ b/ui/src/containers/NodePage.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import { useSelector } from 'react-redux';
+import React, { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import { Breadcrumb } from '@scality/core-ui';
 import { refreshNodesAction, stopRefreshNodesAction } from '../ducks/app/nodes';
 import { useRefreshEffect } from '../services/utils';
@@ -9,13 +9,22 @@ import {
 } from '../components/BreadcrumbStyle';
 import NodePageContent from './NodePageContent';
 import { PageContainer } from '../components/CommonLayoutStyle';
+import { fetchNodesIPsInterfaceAction } from '../ducks/app/nodes';
+import { fetchAlertsAlertmanagerAction } from '../ducks/app/alerts';
+import { getNodeListData } from '../services/NodeUtils';
 import { intl } from '../translations/IntlGlobalProvider';
 
 const NodePage = (props) => {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(fetchNodesIPsInterfaceAction());
+    dispatch(fetchAlertsAlertmanagerAction());
+  }, [dispatch]);
   useRefreshEffect(refreshNodesAction, stopRefreshNodesAction);
-  const theme = useSelector((state) => state.config.theme);
 
+  const theme = useSelector((state) => state.config.theme);
   const nodes = useSelector((state) => state.app.nodes.list);
+  const nodeListData = useSelector((state) => getNodeListData(state, props));
 
   return (
     <PageContainer>
@@ -32,7 +41,10 @@ const NodePage = (props) => {
           ]}
         />
       </BreadcrumbContainer>
-      <NodePageContent nodes={nodes}></NodePageContent>
+      <NodePageContent
+        nodes={nodes}
+        nodeListData={nodeListData}
+      ></NodePageContent>
     </PageContainer>
   );
 };

--- a/ui/src/containers/NodePageContent.js
+++ b/ui/src/containers/NodePageContent.js
@@ -11,13 +11,16 @@ import {
 import { intl } from '../translations/IntlGlobalProvider';
 
 const NodePageContent = (props) => {
+  const { nodeListData } = props;
+
   const history = useHistory();
   const currentNodeName =
     history?.location?.pathname?.split('/')?.slice(2)[0] || '';
+
   return (
     <PageContentContainer>
       <LeftSideInstanceList>
-        <NodeListTable />
+        <NodeListTable nodeListData={nodeListData} />
       </LeftSideInstanceList>
       {currentNodeName ? (
         <RightSidePanel></RightSidePanel>

--- a/ui/src/containers/NodePageContent.js
+++ b/ui/src/containers/NodePageContent.js
@@ -11,7 +11,7 @@ import {
 import { intl } from '../translations/IntlGlobalProvider';
 
 const NodePageContent = (props) => {
-  const { nodeListData } = props;
+  const { nodeTableData } = props;
 
   const history = useHistory();
   const currentNodeName =
@@ -20,7 +20,7 @@ const NodePageContent = (props) => {
   return (
     <PageContentContainer>
       <LeftSideInstanceList>
-        <NodeListTable nodeListData={nodeListData} />
+        <NodeListTable nodeTableData={nodeTableData} />
       </LeftSideInstanceList>
       {currentNodeName ? (
         <RightSidePanel></RightSidePanel>

--- a/ui/src/containers/PrivateRoute.js
+++ b/ui/src/containers/PrivateRoute.js
@@ -3,16 +3,22 @@ import { useSelector } from 'react-redux';
 import { Route } from 'react-router-dom';
 
 const PrivateRoute = ({ component, ...rest }) => {
-  const authenticated = useSelector(state => !!state.oidc.user);
-  const userManager = useSelector(state => state.config.userManager);
+  const authenticated = useSelector((state) => !!state.oidc.user);
+  const userManager = useSelector((state) => state.config.userManager);
+  const isSaltAPIAuthenticated = useSelector((state) => state.login.salt);
 
   if (!authenticated) {
+    // Go to Dex Login Form if not authenticated
     userManager.signinRedirect({
       data: { path: window.location.pathname },
-    }); //Go to Dex Login Form if not authenticated
+    });
     return null;
-  } else {
+  } else if (isSaltAPIAuthenticated) {
+    // To make sure that Salt API is authenticated, before load the components
+    // Otherwise we may get 401 Unauthorized
     return <Route {...rest} component={component} />;
+  } else {
+    return null;
   }
 };
 

--- a/ui/src/containers/PrivateRoute.js
+++ b/ui/src/containers/PrivateRoute.js
@@ -5,7 +5,6 @@ import { Route } from 'react-router-dom';
 const PrivateRoute = ({ component, ...rest }) => {
   const authenticated = useSelector((state) => !!state.oidc.user);
   const userManager = useSelector((state) => state.config.userManager);
-  const isSaltAPIAuthenticated = useSelector((state) => state.login.salt);
 
   if (!authenticated) {
     // Go to Dex Login Form if not authenticated
@@ -13,12 +12,8 @@ const PrivateRoute = ({ component, ...rest }) => {
       data: { path: window.location.pathname },
     });
     return null;
-  } else if (isSaltAPIAuthenticated) {
-    // To make sure that Salt API is authenticated, before load the components
-    // Otherwise we may get 401 Unauthorized
-    return <Route {...rest} component={component} />;
   } else {
-    return null;
+    return <Route {...rest} component={component} />;
   }
 };
 

--- a/ui/src/ducks/app/alerts.js
+++ b/ui/src/ducks/app/alerts.js
@@ -1,0 +1,42 @@
+import { takeEvery, call, put } from 'redux-saga/effects';
+import * as ApiAlertmanager from '../../services/alertmanager/api';
+
+// Actions
+const FETCH_ALERTS_ALERTMANAGER = 'FETCH_ALERTS_ALERTMANAGER';
+const UPDATE_ALERTS_ALERTMANAGER = 'UPDATE_ALERTS_ALERTMANAGER';
+
+// Reducer
+const defaultState = {
+  list: [],
+};
+
+export default function reducer(state = defaultState, action = {}) {
+  switch (action.type) {
+    case UPDATE_ALERTS_ALERTMANAGER:
+      return { ...state, ...action.payload };
+    default:
+      return state;
+  }
+}
+
+// Action Creators
+export const fetchAlertsAlertmanagerAction = () => {
+  return { type: FETCH_ALERTS_ALERTMANAGER };
+};
+
+export const updateAlertsAlertmanagerAction = (payload) => {
+  return { type: UPDATE_ALERTS_ALERTMANAGER, payload };
+};
+
+// Sagas
+export function* fetchAlertsAlertmanager() {
+  const result = yield call(ApiAlertmanager.getAlerts);
+
+  if (!result.error) {
+    yield put(updateAlertsAlertmanagerAction({ list: result }));
+  }
+}
+
+export function* alertsSaga() {
+  yield takeEvery(FETCH_ALERTS_ALERTMANAGER, fetchAlertsAlertmanager);
+}

--- a/ui/src/ducks/app/nodes.js
+++ b/ui/src/ducks/app/nodes.js
@@ -261,14 +261,11 @@ export function* fetchNodes() {
             );
 
           // Store the name of conditions which the status are True in the array
-          // given the avaiable conditions (Ready, DiskPressure, MemoryPressure, PIDPressure, Network Unavailable, Unschedulable)
-          let conditions = [];
-          const activeCondition = node.status.conditions.find(
-            (cond) => cond.status === 'True',
-          );
-          if (activeCondition && activeCondition.types) {
-            conditions.push(activeCondition.type);
-          }
+          // given the available conditions (Ready, DiskPressure, MemoryPressure, PIDPressure, Network Unavailable, Unschedulable)
+          const conditions = node?.status?.conditions?.reduce((acc, cond) => {
+            if (cond.status === 'True' && cond?.type) acc.push(cond.type);
+            return acc;
+          }, []);
 
           let status;
           if (statusType && statusType.status === 'True') {

--- a/ui/src/ducks/app/nodes.js
+++ b/ui/src/ducks/app/nodes.js
@@ -15,7 +15,6 @@ import {
   addNotificationSuccessAction,
   addNotificationErrorAction,
 } from './notifications';
-import { authenticateSaltApi } from '../login';
 import { intl } from '../../translations/IntlGlobalProvider';
 import { addJobAction, JOB_COMPLETED, allJobsSelector } from './salt';
 import { REFRESH_TIMEOUT } from '../../constants';
@@ -470,9 +469,6 @@ export function* stopRefreshNodes() {
 }
 
 export function* fetchNodesIPsInterface() {
-  // Action FETCH_NODES_IPS_INTERFACES is faster than SALT_AUTHENTICATION_SUCCESS, hence we get 401 Unauthorized here
-  // Manually authenticate salt API before get the IPs and Interfaces for Nodes
-  yield call(authenticateSaltApi);
   const result = yield call(ApiSalt.getNodesIPsInterfaces);
 
   if (!result.error) {

--- a/ui/src/ducks/app/nodes.js
+++ b/ui/src/ducks/app/nodes.js
@@ -18,7 +18,7 @@ import {
 import { intl } from '../../translations/IntlGlobalProvider';
 import { addJobAction, JOB_COMPLETED, allJobsSelector } from './salt';
 import { REFRESH_TIMEOUT } from '../../constants';
-
+import { nodesCPWPIPsInterface } from '../../services/NodeUtils';
 import {
   API_STATUS_READY,
   API_STATUS_NOT_READY,
@@ -148,7 +148,7 @@ const defaultState = {
   list: [],
   isRefreshing: false,
   isLoading: false,
-  nodesIPsInterfaces: {},
+  IPsInfo: {},
 };
 
 export default function reducer(state = defaultState, action = {}) {
@@ -472,9 +472,15 @@ export function* fetchNodesIPsInterface() {
   const result = yield call(ApiSalt.getNodesIPsInterfaces);
 
   if (!result.error) {
+    const nodesIPsInfo = result.return[0];
+    const IPsInfo = Object.keys(nodesIPsInfo)?.reduce((ipsInfo, nodeName) => {
+      ipsInfo[nodeName] = nodesCPWPIPsInterface(nodesIPsInfo[nodeName]);
+      return ipsInfo;
+    }, {});
+
     yield put(
       updateNodesIPsInterfacesAction({
-        nodesIPsInterfaces: result.return[0],
+        IPsInfo: IPsInfo,
       }),
     );
   }

--- a/ui/src/ducks/app/nodes.js
+++ b/ui/src/ducks/app/nodes.js
@@ -252,6 +252,17 @@ export function* fetchNodes() {
             node.status.conditions.find(
               (conditon) => conditon.type === 'Ready',
             );
+
+          // Store the name of conditions which the status are True in the array
+          // given the avaiable conditions (Ready, DiskPressure, MemoryPressure, PIDPressure, Network Unavailable, Unschedulable)
+          let conditions = [];
+          const activeCondition = node.status.conditions.find(
+            (cond) => cond.status === 'True',
+          );
+          if (activeCondition && activeCondition.types) {
+            conditions.push(activeCondition.type);
+          }
+
           let status;
           if (statusType && statusType.status === 'True') {
             status = API_STATUS_READY;
@@ -260,7 +271,6 @@ export function* fetchNodes() {
           } else {
             status = API_STATUS_UNKNOWN;
           }
-
           const roleTaintMatched = roleTaintMap.find((item) => {
             const nodeRoles = Object.keys(node.metadata.labels).filter((role) =>
               role.includes(ROLE_PREFIX),
@@ -291,12 +301,12 @@ export function* fetchNodes() {
               rolesLabel.push(intl.translate('infra'));
             }
           }
-
           return {
             name: node.metadata.name,
             metalk8s_version:
               node.metadata.labels['metalk8s.scality.com/version'],
             status: status,
+            conditions: conditions,
             control_plane: roleTaintMatched && roleTaintMatched.control_plane,
             workload_plane: roleTaintMatched && roleTaintMatched.workload_plane,
             bootstrap: roleTaintMatched && roleTaintMatched.bootstrap,

--- a/ui/src/ducks/app/nodes.js
+++ b/ui/src/ducks/app/nodes.js
@@ -271,14 +271,17 @@ export function* fetchNodes() {
           } else {
             status = API_STATUS_UNKNOWN;
           }
+
+          // the Roles of the Node should be the ones that are stored in the labels `node-role.kubernetes.io/<role-name>`
+          let nodeRolesLabels = [];
           const roleTaintMatched = roleTaintMap.find((item) => {
-            const nodeRoles = Object.keys(node.metadata.labels).filter((role) =>
+            nodeRolesLabels = Object.keys(node.metadata.labels).filter((role) =>
               role.includes(ROLE_PREFIX),
             );
 
             return (
-              nodeRoles.length === item.roles.length &&
-              nodeRoles.every((role) => item.roles.includes(role)) &&
+              nodeRolesLabels.length === item.roles.length &&
+              nodeRolesLabels.every((role) => item.roles.includes(role)) &&
               (item.taints && node.spec.taints
                 ? node.spec.taints.every((taint) =>
                     item.taints.find((item) => item.key === taint.key),
@@ -286,6 +289,8 @@ export function* fetchNodes() {
                 : item.taints === node.spec.taints)
             );
           });
+
+          const nodeRoles = nodeRolesLabels?.map((nRL) => nRL.split('/')[1]);
           const rolesLabel = [];
           if (roleTaintMatched) {
             if (roleTaintMatched.bootstrap) {
@@ -311,7 +316,7 @@ export function* fetchNodes() {
             workload_plane: roleTaintMatched && roleTaintMatched.workload_plane,
             bootstrap: roleTaintMatched && roleTaintMatched.bootstrap,
             infra: roleTaintMatched && roleTaintMatched.infra,
-            roles: rolesLabel.join(' / '),
+            roles: nodeRoles.join(' / '),
             deploying: deployingNodes.includes(node.metadata.name),
             internalIP: node?.status?.addresses?.find(
               (ip) => ip.type === 'InternalIP',

--- a/ui/src/ducks/app/nodes.js
+++ b/ui/src/ducks/app/nodes.js
@@ -260,10 +260,11 @@ export function* fetchNodes() {
               (conditon) => conditon.type === 'Ready',
             );
 
-          // Store the name of conditions which the status are True in the array
-          // given the available conditions (Ready, DiskPressure, MemoryPressure, PIDPressure, Network Unavailable, Unschedulable)
+          // Store the name of conditions which the status are True in the array, except "Ready" condition, which we can know from the `status` field.
+          // Given the available conditions (DiskPressure, MemoryPressure, PIDPressure, Network Unavailable, Unschedulable)
           const conditions = node?.status?.conditions?.reduce((acc, cond) => {
-            if (cond.status === 'True' && cond?.type) acc.push(cond.type);
+            if (cond.status === 'True' && cond?.type && cond?.type !== 'Ready')
+              acc.push(cond.type);
             return acc;
           }, []);
 

--- a/ui/src/ducks/app/nodes.test.js
+++ b/ui/src/ducks/app/nodes.test.js
@@ -83,10 +83,6 @@ const nodeForApi = ({ taintRoles = [], showStatus = true, ...props }) => ({
 const defaultNodeForState = {
   name: DEFAULT_NAME,
   metalk8s_version: DEFAULT_CLUSTER_VERSION,
-  workload_plane: true,
-  control_plane: false,
-  bootstrap: false,
-  infra: false,
   status: 'ready',
   deploying: false,
   roles: 'node',
@@ -184,10 +180,6 @@ describe('`fetchNodes` saga', () => {
       ['master', 'etcd'],
       ['master', 'etcd'],
       {
-        wp: false,
-        cp: true,
-        infra: false,
-        bootstrap: false,
         labels: 'master / etcd',
       },
     ],
@@ -195,10 +187,6 @@ describe('`fetchNodes` saga', () => {
       ['bootstrap', 'master', 'etcd', 'infra'],
       ['bootstrap', 'infra'],
       {
-        wp: false,
-        cp: false,
-        infra: false,
-        bootstrap: true,
         labels: 'bootstrap / master / etcd / infra',
       },
     ],
@@ -206,10 +194,6 @@ describe('`fetchNodes` saga', () => {
       ['node'],
       [],
       {
-        wp: true,
-        cp: false,
-        infra: false,
-        bootstrap: false,
         labels: 'node',
       },
     ],
@@ -217,10 +201,6 @@ describe('`fetchNodes` saga', () => {
       ['node', 'master', 'etcd'],
       [],
       {
-        wp: true,
-        cp: true,
-        infra: false,
-        bootstrap: false,
         labels: 'node / master / etcd',
       },
     ],
@@ -228,10 +208,6 @@ describe('`fetchNodes` saga', () => {
       ['infra'],
       ['infra'],
       {
-        wp: false,
-        cp: false,
-        infra: true,
-        bootstrap: false,
         labels: 'infra',
       },
     ],
@@ -239,10 +215,6 @@ describe('`fetchNodes` saga', () => {
       ['infra'],
       [],
       {
-        wp: true,
-        cp: false,
-        infra: true,
-        bootstrap: false,
         labels: 'infra',
       },
     ],
@@ -250,10 +222,6 @@ describe('`fetchNodes` saga', () => {
       ['infra', 'master', 'etcd'],
       ['infra'],
       {
-        wp: false,
-        cp: true,
-        infra: true,
-        bootstrap: false,
         labels: 'infra / master / etcd',
       },
     ],
@@ -267,10 +235,6 @@ describe('`fetchNodes` saga', () => {
 
     const expectedNode = {
       ...defaultNodeForState,
-      workload_plane: expected.wp,
-      control_plane: expected.cp,
-      bootstrap: expected.bootstrap,
-      infra: expected.infra,
       roles: expected.labels,
     };
 

--- a/ui/src/ducks/app/nodes.test.js
+++ b/ui/src/ducks/app/nodes.test.js
@@ -1,4 +1,4 @@
-import { call, put, all, delay, select } from 'redux-saga/effects';
+import { call, put, delay, select } from 'redux-saga/effects';
 import { cloneableGenerator } from '@redux-saga/testing-utils';
 import * as CoreApi from '../../services/k8s/core';
 import history from '../../history';
@@ -72,7 +72,7 @@ const nodeForApi = ({ taintRoles = [], showStatus = true, ...props }) => ({
     : undefined,
   spec: {
     taints: taintRoles.length
-      ? taintRoles.map(role => ({
+      ? taintRoles.map((role) => ({
           key: `node-role.kubernetes.io/${role}`,
           effect: 'NoSchedule',
         }))
@@ -89,7 +89,8 @@ const defaultNodeForState = {
   infra: false,
   status: 'ready',
   deploying: false,
-  roles: 'Workload Plane',
+  roles: 'node',
+  conditions: [],
 };
 
 const formPayload = ({
@@ -125,7 +126,7 @@ describe('`fetchNodes` saga', () => {
 
   expect(gen.next().value).toEqual(select(allJobsSelector));
 
-  const _checkCompletion = _gen => {
+  const _checkCompletion = (_gen) => {
     expect(_gen.next().value).toEqual(delay(1000));
     expect(_gen.next().value).toEqual(
       put({ type: UPDATE_NODES, payload: { isLoading: false } }),
@@ -156,7 +157,7 @@ describe('`fetchNodes` saga', () => {
     const clone = gen.clone();
     const jobs = [
       {
-        type: "deploy-node",
+        type: 'deploy-node',
         node: DEFAULT_NAME,
         jid: '12345',
         completed,
@@ -187,7 +188,7 @@ describe('`fetchNodes` saga', () => {
         cp: true,
         infra: false,
         bootstrap: false,
-        labels: 'Control Plane',
+        labels: 'master / etcd',
       },
     ],
     [
@@ -198,7 +199,7 @@ describe('`fetchNodes` saga', () => {
         cp: false,
         infra: false,
         bootstrap: true,
-        labels: 'Bootstrap',
+        labels: 'bootstrap / master / etcd / infra',
       },
     ],
     [
@@ -209,7 +210,7 @@ describe('`fetchNodes` saga', () => {
         cp: false,
         infra: false,
         bootstrap: false,
-        labels: 'Workload Plane',
+        labels: 'node',
       },
     ],
     [
@@ -220,7 +221,7 @@ describe('`fetchNodes` saga', () => {
         cp: true,
         infra: false,
         bootstrap: false,
-        labels: 'Control Plane / Workload Plane',
+        labels: 'node / master / etcd',
       },
     ],
     [
@@ -231,7 +232,7 @@ describe('`fetchNodes` saga', () => {
         cp: false,
         infra: true,
         bootstrap: false,
-        labels: 'Infra',
+        labels: 'infra',
       },
     ],
     [
@@ -242,7 +243,7 @@ describe('`fetchNodes` saga', () => {
         cp: false,
         infra: true,
         bootstrap: false,
-        labels: 'Workload Plane / Infra',
+        labels: 'infra',
       },
     ],
     [
@@ -253,7 +254,7 @@ describe('`fetchNodes` saga', () => {
         cp: true,
         infra: true,
         bootstrap: false,
-        labels: 'Control Plane / Infra',
+        labels: 'infra / master / etcd',
       },
     ],
   ])('handles Node roles (%j) and taints (%j)', (roles, taints, expected) => {

--- a/ui/src/ducks/config.js
+++ b/ui/src/ducks/config.js
@@ -9,6 +9,7 @@ import * as Api from '../services/api';
 import * as ApiK8s from '../services/k8s/api';
 import * as ApiSalt from '../services/salt/api';
 import * as ApiPrometheus from '../services/prometheus/api';
+import * as ApiAlertmanager from '../services/alertmanager/api';
 import { EN_LANG, FR_LANG, LANGUAGE } from '../constants';
 
 import { authenticateSaltApi } from './login';
@@ -162,6 +163,8 @@ export function* fetchConfig() {
     yield put(setApiConfigAction(result));
     yield call(ApiSalt.initialize, result.url_salt);
     yield call(ApiPrometheus.initialize, result.url_prometheus);
+    yield call(ApiAlertmanager.initialize, result.url_alertmanager);
+
     yield put(
       setUserManagerConfigAction({
         authority: result.url_oidc_provider,

--- a/ui/src/ducks/config.test.js
+++ b/ui/src/ducks/config.test.js
@@ -29,6 +29,7 @@ import * as Api from '../services/api';
 import * as ApiK8s from '../services/k8s/api';
 import * as ApiSalt from '../services/salt/api';
 import * as ApiPrometheus from '../services/prometheus/api';
+import * as ApiAlertmanager from '../services/alertmanager/api';
 
 it('update the theme state and logo path when fetchTheme', () => {
   const gen = fetchTheme();
@@ -68,6 +69,7 @@ it('update the config state when fetchConfig', () => {
     url_prometheus: 'http://172.21.254.46:30222',
     url_oidc_provider: 'http://172.21.254.46:32000',
     url_redirect: 'http://172.21.254.46:3000',
+    url_alertmanager: 'http://172.21.254.46:8443',
   };
 
   expect(gen.next(result).value).toEqual(call(fetchTheme));
@@ -82,6 +84,10 @@ it('update the config state when fetchConfig', () => {
 
   expect(gen.next(result).value).toEqual(
     call(ApiPrometheus.initialize, 'http://172.21.254.46:30222'),
+  );
+
+  expect(gen.next(result).value).toEqual(
+    call(ApiAlertmanager.initialize, 'http://172.21.254.46:8443'),
   );
 
   expect(gen.next().value).toEqual(

--- a/ui/src/ducks/reducer.js
+++ b/ui/src/ducks/reducer.js
@@ -11,7 +11,7 @@ import notifications from './app/notifications';
 import salt from './app/salt';
 import monitoring from './app/monitoring';
 import solutions from './app/solutions';
-
+import alerts from './app/alerts';
 const rootReducer = combineReducers({
   config,
   login,
@@ -24,6 +24,7 @@ const rootReducer = combineReducers({
     monitoring,
     volumes,
     solutions,
+    alerts,
   }),
   oidc: oidcReducer,
 });

--- a/ui/src/ducks/sagas.js
+++ b/ui/src/ducks/sagas.js
@@ -8,6 +8,7 @@ import { solutionsSaga } from './app/solutions';
 import { volumesSaga } from './app/volumes';
 import { authenticateSaga } from './login';
 import { configSaga } from './config';
+import { alertsSaga } from './app/alerts';
 
 export default function* rootSaga() {
   yield all([
@@ -20,5 +21,6 @@ export default function* rootSaga() {
     fork(saltSaga),
     fork(solutionsSaga),
     fork(volumesSaga),
+    fork(alertsSaga),
   ]);
 }

--- a/ui/src/services/NodeUtils.js
+++ b/ui/src/services/NodeUtils.js
@@ -2,30 +2,25 @@ import { createSelector } from 'reselect';
 
 const METALK8S_CONTROL_PLANE_IP = 'metalk8s:control_plane_ip';
 const METALK8S_WORKLOAD_PLANE_IP = 'metalk8s:workload_plane_ip';
+const IP_INTERFACES = 'ip_interfaces';
 
-const nodesIPsInterfacesSelector = (state) =>
-  state.app.nodes.nodesIPsInterfaces;
+const IPsInfoSelector = (state) => state.app.nodes.IPsInfo;
 const nodesSelector = (state) => state.app.nodes.list;
 
 // Return the data used by the Node list table
 export const getNodeListData = createSelector(
   nodesSelector,
-  nodesIPsInterfacesSelector,
-  (nodes, nodesIPsInterfaces) => {
+  IPsInfoSelector,
+  (nodes, nodeIPsInfo) => {
     return (
       nodes?.map((node) => {
+        const IPsInfo = nodeIPsInfo?.[node.name];
         return {
-          // IPs of Control Plane and Workload Plane are in the same Cell with Name
+          // According to the design, the IPs of Control Plane and Workload Plane are in the same Cell with Name
           name: {
             name: node?.name,
-            control_plane_ip:
-              (nodesIPsInterfaces[node.name] &&
-                nodesIPsInterfaces[node.name][METALK8S_CONTROL_PLANE_IP]) ??
-              undefined,
-            workload_plane_ip:
-              (nodesIPsInterfaces[node.name] &&
-                nodesIPsInterfaces[node.name][METALK8S_WORKLOAD_PLANE_IP]) ??
-              undefined,
+            controlPlaneIP: IPsInfo?.controlPlane?.ip,
+            workloadPlaneIP: IPsInfo?.workloadPlane?.ip,
           },
           status: { status: node?.status, conditions: node?.conditions },
           roles: node?.roles,
@@ -34,3 +29,40 @@ export const getNodeListData = createSelector(
     );
   },
 );
+
+// This function returns the IP and interface of Control Plane and Workload Plane for each Node
+// Arguments:
+//  ipsInterfacesObject =
+// {
+//    ip_interface: {
+//      eth1:['10.0.1.42', 'fe80::f816:3eff:fe25:5843'],
+//      eth3:['10.100.0.2', 'fe80::f816:3eff:fe37:2f34']
+// },
+//    metalk8s:control_plane_ip: "10.0.1.42",
+//    metalk8s:workload_plane_ip: "10.100.0.2"
+// }
+// Return
+// {
+//   control_plane: { ip: '10.0.1.42', interface: 'eth1'}
+//   workload_plane: { ip: '10.100.0.2', interface: 'eth3'},
+// }
+export const nodesCPWPIPsInterface = (IPsInterfacesObject) => {
+  return {
+    controlPlane: {
+      ip: IPsInterfacesObject[METALK8S_CONTROL_PLANE_IP],
+      interface: Object.keys(IPsInterfacesObject[IP_INTERFACES]).find((en) =>
+        IPsInterfacesObject[IP_INTERFACES][en].includes(
+          IPsInterfacesObject[METALK8S_CONTROL_PLANE_IP],
+        ),
+      ),
+    },
+    workloadPlane: {
+      ip: IPsInterfacesObject[METALK8S_WORKLOAD_PLANE_IP],
+      interface: Object.keys(IPsInterfacesObject[IP_INTERFACES]).find((en) =>
+        IPsInterfacesObject[IP_INTERFACES][en].includes(
+          IPsInterfacesObject[METALK8S_WORKLOAD_PLANE_IP],
+        ),
+      ),
+    },
+  };
+};

--- a/ui/src/services/NodeUtils.js
+++ b/ui/src/services/NodeUtils.js
@@ -1,0 +1,31 @@
+import { createSelector } from 'reselect';
+import { nodesSelector, nodesIPsInterfacesSelector } from '../ducks/app/nodes';
+
+const METALK8S_CONTROL_PLANE_IP = 'metalk8s:control_plane_ip';
+const METALK8S_WORKLOAD_PLANE_IP = 'metalk8s:workload_plane_ip';
+
+// Return the data used by the Node list table
+export const getNodeListData = createSelector(
+  nodesSelector,
+  nodesIPsInterfacesSelector,
+  (nodes, nodesIPsInterfaces) => {
+    return nodes?.map((node) => {
+      return {
+        // IPs of Control Plane and Workload Plane are in the same Cell with Name
+        name: {
+          name: node?.name,
+          control_plane_ip:
+            (nodesIPsInterfaces[node.name] &&
+              nodesIPsInterfaces[node.name][METALK8S_CONTROL_PLANE_IP]) ||
+            undefined,
+          workload_plane_ip:
+            (nodesIPsInterfaces[node.name] &&
+              nodesIPsInterfaces[node.name][METALK8S_WORKLOAD_PLANE_IP]) ||
+            undefined,
+        },
+        status: { status: node?.status, conditions: node?.conditions },
+        roles: node?.roles,
+      };
+    });
+  },
+);

--- a/ui/src/services/NodeUtils.js
+++ b/ui/src/services/NodeUtils.js
@@ -1,31 +1,36 @@
 import { createSelector } from 'reselect';
-import { nodesSelector, nodesIPsInterfacesSelector } from '../ducks/app/nodes';
 
 const METALK8S_CONTROL_PLANE_IP = 'metalk8s:control_plane_ip';
 const METALK8S_WORKLOAD_PLANE_IP = 'metalk8s:workload_plane_ip';
+
+const nodesIPsInterfacesSelector = (state) =>
+  state.app.nodes.nodesIPsInterfaces;
+const nodesSelector = (state) => state.app.nodes.list;
 
 // Return the data used by the Node list table
 export const getNodeListData = createSelector(
   nodesSelector,
   nodesIPsInterfacesSelector,
   (nodes, nodesIPsInterfaces) => {
-    return nodes?.map((node) => {
-      return {
-        // IPs of Control Plane and Workload Plane are in the same Cell with Name
-        name: {
-          name: node?.name,
-          control_plane_ip:
-            (nodesIPsInterfaces[node.name] &&
-              nodesIPsInterfaces[node.name][METALK8S_CONTROL_PLANE_IP]) ||
-            undefined,
-          workload_plane_ip:
-            (nodesIPsInterfaces[node.name] &&
-              nodesIPsInterfaces[node.name][METALK8S_WORKLOAD_PLANE_IP]) ||
-            undefined,
-        },
-        status: { status: node?.status, conditions: node?.conditions },
-        roles: node?.roles,
-      };
-    });
+    return (
+      nodes?.map((node) => {
+        return {
+          // IPs of Control Plane and Workload Plane are in the same Cell with Name
+          name: {
+            name: node?.name,
+            control_plane_ip:
+              (nodesIPsInterfaces[node.name] &&
+                nodesIPsInterfaces[node.name][METALK8S_CONTROL_PLANE_IP]) ??
+              undefined,
+            workload_plane_ip:
+              (nodesIPsInterfaces[node.name] &&
+                nodesIPsInterfaces[node.name][METALK8S_WORKLOAD_PLANE_IP]) ??
+              undefined,
+          },
+          status: { status: node?.status, conditions: node?.conditions },
+          roles: node?.roles,
+        };
+      }) ?? []
+    );
   },
 );

--- a/ui/src/services/alertmanager/api.js
+++ b/ui/src/services/alertmanager/api.js
@@ -1,0 +1,11 @@
+import ApiClient from '../ApiClient';
+
+let alertmanagerApiClient = null;
+
+export function initialize(apiUrl) {
+  alertmanagerApiClient = new ApiClient({ apiUrl });
+}
+
+export function getAlerts() {
+  return alertmanagerApiClient.get('/api/v2/alerts');
+}

--- a/ui/src/services/salt/api.js
+++ b/ui/src/services/salt/api.js
@@ -50,3 +50,16 @@ export async function prepareEnvironment(environment, version) {
     },
   });
 }
+
+export async function getNodesIPsInterfaces() {
+  return saltApiClient.post('/', {
+    client: 'local',
+    tgt: '*',
+    fun: 'grains.item',
+    arg: [
+      'metalk8s:control_plane_ip',
+      'metalk8s:workload_plane_ip',
+      'ip_interfaces',
+    ],
+  });
+}


### PR DESCRIPTION
**Component**: ui, nodes

**Context**: Fill the node list table

**Summary**:
- Add the Control Plane IP and Workload Plane IP under the Node Name
- Get the Roles by the labels `node-role.kubernetes.io/<role>`
- Be able to retrieve the alerts from alertmanager.
- But haven't implemented the filter to compute the health
- the color of the status depends on the condition and status
          // green for status.conditions['Ready'] == True and all other conditions are false
          // yellow for status.conditions['Ready'] == True and some other conditions are true
          // red for status.conditions['Ready'] == False
          // grey when there is no status.conditions
- Update the unit test in nodes

**Acceptance criteria**: 
![image](https://user-images.githubusercontent.com/18453133/92754611-4ca35e00-f38b-11ea-92e9-1cf5c1b16cb7.png)


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2772 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
