### PR TITLE
ci: Fix environment vars for "retrieve ISO" step

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -1516,8 +1516,8 @@ stages:
           <<: *retrieve_iso
           name: Retrieve promoted ISO image
           env:
+            <<: *_env_retrieve_artifact_retry
             <<: *_env_promoted_artifacts
-            MAX_ATTEMPTS: "300"
       - ShellCommand: &check_promoted_version_iso_checksum
           <<: *check_iso_checksum
           name: Check promoted ISO image with checksum


### PR DESCRIPTION
When making this step generic to allow retrieving Solution ISOs (see
be6efe9), we forgot to update one consumer. This consumer was not
including the step's environment as defaults, which is fixed in this
commit.