### PR TITLE
ui/volumes: Replace Prometheus alerts by AlertManager

### DIFF
--- a/ui/src/components/VolumeActiveAlertsCard.js
+++ b/ui/src/components/VolumeActiveAlertsCard.js
@@ -74,7 +74,7 @@ const ActiveAlertsCard = (props) => {
       name: alert.labels.alertname,
       severity: alert.labels.severity,
       alert_description: alert.annotations.message,
-      active_since: alert.activeAt,
+      active_since: alert.startsAt,
     };
   });
   // React Table for the volume list

--- a/ui/src/containers/VolumePage.js
+++ b/ui/src/containers/VolumePage.js
@@ -5,6 +5,7 @@ import { padding } from '@scality/core-ui/dist/style/theme';
 import VolumeContent from './VolumePageContent';
 import { fetchPodsAction } from '../ducks/app/pods';
 import { refreshNodesAction, stopRefreshNodesAction } from '../ducks/app/nodes';
+import { refreshAlertManagerAction, stopRefreshAlertManagerAction } from '../ducks/app/alerts';
 import { makeGetNodeFromUrl, useRefreshEffect } from '../services/utils';
 import { fetchNodesAction } from '../ducks/app/nodes';
 import {
@@ -16,8 +17,6 @@ import {
 } from '../ducks/app/volumes';
 import {
   fetchVolumeStatsAction,
-  refreshAlertsAction,
-  stopRefreshAlertsAction,
   fetchCurrentVolumeStatsAction,
   refreshCurrentVolumeStatsAction,
   stopRefreshCurrentVolumeStatsAction,
@@ -63,10 +62,12 @@ const VolumePage = (props) => {
     dispatch(fetchCurrentVolumeStatsAction());
     dispatch(fetchPersistentVolumeClaimAction());
   }, [dispatch]);
-  useEffect(() => {
-    dispatch(refreshAlertsAction());
-    return () => dispatch(stopRefreshAlertsAction());
-  }, [dispatch]);
+
+  useRefreshEffect(
+    refreshAlertManagerAction,
+    stopRefreshAlertManagerAction,
+  );
+
 
   // get all the pods for all the nodes
   const theme = useSelector((state) => state.config.theme);
@@ -75,7 +76,8 @@ const VolumePage = (props) => {
   const nodes = useSelector((state) => state.app.nodes.list);
   const volumes = useSelector((state) => state.app.volumes.list);
   const pVList = useSelector((state) => state.app.volumes.pVList);
-  const alerts = useSelector((state) => state.app.monitoring.alert);
+  const alerts = useSelector((state) => state.app.alerts);
+
   const volumeStats = useSelector(
     (state) => state.app.monitoring.volumeStats.metrics,
   );

--- a/ui/src/services/NodeVolumesUtils.js
+++ b/ui/src/services/NodeVolumesUtils.js
@@ -137,7 +137,7 @@ export const volumeGetError = (status) => {
 
 const getPVList = (state) => state?.app?.volumes?.pVList;
 const getPVCList = (state) => state?.app?.volumes?.pVCList;
-const getAlerts = (state) => state?.app?.monitoring?.alert;
+const getAlerts = (state) => state?.app?.alerts;
 const getNodes = (state) => state?.app?.nodes?.list;
 
 const getVolumeLatencyCurrent = (state) =>

--- a/ui/src/services/NodeVolumesUtilsData.js
+++ b/ui/src/services/NodeVolumesUtilsData.js
@@ -1020,5 +1020,6 @@ export const stateApp = {
         isRefreshing: true,
       },
     },
+    alerts: { list : [] },
   },
 };


### PR DESCRIPTION
**Component**: ui, volumes, monitoring

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

Currently the alerts from the volumes page come from the Prometheus API. We want to switch to use AlertManager's API instead.

**Summary**:

The AlertManager service was already implemented. I added a few Redux actions to replicate the current refresh behavior we had with Prometheus.

**Acceptance criteria**: 

* Alerts on the volume page are retrieved from AlertManager's API
* Alerts are displayed properly


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2793 
