### PR TITLE
[UI] add the selection of node table and tabs

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1901,8 +1901,8 @@
       "integrity": "sha512-afmTuJrylUU/0OtqzaRkbyYFFNgCF73Bvel/sw90pvGrWIZ+vyoIJqA6eMSoA6+nb443kTmulmBtC9NerXboNg=="
     },
     "@scality/core-ui": {
-      "version": "github:scality/core-ui#a575945aa4e9cc0f5f1bf6e6c2e8906757e7b3fd",
-      "from": "github:scality/core-ui#a575945"
+      "version": "github:scality/core-ui#23e3c8f904f0c4ab9ed77e8dfbcd7112cf4bc195",
+      "from": "github:scality/core-ui#23e3c8f"
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "4.2.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.7.2",
     "@kubernetes/client-node": "github:scality/kubernetes-client-javascript.git#browser-0.10.2-62-g61d8543",
-    "@scality/core-ui": "github:scality/core-ui.git#a575945",
+    "@scality/core-ui": "github:scality/core-ui.git#23e3c8f",
     "axios": "^0.18.0",
     "formik": "1.5.1",
     "lodash.isempty": "^4.4.0",

--- a/ui/src/components/CommonLayoutStyle.js
+++ b/ui/src/components/CommonLayoutStyle.js
@@ -45,3 +45,9 @@ export const PageContentContainer = styled.div`
   width: 100%;
   background-color: ${(props) => props.theme.brand.primary};
 `;
+
+export const TabContainer = styled.div`
+  background-color: ${(props) => props.theme.brand.primaryDark1};
+  color: ${(props) => props.theme.brand.textPrimary};
+  min-height: 650px;
+`;

--- a/ui/src/components/NodeListTable.js
+++ b/ui/src/components/NodeListTable.js
@@ -83,6 +83,11 @@ const TableRow = styled(HeadRow)`
     outline: none;
     cursor: pointer;
   }
+
+  background-color: ${(props) =>
+    props.selectedNodeName === props.row.values.name.name
+      ? props.theme.brand.backgroundBluer
+      : props.theme.brand.primary};
 `;
 
 // * table body
@@ -191,7 +196,7 @@ function GlobalFilter({
   );
 }
 
-function Table({ columns, data, rowClicked, theme }) {
+function Table({ columns, data, rowClicked, theme, selectedNodeName }) {
   const query = useQuery();
   const querySearch = query.get('search');
 
@@ -266,6 +271,7 @@ function Table({ columns, data, rowClicked, theme }) {
               <TableRow
                 {...row.getRowProps({ onClick: () => rowClicked(row) })}
                 row={row}
+                selectedNodeName={selectedNodeName}
               >
                 {row.cells.map((cell) => {
                   let cellProps = cell.getCellProps({
@@ -303,7 +309,9 @@ function Table({ columns, data, rowClicked, theme }) {
 }
 
 const NodeListTable = (props) => {
-  const { nodeTableData } = props;
+  const history = useHistory();
+  const location = useLocation();
+  const { nodeTableData, selectedNodeName } = props;
 
   const theme = useSelector((state) => state.config.theme);
 
@@ -373,7 +381,24 @@ const NodeListTable = (props) => {
   );
 
   // handle the row selection by updating the URL
-  const onClickRow = (row) => {};
+  const onClickRow = (row) => {
+    const nodeName = row.values.name.name;
+    const isTabSelected =
+      location.pathname.endsWith('health') ||
+      location.pathname.endsWith('alerts') ||
+      location.pathname.endsWith('metrics') ||
+      location.pathname.endsWith('volumes') ||
+      location.pathname.endsWith('pods');
+
+    if (isTabSelected) {
+      // When switch between the nodes, keep the same tab selected
+      const currentTab = location?.pathname?.split('/')?.pop();
+      history.push(`/newNodes/${nodeName}/${currentTab}`);
+    } else {
+      // Set Health tab as default tab
+      history.push(`/newNodes/${nodeName}/health`);
+    }
+  };
 
   return (
     <NodeListContainer>
@@ -382,6 +407,7 @@ const NodeListTable = (props) => {
         data={nodeTableData}
         rowClicked={onClickRow}
         theme={theme}
+        selectedNodeName={selectedNodeName}
       />
     </NodeListContainer>
   );

--- a/ui/src/components/NodePageAlertsTab.js
+++ b/ui/src/components/NodePageAlertsTab.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import { TabContainer } from './CommonLayoutStyle';
+
+const NodePageAlertsTab = (props) => {
+  return <TabContainer>Alerts</TabContainer>;
+};
+
+export default NodePageAlertsTab;

--- a/ui/src/components/NodePageHealthTab.js
+++ b/ui/src/components/NodePageHealthTab.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import { TabContainer } from './CommonLayoutStyle';
+
+const NodePageHealthTab = (props) => {
+  return <TabContainer>Health</TabContainer>;
+};
+
+export default NodePageHealthTab;

--- a/ui/src/components/NodePageMetricsTab.js
+++ b/ui/src/components/NodePageMetricsTab.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import { TabContainer } from './CommonLayoutStyle';
+
+const NodePageMetricsTab = (props) => {
+  return <TabContainer>Metrics</TabContainer>;
+};
+
+export default NodePageMetricsTab;

--- a/ui/src/components/NodePagePodsTab.js
+++ b/ui/src/components/NodePagePodsTab.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import { TabContainer } from './CommonLayoutStyle';
+
+const NodePagePodsTab = (props) => {
+  return <TabContainer>Pods</TabContainer>;
+};
+
+export default NodePagePodsTab;

--- a/ui/src/components/NodePageVolumesTab.js
+++ b/ui/src/components/NodePageVolumesTab.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import { TabContainer } from './CommonLayoutStyle';
+
+const NodePageVolumesTab = (props) => {
+  return <TabContainer>Volumes</TabContainer>;
+};
+
+export default NodePageVolumesTab;

--- a/ui/src/containers/Layout.js
+++ b/ui/src/containers/Layout.js
@@ -230,7 +230,7 @@ const Layout = (props) => {
           />
           <PrivateRoute path="/nodes/:id" component={NodeInformation} />
           <PrivateRoute exact path="/nodes" component={NodeList} />
-          <PrivateRoute exact path="/newNodes" component={NodePage} />
+          <PrivateRoute path="/newNodes" component={NodePage} />
           <PrivateRoute exact path="/environments" component={SolutionList} />
           <PrivateRoute path="/volumes" component={VolumePage} />
           <PrivateRoute

--- a/ui/src/containers/NodePageContent.js
+++ b/ui/src/containers/NodePageContent.js
@@ -1,29 +1,42 @@
 import React from 'react';
+import styled from 'styled-components';
+import { padding } from '@scality/core-ui/dist/style/theme';
 import { useHistory } from 'react-router';
 import NodeListTable from '../components/NodeListTable';
+import NodePageRSP from './NodePageRSP';
 import {
   LeftSideInstanceList,
-  RightSidePanel,
   NoInstanceSelectedContainer,
   NoInstanceSelected,
   PageContentContainer,
 } from '../components/CommonLayoutStyle';
 import { intl } from '../translations/IntlGlobalProvider';
 
+const NodePageRSPContainer = styled.div`
+  flex-direction: column;
+  width: 55%;
+  margin: ${padding.small} ${padding.small} ${padding.small} 0;
+`;
+
 const NodePageContent = (props) => {
   const { nodeTableData } = props;
 
   const history = useHistory();
-  const currentNodeName =
+  const selectedNodeName =
     history?.location?.pathname?.split('/')?.slice(2)[0] || '';
 
   return (
     <PageContentContainer>
       <LeftSideInstanceList>
-        <NodeListTable nodeTableData={nodeTableData} />
+        <NodeListTable
+          nodeTableData={nodeTableData}
+          selectedNodeName={selectedNodeName}
+        />
       </LeftSideInstanceList>
-      {currentNodeName ? (
-        <RightSidePanel></RightSidePanel>
+      {selectedNodeName ? (
+        <NodePageRSPContainer>
+          <NodePageRSP selectedNodeName={selectedNodeName} />
+        </NodePageRSPContainer>
       ) : (
         <NoInstanceSelectedContainer>
           <NoInstanceSelected>

--- a/ui/src/containers/NodePageRSP.js
+++ b/ui/src/containers/NodePageRSP.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import { Switch, Route } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router';
+import styled from 'styled-components';
+import { Tabs } from '@scality/core-ui';
+import { padding } from '@scality/core-ui/dist/style/theme';
+import NodePageHealthTab from '../components/NodePageHealthTab';
+import NodePageAlertsTab from '../components/NodePageAlertsTab';
+import NodePageMetricsTab from '../components/NodePageMetricsTab';
+import NodePageVolumesTab from '../components/NodePageVolumesTab';
+import NodePagePodsTab from '../components/NodePagePodsTab';
+import { intl } from '../translations/IntlGlobalProvider';
+
+const NodePageRSPContainer = styled.div`
+  .sc-tabs {
+    margin: ${padding.smaller} ${padding.small} 0 ${padding.smaller};
+  }
+
+  .sc-tabs-item-content {
+    padding: 0;
+  }
+`;
+
+const NodePageRSP = (props) => {
+  const history = useHistory();
+  const location = useLocation();
+  const { selectedNodeName } = props;
+
+  const isHealthTabActive = location.pathname.endsWith('/health');
+  const isAlertsTabActive = location.pathname.endsWith('/alerts');
+  const isMetricsTabActive = location.pathname.endsWith('/metrics');
+  const isVolumesTabActive = location.pathname.endsWith('/volumes');
+  const isPodsTabActive = location.pathname.endsWith('/pods');
+
+  const items = [
+    {
+      selected: isHealthTabActive,
+      title: 'Health',
+      onClick: () => history.push(`/newNodes/${selectedNodeName}/health`),
+    },
+    {
+      selected: isAlertsTabActive,
+      title: intl.translate('alerts'),
+      onClick: () => history.push(`/newNodes/${selectedNodeName}/alerts`),
+    },
+    {
+      selected: isMetricsTabActive,
+      title: 'Metrics',
+      onClick: () => history.push(`/newNodes/${selectedNodeName}/metrics`),
+    },
+    {
+      selected: isVolumesTabActive,
+      title: intl.translate('volumes'),
+      onClick: () => history.push(`/newNodes/${selectedNodeName}/volumes`),
+    },
+    {
+      selected: isPodsTabActive,
+      title: intl.translate('pods'),
+      onClick: () => history.push(`/newNodes/${selectedNodeName}/pods`),
+    },
+  ];
+
+  return (
+    <NodePageRSPContainer>
+      <Tabs items={items}>
+        <Switch>
+          <Route
+            path={`/newNodes/${selectedNodeName}/health`}
+            component={NodePageHealthTab}
+          />
+          <Route
+            path={`/newNodes/${selectedNodeName}/alerts`}
+            component={NodePageAlertsTab}
+          />
+          <Route
+            path={`/newNodes/${selectedNodeName}/metrics`}
+            component={NodePageMetricsTab}
+          />
+          <Route
+            path={`/newNodes/${selectedNodeName}/volumes`}
+            component={NodePageVolumesTab}
+          />
+          <Route
+            path={`/newNodes/${selectedNodeName}/pods`}
+            component={NodePagePodsTab}
+          />
+        </Switch>
+      </Tabs>
+    </NodePageRSPContainer>
+  );
+};
+
+export default NodePageRSP;


### PR DESCRIPTION
**Component**: ui, nodes

**Context**: 

**Summary**:
- Add the Control Plane IP and Workload Plane IP under the Node Name
- Get the Roles by the labels `node-role.kubernetes.io/<role>`
- Be able to retrieve the alerts from alertmanager.
- But haven't implemented the filter to compute the health
- the color of the status depends on the condition and status
          // green for status.conditions['Ready'] == True and all other conditions are false
          // yellow for status.conditions['Ready'] == True and some other conditions are true
          // red for status.conditions['Ready'] == False
          // grey when there is no status.conditions
- Update the unit test in nodes
- Add the selection of Node, the URL should update too
- Add 5 empty tabs on the right-side panel, the URL should update when switching the tabs

**Acceptance criteria**: 
![image](https://user-images.githubusercontent.com/18453133/92928838-f6442700-f43f-11ea-91c3-f5673d16bb34.png)


---

<!-- Declare one or more issues to close once this PR gets merged -->
Closes: #2772
Closes: #2773

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
