### PR TITLE
ui/volumes: Store metrics timespan in URL

### DIFF
--- a/ui/src/components/VolumeMetricGraphCard.js
+++ b/ui/src/components/VolumeMetricGraphCard.js
@@ -105,7 +105,7 @@ const NoDataGraphText = styled.div`
 `;
 
 const MetricGraphCard = (props) => {
-  const { volumeCondition, volumeMetricGraphData } = props;
+  const { volumeCondition, volumeMetricGraphData, volumeName } = props;
   const dispatch = useDispatch();
   const history = useHistory();
   const query = new URLSearchParams(history?.location?.search);
@@ -144,14 +144,19 @@ const MetricGraphCard = (props) => {
     const urlTimeSpan = queryTimeSpansCodes.find(
       item => item.label === query.get('from')
     );
+
+    // If a time span is specified we apply it
+    // Else if a timespan has been set but is not in the URL yet (change of volume) we write it to the URL
     if (urlTimeSpan) {
       dispatch(updateVolumeStatsAction({ metricsTimeSpan: urlTimeSpan.value }));
       updateMetricsGraph();
+    } else if (metricsTimeSpan !== LAST_TWENTY_FOUR_HOURS && !urlTimeSpan) {
+      writeUrlTimeSpan(metricsTimeSpan);
     }
   }
   
-  // set the timespan if specified in url query
-  useEffect(handleUrlQuery, []);
+  // handle timespan in url query
+  useEffect(handleUrlQuery, [volumeName]);
 
   const updateMetricsGraph = () => dispatch(fetchVolumeStatsAction());
 

--- a/ui/src/containers/VolumePageContent.js
+++ b/ui/src/containers/VolumePageContent.js
@@ -168,6 +168,7 @@ const VolumePageContent = (props) => {
             PVCName={PVCName}
           ></ActiveAlertsCard>
           <MetricGraphCard
+            volumeName={currentVolumeName}
             volumeMetricGraphData={volumeMetricGraphData}
             // the volume condition compute base on the `status` and `bound/unbound`
             volumeCondition={currentVolume.status}

--- a/ui/src/ducks/app/monitoring.js
+++ b/ui/src/ducks/app/monitoring.js
@@ -1,4 +1,4 @@
-import { put, takeEvery, call, all, delay, select } from 'redux-saga/effects';
+import { put, takeEvery, takeLatest, call, all, delay, select } from 'redux-saga/effects';
 import {
   getAlerts,
   queryPrometheus,
@@ -522,10 +522,10 @@ export function* stopRefreshCurrentStats() {
 }
 
 export function* monitoringSaga() {
-  yield takeEvery(FETCH_VOLUMESTATS, fetchVolumeStats);
+  yield takeLatest(FETCH_VOLUMESTATS, fetchVolumeStats);
   yield takeEvery(REFRESH_VOLUMESTATS, refreshVolumeStats);
   yield takeEvery(STOP_REFRESH_VOLUMESTATS, stopRefreshVolumeStats);
-  yield takeEvery(FETCH_CURRENT_VOLUESTATS, fetchCurrentVolumeStats);
+  yield takeLatest(FETCH_CURRENT_VOLUESTATS, fetchCurrentVolumeStats);
   yield takeEvery(REFRESH_CURRENT_VOLUMESTATS, refreshCurrentVolumeStats);
   yield takeEvery(STOP_REFRESH_CURRENT_VOLUMESTATS, stopRefreshCurrentStats);
   yield takeEvery(REFRESH_CLUSTER_STATUS, refreshClusterStatus);


### PR DESCRIPTION
**Component**: ui

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

We want to store the Volume metrics timespan in the URL as a param query to allow users to share the URL while specifying a timespan.

**Summary**:

On timespan selection we write the param query to the URL following the specs described in the issue : 
* Last 7days: `&from=now-7d`
* Last 24hours: `&from=now-24h`
* Last 1 hour: `&from=now-1h`


On metrics card component load, we check if a `from` param query is defined. If it is set we dispatch an Update Volume Stats redux action followed by a data fetch.

To handle URL query strings parsing and generation I used the `query-string` package ( https://www.npmjs.com/package/query-string ). I found this package to be reliable and well-maintained (over 12M weekly downloads), however I can still switch to a custom handmade URL query param system if needed.

**Acceptance criteria**: 
* Changing a timespan on the Volume metrics updates the URL with query params
* On page load if a valid query param is set, the timespan is changed accordingly
* If other query params are set they are preserved 



---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2754 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
