### PR TITLE
Revert storageclass changes (#2742) from 2.5

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -287,6 +287,7 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/addons/prometheus-operator/deployed/namespace.sls'),
     Path('salt/metalk8s/addons/prometheus-operator/deployed/',
             'service-configuration.sls'),
+    Path('salt/metalk8s/addons/prometheus-operator/deployed/storageclass.sls'),
     Path('salt/metalk8s/addons/prometheus-operator/pre-downgrade.sls'),
     Path('salt/metalk8s/addons/prometheus-operator/pre-upgrade.sls'),
 
@@ -300,8 +301,6 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/addons/solutions/deployed/configmap.sls'),
     Path('salt/metalk8s/addons/solutions/deployed/init.sls'),
     Path('salt/metalk8s/addons/solutions/deployed/namespace.sls'),
-
-    Path('salt/metalk8s/addons/storageclass/deployed.sls'),
 
     Path('salt/metalk8s/addons/volumes/deployed.sls'),
     targets.TemplateFile(

--- a/charts/prometheus-operator.yaml
+++ b/charts/prometheus-operator.yaml
@@ -29,7 +29,7 @@ alertmanager:
     storage:
       volumeClaimTemplate:
         spec:
-          storageClassName: metalk8s
+          storageClassName: metalk8s-prometheus
           accessModes: ['ReadWriteOnce']
           resources:
             requests:
@@ -105,7 +105,7 @@ prometheus:
     storageSpec:
       volumeClaimTemplate:
         spec:
-          storageClassName: metalk8s
+          storageClassName: metalk8s-prometheus
           accessModes: ['ReadWriteOnce']
           resources:
             requests:

--- a/docs/installation/post-install.rst
+++ b/docs/installation/post-install.rst
@@ -29,7 +29,7 @@ path for the partitions to use:
      name: <node_name>-prometheus
    spec:
      nodeName: <node_name>
-     storageClassName: metalk8s
+     storageClassName: metalk8s-prometheus
      rawBlockDevice:  # Choose a device with at least 10GiB capacity
        devicePath: <device_path>
      template:
@@ -43,7 +43,7 @@ path for the partitions to use:
      name: <node_name>-alertmanager
    spec:
      nodeName: <node_name>
-     storageClassName: metalk8s
+     storageClassName: metalk8s-prometheus
      rawBlockDevice:  # Choose a device with at least 1GiB capacity
        devicePath: <device_path2>
      template:

--- a/examples/prometheus-sparse.yaml
+++ b/examples/prometheus-sparse.yaml
@@ -8,7 +8,7 @@ metadata:
   name: NODE_NAME-prometheus
 spec:
   nodeName: NODE_NAME
-  storageClassName: metalk8s
+  storageClassName: metalk8s-prometheus
   sparseLoopDevice:
     size: 10Gi
   template:
@@ -22,7 +22,7 @@ metadata:
   name: NODE_NAME-alertmanager
 spec:
   nodeName: NODE_NAME
-  storageClassName: metalk8s
+  storageClassName: metalk8s-prometheus
   sparseLoopDevice:
     size: 1Gi
   template:

--- a/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
@@ -51578,7 +51578,7 @@ spec:
         selector:
           matchLabels:
             app.kubernetes.io/name: prometheus-operator-alertmanager
-        storageClassName: metalk8s
+        storageClassName: metalk8s-prometheus
   tolerations:
   - effect: NoSchedule
     key: node-role.kubernetes.io/bootstrap
@@ -51661,7 +51661,7 @@ spec:
         selector:
           matchLabels:
             app.kubernetes.io/name: prometheus-operator-prometheus
-        storageClassName: metalk8s
+        storageClassName: metalk8s-prometheus
   tolerations:
   - effect: NoSchedule
     key: node-role.kubernetes.io/bootstrap

--- a/salt/metalk8s/addons/prometheus-operator/deployed/init.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/init.sls
@@ -1,6 +1,6 @@
 include:
-  - ...storageclass.deployed
   - .namespace
+  - .storageclass
   - .cleanup
   - .chart
   - .alertmanager-configuration-secret

--- a/salt/metalk8s/addons/prometheus-operator/deployed/storageclass.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/storageclass.sls
@@ -3,7 +3,7 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: metalk8s
+  name: metalk8s-prometheus
   labels:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/part-of: metalk8s

--- a/salt/metalk8s/addons/prometheus-operator/post-upgrade.sls
+++ b/salt/metalk8s/addons/prometheus-operator/post-upgrade.sls
@@ -2,9 +2,3 @@
 
 include:
   - .post-cleanup
-
-Delete old metalk8s-prometheus StorageClass:
-  metalk8s_kubernetes.object_absent:
-    - apiVersion: v1
-    - kind: StorageClass
-    - name: metalk8s-prometheus

--- a/salt/metalk8s/addons/prometheus-operator/post-upgrade.sls
+++ b/salt/metalk8s/addons/prometheus-operator/post-upgrade.sls
@@ -5,6 +5,6 @@ include:
 
 Delete old metalk8s-prometheus StorageClass:
   metalk8s_kubernetes.object_absent:
-    - apiVersion: storage.k8s.io/v1
+    - apiVersion: v1
     - kind: StorageClass
     - name: metalk8s-prometheus

--- a/salt/tests/unit/modules/files/test_metalk8s_volumes.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_volumes.yaml
@@ -4,7 +4,7 @@ _volumes_details: &volumes_details
     kind: Volume
     metadata:
       annotations:
-        kubectl.kubernetes.io/last-applied-configuration: '{"apiVersion":"storage.metalk8s.scality.com/v1alpha1","kind":"Volume","metadata":{"annotations":{},"name":"my-sparse-volume"},"spec":{"nodeName":"bootstrap","sparseLoopDevice":{"size":"1Gi"},"storageClassName":"metalk8s","template":{"metadata":{"labels":{"app.kubernetes.io/name":"prometheus-operator-alertmanager"}}}}}
+        kubectl.kubernetes.io/last-applied-configuration: '{"apiVersion":"storage.metalk8s.scality.com/v1alpha1","kind":"Volume","metadata":{"annotations":{},"name":"my-sparse-volume"},"spec":{"nodeName":"bootstrap","sparseLoopDevice":{"size":"1Gi"},"storageClassName":"metalk8s-prometheus","template":{"metadata":{"labels":{"app.kubernetes.io/name":"prometheus-operator-alertmanager"}}}}}
 
 '
       creationTimestamp: '2020-06-12T13:33:44Z'
@@ -40,11 +40,11 @@ _volumes_details: &volumes_details
             heritage: salt
             metalk8s.scality.com/version: 2.5.1-dev
           managed_fields: null
-          name: metalk8s
+          name: metalk8s-prometheus
           namespace: null
           owner_references: null
           resource_version: '29117'
-          self_link: /apis/storage.k8s.io/v1/storageclasses/metalk8s
+          self_link: /apis/storage.k8s.io/v1/storageclasses/metalk8s-prometheus
           uid: 17ba89c5-0774-49d4-9e34-dc999ec69545
         mount_options:
         - rw
@@ -55,7 +55,7 @@ _volumes_details: &volumes_details
         provisioner: kubernetes.io/no-provisioner
         reclaim_policy: Retain
         volume_binding_mode: WaitForFirstConsumer
-      storageClassName: metalk8s
+      storageClassName: metalk8s-prometheus
       template:
         metadata:
           creationTimestamp: null
@@ -73,7 +73,7 @@ _volumes_details: &volumes_details
     kind: Volume
     metadata:
       annotations:
-        kubectl.kubernetes.io/last-applied-configuration: '{"apiVersion":"storage.metalk8s.scality.com/v1alpha1","kind":"Volume","metadata":{"annotations":{},"name":"my-raw-block-device-volume"},"spec":{"nodeName":"bootstrap","sparseLoopDevice":{"size":"10Gi"},"storageClassName":"metalk8s","template":{"metadata":{"labels":{"app.kubernetes.io/name":"prometheus-operator-prometheus"}}}}}
+        kubectl.kubernetes.io/last-applied-configuration: '{"apiVersion":"storage.metalk8s.scality.com/v1alpha1","kind":"Volume","metadata":{"annotations":{},"name":"my-raw-block-device-volume"},"spec":{"nodeName":"bootstrap","sparseLoopDevice":{"size":"10Gi"},"storageClassName":"metalk8s-prometheus","template":{"metadata":{"labels":{"app.kubernetes.io/name":"prometheus-operator-prometheus"}}}}}
 
 '
       creationTimestamp: '2020-06-12T13:33:44Z'
@@ -109,11 +109,11 @@ _volumes_details: &volumes_details
             heritage: salt
             metalk8s.scality.com/version: 2.5.1-dev
           managed_fields: null
-          name: metalk8s
+          name: metalk8s-prometheus
           namespace: null
           owner_references: null
           resource_version: '29117'
-          self_link: /apis/storage.k8s.io/v1/storageclasses/metalk8s
+          self_link: /apis/storage.k8s.io/v1/storageclasses/metalk8s-prometheus
           uid: 17ba89c5-0774-49d4-9e34-dc999ec69545
         mount_options:
         - rw
@@ -124,7 +124,7 @@ _volumes_details: &volumes_details
         provisioner: kubernetes.io/no-provisioner
         reclaim_policy: Retain
         volume_binding_mode: WaitForFirstConsumer
-      storageClassName: metalk8s
+      storageClassName: metalk8s-prometheus
       template:
         metadata:
           creationTimestamp: null
@@ -298,7 +298,7 @@ _volumes_details: &volumes_details
       name: my-invalid-type-volume
     spec:
       nodeName: bootstrap
-      storageClassName: metalk8s
+      storageClassName: metalk8s-prometheus
       someRandomDevice:
         capacity: 10Gi
 

--- a/tests/kube_utils.py
+++ b/tests/kube_utils.py
@@ -33,7 +33,7 @@ metadata:
   name: {name}
 spec:
   nodeName: bootstrap
-  storageClassName: metalk8s
+  storageClassName: metalk8s-prometheus
   sparseLoopDevice:
     size: 10Gi
 """

--- a/tests/post/features/volume.feature
+++ b/tests/post/features/volume.feature
@@ -3,7 +3,7 @@
 Feature: Volume management
     Scenario: Our StorageClass is deployed
         Given the Kubernetes API is available
-        Then we have a StorageClass 'metalk8s'
+        Then we have a StorageClass 'metalk8s-prometheus'
 
     Scenario: The storage operator is up
         Given the Kubernetes API is available
@@ -18,7 +18,7 @@ Feature: Volume management
               name: test-volume1
             spec:
               nodeName: bootstrap
-              storageClassName: metalk8s
+              storageClassName: metalk8s-prometheus
               sparseLoopDevice:
                 size: 10Gi
               template:
@@ -56,7 +56,7 @@ Feature: Volume management
               name: test-volume4
             spec:
               nodeName: bootstrap
-              storageClassName: metalk8s
+              storageClassName: metalk8s-prometheus
         Then the Volume 'test-volume4' is 'Failed' with code 'InternalError' and message matches 'volume type not found'
 
     Scenario: Create a volume with an invalid volume type
@@ -68,7 +68,7 @@ Feature: Volume management
               name: test-volume5
             spec:
               nodeName: bootstrap
-              storageClassName: metalk8s
+              storageClassName: metalk8s-prometheus
               someRandomDevice:
                 capacity: 10Gi
         Then the Volume 'test-volume5' is 'Failed' with code 'InternalError' and message matches 'volume type not found'
@@ -159,7 +159,7 @@ Feature: Volume management
               name: test-volume11
             spec:
               nodeName: bootstrap
-              storageClassName: metalk8s
+              storageClassName: metalk8s-prometheus
               sparseLoopDevice:
                 size: 10Gi
         Then the Volume 'test-volume11' is 'Pending'
@@ -176,7 +176,7 @@ Feature: Volume management
               name: test-volume12
             spec:
               nodeName: bootstrap
-              storageClassName: metalk8s
+              storageClassName: metalk8s-prometheus
               mode: Block
               sparseLoopDevice:
                 size: 10Gi

--- a/ui/cypress.json
+++ b/ui/cypress.json
@@ -6,7 +6,7 @@
     "password": "password",
     "device_path": "/dev/disk1",
     "volume_capacity": 1,
-    "storage_class":"metalk8s",
+    "storage_class":"metalk8s-prometheus",
     "volume_label_name":"kubernetest.io/name",
     "volume_label_value":"test"
   },

--- a/ui/cypress/integration/common/volume.js
+++ b/ui/cypress/integration/common/volume.js
@@ -32,7 +32,7 @@ Then(
       .eq(0)
       .click();
     cy.get('.sc-select__menu')
-      .find('[data-cy=storageClass-metalk8s]')
+      .find('[data-cy=storageClass-metalk8s-prometheus]')
       .click();
 
     cy.get('.sc-select')
@@ -72,7 +72,7 @@ Then(
       .eq(0)
       .click();
     cy.get('.sc-select__menu')
-      .find('[data-cy=storageClass-metalk8s]')
+      .find('[data-cy=storageClass-metalk8s-prometheus]')
       .click();
 
     cy.get('.sc-select')

--- a/ui/src/ducks/app/volumes.test.js
+++ b/ui/src/ducks/app/volumes.test.js
@@ -675,7 +675,7 @@ it('should delete volume', () => {
         sparseLoopDevice: {
           size: '45Gi',
         },
-        storageClassName: 'metalk8s',
+        storageClassName: 'metalk8s-prometheus',
       },
       status: {
         phase: 'Available',


### PR DESCRIPTION
**Component**: salt, tests, examples, docs

**Context**:
Changes were made in 2.5 when they should have happened in 2.6 only.

**Summary**:
Revert changes done in #2742 to replace the `metalk8s-prometheus` storageclass by `metalk8s` only for development/2.5 branch.

**Acceptance criteria**:
Tests are OK and 2.6 is left untouched.

---

See: #2742