### PR TITLE
[UI] Add timespan selection and auto refresh for metrics tab in node page

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -11816,6 +11816,16 @@
         }
       }
     },
+    "object.omit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "dev": true,
+      "requires": {
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
+      }
+    },
     "object.pick": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",

--- a/ui/src/components/NodeListTable.js
+++ b/ui/src/components/NodeListTable.js
@@ -13,6 +13,13 @@ import { useQuery } from '../services/utils';
 import { fontSize, padding } from '@scality/core-ui/dist/style/theme';
 import CircleStatus from './CircleStatus';
 import { Button } from '@scality/core-ui';
+import {
+  LAST_SEVEN_DAYS,
+  LAST_ONE_HOUR,
+  QUERY_LAST_SEVEN_DAYS,
+  QUERY_LAST_TWENTY_FOUR_HOURS,
+  QUERY_LAST_ONE_HOUR,
+} from '../constants';
 import { intl } from '../translations/IntlGlobalProvider';
 
 const NodeListContainer = styled.div`
@@ -312,8 +319,23 @@ const NodeListTable = (props) => {
   const history = useHistory();
   const location = useLocation();
   const { nodeTableData, selectedNodeName } = props;
-
   const theme = useSelector((state) => state.config.theme);
+
+  let queryTimeSpan;
+  const metricsTimeSpan = useSelector(
+    (state) => state.app.monitoring.nodeStats.metricsTimeSpan,
+  );
+
+  switch (metricsTimeSpan) {
+    case LAST_SEVEN_DAYS:
+      queryTimeSpan = QUERY_LAST_SEVEN_DAYS;
+      break;
+    case LAST_ONE_HOUR:
+      queryTimeSpan = QUERY_LAST_ONE_HOUR;
+      break;
+    default:
+      queryTimeSpan = QUERY_LAST_TWENTY_FOUR_HOURS;
+  }
 
   const columns = React.useMemo(
     () => [
@@ -390,8 +412,12 @@ const NodeListTable = (props) => {
       location.pathname.endsWith('volumes') ||
       location.pathname.endsWith('pods');
 
-    if (isTabSelected) {
-      // When switch between the nodes, keep the same tab selected
+    if (isTabSelected && location.pathname.endsWith('metrics')) {
+      // Keep the same timespan selected for metrics tab, when switch between the nodes
+      const currentTab = location?.pathname?.split('/')?.pop();
+      history.push(`/newNodes/${nodeName}/${currentTab}?from=${queryTimeSpan}`);
+    } else if (isTabSelected) {
+      // Keep the same tab selected when switch between the nodes
       const currentTab = location?.pathname?.split('/')?.pop();
       history.push(`/newNodes/${nodeName}/${currentTab}`);
     } else {

--- a/ui/src/components/NodeListTable.js
+++ b/ui/src/components/NodeListTable.js
@@ -313,6 +313,7 @@ const NodeListTable = (props) => {
   const location = useLocation();
   const { nodeTableData, selectedNodeName } = props;
   const theme = useSelector((state) => state.config.theme);
+  const query = useQuery();
 
   const columns = React.useMemo(
     () => [
@@ -391,13 +392,18 @@ const NodeListTable = (props) => {
 
     if (isTabSelected) {
       const newPath = location.pathname.replace(
-        // eslint-disable-next-line no-useless-escape
-        /\/newNodes\/[^\/]*\//,
+        /\/newNodes\/[^/]*\//,
         `/newNodes/${nodeName}/`,
       );
-      history.push(newPath);
+      history.push({
+        pathname: newPath,
+        search: query.toString(),
+      });
     } else {
-      history.push({ pathname: `/newNodes/${nodeName}/health` });
+      history.push({
+        pathname: `/newNodes/${nodeName}/health`,
+        search: query.toString(),
+      });
     }
   };
 

--- a/ui/src/components/NodeListTable.js
+++ b/ui/src/components/NodeListTable.js
@@ -13,13 +13,6 @@ import { useQuery } from '../services/utils';
 import { fontSize, padding } from '@scality/core-ui/dist/style/theme';
 import CircleStatus from './CircleStatus';
 import { Button } from '@scality/core-ui';
-import {
-  LAST_SEVEN_DAYS,
-  LAST_ONE_HOUR,
-  QUERY_LAST_SEVEN_DAYS,
-  QUERY_LAST_TWENTY_FOUR_HOURS,
-  QUERY_LAST_ONE_HOUR,
-} from '../constants';
 import { intl } from '../translations/IntlGlobalProvider';
 
 const NodeListContainer = styled.div`
@@ -321,22 +314,6 @@ const NodeListTable = (props) => {
   const { nodeTableData, selectedNodeName } = props;
   const theme = useSelector((state) => state.config.theme);
 
-  let queryTimeSpan;
-  const metricsTimeSpan = useSelector(
-    (state) => state.app.monitoring.nodeStats.metricsTimeSpan,
-  );
-
-  switch (metricsTimeSpan) {
-    case LAST_SEVEN_DAYS:
-      queryTimeSpan = QUERY_LAST_SEVEN_DAYS;
-      break;
-    case LAST_ONE_HOUR:
-      queryTimeSpan = QUERY_LAST_ONE_HOUR;
-      break;
-    default:
-      queryTimeSpan = QUERY_LAST_TWENTY_FOUR_HOURS;
-  }
-
   const columns = React.useMemo(
     () => [
       {
@@ -412,17 +389,15 @@ const NodeListTable = (props) => {
       location.pathname.endsWith('volumes') ||
       location.pathname.endsWith('pods');
 
-    if (isTabSelected && location.pathname.endsWith('metrics')) {
-      // Keep the same timespan selected for metrics tab, when switch between the nodes
-      const currentTab = location?.pathname?.split('/')?.pop();
-      history.push(`/newNodes/${nodeName}/${currentTab}?from=${queryTimeSpan}`);
-    } else if (isTabSelected) {
-      // Keep the same tab selected when switch between the nodes
-      const currentTab = location?.pathname?.split('/')?.pop();
-      history.push(`/newNodes/${nodeName}/${currentTab}`);
+    if (isTabSelected) {
+      const newPath = location.pathname.replace(
+        // eslint-disable-next-line no-useless-escape
+        /\/newNodes\/[^\/]*\//,
+        `/newNodes/${nodeName}/`,
+      );
+      history.push(newPath);
     } else {
-      // Set Health tab as default tab
-      history.push(`/newNodes/${nodeName}/health`);
+      history.push({ pathname: `/newNodes/${nodeName}/health` });
     }
   };
 

--- a/ui/src/components/NodePageMetricsTab.js
+++ b/ui/src/components/NodePageMetricsTab.js
@@ -168,8 +168,10 @@ const NodePageMetricsTab = (props) => {
     type: 'temporal',
     axis: {
       // Refer to all the available time format: https://github.com/d3/d3-time-format#locale_format
-      // format: '%m/%d %H:%M',
-      format: '%H:%M', // when the timespan is `Last 24 hours`
+      format:
+        metricsTimeSpan === (LAST_ONE_HOUR || LAST_TWENTY_FOUR_HOURS)
+          ? '%H:%M'
+          : '%m/%d',
       // Boolean value that determines whether the axis should include ticks.
       ticks: true,
       tickCount: 4,

--- a/ui/src/components/NodePageMetricsTab.js
+++ b/ui/src/components/NodePageMetricsTab.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import { useHistory } from 'react-router';
 import styled from 'styled-components';
 import {
   fontSize,
@@ -27,6 +28,9 @@ import {
   SAMPLE_FREQUENCY_LAST_SEVEN_DAYS,
   SAMPLE_FREQUENCY_LAST_TWENTY_FOUR_HOURS,
   SAMPLE_FREQUENCY_LAST_ONE_HOUR,
+  QUERY_LAST_SEVEN_DAYS,
+  QUERY_LAST_TWENTY_FOUR_HOURS,
+  QUERY_LAST_ONE_HOUR,
 } from '../constants';
 
 const GraphsContainer = styled.div`
@@ -74,9 +78,11 @@ const NodePageMetricsTab = (props) => {
     instanceIP,
     controlPlaneInterface,
     workloadPlaneInterface,
+    selectedNodeName,
   } = props;
   const dispatch = useDispatch();
   const theme = useSelector((state) => state.config.theme);
+  const history = useHistory();
 
   const metricsTimeSpan = useSelector(
     (state) => state.app.monitoring.nodeStats.metricsTimeSpan,
@@ -245,6 +251,9 @@ const NodePageMetricsTab = (props) => {
       onClick: () => {
         dispatch(updateNodeStatsAction({ metricsTimeSpan: LAST_SEVEN_DAYS }));
         updateMetricsGraph();
+        history.push(
+          `/newNodes/${selectedNodeName}/metrics?from=${QUERY_LAST_SEVEN_DAYS}`,
+        );
       },
       selected: metricsTimeSpan === LAST_SEVEN_DAYS,
     },
@@ -255,6 +264,9 @@ const NodePageMetricsTab = (props) => {
           updateNodeStatsAction({ metricsTimeSpan: LAST_TWENTY_FOUR_HOURS }),
         );
         updateMetricsGraph();
+        history.push(
+          `/newNodes/${selectedNodeName}/metrics?from=${QUERY_LAST_TWENTY_FOUR_HOURS}`,
+        );
       },
       selected: metricsTimeSpan === LAST_TWENTY_FOUR_HOURS,
     },
@@ -263,6 +275,9 @@ const NodePageMetricsTab = (props) => {
       onClick: () => {
         dispatch(updateNodeStatsAction({ metricsTimeSpan: LAST_ONE_HOUR }));
         updateMetricsGraph();
+        history.push(
+          `/newNodes/${selectedNodeName}/metrics?from=${QUERY_LAST_ONE_HOUR}`,
+        );
       },
       selected: metricsTimeSpan === LAST_ONE_HOUR,
     },

--- a/ui/src/components/VolumeMetricGraphCard.js
+++ b/ui/src/components/VolumeMetricGraphCard.js
@@ -28,6 +28,7 @@ import {
   SAMPLE_FREQUENCY_LAST_SEVEN_DAYS,
   SAMPLE_FREQUENCY_LAST_TWENTY_FOUR_HOURS,
   SAMPLE_FREQUENCY_LAST_ONE_HOUR,
+  queryTimeSpansCodes,
 } from '../constants';
 import { intl } from '../translations/IntlGlobalProvider';
 
@@ -114,22 +115,6 @@ const MetricGraphCard = (props) => {
   const metricsTimeSpan = useSelector(
     (state) => state.app.monitoring.volumeStats.metricsTimeSpan,
   );
-
-  // reference array to ensure consistency in encoding/decoding query params
-  const queryTimeSpansCodes = [
-    {
-      label: 'now-7d',
-      value: LAST_SEVEN_DAYS,
-    },
-    {
-      label: 'now-24h',
-      value: LAST_TWENTY_FOUR_HOURS,
-    },
-    {
-      label: 'now-1h',
-      value: LAST_ONE_HOUR,
-    },
-  ];
 
   // write the selected timespan in URL
   const writeUrlTimeSpan = (timespan) => {

--- a/ui/src/constants.js
+++ b/ui/src/constants.js
@@ -43,4 +43,8 @@ export const SAMPLE_FREQUENCY_LAST_SEVEN_DAYS = 60 * 60;
 export const SAMPLE_FREQUENCY_LAST_TWENTY_FOUR_HOURS = 720;
 export const SAMPLE_FREQUENCY_LAST_ONE_HOUR = 30;
 
+export const QUERY_LAST_SEVEN_DAYS = 'now-7d';
+export const QUERY_LAST_TWENTY_FOUR_HOURS = 'now-24h';
+export const QUERY_LAST_ONE_HOUR = 'now-1h';
+
 export const PORT_NODE_EXPORTER = '9100';

--- a/ui/src/constants.js
+++ b/ui/src/constants.js
@@ -43,8 +43,19 @@ export const SAMPLE_FREQUENCY_LAST_SEVEN_DAYS = 60 * 60;
 export const SAMPLE_FREQUENCY_LAST_TWENTY_FOUR_HOURS = 720;
 export const SAMPLE_FREQUENCY_LAST_ONE_HOUR = 30;
 
-export const QUERY_LAST_SEVEN_DAYS = 'now-7d';
-export const QUERY_LAST_TWENTY_FOUR_HOURS = 'now-24h';
-export const QUERY_LAST_ONE_HOUR = 'now-1h';
-
 export const PORT_NODE_EXPORTER = '9100';
+
+export const queryTimeSpansCodes = [
+  {
+    label: 'now-7d',
+    value: LAST_SEVEN_DAYS,
+  },
+  {
+    label: 'now-24h',
+    value: LAST_TWENTY_FOUR_HOURS,
+  },
+  {
+    label: 'now-1h',
+    value: LAST_ONE_HOUR,
+  },
+];

--- a/ui/src/containers/NodePageMetricsTab.js
+++ b/ui/src/containers/NodePageMetricsTab.js
@@ -19,6 +19,7 @@ import { TabContainer } from '../components/CommonLayoutStyle';
 import {
   addMissingDataPoint,
   fromUnixTimestampToDate,
+  useQuery,
 } from '../services/utils';
 import {
   LAST_SEVEN_DAYS,
@@ -77,7 +78,7 @@ const NodePageMetricsTab = (props) => {
   const dispatch = useDispatch();
   const theme = useSelector((state) => state.config.theme);
   const history = useHistory();
-  const query = new URLSearchParams(history?.location?.search);
+  const query = useQuery();
 
   const metricsTimeSpan = useSelector(
     (state) => state.app.monitoring.nodeStats.metricsTimeSpan,

--- a/ui/src/containers/NodePageMetricsTab.js
+++ b/ui/src/containers/NodePageMetricsTab.js
@@ -8,10 +8,7 @@ import {
   fontWeight,
 } from '@scality/core-ui/dist/style/theme';
 import { LineChart, Loader, Dropdown } from '@scality/core-ui';
-import {
-  updateNodeStatsAction,
-  updateNodeStatsFetchArgumentAction,
-} from '../ducks/app/monitoring';
+import { updateNodeStatsFetchArgumentAction } from '../ducks/app/monitoring';
 import {
   yAxisUsage,
   yAxis,
@@ -246,41 +243,19 @@ const NodePageMetricsTab = (props) => {
     }
   };
 
+  // Dropdown items
   const metricsTimeSpanItems = [
-    {
-      label: LAST_SEVEN_DAYS,
-      onClick: () => {
-        dispatch(
-          updateNodeStatsAction({ metricsTimeSpan: LAST_SEVEN_DAYS }),
-          updateNodeStatsFetchArgumentAction(),
-        );
-        writeUrlTimeSpan(LAST_SEVEN_DAYS);
-      },
-      selected: metricsTimeSpan === LAST_SEVEN_DAYS,
+    LAST_SEVEN_DAYS,
+    LAST_TWENTY_FOUR_HOURS,
+    LAST_ONE_HOUR,
+  ].map((option) => ({
+    label: option,
+    onClick: () => {
+      dispatch(updateNodeStatsFetchArgumentAction({ metricsTimeSpan: option }));
+      writeUrlTimeSpan(option);
     },
-    {
-      label: LAST_TWENTY_FOUR_HOURS,
-      onClick: () => {
-        dispatch(
-          updateNodeStatsAction({ metricsTimeSpan: LAST_TWENTY_FOUR_HOURS }),
-          updateNodeStatsFetchArgumentAction(),
-        );
-        writeUrlTimeSpan(LAST_TWENTY_FOUR_HOURS);
-      },
-      selected: metricsTimeSpan === LAST_TWENTY_FOUR_HOURS,
-    },
-    {
-      label: LAST_ONE_HOUR,
-      onClick: () => {
-        dispatch(
-          updateNodeStatsAction({ metricsTimeSpan: LAST_ONE_HOUR }),
-          updateNodeStatsFetchArgumentAction(),
-        );
-        writeUrlTimeSpan(LAST_ONE_HOUR);
-      },
-      selected: metricsTimeSpan === LAST_ONE_HOUR,
-    },
-  ];
+    selected: metricsTimeSpan === option,
+  }));
 
   const metricsTimeSpanDropdownItems = metricsTimeSpanItems?.filter(
     (mTS) => mTS.label !== metricsTimeSpan,

--- a/ui/src/containers/NodePageMetricsTab.js
+++ b/ui/src/containers/NodePageMetricsTab.js
@@ -12,8 +12,8 @@ import {
   updateNodeStatsAction,
   fetchNodeStatsAction,
 } from '../ducks/app/monitoring';
-import { TabContainer } from './CommonLayoutStyle';
 import { yAxisUsage, yAxis, yAxisWriteRead, yAxisInOut } from './LinechartSpec';
+import { TabContainer } from '../components/CommonLayoutStyle';
 import {
   addMissingDataPoint,
   fromUnixTimestampToDate,

--- a/ui/src/containers/NodePageMetricsTab.js
+++ b/ui/src/containers/NodePageMetricsTab.js
@@ -10,7 +10,7 @@ import {
 import { LineChart, Loader, Dropdown } from '@scality/core-ui';
 import {
   updateNodeStatsAction,
-  fetchNodeStatsAction,
+  updateNodeStatsFetchArgumentAction,
 } from '../ducks/app/monitoring';
 import {
   yAxisUsage,
@@ -75,12 +75,7 @@ const DropdownContainer = styled.div`
 `;
 
 const NodePageMetricsTab = (props) => {
-  const {
-    nodeStats,
-    instanceIP,
-    controlPlaneInterface,
-    workloadPlaneInterface,
-  } = props;
+  const { nodeStats } = props;
   const dispatch = useDispatch();
   const theme = useSelector((state) => state.config.theme);
   const history = useHistory();
@@ -89,15 +84,6 @@ const NodePageMetricsTab = (props) => {
   const metricsTimeSpan = useSelector(
     (state) => state.app.monitoring.nodeStats.metricsTimeSpan,
   );
-
-  const updateMetricsGraph = () =>
-    dispatch(
-      fetchNodeStatsAction({
-        instanceIP,
-        controlPlaneInterface,
-        workloadPlaneInterface,
-      }),
-    );
 
   let sampleDuration = null;
   let sampleFrequency = null;
@@ -278,8 +264,10 @@ const NodePageMetricsTab = (props) => {
     {
       label: LAST_SEVEN_DAYS,
       onClick: () => {
-        dispatch(updateNodeStatsAction({ metricsTimeSpan: LAST_SEVEN_DAYS }));
-        updateMetricsGraph();
+        dispatch(
+          updateNodeStatsAction({ metricsTimeSpan: LAST_SEVEN_DAYS }),
+          updateNodeStatsFetchArgumentAction(),
+        );
         writeUrlTimeSpan(LAST_SEVEN_DAYS);
       },
       selected: metricsTimeSpan === LAST_SEVEN_DAYS,
@@ -289,8 +277,8 @@ const NodePageMetricsTab = (props) => {
       onClick: () => {
         dispatch(
           updateNodeStatsAction({ metricsTimeSpan: LAST_TWENTY_FOUR_HOURS }),
+          updateNodeStatsFetchArgumentAction(),
         );
-        updateMetricsGraph();
         writeUrlTimeSpan(LAST_TWENTY_FOUR_HOURS);
       },
       selected: metricsTimeSpan === LAST_TWENTY_FOUR_HOURS,
@@ -298,9 +286,11 @@ const NodePageMetricsTab = (props) => {
     {
       label: LAST_ONE_HOUR,
       onClick: () => {
-        dispatch(updateNodeStatsAction({ metricsTimeSpan: LAST_ONE_HOUR }));
-        updateMetricsGraph();
-        writeUrlTimeSpan(LAST_TWENTY_FOUR_HOURS);
+        dispatch(
+          updateNodeStatsAction({ metricsTimeSpan: LAST_ONE_HOUR }),
+          updateNodeStatsFetchArgumentAction(),
+        );
+        writeUrlTimeSpan(LAST_ONE_HOUR);
       },
       selected: metricsTimeSpan === LAST_ONE_HOUR,
     },

--- a/ui/src/containers/NodePageMetricsTab.js
+++ b/ui/src/containers/NodePageMetricsTab.js
@@ -12,7 +12,12 @@ import {
   updateNodeStatsAction,
   fetchNodeStatsAction,
 } from '../ducks/app/monitoring';
-import { yAxisUsage, yAxis, yAxisWriteRead, yAxisInOut } from './LinechartSpec';
+import {
+  yAxisUsage,
+  yAxis,
+  yAxisWriteRead,
+  yAxisInOut,
+} from '../components/LinechartSpec';
 import { TabContainer } from '../components/CommonLayoutStyle';
 import {
   addMissingDataPoint,
@@ -28,9 +33,6 @@ import {
   SAMPLE_FREQUENCY_LAST_SEVEN_DAYS,
   SAMPLE_FREQUENCY_LAST_TWENTY_FOUR_HOURS,
   SAMPLE_FREQUENCY_LAST_ONE_HOUR,
-  QUERY_LAST_SEVEN_DAYS,
-  QUERY_LAST_TWENTY_FOUR_HOURS,
-  QUERY_LAST_ONE_HOUR,
 } from '../constants';
 
 const GraphsContainer = styled.div`
@@ -78,11 +80,11 @@ const NodePageMetricsTab = (props) => {
     instanceIP,
     controlPlaneInterface,
     workloadPlaneInterface,
-    selectedNodeName,
   } = props;
   const dispatch = useDispatch();
   const theme = useSelector((state) => state.config.theme);
   const history = useHistory();
+  const query = new URLSearchParams(history?.location?.search);
 
   const metricsTimeSpan = useSelector(
     (state) => state.app.monitoring.nodeStats.metricsTimeSpan,
@@ -247,15 +249,38 @@ const NodePageMetricsTab = (props) => {
   };
   const lineConfig = { strokeWidth: 1.5 };
 
+  const queryTimeSpansCodes = [
+    {
+      label: 'now-7d',
+      value: LAST_SEVEN_DAYS,
+    },
+    {
+      label: 'now-24h',
+      value: LAST_TWENTY_FOUR_HOURS,
+    },
+    {
+      label: 'now-1h',
+      value: LAST_ONE_HOUR,
+    },
+  ];
+
+  // write the selected timespan in URL
+  const writeUrlTimeSpan = (timespan) => {
+    let formatted = queryTimeSpansCodes.find((item) => item.value === timespan);
+
+    if (formatted) {
+      query.set('from', formatted.label);
+      history.push({ search: query.toString() });
+    }
+  };
+
   const metricsTimeSpanItems = [
     {
       label: LAST_SEVEN_DAYS,
       onClick: () => {
         dispatch(updateNodeStatsAction({ metricsTimeSpan: LAST_SEVEN_DAYS }));
         updateMetricsGraph();
-        history.push(
-          `/newNodes/${selectedNodeName}/metrics?from=${QUERY_LAST_SEVEN_DAYS}`,
-        );
+        writeUrlTimeSpan(LAST_SEVEN_DAYS);
       },
       selected: metricsTimeSpan === LAST_SEVEN_DAYS,
     },
@@ -266,9 +291,7 @@ const NodePageMetricsTab = (props) => {
           updateNodeStatsAction({ metricsTimeSpan: LAST_TWENTY_FOUR_HOURS }),
         );
         updateMetricsGraph();
-        history.push(
-          `/newNodes/${selectedNodeName}/metrics?from=${QUERY_LAST_TWENTY_FOUR_HOURS}`,
-        );
+        writeUrlTimeSpan(LAST_TWENTY_FOUR_HOURS);
       },
       selected: metricsTimeSpan === LAST_TWENTY_FOUR_HOURS,
     },
@@ -277,9 +300,7 @@ const NodePageMetricsTab = (props) => {
       onClick: () => {
         dispatch(updateNodeStatsAction({ metricsTimeSpan: LAST_ONE_HOUR }));
         updateMetricsGraph();
-        history.push(
-          `/newNodes/${selectedNodeName}/metrics?from=${QUERY_LAST_ONE_HOUR}`,
-        );
+        writeUrlTimeSpan(LAST_TWENTY_FOUR_HOURS);
       },
       selected: metricsTimeSpan === LAST_ONE_HOUR,
     },

--- a/ui/src/containers/NodePageMetricsTab.js
+++ b/ui/src/containers/NodePageMetricsTab.js
@@ -33,6 +33,7 @@ import {
   SAMPLE_FREQUENCY_LAST_SEVEN_DAYS,
   SAMPLE_FREQUENCY_LAST_TWENTY_FOUR_HOURS,
   SAMPLE_FREQUENCY_LAST_ONE_HOUR,
+  queryTimeSpansCodes,
 } from '../constants';
 
 const GraphsContainer = styled.div`
@@ -234,21 +235,6 @@ const NodePageMetricsTab = (props) => {
     },
   };
   const lineConfig = { strokeWidth: 1.5 };
-
-  const queryTimeSpansCodes = [
-    {
-      label: 'now-7d',
-      value: LAST_SEVEN_DAYS,
-    },
-    {
-      label: 'now-24h',
-      value: LAST_TWENTY_FOUR_HOURS,
-    },
-    {
-      label: 'now-1h',
-      value: LAST_ONE_HOUR,
-    },
-  ];
 
   // write the selected timespan in URL
   const writeUrlTimeSpan = (timespan) => {

--- a/ui/src/containers/NodePageRSP.js
+++ b/ui/src/containers/NodePageRSP.js
@@ -25,6 +25,7 @@ import {
   LAST_ONE_HOUR,
   QUERY_LAST_SEVEN_DAYS,
   QUERY_LAST_ONE_HOUR,
+  QUERY_LAST_TWENTY_FOUR_HOURS,
 } from '../constants';
 import { intl } from '../translations/IntlGlobalProvider';
 
@@ -56,19 +57,38 @@ const NodePageRSP = (props) => {
   );
   const theme = useSelector((state) => state.config.theme);
 
-  // we should initialize the `metricsTimeSpan` in redux base on the URL query.
+  // Initialize the `metricsTimeSpan` in redux base on the URL query.
+  // Keep the selected timespan for metrics tab when switch the tabs
   const query = useQuery();
-  const queryTimespan = query.get('from');
-  let metricsTimeSpan = LAST_TWENTY_FOUR_HOURS;
-  switch (queryTimespan) {
-    case QUERY_LAST_SEVEN_DAYS:
-      metricsTimeSpan = LAST_SEVEN_DAYS;
-      break;
-    case QUERY_LAST_ONE_HOUR:
-      metricsTimeSpan = LAST_ONE_HOUR;
-      break;
-    default:
-      metricsTimeSpan = LAST_TWENTY_FOUR_HOURS;
+  const nodeMetricsTimeSpan = useSelector(
+    (state) => state.app.monitoring.nodeStats.metricsTimeSpan,
+  );
+
+  let metricsTimeSpan;
+  let queryTimespan = query.get('from');
+  if (queryTimespan) {
+    switch (queryTimespan) {
+      case QUERY_LAST_SEVEN_DAYS:
+        metricsTimeSpan = LAST_SEVEN_DAYS;
+        break;
+      case QUERY_LAST_ONE_HOUR:
+        metricsTimeSpan = LAST_ONE_HOUR;
+        break;
+      default:
+        metricsTimeSpan = LAST_TWENTY_FOUR_HOURS;
+    }
+  } else {
+    metricsTimeSpan = nodeMetricsTimeSpan;
+    switch (nodeMetricsTimeSpan) {
+      case LAST_SEVEN_DAYS:
+        queryTimespan = QUERY_LAST_SEVEN_DAYS;
+        break;
+      case LAST_ONE_HOUR:
+        queryTimespan = QUERY_LAST_ONE_HOUR;
+        break;
+      default:
+        queryTimespan = QUERY_LAST_TWENTY_FOUR_HOURS;
+    }
   }
 
   // retrieve the podlist data

--- a/ui/src/containers/NodePageRSP.js
+++ b/ui/src/containers/NodePageRSP.js
@@ -107,7 +107,13 @@ const NodePageRSP = (props) => {
           <Route
             path={`/newNodes/${selectedNodeName}/metrics`}
             render={() => (
-              <NodePageMetricsTab nodeStats={nodeStats}></NodePageMetricsTab>
+              <NodePageMetricsTab
+                nodeStats={nodeStats}
+                instanceIP={instanceIP}
+                controlPlaneInterface={controlPlaneInterface}
+                workloadPlaneInterface={workloadPlaneInterface}
+                selectedNodeName={selectedNodeName}
+              />
             )}
           />
           <Route

--- a/ui/src/containers/NodePageRSP.js
+++ b/ui/src/containers/NodePageRSP.js
@@ -16,7 +16,7 @@ import {
 } from '../ducks/app/monitoring';
 import NodePageHealthTab from '../components/NodePageHealthTab';
 import NodePageAlertsTab from '../components/NodePageAlertsTab';
-import NodePageMetricsTab from '../components/NodePageMetricsTab';
+import NodePageMetricsTab from './NodePageMetricsTab';
 import NodePageVolumesTab from '../components/NodePageVolumesTab';
 import NodePagePodsTab from '../components/NodePagePodsTab';
 import {

--- a/ui/src/containers/NodePageRSP.js
+++ b/ui/src/containers/NodePageRSP.js
@@ -9,7 +9,7 @@ import { fetchPodsAction } from '../ducks/app/pods';
 import { getPodsListData } from '../services/PodUtils';
 import { useQuery, useRefreshEffect } from '../services/utils';
 import {
-  fetchNodeStatsAction,
+  updateNodeStatsFetchArgumentAction,
   updateNodeStatsAction,
   refreshNodeStatsAction,
   stopRefreshNodeStatsAction,
@@ -95,6 +95,7 @@ const NodePageRSP = (props) => {
   const pods = useSelector((state) => state.app.pods.list);
   const podsListData = getPodsListData(selectedNodeName, pods);
   useEffect(() => {
+    dispatch(updateNodeStatsFetchArgumentAction());
     dispatch(fetchPodsAction());
     dispatch(
       updateNodeStatsAction({
@@ -104,7 +105,6 @@ const NodePageRSP = (props) => {
         workloadPlaneInterface,
       }),
     );
-    dispatch(fetchNodeStatsAction());
   }, [
     metricsTimeSpan,
     instanceIP,

--- a/ui/src/containers/NodePageRSP.js
+++ b/ui/src/containers/NodePageRSP.js
@@ -19,14 +19,7 @@ import NodePageAlertsTab from '../components/NodePageAlertsTab';
 import NodePageMetricsTab from './NodePageMetricsTab';
 import NodePageVolumesTab from '../components/NodePageVolumesTab';
 import NodePagePodsTab from '../components/NodePagePodsTab';
-import {
-  LAST_SEVEN_DAYS,
-  LAST_TWENTY_FOUR_HOURS,
-  LAST_ONE_HOUR,
-  QUERY_LAST_SEVEN_DAYS,
-  QUERY_LAST_ONE_HOUR,
-  QUERY_LAST_TWENTY_FOUR_HOURS,
-} from '../constants';
+import { queryTimeSpansCodes } from '../constants';
 import { intl } from '../translations/IntlGlobalProvider';
 
 const NodePageRSPContainer = styled.div`
@@ -57,38 +50,23 @@ const NodePageRSP = (props) => {
   );
   const theme = useSelector((state) => state.config.theme);
 
-  // Initialize the `metricsTimeSpan` in redux base on the URL query.
-  // Keep the selected timespan for metrics tab when switch the tabs
+  // Initialize the `metricsTimeSpan` in saga state base on the URL query.
+  // In order to keep the selected timespan for metrics tab when switch between the tabs.
   const query = useQuery();
   const nodeMetricsTimeSpan = useSelector(
     (state) => state.app.monitoring.nodeStats.metricsTimeSpan,
   );
 
   let metricsTimeSpan;
-  let queryTimespan = query.get('from');
+  const queryTimespan = query.get('from');
+
   if (queryTimespan) {
-    switch (queryTimespan) {
-      case QUERY_LAST_SEVEN_DAYS:
-        metricsTimeSpan = LAST_SEVEN_DAYS;
-        break;
-      case QUERY_LAST_ONE_HOUR:
-        metricsTimeSpan = LAST_ONE_HOUR;
-        break;
-      default:
-        metricsTimeSpan = LAST_TWENTY_FOUR_HOURS;
-    }
+    // If timespan query specified in query string
+    metricsTimeSpan = queryTimeSpansCodes?.find(
+      (timespan) => timespan.label === queryTimespan,
+    )?.value;
   } else {
     metricsTimeSpan = nodeMetricsTimeSpan;
-    switch (nodeMetricsTimeSpan) {
-      case LAST_SEVEN_DAYS:
-        queryTimespan = QUERY_LAST_SEVEN_DAYS;
-        break;
-      case LAST_ONE_HOUR:
-        queryTimespan = QUERY_LAST_ONE_HOUR;
-        break;
-      default:
-        queryTimespan = QUERY_LAST_TWENTY_FOUR_HOURS;
-    }
   }
 
   // retrieve the podlist data

--- a/ui/src/containers/NodePageRSP.js
+++ b/ui/src/containers/NodePageRSP.js
@@ -95,13 +95,6 @@ const NodePageRSP = (props) => {
   const pods = useSelector((state) => state.app.pods.list);
   const podsListData = getPodsListData(selectedNodeName, pods);
   useEffect(() => {
-    dispatch(
-      fetchNodeStatsAction({
-        instanceIP,
-        controlPlaneInterface,
-        workloadPlaneInterface,
-      }),
-    );
     dispatch(fetchPodsAction());
     dispatch(
       updateNodeStatsAction({
@@ -111,6 +104,7 @@ const NodePageRSP = (props) => {
         workloadPlaneInterface,
       }),
     );
+    dispatch(fetchNodeStatsAction());
   }, [
     metricsTimeSpan,
     instanceIP,

--- a/ui/src/containers/NodePageRSP.js
+++ b/ui/src/containers/NodePageRSP.js
@@ -22,6 +22,7 @@ const NodePageRSPContainer = styled.div`
 
   .sc-tabs-item-content {
     padding: 0;
+    overflow-y: auto;
   }
 `;
 

--- a/ui/src/containers/NodePageRSP.js
+++ b/ui/src/containers/NodePageRSP.js
@@ -10,7 +10,6 @@ import { getPodsListData } from '../services/PodUtils';
 import { useQuery, useRefreshEffect } from '../services/utils';
 import {
   updateNodeStatsFetchArgumentAction,
-  updateNodeStatsAction,
   refreshNodeStatsAction,
   stopRefreshNodeStatsAction,
 } from '../ducks/app/monitoring';
@@ -73,16 +72,15 @@ const NodePageRSP = (props) => {
   const pods = useSelector((state) => state.app.pods.list);
   const podsListData = getPodsListData(selectedNodeName, pods);
   useEffect(() => {
-    dispatch(updateNodeStatsFetchArgumentAction());
-    dispatch(fetchPodsAction());
     dispatch(
-      updateNodeStatsAction({
+      updateNodeStatsFetchArgumentAction({
         metricsTimeSpan,
         instanceIP,
         controlPlaneInterface,
         workloadPlaneInterface,
       }),
     );
+    dispatch(fetchPodsAction());
   }, [
     metricsTimeSpan,
     instanceIP,

--- a/ui/src/ducks/app/monitoring.js
+++ b/ui/src/ducks/app/monitoring.js
@@ -203,8 +203,8 @@ export const stopRefreshCurrentVolumeStatsAction = () => {
 export const updateCurrentVolumeStatsAction = (payload) => {
   return { type: UPDATE_CURRENT_VOLUMESTATS, payload };
 };
-export const fetchNodeStatsAction = (payload) => {
-  return { type: FETCH_NODESTATS, payload };
+export const fetchNodeStatsAction = () => {
+  return { type: FETCH_NODESTATS };
 };
 export const updateNodeStatsAction = (payload) => {
   return { type: UPDATE_NODESTATS, payload };
@@ -583,8 +583,10 @@ export function* stopRefreshCurrentStats() {
   yield put(updateCurrentVolumeStatsAction({ isRefreshing: false }));
 }
 
-export function* fetchNodeStats({ payload }) {
-  const { instanceIP, controlPlaneInterface, workloadPlaneInterface } = payload;
+export function* fetchNodeStats() {
+  const instanceIP = yield select(instanceIPSelector);
+  const controlPlaneInterface = yield select(controlPlaneInterfaceSelector);
+  const workloadPlaneInterface = yield select(workloadPlaneInterfaceSelector);
 
   let cpuUsage = [];
   let systemLoad = [];
@@ -752,20 +754,10 @@ export function* fetchNodeStats({ payload }) {
 }
 
 export function* refreshNodeStats() {
-  const instanceIP = yield select(instanceIPSelector);
-  const controlPlaneInterface = yield select(controlPlaneInterfaceSelector);
-  const workloadPlaneInterface = yield select(workloadPlaneInterfaceSelector);
-
   yield put(updateNodeStatsAction({ isRefreshing: true }));
-  if (instanceIP && controlPlaneInterface && workloadPlaneInterface) {
-    yield call(fetchNodeStats, {
-      payload: {
-        instanceIP: instanceIP,
-        controlPlaneInterface: controlPlaneInterface,
-        workloadPlaneInterface: workloadPlaneInterface,
-      },
-    });
-  }
+
+  yield call(fetchNodeStats);
+
   yield delay(REFRESH_METRCIS_GRAPH);
 
   const isRefreshing = yield select(isNodeStatsRefreshing);

--- a/ui/src/ducks/app/monitoring.js
+++ b/ui/src/ducks/app/monitoring.js
@@ -60,6 +60,7 @@ const UPDATE_NODESTATS = 'UPDATE_NODESTATS';
 const FETCH_NODESTATS = 'FETCH_NODESTATS';
 const REFRESH_NODESTATS = 'REFRESH_NODESTATS';
 const STOP_REFRESH_NODESTATS = 'STOP_REFRESH_NODESTATS';
+const UPDATE_NODESTATS_FETCH_ARG = 'UPDATE_NODESTATS_FETCH_ARG';
 
 // Reducer
 const defaultState = {
@@ -218,6 +219,9 @@ export const refreshNodeStatsAction = () => {
 };
 export const stopRefreshNodeStatsAction = () => {
   return { type: STOP_REFRESH_NODESTATS };
+};
+export const updateNodeStatsFetchArgumentAction = () => {
+  return { type: UPDATE_NODESTATS_FETCH_ARG };
 };
 
 // Selectors
@@ -769,10 +773,9 @@ export function* watchRefreshNodeStats() {
         // If the refresh period expires before we receive a halt,
         // we can refresh the stats
         requeue: delay(REFRESH_METRCIS_GRAPH),
-        // NOTE: This action doesn't exist, but it should, so that
         // whenever we change one of the parameters for "fetchNodeStats",
         // it gets triggered again
-        // update: take(UPDATE_SELECTED_NODE),
+        update: take(UPDATE_NODESTATS_FETCH_ARG),
       });
       if (interrupt) {
         yield cancel(fetchNodeStats);

--- a/ui/src/ducks/app/monitoring.js
+++ b/ui/src/ducks/app/monitoring.js
@@ -56,10 +56,12 @@ const FETCH_CURRENT_VOLUESTATS = 'FETCH_CURRENT_VOLUESTATS';
 const REFRESH_CURRENT_VOLUMESTATS = 'REFRESH_CURRENT_VOLUMESTATS';
 const STOP_REFRESH_CURRENT_VOLUMESTATS = 'STOP_REFRESH_CURRENT_VOLUMESTATS';
 
+// To update the `app.monitoring.nodeStats.metrics`
 const UPDATE_NODESTATS = 'UPDATE_NODESTATS';
 const FETCH_NODESTATS = 'FETCH_NODESTATS';
 const REFRESH_NODESTATS = 'REFRESH_NODESTATS';
 const STOP_REFRESH_NODESTATS = 'STOP_REFRESH_NODESTATS';
+// To update the arguments to fetch nodeStats
 const UPDATE_NODESTATS_FETCH_ARG = 'UPDATE_NODESTATS_FETCH_ARG';
 
 // Reducer
@@ -143,6 +145,7 @@ export default function reducer(state = defaultState, action = {}) {
         volumeCurrentStats: { ...state.volumeCurrentStats, ...action.payload },
       };
     case UPDATE_NODESTATS:
+    case UPDATE_NODESTATS_FETCH_ARG:
       return {
         ...state,
         nodeStats: { ...state.nodeStats, ...action.payload },
@@ -220,8 +223,8 @@ export const refreshNodeStatsAction = () => {
 export const stopRefreshNodeStatsAction = () => {
   return { type: STOP_REFRESH_NODESTATS };
 };
-export const updateNodeStatsFetchArgumentAction = () => {
-  return { type: UPDATE_NODESTATS_FETCH_ARG };
+export const updateNodeStatsFetchArgumentAction = (payload) => {
+  return { type: UPDATE_NODESTATS_FETCH_ARG, payload };
 };
 
 // Selectors

--- a/ui/src/ducks/app/monitoring.js
+++ b/ui/src/ducks/app/monitoring.js
@@ -1,4 +1,12 @@
-import { put, takeEvery, takeLatest, call, all, delay, select } from 'redux-saga/effects';
+import {
+  put,
+  takeEvery,
+  takeLatest,
+  call,
+  all,
+  delay,
+  select,
+} from 'redux-saga/effects';
 import {
   getAlerts,
   queryPrometheus,

--- a/ui/src/services/PodUtils.js
+++ b/ui/src/services/PodUtils.js
@@ -8,7 +8,7 @@ export const getPodsListData = (nodeName, pods) => {
     podsList?.map((pod) => {
       const age = fromMilliSectoAge(new Date() - pod.startTime);
 
-      const numContainer = pod.containerStatuses.length;
+      const numContainer = pod?.containerStatuses?.length;
       const containerReady =
         pod?.containerStatuses?.filter((pCS) => pCS.ready === true) ?? [];
       return {


### PR DESCRIPTION
**Component**: ui, nodes

**Context**:  Add timespan selection and auto-refresh for metrics tab in the Node page

**Summary**:
- Add timespan selection in `metrics` tab, by default is Last 24 hours
- Add selected timespan in URL query
- Add auto-fresh of graphs every 1 min
- Keep the selected timespan when we switch back to metrics tab
- When we select a node from the list, we don't add the default the timespan(from=now-24h) in the URL. 
- The style of dropdown component is not the same as design. (Need to work on it in Core-ui)
- Launch a long-time running saga at the root of saga to watch the Refresh_NODESTATS action.

**Acceptance criteria**: 
![image](https://user-images.githubusercontent.com/18453133/93862114-e0e1bf00-fcc1-11ea-9d6d-49cf13e0f08f.png)

![image](https://user-images.githubusercontent.com/18453133/93861686-36699c00-fcc1-11ea-91b3-2c8358ad2a34.png)


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2776 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
