### PR TITLE
[UI] New volumes page

### DIFF
--- a/ui/public/brand/theme.json
+++ b/ui/public/brand/theme.json
@@ -1,7 +1,8 @@
 {
   "theme":{
     "light":{
-      "brand":{      
+      "brand":{
+        "alert": "#A39300",
         "base": "#607080",
         "primary": "#FAF9FB",
         "primaryDark1": "#F7F6F9",
@@ -10,41 +11,46 @@
         "secondaryDark1": "#1C3D59",
         "secondaryDark2": "#1C2E3F",
         "success": "#006F62",
-        "healthy": "#25AC56",
-        "healthyLight": "#75FE63",
-        "warning": "#FFC10A",
-        "danger": "#EF3340",
-        "critical": "#BE2543",
+        "healthy": "#24871D",
+        "healthyLight": "#33A919",
+        "warning": "#946F00",
+        "danger": "#AA1D05",
+        "critical": "#BE321F",
         "background": "#ffffff",
         "backgroundBluer": "#ECF4FF",
         "textPrimary": "#313B44",
         "textSecondary": "#8593A0",
-        "borderLight": "#A5A5A5",
-        "border": "#A5A5A5"
+        "textTertiary": "#A7B6C3",
+        "borderLight": "#EBEBEB",
+        "border": "#A5A5A5",
+        "info": "#8C8C8C"
       },
       "logo_path":"/brand/assets/branding-light.svg"
     },
     "dark":{
       "brand":{
-        "base": "#6A7B92",
-        "primary": "#1D1D1F",
-        "primaryDark1": "#171718",
+        "alert": "#FFE508",
+        "base": "#7B7B7B",
+        "primary": "#1D1D1D",
+        "primaryDark1": "#171717",
         "primaryDark2": "#0A0A0A",
-        "secondary": "#037AFF",
+        "secondary": "#055DFF",
         "secondaryDark1": "#1C3D59",
         "secondaryDark2": "#1C2E3F",
         "success": "#006F62",
-        "healthy": "#25AC56",
-        "healthyLight": "#75FE63",
+        "healthy": "#30AC26",
+        "healthyLight": "#69E44C",
         "warning": "#FFC10A",
-        "danger": "#EF3340",
-        "critical": "#BE2543",
-        "background": "#121214",
-        "backgroundBluer": "#182A41",
+        "danger": "#AA1D05",
+        "critical": "#BE321F",
+        "background": "#121212",
+        "backgroundBluer": "#192A41",
         "textPrimary": "#FFFFFF",
-        "textSecondary": "#A8B5C1",
-        "borderLight": "#2C3137",
-        "border": "#A5A5A5"
+        "textSecondary": "#B5B5B5",
+        "textTertiary": "#DFDFDF",
+        "borderLight": "#A5A5A5",
+        "border": "#313131",
+        "info": "#434343"
       },
       "logo_path":"/brand/assets/branding-dark.svg"
     },

--- a/ui/src/components/ActiveAlertsCounter.js
+++ b/ui/src/components/ActiveAlertsCounter.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useHistory, useLocation } from 'react-router';
+import { padding, fontSize } from '@scality/core-ui/dist/style/theme';
+import { STATUS_WARNING, STATUS_CRITICAL } from '../constants.js';
+
+export const CountersWrapper = styled.div`
+  color: ${(props) => props.theme.brand.textPrimary};
+  display: flex;
+  justify-content: space-around;
+`;
+
+export const CounterWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  cursor: pointer;
+`;
+
+export const CounterValueWrapper = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+export const CounterTitle = styled.div`
+  padding: ${padding.smaller} 0px;
+  text-align: center;
+  font-size: ${fontSize.small};
+`;
+export const CounterValue = styled.div`
+  font-size: ${fontSize.larger};
+  padding-left: ${padding.smaller};
+`;
+
+export const CounterIcon = styled.i`
+  color: ${(props) => {
+    const theme = props.theme.brand;
+    let color = theme.textPrimary;
+
+    switch (props.status) {
+      case STATUS_WARNING:
+        color = theme.warning;
+        break;
+      case STATUS_CRITICAL:
+        color = theme.danger;
+        break;
+      default:
+        color = theme.textPrimary;
+    }
+    return color;
+  }};
+`;
+
+const ActiveAlertsCounter = (props) => {
+  const { alerts, baseLink } = props;
+  const history = useHistory();
+  const location = useLocation();
+
+  const getLink = (status) => {
+    const query = new URLSearchParams(location.search);
+    const existing = query.getAll('severity');
+    if (existing.indexOf(status) === -1) {
+      query.set('severity', status);
+    }
+    return `${baseLink}?${query.toString()}`;
+  };
+
+  const criticalCounter = alerts?.filter(
+    (item) => item?.labels?.severity === STATUS_CRITICAL,
+  ).length;
+  const warningCounter = alerts?.filter(
+    (item) => item?.labels?.severity === STATUS_WARNING,
+  ).length;
+
+  return (
+    <CountersWrapper>
+      <CounterWrapper onClick={() => history.push(getLink(STATUS_CRITICAL))}>
+        <CounterTitle>Critical</CounterTitle>
+        <CounterValueWrapper>
+          <CounterIcon
+            className="fas fa-times-circle"
+            status={STATUS_CRITICAL}
+          />
+          <CounterValue>{criticalCounter}</CounterValue>
+        </CounterValueWrapper>
+      </CounterWrapper>
+      <CounterWrapper onClick={() => history.push(getLink(STATUS_WARNING))}>
+        <CounterTitle>Warning</CounterTitle>
+        <CounterValueWrapper>
+          <CounterIcon
+            className="fas fa-exclamation-triangle"
+            status={STATUS_WARNING}
+          />
+          <CounterValue>{warningCounter}</CounterValue>
+        </CounterValueWrapper>
+      </CounterWrapper>
+    </CountersWrapper>
+  );
+};
+
+export default ActiveAlertsCounter;

--- a/ui/src/components/ActiveAlertsCounter.js
+++ b/ui/src/components/ActiveAlertsCounter.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { useHistory, useLocation } from 'react-router';
+import { useHistory, useLocation, useRouteMatch } from 'react-router';
 import { padding, fontSize } from '@scality/core-ui/dist/style/theme';
 import { STATUS_WARNING, STATUS_CRITICAL } from '../constants.js';
 
@@ -51,9 +51,10 @@ export const CounterIcon = styled.i`
 `;
 
 const ActiveAlertsCounter = (props) => {
-  const { criticalCounter, warningCounter, baseLink } = props;
+  const { criticalCounter, warningCounter } = props;
   const history = useHistory();
   const location = useLocation();
+  const match = useRouteMatch();
 
   const getLink = (status) => {
     const query = new URLSearchParams(location.search);
@@ -61,7 +62,7 @@ const ActiveAlertsCounter = (props) => {
     if (existing.indexOf(status) === -1) {
       query.set('severity', status);
     }
-    return `${baseLink}?${query.toString()}`;
+    return `${match.url.replace(/\/overview/, '/alerts')}?${query.toString()}`;
   };
 
   return (

--- a/ui/src/components/ActiveAlertsCounter.js
+++ b/ui/src/components/ActiveAlertsCounter.js
@@ -51,7 +51,7 @@ export const CounterIcon = styled.i`
 `;
 
 const ActiveAlertsCounter = (props) => {
-  const { alerts, baseLink } = props;
+  const { criticalCounter, warningCounter, baseLink } = props;
   const history = useHistory();
   const location = useLocation();
 
@@ -63,13 +63,6 @@ const ActiveAlertsCounter = (props) => {
     }
     return `${baseLink}?${query.toString()}`;
   };
-
-  const criticalCounter = alerts?.filter(
-    (item) => item?.labels?.severity === STATUS_CRITICAL,
-  ).length;
-  const warningCounter = alerts?.filter(
-    (item) => item?.labels?.severity === STATUS_WARNING,
-  ).length;
 
   return (
     <CountersWrapper>

--- a/ui/src/components/ActiveAlertsCounter.js
+++ b/ui/src/components/ActiveAlertsCounter.js
@@ -38,7 +38,7 @@ export const CounterIcon = styled.i`
 
     switch (props.status) {
       case STATUS_WARNING:
-        color = theme.warning;
+        color = theme.alert;
         break;
       case STATUS_CRITICAL:
         color = theme.danger;

--- a/ui/src/components/ActiveAlertsFilters.js
+++ b/ui/src/components/ActiveAlertsFilters.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Dropdown } from '@scality/core-ui';
+import { useHistory } from 'react-router';
+import { useQuery } from '../services/utils';
+import { padding } from '@scality/core-ui/dist/style/theme';
+import { STATUS_WARNING, STATUS_CRITICAL } from '../constants.js';
+
+export const FilterIcon = styled.i`
+  color: ${(props) => {
+    const theme = props.theme.brand;
+    let color = theme.textPrimary;
+
+    switch (props.status) {
+      case STATUS_WARNING:
+        color = theme.warning;
+        break;
+      case STATUS_CRITICAL:
+        color = theme.danger;
+        break;
+      default:
+        color = theme.textPrimary;
+    }
+    return color;
+  }};
+  padding: ${padding.smaller};
+`;
+
+const ActiveAlertsFilter = (props) => {
+  const { baseLink } = props;
+  const history = useHistory();
+  const query = useQuery();
+  const selectedFilter = query.get('severity');
+
+  let items = [
+    {
+      label: 'All',
+      value: 'all',
+      onClick: () => {
+        query.delete('severity');
+        history.push(`${baseLink}?${query.toString()}`);
+      },
+      iconCode: '',
+    },
+    {
+      label: 'Critical',
+      value: STATUS_CRITICAL,
+      onClick: () => {
+        query.set('severity', STATUS_CRITICAL);
+        history.push(`${baseLink}?${query.toString()}`);
+      },
+      iconCode: 'fas fa-times-circle',
+    },
+    {
+      label: 'Warning',
+      value: STATUS_WARNING,
+      onClick: () => {
+        query.set('severity', STATUS_WARNING);
+        history.push(`${baseLink}?${query.toString()}`);
+      },
+      iconCode: 'fas fa-exclamation-triangle',
+    },
+  ];
+
+  const dropDownLabel = (() => {
+    if (!selectedFilter) return items[0].label;
+
+    const item = items.find((item) => item.value === selectedFilter);
+    return (
+      <span>
+        {item.value !== 'all' && (
+          <FilterIcon status={item.value} className={item.iconCode} />
+        )}
+        {item.label}
+      </span>
+    );
+  })();
+
+  if (selectedFilter) {
+    items = items.filter((item) => item.value !== selectedFilter);
+  } else {
+    items.splice(0, 1);
+  }
+
+  return <Dropdown items={items} text={dropDownLabel} size="small" />;
+};
+
+export default ActiveAlertsFilter;

--- a/ui/src/components/ActiveAlertsFilters.js
+++ b/ui/src/components/ActiveAlertsFilters.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Dropdown } from '@scality/core-ui';
-import { useHistory } from 'react-router';
+import { useHistory, useRouteMatch } from 'react-router';
 import { useQuery } from '../services/utils';
 import { padding } from '@scality/core-ui/dist/style/theme';
 import { STATUS_WARNING, STATUS_CRITICAL } from '../constants.js';
@@ -33,9 +33,9 @@ export const ActiveAlertsFilterWrapper = styled.div`
 `;
 
 const ActiveAlertsFilter = (props) => {
-  const { baseLink } = props;
   const history = useHistory();
   const query = useQuery();
+  const match = useRouteMatch();
   const selectedFilter = query.get('severity');
 
   let items = [
@@ -44,7 +44,7 @@ const ActiveAlertsFilter = (props) => {
       value: 'all',
       onClick: () => {
         query.delete('severity');
-        history.push(`${baseLink}?${query.toString()}`);
+        history.push(`${match.url}?${query.toString()}`);
       },
       iconCode: '',
     },
@@ -53,7 +53,7 @@ const ActiveAlertsFilter = (props) => {
       value: STATUS_CRITICAL,
       onClick: () => {
         query.set('severity', STATUS_CRITICAL);
-        history.push(`${baseLink}?${query.toString()}`);
+        history.push(`${match.url}?${query.toString()}`);
       },
       iconCode: 'fas fa-times-circle',
     },
@@ -62,7 +62,7 @@ const ActiveAlertsFilter = (props) => {
       value: STATUS_WARNING,
       onClick: () => {
         query.set('severity', STATUS_WARNING);
-        history.push(`${baseLink}?${query.toString()}`);
+        history.push(`${match.url}?${query.toString()}`);
       },
       iconCode: 'fas fa-exclamation-triangle',
     },

--- a/ui/src/components/ActiveAlertsFilters.js
+++ b/ui/src/components/ActiveAlertsFilters.js
@@ -26,6 +26,12 @@ export const FilterIcon = styled.i`
   padding: ${padding.smaller};
 `;
 
+export const ActiveAlertsFilterWrapper = styled.div`
+  .sc-dropdown > div {
+    background-color: ${(props) => props.theme.brand.info};
+  }
+`;
+
 const ActiveAlertsFilter = (props) => {
   const { baseLink } = props;
   const history = useHistory();
@@ -82,7 +88,11 @@ const ActiveAlertsFilter = (props) => {
     items.splice(0, 1);
   }
 
-  return <Dropdown items={items} text={dropDownLabel} size="small" />;
+  return (
+    <ActiveAlertsFilterWrapper>
+      <Dropdown items={items} text={dropDownLabel} size="small" />
+    </ActiveAlertsFilterWrapper>
+  );
 };
 
 export default ActiveAlertsFilter;

--- a/ui/src/components/CommonLayoutStyle.js
+++ b/ui/src/components/CommonLayoutStyle.js
@@ -64,3 +64,12 @@ export const TabTitle = styled.div`
   font-weight: ${fontWeight.bold};
   padding: 35px 0 ${padding.small} ${padding.large};
 `;
+
+export const TextBadge = styled.span`
+  background-color: ${(props) => props.theme.brand.base};
+  color: ${(props) => props.theme.brand.textPrimary};
+  padding: 2px ${padding.small};
+  border-radius: 4px;
+  font-size: ${fontSize.small}
+  font-weight: ${fontWeight.bold}
+`;

--- a/ui/src/components/CommonLayoutStyle.js
+++ b/ui/src/components/CommonLayoutStyle.js
@@ -66,7 +66,7 @@ export const TabTitle = styled.div`
 `;
 
 export const TextBadge = styled.span`
-  background-color: ${(props) => props.theme.brand.base};
+  background-color: ${(props) => props.theme.brand.info};
   color: ${(props) => props.theme.brand.textPrimary};
   padding: 2px ${padding.small};
   border-radius: 4px;

--- a/ui/src/components/CommonLayoutStyle.js
+++ b/ui/src/components/CommonLayoutStyle.js
@@ -1,5 +1,9 @@
 import styled from 'styled-components';
-import { padding } from '@scality/core-ui/dist/style/theme';
+import {
+  padding,
+  fontSize,
+  fontWeight,
+} from '@scality/core-ui/dist/style/theme';
 
 export const PageContainer = styled.div`
   display: flex;

--- a/ui/src/components/CommonLayoutStyle.js
+++ b/ui/src/components/CommonLayoutStyle.js
@@ -70,6 +70,7 @@ export const TextBadge = styled.span`
   color: ${(props) => props.theme.brand.textPrimary};
   padding: 2px ${padding.small};
   border-radius: 4px;
-  font-size: ${fontSize.small}
-  font-weight: ${fontWeight.bold}
+  font-size: ${fontSize.small};
+  font-weight: ${fontWeight.bold};
+  margin-left: ${padding.smaller};
 `;

--- a/ui/src/components/VolumeAlertsTab.js
+++ b/ui/src/components/VolumeAlertsTab.js
@@ -1,20 +1,22 @@
 import React from 'react';
 import { FormattedDate, FormattedTime } from 'react-intl';
+import { useRouteMatch, useLocation } from 'react-router';
 import styled from 'styled-components';
 import {
   fontSize,
   padding,
   fontWeight,
 } from '@scality/core-ui/dist/style/theme';
+import ActiveAlertsFilters from './ActiveAlertsFilters';
 import { Chips } from '@scality/core-ui';
 import { useTable } from 'react-table';
 import { intl } from '../translations/IntlGlobalProvider';
 
+
 const ActiveAlertsCardContainer = styled.div`
   min-height: 75px;
-  background-color: ${(props) => props.theme.brand.primaryDark1};
   margin: ${padding.small};
-  padding: 0 ${padding.large} ${padding.small} 0;
+  padding: ${padding.small};
 `;
 
 const ActiveAlertsTitle = styled.div`
@@ -22,6 +24,8 @@ const ActiveAlertsTitle = styled.div`
   font-size: ${fontSize.base};
   font-weight: ${fontWeight.bold};
   padding: ${padding.small} 0 0 ${padding.large};
+  display: flex;
+  justify-content: space-between;
 `;
 
 const ActiveAlertsTableContainer = styled.div`
@@ -45,6 +49,8 @@ const ActiveAlertsTableContainer = styled.div`
     th {
       font-weight: bold;
       height: 56px;
+      text-align: left;
+      padding: 0.5rem;
     }
 
     td {
@@ -68,8 +74,12 @@ const NoActiveAlerts = styled.div`
 
 const ActiveAlertsCard = (props) => {
   const { alertlist, PVCName } = props;
+  const match = useRouteMatch();
+  const location = useLocation();
+  const query = new URLSearchParams(location.search);
+  const selectedFilter = query.get('severity');
 
-  const activeAlertListData = alertlist?.map((alert) => {
+  let activeAlertListData = alertlist?.map((alert) => {
     return {
       name: alert.labels.alertname,
       severity: alert.labels.severity,
@@ -77,6 +87,8 @@ const ActiveAlertsCard = (props) => {
       active_since: alert.startsAt,
     };
   });
+  if (activeAlertListData && selectedFilter)
+    activeAlertListData = activeAlertListData.filter(item => item.severity === selectedFilter);
   // React Table for the volume list
   function Table({ columns, data }) {
     // Use the state and functions returned from useTable to build your UI
@@ -145,6 +157,7 @@ const ActiveAlertsCard = (props) => {
                       <td {...cell.getCellProps()}>{cell.render('Cell')}</td>
                     );
                   }
+                  return null;
                 })}
               </tr>
             );
@@ -166,8 +179,15 @@ const ActiveAlertsCard = (props) => {
 
   return (
     <ActiveAlertsCardContainer>
-      <ActiveAlertsTitle>{intl.translate('active_alerts')}</ActiveAlertsTitle>
-      {PVCName && alertlist.length !== 0 ? (
+      <ActiveAlertsTitle>
+        <div>
+          {intl.translate('active_alerts')}
+        </div>
+        <ActiveAlertsFilters
+          baseLink={`${match.url}/alerts`}
+        />
+      </ActiveAlertsTitle>
+      {PVCName && activeAlertListData.length !== 0 ? (
         <ActiveAlertsTableContainer>
           <Table columns={columns} data={activeAlertListData} />
         </ActiveAlertsTableContainer>

--- a/ui/src/components/VolumeAlertsTab.js
+++ b/ui/src/components/VolumeAlertsTab.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FormattedDate, FormattedTime } from 'react-intl';
-import { useRouteMatch, useLocation } from 'react-router';
+import { useLocation } from 'react-router';
 import styled from 'styled-components';
 import {
   fontSize,
@@ -11,7 +11,6 @@ import ActiveAlertsFilters from './ActiveAlertsFilters';
 import { Chips } from '@scality/core-ui';
 import { useTable } from 'react-table';
 import { intl } from '../translations/IntlGlobalProvider';
-
 
 const ActiveAlertsCardContainer = styled.div`
   min-height: 75px;
@@ -74,7 +73,6 @@ const NoActiveAlerts = styled.div`
 
 const ActiveAlertsCard = (props) => {
   const { alertlist, PVCName } = props;
-  const match = useRouteMatch();
   const location = useLocation();
   const query = new URLSearchParams(location.search);
   const selectedFilter = query.get('severity');
@@ -88,7 +86,9 @@ const ActiveAlertsCard = (props) => {
     };
   });
   if (activeAlertListData && selectedFilter)
-    activeAlertListData = activeAlertListData.filter(item => item.severity === selectedFilter);
+    activeAlertListData = activeAlertListData.filter(
+      (item) => item.severity === selectedFilter,
+    );
   // React Table for the volume list
   function Table({ columns, data }) {
     // Use the state and functions returned from useTable to build your UI
@@ -180,12 +180,8 @@ const ActiveAlertsCard = (props) => {
   return (
     <ActiveAlertsCardContainer>
       <ActiveAlertsTitle>
-        <div>
-          {intl.translate('active_alerts')}
-        </div>
-        <ActiveAlertsFilters
-          baseLink={`${match.url}/alerts`}
-        />
+        <div>{intl.translate('active_alerts')}</div>
+        <ActiveAlertsFilters />
       </ActiveAlertsTitle>
       {PVCName && activeAlertListData.length !== 0 ? (
         <ActiveAlertsTableContainer>

--- a/ui/src/components/VolumeListTable.js
+++ b/ui/src/components/VolumeListTable.js
@@ -25,6 +25,7 @@ const VolumeListContainer = styled.div`
   font-family: 'Lato';
   font-size: ${fontSize.base};
   border-color: ${(props) => props.theme.brand.borderLight};
+  background-color: ${(props) => props.theme.brand.primary};
   .sc-progressbarcontainer {
     width: 100%;
   }
@@ -400,12 +401,26 @@ const VolumeListTable = (props) => {
   const onClickRow = (row) => {
     const query = new URLSearchParams(location.search);
     const isAddNodeFilter = query.has('node');
+    const isTabSelected = location.pathname.endsWith('/alerts');
 
-    // there are two possiable URLs
     if (isAddNodeFilter) {
       history.push(`/volumes/${row.values.name}?node=${nodeName}`);
     } else {
-      history.push(`/volumes/${row.values.name}`);
+      if (isTabSelected) {
+        const newPath = location.pathname.replace(
+          /\/volumes\/[^/]*\//,
+          `/volumes/${row.values.name}/`,
+        );
+        history.push({
+          pathname: newPath,
+          search: query.toString(),
+        });
+      } else {
+        history.push({
+          pathname: `/volumes/${row.values.name}/overview`,
+          search: query.toString(),
+        });
+      }
     }
   };
 

--- a/ui/src/components/VolumeOverviewTab.js
+++ b/ui/src/components/VolumeOverviewTab.js
@@ -53,6 +53,13 @@ const InformationValue = styled.span`
   font-size: ${fontSize.base};
 `;
 
+const ClickableInformationValue = styled.span`
+  color: ${(props) => props.theme.brand.secondary};
+  font-size: ${fontSize.base};
+  font-weight: ${fontWeight.semibold};
+  cursor: pointer;
+`;
+
 const DeleteButton = styled(Button)`
   padding: ${padding.base};
   font-size: ${fontSize.small};
@@ -128,7 +135,6 @@ const AlertsCounterContainer = styled.div`
   flex-direction: column;
 `;
 
-
 const VolumeDetailCard = (props) => {
   const {
     name,
@@ -147,7 +153,7 @@ const VolumeDetailCard = (props) => {
     volumeListData,
     pVList,
     health,
-    alertlist
+    alertlist,
   } = props;
 
   const dispatch = useDispatch();
@@ -190,6 +196,10 @@ const VolumeDetailCard = (props) => {
     }
   };
 
+  const onClickNodeName = () => {
+    history.push(`/nodes/${nodeName}`);
+  };
+
   const onClickCancelButton = () => {
     setisDeleteConfirmationModalOpen(false);
   };
@@ -216,7 +226,9 @@ const VolumeDetailCard = (props) => {
         </VolumeNameTitle>
         <InformationSpan>
           <InformationLabel>{intl.translate('node')}</InformationLabel>
-          <InformationValue>{nodeName}</InformationValue>
+          <ClickableInformationValue onClick={onClickNodeName}>
+            {nodeName}
+          </ClickableInformationValue>
         </InformationSpan>
         <InformationSpan>
           <InformationLabel>{intl.translate('size')}</InformationLabel>
@@ -298,8 +310,7 @@ const VolumeDetailCard = (props) => {
             data-cy="delete_volume_button"
           ></DeleteButton>
         </DeleteButtonContainer>
-        {
-          alertlist &&
+        {alertlist && (
           <AlertsCounterContainer>
             <VolumeSectionTitle>
               {intl.translate('active_alerts')}
@@ -309,7 +320,7 @@ const VolumeDetailCard = (props) => {
               baseLink={`${match.url}/${name}/alerts`}
             />
           </AlertsCounterContainer>
-        }
+        )}
         {condition === VOLUME_CONDITION_LINK && (
           <VolumeUsage>
             <VolumeSectionTitle>{intl.translate('usage')}</VolumeSectionTitle>

--- a/ui/src/components/VolumeOverviewTab.js
+++ b/ui/src/components/VolumeOverviewTab.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useLocation, useRouteMatch } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { useHistory } from 'react-router';
 import { FormattedDate, FormattedTime } from 'react-intl';
 import styled from 'styled-components';
@@ -168,7 +168,6 @@ const VolumeDetailCard = (props) => {
   const history = useHistory();
   const location = useLocation();
   const query = new URLSearchParams(location.search);
-  const match = useRouteMatch();
   const theme = useSelector((state) => state.config.theme);
 
   const deleteVolume = (deleteVolumeName) =>
@@ -333,7 +332,6 @@ const VolumeDetailCard = (props) => {
                   (item) => item?.labels?.severity === STATUS_WARNING,
                 ).length
               }
-              baseLink={`${match.url}/${name}/alerts`}
             />
           </AlertsCounterContainer>
         )}

--- a/ui/src/components/VolumeOverviewTab.js
+++ b/ui/src/components/VolumeOverviewTab.js
@@ -228,7 +228,7 @@ const VolumeDetailCard = (props) => {
     <VolumeDetailCardContainer>
       <VolumeInformation>
         <VolumeNameTitle data-cy="volume_detail_card_name">
-          <CircleStatus className="fas fa-circle fa-2x" status={health} />
+          <CircleStatus className="fas fa-circle" status={health} />
           {name}
         </VolumeNameTitle>
         <InformationSpan>

--- a/ui/src/components/VolumeOverviewTab.js
+++ b/ui/src/components/VolumeOverviewTab.js
@@ -13,7 +13,11 @@ import CircleStatus from './CircleStatus';
 import ActiveAlertsCounter from './ActiveAlertsCounter';
 import { isVolumeDeletable } from '../services/NodeVolumesUtils';
 import { deleteVolumeAction } from '../ducks/app/volumes';
-import { VOLUME_CONDITION_LINK } from '../constants';
+import {
+  VOLUME_CONDITION_LINK,
+  STATUS_CRITICAL,
+  STATUS_WARNING,
+} from '../constants';
 import { Button, Modal, ProgressBar, Loader } from '@scality/core-ui';
 import { intl } from '../translations/IntlGlobalProvider';
 
@@ -316,7 +320,16 @@ const VolumeDetailCard = (props) => {
               {intl.translate('active_alerts')}
             </VolumeSectionTitle>
             <ActiveAlertsCounter
-              alerts={alertlist}
+              criticalCounter={
+                alertlist?.filter(
+                  (item) => item?.labels?.severity === STATUS_CRITICAL,
+                ).length
+              }
+              warningCounter={
+                alertlist?.filter(
+                  (item) => item?.labels?.severity === STATUS_WARNING,
+                ).length
+              }
               baseLink={`${match.url}/${name}/alerts`}
             />
           </AlertsCounterContainer>

--- a/ui/src/components/VolumeOverviewTab.js
+++ b/ui/src/components/VolumeOverviewTab.js
@@ -36,6 +36,10 @@ const VolumeNameTitle = styled.div`
   color: ${(props) => props.theme.brand.textPrimary};
   font-size: ${fontSize.larger};
   padding: ${padding.small} 0 ${padding.larger} ${padding.large};
+
+  > i {
+    margin-right: ${padding.small};
+  }
 `;
 
 const InformationSpan = styled.div`
@@ -225,7 +229,6 @@ const VolumeDetailCard = (props) => {
       <VolumeInformation>
         <VolumeNameTitle data-cy="volume_detail_card_name">
           <CircleStatus className="fas fa-circle fa-2x" status={health} />
-          &nbsp;
           {name}
         </VolumeNameTitle>
         <InformationSpan>

--- a/ui/src/components/VolumeOverviewTab.js
+++ b/ui/src/components/VolumeOverviewTab.js
@@ -321,7 +321,7 @@ const VolumeDetailCard = (props) => {
                   topRightLabel={`${volumeUsagePercentage}%`}
                   bottomLeftLabel={`${volumeUsageBytes} USED`}
                   bottomRightLabel={`${storageCapacity} TOTAL`}
-                  backgroundColor={theme.brand.borderLight}
+                  backgroundColor={theme.brand.base}
                 />
               </ProgressBarContainer>
             ) : (

--- a/ui/src/containers/Layout.js
+++ b/ui/src/containers/Layout.js
@@ -232,7 +232,7 @@ const Layout = (props) => {
           <PrivateRoute exact path="/nodes" component={NodeList} />
           <PrivateRoute path="/newNodes" component={NodePage} />
           <PrivateRoute exact path="/environments" component={SolutionList} />
-          <PrivateRoute path="/volumes" component={VolumePage} />
+          <PrivateRoute path="/volumes/:name?" component={VolumePage} />
           <PrivateRoute
             exact
             path="/environments/create-environment"

--- a/ui/src/containers/VolumePageContent.js
+++ b/ui/src/containers/VolumePageContent.js
@@ -155,7 +155,7 @@ const VolumePageContent = (props) => {
   };
 
   const isAlertsPage = location.pathname.endsWith('/alerts');
-  const isOverviewPage = location.pathname.endsWith('/overview') || !isAlertsPage;
+  const isOverviewPage = location.pathname.endsWith('/overview');
   const isMetricsPage = location.pathname.endsWith('/metrics');
   const isDetailsPage = location.pathname.endsWith('/details');
 

--- a/ui/src/containers/VolumePageContent.js
+++ b/ui/src/containers/VolumePageContent.js
@@ -1,8 +1,15 @@
+// Temporarily disable the `no-unused-vars` lint until the refactoring is complete.
+/* eslint-disable no-unused-vars */
+
 import React from 'react';
-import { useHistory } from 'react-router';
+import { useSelector } from 'react-redux';
+import styled from 'styled-components';
+import { useHistory, useLocation, useRouteMatch } from 'react-router';
+import { Tabs } from '@scality/core-ui';
+import { padding } from '@scality/core-ui/dist/style/theme';
 import VolumeListTable from '../components/VolumeListTable';
-import VolumeDetailCard from '../components/VolumeDetailCard';
-import ActiveAlertsCard from '../components/VolumeActiveAlertsCard';
+import VolumeOverviewTab from '../components/VolumeOverviewTab';
+import VolumeAlertsTab from '../components/VolumeAlertsTab';
 import MetricGraphCard from '../components/VolumeMetricGraphCard';
 import {
   SPARSE_LOOP_DEVICE,
@@ -12,15 +19,37 @@ import {
 import { computeVolumeGlobalStatus } from '../services/NodeVolumesUtils';
 import {
   LeftSideInstanceList,
-  RightSidePanel,
   NoInstanceSelectedContainer,
   NoInstanceSelected,
-  PageContentContainer,
+  TextBadge
 } from '../components/CommonLayoutStyle';
 import { intl } from '../translations/IntlGlobalProvider';
 
+const VolumePageContentContainer = styled.div`
+display: flex;
+flex-direction: row;
+height: 100%;
+width: 100%;
+
+.sc-tabs {
+  margin: 0 ${padding.small} 0 ${padding.smaller};
+}
+
+.sc-tabs-item-content {
+  background-color: ${(props) => props.theme.brand.primary};
+  padding: ${padding.small}
+}
+`;
+
+const RightSidePanel = styled.div`
+  flex-direction: column;
+  width: 55%;
+  overflow-y: scroll;
+  margin: 0 ${padding.small} ${padding.small} 0;
+`;
+
 // <VolumePageContent> component extracts volume name from URL and holds the volume-specific data.
-// The three components in RightSidePanel (<VolumeDetailCard> / <ActiveAlertsCard> / <MetricGraphCard>) are dumb components,
+// The three components in RightSidePanel (<VolumeOverviewTab> / <VolumeAlertsTab> / <MetricGraphCard>) are dumb components,
 // so that with the implementation of Tabs no re-render should happen during the switch.
 const VolumePageContent = (props) => {
   const {
@@ -35,8 +64,13 @@ const VolumePageContent = (props) => {
   } = props;
 
   const history = useHistory();
-  const currentVolumeName =
-    history?.location?.pathname?.split('/').slice(2)[0] || '';
+  const location = useLocation();
+  const match = useRouteMatch();
+  const query = new URLSearchParams(location.search);
+
+  const theme = useSelector((state) => state.config.theme);
+
+  const currentVolumeName = match.params.name;
   const volume = volumes?.find(
     (volume) => volume.metadata.name === currentVolumeName,
   );
@@ -119,8 +153,26 @@ const VolumePageContent = (props) => {
     queryStartingTime,
   };
 
+  const isAlertsPage = location.pathname.endsWith('/alerts');
+  const isOverviewPage = location.pathname.endsWith('/overview') || !isAlertsPage;
+  const isMetricsPage = location.pathname.endsWith('/metrics');
+  const isDetailsPage = location.pathname.endsWith('/details');
+
+  const tabsItems = [
+    {
+      selected: isOverviewPage,
+      title: intl.translate('overview'),
+      onClick: () => history.push(`${match.url}/overview${query.toString() && `?${query.toString()}`}`),
+    },
+    {
+      selected: isAlertsPage,
+      title: (<span>{intl.translate('alerts')}&nbsp;&nbsp;<TextBadge>{alertlist?.length}</TextBadge></span>),
+      onClick: () => history.push(`${match.url}/alerts${query.toString() && `?${query.toString()}`}`),
+    },
+  ];
+
   return (
-    <PageContentContainer>
+    <VolumePageContentContainer>
       <LeftSideInstanceList>
         <VolumeListTable
           volumeListData={volumeListData}
@@ -131,49 +183,51 @@ const VolumePageContent = (props) => {
 
       {currentVolumeName && volume ? (
         <RightSidePanel>
-          <VolumeDetailCard
-            name={currentVolumeName}
-            nodeName={volume?.spec?.nodeName}
-            storage={pV?.spec?.capacity?.storage ?? intl.translate('unknown')}
-            status={volumeStatus ?? intl.translate('unknown')}
-            storageClassName={volume?.spec?.storageClassName}
-            creationTimestamp={volume?.metadata?.creationTimestamp}
-            volumeType={
-              volume?.spec?.rawBlockDevice
-                ? RAW_BLOCK_DEVICE
-                : SPARSE_LOOP_DEVICE
+          <Tabs activeColor={theme.brand.primary} items={tabsItems}>
+            {
+              isOverviewPage &&
+              <VolumeOverviewTab
+                name={currentVolumeName}
+                nodeName={volume?.spec?.nodeName}
+                storage={pV?.spec?.capacity?.storage ?? intl.translate('unknown')}
+                status={volumeStatus ?? intl.translate('unknown')}
+                storageClassName={volume?.spec?.storageClassName}
+                creationTimestamp={volume?.metadata?.creationTimestamp}
+                volumeType={
+                  volume?.spec?.rawBlockDevice
+                    ? RAW_BLOCK_DEVICE
+                    : SPARSE_LOOP_DEVICE
+                }
+                usedPodName={UsedPod ? UsedPod?.name : intl.translate('not_used')}
+                devicePath={
+                  volume?.spec?.rawBlockDevice?.devicePath ??
+                  intl.translate('not_applicable')
+                }
+                volumeUsagePercentage={currentVolume?.usage}
+                volumeUsageBytes={currentVolume?.usageRawData ?? 0}
+                storageCapacity={
+                  volumeListData?.find((vol) => vol.name === currentVolumeName)
+                    .storageCapacity
+                }
+                health={
+                  volumeListData?.find((vol) => vol.name === currentVolumeName)
+                    .health
+                }
+                condition={currentVolume.status}
+                // the delete button inside the volume detail card should know that which volume is the first one
+                volumeListData={volumeListData}
+                pVList={pVList}
+                alertlist={alertlist}
+              />
             }
-            usedPodName={UsedPod ? UsedPod?.name : intl.translate('not_used')}
-            devicePath={
-              volume?.spec?.rawBlockDevice?.devicePath ??
-              intl.translate('not_applicable')
-            }
-            volumeUsagePercentage={currentVolume?.usage}
-            volumeUsageBytes={currentVolume?.usageRawData ?? 0}
-            storageCapacity={
-              volumeListData?.find((vol) => vol.name === currentVolumeName)
-                .storageCapacity
-            }
-            health={
-              volumeListData?.find((vol) => vol.name === currentVolumeName)
-                .health
-            }
-            condition={currentVolume.status}
-            // the delete button inside the volume detail card should know that which volume is the first one
-            volumeListData={volumeListData}
-            pVList={pVList}
-          ></VolumeDetailCard>
-          <ActiveAlertsCard
-            alertlist={alertlist}
-            PVCName={PVCName}
-          ></ActiveAlertsCard>
-          <MetricGraphCard
-            volumeName={currentVolumeName}
-            volumeMetricGraphData={volumeMetricGraphData}
-            // the volume condition compute base on the `status` and `bound/unbound`
-            volumeCondition={currentVolume.status}
-            // Hardcode the port number for prometheus metrics
-          ></MetricGraphCard>
+            {
+              isAlertsPage &&
+              <VolumeAlertsTab
+                alertlist={alertlist}
+                PVCName={PVCName}
+              />
+              }
+          </Tabs>
         </RightSidePanel>
       ) : (
         <NoInstanceSelectedContainer>
@@ -182,7 +236,7 @@ const VolumePageContent = (props) => {
           </NoInstanceSelected>
         </NoInstanceSelectedContainer>
       )}
-    </PageContentContainer>
+    </VolumePageContentContainer>
   );
 };
 

--- a/ui/src/containers/VolumePageContent.js
+++ b/ui/src/containers/VolumePageContent.js
@@ -5,6 +5,7 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 import { useHistory, useLocation, useRouteMatch } from 'react-router';
+import { Switch, Route } from 'react-router-dom';
 import { Tabs } from '@scality/core-ui';
 import { padding } from '@scality/core-ui/dist/style/theme';
 import VolumeListTable from '../components/VolumeListTable';
@@ -184,49 +185,55 @@ const VolumePageContent = (props) => {
       {currentVolumeName && volume ? (
         <RightSidePanel>
           <Tabs activeColor={theme.brand.primary} items={tabsItems}>
-            {
-              isOverviewPage &&
-              <VolumeOverviewTab
-                name={currentVolumeName}
-                nodeName={volume?.spec?.nodeName}
-                storage={pV?.spec?.capacity?.storage ?? intl.translate('unknown')}
-                status={volumeStatus ?? intl.translate('unknown')}
-                storageClassName={volume?.spec?.storageClassName}
-                creationTimestamp={volume?.metadata?.creationTimestamp}
-                volumeType={
-                  volume?.spec?.rawBlockDevice
-                    ? RAW_BLOCK_DEVICE
-                    : SPARSE_LOOP_DEVICE
-                }
-                usedPodName={UsedPod ? UsedPod?.name : intl.translate('not_used')}
-                devicePath={
-                  volume?.spec?.rawBlockDevice?.devicePath ??
-                  intl.translate('not_applicable')
-                }
-                volumeUsagePercentage={currentVolume?.usage}
-                volumeUsageBytes={currentVolume?.usageRawData ?? 0}
-                storageCapacity={
-                  volumeListData?.find((vol) => vol.name === currentVolumeName)
-                    .storageCapacity
-                }
-                health={
-                  volumeListData?.find((vol) => vol.name === currentVolumeName)
-                    .health
-                }
-                condition={currentVolume.status}
-                // the delete button inside the volume detail card should know that which volume is the first one
-                volumeListData={volumeListData}
-                pVList={pVList}
-                alertlist={alertlist}
+            <Switch>
+              <Route
+                path={`${match.url}/overview`}
+                render={() => (
+                  <VolumeOverviewTab
+                    name={currentVolumeName}
+                    nodeName={volume?.spec?.nodeName}
+                    storage={pV?.spec?.capacity?.storage ?? intl.translate('unknown')}
+                    status={volumeStatus ?? intl.translate('unknown')}
+                    storageClassName={volume?.spec?.storageClassName}
+                    creationTimestamp={volume?.metadata?.creationTimestamp}
+                    volumeType={
+                      volume?.spec?.rawBlockDevice
+                        ? RAW_BLOCK_DEVICE
+                        : SPARSE_LOOP_DEVICE
+                    }
+                    usedPodName={UsedPod ? UsedPod?.name : intl.translate('not_used')}
+                    devicePath={
+                      volume?.spec?.rawBlockDevice?.devicePath ??
+                      intl.translate('not_applicable')
+                    }
+                    volumeUsagePercentage={currentVolume?.usage}
+                    volumeUsageBytes={currentVolume?.usageRawData ?? 0}
+                    storageCapacity={
+                      volumeListData?.find((vol) => vol.name === currentVolumeName)
+                        .storageCapacity
+                    }
+                    health={
+                      volumeListData?.find((vol) => vol.name === currentVolumeName)
+                        .health
+                    }
+                    condition={currentVolume.status}
+                    // the delete button inside the volume detail card should know that which volume is the first one
+                    volumeListData={volumeListData}
+                    pVList={pVList}
+                    alertlist={alertlist}
+                  />
+                )}
               />
-            }
-            {
-              isAlertsPage &&
-              <VolumeAlertsTab
-                alertlist={alertlist}
-                PVCName={PVCName}
+              <Route
+                path={`${match.url}/alerts`}
+                render={() => (
+                  <VolumeAlertsTab
+                    alertlist={alertlist}
+                    PVCName={PVCName}
+                  />
+                )}
               />
-              }
+            </Switch>
           </Tabs>
         </RightSidePanel>
       ) : (

--- a/ui/src/containers/VolumePageContent.js
+++ b/ui/src/containers/VolumePageContent.js
@@ -36,6 +36,24 @@ width: 100%;
   margin: 0 ${padding.small} 0 ${padding.smaller};
 }
 
+.sc-tabs-bar {
+  height: 40px;
+}
+
+.sc-tabs-item {
+  background-color: ${(props) => props.theme.brand.border};
+  margin-right: ${padding.smaller}
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+
+  .sc-tabs-item-title {
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+    height: 40px;
+    padding: ${padding.small}
+  }
+}
+
 .sc-tabs-item-content {
   background-color: ${(props) => props.theme.brand.primary};
   padding: ${padding.small}

--- a/ui/src/containers/VolumePageContent.js
+++ b/ui/src/containers/VolumePageContent.js
@@ -167,7 +167,7 @@ const VolumePageContent = (props) => {
     },
     {
       selected: isAlertsPage,
-      title: (<span>{intl.translate('alerts')}&nbsp;&nbsp;<TextBadge>{alertlist?.length}</TextBadge></span>),
+      title: (<span>{intl.translate('alerts')}<TextBadge>{alertlist?.length}</TextBadge></span>),
       onClick: () => history.push(`${match.url}/alerts${query.toString() && `?${query.toString()}`}`),
     },
   ];

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -158,11 +158,14 @@
   "node": "Node",
   "used_by": "Used By",
   "backend_disk": "Backend Disk",
-  "active_alerts": "ACTIVE ALERTS",
+  "active_alerts": "Active alerts",
   "metrics": "METRICS",
   "volume_is_not_bound": "The volume is not bound yet",
   "no_active_alerts": "No active alerts",
   "not_used": "Not used",
   "no_volume_selected": "No Volume Selected",
-  "no_node_selected": "No Node Selected"
+  "no_node_selected": "No Node Selected",
+  "overview": "Overview",
+  "volume_usage": "Volume Usage",
+  "usage": "Usage"
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -158,11 +158,14 @@
   "node": "Nœud",
   "used_by": "Utilisé Par",
   "backend_disk": "Backend Disk",
-  "active_alerts": "ALERTS ACTIVES",
+  "active_alerts": "Alertes actives",
   "metrics": "MÉTRIQUE",
   "volume_is_not_bound": "Le volume n'est pas encore lié",
   "no_active_alerts": "Aucune alerte active",
   "not_used": "Non utilisé",
   "no_volume_selected": "Aucun volume sélectionné",
-  "no_node_selected": "Aucun nœud sélectionné"
+  "no_node_selected": "Aucun nœud sélectionné",
+  "overview": "Aperçu",
+  "volume_usage": "Utilisation du Volume",
+  "usage": "Utilisation"
 }


### PR DESCRIPTION
**Component**:

ui, volumes

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

We want to adapt the volumes page so it looks like the new node page (tab based).

**Summary**:

I refactored most of the Volume view. There were also small adaptations compared to the base view (alerts filtering in URL, ...) as described in #2751 .

Some components (ActiveAlertsFilters, ActiveAlertsCounter) were designed to be re-usable in other views.

EDIT : Missing tabs (metrics and details) were added in #2866 targeting this branch.

![Screenshot 2020-10-15 at 15 41 13](https://user-images.githubusercontent.com/3480526/96139475-35faa480-0eff-11eb-8a0f-189b2a388aaa.png)
![Screenshot 2020-10-15 at 15 41 26](https://user-images.githubusercontent.com/3480526/96139487-372bd180-0eff-11eb-8634-ff0daacdf242.png)
![Screenshot 2020-10-15 at 15 41 46](https://user-images.githubusercontent.com/3480526/96139497-38f59500-0eff-11eb-8d25-c2d5f245d039.png)
![Screenshot 2020-10-15 at 15 41 59](https://user-images.githubusercontent.com/3480526/96139502-3a26c200-0eff-11eb-94df-965911f9351a.png)



**Acceptance criteria**: 

* Volumes page right panel is separated in four tabs Overview, Alerts, Metrics, Details
* Total number of alerts is displayed in Alerts tab header
* It is possible to filter by alert severity on the Alert tab
* Clicking on an alert category in the overview tab opens the alerts tab and filters by the corresponding category
* When switching to another volume the selected tab is preserved
---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2751 
