### PR TITLE
[UI] Add node deployment in overview tab

### DIFF
--- a/ui/public/brand/theme.json
+++ b/ui/public/brand/theme.json
@@ -1,7 +1,8 @@
 {
   "theme":{
     "light":{
-      "brand":{      
+      "brand":{
+        "alert": "#A39300",
         "base": "#607080",
         "primary": "#FAF9FB",
         "primaryDark1": "#F7F6F9",
@@ -10,41 +11,46 @@
         "secondaryDark1": "#1C3D59",
         "secondaryDark2": "#1C2E3F",
         "success": "#006F62",
-        "healthy": "#25AC56",
-        "healthyLight": "#75FE63",
-        "warning": "#FFC10A",
-        "danger": "#EF3340",
-        "critical": "#BE2543",
+        "healthy": "#24871D",
+        "healthyLight": "#33A919",
+        "warning": "#946F00",
+        "danger": "#AA1D05",
+        "critical": "#BE321F",
         "background": "#ffffff",
         "backgroundBluer": "#ECF4FF",
         "textPrimary": "#313B44",
         "textSecondary": "#8593A0",
-        "borderLight": "#A5A5A5",
-        "border": "#A5A5A5"
+        "textTertiary": "#A7B6C3",
+        "borderLight": "#EBEBEB",
+        "border": "#A5A5A5",
+        "info": "#8C8C8C"
       },
       "logo_path":"/brand/assets/branding-light.svg"
     },
     "dark":{
       "brand":{
-        "base": "#6A7B92",
-        "primary": "#1D1D1F",
-        "primaryDark1": "#171718",
+        "alert": "#FFE508",
+        "base": "#7B7B7B",
+        "primary": "#1D1D1D",
+        "primaryDark1": "#171717",
         "primaryDark2": "#0A0A0A",
-        "secondary": "#037AFF",
+        "secondary": "#055DFF",
         "secondaryDark1": "#1C3D59",
         "secondaryDark2": "#1C2E3F",
         "success": "#006F62",
-        "healthy": "#25AC56",
-        "healthyLight": "#75FE63",
+        "healthy": "#30AC26",
+        "healthyLight": "#69E44C",
         "warning": "#FFC10A",
-        "danger": "#EF3340",
-        "critical": "#BE2543",
-        "background": "#121214",
-        "backgroundBluer": "#182A41",
+        "danger": "#AA1D05",
+        "critical": "#BE321F",
+        "background": "#121212",
+        "backgroundBluer": "#192A41",
         "textPrimary": "#FFFFFF",
-        "textSecondary": "#A8B5C1",
-        "borderLight": "#2C3137",
-        "border": "#A5A5A5"
+        "textSecondary": "#B5B5B5",
+        "textTertiary": "#DFDFDF",
+        "borderLight": "#A5A5A5",
+        "border": "#313131",
+        "info": "#434343"
       },
       "logo_path":"/brand/assets/branding-dark.svg"
     },

--- a/ui/src/components/CommonLayoutStyle.js
+++ b/ui/src/components/CommonLayoutStyle.js
@@ -52,4 +52,5 @@ export const TabContainer = styled.div`
   background-color: ${(props) => props.theme.brand.primary};
   color: ${(props) => props.theme.brand.textPrimary};
   padding-top: ${padding.base};
+  padding-bottom: ${padding.base};
 `;

--- a/ui/src/components/NodeListTable.js
+++ b/ui/src/components/NodeListTable.js
@@ -275,8 +275,12 @@ function Table({ columns, data, rowClicked, theme, selectedNodeName }) {
                       <Cell {...cellProps}>
                         <NodeNameText>{cell.value.name}</NodeNameText>
                         <div>
-                          <IPText>CP: {cell.value.controlPlaneIP}</IPText>
-                          <IPText>WP: {cell.value.workloadPlaneIP}</IPText>
+                          {cell.value.controlPlaneIP ? (
+                            <IPText>CP: {cell.value.controlPlaneIP}</IPText>
+                          ) : null}
+                          {cell.value.workloadPlaneIP ? (
+                            <IPText>WP: {cell.value.workloadPlaneIP}</IPText>
+                          ) : null}
                         </div>
                       </Cell>
                     );
@@ -339,10 +343,10 @@ const NodeListTable = (props) => {
         accessor: 'status',
         cellStyle: { textAlign: 'center', width: '80px' },
         Cell: (cellProps) => {
-          const { statusColor, computedStatus } = cellProps.value;
+          const { statusTextColor, computedStatus } = cellProps.value;
           return computedStatus.map((status) => {
             return (
-              <StatusText textColor={statusColor}>
+              <StatusText textColor={statusTextColor}>
                 {intl.translate(`${status}`)}
               </StatusText>
             );

--- a/ui/src/components/NodeListTable.js
+++ b/ui/src/components/NodeListTable.js
@@ -89,7 +89,7 @@ const TableRow = styled(HeadRow)`
   background-color: ${(props) =>
     props.selectedNodeName === props.row.values.name.name
       ? props.theme.brand.backgroundBluer
-      : props.theme.brand.primaryDark1};
+      : props.theme.brand.background};
 `;
 
 // * table body

--- a/ui/src/components/NodePageOverviewTab.js
+++ b/ui/src/components/NodePageOverviewTab.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { FormattedDate, FormattedTime } from 'react-intl';
 import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
@@ -7,7 +8,11 @@ import {
   fontSize,
   fontWeight,
 } from '@scality/core-ui/dist/style/theme';
+import { Button, Steppers, Loader } from '@scality/core-ui';
+import isEmpty from 'lodash.isempty';
+import { deployNodeAction } from '../ducks/app/nodes';
 import { TabContainer } from './CommonLayoutStyle';
+import { API_STATUS_UNKNOWN } from '../constants.js';
 import { intl } from '../translations/IntlGlobalProvider';
 
 const InformationSpan = styled.div`
@@ -32,18 +37,19 @@ const InformationValue = styled.span`
 const NodeNameContainer = styled.div`
   display: flex;
   align-items: center;
+  justify-content: space-between;
   padding: ${padding.base} 0 ${padding.larger} ${padding.base};
 `;
 
 const NodeName = styled.div`
+  display: flex;
+  align-items: center;
   font-size: ${fontSize.larger};
-  padding-left: ${padding.small};
 `;
 
+// TODO: The color of the circle should depend on the Health
 const NodeStatusCircle = styled.div`
-  color: ${(props) => {
-    return props.color;
-  }};
+  padding-right: ${padding.small};
 `;
 
 const StatusText = styled.span`
@@ -52,10 +58,101 @@ const StatusText = styled.span`
   }};
 `;
 
+const DeployButton = styled(Button)`
+  margin-right: ${padding.base};
+`;
+
+const NodeInformationWrapper = styled.div``;
+
+const NodeDeploymentWrapper = styled.div`
+  padding: ${padding.smaller} 0 0 ${padding.small};
+
+  margin: ${padding.base} ${padding.base} 0 ${padding.base};
+  background-color: ${(props) => props.theme.brand.primaryDark1};
+`;
+
+const NodeDeploymentTitle = styled.div`
+  color: ${(props) => props.theme.brand.textPrimary};
+  font-weight: ${fontWeight.bold};
+  font-size: ${fontSize.base};
+`;
+
+const NodeDeploymentStatus = styled.div`
+  padding: ${padding.base};
+  font-size: ${fontSize.base};
+`;
+
+const InfoMessage = styled.div`
+  color: ${(props) => props.theme.brand.textPrimary};
+  font-size: ${fontSize.base};
+  padding: ${padding.base};
+`;
+
+const NodeDeploymentContent = styled.div`
+  display: flex;
+`;
+
+const ErrorLabel = styled.span`
+  color: ${(props) => props.theme.brand.critical};
+`;
+
 const NodePageOverviewTab = (props) => {
   const { nodeTableData, nodes, volumes, pods } = props;
   // Retrieve the node name from URL parameter
   const { name } = useParams();
+  const dispatch = useDispatch();
+
+  const jobs = useSelector((state) =>
+    state.app.salt.jobs.filter(
+      (job) => job.type === 'deploy-node' && job.node === name,
+    ),
+  );
+
+  let activeJob = jobs.find((job) => !job.completed);
+  if (activeJob === undefined) {
+    // Pick most recent one
+    const sortedJobs = jobs.sort(
+      (jobA, jobB) => Date(jobA.completedAt) >= Date(jobB.completedAt),
+    );
+    activeJob = sortedJobs[0];
+  }
+
+  let steps = [{ title: intl.translate('node_registered') }];
+  let success = false;
+  if (activeJob) {
+    if (activeJob.events.find((event) => event.tag.includes('/new'))) {
+      steps.push({ title: intl.translate('deployment_started') });
+    }
+
+    if (activeJob.completed) {
+      const status = activeJob.status;
+      steps.push({
+        title: intl.translate('completed'),
+        content: (
+          <span>
+            {!status.success && (
+              <ErrorLabel>
+                {`${intl.translate('error')}: ${status.step} - ${
+                  status.comment
+                }`}
+              </ErrorLabel>
+            )}
+          </span>
+        ),
+      });
+      success = status.success;
+    } else {
+      steps.push({
+        title: intl.translate('deploying'),
+        content: <Loader size="larger" />,
+      });
+    }
+  }
+
+  // TODO: Remove this workaround and actually handle showing a failed step
+  //       in the Steppers component
+  const activeStep = success ? steps.length : steps.length - 1;
+
   // The node object used by Node List Table
   const currentNode = nodeTableData?.find((node) => node.name.name === name);
   const currentNodeReturnByK8S = nodes?.find((node) => node.name === name);
@@ -72,84 +169,129 @@ const NodePageOverviewTab = (props) => {
     (pod) => pod.nodeName === name,
   );
 
-  const statusColor = currentNode?.status?.statusColor;
-
   return (
     <TabContainer>
       <NodeNameContainer>
-        <NodeStatusCircle color={statusColor}>
-          <i className="fas fa-circle fa-2x"></i>
-        </NodeStatusCircle>
-        <NodeName>{name}</NodeName>
-      </NodeNameContainer>
-      <InformationSpan>
-        <InformationLabel>Control Plane IP</InformationLabel>
-        <InformationValue>{currentNode?.name?.controlPlaneIP}</InformationValue>
-      </InformationSpan>
-      <InformationSpan>
-        <InformationLabel>Workload Plane IP</InformationLabel>
-        <InformationValue>
-          {currentNode?.name?.workloadPlaneIP}
-        </InformationValue>
-      </InformationSpan>
-      <InformationSpan>
-        <InformationLabel>Roles</InformationLabel>
-        <InformationValue>{currentNode?.roles}</InformationValue>
-      </InformationSpan>
-      <InformationSpan>
-        <InformationLabel>Status</InformationLabel>
-        <InformationValue>
-          {currentNode?.status?.computedStatus?.map((cond) => {
-            return (
-              <StatusText
-                key={cond}
-                textColor={currentNode?.status?.statusColor}
-              >
-                {intl.translate(`${cond}`)}
-              </StatusText>
-            );
-          })}
-        </InformationValue>
-      </InformationSpan>
-      <InformationSpan>
-        <InformationLabel>{intl.translate('creationTime')}</InformationLabel>
-        {creationTimestamp ? (
-          <InformationValue>
-            <FormattedDate
-              value={creationTimestamp}
-              year="numeric"
-              month="short"
-              day="2-digit"
-            />{' '}
-            <FormattedTime
-              hour="2-digit"
-              minute="2-digit"
-              second="2-digit"
-              value={creationTimestamp}
+        <NodeName>
+          <NodeStatusCircle>
+            <i className="fas fa-circle fa-2x"></i>
+          </NodeStatusCircle>
+          <div>{name}</div>
+        </NodeName>
+        {currentNodeReturnByK8S?.status === API_STATUS_UNKNOWN ? (
+          !currentNodeReturnByK8S?.deploying ? (
+            <DeployButton
+              text={intl.translate('deploy')}
+              variant="secondary"
+              onClick={() => {
+                dispatch(deployNodeAction({ name }));
+              }}
             />
+          ) : (
+            <DeployButton
+              text={intl.translate('deploying')}
+              disabled
+              icon={<Loader size="smaller" />}
+            />
+          )
+        ) : null}
+      </NodeNameContainer>
+
+      <NodeInformationWrapper>
+        <InformationSpan>
+          <InformationLabel>Control Plane IP</InformationLabel>
+          <InformationValue>
+            {currentNode?.name?.controlPlaneIP ?? intl.translate('unknown')}
           </InformationValue>
-        ) : (
-          ''
-        )}
-      </InformationSpan>
-      <InformationSpan>
-        <InformationLabel>K8s Version</InformationLabel>
-        <InformationValue>
-          {currentNodeReturnByK8S?.kubeletVersion}
-        </InformationValue>
-      </InformationSpan>
-      <InformationSpan>
-        <InformationLabel>Volumes</InformationLabel>
-        <InformationValue>
-          {volumesAttachedCurrentNode?.length ?? intl.translate('unknown')}
-        </InformationValue>
-      </InformationSpan>
-      <InformationSpan>
-        <InformationLabel>Pods</InformationLabel>
-        <InformationValue>
-          {podsScheduledOnCurrentNode?.length ?? intl.translate('unknown')}
-        </InformationValue>
-      </InformationSpan>
+        </InformationSpan>
+        <InformationSpan>
+          <InformationLabel>Workload Plane IP</InformationLabel>
+          <InformationValue>
+            {currentNode?.name?.workloadPlaneIP ?? intl.translate('unknown')}
+          </InformationValue>
+        </InformationSpan>
+        <InformationSpan>
+          <InformationLabel>Roles</InformationLabel>
+          <InformationValue>{currentNode?.roles}</InformationValue>
+        </InformationSpan>
+        <InformationSpan>
+          <InformationLabel>Status</InformationLabel>
+          <InformationValue>
+            {currentNode?.status?.computedStatus?.map((cond) => {
+              return (
+                <StatusText
+                  key={cond}
+                  textColor={currentNode?.status?.statusTextColor}
+                >
+                  {intl.translate(`${cond}`)}
+                </StatusText>
+              );
+            })}
+          </InformationValue>
+        </InformationSpan>
+        <InformationSpan>
+          <InformationLabel>{intl.translate('creationTime')}</InformationLabel>
+          {creationTimestamp ? (
+            <InformationValue>
+              <FormattedDate
+                value={creationTimestamp}
+                year="numeric"
+                month="short"
+                day="2-digit"
+              />{' '}
+              <FormattedTime
+                hour="2-digit"
+                minute="2-digit"
+                second="2-digit"
+                value={creationTimestamp}
+              />
+            </InformationValue>
+          ) : (
+            ''
+          )}
+        </InformationSpan>
+        <InformationSpan>
+          <InformationLabel>K8s Version</InformationLabel>
+          <InformationValue>
+            {currentNodeReturnByK8S?.kubeletVersion &&
+            currentNodeReturnByK8S?.kubeletVersion !== ''
+              ? currentNodeReturnByK8S?.kubeletVersion
+              : intl.translate('unknown')}
+          </InformationValue>
+        </InformationSpan>
+        <InformationSpan>
+          <InformationLabel>Volumes</InformationLabel>
+          <InformationValue>
+            {volumesAttachedCurrentNode?.length ?? intl.translate('unknown')}
+          </InformationValue>
+        </InformationSpan>
+        <InformationSpan>
+          <InformationLabel>Pods</InformationLabel>
+          <InformationValue>
+            {podsScheduledOnCurrentNode?.length ?? intl.translate('unknown')}
+          </InformationValue>
+        </InformationSpan>
+      </NodeInformationWrapper>
+      {currentNodeReturnByK8S?.status === API_STATUS_UNKNOWN ? (
+        <NodeDeploymentWrapper>
+          <NodeDeploymentTitle>
+            {intl.translate('deployment')}
+          </NodeDeploymentTitle>
+          {activeJob === undefined ? (
+            <InfoMessage>
+              {intl.translate('no_deployment_found', { name: name })}
+            </InfoMessage>
+          ) : activeJob.completed && isEmpty(activeJob.status) ? (
+            <InfoMessage>{intl.translate('refreshing_job')}</InfoMessage>
+          ) : (
+            <NodeDeploymentContent>
+              <NodeDeploymentStatus>
+                <Steppers steps={steps} activeStep={activeStep} />
+              </NodeDeploymentStatus>
+            </NodeDeploymentContent>
+          )}
+        </NodeDeploymentWrapper>
+      ) : null}
     </TabContainer>
   );
 };

--- a/ui/src/components/NodePagePodsTab.js
+++ b/ui/src/components/NodePagePodsTab.js
@@ -78,7 +78,7 @@ const StatusText = styled.div`
 `;
 
 const ExternalLink = styled.a`
-  color: ${(props) => props.theme.brand.border};
+  color: ${(props) => props.theme.brand.textSecondary};
 `;
 
 function Table({ columns, data }) {

--- a/ui/src/containers/NodePageRSP.js
+++ b/ui/src/containers/NodePageRSP.js
@@ -4,7 +4,7 @@ import { Switch, Route } from 'react-router-dom';
 import { useHistory, useLocation, useRouteMatch } from 'react-router';
 import styled from 'styled-components';
 import { Tabs } from '@scality/core-ui';
-import { padding } from '@scality/core-ui/dist/style/theme';
+import { padding, fontSize } from '@scality/core-ui/dist/style/theme';
 import { fetchPodsAction } from '../ducks/app/pods';
 import { getPodsListData } from '../services/PodUtils';
 import { useQuery, useRefreshEffect } from '../services/utils';
@@ -28,9 +28,24 @@ import { intl } from '../translations/IntlGlobalProvider';
 const NodePageRSPContainer = styled.div`
   flex-direction: column;
   width: 51%;
-  padding: 0 ${padding.small} ${padding.small} ${padding.small};
+  padding-left: ${padding.small};
   .sc-tabs {
     margin-top: 0;
+  }
+  .sc-tabs-bar {
+    height: 40px;
+  }
+  .sc-tabs-item-title {
+    height: 40px;
+    font-size: ${fontSize.base};
+    // set the title vertical align
+    padding: 12px 0 ${padding.base};
+  }
+  .sc-tabs-item {
+    margin-right: ${padding.smaller};
+    background-color: ${(props) => props.theme.brand.border};
+    border-radius: 3px 3px;
+    height: 40px;
   }
   .sc-tabs-item-content {
     padding: 0;

--- a/ui/src/services/NodeUtils.js
+++ b/ui/src/services/NodeUtils.js
@@ -1,4 +1,5 @@
 import { createSelector } from 'reselect';
+import { API_STATUS_UNKNOWN } from '../constants';
 
 const METALK8S_CONTROL_PLANE_IP = 'metalk8s:control_plane_ip';
 const METALK8S_WORKLOAD_PLANE_IP = 'metalk8s:workload_plane_ip';
@@ -17,7 +18,7 @@ export const getNodeListData = createSelector(
     return (
       nodes?.map((node) => {
         const IPsInfo = nodeIPsInfo?.[node.name];
-        let statusColor;
+        let statusTextColor;
         const computedStatus = [];
         // The rules of the color of the node status
         // "green" when status.conditions['Ready'] == True and all other conditions are false
@@ -25,18 +26,21 @@ export const getNodeListData = createSelector(
         // "red" when status.conditions['Ready'] == False
         // "grey" when there is no status.conditions
         if (node?.status === 'ready' && node?.conditions.length === 0) {
-          statusColor = brand?.healthy;
+          statusTextColor = brand?.healthy;
           computedStatus.push('ready');
         } else if (node?.status === 'ready' && node?.conditions.length !== 0) {
-          statusColor = brand?.warning;
+          statusTextColor = brand?.warning;
           nodes.conditions.map((cond) => {
             return computedStatus.push(cond);
           });
+        } else if (node.deploying && node.status === API_STATUS_UNKNOWN) {
+          statusTextColor = brand?.textSecondary;
+          computedStatus.push('deploying');
         } else if (node?.status !== 'ready') {
-          statusColor = brand?.critical;
-          computedStatus.push('notReady');
+          statusTextColor = brand?.critical;
+          computedStatus.push('not_ready');
         } else {
-          statusColor = brand?.textSecondary;
+          statusTextColor = brand?.textSecondary;
           computedStatus.push('unknown');
         }
 
@@ -50,7 +54,7 @@ export const getNodeListData = createSelector(
           status: {
             status: node?.status,
             conditions: node?.conditions,
-            statusColor,
+            statusTextColor,
             computedStatus,
           },
           roles: node?.roles,


### PR DESCRIPTION
**Component**: ui, nodes

**Context**: 
Add node deployment 

**Summary**:
- Add node deployment in Overview Tab. Since we have enough space after the node detail. I changed the layout @Cuervino 
- Update the theme.json according to the final version of color-palette.

**Acceptance criteria**: 
Not Deployed Node:
![image](https://user-images.githubusercontent.com/18453133/96137658-2ed29700-0efd-11eb-80c4-a42cee07f150.png)
Deploying:
![image](https://user-images.githubusercontent.com/18453133/96137687-38f49580-0efd-11eb-8e7b-3e4f0880584d.png)
Ready Node:
![image](https://user-images.githubusercontent.com/18453133/96137719-427dfd80-0efd-11eb-9a24-51989a092f79.png)
Deploy error:
![image](https://user-images.githubusercontent.com/18453133/96137813-66414380-0efd-11eb-9a94-62bd856499d7.png)

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2791

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
