### PR TITLE
Bump k8s 1.17.13 + Add backup before and after upgrade and downgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ### Enhancements
 - [#2674](https://github.com/scality/metalk8s/issues/2674) - Bump K8S version
-to 1.17.9 (PR [#2363](https://github.com/scality/metalk8s/pull/2679))
+to 1.17.13 (PR [#2859](https://github.com/scality/metalk8s/pull/2859))
 
 - [#2572](https://github.com/scality/metalk8s/issues/2572) - Bump CoreDNS
 version to 1.6.5 (PR [#2582](https://github.com/scality/metalk8s/pull/2582))

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -18,7 +18,7 @@ Image = namedtuple('Image', ('name', 'version', 'digest'))
 # Project-wide versions {{{
 
 CALICO_VERSION     : str = '3.16.1'
-K8S_VERSION        : str = '1.17.9'
+K8S_VERSION        : str = '1.17.13'
 SALT_VERSION       : str = '3000.3'
 CONTAINERD_VERSION : str = '1.2.13'
 CONTAINERD_RELEASE : str = '2.el7'
@@ -122,22 +122,22 @@ CONTAINER_IMAGES : Tuple[Image, ...] = (
     Image(
         name='kube-apiserver',
         version=_version_prefix(K8S_VERSION),
-        digest='sha256:9d9f9b92e7c88b74618ee6e063886ad6aedd9c144c41702f4eded0f01d221536',
+        digest='sha256:ffdc2f826e3de98608d7e9b41ca0015ec45f066687491142d18a2879fb4a0c22',
     ),
     Image(
         name='kube-controller-manager',
         version=_version_prefix(K8S_VERSION),
-        digest='sha256:44fe07451d8e06de8dbe90a3840f844943a28eea25dc9048ce47b149b4e70025',
+        digest='sha256:e691a036126c48a7c994042f14f15fcc9a78d1bb28a71985841511153c598332',
     ),
     Image(
         name='kube-proxy',
         version=_version_prefix(K8S_VERSION),
-        digest='sha256:c10b65e55f5c121e3b6f293e1d89baad71a949d31569855c4f62a15920054ded',
+        digest='sha256:17fb24a64882f39f9c41a27ba33b325b8ec7627a771dd4f0a71c2167bfbf40c4',
     ),
     Image(
         name='kube-scheduler',
         version=_version_prefix(K8S_VERSION),
-        digest='sha256:5127fcc4861cf7ba0d2fc55a0d06a54f77c3e0cdbd6aaa32d76e95d8401d5ddb',
+        digest='sha256:2f9099bbcf24c472f86b2ebeb18a8b7e8f8220aa13fd274fa96aebf341abfeef',
     ),
     Image(
         name='kube-state-metrics',

--- a/scripts/downgrade.sh.in
+++ b/scripts/downgrade.sh.in
@@ -180,8 +180,13 @@ fi
 
 run "Performing Pre-Downgrade checks" precheck_downgrade
 [ $DRY_RUN -eq 1 ] && exit 0
+
+"$BASE_DIR"/backup.sh
+
 run "Setting cluster version to $DESTINATION_VERSION" patch_kubesystem_namespace
 run "Launching the pre-downgrade" launch_pre_downgrade
 run "Downgrading bootstrap" downgrade_bootstrap
 run "Launching the downgrade" launch_downgrade
 run "Launching the post-downgrade" launch_post_downgrade
+
+"$BASE_DIR"/backup.sh

--- a/scripts/upgrade.sh.in
+++ b/scripts/upgrade.sh.in
@@ -145,8 +145,13 @@ patch_kubesystem_namespace() {
 
 run "Performing Pre-Upgrade checks" precheck_upgrade
 [ $DRY_RUN -eq 1 ] && exit 0
+
+"$BASE_DIR"/backup.sh
+
 run "Upgrading bootstrap" upgrade_bootstrap
 run "Setting cluster version to $DESTINATION_VERSION" patch_kubesystem_namespace
 run "Launching the pre-upgrade" launch_pre_upgrade
 run "Launching the upgrade" launch_upgrade
 run "Launching the post-upgrade" launch_post_upgrade
+
+"$BASE_DIR"/backup.sh


### PR DESCRIPTION
**Component**:

'kubernetes', 'scripts'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Summary**:

- Bump Kubernetes version to 1.17.13
- Add a backup before and after upgrade and downgrade

---
