### PR TITLE
Deploy Calico CNI plugin for all node roles

### DIFF
--- a/salt/metalk8s/roles/etcd/init.sls
+++ b/salt/metalk8s/roles/etcd/init.sls
@@ -1,3 +1,3 @@
 include:
-  - metalk8s.roles.internal.node-without-calico
+  - metalk8s.roles.node
   - metalk8s.kubernetes.etcd

--- a/salt/metalk8s/roles/master/init.sls
+++ b/salt/metalk8s/roles/master/init.sls
@@ -1,5 +1,5 @@
 include:
-  - metalk8s.roles.internal.node-without-calico
+  - metalk8s.roles.node
   - metalk8s.kubernetes.apiserver
   - metalk8s.kubernetes.controller-manager
   - metalk8s.kubernetes.scheduler


### PR DESCRIPTION
**Component**: salt

**Context**:
Calico is now needed on all nodes to be able to run fluent-bit.

**Summary**:
Add Calico CNI plugin on master & etcd roles

**Acceptance criteria**:

Tested, looks great, fluent-bit is now running on etcd/master nodes.

---

Closes: #2380