### PR TITLE
[UI] Add the pod tab in new node page

### DIFF
--- a/ui/src/components/NodePagePodsTab.js
+++ b/ui/src/components/NodePagePodsTab.js
@@ -4,6 +4,7 @@ import { useTable } from 'react-table';
 import styled from 'styled-components';
 import { fontSize, padding } from '@scality/core-ui/dist/style/theme';
 import { TabContainer } from './CommonLayoutStyle';
+import { intl } from '../translations/IntlGlobalProvider';
 
 const PodTableContainer = styled.div`
   color: ${(props) => props.theme.brand.textPrimary};
@@ -106,7 +107,15 @@ function Table({ columns, data }) {
                     ...cell.column.cellStyle,
                   },
                 });
-                return <Cell {...cellProps}>{cell.render('Cell')}</Cell>;
+                if (cell.column.Header !== 'Name' && cell.value === undefined) {
+                  return (
+                    <Cell {...cellProps}>
+                      <div>{intl.translate('unknown')}</div>
+                    </Cell>
+                  );
+                } else {
+                  return <Cell {...cellProps}>{cell.render('Cell')}</Cell>;
+                }
               })}
             </TableRow>
           );

--- a/ui/src/components/NodePagePodsTab.js
+++ b/ui/src/components/NodePagePodsTab.js
@@ -1,8 +1,179 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
+import { useTable } from 'react-table';
+import styled from 'styled-components';
+import { fontSize, padding } from '@scality/core-ui/dist/style/theme';
 import { TabContainer } from './CommonLayoutStyle';
 
+const PodTableContainer = styled.div`
+  color: ${(props) => props.theme.brand.textPrimary};
+  padding: ${padding.large};
+  font-family: 'Lato';
+  font-size: ${fontSize.base};
+  border-color: ${(props) => props.theme.brand.borderLight};
+  .ReactTable .rt-thead {
+    overflow-y: scroll;
+  }
+  table {
+    border-spacing: 0;
+    th {
+      font-weight: bold;
+      height: 56px;
+      text-align: left;
+      padding: ${padding.smaller};
+    }
+  }
+`;
+
+const HeadRow = styled.tr`
+  width: 100%;
+  /* To display scroll bar on the table */
+  display: table;
+  table-layout: fixed;
+`;
+
+const TableRow = styled(HeadRow)`
+  height: 40px;
+`;
+
+// * table body
+const Body = styled.tbody`
+  /* To display scroll bar on the table */
+  display: block;
+  height: calc(100vh - 250px);
+  overflow: auto;
+  overflow-y: scroll;
+`;
+
+const Cell = styled.td`
+  overflow-wrap: break-word;
+  border-top: 1px solid #424242;
+`;
+
+// the color of the status depends on if all the containers are running
+const StatusText = styled.div`
+  color: ${(props) => {
+    if (props.isAllContainerRunning) {
+      return props.theme.brand.healthy;
+    } else {
+      return props.theme.brand.warning;
+    }
+  }}};
+`;
+
+const ExternalLink = styled.a`
+  color: ${(props) => props.theme.brand.border};
+`;
+
+function Table({ columns, data }) {
+  // Use the state and functions returned from useTable to build your UI
+  const {
+    getTableProps,
+    getTableBodyProps,
+    headerGroups,
+    rows,
+    prepareRow,
+  } = useTable({
+    columns,
+    data,
+  });
+
+  // Render the UI for your table
+  return (
+    <table {...getTableProps()}>
+      <thead>
+        {headerGroups.map((headerGroup) => {
+          return (
+            <HeadRow {...headerGroup.getHeaderGroupProps()}>
+              {headerGroup.headers.map((column) => {
+                const headerStyleProps = column.getHeaderProps({
+                  style: column.cellStyle,
+                });
+                return <th {...headerStyleProps}>{column.render('Header')}</th>;
+              })}
+            </HeadRow>
+          );
+        })}
+      </thead>
+      <Body {...getTableBodyProps()}>
+        {rows.map((row, i) => {
+          prepareRow(row);
+          return (
+            <TableRow {...row.getRowProps()}>
+              {row.cells.map((cell) => {
+                let cellProps = cell.getCellProps({
+                  style: {
+                    ...cell.column.cellStyle,
+                  },
+                });
+                return <Cell {...cellProps}>{cell.render('Cell')}</Cell>;
+              })}
+            </TableRow>
+          );
+        })}
+      </Body>
+    </table>
+  );
+}
+
 const NodePagePodsTab = (props) => {
-  return <TabContainer>Pods</TabContainer>;
+  const { pods } = props;
+  const config = useSelector((state) => state.config);
+
+  const columns = React.useMemo(
+    () => [
+      {
+        Header: 'Name',
+        accessor: 'name',
+        cellStyle: { width: '250px' },
+      },
+      {
+        Header: 'Status',
+        accessor: 'status',
+        Cell: (cellProps) => {
+          const { status, isAllContainerRunning } = cellProps.value;
+          return (
+            <StatusText isAllContainerRunning={isAllContainerRunning}>
+              {status}
+            </StatusText>
+          );
+        },
+      },
+      {
+        Header: 'Age',
+        accessor: 'age',
+      },
+      {
+        Header: 'Namespace',
+        accessor: 'namespace',
+        cellStyle: { width: '150px' },
+      },
+      {
+        Header: 'Logs',
+        accessor: 'log',
+        cellStyle: { textAlign: 'center' },
+        Cell: ({ value }) => {
+          return (
+            <ExternalLink
+              href={`${config.api.url_grafana}/dashboard/db/logs?orgId=1&var-logs=Loki&var-logmetrics=Prometheus&var-metrics=Prometheus&var-podlogs=.*&var-systemlogs=.%2B&var-deployment=calico-kube-controllers&var-pod=${value}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <i className="fas fa-chart-line" />
+            </ExternalLink>
+          );
+        },
+      },
+    ],
+    [config],
+  );
+  return (
+    <TabContainer>
+      <PodTableContainer>
+        <Table columns={columns} data={pods} />
+      </PodTableContainer>
+    </TabContainer>
+  );
 };
 
 export default NodePagePodsTab;

--- a/ui/src/containers/NodePageRSP.js
+++ b/ui/src/containers/NodePageRSP.js
@@ -6,6 +6,8 @@ import styled from 'styled-components';
 import { Tabs } from '@scality/core-ui';
 import { padding } from '@scality/core-ui/dist/style/theme';
 import { fetchNodeStatsAction } from '../ducks/app/monitoring';
+import { fetchPodsAction } from '../ducks/app/pods';
+import { getPodsListData } from '../services/PodUtils';
 import NodePageHealthTab from '../components/NodePageHealthTab';
 import NodePageAlertsTab from '../components/NodePageAlertsTab';
 import NodePageMetricsTab from '../components/NodePageMetricsTab';
@@ -49,6 +51,12 @@ const NodePageRSP = (props) => {
     );
   }, [instanceIP, controlPlaneInterface, workloadPlaneInterface, dispatch]);
 
+  useEffect(() => {
+    dispatch(fetchPodsAction());
+  }, [dispatch]);
+  // retrieve the podlist data
+  const pods = useSelector((state) => state.app.pods.list);
+  const podsListData = getPodsListData(selectedNodeName, pods);
   const isHealthTabActive = location.pathname.endsWith('/health');
   const isAlertsTabActive = location.pathname.endsWith('/alerts');
   const isMetricsTabActive = location.pathname.endsWith('/metrics');
@@ -107,7 +115,9 @@ const NodePageRSP = (props) => {
           />
           <Route
             path={`/newNodes/${selectedNodeName}/pods`}
-            component={NodePagePodsTab}
+            render={() => (
+              <NodePagePodsTab pods={podsListData}></NodePagePodsTab>
+            )}
           />
         </Switch>
       </Tabs>

--- a/ui/src/ducks/app/pods.js
+++ b/ui/src/ducks/app/pods.js
@@ -48,6 +48,7 @@ export function* fetchPods() {
             name: volume.name,
             persistentVolumeClaim: volume?.persistentVolumeClaim?.claimName,
           })),
+          containerStatuses: pod?.status?.containerStatuses,
         })),
       ),
     );

--- a/ui/src/ducks/app/pods.test.js
+++ b/ui/src/ducks/app/pods.test.js
@@ -13,23 +13,24 @@ it('update the pods state when fetchPods', () => {
         {
           metadata: {
             name: 'coredns',
-            namespace: 'kube-system'
+            namespace: 'kube-system',
           },
           status: {
             phase: 'Running',
             startTime: '2019-29-03',
             containerStatuses: [
               {
-                restartCount: '2'
-              }
-            ]
+                restartCount: '2',
+                ready: true,
+              },
+            ],
           },
           spec: {
-            nodeName: 'bootstrap'
-          }
-        }
-      ]
-    }
+            nodeName: 'bootstrap',
+          },
+        },
+      ],
+    },
   };
 
   const pods = [
@@ -39,11 +40,17 @@ it('update the pods state when fetchPods', () => {
       nodeName: 'bootstrap',
       status: 'Running',
       startTime: '2019-29-03',
-      restartCount: '2'
-    }
+      restartCount: '2',
+      containerStatuses: [
+        {
+          restartCount: '2',
+          ready: true,
+        },
+      ],
+    },
   ];
 
   expect(gen.next(result).value).toEqual(
-    put({ type: SET_PODS, payload: pods })
+    put({ type: SET_PODS, payload: pods }),
   );
 });

--- a/ui/src/services/PodUtils.js
+++ b/ui/src/services/PodUtils.js
@@ -1,0 +1,26 @@
+import { fromMilliSectoAge } from './utils.js';
+
+// Return the pod list for the Pod Tab in Node Page
+export const getPodsListData = (nodeName, pods) => {
+  const podsList = pods?.filter((pod) => pod.nodeName === nodeName);
+
+  return (
+    podsList?.map((pod) => {
+      const age = fromMilliSectoAge(new Date() - pod.startTime);
+
+      const numContainer = pod.containerStatuses.length;
+      const containerReady =
+        pod?.containerStatuses?.filter((pCS) => pCS.ready === true) ?? [];
+      return {
+        name: pod.name,
+        age: age,
+        namespace: pod.namespace,
+        status: {
+          status: `${pod.status} (${containerReady.length}/${numContainer})`,
+          isAllContainerRunning: containerReady.length === numContainer,
+        },
+        log: pod.name,
+      };
+    }) ?? []
+  );
+};

--- a/ui/src/services/utils.js
+++ b/ui/src/services/utils.js
@@ -329,3 +329,35 @@ export const fromUnixTimestampToDate = (date) => {
     return new Date(date * 1000);
   }
 };
+
+// Convert the timestamp from milliseconds to Age.
+// For example: 1h1s, 1d1h, 1d1s, 1d
+export const fromMilliSectoAge = (milliSecTime) => {
+  if (milliSecTime >= 1000) {
+    let day, hour, minute, second;
+    const age = [];
+
+    second = Math.floor(milliSecTime / 1000);
+    minute = Math.floor(second / 60);
+    hour = Math.floor(minute / 60);
+    day = Math.floor(hour / 24);
+
+    second = second % 60;
+    minute = minute % 60;
+    hour = hour % 24;
+
+    if (day > 0) {
+      age.push(day + 'd');
+    }
+    if (hour > 0) {
+      age.push(hour + 'h');
+    }
+    if (minute > 0) {
+      age.push(minute + 'm');
+    }
+    if (second > 0) {
+      age.push(second + 's');
+    }
+    return age.slice(0, 2).join('');
+  }
+};

--- a/ui/src/services/utils.test.js
+++ b/ui/src/services/utils.test.js
@@ -1,8 +1,4 @@
-import {
-  sortCapacity,
-  addMissingDataPoint,
-  jointDataPointBaseonTimeSeries,
-} from './utils';
+import { sortCapacity, addMissingDataPoint, fromMilliSectoAge } from './utils';
 
 const testcases = [
   { storageCapacity: '1Ki' },
@@ -217,4 +213,25 @@ it('should return all zero when the original dataset is all zero', () => {
     sampleFrequency,
   );
   expect(result).toEqual(originalValueWithAllZero);
+});
+
+// test for fromMilliSectoAge
+it('should return undefined if {milliSecTime} is zero or negative number', () => {
+  const result = fromMilliSectoAge(0);
+  expect(result).toEqual(undefined);
+});
+
+it('should return undefined if {milliSecTime} is less than 1 second', () => {
+  const result = fromMilliSectoAge(999);
+  expect(result).toEqual(undefined);
+});
+
+it('should return 1h1s if {milliSecTime} is 3601000', () => {
+  const result = fromMilliSectoAge(3601000);
+  expect(result).toEqual('1h1s');
+});
+
+it('should return 1d1m instead of 1d1m1s or 1d1s', () => {
+  const result = fromMilliSectoAge(86461000);
+  expect(result).toEqual('1d1m');
 });


### PR DESCRIPTION
**Component**: ui, nodes

**Context**:  Add pod tab in the New Node Page.

**Summary**:
- When we hover on the graph icon in the log column, we can see the URL at the button left. 
- When we click on the graph icon, we should be redirected to the `logs dashboard` in Grafana filer by the current pod. 
Note that, another tab in the browser should be open. 
- The color of the `Status` is either yellow or green, depending on if all the containers running.
- The format of the Age is displayed refer to the `kubectl get pod`.

**Acceptance criteria**: 
![image](https://user-images.githubusercontent.com/18453133/94653373-c5973500-02fb-11eb-8266-ae27eb296d49.png)


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2778

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
