### PR TITLE
Upgrade Kubelet after APIServer

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -596,6 +596,7 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/repo/debian.sls'),
 
     Path('salt/metalk8s/roles/bootstrap/absent.sls'),
+    Path('salt/metalk8s/roles/bootstrap/components.sls'),
     Path('salt/metalk8s/roles/bootstrap/init.sls'),
     Path('salt/metalk8s/roles/bootstrap/local.sls'),
     Path('salt/metalk8s/roles/ca/absent.sls'),

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -549,6 +549,7 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
 
     Path('salt/metalk8s/node/grains.sls'),
 
+    Path('salt/metalk8s/orchestrate/apiserver.sls'),
     Path('salt/metalk8s/orchestrate/deploy_node.sls'),
     Path('salt/metalk8s/orchestrate/etcd.sls'),
     Path('salt/metalk8s/orchestrate/register_etcd.sls'),

--- a/docs/developer/deploy/upgrade.rst
+++ b/docs/developer/deploy/upgrade.rst
@@ -57,4 +57,4 @@ If upgrading from the same patch, minor and major version:
 
   .. parsed-literal::
 
-    /srv/scality/metalk8s-|version|-dev/upgrade.sh --destination-version |version|
+    /srv/scality/metalk8s-|version|-dev/upgrade.sh

--- a/docs/operation/upgrade.rst
+++ b/docs/operation/upgrade.rst
@@ -39,8 +39,7 @@ changes to be carried out in your MetalK8s cluster.
 
    .. code::
 
-     /srv/scality/metalk8s-X.X.X/upgrade.sh --destination-version \
-       <destination_version> --dry-run --verbose
+     /srv/scality/metalk8s-X.X.X/upgrade.sh --dry-run --verbose
 
 Backup old credentials
 ----------------------
@@ -68,8 +67,7 @@ Ensure that the upgrade pre-requisites above have been met before you make
 any step further.
 
 To upgrade a MetalK8s cluster, run the utility script shipped
-with the **new** version you want to upgrade to providing it with the
-destination version:
+with the **new** version you want to upgrade to:
 
 .. important::
 
@@ -81,4 +79,4 @@ destination version:
 
    .. code::
 
-     /srv/scality/metalk8s-X.X.X/upgrade.sh --destination-version <destination_version>
+     /srv/scality/metalk8s-X.X.X/upgrade.sh

--- a/salt/metalk8s/orchestrate/apiserver.sls
+++ b/salt/metalk8s/orchestrate/apiserver.sls
@@ -1,0 +1,45 @@
+{%- set dest_version = pillar.orchestrate.dest_version %}
+{%- set master_nodes = salt.metalk8s.minions_by_role('master') %}
+
+{%- for node in master_nodes | sort %}
+
+Sync {{ node }} minion:
+  salt.function:
+    - name: saltutil.sync_all
+    - tgt: {{ node }}
+    - kwarg:
+        saltenv: metalk8s-{{ dest_version }}
+
+Check pillar on {{ node }}:
+  salt.function:
+    - name: metalk8s.check_pillar_keys
+    - tgt: {{ node }}
+    - kwarg:
+        keys:
+          - metalk8s.endpoints.repositories.ip
+          - metalk8s.endpoints.repositories.ports.http
+        # We cannot raise when using `salt.function` as we need to return
+        # `False` to have a failed state
+        # https://github.com/saltstack/salt/issues/55503
+        raise_error: False
+    - retry:
+        attempts: 5
+    - require:
+      - salt: Sync {{ node }} minion
+
+Deploy apiserver {{ node }} to {{ dest_version }}:
+  salt.state:
+    - tgt: {{ node }}
+    - sls:
+      - metalk8s.kubernetes.apiserver
+    - saltenv: metalk8s-{{ dest_version }}
+    - require:
+      - salt: Check pillar on {{ node }}
+  {%- if previous_node is defined %}
+      - salt: Deploy apiserver {{ previous_node }} to {{ dest_version }}
+  {%- endif %}
+
+  {#- Ugly but needed since we have jinja2.7 (`loop.previtem` added in 2.10) #}
+  {%- set previous_node = node %}
+
+{%- endfor %}

--- a/salt/metalk8s/orchestrate/upgrade/init.sls
+++ b/salt/metalk8s/orchestrate/upgrade/init.sls
@@ -22,6 +22,18 @@ Upgrade etcd cluster:
     - require:
       - salt: Execute the upgrade prechecks
 
+Upgrade apiserver instances:
+  salt.runner:
+    - name: state.orchestrate
+    - mods:
+      - metalk8s.orchestrate.apiserver
+    - saltenv: {{ saltenv }}
+    - pillar:
+        orchestrate:
+          dest_version: {{ dest_version }}
+    - require:
+      - salt: Upgrade etcd cluster
+
 {%- set cp_nodes = salt.metalk8s.minions_by_role('master') | sort %}
 {%- set other_nodes = pillar.metalk8s.nodes.keys() | difference(cp_nodes) | sort %}
 
@@ -53,6 +65,8 @@ Check pillar on {{ node }} before installing apiserver-proxy:
         raise_error: False
     - retry:
         attempts: 5
+    - require:
+      - salt: Upgrade apiserver instances
 
 Install apiserver-proxy on {{ node }}:
   salt.state:

--- a/salt/metalk8s/roles/bootstrap/components.sls
+++ b/salt/metalk8s/roles/bootstrap/components.sls
@@ -1,0 +1,4 @@
+include:
+  - metalk8s.repo.installed
+  - metalk8s.salt.master.certs.salt-api
+  - metalk8s.salt.master.installed

--- a/salt/metalk8s/roles/bootstrap/local.sls
+++ b/salt/metalk8s/roles/bootstrap/local.sls
@@ -2,8 +2,5 @@ include:
   - metalk8s.archives.mounted
   - metalk8s.kubernetes.kubelet.standalone
   - metalk8s.internal.preflight
-  - metalk8s.repo.installed
-  - metalk8s.salt.master.certs.salt-api
-  - metalk8s.salt.master.configured
-  - metalk8s.salt.master.installed
+  - .components
   - metalk8s.kubectl

--- a/scripts/upgrade.sh.in
+++ b/scripts/upgrade.sh.in
@@ -82,7 +82,7 @@ upgrade_bootstrap () {
         saltenv="$SALTENV"
 
     "${SALT_CALL}" --local --retcode-passthrough state.sls sync_mods="all" \
-        metalk8s.roles.bootstrap.local saltenv="$SALTENV" \
+        metalk8s.roles.bootstrap.components saltenv="$SALTENV" \
         pillar="{'metalk8s': {'endpoints': {'salt-master': $saltmaster_endpoint, \
         'repositories': $repo_endpoint}}}"
 }

--- a/scripts/upgrade.sh.in
+++ b/scripts/upgrade.sh.in
@@ -6,8 +6,10 @@ set -o pipefail
 VERBOSE=${VERBOSE:-0}
 LOGFILE=/var/log/metalk8s/upgrade.log
 DRY_RUN=0
-SALTENV=${SALTENV:-}
-DESTINATION_VERSION=""
+DESTINATION_VERSION=${DESTINATION_VERSION:-@@VERSION}
+# SALTENV must be equal to script version and DESTINATION_VERSION
+# (checked by the precheck orchestrate)
+SALTENV="metalk8s-$DESTINATION_VERSION"
 SALT_CALL=${SALT_CALL:-salt-call}
 BASE_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 
@@ -15,8 +17,6 @@ BASE_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 _usage() {
     echo "upgrade.sh [options]"
     echo "Options:"
-    echo "--destination-version "
-    echo "   <destination-version>:        Destination version to upgrade to"
     echo "-l/--log-file <logfile_path>:    Path to log file"
     echo "-v/--verbose:                    Run in verbose mode"
     echo "-d/--dry-run:                    Run actions in dry run mode"
@@ -32,10 +32,6 @@ while (( "$#" )); do
     -v|--verbose)
       VERBOSE=1
       shift
-      ;;
-    --destination-version)
-      DESTINATION_VERSION="$2"
-      shift 2
       ;;
     -l|--log-file)
       LOGFILE="$2"
@@ -146,22 +142,6 @@ patch_kubesystem_namespace() {
         patch="{'metadata': {'annotations': \
         {'metalk8s.scality.com/cluster-version': '$DESTINATION_VERSION'}}}"
 }
-
-get_cluster_version() {
-    DESTINATION_VERSION=$("${SALT_CALL}" \
-        pillar.get metalk8s:cluster_version --out txt | cut -c 8-)
-}
-
-if [ -z "$DESTINATION_VERSION" ]; then
-    get_cluster_version
-    run "Getting cluster version $DESTINATION_VERSION"
-fi
-
-# SALTENV should be equal to script version and DESTINATION_VERSION
-# (checked by the precheck orchestrate)
-if [ -z "$SALTENV" ]; then
-    SALTENV="metalk8s-@@VERSION"
-fi
 
 run "Performing Pre-Upgrade checks" precheck_upgrade
 [ $DRY_RUN -eq 1 ] && exit 0


### PR DESCRIPTION
**Component**: salt, scripts

**Context**: 
Upgrade fails because we upgrade Kubelet version before APIServer one, we end up with a kubelet version superior than the APIServer, which is not supported.

**Summary**:
Ensure all APIServer are upgraded to the new version before upgrading anything else.
We probably want to do the opposite for the downgrade (downgrade Kubelet on all nodes first or rather downgrade all APIServer instances last).
We may also want to do another bootstrap role instead of using a pillar entry.

**Acceptance criteria**: 
Upgrade from 2.5.1  to 2.6.0-dev works

---

Closes: #2811