### PR TITLE
salt: Fix Kubernetes `replace_object` for Service with ClusterIP

### DIFF
--- a/salt/_modules/metalk8s_kubernetes.py
+++ b/salt/_modules/metalk8s_kubernetes.py
@@ -195,7 +195,9 @@ def _object_manipulation_function(action):
             if 'resourceVersion' in old_object['metadata']:
                 call_kwargs['body'].metadata.resourceVersion = \
                     old_object['metadata']['resourceVersion']
-            if obj.api_version == 'v1' and obj.kind == 'Service':
+            # Keep `cluster_ip` if not present in the body
+            if obj.api_version == 'v1' and obj.kind == 'Service' \
+                    and not call_kwargs['body'].spec.cluster_ip:
                 call_kwargs['body'].spec.cluster_ip = \
                     old_object['spec']['cluster_ip']
 

--- a/salt/tests/unit/modules/files/test_metalk8s_kubernetes.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_kubernetes.yaml
@@ -253,7 +253,7 @@ replace_object:
           heritage: salt
         resourceVersion: "123456"
 
-    # Replace service object (special case we need to keep cluster_ip)
+  # Replace service object (special case we need to keep cluster_ip)
   - manifest:
       apiVersion: v1
       kind: Service
@@ -280,6 +280,40 @@ replace_object:
         resourceVersion: "123456"
       spec:
         clusterIP: "10.11.12.13"
+
+  # Replace service object (special case: cluster_ip set in the manifest and
+  # old_object, keep the manifest one)
+  # NOTE: This test just ensure we keep the one from input manifest and not
+  #       replace it with the one from old_object, but in practice apiServer
+  #       will reject this call since cluster_ip is immutable field
+  - manifest:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: my_service
+      spec:
+        clusterIP: "20.21.22.23"
+    old_object:
+      # Old object is considered as k8s object so snake case
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: my_service
+        resource_version: "123456"
+      spec:
+        cluster_ip: "10.11.12.13"
+    result:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: my_service
+        labels:
+          metalk8s.scality.com/version: unknown
+          app.kubernetes.io/managed-by: salt
+          heritage: salt
+        resourceVersion: "123456"
+      spec:
+        clusterIP: "20.21.22.23"
 
   # Error when replacing object
   - manifest:

--- a/salt/tests/unit/modules/test_metalk8s_kubernetes.py
+++ b/salt/tests/unit/modules/test_metalk8s_kubernetes.py
@@ -48,7 +48,7 @@ class Metalk8sKubernetesTestCase(TestCase, LoaderModuleMockMixin):
             obj.metadata.resourceVersion = meta.get('resourceVersion')
             obj.metadata.resource_version = meta.get('resource_version')
 
-            obj.spec.cluster_ip = manifest.get('spec', {}).get('cluster_ip')
+            obj.spec.cluster_ip = manifest.get('spec', {}).get('clusterIP')
 
             def _to_dict():
                 if obj.metadata.resourceVersion:
@@ -58,6 +58,8 @@ class Metalk8sKubernetesTestCase(TestCase, LoaderModuleMockMixin):
                 if obj.spec.cluster_ip:
                     manifest.setdefault('spec', {})['clusterIP'] = \
                         obj.spec.cluster_ip
+                    if 'cluster_ip' in manifest.get('spec', {}):
+                        del manifest['spec']['cluster_ip']
 
                 return manifest
 


### PR DESCRIPTION
**Component**:

'salt'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

#2794 

**Summary**:

Before this commit when we tried to replace a Service with `clusterIP`
the `clusterIP` were always replaced with the one from old_object, which
is wrong, if we provide a `clusterIP` in the input manifest we should
keep this one and not replace it with the one from old_object.
So that we let apiServer reject this call and not report a "Success"
where at the end `clusterIP` not get updated at all

---

Fixes: #2794 
