### PR TITLE
[UI] New volumes page - Metrics & Details Tabs

### DIFF
--- a/ui/cypress/integration/common/volume.js
+++ b/ui/cypress/integration/common/volume.js
@@ -38,7 +38,7 @@ And('I click [Create] button', () => {
 });
 
 Then(`I am redirected to the {string} volume page`, (volumeName) => {
-  cy.location('pathname').should('eq', `/volumes/${volumeName}`);
+  cy.location('pathname').should('eq', `/volumes/${volumeName}/overview`);
 });
 
 And(`the volume {string} becomes Ready`, (volumeName) => {

--- a/ui/src/components/ActiveAlertsCounter.js
+++ b/ui/src/components/ActiveAlertsCounter.js
@@ -39,7 +39,7 @@ export const CounterIcon = styled.i`
 
     switch (props.status) {
       case STATUS_WARNING:
-        color = theme.warning;
+        color = theme.alert;
         break;
       case STATUS_CRITICAL:
         color = theme.danger;

--- a/ui/src/components/ActiveAlertsCounter.js
+++ b/ui/src/components/ActiveAlertsCounter.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useRouteMatch } from 'react-router';
 import styled from 'styled-components';
 import { useHistory, useLocation, useRouteMatch } from 'react-router';
 import { padding, fontSize } from '@scality/core-ui/dist/style/theme';

--- a/ui/src/components/ActiveAlertsCounter.js
+++ b/ui/src/components/ActiveAlertsCounter.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useRouteMatch } from 'react-router';
 import styled from 'styled-components';
-import { useHistory, useLocation } from 'react-router';
+import { useHistory, useLocation, useRouteMatch } from 'react-router';
 import { padding, fontSize } from '@scality/core-ui/dist/style/theme';
 import { STATUS_WARNING, STATUS_CRITICAL } from '../constants.js';
 

--- a/ui/src/components/ActiveAlertsFilters.js
+++ b/ui/src/components/ActiveAlertsFilters.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Dropdown } from '@scality/core-ui';
+import { useHistory } from 'react-router';
+import { useQuery } from '../services/utils';
+import { padding } from '@scality/core-ui/dist/style/theme';
+import { STATUS_WARNING, STATUS_CRITICAL } from '../constants.js';
+
+export const FilterIcon = styled.i`
+  color: ${(props) => {
+    const theme = props.theme.brand;
+    let color = theme.textPrimary;
+
+    switch (props.status) {
+      case STATUS_WARNING:
+        color = theme.warning;
+        break;
+      case STATUS_CRITICAL:
+        color = theme.danger;
+        break;
+      default:
+        color = theme.textPrimary;
+    }
+    return color;
+  }};
+  padding: ${padding.smaller};
+`;
+
+const ActiveAlertsFilter = (props) => {
+  const { baseLink } = props;
+  const history = useHistory();
+  const query = useQuery();
+  const selectedFilter = query.get('severity');
+
+  let items = [
+    {
+      label: 'All',
+      value: 'all',
+      onClick: () => {
+        query.delete('severity');
+        history.push(`${baseLink}?${query.toString()}`);
+      },
+      iconCode: '',
+    },
+    {
+      label: 'Critical',
+      value: STATUS_CRITICAL,
+      onClick: () => {
+        query.set('severity', STATUS_CRITICAL);
+        history.push(`${baseLink}?${query.toString()}`);
+      },
+      iconCode: 'fas fa-times-circle',
+    },
+    {
+      label: 'Warning',
+      value: STATUS_WARNING,
+      onClick: () => {
+        query.set('severity', STATUS_WARNING);
+        history.push(`${baseLink}?${query.toString()}`);
+      },
+      iconCode: 'fas fa-exclamation-triangle',
+    },
+  ];
+
+  const dropDownLabel = (() => {
+    if (!selectedFilter) return items[0].label;
+
+    const item = items.find((item) => item.value === selectedFilter);
+    return (
+      <span>
+        {item.value !== 'all' && (
+          <FilterIcon status={item.value} className={item.iconCode} />
+        )}
+        {item.label}
+      </span>
+    );
+  })();
+
+  if (selectedFilter) {
+    items = items.filter((item) => item.value !== selectedFilter);
+  } else {
+    items.splice(0, 1);
+  }
+
+  return <Dropdown items={items} text={dropDownLabel} size="small" />;
+};
+
+export default ActiveAlertsFilter;

--- a/ui/src/components/ActiveAlertsFilters.js
+++ b/ui/src/components/ActiveAlertsFilters.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Dropdown } from '@scality/core-ui';
-import { useHistory } from 'react-router';
+import { useHistory, useRouteMatch } from 'react-router';
 import { useQuery } from '../services/utils';
 import { padding } from '@scality/core-ui/dist/style/theme';
 import { STATUS_WARNING, STATUS_CRITICAL } from '../constants.js';
@@ -33,9 +33,9 @@ export const ActiveAlertsFilterWrapper = styled.div`
 `;
 
 const ActiveAlertsFilter = (props) => {
-  const { baseLink } = props;
   const history = useHistory();
   const query = useQuery();
+  const match = useRouteMatch();
   const selectedFilter = query.get('severity');
 
   let items = [
@@ -44,7 +44,7 @@ const ActiveAlertsFilter = (props) => {
       value: 'all',
       onClick: () => {
         query.delete('severity');
-        history.push(`${baseLink}?${query.toString()}`);
+        history.push(`${match.url}?${query.toString()}`);
       },
       iconCode: '',
     },
@@ -53,7 +53,7 @@ const ActiveAlertsFilter = (props) => {
       value: STATUS_CRITICAL,
       onClick: () => {
         query.set('severity', STATUS_CRITICAL);
-        history.push(`${baseLink}?${query.toString()}`);
+        history.push(`${match.url}?${query.toString()}`);
       },
       iconCode: 'fas fa-times-circle',
     },
@@ -62,7 +62,7 @@ const ActiveAlertsFilter = (props) => {
       value: STATUS_WARNING,
       onClick: () => {
         query.set('severity', STATUS_WARNING);
-        history.push(`${baseLink}?${query.toString()}`);
+        history.push(`${match.url}?${query.toString()}`);
       },
       iconCode: 'fas fa-exclamation-triangle',
     },

--- a/ui/src/components/ActiveAlertsFilters.js
+++ b/ui/src/components/ActiveAlertsFilters.js
@@ -26,6 +26,12 @@ export const FilterIcon = styled.i`
   padding: ${padding.smaller};
 `;
 
+export const ActiveAlertsFilterWrapper = styled.div`
+  .sc-dropdown > div {
+    background-color: ${(props) => props.theme.brand.info};
+  }
+`;
+
 const ActiveAlertsFilter = (props) => {
   const { baseLink } = props;
   const history = useHistory();
@@ -82,7 +88,11 @@ const ActiveAlertsFilter = (props) => {
     items.splice(0, 1);
   }
 
-  return <Dropdown items={items} text={dropDownLabel} size="small" />;
+  return (
+    <ActiveAlertsFilterWrapper>
+      <Dropdown items={items} text={dropDownLabel} size="small" />
+    </ActiveAlertsFilterWrapper>
+  );
 };
 
 export default ActiveAlertsFilter;

--- a/ui/src/components/CommonLayoutStyle.js
+++ b/ui/src/components/CommonLayoutStyle.js
@@ -68,3 +68,12 @@ export const TextBadge = styled.span`
   font-weight: ${fontWeight.bold};
   margin-left: ${padding.smaller};
 `;
+
+export const TextBadge = styled.span`
+  background-color: ${(props) => props.theme.brand.base};
+  color: ${(props) => props.theme.brand.textPrimary};
+  padding: 2px ${padding.small};
+  border-radius: 4px;
+  font-size: ${fontSize.small}
+  font-weight: ${fontWeight.bold}
+`;

--- a/ui/src/components/CommonLayoutStyle.js
+++ b/ui/src/components/CommonLayoutStyle.js
@@ -69,16 +69,6 @@ export const TextBadge = styled.span`
   margin-left: ${padding.smaller};
 `;
 
-export const TextBadge = styled.span`
-  background-color: ${(props) => props.theme.brand.info};
-  color: ${(props) => props.theme.brand.textPrimary};
-  padding: 2px ${padding.small};
-  border-radius: 4px;
-  font-size: ${fontSize.small};
-  font-weight: ${fontWeight.bold};
-  margin-left: ${padding.smaller};
-`;
-
 export const VolumeTab = styled.div`
   overflow: scroll;
   max-height: calc(100vh - 188px);

--- a/ui/src/components/CommonLayoutStyle.js
+++ b/ui/src/components/CommonLayoutStyle.js
@@ -74,6 +74,7 @@ export const TextBadge = styled.span`
   color: ${(props) => props.theme.brand.textPrimary};
   padding: 2px ${padding.small};
   border-radius: 4px;
-  font-size: ${fontSize.small}
-  font-weight: ${fontWeight.bold}
+  font-size: ${fontSize.small};
+  font-weight: ${fontWeight.bold};
+  margin-left: ${padding.smaller};
 `;

--- a/ui/src/components/CommonLayoutStyle.js
+++ b/ui/src/components/CommonLayoutStyle.js
@@ -70,7 +70,7 @@ export const TextBadge = styled.span`
 `;
 
 export const TextBadge = styled.span`
-  background-color: ${(props) => props.theme.brand.base};
+  background-color: ${(props) => props.theme.brand.info};
   color: ${(props) => props.theme.brand.textPrimary};
   padding: 2px ${padding.small};
   border-radius: 4px;

--- a/ui/src/components/CommonLayoutStyle.js
+++ b/ui/src/components/CommonLayoutStyle.js
@@ -78,3 +78,9 @@ export const TextBadge = styled.span`
   font-weight: ${fontWeight.bold};
   margin-left: ${padding.smaller};
 `;
+
+export const VolumeTab = styled.div`
+  overflow: scroll;
+  max-height: calc(100vh - 188px);
+  color: ${(props) => props.theme.brand.textPrimary};
+`;

--- a/ui/src/components/NodeDetailsTab.js
+++ b/ui/src/components/NodeDetailsTab.js
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 import { padding, fontSize } from '@scality/core-ui/dist/style/theme';
 import { TabContainer } from './CommonLayoutStyle';
+import { intl } from '../translations/IntlGlobalProvider';
 
 const NodeObjectContent = styled.div`
   padding: ${padding.large} 50px 0 ${padding.larger};
@@ -10,6 +11,11 @@ const NodeObjectContent = styled.div`
   overflow-y: auto;
   height: 78vh;
   font-size: ${fontSize.base};
+`;
+
+const ErrorText = styled.div`
+  text-align: center;
+  padding: ${padding.base};
 `;
 
 const NodePageDetailsTab = (props) => {
@@ -20,7 +26,11 @@ const NodePageDetailsTab = (props) => {
   return (
     <TabContainer>
       <NodeObjectContent>
-        {currentNodeObject && JSON.stringify(currentNodeObject, null, '\t')}
+        {currentNodeObject ? (
+          JSON.stringify(currentNodeObject, null, '\t')
+        ) : (
+          <ErrorText>{intl.translate('error_volume_details')}</ErrorText>
+        )}
       </NodeObjectContent>
     </TabContainer>
   );

--- a/ui/src/components/NodeDetailsTab.js
+++ b/ui/src/components/NodeDetailsTab.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
-import { padding } from '@scality/core-ui/dist/style/theme';
+import { padding, fontSize } from '@scality/core-ui/dist/style/theme';
 import { TabContainer } from './CommonLayoutStyle';
 
 const NodeObjectContent = styled.div`
@@ -9,6 +9,7 @@ const NodeObjectContent = styled.div`
   white-space: pre-wrap;
   overflow-y: auto;
   height: 78vh;
+  font-size: ${fontSize.base};
 `;
 
 const NodePageDetailsTab = (props) => {

--- a/ui/src/components/NodePageAlertsTab.js
+++ b/ui/src/components/NodePageAlertsTab.js
@@ -13,6 +13,7 @@ import ActiveAlertsFilter from './ActiveAlertsFilter';
 import { useQuery } from '../services/utils';
 import { TabContainer } from './CommonLayoutStyle';
 import { STATUS_WARNING, STATUS_CRITICAL } from '../constants';
+import { intl } from '../translations/IntlGlobalProvider';
 
 const ActiveAlertsTableContainer = styled.div`
   color: ${(props) => props.theme.brand.textPrimary};
@@ -60,6 +61,7 @@ const Body = styled.tbody`
 const ActiveAlertsText = styled.div`
   color: ${(props) => props.theme.brand.textTertiary};
   font-weight: ${fontWeight.bold};
+  font-size: ${fontSize.base};
 `;
 
 const TitleContainer = styled.div`
@@ -223,7 +225,9 @@ const NodePageAlertsTab = (props) => {
   return (
     <TabContainer>
       <TitleContainer>
-        <ActiveAlertsText theme={theme}>Active Alert</ActiveAlertsText>
+        <ActiveAlertsText theme={theme}>
+          {intl.translate('active_alert')}
+        </ActiveAlertsText>
         <ActiveAlertsFilter />
       </TitleContainer>
       <ActiveAlertsTableContainer>

--- a/ui/src/components/NodePageOverviewTab.js
+++ b/ui/src/components/NodePageOverviewTab.js
@@ -71,6 +71,7 @@ const Detail = styled.div`
 
 const ActiveAlertTitle = styled.div`
   padding-bottom: ${padding.base};
+  font-size: ${fontSize.base};
 `;
 
 const ActiveAlertWrapper = styled.div`
@@ -299,7 +300,7 @@ const NodePageOverviewTab = (props) => {
           </div>
           <ActiveAlertWrapper>
             <ActiveAlertTitle>
-              {intl.translate('active_alerts')}
+              {intl.translate('active_alert')}
             </ActiveAlertTitle>
             <ActiveAlertsCounter
               criticalCounter={currentNode?.health?.criticalAlertsCounter}

--- a/ui/src/components/VolumeAlertsTab.js
+++ b/ui/src/components/VolumeAlertsTab.js
@@ -1,20 +1,22 @@
 import React from 'react';
 import { FormattedDate, FormattedTime } from 'react-intl';
+import { useRouteMatch, useLocation } from 'react-router';
 import styled from 'styled-components';
 import {
   fontSize,
   padding,
   fontWeight,
 } from '@scality/core-ui/dist/style/theme';
+import ActiveAlertsFilters from './ActiveAlertsFilters';
 import { Chips } from '@scality/core-ui';
 import { useTable } from 'react-table';
 import { intl } from '../translations/IntlGlobalProvider';
 
+
 const ActiveAlertsCardContainer = styled.div`
   min-height: 75px;
-  background-color: ${(props) => props.theme.brand.primaryDark1};
   margin: ${padding.small};
-  padding: 0 ${padding.large} ${padding.small} 0;
+  padding: ${padding.small};
 `;
 
 const ActiveAlertsTitle = styled.div`
@@ -22,6 +24,8 @@ const ActiveAlertsTitle = styled.div`
   font-size: ${fontSize.base};
   font-weight: ${fontWeight.bold};
   padding: ${padding.small} 0 0 ${padding.large};
+  display: flex;
+  justify-content: space-between;
 `;
 
 const ActiveAlertsTableContainer = styled.div`
@@ -45,6 +49,8 @@ const ActiveAlertsTableContainer = styled.div`
     th {
       font-weight: bold;
       height: 56px;
+      text-align: left;
+      padding: 0.5rem;
     }
 
     td {
@@ -68,8 +74,12 @@ const NoActiveAlerts = styled.div`
 
 const ActiveAlertsCard = (props) => {
   const { alertlist, PVCName } = props;
+  const match = useRouteMatch();
+  const location = useLocation();
+  const query = new URLSearchParams(location.search);
+  const selectedFilter = query.get('severity');
 
-  const activeAlertListData = alertlist?.map((alert) => {
+  let activeAlertListData = alertlist?.map((alert) => {
     return {
       name: alert.labels.alertname,
       severity: alert.labels.severity,
@@ -77,6 +87,8 @@ const ActiveAlertsCard = (props) => {
       active_since: alert.startsAt,
     };
   });
+  if (activeAlertListData && selectedFilter)
+    activeAlertListData = activeAlertListData.filter(item => item.severity === selectedFilter);
   // React Table for the volume list
   function Table({ columns, data }) {
     // Use the state and functions returned from useTable to build your UI
@@ -145,6 +157,7 @@ const ActiveAlertsCard = (props) => {
                       <td {...cell.getCellProps()}>{cell.render('Cell')}</td>
                     );
                   }
+                  return null;
                 })}
               </tr>
             );
@@ -166,8 +179,15 @@ const ActiveAlertsCard = (props) => {
 
   return (
     <ActiveAlertsCardContainer>
-      <ActiveAlertsTitle>{intl.translate('active_alerts')}</ActiveAlertsTitle>
-      {PVCName && alertlist.length !== 0 ? (
+      <ActiveAlertsTitle>
+        <div>
+          {intl.translate('active_alerts')}
+        </div>
+        <ActiveAlertsFilters
+          baseLink={`${match.url}/alerts`}
+        />
+      </ActiveAlertsTitle>
+      {PVCName && activeAlertListData.length !== 0 ? (
         <ActiveAlertsTableContainer>
           <Table columns={columns} data={activeAlertListData} />
         </ActiveAlertsTableContainer>

--- a/ui/src/components/VolumeAlertsTab.js
+++ b/ui/src/components/VolumeAlertsTab.js
@@ -181,7 +181,7 @@ const ActiveAlertsCard = (props) => {
     <VolumeTab>
       <ActiveAlertsCardContainer>
         <ActiveAlertsTitle>
-          <div>{intl.translate('active_alerts')}</div>
+          <div>{intl.translate('active_alert')}</div>
           <ActiveAlertsFilters />
         </ActiveAlertsTitle>
         {PVCName && activeAlertListData.length !== 0 ? (

--- a/ui/src/components/VolumeAlertsTab.js
+++ b/ui/src/components/VolumeAlertsTab.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FormattedDate, FormattedTime } from 'react-intl';
-import { useRouteMatch, useLocation } from 'react-router';
+import { useLocation } from 'react-router';
 import styled from 'styled-components';
 import {
   fontSize,
@@ -11,7 +11,6 @@ import ActiveAlertsFilters from './ActiveAlertsFilters';
 import { Chips } from '@scality/core-ui';
 import { useTable } from 'react-table';
 import { intl } from '../translations/IntlGlobalProvider';
-
 
 const ActiveAlertsCardContainer = styled.div`
   min-height: 75px;
@@ -74,7 +73,6 @@ const NoActiveAlerts = styled.div`
 
 const ActiveAlertsCard = (props) => {
   const { alertlist, PVCName } = props;
-  const match = useRouteMatch();
   const location = useLocation();
   const query = new URLSearchParams(location.search);
   const selectedFilter = query.get('severity');
@@ -88,7 +86,9 @@ const ActiveAlertsCard = (props) => {
     };
   });
   if (activeAlertListData && selectedFilter)
-    activeAlertListData = activeAlertListData.filter(item => item.severity === selectedFilter);
+    activeAlertListData = activeAlertListData.filter(
+      (item) => item.severity === selectedFilter,
+    );
   // React Table for the volume list
   function Table({ columns, data }) {
     // Use the state and functions returned from useTable to build your UI
@@ -180,12 +180,8 @@ const ActiveAlertsCard = (props) => {
   return (
     <ActiveAlertsCardContainer>
       <ActiveAlertsTitle>
-        <div>
-          {intl.translate('active_alerts')}
-        </div>
-        <ActiveAlertsFilters
-          baseLink={`${match.url}/alerts`}
-        />
+        <div>{intl.translate('active_alerts')}</div>
+        <ActiveAlertsFilters />
       </ActiveAlertsTitle>
       {PVCName && activeAlertListData.length !== 0 ? (
         <ActiveAlertsTableContainer>

--- a/ui/src/components/VolumeAlertsTab.js
+++ b/ui/src/components/VolumeAlertsTab.js
@@ -11,9 +11,9 @@ import ActiveAlertsFilters from './ActiveAlertsFilters';
 import { Chips } from '@scality/core-ui';
 import { useTable } from 'react-table';
 import { intl } from '../translations/IntlGlobalProvider';
+import { VolumeTab } from './CommonLayoutStyle';
 
 const ActiveAlertsCardContainer = styled.div`
-  min-height: 75px;
   margin: ${padding.small};
   padding: ${padding.small};
 `;
@@ -178,19 +178,21 @@ const ActiveAlertsCard = (props) => {
   );
 
   return (
-    <ActiveAlertsCardContainer>
-      <ActiveAlertsTitle>
-        <div>{intl.translate('active_alerts')}</div>
-        <ActiveAlertsFilters />
-      </ActiveAlertsTitle>
-      {PVCName && activeAlertListData.length !== 0 ? (
-        <ActiveAlertsTableContainer>
-          <Table columns={columns} data={activeAlertListData} />
-        </ActiveAlertsTableContainer>
-      ) : (
-        <NoActiveAlerts>{intl.translate('no_active_alerts')}</NoActiveAlerts>
-      )}
-    </ActiveAlertsCardContainer>
+    <VolumeTab>
+      <ActiveAlertsCardContainer>
+        <ActiveAlertsTitle>
+          <div>{intl.translate('active_alerts')}</div>
+          <ActiveAlertsFilters />
+        </ActiveAlertsTitle>
+        {PVCName && activeAlertListData.length !== 0 ? (
+          <ActiveAlertsTableContainer>
+            <Table columns={columns} data={activeAlertListData} />
+          </ActiveAlertsTableContainer>
+        ) : (
+          <NoActiveAlerts>{intl.translate('no_active_alerts')}</NoActiveAlerts>
+        )}
+      </ActiveAlertsCardContainer>
+    </VolumeTab>
   );
 };
 

--- a/ui/src/components/VolumeDetailsTab.js
+++ b/ui/src/components/VolumeDetailsTab.js
@@ -14,13 +14,13 @@ const ErrorText = styled.div`
 `;
 
 const VolumeDetailsTab = (props) => {
-  const { data, error } = props.currentVolumeObject;
+  const { data } = props.currentVolumeObject;
 
   return (
     <VolumeTab>
       <VolumeObjectContent>
         {data && JSON.stringify(data, null, '\t')}
-        {error && (
+        {!data && (
           <ErrorText>{intl.translate('error_volume_details')}</ErrorText>
         )}
       </VolumeObjectContent>

--- a/ui/src/components/VolumeDetailsTab.js
+++ b/ui/src/components/VolumeDetailsTab.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import styled from 'styled-components';
+import { intl } from '../translations/IntlGlobalProvider';
+import { padding } from '@scality/core-ui/dist/style/theme';
+
+const DetailsTabContainer = styled.div`
+  color: ${(props) => props.theme.brand.textPrimary};
+`;
+
+const VolumeObjectContent = styled.div`
+  white-space: pre-wrap;
+  overflow: scroll;
+`;
+
+const ErrorText = styled.div`
+  text-align: center;
+  padding: ${padding.base};
+`;
+
+const VolumeDetailsTab = (props) => {
+  const { data, error } = props.currentVolumeObject;
+
+  return (
+    <DetailsTabContainer>
+      <VolumeObjectContent>
+        {data && JSON.stringify(data, null, '\t')}
+        {error && (
+          <ErrorText>{intl.translate('error_volume_details')}</ErrorText>
+        )}
+      </VolumeObjectContent>
+    </DetailsTabContainer>
+  );
+};
+
+export default VolumeDetailsTab;

--- a/ui/src/components/VolumeDetailsTab.js
+++ b/ui/src/components/VolumeDetailsTab.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import styled from 'styled-components';
 import { intl } from '../translations/IntlGlobalProvider';
-import { padding } from '@scality/core-ui/dist/style/theme';
+import { padding, fontSize } from '@scality/core-ui/dist/style/theme';
 import { VolumeTab } from './CommonLayoutStyle';
 
 const VolumeObjectContent = styled.div`
   white-space: pre-wrap;
+  font-size: ${fontSize.base};
 `;
 
 const ErrorText = styled.div`

--- a/ui/src/components/VolumeDetailsTab.js
+++ b/ui/src/components/VolumeDetailsTab.js
@@ -2,14 +2,10 @@ import React from 'react';
 import styled from 'styled-components';
 import { intl } from '../translations/IntlGlobalProvider';
 import { padding } from '@scality/core-ui/dist/style/theme';
-
-const DetailsTabContainer = styled.div`
-  color: ${(props) => props.theme.brand.textPrimary};
-`;
+import { VolumeTab } from './CommonLayoutStyle';
 
 const VolumeObjectContent = styled.div`
   white-space: pre-wrap;
-  overflow: scroll;
 `;
 
 const ErrorText = styled.div`
@@ -21,14 +17,14 @@ const VolumeDetailsTab = (props) => {
   const { data, error } = props.currentVolumeObject;
 
   return (
-    <DetailsTabContainer>
+    <VolumeTab>
       <VolumeObjectContent>
         {data && JSON.stringify(data, null, '\t')}
         {error && (
           <ErrorText>{intl.translate('error_volume_details')}</ErrorText>
         )}
       </VolumeObjectContent>
-    </DetailsTabContainer>
+    </VolumeTab>
   );
 };
 

--- a/ui/src/components/VolumeListTable.js
+++ b/ui/src/components/VolumeListTable.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { useHistory } from 'react-router';
 import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
@@ -15,6 +15,9 @@ import {
   padding,
   fontWeight,
 } from '@scality/core-ui/dist/style/theme';
+import {
+  clearCurrentVolumeObjectAction
+} from '../ducks/app/volumes';
 import CircleStatus from './CircleStatus';
 import { Button, ProgressBar, Tooltip } from '@scality/core-ui';
 import { intl } from '../translations/IntlGlobalProvider';
@@ -339,6 +342,7 @@ const VolumeListTable = (props) => {
     isSearchBar,
   } = props;
   const history = useHistory();
+  const dispatch = useDispatch();
   const location = useLocation();
 
   const theme = useSelector((state) => state.config.theme);
@@ -441,9 +445,11 @@ const VolumeListTable = (props) => {
     const isAddNodeFilter = query.has('node');
     const isTabSelected =
     location.pathname.endsWith('/alerts')
-    || location.pathname.endsWith('/metrics');
-
-    // there are two possiable URLs
+    || location.pathname.endsWith('/metrics')
+    || location.pathname.endsWith('/details');
+    
+    // Clearing selected volume object
+    dispatch(clearCurrentVolumeObjectAction());
     if (isAddNodeFilter || !isNodeColumn) {
       history.push(`/volumes/${row.values.name}?node=${nodeName}`);
     } else {

--- a/ui/src/components/VolumeListTable.js
+++ b/ui/src/components/VolumeListTable.js
@@ -439,7 +439,9 @@ const VolumeListTable = (props) => {
   const onClickRow = (row) => {
     const query = new URLSearchParams(location.search);
     const isAddNodeFilter = query.has('node');
-    const isTabSelected = location.pathname.endsWith('/alerts');
+    const isTabSelected =
+    location.pathname.endsWith('/alerts')
+    || location.pathname.endsWith('/metrics');
 
     // there are two possiable URLs
     if (isAddNodeFilter || !isNodeColumn) {

--- a/ui/src/components/VolumeListTable.js
+++ b/ui/src/components/VolumeListTable.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router';
 import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
@@ -15,7 +15,6 @@ import {
   padding,
   fontWeight,
 } from '@scality/core-ui/dist/style/theme';
-import { clearCurrentVolumeObjectAction } from '../ducks/app/volumes';
 import CircleStatus from './CircleStatus';
 import { Button, ProgressBar, Tooltip } from '@scality/core-ui';
 import { intl } from '../translations/IntlGlobalProvider';
@@ -339,7 +338,6 @@ const VolumeListTable = (props) => {
     isSearchBar,
   } = props;
   const history = useHistory();
-  const dispatch = useDispatch();
   const location = useLocation();
 
   const theme = useSelector((state) => state.config.theme);
@@ -445,8 +443,6 @@ const VolumeListTable = (props) => {
       location.pathname.endsWith('/metrics') ||
       location.pathname.endsWith('/details');
 
-    // Clearing selected volume object
-    dispatch(clearCurrentVolumeObjectAction());
     if (isAddNodeFilter || !isNodeColumn) {
       history.push(`/volumes/${row.values.name}?node=${nodeName}`);
     } else {

--- a/ui/src/components/VolumeListTable.js
+++ b/ui/src/components/VolumeListTable.js
@@ -444,7 +444,7 @@ const VolumeListTable = (props) => {
       location.pathname.endsWith('/details');
 
     if (isAddNodeFilter || !isNodeColumn) {
-      history.push(`/volumes/${row.values.name}?node=${nodeName}`);
+      history.push(`/volumes/${row.values.name}/overview?node=${nodeName}`);
     } else {
       if (isTabSelected) {
         const newPath = location.pathname.replace(

--- a/ui/src/components/VolumeListTable.js
+++ b/ui/src/components/VolumeListTable.js
@@ -15,22 +15,22 @@ import {
   padding,
   fontWeight,
 } from '@scality/core-ui/dist/style/theme';
-import {
-  clearCurrentVolumeObjectAction
-} from '../ducks/app/volumes';
+import { clearCurrentVolumeObjectAction } from '../ducks/app/volumes';
 import CircleStatus from './CircleStatus';
 import { Button, ProgressBar, Tooltip } from '@scality/core-ui';
 import { intl } from '../translations/IntlGlobalProvider';
 
 const VolumeListContainer = styled.div`
   color: ${(props) => props.theme.brand.textPrimary};
-  padding: ${padding.base};
   font-family: 'Lato';
   font-size: ${fontSize.base};
   border-color: ${(props) => props.theme.brand.borderLight};
   background-color: ${(props) => props.theme.brand.primary};
   .sc-progressbarcontainer {
     width: 100%;
+  }
+  .sc-progressbarcontainer > div {
+    background-color: ${(props) => props.theme.brand.secondaryDark1};
   }
   .ReactTable .rt-thead {
     overflow-y: scroll;
@@ -60,10 +60,9 @@ const VolumeListContainer = styled.div`
     td {
       margin: 0;
       padding: 0.5rem;
-      border-bottom: 1px solid black;
       text-align: left;
       padding: 5px;
-
+      border: none;
       :last-child {
         border-right: 0;
       }
@@ -83,8 +82,6 @@ const TableRow = styled(HeadRow)`
   &:hover,
   &:focus {
     background-color: ${(props) => props.theme.brand.backgroundBluer};
-    border-top: 1px solid ${(props) => props.theme.brand.secondary};
-    border-bottom: 1px solid ${(props) => props.theme.brand.secondary};
     outline: none;
     cursor: pointer;
   }
@@ -350,6 +347,16 @@ const VolumeListTable = (props) => {
   const columns = React.useMemo(
     () => [
       {
+        Header: 'Health',
+        accessor: 'health',
+        cellStyle: { textAlign: 'center', width: '50px' },
+        Cell: (cellProps) => {
+          return (
+            <CircleStatus className="fas fa-circle" status={cellProps.value} />
+          );
+        },
+      },
+      {
         Header: 'Name',
         accessor: 'name',
       },
@@ -372,16 +379,6 @@ const VolumeListTable = (props) => {
         Header: 'Size',
         accessor: 'storageCapacity',
         cellStyle: { textAlign: 'center', width: '70px' },
-      },
-      {
-        Header: 'Health',
-        accessor: 'health',
-        cellStyle: { textAlign: 'center', width: '50px' },
-        Cell: (cellProps) => {
-          return (
-            <CircleStatus className="fas fa-circle" status={cellProps.value} />
-          );
-        },
       },
       {
         Header: 'Status',
@@ -444,10 +441,10 @@ const VolumeListTable = (props) => {
     const query = new URLSearchParams(location.search);
     const isAddNodeFilter = query.has('node');
     const isTabSelected =
-    location.pathname.endsWith('/alerts')
-    || location.pathname.endsWith('/metrics')
-    || location.pathname.endsWith('/details');
-    
+      location.pathname.endsWith('/alerts') ||
+      location.pathname.endsWith('/metrics') ||
+      location.pathname.endsWith('/details');
+
     // Clearing selected volume object
     dispatch(clearCurrentVolumeObjectAction());
     if (isAddNodeFilter || !isNodeColumn) {

--- a/ui/src/components/VolumeListTable.js
+++ b/ui/src/components/VolumeListTable.js
@@ -25,6 +25,7 @@ const VolumeListContainer = styled.div`
   font-family: 'Lato';
   font-size: ${fontSize.base};
   border-color: ${(props) => props.theme.brand.borderLight};
+  background-color: ${(props) => props.theme.brand.primary};
   .sc-progressbarcontainer {
     width: 100%;
   }
@@ -438,12 +439,27 @@ const VolumeListTable = (props) => {
   const onClickRow = (row) => {
     const query = new URLSearchParams(location.search);
     const isAddNodeFilter = query.has('node');
+    const isTabSelected = location.pathname.endsWith('/alerts');
 
     // there are two possiable URLs
     if (isAddNodeFilter || !isNodeColumn) {
       history.push(`/volumes/${row.values.name}?node=${nodeName}`);
     } else {
-      history.push(`/volumes/${row.values.name}`);
+      if (isTabSelected) {
+        const newPath = location.pathname.replace(
+          /\/volumes\/[^/]*\//,
+          `/volumes/${row.values.name}/`,
+        );
+        history.push({
+          pathname: newPath,
+          search: query.toString(),
+        });
+      } else {
+        history.push({
+          pathname: `/volumes/${row.values.name}/overview`,
+          search: query.toString(),
+        });
+      }
     }
   };
 

--- a/ui/src/components/VolumeMetricsTab.js
+++ b/ui/src/components/VolumeMetricsTab.js
@@ -31,6 +31,7 @@ import {
   queryTimeSpansCodes,
 } from '../constants';
 import { intl } from '../translations/IntlGlobalProvider';
+import { VolumeTab } from './CommonLayoutStyle';
 
 const MetricGraphCardContainer = styled.div`
   min-height: 270px;
@@ -364,107 +365,111 @@ const MetricsTab = (props) => {
   );
 
   return (
-    <MetricGraphCardContainer>
-      <MetricGraphTitle>
-        {volumeCondition === VOLUME_CONDITION_LINK && (
-          <Dropdown
-            items={metricsTimeSpanDropdownItems}
-            text={metricsTimeSpan}
-            size="small"
-          />
+    <VolumeTab>
+      <MetricGraphCardContainer>
+        <MetricGraphTitle>
+          {volumeCondition === VOLUME_CONDITION_LINK && (
+            <Dropdown
+              items={metricsTimeSpanDropdownItems}
+              text={metricsTimeSpan}
+              size="small"
+            />
+          )}
+          {config.api?.url_grafana && (
+            <Button
+              text={intl.translate('advanced_metrics')}
+              variant={'base'}
+              onClick={() => {}}
+              icon={<i className="fas fa-external-link-alt" />}
+              size={'small'}
+              href={`${config.api.url_grafana}/dashboard/db/kubernetes-persistent-volumes`}
+              target="_blank"
+              rel="noopener noreferrer"
+            />
+          )}
+        </MetricGraphTitle>
+        {volumeCondition === VOLUME_CONDITION_LINK ? (
+          <GraphsContainer>
+            <RowGraphContainer>
+              <UsageGraph>
+                <GraphTitle>USAGE (%)</GraphTitle>
+                {volumeUsageData?.length > 0 ? (
+                  <LineChart
+                    id={'volume_usage_id'}
+                    data={volumeUsageData}
+                    xAxis={xAxis}
+                    yAxis={yAxisUsage}
+                    color={colorUsage}
+                    width={285}
+                    height={80}
+                    tooltip={false}
+                  />
+                ) : (
+                  <NoDataGraphText>No available usage data</NoDataGraphText>
+                )}
+              </UsageGraph>
+              <LatencyGraph>
+                <GraphTitle>LATENCY (µs) </GraphTitle>
+                {volumeLatencyData?.length > 0 ? (
+                  <LineChart
+                    id={'volume_latency_id'}
+                    data={volumeLatencyData}
+                    xAxis={xAxis}
+                    yAxis={yAxisWriteRead}
+                    color={colors}
+                    width={285}
+                    height={80}
+                    tooltip={false}
+                  />
+                ) : (
+                  <NoDataGraphText>No available latency data</NoDataGraphText>
+                )}
+              </LatencyGraph>
+            </RowGraphContainer>
+            <SecondRowGraphContainer>
+              <TroughputGraph>
+                <GraphTitle>THROUGHPUT (MB/s)</GraphTitle>
+                {volumeThroughputData?.length > 0 ? (
+                  <LineChart
+                    id={'volume_throughput_id'}
+                    data={volumeThroughputData}
+                    xAxis={xAxis}
+                    yAxis={yAxisWriteRead}
+                    color={colors}
+                    width={285}
+                    height={80}
+                    tooltip={false}
+                  />
+                ) : (
+                  <NoDataGraphText>
+                    No available throughput data
+                  </NoDataGraphText>
+                )}
+              </TroughputGraph>
+              <IOPSGraph>
+                <GraphTitle>IOPS</GraphTitle>
+                {volumeIOPSData?.length > 0 ? (
+                  <LineChart
+                    id={'volume_IOPS_id'}
+                    data={volumeIOPSData}
+                    xAxis={xAxis}
+                    yAxis={yAxisWriteRead}
+                    color={colors}
+                    width={285}
+                    height={80}
+                    tooltip={false}
+                  />
+                ) : (
+                  <NoDataGraphText>No available IOPS data</NoDataGraphText>
+                )}
+              </IOPSGraph>
+            </SecondRowGraphContainer>
+          </GraphsContainer>
+        ) : (
+          <NoMetricsText>{intl.translate('volume_is_not_bound')}</NoMetricsText>
         )}
-        {config.api?.url_grafana && (
-          <Button
-            text={intl.translate('advanced_metrics')}
-            variant={'base'}
-            onClick={() => {}}
-            icon={<i className="fas fa-external-link-alt" />}
-            size={'small'}
-            href={`${config.api.url_grafana}/dashboard/db/kubernetes-persistent-volumes`}
-            target="_blank"
-            rel="noopener noreferrer"
-          />
-        )}
-      </MetricGraphTitle>
-      {volumeCondition === VOLUME_CONDITION_LINK ? (
-        <GraphsContainer>
-          <RowGraphContainer>
-            <UsageGraph>
-              <GraphTitle>USAGE (%)</GraphTitle>
-              {volumeUsageData?.length > 0 ? (
-                <LineChart
-                  id={'volume_usage_id'}
-                  data={volumeUsageData}
-                  xAxis={xAxis}
-                  yAxis={yAxisUsage}
-                  color={colorUsage}
-                  width={285}
-                  height={80}
-                  tooltip={false}
-                />
-              ) : (
-                <NoDataGraphText>No available usage data</NoDataGraphText>
-              )}
-            </UsageGraph>
-            <LatencyGraph>
-              <GraphTitle>LATENCY (µs) </GraphTitle>
-              {volumeLatencyData?.length > 0 ? (
-                <LineChart
-                  id={'volume_latency_id'}
-                  data={volumeLatencyData}
-                  xAxis={xAxis}
-                  yAxis={yAxisWriteRead}
-                  color={colors}
-                  width={285}
-                  height={80}
-                  tooltip={false}
-                />
-              ) : (
-                <NoDataGraphText>No available latency data</NoDataGraphText>
-              )}
-            </LatencyGraph>
-          </RowGraphContainer>
-          <SecondRowGraphContainer>
-            <TroughputGraph>
-              <GraphTitle>THROUGHPUT (MB/s)</GraphTitle>
-              {volumeThroughputData?.length > 0 ? (
-                <LineChart
-                  id={'volume_throughput_id'}
-                  data={volumeThroughputData}
-                  xAxis={xAxis}
-                  yAxis={yAxisWriteRead}
-                  color={colors}
-                  width={285}
-                  height={80}
-                  tooltip={false}
-                />
-              ) : (
-                <NoDataGraphText>No available throughput data</NoDataGraphText>
-              )}
-            </TroughputGraph>
-            <IOPSGraph>
-              <GraphTitle>IOPS</GraphTitle>
-              {volumeIOPSData?.length > 0 ? (
-                <LineChart
-                  id={'volume_IOPS_id'}
-                  data={volumeIOPSData}
-                  xAxis={xAxis}
-                  yAxis={yAxisWriteRead}
-                  color={colors}
-                  width={285}
-                  height={80}
-                  tooltip={false}
-                />
-              ) : (
-                <NoDataGraphText>No available IOPS data</NoDataGraphText>
-              )}
-            </IOPSGraph>
-          </SecondRowGraphContainer>
-        </GraphsContainer>
-      ) : (
-        <NoMetricsText>{intl.translate('volume_is_not_bound')}</NoMetricsText>
-      )}
-    </MetricGraphCardContainer>
+      </MetricGraphCardContainer>
+    </VolumeTab>
   );
 };
 

--- a/ui/src/components/VolumeMetricsTab.js
+++ b/ui/src/components/VolumeMetricsTab.js
@@ -73,14 +73,6 @@ const RowGraphContainer = styled.div`
   display: flex;
   flex-direction: row;
   padding-left: 3px;
-  justify-content: space-around;
-`;
-
-const SecondRowGraphContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  padding-left: 3px;
-  justify-content: space-around;
 `;
 
 const GraphTitle = styled.div`
@@ -90,21 +82,11 @@ const GraphTitle = styled.div`
   padding: ${padding.small} 0 0 ${padding.larger};
 `;
 
-const UsageGraph = styled.div`
-  min-width: 308px;
+const LeftGraphContainer = styled.div`
+  padding-left: 0px;
 `;
 
-const LatencyGraph = styled.div`
-  min-width: 308px;
-  padding-left: ${padding.large};
-`;
-
-const TroughputGraph = styled.div`
-  min-width: 308px;
-`;
-
-const IOPSGraph = styled.div`
-  min-width: 308px;
+const RightGraphContainer = styled.div`
   padding-left: ${padding.large};
 `;
 
@@ -391,7 +373,7 @@ const MetricsTab = (props) => {
         {volumeCondition === VOLUME_CONDITION_LINK ? (
           <GraphsContainer>
             <RowGraphContainer>
-              <UsageGraph>
+              <LeftGraphContainer>
                 <GraphTitle>USAGE (%)</GraphTitle>
                 {volumeUsageData?.length > 0 ? (
                   <LineChart
@@ -400,15 +382,15 @@ const MetricsTab = (props) => {
                     xAxis={xAxis}
                     yAxis={yAxisUsage}
                     color={colorUsage}
-                    width={285}
-                    height={80}
+                    width={window.innerWidth / 4 - 110}
+                    height={window.innerHeight / 6 - 30}
                     tooltip={false}
                   />
                 ) : (
                   <NoDataGraphText>No available usage data</NoDataGraphText>
                 )}
-              </UsageGraph>
-              <LatencyGraph>
+              </LeftGraphContainer>
+              <RightGraphContainer>
                 <GraphTitle>LATENCY (µs) </GraphTitle>
                 {volumeLatencyData?.length > 0 ? (
                   <LineChart
@@ -417,17 +399,17 @@ const MetricsTab = (props) => {
                     xAxis={xAxis}
                     yAxis={yAxisWriteRead}
                     color={colors}
-                    width={285}
-                    height={80}
+                    width={window.innerWidth / 4 - 110}
+                    height={window.innerHeight / 6 - 30}
                     tooltip={false}
                   />
                 ) : (
                   <NoDataGraphText>No available latency data</NoDataGraphText>
                 )}
-              </LatencyGraph>
+              </RightGraphContainer>
             </RowGraphContainer>
-            <SecondRowGraphContainer>
-              <TroughputGraph>
+            <RowGraphContainer>
+              <LeftGraphContainer>
                 <GraphTitle>THROUGHPUT (MB/s)</GraphTitle>
                 {volumeThroughputData?.length > 0 ? (
                   <LineChart
@@ -436,8 +418,8 @@ const MetricsTab = (props) => {
                     xAxis={xAxis}
                     yAxis={yAxisWriteRead}
                     color={colors}
-                    width={285}
-                    height={80}
+                    width={window.innerWidth / 4 - 110}
+                    height={window.innerHeight / 6 - 30}
                     tooltip={false}
                   />
                 ) : (
@@ -445,8 +427,8 @@ const MetricsTab = (props) => {
                     No available throughput data
                   </NoDataGraphText>
                 )}
-              </TroughputGraph>
-              <IOPSGraph>
+              </LeftGraphContainer>
+              <RightGraphContainer>
                 <GraphTitle>IOPS</GraphTitle>
                 {volumeIOPSData?.length > 0 ? (
                   <LineChart
@@ -455,15 +437,15 @@ const MetricsTab = (props) => {
                     xAxis={xAxis}
                     yAxis={yAxisWriteRead}
                     color={colors}
-                    width={285}
-                    height={80}
+                    width={window.innerWidth / 4 - 110}
+                    height={window.innerHeight / 6 - 30}
                     tooltip={false}
                   />
                 ) : (
                   <NoDataGraphText>No available IOPS data</NoDataGraphText>
                 )}
-              </IOPSGraph>
-            </SecondRowGraphContainer>
+              </RightGraphContainer>
+            </RowGraphContainer>
           </GraphsContainer>
         ) : (
           <NoMetricsText>{intl.translate('volume_is_not_bound')}</NoMetricsText>

--- a/ui/src/components/VolumeMetricsTab.js
+++ b/ui/src/components/VolumeMetricsTab.js
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { useHistory } from 'react-router';
 import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
-import { LineChart, Dropdown } from '@scality/core-ui';
+import { LineChart, Dropdown, Button } from '@scality/core-ui';
 import {
   fetchVolumeStatsAction,
   updateVolumeStatsAction,
@@ -34,19 +34,25 @@ import { intl } from '../translations/IntlGlobalProvider';
 
 const MetricGraphCardContainer = styled.div`
   min-height: 270px;
-  background-color: ${(props) => props.theme.brand.primaryDark1};
-  margin: ${padding.small};
-  padding-bottom: ${padding.large};
+
+  .sc-vegachart svg {
+    background-color: inherit !important;
+  }
 `;
 
 const MetricGraphTitle = styled.div`
   color: ${(props) => props.theme.brand.textPrimary};
   font-size: ${fontSize.base};
   font-weight: ${fontWeight.bold};
-  padding: ${padding.small} 0 0 ${padding.large};
+  padding: ${padding.small};
   display: flex;
+  flex-direction: row-reverse;
   .sc-dropdown {
     padding-left: 25px;
+  }
+
+  .sc-button {
+    font-size: ${fontSize.small};
   }
 `;
 
@@ -60,12 +66,14 @@ const RowGraphContainer = styled.div`
   display: flex;
   flex-direction: row;
   padding-left: 3px;
+  justify-content: space-around;
 `;
 
 const SecondRowGraphContainer = styled.div`
   display: flex;
   flex-direction: row;
   padding-left: 3px;
+  justify-content: space-around;
 `;
 
 const GraphTitle = styled.div`
@@ -115,6 +123,7 @@ const MetricsTab = (props) => {
   const metricsTimeSpan = useSelector(
     (state) => state.app.monitoring.volumeStats.metricsTimeSpan,
   );
+  const config = useSelector((state) => state.config);
 
   // write the selected timespan in URL
   const writeUrlTimeSpan = (timespan) => {
@@ -351,12 +360,23 @@ const MetricsTab = (props) => {
   return (
     <MetricGraphCardContainer>
       <MetricGraphTitle>
-        {intl.translate('metrics')}
         {volumeCondition === VOLUME_CONDITION_LINK && (
           <Dropdown
             items={metricsTimeSpanDropdownItems}
             text={metricsTimeSpan}
             size="smaller"
+          />
+        )}
+        {config.api?.url_grafana && (
+          <Button
+            text={intl.translate('advanced_metrics')}
+            variant={'base'}
+            onClick={() => {}}
+            icon={<i className="fas fa-external-link-alt" />}
+            size={'smaller'}
+            href={`${config.api.url_grafana}/dashboard/db/kubernetes-persistent-volumes`}
+            target="_blank"
+            rel="noopener noreferrer"
           />
         )}
       </MetricGraphTitle>

--- a/ui/src/components/VolumeMetricsTab.js
+++ b/ui/src/components/VolumeMetricsTab.js
@@ -106,7 +106,7 @@ const NoDataGraphText = styled.div`
   padding: ${padding.small} 0 0 ${padding.larger};
 `;
 
-const MetricGraphCard = (props) => {
+const MetricsTab = (props) => {
   const { volumeCondition, volumeMetricGraphData, volumeName } = props;
   const dispatch = useDispatch();
   const history = useHistory();
@@ -442,4 +442,4 @@ const MetricGraphCard = (props) => {
   );
 };
 
-export default MetricGraphCard;
+export default MetricsTab;

--- a/ui/src/components/VolumeMetricsTab.js
+++ b/ui/src/components/VolumeMetricsTab.js
@@ -50,9 +50,15 @@ const MetricGraphTitle = styled.div`
   .sc-dropdown {
     padding-left: 25px;
   }
-
+  
+  .sc-dropdown > div {
+    background-color: ${(props) => props.theme.brand.primary};
+    border: 1px solid ${(props) => props.theme.brand.borderLight}
+    border-radius: 3px;
+  }
+  
   .sc-button {
-    font-size: ${fontSize.small};
+    background-color: ${(props) => props.theme.brand.info};
   }
 `;
 
@@ -364,7 +370,7 @@ const MetricsTab = (props) => {
           <Dropdown
             items={metricsTimeSpanDropdownItems}
             text={metricsTimeSpan}
-            size="smaller"
+            size="small"
           />
         )}
         {config.api?.url_grafana && (
@@ -373,7 +379,7 @@ const MetricsTab = (props) => {
             variant={'base'}
             onClick={() => {}}
             icon={<i className="fas fa-external-link-alt" />}
-            size={'smaller'}
+            size={'small'}
             href={`${config.api.url_grafana}/dashboard/db/kubernetes-persistent-volumes`}
             target="_blank"
             rel="noopener noreferrer"

--- a/ui/src/components/VolumeOverviewTab.js
+++ b/ui/src/components/VolumeOverviewTab.js
@@ -324,7 +324,7 @@ const VolumeDetailCard = (props) => {
           {alertlist && (
             <AlertsCounterContainer>
               <VolumeSectionTitle>
-                {intl.translate('active_alerts')}
+                {intl.translate('active_alert')}
               </VolumeSectionTitle>
               <ActiveAlertsCounter
                 criticalCounter={

--- a/ui/src/components/VolumeOverviewTab.js
+++ b/ui/src/components/VolumeOverviewTab.js
@@ -53,6 +53,13 @@ const InformationValue = styled.span`
   font-size: ${fontSize.base};
 `;
 
+const ClickableInformationValue = styled.span`
+  color: ${(props) => props.theme.brand.secondary};
+  font-size: ${fontSize.base};
+  font-weight: ${fontWeight.semibold};
+  cursor: pointer;
+`;
+
 const DeleteButton = styled(Button)`
   padding: ${padding.base};
   font-size: ${fontSize.small};
@@ -128,7 +135,6 @@ const AlertsCounterContainer = styled.div`
   flex-direction: column;
 `;
 
-
 const VolumeDetailCard = (props) => {
   const {
     name,
@@ -147,7 +153,7 @@ const VolumeDetailCard = (props) => {
     volumeListData,
     pVList,
     health,
-    alertlist
+    alertlist,
   } = props;
 
   const dispatch = useDispatch();
@@ -190,6 +196,10 @@ const VolumeDetailCard = (props) => {
     }
   };
 
+  const onClickNodeName = () => {
+    history.push(`/nodes/${nodeName}`);
+  };
+
   const onClickCancelButton = () => {
     setisDeleteConfirmationModalOpen(false);
   };
@@ -216,7 +226,9 @@ const VolumeDetailCard = (props) => {
         </VolumeNameTitle>
         <InformationSpan>
           <InformationLabel>{intl.translate('node')}</InformationLabel>
-          <InformationValue>{nodeName}</InformationValue>
+          <ClickableInformationValue onClick={onClickNodeName}>
+            {nodeName}
+          </ClickableInformationValue>
         </InformationSpan>
         <InformationSpan>
           <InformationLabel>{intl.translate('size')}</InformationLabel>
@@ -298,8 +310,7 @@ const VolumeDetailCard = (props) => {
             data-cy="delete_volume_button"
           ></DeleteButton>
         </DeleteButtonContainer>
-        {
-          alertlist &&
+        {alertlist && (
           <AlertsCounterContainer>
             <VolumeSectionTitle>
               {intl.translate('active_alerts')}
@@ -309,7 +320,7 @@ const VolumeDetailCard = (props) => {
               baseLink={`${match.url}/${name}/alerts`}
             />
           </AlertsCounterContainer>
-        }
+        )}
         {condition === VOLUME_CONDITION_LINK && (
           <VolumeUsage>
             <VolumeSectionTitle>{intl.translate('usage')}</VolumeSectionTitle>

--- a/ui/src/components/VolumeOverviewTab.js
+++ b/ui/src/components/VolumeOverviewTab.js
@@ -37,8 +37,10 @@ const VolumeNameTitle = styled.div`
   color: ${(props) => props.theme.brand.textPrimary};
   font-size: ${fontSize.larger};
   padding: ${padding.small} 0 ${padding.larger} ${padding.large};
+  display: flex;
+  justify-content: space-between;
 
-  > i {
+  i.fa-circle {
     margin-right: ${padding.small};
   }
 `;
@@ -71,17 +73,12 @@ const ClickableInformationValue = styled.span`
 
 const DeleteButton = styled(Button)`
   padding: ${padding.base};
+  margin: 0px ${padding.base};
   font-size: ${fontSize.small};
   background-color: ${(props) => props.theme.brand.critical};
   ${(props) => {
     if (props.disabled) return { opacity: 0.2 };
   }};
-`;
-
-const DeleteButtonContainer = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  padding-top: ${padding.base};
 `;
 
 const VolumeGraph = styled.div`
@@ -226,12 +223,25 @@ const VolumeDetailCard = (props) => {
 
   return (
     <VolumeTab>
+      <VolumeNameTitle data-cy="volume_detail_card_name">
+        <div>
+          <CircleStatus className="fas fa-circle" status={health} />
+          {name}
+        </div>
+        <DeleteButton
+          variant="danger"
+          icon={<i className="fas fa-sm fa-trash" />}
+          text={intl.translate('delete_volume')}
+          onClick={(e) => {
+            e.stopPropagation();
+            setisDeleteConfirmationModalOpen(true);
+          }}
+          disabled={!isEnableClick}
+          data-cy="delete_volume_button"
+        />
+      </VolumeNameTitle>
       <VolumeDetailCardContainer>
         <VolumeInformation>
-          <VolumeNameTitle data-cy="volume_detail_card_name">
-            <CircleStatus className="fas fa-circle" status={health} />
-            {name}
-          </VolumeNameTitle>
           <InformationSpan>
             <InformationLabel>{intl.translate('node')}</InformationLabel>
             <ClickableInformationValue onClick={onClickNodeName}>
@@ -311,19 +321,6 @@ const VolumeDetailCard = (props) => {
         </VolumeInformation>
 
         <VolumeGraph>
-          <DeleteButtonContainer>
-            <DeleteButton
-              variant="danger"
-              icon={<i className="fas fa-sm fa-trash" />}
-              text={intl.translate('delete_volume')}
-              onClick={(e) => {
-                e.stopPropagation();
-                setisDeleteConfirmationModalOpen(true);
-              }}
-              disabled={!isEnableClick}
-              data-cy="delete_volume_button"
-            ></DeleteButton>
-          </DeleteButtonContainer>
           {alertlist && (
             <AlertsCounterContainer>
               <VolumeSectionTitle>

--- a/ui/src/components/VolumeOverviewTab.js
+++ b/ui/src/components/VolumeOverviewTab.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useLocation, useRouteMatch } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { useHistory } from 'react-router';
 import { FormattedDate, FormattedTime } from 'react-intl';
 import styled from 'styled-components';
@@ -168,7 +168,6 @@ const VolumeDetailCard = (props) => {
   const history = useHistory();
   const location = useLocation();
   const query = new URLSearchParams(location.search);
-  const match = useRouteMatch();
   const theme = useSelector((state) => state.config.theme);
 
   const deleteVolume = (deleteVolumeName) =>
@@ -333,7 +332,6 @@ const VolumeDetailCard = (props) => {
                   (item) => item?.labels?.severity === STATUS_WARNING,
                 ).length
               }
-              baseLink={`${match.url}/${name}/alerts`}
             />
           </AlertsCounterContainer>
         )}

--- a/ui/src/components/VolumeOverviewTab.js
+++ b/ui/src/components/VolumeOverviewTab.js
@@ -228,7 +228,7 @@ const VolumeDetailCard = (props) => {
     <VolumeDetailCardContainer>
       <VolumeInformation>
         <VolumeNameTitle data-cy="volume_detail_card_name">
-          <CircleStatus className="fas fa-circle fa-2x" status={health} />
+          <CircleStatus className="fas fa-circle" status={health} />
           {name}
         </VolumeNameTitle>
         <InformationSpan>

--- a/ui/src/components/VolumeOverviewTab.js
+++ b/ui/src/components/VolumeOverviewTab.js
@@ -13,7 +13,11 @@ import CircleStatus from './CircleStatus';
 import ActiveAlertsCounter from './ActiveAlertsCounter';
 import { isVolumeDeletable } from '../services/NodeVolumesUtils';
 import { deleteVolumeAction } from '../ducks/app/volumes';
-import { VOLUME_CONDITION_LINK } from '../constants';
+import {
+  VOLUME_CONDITION_LINK,
+  STATUS_CRITICAL,
+  STATUS_WARNING,
+} from '../constants';
 import { Button, Modal, ProgressBar, Loader } from '@scality/core-ui';
 import { intl } from '../translations/IntlGlobalProvider';
 
@@ -316,7 +320,16 @@ const VolumeDetailCard = (props) => {
               {intl.translate('active_alerts')}
             </VolumeSectionTitle>
             <ActiveAlertsCounter
-              alerts={alertlist}
+              criticalCounter={
+                alertlist?.filter(
+                  (item) => item?.labels?.severity === STATUS_CRITICAL,
+                ).length
+              }
+              warningCounter={
+                alertlist?.filter(
+                  (item) => item?.labels?.severity === STATUS_WARNING,
+                ).length
+              }
               baseLink={`${match.url}/${name}/alerts`}
             />
           </AlertsCounterContainer>

--- a/ui/src/components/VolumeOverviewTab.js
+++ b/ui/src/components/VolumeOverviewTab.js
@@ -36,6 +36,10 @@ const VolumeNameTitle = styled.div`
   color: ${(props) => props.theme.brand.textPrimary};
   font-size: ${fontSize.larger};
   padding: ${padding.small} 0 ${padding.larger} ${padding.large};
+
+  > i {
+    margin-right: ${padding.small};
+  }
 `;
 
 const InformationSpan = styled.div`
@@ -225,7 +229,6 @@ const VolumeDetailCard = (props) => {
       <VolumeInformation>
         <VolumeNameTitle data-cy="volume_detail_card_name">
           <CircleStatus className="fas fa-circle fa-2x" status={health} />
-          &nbsp;
           {name}
         </VolumeNameTitle>
         <InformationSpan>

--- a/ui/src/components/VolumeOverviewTab.js
+++ b/ui/src/components/VolumeOverviewTab.js
@@ -321,7 +321,7 @@ const VolumeDetailCard = (props) => {
                   topRightLabel={`${volumeUsagePercentage}%`}
                   bottomLeftLabel={`${volumeUsageBytes} USED`}
                   bottomRightLabel={`${storageCapacity} TOTAL`}
-                  backgroundColor={theme.brand.borderLight}
+                  backgroundColor={theme.brand.base}
                 />
               </ProgressBarContainer>
             ) : (

--- a/ui/src/components/VolumeOverviewTab.js
+++ b/ui/src/components/VolumeOverviewTab.js
@@ -20,6 +20,7 @@ import {
 } from '../constants';
 import { Button, Modal, ProgressBar, Loader } from '@scality/core-ui';
 import { intl } from '../translations/IntlGlobalProvider';
+import { VolumeTab } from './CommonLayoutStyle';
 
 const VolumeDetailCardContainer = styled.div`
   display: flex;
@@ -224,168 +225,176 @@ const VolumeDetailCard = (props) => {
     : [];
 
   return (
-    <VolumeDetailCardContainer>
-      <VolumeInformation>
-        <VolumeNameTitle data-cy="volume_detail_card_name">
-          <CircleStatus className="fas fa-circle" status={health} />
-          {name}
-        </VolumeNameTitle>
-        <InformationSpan>
-          <InformationLabel>{intl.translate('node')}</InformationLabel>
-          <ClickableInformationValue onClick={onClickNodeName}>
-            {nodeName}
-          </ClickableInformationValue>
-        </InformationSpan>
-        <InformationSpan>
-          <InformationLabel>{intl.translate('size')}</InformationLabel>
-          <InformationValue>{storage}</InformationValue>
-        </InformationSpan>
-        <InformationSpan>
-          <InformationLabel>{intl.translate('status')}</InformationLabel>
-          <InformationValue data-cy="volume_status_value">
-            {status}
-          </InformationValue>
-        </InformationSpan>
-        <InformationSpan>
-          <InformationLabel>{intl.translate('storageClass')}</InformationLabel>
-          <InformationValue>{storageClassName}</InformationValue>
-        </InformationSpan>
-        <InformationSpan>
-          <InformationLabel>{intl.translate('creationTime')}</InformationLabel>
-          {creationTimestamp ? (
-            <InformationValue>
-              <FormattedDate
-                value={creationTimestamp}
-                year="numeric"
-                month="short"
-                day="2-digit"
-              />{' '}
-              <FormattedTime
-                hour="2-digit"
-                minute="2-digit"
-                second="2-digit"
-                value={creationTimestamp}
-              />
+    <VolumeTab>
+      <VolumeDetailCardContainer>
+        <VolumeInformation>
+          <VolumeNameTitle data-cy="volume_detail_card_name">
+            <CircleStatus className="fas fa-circle" status={health} />
+            {name}
+          </VolumeNameTitle>
+          <InformationSpan>
+            <InformationLabel>{intl.translate('node')}</InformationLabel>
+            <ClickableInformationValue onClick={onClickNodeName}>
+              {nodeName}
+            </ClickableInformationValue>
+          </InformationSpan>
+          <InformationSpan>
+            <InformationLabel>{intl.translate('size')}</InformationLabel>
+            <InformationValue>{storage}</InformationValue>
+          </InformationSpan>
+          <InformationSpan>
+            <InformationLabel>{intl.translate('status')}</InformationLabel>
+            <InformationValue data-cy="volume_status_value">
+              {status}
             </InformationValue>
-          ) : (
-            ''
-          )}
-        </InformationSpan>
-        <InformationSpan>
-          <InformationLabel>{intl.translate('volume_type')}</InformationLabel>
-          <InformationValue>{volumeType}</InformationValue>
-        </InformationSpan>
-        <InformationSpan>
-          <InformationLabel>{intl.translate('used_by')}</InformationLabel>
-          <InformationValue>{usedPodName}</InformationValue>
-        </InformationSpan>
-        <InformationSpan>
-          <InformationLabel>{intl.translate('backend_disk')}</InformationLabel>
-          <InformationValue>{devicePath}</InformationValue>
-        </InformationSpan>
-        <InformationSpan>
-          <InformationLabel>{intl.translate('labels')}</InformationLabel>
-          <InformationValue>
-            {labels?.map((label) => {
-              return (
-                <div key={label.name}>
-                  <LabelName data-cy="volume_label_name">
-                    {label.name}
-                  </LabelName>
-                  <LabelValue data-cy="volume_label_value">
-                    {label.value}
-                  </LabelValue>
-                </div>
-              );
-            })}
-          </InformationValue>
-        </InformationSpan>
-      </VolumeInformation>
-
-      <VolumeGraph>
-        <DeleteButtonContainer>
-          <DeleteButton
-            variant="danger"
-            icon={<i className="fas fa-sm fa-trash" />}
-            text={intl.translate('delete_volume')}
-            onClick={(e) => {
-              e.stopPropagation();
-              setisDeleteConfirmationModalOpen(true);
-            }}
-            disabled={!isEnableClick}
-            data-cy="delete_volume_button"
-          ></DeleteButton>
-        </DeleteButtonContainer>
-        {alertlist && (
-          <AlertsCounterContainer>
-            <VolumeSectionTitle>
-              {intl.translate('active_alerts')}
-            </VolumeSectionTitle>
-            <ActiveAlertsCounter
-              criticalCounter={
-                alertlist?.filter(
-                  (item) => item?.labels?.severity === STATUS_CRITICAL,
-                ).length
-              }
-              warningCounter={
-                alertlist?.filter(
-                  (item) => item?.labels?.severity === STATUS_WARNING,
-                ).length
-              }
-            />
-          </AlertsCounterContainer>
-        )}
-        {condition === VOLUME_CONDITION_LINK && (
-          <VolumeUsage>
-            <VolumeSectionTitle>{intl.translate('usage')}</VolumeSectionTitle>
-            {volumeUsagePercentage !== intl.translate('unknown') ? (
-              <ProgressBarContainer>
-                <ProgressBar
-                  size="base"
-                  percentage={volumeUsagePercentage}
-                  topRightLabel={`${volumeUsagePercentage}%`}
-                  bottomLeftLabel={`${volumeUsageBytes} USED`}
-                  bottomRightLabel={`${storageCapacity} TOTAL`}
-                  backgroundColor={theme.brand.base}
+          </InformationSpan>
+          <InformationSpan>
+            <InformationLabel>
+              {intl.translate('storageClass')}
+            </InformationLabel>
+            <InformationValue>{storageClassName}</InformationValue>
+          </InformationSpan>
+          <InformationSpan>
+            <InformationLabel>
+              {intl.translate('creationTime')}
+            </InformationLabel>
+            {creationTimestamp ? (
+              <InformationValue>
+                <FormattedDate
+                  value={creationTimestamp}
+                  year="numeric"
+                  month="short"
+                  day="2-digit"
+                />{' '}
+                <FormattedTime
+                  hour="2-digit"
+                  minute="2-digit"
+                  second="2-digit"
+                  value={creationTimestamp}
                 />
-              </ProgressBarContainer>
+              </InformationValue>
             ) : (
-              <LoaderContainer size="small" />
+              ''
             )}
-          </VolumeUsage>
-        )}
-      </VolumeGraph>
-      <Modal
-        close={() => setisDeleteConfirmationModalOpen(false)}
-        isOpen={isDeleteConfirmationModalOpen}
-        title={intl.translate('delete_volume')}
-        footer={
-          <NotificationButtonGroup>
-            <CancelButton
-              outlined
-              text={intl.translate('cancel')}
-              onClick={onClickCancelButton}
-            />
-            <Button
+          </InformationSpan>
+          <InformationSpan>
+            <InformationLabel>{intl.translate('volume_type')}</InformationLabel>
+            <InformationValue>{volumeType}</InformationValue>
+          </InformationSpan>
+          <InformationSpan>
+            <InformationLabel>{intl.translate('used_by')}</InformationLabel>
+            <InformationValue>{usedPodName}</InformationValue>
+          </InformationSpan>
+          <InformationSpan>
+            <InformationLabel>
+              {intl.translate('backend_disk')}
+            </InformationLabel>
+            <InformationValue>{devicePath}</InformationValue>
+          </InformationSpan>
+          <InformationSpan>
+            <InformationLabel>{intl.translate('labels')}</InformationLabel>
+            <InformationValue>
+              {labels?.map((label) => {
+                return (
+                  <div key={label.name}>
+                    <LabelName data-cy="volume_label_name">
+                      {label.name}
+                    </LabelName>
+                    <LabelValue data-cy="volume_label_value">
+                      {label.value}
+                    </LabelValue>
+                  </div>
+                );
+              })}
+            </InformationValue>
+          </InformationSpan>
+        </VolumeInformation>
+
+        <VolumeGraph>
+          <DeleteButtonContainer>
+            <DeleteButton
               variant="danger"
-              text={intl.translate('delete')}
-              onClick={() => {
-                onClickDeleteButton(name, nodeName);
+              icon={<i className="fas fa-sm fa-trash" />}
+              text={intl.translate('delete_volume')}
+              onClick={(e) => {
+                e.stopPropagation();
+                setisDeleteConfirmationModalOpen(true);
               }}
-              data-cy="confirm_deletion_button"
-            ></Button>
-          </NotificationButtonGroup>
-        }
-      >
-        <ModalBody>
-          <div>{intl.translate('delete_a_volume_warning')}</div>
-          <div>
-            {intl.translate('delete_a_volume_confirm')}
-            <strong>{name}</strong>?
-          </div>
-        </ModalBody>
-      </Modal>
-    </VolumeDetailCardContainer>
+              disabled={!isEnableClick}
+              data-cy="delete_volume_button"
+            ></DeleteButton>
+          </DeleteButtonContainer>
+          {alertlist && (
+            <AlertsCounterContainer>
+              <VolumeSectionTitle>
+                {intl.translate('active_alerts')}
+              </VolumeSectionTitle>
+              <ActiveAlertsCounter
+                criticalCounter={
+                  alertlist?.filter(
+                    (item) => item?.labels?.severity === STATUS_CRITICAL,
+                  ).length
+                }
+                warningCounter={
+                  alertlist?.filter(
+                    (item) => item?.labels?.severity === STATUS_WARNING,
+                  ).length
+                }
+              />
+            </AlertsCounterContainer>
+          )}
+          {condition === VOLUME_CONDITION_LINK && (
+            <VolumeUsage>
+              <VolumeSectionTitle>{intl.translate('usage')}</VolumeSectionTitle>
+              {volumeUsagePercentage !== intl.translate('unknown') ? (
+                <ProgressBarContainer>
+                  <ProgressBar
+                    size="base"
+                    percentage={volumeUsagePercentage}
+                    topRightLabel={`${volumeUsagePercentage}%`}
+                    bottomLeftLabel={`${volumeUsageBytes} USED`}
+                    bottomRightLabel={`${storageCapacity} TOTAL`}
+                    backgroundColor={theme.brand.base}
+                  />
+                </ProgressBarContainer>
+              ) : (
+                <LoaderContainer size="small" />
+              )}
+            </VolumeUsage>
+          )}
+        </VolumeGraph>
+        <Modal
+          close={() => setisDeleteConfirmationModalOpen(false)}
+          isOpen={isDeleteConfirmationModalOpen}
+          title={intl.translate('delete_volume')}
+          footer={
+            <NotificationButtonGroup>
+              <CancelButton
+                outlined
+                text={intl.translate('cancel')}
+                onClick={onClickCancelButton}
+              />
+              <Button
+                variant="danger"
+                text={intl.translate('delete')}
+                onClick={() => {
+                  onClickDeleteButton(name, nodeName);
+                }}
+                data-cy="confirm_deletion_button"
+              ></Button>
+            </NotificationButtonGroup>
+          }
+        >
+          <ModalBody>
+            <div>{intl.translate('delete_a_volume_warning')}</div>
+            <div>
+              {intl.translate('delete_a_volume_confirm')}
+              <strong>{name}</strong>?
+            </div>
+          </ModalBody>
+        </Modal>
+      </VolumeDetailCardContainer>
+    </VolumeTab>
   );
 };
 

--- a/ui/src/containers/CreateVolume.js
+++ b/ui/src/containers/CreateVolume.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useRouteMatch, useHistory } from 'react-router';
+import { useHistory } from 'react-router';
 import { Formik, Form } from 'formik';
 import * as yup from 'yup';
 import styled from 'styled-components';
@@ -154,7 +154,6 @@ const DocumentationIcon = styled.div`
 const CreateVolume = (props) => {
   const dispatch = useDispatch();
   const history = useHistory();
-  const match = useRouteMatch();
 
   const createVolume = (newVolumes) => dispatch(createVolumeAction(newVolumes));
 
@@ -525,9 +524,7 @@ const CreateVolume = (props) => {
                       text={intl.translate('cancel')}
                       type="button"
                       outlined
-                      onClick={() =>
-                        history.push(`/nodes/${match.params.id}/volumes`)
-                      }
+                      onClick={() => history.goBack()}
                     />
                     <Button
                       text={intl.translate('create')}

--- a/ui/src/containers/Layout.js
+++ b/ui/src/containers/Layout.js
@@ -228,7 +228,7 @@ const Layout = (props) => {
           />
           <PrivateRoute path="/nodes" component={NodePage} />
           <PrivateRoute exact path="/environments" component={SolutionList} />
-          <PrivateRoute path="/volumes" component={VolumePage} />
+          <PrivateRoute path="/volumes/:name?" component={VolumePage} />
           <PrivateRoute
             exact
             path="/environments/create-environment"

--- a/ui/src/containers/VolumePage.js
+++ b/ui/src/containers/VolumePage.js
@@ -17,7 +17,6 @@ import {
   stopRefreshPersistentVolumesAction,
   fetchPersistentVolumeClaimAction,
   fetchCurrentVolumeObjectAction,
-  clearCurrentVolumeObjectAction,
 } from '../ducks/app/volumes';
 import {
   fetchVolumeStatsAction,
@@ -48,9 +47,6 @@ const VolumePage = (props) => {
   useEffect(() => {
     if (currentVolumeName)
       dispatch(fetchCurrentVolumeObjectAction(currentVolumeName));
-    return(() => {
-      dispatch(clearCurrentVolumeObjectAction());
-    })
   }, [dispatch, currentVolumeName]);
 
 

--- a/ui/src/containers/VolumePage.js
+++ b/ui/src/containers/VolumePage.js
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { useRouteMatch } from 'react-router';
 import { useSelector, useDispatch } from 'react-redux';
 import VolumeContent from './VolumePageContent';
 import { fetchPodsAction } from '../ducks/app/pods';
@@ -15,6 +16,8 @@ import {
   refreshPersistentVolumesAction,
   stopRefreshPersistentVolumesAction,
   fetchPersistentVolumeClaimAction,
+  fetchCurrentVolumeObjectAction,
+  clearCurrentVolumeObjectAction,
 } from '../ducks/app/volumes';
 import {
   fetchVolumeStatsAction,
@@ -36,6 +39,17 @@ import { intl } from '../translations/IntlGlobalProvider';
 // <VolumeContent> component extracts the current volume name from URL and sends volume specific data to sub components.
 const VolumePage = (props) => {
   const dispatch = useDispatch();
+  const match = useRouteMatch();
+  const currentVolumeName = match.params.name;
+
+  useEffect(() => {
+    if (currentVolumeName)
+      dispatch(fetchCurrentVolumeObjectAction(currentVolumeName));
+    return(() => {
+      dispatch(clearCurrentVolumeObjectAction());
+    })
+  }, [dispatch, currentVolumeName]);
+
 
   useRefreshEffect(refreshNodesAction, stopRefreshNodesAction);
   useRefreshEffect(refreshVolumesAction, stopRefreshVolumesAction);
@@ -64,6 +78,7 @@ const VolumePage = (props) => {
   const node = useSelector((state) => makeGetNodeFromUrl(state, props));
   const nodes = useSelector((state) => state.app.nodes.list);
   const volumes = useSelector((state) => state.app.volumes.list);
+  const currentVolumeObject = useSelector((state) => state.app.volumes.currentVolumeObject);
   const pVList = useSelector((state) => state.app.volumes.pVList);
   const alerts = useSelector((state) => state.app.alerts);
 
@@ -99,6 +114,7 @@ const VolumePage = (props) => {
         pods={pods}
         alerts={alerts}
         volumeStats={volumeStats}
+        currentVolumeObject={currentVolumeObject}
       ></VolumeContent>
     </PageContainer>
   );

--- a/ui/src/containers/VolumePage.js
+++ b/ui/src/containers/VolumePage.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useRouteMatch } from 'react-router';
+import { useRouteMatch, useHistory } from 'react-router';
 import { useSelector, useDispatch } from 'react-redux';
 import VolumeContent from './VolumePageContent';
 import { fetchPodsAction } from '../ducks/app/pods';
@@ -33,6 +33,7 @@ import { getVolumeListData } from '../services/NodeVolumesUtils';
 import { Breadcrumb } from '@scality/core-ui';
 import { PageContainer } from '../components/CommonLayoutStyle';
 import { intl } from '../translations/IntlGlobalProvider';
+import { useQuery } from '../services/utils';
 
 // <VolumePage> component fetchs all the data used by volume page from redux store.
 // the data for <VolumeMetricGraphCard>: get the default metrics time span `last 24 hours`, and the component itself can change the time span base on the dropdown selection.
@@ -41,6 +42,8 @@ const VolumePage = (props) => {
   const dispatch = useDispatch();
   const match = useRouteMatch();
   const currentVolumeName = match.params.name;
+  const query = useQuery();
+  const history = useHistory();
 
   useEffect(() => {
     if (currentVolumeName)
@@ -89,6 +92,16 @@ const VolumePage = (props) => {
   const volumeListData = useSelector((state) =>
     getVolumeListData(state, props),
   );
+
+  // If data has been retrieved and no volume is selected yet we select the first one
+  useEffect(() => {
+    if (volumeListData.length && !currentVolumeName) {
+      history.push({
+        pathname: `/volumes/${volumeListData[0]?.name}/overview`,
+        search: query.toString(),
+      });
+    }
+  }, [volumeListData, currentVolumeName, query, history])
 
   return (
     <PageContainer>

--- a/ui/src/containers/VolumePageContent.js
+++ b/ui/src/containers/VolumePageContent.js
@@ -155,7 +155,7 @@ const VolumePageContent = (props) => {
   };
 
   const isAlertsPage = location.pathname.endsWith('/alerts');
-  const isOverviewPage = location.pathname.endsWith('/overview') || !isAlertsPage;
+  const isOverviewPage = location.pathname.endsWith('/overview');
   const isMetricsPage = location.pathname.endsWith('/metrics');
   const isDetailsPage = location.pathname.endsWith('/details');
 

--- a/ui/src/containers/VolumePageContent.js
+++ b/ui/src/containers/VolumePageContent.js
@@ -1,8 +1,15 @@
+// Temporarily disable the `no-unused-vars` lint until the refactoring is complete.
+/* eslint-disable no-unused-vars */
+
 import React from 'react';
-import { useHistory } from 'react-router';
+import { useSelector } from 'react-redux';
+import styled from 'styled-components';
+import { useHistory, useLocation, useRouteMatch } from 'react-router';
+import { Tabs } from '@scality/core-ui';
+import { padding } from '@scality/core-ui/dist/style/theme';
 import VolumeListTable from '../components/VolumeListTable';
-import VolumeDetailCard from '../components/VolumeDetailCard';
-import ActiveAlertsCard from '../components/VolumeActiveAlertsCard';
+import VolumeOverviewTab from '../components/VolumeOverviewTab';
+import VolumeAlertsTab from '../components/VolumeAlertsTab';
 import MetricGraphCard from '../components/VolumeMetricGraphCard';
 import {
   SPARSE_LOOP_DEVICE,
@@ -12,15 +19,37 @@ import {
 import { computeVolumeGlobalStatus } from '../services/NodeVolumesUtils';
 import {
   LeftSideInstanceList,
-  RightSidePanel,
   NoInstanceSelectedContainer,
   NoInstanceSelected,
-  PageContentContainer,
+  TextBadge
 } from '../components/CommonLayoutStyle';
 import { intl } from '../translations/IntlGlobalProvider';
 
+const VolumePageContentContainer = styled.div`
+display: flex;
+flex-direction: row;
+height: 100%;
+width: 100%;
+
+.sc-tabs {
+  margin: 0 ${padding.small} 0 ${padding.smaller};
+}
+
+.sc-tabs-item-content {
+  background-color: ${(props) => props.theme.brand.primary};
+  padding: ${padding.small}
+}
+`;
+
+const RightSidePanel = styled.div`
+  flex-direction: column;
+  width: 55%;
+  overflow-y: scroll;
+  margin: 0 ${padding.small} ${padding.small} 0;
+`;
+
 // <VolumePageContent> component extracts volume name from URL and holds the volume-specific data.
-// The three components in RightSidePanel (<VolumeDetailCard> / <ActiveAlertsCard> / <MetricGraphCard>) are dumb components,
+// The three components in RightSidePanel (<VolumeOverviewTab> / <VolumeAlertsTab> / <MetricGraphCard>) are dumb components,
 // so that with the implementation of Tabs no re-render should happen during the switch.
 const VolumePageContent = (props) => {
   const {
@@ -35,8 +64,13 @@ const VolumePageContent = (props) => {
   } = props;
 
   const history = useHistory();
-  const currentVolumeName =
-    history?.location?.pathname?.split('/').slice(2)[0] || '';
+  const location = useLocation();
+  const match = useRouteMatch();
+  const query = new URLSearchParams(location.search);
+
+  const theme = useSelector((state) => state.config.theme);
+
+  const currentVolumeName = match.params.name;
   const volume = volumes?.find(
     (volume) => volume.metadata.name === currentVolumeName,
   );
@@ -119,8 +153,26 @@ const VolumePageContent = (props) => {
     queryStartingTime,
   };
 
+  const isAlertsPage = location.pathname.endsWith('/alerts');
+  const isOverviewPage = location.pathname.endsWith('/overview') || !isAlertsPage;
+  const isMetricsPage = location.pathname.endsWith('/metrics');
+  const isDetailsPage = location.pathname.endsWith('/details');
+
+  const tabsItems = [
+    {
+      selected: isOverviewPage,
+      title: intl.translate('overview'),
+      onClick: () => history.push(`${match.url}/overview${query.toString() && `?${query.toString()}`}`),
+    },
+    {
+      selected: isAlertsPage,
+      title: (<span>{intl.translate('alerts')}&nbsp;&nbsp;<TextBadge>{alertlist?.length}</TextBadge></span>),
+      onClick: () => history.push(`${match.url}/alerts${query.toString() && `?${query.toString()}`}`),
+    },
+  ];
+
   return (
-    <PageContentContainer>
+    <VolumePageContentContainer>
       <LeftSideInstanceList>
         <VolumeListTable
           volumeListData={volumeListData}
@@ -132,49 +184,51 @@ const VolumePageContent = (props) => {
 
       {currentVolumeName && volume ? (
         <RightSidePanel>
-          <VolumeDetailCard
-            name={currentVolumeName}
-            nodeName={volume?.spec?.nodeName}
-            storage={pV?.spec?.capacity?.storage ?? intl.translate('unknown')}
-            status={volumeStatus ?? intl.translate('unknown')}
-            storageClassName={volume?.spec?.storageClassName}
-            creationTimestamp={volume?.metadata?.creationTimestamp}
-            volumeType={
-              volume?.spec?.rawBlockDevice
-                ? RAW_BLOCK_DEVICE
-                : SPARSE_LOOP_DEVICE
+          <Tabs activeColor={theme.brand.primary} items={tabsItems}>
+            {
+              isOverviewPage &&
+              <VolumeOverviewTab
+                name={currentVolumeName}
+                nodeName={volume?.spec?.nodeName}
+                storage={pV?.spec?.capacity?.storage ?? intl.translate('unknown')}
+                status={volumeStatus ?? intl.translate('unknown')}
+                storageClassName={volume?.spec?.storageClassName}
+                creationTimestamp={volume?.metadata?.creationTimestamp}
+                volumeType={
+                  volume?.spec?.rawBlockDevice
+                    ? RAW_BLOCK_DEVICE
+                    : SPARSE_LOOP_DEVICE
+                }
+                usedPodName={UsedPod ? UsedPod?.name : intl.translate('not_used')}
+                devicePath={
+                  volume?.spec?.rawBlockDevice?.devicePath ??
+                  intl.translate('not_applicable')
+                }
+                volumeUsagePercentage={currentVolume?.usage}
+                volumeUsageBytes={currentVolume?.usageRawData ?? 0}
+                storageCapacity={
+                  volumeListData?.find((vol) => vol.name === currentVolumeName)
+                    .storageCapacity
+                }
+                health={
+                  volumeListData?.find((vol) => vol.name === currentVolumeName)
+                    .health
+                }
+                condition={currentVolume.status}
+                // the delete button inside the volume detail card should know that which volume is the first one
+                volumeListData={volumeListData}
+                pVList={pVList}
+                alertlist={alertlist}
+              />
             }
-            usedPodName={UsedPod ? UsedPod?.name : intl.translate('not_used')}
-            devicePath={
-              volume?.spec?.rawBlockDevice?.devicePath ??
-              intl.translate('not_applicable')
-            }
-            volumeUsagePercentage={currentVolume?.usage}
-            volumeUsageBytes={currentVolume?.usageRawData ?? 0}
-            storageCapacity={
-              volumeListData?.find((vol) => vol.name === currentVolumeName)
-                .storageCapacity
-            }
-            health={
-              volumeListData?.find((vol) => vol.name === currentVolumeName)
-                .health
-            }
-            condition={currentVolume.status}
-            // the delete button inside the volume detail card should know that which volume is the first one
-            volumeListData={volumeListData}
-            pVList={pVList}
-          ></VolumeDetailCard>
-          <ActiveAlertsCard
-            alertlist={alertlist}
-            PVCName={PVCName}
-          ></ActiveAlertsCard>
-          <MetricGraphCard
-            volumeName={currentVolumeName}
-            volumeMetricGraphData={volumeMetricGraphData}
-            // the volume condition compute base on the `status` and `bound/unbound`
-            volumeCondition={currentVolume.status}
-            // Hardcode the port number for prometheus metrics
-          ></MetricGraphCard>
+            {
+              isAlertsPage &&
+              <VolumeAlertsTab
+                alertlist={alertlist}
+                PVCName={PVCName}
+              />
+              }
+          </Tabs>
         </RightSidePanel>
       ) : (
         <NoInstanceSelectedContainer>
@@ -183,7 +237,7 @@ const VolumePageContent = (props) => {
           </NoInstanceSelected>
         </NoInstanceSelectedContainer>
       )}
-    </PageContentContainer>
+    </VolumePageContentContainer>
   );
 };
 

--- a/ui/src/containers/VolumePageContent.js
+++ b/ui/src/containers/VolumePageContent.js
@@ -207,6 +207,7 @@ const VolumePageContent = (props) => {
           nodeName={node?.name}
           volumeName={currentVolumeName}
           isSearchBar={true}
+          isNodeColumn={true}
         ></VolumeListTable>
       </LeftSideInstanceList>
 

--- a/ui/src/containers/VolumePageContent.js
+++ b/ui/src/containers/VolumePageContent.js
@@ -1,6 +1,3 @@
-// Temporarily disable the `no-unused-vars` lint until the refactoring is complete.
-/* eslint-disable no-unused-vars */
-
 import React from 'react';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
@@ -11,7 +8,7 @@ import { padding } from '@scality/core-ui/dist/style/theme';
 import VolumeListTable from '../components/VolumeListTable';
 import VolumeOverviewTab from '../components/VolumeOverviewTab';
 import VolumeAlertsTab from '../components/VolumeAlertsTab';
-import MetricGraphCard from '../components/VolumeMetricGraphCard';
+import VolumeMetricsTab from '../components/VolumeMetricsTab';
 import {
   SPARSE_LOOP_DEVICE,
   RAW_BLOCK_DEVICE,
@@ -175,7 +172,6 @@ const VolumePageContent = (props) => {
   const isAlertsPage = location.pathname.endsWith('/alerts');
   const isOverviewPage = location.pathname.endsWith('/overview');
   const isMetricsPage = location.pathname.endsWith('/metrics');
-  const isDetailsPage = location.pathname.endsWith('/details');
 
   const tabsItems = [
     {
@@ -187,6 +183,11 @@ const VolumePageContent = (props) => {
       selected: isAlertsPage,
       title: (<span>{intl.translate('alerts')}<TextBadge>{alertlist?.length}</TextBadge></span>),
       onClick: () => history.push(`${match.url}/alerts${query.toString() && `?${query.toString()}`}`),
+    },
+    {
+      selected: isMetricsPage,
+      title: (<span>{intl.translate('metrics')}</span>),
+      onClick: () => history.push(`${match.url}/metrics${query.toString() && `?${query.toString()}`}`),
     },
   ];
 
@@ -249,6 +250,18 @@ const VolumePageContent = (props) => {
                   <VolumeAlertsTab
                     alertlist={alertlist}
                     PVCName={PVCName}
+                  />
+                )}
+              />
+              <Route
+                path={`${match.url}/metrics`}
+                render={() => (
+                  <VolumeMetricsTab
+                  volumeName={currentVolumeName}
+                  volumeMetricGraphData={volumeMetricGraphData}
+                  // the volume condition compute base on the `status` and `bound/unbound`
+                  volumeCondition={currentVolume.status}
+                  // Hardcode the port number for prometheus metrics
                   />
                 )}
               />

--- a/ui/src/containers/VolumePageContent.js
+++ b/ui/src/containers/VolumePageContent.js
@@ -36,6 +36,24 @@ width: 100%;
   margin: 0 ${padding.small} 0 ${padding.smaller};
 }
 
+.sc-tabs-bar {
+  height: 40px;
+}
+
+.sc-tabs-item {
+  background-color: ${(props) => props.theme.brand.border};
+  margin-right: ${padding.smaller}
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+
+  .sc-tabs-item-title {
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+    height: 40px;
+    padding: ${padding.small}
+  }
+}
+
 .sc-tabs-item-content {
   background-color: ${(props) => props.theme.brand.primary};
   padding: ${padding.small}

--- a/ui/src/containers/VolumePageContent.js
+++ b/ui/src/containers/VolumePageContent.js
@@ -5,6 +5,7 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 import { useHistory, useLocation, useRouteMatch } from 'react-router';
+import { Switch, Route } from 'react-router-dom';
 import { Tabs } from '@scality/core-ui';
 import { padding } from '@scality/core-ui/dist/style/theme';
 import VolumeListTable from '../components/VolumeListTable';
@@ -185,49 +186,55 @@ const VolumePageContent = (props) => {
       {currentVolumeName && volume ? (
         <RightSidePanel>
           <Tabs activeColor={theme.brand.primary} items={tabsItems}>
-            {
-              isOverviewPage &&
-              <VolumeOverviewTab
-                name={currentVolumeName}
-                nodeName={volume?.spec?.nodeName}
-                storage={pV?.spec?.capacity?.storage ?? intl.translate('unknown')}
-                status={volumeStatus ?? intl.translate('unknown')}
-                storageClassName={volume?.spec?.storageClassName}
-                creationTimestamp={volume?.metadata?.creationTimestamp}
-                volumeType={
-                  volume?.spec?.rawBlockDevice
-                    ? RAW_BLOCK_DEVICE
-                    : SPARSE_LOOP_DEVICE
-                }
-                usedPodName={UsedPod ? UsedPod?.name : intl.translate('not_used')}
-                devicePath={
-                  volume?.spec?.rawBlockDevice?.devicePath ??
-                  intl.translate('not_applicable')
-                }
-                volumeUsagePercentage={currentVolume?.usage}
-                volumeUsageBytes={currentVolume?.usageRawData ?? 0}
-                storageCapacity={
-                  volumeListData?.find((vol) => vol.name === currentVolumeName)
-                    .storageCapacity
-                }
-                health={
-                  volumeListData?.find((vol) => vol.name === currentVolumeName)
-                    .health
-                }
-                condition={currentVolume.status}
-                // the delete button inside the volume detail card should know that which volume is the first one
-                volumeListData={volumeListData}
-                pVList={pVList}
-                alertlist={alertlist}
+            <Switch>
+              <Route
+                path={`${match.url}/overview`}
+                render={() => (
+                  <VolumeOverviewTab
+                    name={currentVolumeName}
+                    nodeName={volume?.spec?.nodeName}
+                    storage={pV?.spec?.capacity?.storage ?? intl.translate('unknown')}
+                    status={volumeStatus ?? intl.translate('unknown')}
+                    storageClassName={volume?.spec?.storageClassName}
+                    creationTimestamp={volume?.metadata?.creationTimestamp}
+                    volumeType={
+                      volume?.spec?.rawBlockDevice
+                        ? RAW_BLOCK_DEVICE
+                        : SPARSE_LOOP_DEVICE
+                    }
+                    usedPodName={UsedPod ? UsedPod?.name : intl.translate('not_used')}
+                    devicePath={
+                      volume?.spec?.rawBlockDevice?.devicePath ??
+                      intl.translate('not_applicable')
+                    }
+                    volumeUsagePercentage={currentVolume?.usage}
+                    volumeUsageBytes={currentVolume?.usageRawData ?? 0}
+                    storageCapacity={
+                      volumeListData?.find((vol) => vol.name === currentVolumeName)
+                        .storageCapacity
+                    }
+                    health={
+                      volumeListData?.find((vol) => vol.name === currentVolumeName)
+                        .health
+                    }
+                    condition={currentVolume.status}
+                    // the delete button inside the volume detail card should know that which volume is the first one
+                    volumeListData={volumeListData}
+                    pVList={pVList}
+                    alertlist={alertlist}
+                  />
+                )}
               />
-            }
-            {
-              isAlertsPage &&
-              <VolumeAlertsTab
-                alertlist={alertlist}
-                PVCName={PVCName}
+              <Route
+                path={`${match.url}/alerts`}
+                render={() => (
+                  <VolumeAlertsTab
+                    alertlist={alertlist}
+                    PVCName={PVCName}
+                  />
+                )}
               />
-              }
+            </Switch>
           </Tabs>
         </RightSidePanel>
       ) : (

--- a/ui/src/containers/VolumePageContent.js
+++ b/ui/src/containers/VolumePageContent.js
@@ -167,7 +167,7 @@ const VolumePageContent = (props) => {
     },
     {
       selected: isAlertsPage,
-      title: (<span>{intl.translate('alerts')}&nbsp;&nbsp;<TextBadge>{alertlist?.length}</TextBadge></span>),
+      title: (<span>{intl.translate('alerts')}<TextBadge>{alertlist?.length}</TextBadge></span>),
       onClick: () => history.push(`${match.url}/alerts${query.toString() && `?${query.toString()}`}`),
     },
   ];

--- a/ui/src/containers/VolumePageContent.js
+++ b/ui/src/containers/VolumePageContent.js
@@ -9,6 +9,7 @@ import VolumeListTable from '../components/VolumeListTable';
 import VolumeOverviewTab from '../components/VolumeOverviewTab';
 import VolumeAlertsTab from '../components/VolumeAlertsTab';
 import VolumeMetricsTab from '../components/VolumeMetricsTab';
+import VolumeDetailsTab from '../components/VolumeDetailsTab';
 import {
   SPARSE_LOOP_DEVICE,
   RAW_BLOCK_DEVICE,
@@ -77,6 +78,7 @@ const VolumePageContent = (props) => {
     pods,
     alerts,
     volumeStats,
+    currentVolumeObject,
   } = props;
 
   const history = useHistory();
@@ -172,6 +174,7 @@ const VolumePageContent = (props) => {
   const isAlertsPage = location.pathname.endsWith('/alerts');
   const isOverviewPage = location.pathname.endsWith('/overview');
   const isMetricsPage = location.pathname.endsWith('/metrics');
+  const isDetailsPage = location.pathname.endsWith('/details');
 
   const tabsItems = [
     {
@@ -188,6 +191,11 @@ const VolumePageContent = (props) => {
       selected: isMetricsPage,
       title: (<span>{intl.translate('metrics')}</span>),
       onClick: () => history.push(`${match.url}/metrics${query.toString() && `?${query.toString()}`}`),
+    },
+    {
+      selected: isDetailsPage,
+      title: (<span>{intl.translate('details')}</span>),
+      onClick: () => history.push(`${match.url}/details${query.toString() && `?${query.toString()}`}`),
     },
   ];
 
@@ -262,6 +270,14 @@ const VolumePageContent = (props) => {
                   // the volume condition compute base on the `status` and `bound/unbound`
                   volumeCondition={currentVolume.status}
                   // Hardcode the port number for prometheus metrics
+                  />
+                )}
+              />
+              <Route
+                path={`${match.url}/details`}
+                render={() => (
+                  <VolumeDetailsTab
+                    currentVolumeObject={currentVolumeObject}
                   />
                 )}
               />

--- a/ui/src/ducks/app/volumes.js
+++ b/ui/src/ducks/app/volumes.js
@@ -268,7 +268,7 @@ export function* createVolumes({ payload }) {
     if (!result.error) {
       yield call(
         history.push,
-        `/volumes/${newVolume.name}?node=${newVolume.node}`,
+        `/volumes/${newVolume.name}/overview?node=${newVolume.node}`,
       );
       yield put(
         addNotificationSuccessAction({

--- a/ui/src/ducks/app/volumes.js
+++ b/ui/src/ducks/app/volumes.js
@@ -34,7 +34,6 @@ const UPDATE_PERSISTENT_VOLUMES_REFRESHING =
 const UPDATE_VOLUMES = 'UPDATE_VOLUMES';
 const FETCH_CURRENT_VOLUME_OBJECT = 'FETCH_CURRENT_VOLUME_OBJECT';
 const SET_CURRENT_VOLUME_OBJECT = 'SET_CURRENT_VOLUME_OBJECT';
-const CLEAR_CURRENT_VOLUME_OBJECT = 'CLEAR_CURRENT_VOLUME_OBJECT';
 
 // Reducer
 const defaultState = {
@@ -75,11 +74,6 @@ export default function reducer(state = defaultState, action = {}) {
     }
     case SET_CURRENT_VOLUME_OBJECT:
       return { ...state, currentVolumeObject: action.payload };
-    case CLEAR_CURRENT_VOLUME_OBJECT:
-      return {
-        ...state,
-        currentVolumeObject: defaultState.currentVolumeObject,
-      };
     default:
       return state;
   }
@@ -163,10 +157,6 @@ export const fetchCurrentVolumeObjectAction = (volumeName) => {
 
 export const setCurrentVolumeObjectAction = (payload) => {
   return { type: SET_CURRENT_VOLUME_OBJECT, payload };
-};
-
-export const clearCurrentVolumeObjectAction = () => {
-  return { type: CLEAR_CURRENT_VOLUME_OBJECT };
 };
 
 // Selectors

--- a/ui/src/ducks/app/volumes.js
+++ b/ui/src/ducks/app/volumes.js
@@ -46,7 +46,6 @@ const defaultState = {
   isLoading: false,
   isSCLoading: false,
   currentVolumeObject: {
-    error: null,
     data: null,
   },
 };
@@ -326,11 +325,9 @@ export function* fetchPersistentVolumeClaims() {
 export function* fetchCurrentVolumeObject({ volumeName }) {
   const result = yield call(VolumesApi.getVolumeObject, volumeName);
   if (!result.error) {
-    yield put(setCurrentVolumeObjectAction({ data: result.body, error: null }));
+    yield put(setCurrentVolumeObjectAction({ data: result.body }));
   } else {
-    yield put(
-      setCurrentVolumeObjectAction({ data: null, error: result.error }),
-    );
+    yield put(setCurrentVolumeObjectAction({ data: null }));
   }
 }
 

--- a/ui/src/ducks/app/volumes.test.js
+++ b/ui/src/ducks/app/volumes.test.js
@@ -347,7 +347,10 @@ it('create volume with the type sparseloopdevice', () => {
   };
 
   expect(gen.next(result).value).toEqual(
-    call(history.push, `/volumes/${newVolume.name}?node=${newVolume.node}`),
+    call(
+      history.push,
+      `/volumes/${newVolume.name}/overview?node=${newVolume.node}`,
+    ),
   );
 
   expect(gen.next().value.payload.action.type).toEqual(
@@ -421,7 +424,10 @@ it('create a volume with the type rawBlockdevice', () => {
   };
 
   expect(gen.next(result).value).toEqual(
-    call(history.push, `/volumes/${newVolume.name}?node=${newVolume.node}`),
+    call(
+      history.push,
+      `/volumes/${newVolume.name}/overview?node=${newVolume.node}`,
+    ),
   );
   expect(gen.next().value.payload.action.type).toEqual(
     ADD_NOTIFICATION_SUCCESS,

--- a/ui/src/ducks/app/volumes.test.js
+++ b/ui/src/ducks/app/volumes.test.js
@@ -716,7 +716,7 @@ it('updates the current volume object on API success', () => {
     },
   };
   expect(gen.next(result).value).toEqual(
-    put(setCurrentVolumeObjectAction({ data: result.body, error: null })),
+    put(setCurrentVolumeObjectAction({ data: result.body })),
   );
   gen.next(result);
   const finalGen = gen.next();
@@ -732,7 +732,7 @@ it('does not update the current volume object on API error', () => {
     },
   };
   expect(gen.next(result).value).toEqual(
-    put(setCurrentVolumeObjectAction({ data: null, error: result.error })),
+    put(setCurrentVolumeObjectAction({ data: null })),
   );
   const finalGen = gen.next();
   expect(finalGen.done).toEqual(true);

--- a/ui/src/ducks/app/volumes.test.js
+++ b/ui/src/ducks/app/volumes.test.js
@@ -20,6 +20,8 @@ import {
   stopRefreshPersistentVolumes,
   updateStorageClassAction,
   deleteVolume,
+  fetchCurrentVolumeObject,
+  setCurrentVolumeObjectAction,
 } from './volumes';
 import * as VolumesApi from '../../services/k8s/volumes';
 import { SET_STORAGECLASS } from './volumes.js';
@@ -703,4 +705,35 @@ it('should display the error notification when there is error in delete volume',
   );
   expect(gen.next().value).toEqual(call(fetchVolumes));
   expect(gen.next().done).toEqual(true);
+});
+
+it('updates the current volume object on API success', () => {
+  const gen = fetchCurrentVolumeObject({ volumeName: 'test' });
+  expect(gen.next().value).toEqual(call(VolumesApi.getVolumeObject, 'test'));
+  const result = {
+    body: {
+      resultTest: 'test',
+    },
+  };
+  expect(gen.next(result).value).toEqual(
+    put(setCurrentVolumeObjectAction({ data: result.body, error: null })),
+  );
+  gen.next(result);
+  const finalGen = gen.next();
+  expect(finalGen.done).toEqual(true);
+});
+
+it('does not update the current volume object on API error', () => {
+  const gen = fetchCurrentVolumeObject({ volumeName: 'test' });
+  expect(gen.next().value).toEqual(call(VolumesApi.getVolumeObject, 'test'));
+  const result = {
+    error: {
+      errorText: 'test',
+    },
+  };
+  expect(gen.next(result).value).toEqual(
+    put(setCurrentVolumeObjectAction({ data: null, error: result.error })),
+  );
+  const finalGen = gen.next();
+  expect(finalGen.done).toEqual(true);
 });

--- a/ui/src/services/NodeVolumesUtils.js
+++ b/ui/src/services/NodeVolumesUtils.js
@@ -175,7 +175,7 @@ export const getVolumeListData = createSelector(
       );
     }
 
-    return nodeVolumes?.map((volume) => {
+    nodeVolumes = nodeVolumes?.map((volume) => {
       const volumePV = pVList?.find(
         (pV) => pV.metadata.name === volume.metadata.name,
       );
@@ -269,5 +269,17 @@ export const getVolumeListData = createSelector(
         errorReason: volume?.status?.conditions[0]?.reason,
       };
     });
+
+    // Initial data sorting
+    // Following sorts should be handled by react-table directly in the component
+    return nodeVolumes.sort((a, b) => {
+      const weights = {};
+      weights[STATUS_CRITICAL] = 3;
+      weights[STATUS_WARNING] = 2;
+      weights[STATUS_NONE] = 1;
+      weights[STATUS_HEALTH] = 0;
+
+      return weights[b.health] - weights[a.health];
+    })
   },
 );

--- a/ui/src/services/k8s/volumes.js
+++ b/ui/src/services/k8s/volumes.js
@@ -63,3 +63,16 @@ export async function getPersistentVolumeClaims() {
     return { error };
   }
 }
+
+export async function getVolumeObject(volumeName) {
+  try {
+    return await customObjects.getClusterCustomObject(
+      'storage.metalk8s.scality.com',
+      'v1alpha1',
+      'volumes',
+      volumeName,
+    );
+  } catch (error) {
+    return { error };
+  }
+}

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -159,7 +159,7 @@
   "used_by": "Used By",
   "backend_disk": "Backend Disk",
   "active_alerts": "Active alerts",
-  "metrics": "METRICS",
+  "metrics": "Metrics",
   "volume_is_not_bound": "The volume is not bound yet",
   "no_active_alerts": "No active alerts",
   "not_used": "Not used",

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -170,5 +170,8 @@
   "PIDPressure": "Insufficient PID available",
   "NetworkUnavailable": "Network Unavailable",
   "Unschedulable": "Unschedulable",
-  "advanced_metrics": "Advanced Metrics"
+  "advanced_metrics": "Advanced Metrics",
+  "overview": "Overview",
+  "volume_usage": "Volume Usage",
+  "usage": "Usage"
 }

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -160,6 +160,7 @@
   "backend_disk": "Backend Disk",
   "active_alerts": "Active alerts",
   "metrics": "Metrics",
+  "advanced_metrics": "Advanced Metrics",
   "volume_is_not_bound": "The volume is not bound yet",
   "no_active_alerts": "No active alerts",
   "not_used": "Not used",

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -158,7 +158,7 @@
   "node": "Node",
   "used_by": "Used By",
   "backend_disk": "Backend Disk",
-  "active_alerts": "Active alerts",
+  "active_alert": "Active Alert",
   "metrics": "Metrics",
   "advanced_metrics": "Advanced Metrics",
   "volume_is_not_bound": "The volume is not bound yet",

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -171,8 +171,8 @@
   "PIDPressure": "Insufficient PID available",
   "NetworkUnavailable": "Network Unavailable",
   "Unschedulable": "Unschedulable",
-  "advanced_metrics": "Advanced Metrics",
   "overview": "Overview",
   "volume_usage": "Volume Usage",
-  "usage": "Usage"
+  "usage": "Usage",
+  "error_volume_details": "Volume details request has failed."
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -170,5 +170,8 @@
   "PIDPressure": "PID disponible insuffisant",
   "NetworkUnavailable": "Réseau indisponible",
   "Unschedulable": "Non planifiable",
-  "advanced_metrics": "Métrique avancée"
+  "advanced_metrics": "Métrique avancée",
+  "overview": "Aperçu",
+  "volume_usage": "Utilisation du Volume",
+  "usage": "Utilisation"
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -171,8 +171,8 @@
   "PIDPressure": "PID disponible insuffisant",
   "NetworkUnavailable": "Réseau indisponible",
   "Unschedulable": "Non planifiable",
-  "advanced_metrics": "Métrique avancée",
   "overview": "Aperçu",
   "volume_usage": "Utilisation du Volume",
-  "usage": "Utilisation"
+  "usage": "Utilisation",
+  "error_volume_details": "Échec de la récuperation des details du volume."
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -159,7 +159,7 @@
   "used_by": "Utilisé Par",
   "backend_disk": "Backend Disk",
   "active_alerts": "Alertes actives",
-  "metrics": "MÉTRIQUE",
+  "metrics": "Métrique",
   "volume_is_not_bound": "Le volume n'est pas encore lié",
   "no_active_alerts": "Aucune alerte active",
   "not_used": "Non utilisé",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -160,6 +160,7 @@
   "backend_disk": "Backend Disk",
   "active_alerts": "Alertes actives",
   "metrics": "Métrique",
+  "advanced_metrics": "Métrique avancée",
   "volume_is_not_bound": "Le volume n'est pas encore lié",
   "no_active_alerts": "Aucune alerte active",
   "not_used": "Non utilisé",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -158,7 +158,7 @@
   "node": "Nœud",
   "used_by": "Utilisé Par",
   "backend_disk": "Backend Disk",
-  "active_alerts": "Alertes actives",
+  "active_alert": "Alerte Active",
   "metrics": "Métrique",
   "advanced_metrics": "Métrique avancée",
   "volume_is_not_bound": "Le volume n'est pas encore lié",


### PR DESCRIPTION
**Component**:

ui, volumes

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

We want to adapt the volumes page so it looks like the new node page (tab based).

**This specific PR adds the Metrics and Details tabs as well as the new table styling. It is meant to be merged in the feature branch #2835** 

**Summary**:

I refactored most of the Volume view. There were also small adaptations compared to the base view (alerts filtering in URL, ...) as described in #2751 .

Some components (ActiveAlertsFilters, ActiveAlertsCounter) were designed to be re-usable in other views.

![Screenshot 2020-10-15 at 15 41 13](https://user-images.githubusercontent.com/3480526/96138852-7dccfc00-0efe-11eb-8069-0c2f22e0b8f9.png)
![Screenshot 2020-10-15 at 15 41 26](https://user-images.githubusercontent.com/3480526/96138858-80c7ec80-0efe-11eb-9b3a-935befdb6a77.png)
![Screenshot 2020-10-15 at 15 41 46](https://user-images.githubusercontent.com/3480526/96138868-832a4680-0efe-11eb-84e7-e865f05b759d.png)
![Screenshot 2020-10-15 at 15 41 59](https://user-images.githubusercontent.com/3480526/96138875-84f40a00-0efe-11eb-92e3-13dfacacf558.png)



**Acceptance criteria**: 

* Volumes page right panel is separated in four tabs Overview, Alerts, Metrics, Details
* Total number of alerts is displayed in Alerts tab header
* It is possible to filter by alert severity on the Alert tab
* Clicking on an alert category in the overview tab opens the alerts tab and filters by the corresponding category
* When switching to another volume the selected tab is preserved
---


Refs: #2751 
