### PR TITLE
[UI-improvement] Running the tasks to fetch graphs data in parallel

### DIFF
--- a/ui/src/components/VolumeListTable.js
+++ b/ui/src/components/VolumeListTable.js
@@ -75,6 +75,7 @@ const HeadRow = styled.tr`
 `;
 
 const TableRow = styled(HeadRow)`
+  height: 48px;
   &:hover,
   &:focus {
     background-color: ${(props) => props.theme.brand.backgroundBluer};

--- a/ui/src/ducks/app/monitoring.js
+++ b/ui/src/ducks/app/monitoring.js
@@ -307,13 +307,13 @@ export function* stopRefreshClusterStatus() {
 }
 
 export function* fetchVolumeStats() {
-  let volumeUsage = {};
-  let volumeThroughputWrite = {};
-  let volumeThroughputRead = {};
-  let volumeLatencyWrite = {};
-  let volumeLatencyRead = {};
-  let volumeIOPSRead = {};
-  let volumeIOPSWrite = {};
+  let volumeUsage = [];
+  let volumeThroughputWrite = [];
+  let volumeThroughputRead = [];
+  let volumeLatencyWrite = [];
+  let volumeLatencyRead = [];
+  let volumeIOPSRead = [];
+  let volumeIOPSWrite = [];
 
   let sampleDuration;
   let sampleFrequency;
@@ -455,9 +455,9 @@ export function* fetchVolumeStats() {
 }
 
 export function* fetchCurrentVolumeStats() {
-  let volumeUsedCurrent = {};
-  let volumeCapacityCurrent = {};
-  let volumeLatencyCurrent = {};
+  let volumeUsedCurrent = [];
+  let volumeCapacityCurrent = [];
+  let volumeLatencyCurrent = [];
 
   const volumeLatencyCurrentQuery = `irate(node_disk_io_time_seconds_total[1h]) * 1000000`;
   // Grafana - Used Space: kubelet_volume_stats_capacity_bytes - kubelet_volume_stats_available_bytes

--- a/ui/src/ducks/app/monitoring.js
+++ b/ui/src/ducks/app/monitoring.js
@@ -441,13 +441,13 @@ export function* fetchVolumeStats() {
   }
 
   const metrics = {
-    volumeUsage: volumeUsage,
-    volumeThroughputWrite: volumeThroughputWrite,
-    volumeThroughputRead: volumeThroughputRead,
-    volumeLatencyWrite: volumeLatencyWrite,
-    volumeLatencyRead: volumeLatencyRead,
-    volumeIOPSWrite: volumeIOPSWrite,
-    volumeIOPSRead: volumeIOPSRead,
+    volumeUsage,
+    volumeThroughputWrite,
+    volumeThroughputRead,
+    volumeLatencyWrite,
+    volumeLatencyRead,
+    volumeIOPSWrite,
+    volumeIOPSRead,
     queryStartingTime: startingTimestamp,
   };
 
@@ -487,9 +487,9 @@ export function* fetchCurrentVolumeStats() {
   }
 
   const metrics = {
-    volumeUsedCurrent: volumeUsedCurrent,
-    volumeCapacityCurrent: volumeCapacityCurrent,
-    volumeLatencyCurrent: volumeLatencyCurrent,
+    volumeUsedCurrent,
+    volumeCapacityCurrent,
+    volumeLatencyCurrent,
   };
   yield put(updateCurrentVolumeStatsAction({ metrics: metrics }));
 }

--- a/ui/src/ducks/app/monitoring.js
+++ b/ui/src/ducks/app/monitoring.js
@@ -351,61 +351,66 @@ export function* fetchVolumeStats() {
   const volumeLatencyWriteQuery = `sum(irate(node_disk_write_time_seconds_total[5m]) / irate(node_disk_writes_completed_total[5m])) by (instance, device) * 1000000`;
   const volumeLatencyReadQuery = `sum(irate(node_disk_read_time_seconds_total[5m]) / irate(node_disk_reads_completed_total[5m])) by (instance, device) * 1000000`;
 
-  const volumeUsageQueryResult = yield call(
-    queryPrometheusRange,
-    startingTimeISO,
-    currentTimeISO,
-    sampleFrequency,
-    volumeUsageQuery,
-  );
-
-  const volumeThroughputReadQueryResult = yield call(
-    queryPrometheusRange,
-    startingTimeISO,
-    currentTimeISO,
-    sampleFrequency,
-    volumeThroughputReadQuery,
-  );
-
-  const volumeThroughputWriteQueryResult = yield call(
-    queryPrometheusRange,
-    startingTimeISO,
-    currentTimeISO,
-    sampleFrequency,
-    volumeThroughputWriteQuery,
-  );
-
-  const volumeLatencyQueryWriteResult = yield call(
-    queryPrometheusRange,
-    startingTimeISO,
-    currentTimeISO,
-    sampleFrequency,
-    volumeLatencyWriteQuery,
-  );
-
-  const volumeLatencyQueryReadResult = yield call(
-    queryPrometheusRange,
-    startingTimeISO,
-    currentTimeISO,
-    sampleFrequency,
-    volumeLatencyReadQuery,
-  );
-
-  const volumeIOPSReadQueryResult = yield call(
-    queryPrometheusRange,
-    startingTimeISO,
-    currentTimeISO,
-    sampleFrequency,
-    volumeIOPSReadQuery,
-  );
-
-  const volumeIOPSWriteQueryResult = yield call(
-    queryPrometheusRange,
-    startingTimeISO,
-    currentTimeISO,
-    sampleFrequency,
-    volumeIOPSWriteQuery,
-  );
+  // Effects will get executed in parallel
+  const [
+    volumeUsageQueryResult,
+    volumeThroughputReadQueryResult,
+    volumeThroughputWriteQueryResult,
+    volumeLatencyQueryWriteResult,
+    volumeLatencyQueryReadResult,
+    volumeIOPSReadQueryResult,
+    volumeIOPSWriteQueryResult,
+  ] = yield all([
+    call(
+      queryPrometheusRange,
+      startingTimeISO,
+      currentTimeISO,
+      sampleFrequency,
+      volumeUsageQuery,
+    ),
+    call(
+      queryPrometheusRange,
+      startingTimeISO,
+      currentTimeISO,
+      sampleFrequency,
+      volumeThroughputReadQuery,
+    ),
+    call(
+      queryPrometheusRange,
+      startingTimeISO,
+      currentTimeISO,
+      sampleFrequency,
+      volumeThroughputWriteQuery,
+    ),
+    call(
+      queryPrometheusRange,
+      startingTimeISO,
+      currentTimeISO,
+      sampleFrequency,
+      volumeLatencyWriteQuery,
+    ),
+    call(
+      queryPrometheusRange,
+      startingTimeISO,
+      currentTimeISO,
+      sampleFrequency,
+      volumeLatencyReadQuery,
+    ),
+    call(
+      queryPrometheusRange,
+      startingTimeISO,
+      currentTimeISO,
+      sampleFrequency,
+      volumeIOPSReadQuery,
+    ),
+    call(
+      queryPrometheusRange,
+      startingTimeISO,
+      currentTimeISO,
+      sampleFrequency,
+      volumeIOPSWriteQuery,
+    ),
+  ]);
 
   if (!volumeUsageQueryResult.error) {
     volumeUsage = volumeUsageQueryResult.data.result;
@@ -459,26 +464,24 @@ export function* fetchCurrentVolumeStats() {
   const volumeUsedQuery = 'kubelet_volume_stats_used_bytes';
   const volumeCapacityQuery = 'kubelet_volume_stats_capacity_bytes';
 
-  const volumeUsedCurrentQueryResult = yield call(
-    queryPrometheus,
-    volumeUsedQuery,
-  );
+  const [
+    volumeUsedCurrentQueryResult,
+    volumeCapacityCurrentQueryResult,
+    volumeLatencyCurrentResult,
+  ] = yield all([
+    call(queryPrometheus, volumeUsedQuery),
+    call(queryPrometheus, volumeCapacityQuery),
+    call(queryPrometheus, volumeLatencyCurrentQuery),
+  ]);
+
   if (!volumeUsedCurrentQueryResult.error) {
     volumeUsedCurrent = volumeUsedCurrentQueryResult.data.result;
   }
 
-  const volumeCapacityCurrentQueryResult = yield call(
-    queryPrometheus,
-    volumeCapacityQuery,
-  );
   if (!volumeCapacityCurrentQueryResult.error) {
     volumeCapacityCurrent = volumeCapacityCurrentQueryResult.data.result;
   }
 
-  const volumeLatencyCurrentResult = yield call(
-    queryPrometheus,
-    volumeLatencyCurrentQuery,
-  );
   if (!volumeLatencyCurrentResult.error) {
     volumeLatencyCurrent = volumeLatencyCurrentResult.data.result;
   }


### PR DESCRIPTION
**Component**: ui, volumes

**Context**:  We should call the Prometheus API to fetch the data for the Metrics graphs in parallel.

**Summary**:
- Execute the tasks in parallel.
- Set the height of the row in the volume list table(A UI improvement)

**Acceptance criteria**: 

![image](https://user-images.githubusercontent.com/18453133/94433014-f52d2c80-0197-11eb-9a9c-236bc691892f.png)


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
