### PR TITLE
Fix upgrade with Solutions imported

### DIFF
--- a/salt/metalk8s/salt/master/installed.sls
+++ b/salt/metalk8s/salt/master/installed.sls
@@ -8,7 +8,7 @@
 {%- set salt_ip = grains['metalk8s']['control_plane_ip'] -%}
 
 {%- set solution_archives = {} %}
-{%- set solutions_available = pillar.metalk8s.get('solutions', {}).get('available', {}) %}
+{%- set solutions_available = salt.metalk8s_solutions.list_available() %}
 {%- for versions in solutions_available.values() %}
   {%- for version in versions %}
     {%- set version_sanitized = version.id | replace('.', '-') %}


### PR DESCRIPTION
**Component**: salt, upgrade

**Context**: 
During Salt master installation, we need to retrieve the list of Solutions ISO to mount into the Salt master container, to do that we we're relying on the `metalk8s_solutions` external pillar to retrieve the list of Solutions.
The issue is that, we need to upgrade the master using the `--local` option of Salt to avoid having it unresponsive during the execution of the state (because the Salt master container can be replaced if its configuration change).
The wrong side of using this option is that we can't access external pillar computed by the Salt master.
We were ending up with a configuration change during the upgrade orchestration, even we if the Salt master was upgraded prior to the upgrade, which broke the whole upgrade because the master became unresponsive.

**Summary**:
We now rely directly on the `metalk8s_solutions` module, which anyway makes more sense since these solutions ISO are local to the bootstrap host.

**Acceptance criteria**:
Upgrade with at least a solution imported should now work

---

Closes: #2832