### PR TITLE
salt: Make salt module compatible with Python3

### DIFF
--- a/salt/_modules/metalk8s.py
+++ b/salt/_modules/metalk8s.py
@@ -5,6 +5,7 @@ Module for handling MetalK8s specific calls.
 import logging
 import os.path
 import re
+import six
 import socket
 import time
 
@@ -195,7 +196,7 @@ def get_archives(archives=None):
     if not archives:
         archives = __pillar__.get('metalk8s', {}).get('archives', [])
 
-    if isinstance(archives, basestring):
+    if isinstance(archives, six.string_types):
         archives = [str(archives)]
     elif not isinstance(archives, list):
         raise CommandExecutionError(
@@ -316,7 +317,7 @@ def format_slots(data):
     if isinstance(data, dict):
         return {key: format_slots(value) for key, value in data.items()}
 
-    if isinstance(data, basestring) and data.startswith('__slot__:'):
+    if isinstance(data, six.string_types) and data.startswith('__slot__:'):
         fmt = data.split(":", 2)
         if len(fmt) != 3:
             log.warning(

--- a/salt/_modules/metalk8s_etcd.py
+++ b/salt/_modules/metalk8s_etcd.py
@@ -3,7 +3,7 @@
 Module for handling etcd client specific calls.
 '''
 import logging
-from urlparse import urlparse
+from six.moves.urllib.parse import urlparse
 
 from salt.exceptions import CommandExecutionError
 

--- a/salt/_modules/metalk8s_kubernetes.py
+++ b/salt/_modules/metalk8s_kubernetes.py
@@ -70,7 +70,7 @@ def _handle_error(exception, action):
             isinstance(exception, ApiException) and exception.status == 404:
         return None
     else:
-        raise CommandExecutionError(base_msg + str(exception).decode('utf-8'))
+        raise CommandExecutionError(base_msg + str(exception))
 
 
 def _object_manipulation_function(action):

--- a/salt/_modules/metalk8s_network.py
+++ b/salt/_modules/metalk8s_network.py
@@ -31,7 +31,7 @@ def _pick_nth_service_ip(n):
             'Pillar key "networks:service" must be set.'
         )
 
-    network = ipaddress.IPv4Network(unicode(cidr))
+    network = ipaddress.IPv4Network(cidr)
     # NOTE: hosts() method below returns usable hosts in a network.
     # The usable hosts are all the IP addresses that belong to the network,
     # except the network address itself and the network broadcast address.

--- a/salt/_modules/metalk8s_volumes.py
+++ b/salt/_modules/metalk8s_volumes.py
@@ -11,6 +11,7 @@ import json
 import re
 import operator
 import os
+import six
 import time
 
 import logging
@@ -215,11 +216,9 @@ def device_info(name):
 # Volume {{{
 
 
-class Volume(object):
+@six.add_metaclass(abc.ABCMeta)
+class Volume():
     """Volume interface."""
-
-    # XXX: Will need to be updated when moving to Python 3
-    __metaclass__ = abc.ABCMeta
 
     def __init__(self, volume):
         self._volume = volume
@@ -295,7 +294,7 @@ class Volume(object):
                             .format(self.path))
         storage_class = self.get('spec.storageClass')
         # If we got a string that means the name wasn't replaced by the object.
-        if isinstance(storage_class, basestring):
+        if isinstance(storage_class, six.string_types):
             raise Exception('StorageClass {} not found'.format(storage_class))
         params = storage_class['parameters']
         # mkfs options, if any, are stored as JSON-encoded list.

--- a/salt/_states/kubeconfig.py
+++ b/salt/_states/kubeconfig.py
@@ -65,12 +65,12 @@ def _validateKubeConfig(filename,
         return False
 
     try:
-        client_key = b64decode(b64_client_key)
-        client_cert = b64decode(b64_client_cert)
+        client_key = b64decode(b64_client_key).decode()
+        client_cert = b64decode(b64_client_cert).decode()
     except TypeError:
         return False
 
-    ca_pem_cert = b64decode(current_ca_data)
+    ca_pem_cert = b64decode(current_ca_data).decode()
 
     client_cert_detail = __salt__['x509.read_certificate'](client_cert)
 
@@ -181,8 +181,8 @@ def managed(name,
             {
                 'name': user,
                 'user': {
-                    'client-certificate-data': b64encode(client_cert),
-                    'client-key-data': b64encode(client_priv_key)
+                    'client-certificate-data': b64encode(client_cert.encode()),
+                    'client-key-data': b64encode(client_priv_key.encode())
                 }
             }
         ]

--- a/salt/_utils/volume_utils.py
+++ b/salt/_utils/volume_utils.py
@@ -332,7 +332,7 @@ def get_blkid_probe(
     use_partitions=False, partitions_flags=0,
 ):
     """Return a probe for the specified device."""
-    c_probe = new_probe_from_filename(filepath)
+    c_probe = new_probe_from_filename(filepath.encode())
     try:
         probe = _Probe(c_probe)
         probe.configure(use_superblocks, superblocks_flags,

--- a/salt/tests/unit/modules/files/test_metalk8s_package_manager_yum.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_package_manager_yum.yaml
@@ -154,22 +154,15 @@ check_pkg_availability:
   # check 1 package not available - error when retrieving it
   - pkgs_info:
       nonexistent_pkg: {}
-    ybase_installs: False
-    raise_msg: "No candidate found for package: nonexistent_pkg"
+    yum_install_retcode: 1
+    raise_msg: "Check availability of package nonexistent_pkg failed: Oh ! No ! An ErRoR"
 
   # check 1 package not available with version - error when retrieving it
   - pkgs_info:
       nonexistent_pkg:
         version: "3.11.12"
-    ybase_installs: False
-    raise_msg: "No candidate found for package: nonexistent_pkg-3.11.12"
-
-  # check 1 package available - error when checking dependencies
-  - pkgs_info:
-      missing_deps_pkg:
-        version: "3.11.12"
-    ybase_process_trans: False
-    raise_msg: "Some package dependencies are missing: .*"
+    yum_install_retcode: 1
+    raise_msg: "Check availability of package nonexistent_pkg-3.11.12 failed: Oh ! No ! An ErRoR"
 
   # check 3 package (2 available, 1 not available) - error when retrieving it
   - pkgs_info:
@@ -178,17 +171,6 @@ check_pkg_availability:
       nonexistent_pkg: {}
       my_second_package:
         version: null
-    ybase_installs:
-      nonexistent_pkg: False
-    raise_msg: "No candidate found for package: nonexistent_pkg"
-
-  # check 3 package available - error when checking dependencies
-  - pkgs_info:
-      my_first_package:
-        version: "3.11.12"
-      my_second_package:
-        version: null
-      my_third_package:
-        version: "3.10.5-0.el7"
-    ybase_process_trans: False
-    raise_msg: "Some package dependencies are missing: .*"
+    yum_install_retcode:
+      nonexistent_pkg: 1
+    raise_msg: "Check availability of package nonexistent_pkg failed: Oh ! No ! An ErRoR"


### PR DESCRIPTION
**Component**:

'salt'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

We will migrate Salt to python3 in development/2.7 but first, let's make salt modules compatible with python2 and python3

**Summary**:

Make all custom salt modules, states, ... compatible with Python3 using
six:
- replace `basestring` with `six.string_types`
- replace `urlparse` with `six.moves.urllib.parse`
- do not try to decode string object
- do not convert string to unicode
- do not use `yum` Python API as it's only available with Python2
- encode and decode string object when using `base64`

NOTE: We do this change before migrating to Python3, so that future
downgrade will be simpler

---

Refs: #2203
