### PR TITLE
Calico disable Felix usage reporting, and add some comments

### DIFF
--- a/salt/metalk8s/kubernetes/cni/calico/deployed.sls
+++ b/salt/metalk8s/kubernetes/cni/calico/deployed.sls
@@ -3712,6 +3712,10 @@ spec:
               value: "info"
             - name: FELIX_HEALTHENABLED
               value: "true"
+            # Note: We do not want to report about outgoing connections
+            #       in Metalk8s
+            - name: FELIX_USAGEREPORTINGENABLED
+              value: "false"
           securityContext:
             privileged: true
           resources:

--- a/salt/metalk8s/kubernetes/cni/calico/deployed.sls
+++ b/salt/metalk8s/kubernetes/cni/calico/deployed.sls
@@ -3840,6 +3840,8 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+        # Note: We want to tie `calico-kube-controllers` Pod on master node
+        #       in MetalK8s
         node-role.kubernetes.io/master: ''
       tolerations:
         # Mark the pod as a critical add-on for rescheduling.
@@ -3847,6 +3849,7 @@ spec:
           operator: Exists
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+        # Note: Add tolerations for MetalK8s taints
         - key: node-role.kubernetes.io/bootstrap
           effect: NoSchedule
         - key: node-role.kubernetes.io/infra


### PR DESCRIPTION
**Component**:

'salt'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

**Summary**:

- We do not want to report about outgoing connection in Calico
- Add comment about tuning in Calico manifest to make future Calico upgrade easier

---
