### PR TITLE
Bump k8s for metalk8s development/2.7

### DIFF
--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -101,8 +101,8 @@ CONTAINER_IMAGES : Tuple[Image, ...] = (
     ),
     Image(
         name='coredns',
-        version='1.6.5',
-        digest='sha256:7ec975f167d815311a7136c32e70735f0d00b73781365df1befd46ed35bd4fe7',
+        version='1.6.7',
+        digest='sha256:2c8d61c46f484d881db43b34d13ca47a269336e576c81cf007ca740fa9ec0800',
     ),
     Image(
         name='dex',

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -604,8 +604,7 @@ stages:
           name: Trigger upgrade and downgrade test stages simultaneously
           stage_names:
             - single-node-upgrade-centos
-            # Cannot downgrade from a 3.4 etcd cluster to 3.3
-            # - single-node-downgrade-centos
+            - single-node-downgrade-centos
           waitForFinish: True
 
   create-upload-testrail-objects:
@@ -1476,8 +1475,7 @@ stages:
           doStepIf: "%(prop:minor_present)s"
           stage_names:
             - single-node-upgrade-promoted-centos
-            # Cannot downgrade from a 3.4 etcd cluster to 3.3
-            #- single-node-downgrade-promoted-centos
+            - single-node-downgrade-promoted-centos
 
 
 # --- Upgrade for promoted versions ---

--- a/eve/wait_pods_status.sh
+++ b/eve/wait_pods_status.sh
@@ -117,4 +117,8 @@ done
 echo "Pods are still not $STATUS after $RETRY retries in" \
      "$SECONDS seconds!"
 
+kubectl get pods "$NAMESPACE" \
+    --field-selector="status.phase!=$STATUS" \
+    --kubeconfig="$KUBECONFIG"
+
 exit 1

--- a/examples/metalk8s-solution-example/ui/deploy/deployment.yaml
+++ b/examples/metalk8s-solution-example/ui/deploy/deployment.yaml
@@ -38,7 +38,7 @@ spec:
         operator: "Exists"
         effect: "NoSchedule"
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         node-role.kubernetes.io/infra: ''
       containers:
         - name: example-solution-ui

--- a/salt/_utils/kubernetes_utils.py
+++ b/salt/_utils/kubernetes_utils.py
@@ -269,18 +269,6 @@ if HAS_LIBS:
             name='namespaced_stateful_set',
         ),
         # }}}
-        # /apis/apps/v1beta2/ {{{
-        ('apps/v1beta2', 'DaemonSet'): KindInfo(
-            model=k8s_client.V1beta2DaemonSet,
-            api_cls=k8s_client.AppsV1beta2Api,
-            name='namespaced_daemon_set',
-        ),
-        ('apps/v1beta2', 'Deployment'): KindInfo(
-            model=k8s_client.V1beta2Deployment,
-            api_cls=k8s_client.AppsV1beta2Api,
-            name='namespaced_deployment',
-        ),
-        # }}}
         # /apis/extensions/v1beta1/ {{{
         ('extensions/v1beta1', 'Ingress'): KindInfo(
             model=k8s_client.ExtensionsV1beta1Ingress,

--- a/salt/metalk8s/addons/ui/deployed/files/metalk8s-ui-deployment.yaml
+++ b/salt/metalk8s/addons/ui/deployed/files/metalk8s-ui-deployment.yaml
@@ -28,7 +28,7 @@ spec:
         operator: "Exists"
         effect: "NoSchedule"
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         node-role.kubernetes.io/infra: ''
       containers:
         - name: metalk8s-ui

--- a/salt/metalk8s/kubernetes/apiserver-proxy/files/apiserver-proxy.yaml.j2
+++ b/salt/metalk8s/kubernetes/apiserver-proxy/files/apiserver-proxy.yaml.j2
@@ -17,7 +17,7 @@ spec:
   hostNetwork: true
   dnsPolicy: ClusterFirstWithHostNet
   nodeSelector:
-    beta.kubernetes.io/os: linux
+    kubernetes.io/os: linux
   securityContext:
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false

--- a/salt/metalk8s/kubernetes/coredns/files/coredns-deployment.yaml.j2
+++ b/salt/metalk8s/kubernetes/coredns/files/coredns-deployment.yaml.j2
@@ -37,7 +37,7 @@ spec:
           operator: "Exists"
           effect: "NoSchedule"
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         node-role.kubernetes.io/infra: ''
       containers:
       - name: coredns
@@ -83,8 +83,8 @@ spec:
           failureThreshold: 5
         readinessProbe:
           httpGet:
-            path: /health
-            port: 8080
+            path: /ready
+            port: 8181
             scheme: HTTP
       dnsPolicy: Default
       serviceAccountName: coredns

--- a/tests/post/steps/test_service_configuration.py
+++ b/tests/post/steps/test_service_configuration.py
@@ -197,6 +197,8 @@ class ClusterServiceConfiguration:
             'state.sls',
             'metalk8s.deployed',
             'saltenv=metalk8s-{}'.format(self.version),
+            '--log-level=warning',
+            '--out=json'
         ]
 
         utils.run_salt_command(self.host, cmd, self.ssh_config)


### PR DESCRIPTION
**Component**:

'kubernetes'

**Context**: 

Development/2.7 initialization

**Summary**:

- Bump K8s to 1.18.9
- Bump coredns to 1.6.7
- Enable back downgrade test

---
