### PR TITLE
[UI] Fix pod status display issue and the error for fetchNodeStats cancellation 

### DIFF
--- a/ui/src/constants.js
+++ b/ui/src/constants.js
@@ -22,6 +22,8 @@ export const STATUS_AVAILABLE = 'Available';
 export const STATUS_RELEASED = 'Released';
 export const STATUS_UNKNOWN = 'Unknown';
 export const STATUS_READY = 'Ready';
+export const STATUS_RUNNING = 'Running';
+export const STATUS_SUCCEEDED = 'Succeeded';
 
 export const SPARSE_LOOP_DEVICE = 'sparseLoopDevice';
 export const RAW_BLOCK_DEVICE = 'rawBlockDevice';

--- a/ui/src/ducks/app/monitoring.js
+++ b/ui/src/ducks/app/monitoring.js
@@ -770,7 +770,7 @@ export function* watchRefreshNodeStats() {
   while (true) {
     yield take(REFRESH_NODESTATS);
     while (true) {
-      yield fork(fetchNodeStats);
+      const fetchNodeStatsTask = yield fork(fetchNodeStats);
       const { interrupt } = yield race({
         interrupt: take(STOP_REFRESH_NODESTATS),
         // If the refresh period expires before we receive a halt,
@@ -781,7 +781,7 @@ export function* watchRefreshNodeStats() {
         update: take(UPDATE_NODESTATS_FETCH_ARG),
       });
       if (interrupt) {
-        yield cancel(fetchNodeStats);
+        yield cancel(fetchNodeStatsTask);
         break;
       }
     }

--- a/ui/src/services/PodUtils.js
+++ b/ui/src/services/PodUtils.js
@@ -3,21 +3,24 @@ import { fromMilliSectoAge } from './utils.js';
 // Return the pod list for the Pod Tab in Node Page
 export const getPodsListData = (nodeName, pods) => {
   const podsList = pods?.filter((pod) => pod.nodeName === nodeName);
-
   return (
     podsList?.map((pod) => {
       const age = fromMilliSectoAge(new Date() - pod.startTime);
 
-      const numContainer = pod?.containerStatuses?.length;
-      const containerReady =
-        pod?.containerStatuses?.filter((pCS) => pCS.ready === true) ?? [];
+      const numContainer = pod?.containerStatuses?.length ?? 0;
+      const numContainerRunning =
+        pod?.containerStatuses?.filter(
+          (container) => container.state.running !== undefined,
+        )?.length ?? 0;
+
       return {
         name: pod.name,
         age: age,
         namespace: pod.namespace,
         status: {
-          status: `${pod.status} (${containerReady.length}/${numContainer})`,
-          isAllContainerRunning: containerReady.length === numContainer,
+          status: pod.status,
+          numContainer: numContainer,
+          numContainerRunning: numContainerRunning,
         },
         log: pod.name,
       };


### PR DESCRIPTION
**Component**: ui

**Context**:  
There are 2 bugs:
- The status of the pod didn't display correctly. 
- The cancellation of the fetchNodeStats throw error in `watchRefreshNodeStats`

**Summary**:
Worked on the color specification for Pod status, please see:

- Pod Running + All Containers are Running => **Green**
- Pod Running + At least one container is running => **Orange**
- Pod Pending => **Orange**
- Pod Succeeded => **Green**
- Pod Failed => **Red**
- Pod Unknown => **Red**


**Acceptance criteria**: 
![image](https://user-images.githubusercontent.com/18453133/95849341-a4006980-0d4f-11eb-9fa0-988ee6d0f0c8.png)


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2847 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
