### PR TITLE
packages: containerd 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Release 2.7.0 (in development)
+### Enhancements
+- [#2855](https://github.com/scality/metalk8s/issues/2855) - Bump `containerd`
+  version to 1.4.1 (PR [#2869](https://github.com/scality/metalk8s/pull/2869))
+
 ## Release 2.6.0 (in development)
 
 ### Breaking changes

--- a/buildchain/buildchain/packaging.py
+++ b/buildchain/buildchain/packaging.py
@@ -308,6 +308,7 @@ CALICO_RPM = _rpm_package(
 CONTAINERD_RPM = _rpm_package(
     name='containerd',
     sources=[
+        Path('0001-Revert-commit-for-Windows-metrics.patch'),
         Path('containerd.service'),
         Path('containerd.toml'),
         Path('containerd-{}.tar.gz'.format(versions.CONTAINERD_VERSION)),

--- a/buildchain/buildchain/targets/package.py
+++ b/buildchain/buildchain/targets/package.py
@@ -87,7 +87,7 @@ class RPMPackage(Package):
     """A RPM software package for CentOS 7."""
 
     SUFFIX = 'el7'
-    SOURCE_URL_PATTERN = re.compile(r'^Source\d+:\s+(?P<url>.+)$')
+    SOURCE_URL_PATTERN = re.compile(r'^(Source|Patch)\d+:\s+(?P<url>.+)$')
 
     def __init__(
         self,

--- a/buildchain/buildchain/targets/repository.py
+++ b/buildchain/buildchain/targets/repository.py
@@ -215,7 +215,7 @@ class RPMRepository(Repository):
                 builder=self.builder,
                 environment=env,
                 mounts=self._get_buildrpm_mounts(pkg.srpm, rpm.parent),
-                tmpfs={'/home/build': '', '/var/tmp': ''},
+                tmpfs={'/home/build': 'exec', '/var/tmp': ''},
                 run_config=docker_command.default_run_config(
                     constants.REDHAT_ENTRYPOINT
                 )

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -20,8 +20,8 @@ Image = namedtuple('Image', ('name', 'version', 'digest'))
 CALICO_VERSION     : str = '3.16.1'
 K8S_VERSION        : str = '1.18.9'
 SALT_VERSION       : str = '3000.3'
-CONTAINERD_VERSION : str = '1.2.13'
-CONTAINERD_RELEASE : str = '2.el7'
+CONTAINERD_VERSION : str = '1.4.1'
+CONTAINERD_RELEASE : str = '1.el7'
 
 def load_version_information() -> None:
     """Load version information from `VERSION`."""

--- a/packages/redhat/0001-Revert-commit-for-Windows-metrics.patch
+++ b/packages/redhat/0001-Revert-commit-for-Windows-metrics.patch
@@ -1,0 +1,157 @@
+From beb23ffb0624b40b2ee1bc56730e54943bd3020f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Robert-Andr=C3=A9=20Mauchin?= <zebob.m@gmail.com>
+Date: Thu, 1 Oct 2020 07:19:45 +0200
+Subject: [PATCH] Revert commit for Windows metrics
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Robert-André Mauchin <zebob.m@gmail.com>
+---
+ cmd/ctr/commands/tasks/metrics.go | 113 ------------------------------
+ 1 file changed, 113 deletions(-)
+
+diff --git a/cmd/ctr/commands/tasks/metrics.go b/cmd/ctr/commands/tasks/metrics.go
+index a83e45ef..f8371401 100644
+--- a/cmd/ctr/commands/tasks/metrics.go
++++ b/cmd/ctr/commands/tasks/metrics.go
+@@ -25,9 +25,6 @@ import (
+ 	"os"
+ 	"text/tabwriter"
+ 
+-	wstats "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats"
+-	v1 "github.com/containerd/cgroups/stats/v1"
+-	v2 "github.com/containerd/cgroups/v2/stats"
+ 	"github.com/containerd/containerd/cmd/ctr/commands"
+ 	"github.com/containerd/typeurl"
+ 	"github.com/urfave/cli"
+@@ -79,42 +76,12 @@ var metricsCommand = cli.Command{
+ 		if err != nil {
+ 			return err
+ 		}
+-		var (
+-			data         *v1.Metrics
+-			data2        *v2.Metrics
+-			windowsStats *wstats.Statistics
+-		)
+-		switch v := anydata.(type) {
+-		case *v1.Metrics:
+-			data = v
+-		case *v2.Metrics:
+-			data2 = v
+-		case *wstats.Statistics:
+-			windowsStats = v
+-		default:
+-			return errors.New("cannot convert metric data to cgroups.Metrics or windows.Statistics")
+-		}
+ 
+ 		switch context.String(formatFlag) {
+ 		case formatTable:
+ 			w := tabwriter.NewWriter(os.Stdout, 1, 8, 4, ' ', 0)
+ 			fmt.Fprintf(w, "ID\tTIMESTAMP\t\n")
+ 			fmt.Fprintf(w, "%s\t%s\t\n\n", metric.ID, metric.Timestamp)
+-			if data != nil {
+-				printCgroupMetricsTable(w, data)
+-			} else if data2 != nil {
+-				printCgroup2MetricsTable(w, data2)
+-			} else {
+-				if windowsStats.GetLinux() != nil {
+-					printCgroupMetricsTable(w, windowsStats.GetLinux())
+-				} else if windowsStats.GetWindows() != nil {
+-					printWindowsContainerStatistics(w, windowsStats.GetWindows())
+-				}
+-				// Print VM stats if its isolated
+-				if windowsStats.VM != nil {
+-					printWindowsVMStatistics(w, windowsStats.VM)
+-				}
+-			}
+ 			return w.Flush()
+ 		case formatJSON:
+ 			marshaledJSON, err := json.MarshalIndent(anydata, "", "  ")
+@@ -128,83 +95,3 @@ var metricsCommand = cli.Command{
+ 		}
+ 	},
+ }
+-
+-func printCgroupMetricsTable(w *tabwriter.Writer, data *v1.Metrics) {
+-	fmt.Fprintf(w, "METRIC\tVALUE\t\n")
+-	if data.Memory != nil {
+-		fmt.Fprintf(w, "memory.usage_in_bytes\t%d\t\n", data.Memory.Usage.Usage)
+-		fmt.Fprintf(w, "memory.limit_in_bytes\t%d\t\n", data.Memory.Usage.Limit)
+-		fmt.Fprintf(w, "memory.stat.cache\t%d\t\n", data.Memory.TotalCache)
+-	}
+-	if data.CPU != nil {
+-		fmt.Fprintf(w, "cpuacct.usage\t%d\t\n", data.CPU.Usage.Total)
+-		fmt.Fprintf(w, "cpuacct.usage_percpu\t%v\t\n", data.CPU.Usage.PerCPU)
+-	}
+-	if data.Pids != nil {
+-		fmt.Fprintf(w, "pids.current\t%v\t\n", data.Pids.Current)
+-		fmt.Fprintf(w, "pids.limit\t%v\t\n", data.Pids.Limit)
+-	}
+-}
+-
+-func printCgroup2MetricsTable(w *tabwriter.Writer, data *v2.Metrics) {
+-	fmt.Fprintf(w, "METRIC\tVALUE\t\n")
+-	if data.Pids != nil {
+-		fmt.Fprintf(w, "pids.current\t%v\t\n", data.Pids.Current)
+-		fmt.Fprintf(w, "pids.limit\t%v\t\n", data.Pids.Limit)
+-	}
+-	if data.CPU != nil {
+-		fmt.Fprintf(w, "cpu.usage_usec\t%v\t\n", data.CPU.UsageUsec)
+-		fmt.Fprintf(w, "cpu.user_usec\t%v\t\n", data.CPU.UserUsec)
+-		fmt.Fprintf(w, "cpu.system_usec\t%v\t\n", data.CPU.SystemUsec)
+-		fmt.Fprintf(w, "cpu.nr_periods\t%v\t\n", data.CPU.NrPeriods)
+-		fmt.Fprintf(w, "cpu.nr_throttled\t%v\t\n", data.CPU.NrThrottled)
+-		fmt.Fprintf(w, "cpu.throttled_usec\t%v\t\n", data.CPU.ThrottledUsec)
+-	}
+-	if data.Memory != nil {
+-		fmt.Fprintf(w, "memory.usage\t%v\t\n", data.Memory.Usage)
+-		fmt.Fprintf(w, "memory.usage_limit\t%v\t\n", data.Memory.UsageLimit)
+-		fmt.Fprintf(w, "memory.swap_usage\t%v\t\n", data.Memory.SwapUsage)
+-		fmt.Fprintf(w, "memory.swap_limit\t%v\t\n", data.Memory.SwapLimit)
+-	}
+-}
+-
+-func printWindowsContainerStatistics(w *tabwriter.Writer, stats *wstats.WindowsContainerStatistics) {
+-	fmt.Fprintf(w, "METRIC\tVALUE\t\n")
+-	fmt.Fprintf(w, "timestamp\t%s\t\n", stats.Timestamp)
+-	fmt.Fprintf(w, "start_time\t%s\t\n", stats.ContainerStartTime)
+-	fmt.Fprintf(w, "uptime_ns\t%d\t\n", stats.UptimeNS)
+-	if stats.Processor != nil {
+-		fmt.Fprintf(w, "cpu.total_runtime_ns\t%d\t\n", stats.Processor.TotalRuntimeNS)
+-		fmt.Fprintf(w, "cpu.runtime_user_ns\t%d\t\n", stats.Processor.RuntimeUserNS)
+-		fmt.Fprintf(w, "cpu.runtime_kernel_ns\t%d\t\n", stats.Processor.RuntimeKernelNS)
+-	}
+-	if stats.Memory != nil {
+-		fmt.Fprintf(w, "memory.commit_bytes\t%d\t\n", stats.Memory.MemoryUsageCommitBytes)
+-		fmt.Fprintf(w, "memory.commit_peak_bytes\t%d\t\n", stats.Memory.MemoryUsageCommitPeakBytes)
+-		fmt.Fprintf(w, "memory.private_working_set_bytes\t%d\t\n", stats.Memory.MemoryUsagePrivateWorkingSetBytes)
+-	}
+-	if stats.Storage != nil {
+-		fmt.Fprintf(w, "storage.read_count_normalized\t%d\t\n", stats.Storage.ReadCountNormalized)
+-		fmt.Fprintf(w, "storage.read_size_bytes\t%d\t\n", stats.Storage.ReadSizeBytes)
+-		fmt.Fprintf(w, "storage.write_count_normalized\t%d\t\n", stats.Storage.WriteCountNormalized)
+-		fmt.Fprintf(w, "storage.write_size_bytes\t%d\t\n", stats.Storage.WriteSizeBytes)
+-	}
+-}
+-
+-func printWindowsVMStatistics(w *tabwriter.Writer, stats *wstats.VirtualMachineStatistics) {
+-	fmt.Fprintf(w, "METRIC\tVALUE\t\n")
+-	if stats.Processor != nil {
+-		fmt.Fprintf(w, "vm.cpu.total_runtime_ns\t%d\t\n", stats.Processor.TotalRuntimeNS)
+-	}
+-	if stats.Memory != nil {
+-		fmt.Fprintf(w, "vm.memory.working_set_bytes\t%d\t\n", stats.Memory.WorkingSetBytes)
+-		fmt.Fprintf(w, "vm.memory.virtual_node_count\t%d\t\n", stats.Memory.VirtualNodeCount)
+-		fmt.Fprintf(w, "vm.memory.available\t%d\t\n", stats.Memory.VmMemory.AvailableMemory)
+-		fmt.Fprintf(w, "vm.memory.available_buffer\t%d\t\n", stats.Memory.VmMemory.AvailableMemoryBuffer)
+-		fmt.Fprintf(w, "vm.memory.reserved\t%d\t\n", stats.Memory.VmMemory.ReservedMemory)
+-		fmt.Fprintf(w, "vm.memory.assigned\t%d\t\n", stats.Memory.VmMemory.AssignedMemory)
+-		fmt.Fprintf(w, "vm.memory.slp_active\t%t\t\n", stats.Memory.VmMemory.SlpActive)
+-		fmt.Fprintf(w, "vm.memory.balancing_enabled\t%t\t\n", stats.Memory.VmMemory.BalancingEnabled)
+-		fmt.Fprintf(w, "vm.memory.dm_operation_in_progress\t%t\t\n", stats.Memory.VmMemory.DmOperationInProgress)
+-	}
+-}
+-- 
+2.28.0
+

--- a/packages/redhat/containerd.spec
+++ b/packages/redhat/containerd.spec
@@ -1,5 +1,5 @@
 %global goipath github.com/containerd/containerd
-Version:        1.2.13
+Version:        1.4.1
 
 %if %{defined fedora}
 %gometa
@@ -32,13 +32,15 @@ go build -compiler gc -tags="rpm_crashtraceback ${BUILDTAGS:-seccomp}" -ldflags 
 
 
 Name:           containerd
-Release:        2%{?dist}
+Release:        1%{?dist}
 Summary:        An industry-standard container runtime
 License:        ASL 2.0
 URL:            https://containerd.io
 Source0:        %{gosource}
 Source1:        containerd.service
 Source2:        containerd.toml
+# Carve out code requiring github.com/Microsoft/hcsshim
+Patch0:         0001-Revert-commit-for-Windows-metrics.patch
 
 BuildRequires:  golang >= 1.10
 BuildRequires:  btrfs-progs-devel
@@ -50,90 +52,99 @@ Requires:       runc
 
 # vendored libraries
 # grep -v -e '^$' -e '^#' containerd-*/vendor.conf | sort | awk '{print "Provides:       bundled(golang("$1")) = "$2}'
-Provides:       bundled(golang(github.com/beorn7/perks)) = 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
-Provides:       bundled(golang(github.com/blang/semver)) = v3.1.0
-Provides:       bundled(golang(github.com/BurntSushi/toml)) = a368813c5e648fee92e5f6c30e3944ff9d5e8895
-Provides:       bundled(golang(github.com/containerd/aufs)) = ffa39970e26ad01d81f540b21e65f9c1841a5f92
-Provides:       bundled(golang(github.com/containerd/btrfs)) = 2e1aa0ddf94f91fa282b6ed87c23bf0d64911244
-Provides:       bundled(golang(github.com/containerd/cgroups)) = c4b9ac5c7601384c965b9646fc515884e091ebb9
-Provides:       bundled(golang(github.com/containerd/console)) = c12b1e7919c14469339a5d38f2f8ed9b64a9de23
-Provides:       bundled(golang(github.com/containerd/continuity)) = bd77b46c8352f74eb12c85bdc01f4b90f69d66b4
-Provides:       bundled(golang(github.com/containerd/cri)) = b1052f3b73fb9f0a6805d3c20e884a4cef265a38
-Provides:       bundled(golang(github.com/containerd/fifo)) = 3d5202aec260678c48179c56f40e6f38a095738c
-Provides:       bundled(golang(github.com/containerd/go-cni)) = 40bcf8ec8acd7372be1d77031d585d5d8e561c90
-Provides:       bundled(golang(github.com/containerd/go-runc)) = e029b79d8cda8374981c64eba71f28ec38e5526f
-Provides:       bundled(golang(github.com/containerd/ttrpc)) = 92c8520ef9f86600c650dd540266a007bf03670f
-Provides:       bundled(golang(github.com/containerd/typeurl)) = a93fcdb778cd272c6e9b3028b2f42d813e785d40
-Provides:       bundled(golang(github.com/containerd/zfs)) = 2ceb2dbb8154202ed1b8fd32e4ea25b491d7b251
-Provides:       bundled(golang(github.com/containernetworking/cni)) = v0.6.0
-Provides:       bundled(golang(github.com/containernetworking/plugins)) = v0.7.5
-Provides:       bundled(golang(github.com/coreos/go-systemd)) = 48702e0da86bd25e76cfef347e2adeb434a0d0a6
-Provides:       bundled(golang(github.com/davecgh/go-spew)) = v1.1.0
-Provides:       bundled(golang(github.com/docker/distribution)) = 0d3efadf0154c2b8a4e7b6621fff9809655cc580
-Provides:       bundled(golang(github.com/docker/docker)) = 86f080cff0914e9694068ed78d503701667c4c00
-Provides:       bundled(golang(github.com/docker/go-events)) = 9461782956ad83b30282bf90e31fa6a70c255ba9
-Provides:       bundled(golang(github.com/docker/go-metrics)) = 4ea375f7759c82740c893fc030bc37088d2ec098
-Provides:       bundled(golang(github.com/docker/go-units)) = v0.3.1
+Provides:       bundled(golang(github.com/beorn7/perks)) = v1.0.1
+Provides:       bundled(golang(github.com/BurntSushi/toml)) = v0.3.1
+Provides:       bundled(golang(github.com/cespare/xxhash/v2)) = v2.1.1
+Provides:       bundled(golang(github.com/cilium/ebpf)) = 1c8d4c9ef7759622653a1d319284a44652333b28
+Provides:       bundled(golang(github.com/containerd/aufs)) = 371312c1e31c210a21e49bf3dfd3f31729ed9f2f
+Provides:       bundled(golang(github.com/containerd/btrfs)) = 153935315f4ab9be5bf03650a1341454b05efa5d
+Provides:       bundled(golang(github.com/containerd/cgroups)) = 318312a373405e5e91134d8063d04d59768a1bff
+Provides:       bundled(golang(github.com/containerd/console)) = v1.0.0
+Provides:       bundled(golang(github.com/containerd/continuity)) = efbc4488d8fe1bdc16bde3b2d2990d9b3a899165
+Provides:       bundled(golang(github.com/containerd/cri)) = 4e6644c8cf7fb825f62e0007421b7d83dfeab5a1
+Provides:       bundled(golang(github.com/containerd/fifo)) = f15a3290365b9d2627d189e619ab4008e0069caf
+Provides:       bundled(golang(github.com/containerd/go-cni)) = v1.0.1
+Provides:       bundled(golang(github.com/containerd/go-runc)) = 7016d3ce2328dd2cb1192b2076ebd565c4e8df0c
+Provides:       bundled(golang(github.com/containerd/imgcrypt)) = v1.0.1
+Provides:       bundled(golang(github.com/containerd/ttrpc)) = v1.0.1
+Provides:       bundled(golang(github.com/containerd/typeurl)) = v1.0.1
+Provides:       bundled(golang(github.com/containerd/zfs)) = 9abf673ca6ff9ab8d9bd776a4ceff8f6dc699c3d
+Provides:       bundled(golang(github.com/containernetworking/cni)) = v0.8.0
+Provides:       bundled(golang(github.com/containernetworking/plugins)) = v0.8.6
+Provides:       bundled(golang(github.com/containers/ocicrypt)) = v1.0.1
+Provides:       bundled(golang(github.com/coreos/go-systemd/v22)) = v22.1.0
+Provides:       bundled(golang(github.com/cpuguy83/go-md2man/v2)) = v2.0.0
+Provides:       bundled(golang(github.com/davecgh/go-spew)) = v1.1.1
+Provides:       bundled(golang(github.com/docker/docker)) = 4634ce647cf2ce2c6031129ccd109e557244986f
+Provides:       bundled(golang(github.com/docker/go-events)) = e31b211e4f1cd09aa76fe4ac244571fab96ae47f
+Provides:       bundled(golang(github.com/docker/go-metrics)) = v0.0.1
+Provides:       bundled(golang(github.com/docker/go-units)) = v0.4.0
 Provides:       bundled(golang(github.com/docker/spdystream)) = 449fdfce4d962303d702fec724ef0ad181c92528
-Provides:       bundled(golang(github.com/emicklei/go-restful)) = v2.2.1
-Provides:       bundled(golang(github.com/ghodss/yaml)) = v1.0.0
-Provides:       bundled(golang(github.com/godbus/dbus)) = c7fdd8b5cd55e87b4e1f4e372cdb1db61dd6c66f
-Provides:       bundled(golang(github.com/gogo/googleapis)) = 08a7655d27152912db7aaf4f983275eaf8d128ef
-Provides:       bundled(golang(github.com/gogo/protobuf)) = v1.0.0
-Provides:       bundled(golang(github.com/golang/glog)) = 44145f04b68cf362d9c4df2182967c2275eaefed
-Provides:       bundled(golang(github.com/golang/protobuf)) = v1.1.0
-Provides:       bundled(golang(github.com/google/go-cmp)) = v0.1.0
-Provides:       bundled(golang(github.com/google/gofuzz)) = 44d81051d367757e1c7c6a5a86423ece9afcf63c
+Provides:       bundled(golang(github.com/emicklei/go-restful)) = v2.9.5
+Provides:       bundled(golang(github.com/fsnotify/fsnotify)) = v1.4.9
+Provides:       bundled(golang(github.com/fullsailor/pkcs7)) = 8306686428a5fe132eac8cb7c4848af725098bd4
+Provides:       bundled(golang(github.com/godbus/dbus/v5)) = v5.0.3
+Provides:       bundled(golang(github.com/gogo/googleapis)) = v1.3.2
+Provides:       bundled(golang(github.com/gogo/protobuf)) = v1.3.1
+Provides:       bundled(golang(github.com/golang/protobuf)) = v1.3.5
+Provides:       bundled(golang(github.com/go-logr/logr)) = v0.2.0
+Provides:       bundled(golang(github.com/google/go-cmp)) = v0.2.0
+Provides:       bundled(golang(github.com/google/gofuzz)) = v1.1.0
 Provides:       bundled(golang(github.com/google/uuid)) = v1.1.1
-Provides:       bundled(golang(github.com/grpc-ecosystem/go-grpc-prometheus)) = 6b7015e65d366bf3f19b2b2a000a831940f0f7e0
-Provides:       bundled(golang(github.com/hashicorp/errwrap)) = 7554cd9344cec97297fa6649b055a8c98c2a1e55
-Provides:       bundled(golang(github.com/hashicorp/go-multierror)) = ed905158d87462226a13fe39ddf685ea65f1c11f
-Provides:       bundled(golang(github.com/json-iterator/go)) = 1.1.5
-Provides:       bundled(golang(github.com/matttproud/golang_protobuf_extensions)) = v1.0.0
-Provides:       bundled(golang(github.com/Microsoft/go-winio)) = v0.4.11
-Provides:       bundled(golang(github.com/Microsoft/hcsshim)) = v0.8.1
+Provides:       bundled(golang(github.com/grpc-ecosystem/go-grpc-prometheus)) = v1.2.0
+Provides:       bundled(golang(github.com/hashicorp/errwrap)) = v1.0.0
+Provides:       bundled(golang(github.com/hashicorp/golang-lru)) = v0.5.3
+Provides:       bundled(golang(github.com/hashicorp/go-multierror)) = v1.0.0
+Provides:       bundled(golang(github.com/imdario/mergo)) = v0.3.7
+Provides:       bundled(golang(github.com/json-iterator/go)) = v1.1.10
+Provides:       bundled(golang(github.com/konsorten/go-windows-terminal-sequences)) = v1.0.3
+Provides:       bundled(golang(github.com/matttproud/golang_protobuf_extensions)) = v1.0.1
+Provides:       bundled(golang(github.com/Microsoft/go-winio)) = v0.4.14
+Provides:       bundled(golang(github.com/Microsoft/hcsshim)) = v0.8.9
 Provides:       bundled(golang(github.com/mistifyio/go-zfs)) = f784269be439d704d3dfa1906f45dd848fed2beb
 Provides:       bundled(golang(github.com/modern-go/concurrent)) = 1.0.3
-Provides:       bundled(golang(github.com/modern-go/reflect2)) = 1.0.1
-Provides:       bundled(golang(github.com/opencontainers/go-digest)) = c9281466c8b2f606084ac71339773efd177436e7
+Provides:       bundled(golang(github.com/modern-go/reflect2)) = v1.0.1
+Provides:       bundled(golang(github.com/opencontainers/go-digest)) = v1.0.0
 Provides:       bundled(golang(github.com/opencontainers/image-spec)) = v1.0.1
-Provides:       bundled(golang(github.com/opencontainers/runc)) = dc9208a3303feef5b3839f4323d9beb36df0a9dd
-Provides:       bundled(golang(github.com/opencontainers/runtime-spec)) = eba862dc2470385a233c7507392675cbeadf7353
-Provides:       bundled(golang(github.com/opencontainers/runtime-tools)) = v0.6.0
-Provides:       bundled(golang(github.com/opencontainers/selinux)) = 5215b1806f52b1fcc2070a8826c542c9d33cd3cf
-Provides:       bundled(golang(github.com/pkg/errors)) = v0.8.0
-Provides:       bundled(golang(github.com/prometheus/client_golang)) = f4fb1b73fb099f396a7f0036bf86aa8def4ed823
-Provides:       bundled(golang(github.com/prometheus/client_model)) = 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
-Provides:       bundled(golang(github.com/prometheus/common)) = 89604d197083d4781071d3c65855d24ecfb0a563
-Provides:       bundled(golang(github.com/prometheus/procfs)) = cb4147076ac75738c9a7d279075a253c0cc5acbd
-Provides:       bundled(golang(github.com/seccomp/libseccomp-golang)) = v0.9.1
-Provides:       bundled(golang(github.com/sirupsen/logrus)) = v1.0.0
-Provides:       bundled(golang(github.com/syndtr/gocapability)) = db04d3cc01c8b54962a58ec7e491717d06cfcc16
+Provides:       bundled(golang(github.com/opencontainers/runc)) = v1.0.0-rc92
+Provides:       bundled(golang(github.com/opencontainers/runtime-spec)) = 4d89ac9fbff6c455f46a5bb59c6b1bb7184a5e43
+Provides:       bundled(golang(github.com/opencontainers/selinux)) = v1.6.0
+Provides:       bundled(golang(github.com/pkg/errors)) = v0.9.1
+Provides:       bundled(golang(github.com/prometheus/client_golang)) = v1.6.0
+Provides:       bundled(golang(github.com/prometheus/client_model)) = v0.2.0
+Provides:       bundled(golang(github.com/prometheus/common)) = v0.9.1
+Provides:       bundled(golang(github.com/prometheus/procfs)) = v0.0.11
+Provides:       bundled(golang(github.com/russross/blackfriday/v2)) = v2.0.1
+Provides:       bundled(golang(github.com/shurcooL/sanitized_anchor_name)) = v1.0.0
+Provides:       bundled(golang(github.com/sirupsen/logrus)) = v1.6.0
+Provides:       bundled(golang(github.com/syndtr/gocapability)) = d98352740cb2c55f81556b63d4a1ec64c5a319c2
 Provides:       bundled(golang(github.com/tchap/go-patricia)) = v2.2.6
-Provides:       bundled(golang(github.com/urfave/cli)) = 7bc6a0acffa589f415f88aca16cc1de5ffd66f9c
-Provides:       bundled(golang(github.com/xeipuuv/gojsonpointer)) = 4e3ac2762d5f479393488629ee9370b50873b3a6
-Provides:       bundled(golang(github.com/xeipuuv/gojsonreference)) = bd5ef7bd5415a7ac448318e64f11a24cd21e594b
-Provides:       bundled(golang(github.com/xeipuuv/gojsonschema)) = 1d523034197ff1f222f6429836dd36a2457a1874
-Provides:       bundled(golang(go.etcd.io/bbolt)) = v1.3.1-etcd.8
-Provides:       bundled(golang(golang.org/x/crypto)) = 69ecbb4d6d5dab05e49161c6e77ea40a030884e1
-Provides:       bundled(golang(golang.org/x/net)) = b3756b4b77d7b13260a0a2ec658753cf48922eac
-Provides:       bundled(golang(golang.org/x/oauth2)) = a6bd8cefa1811bd24b86f8902872e4e8225f74c4
-Provides:       bundled(golang(golang.org/x/sync)) = 450f422ab23cf9881c94e2db30cac0eb1b7cf80c
-Provides:       bundled(golang(golang.org/x/sys)) = 41f3e6584952bb034a481797859f6ab34b6803bd
-Provides:       bundled(golang(golang.org/x/text)) = 19e51611da83d6be54ddafce4a4af510cb3e9ea4
-Provides:       bundled(golang(golang.org/x/time)) = f51c12702a4d776e4c1fa9b0fabab841babae631
-Provides:       bundled(golang(google.golang.org/appengine)) = 54a98f90d1c46b7731eb8fb305d2a321c30ef610
-Provides:       bundled(golang(google.golang.org/genproto)) = d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
-Provides:       bundled(golang(google.golang.org/grpc)) = 39e8a7b072a67ca2a75f57fa2e0d50995f5b22f6
-Provides:       bundled(golang(gopkg.in/inf.v0)) = 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
-Provides:       bundled(golang(gopkg.in/yaml.v2)) = 53403b58ad1b561927d19068c655246f2db79d48
-Provides:       bundled(golang(gotest.tools)) = v2.1.0
-Provides:       bundled(golang(k8s.io/api)) = kubernetes-1.12.0
-Provides:       bundled(golang(k8s.io/apimachinery)) = kubernetes-1.12.0
-Provides:       bundled(golang(k8s.io/apiserver)) = kubernetes-1.12.0
-Provides:       bundled(golang(k8s.io/client-go)) = kubernetes-1.12.0
-Provides:       bundled(golang(k8s.io/kubernetes)) = v1.12.0
-Provides:       bundled(golang(k8s.io/utils)) = cd34563cd63c2bd7c6fe88a73c4dcf34ed8a67cb
+Provides:       bundled(golang(github.com/urfave/cli)) = v1.22.1
+Provides:       bundled(golang(github.com/willf/bitset)) = d5bec3311243426a3c6d1b7a795f24b17c686dbb
+Provides:       bundled(golang(go.etcd.io/bbolt)) = v1.3.5
+Provides:       bundled(golang(golang.org/x/crypto)) = 75b288015ac94e66e3d6715fb68a9b41bf046ec2
+Provides:       bundled(golang(golang.org/x/net)) = ab34263943818b32f575efc978a3d24e80b04bd7
+Provides:       bundled(golang(golang.org/x/oauth2)) = 858c2ad4c8b6c5d10852cb89079f6ca1c7309787
+Provides:       bundled(golang(golang.org/x/sync)) = 42b317875d0fa942474b76e1b46a6060d720ae6e
+Provides:       bundled(golang(golang.org/x/sys)) = ed371f2e16b4b305ee99df548828de367527b76b
+Provides:       bundled(golang(golang.org/x/text)) = v0.3.3
+Provides:       bundled(golang(golang.org/x/time)) = 555d28b269f0569763d25dbe1a237ae74c6bcc82
+Provides:       bundled(golang(google.golang.org/genproto)) = e50cd9704f63023d62cd06a1994b98227fc4d21a
+Provides:       bundled(golang(google.golang.org/grpc)) = v1.27.1
+Provides:       bundled(golang(go.opencensus.io)) = v0.22.0
+Provides:       bundled(golang(gopkg.in/inf.v0)) = v0.9.1
+Provides:       bundled(golang(gopkg.in/square/go-jose.v2)) = v2.3.1
+Provides:       bundled(golang(gopkg.in/yaml.v2)) = v2.2.8
+Provides:       bundled(golang(gotest.tools/v3)) = v3.0.2
+Provides:       bundled(golang(k8s.io/apimachinery)) = v0.19.0-rc.4
+Provides:       bundled(golang(k8s.io/apiserver)) = v0.19.0-rc.4
+Provides:       bundled(golang(k8s.io/api)) = v0.19.0-rc.4
+Provides:       bundled(golang(k8s.io/client-go)) = v0.19.0-rc.4
+Provides:       bundled(golang(k8s.io/cri-api)) = v0.19.0-rc.4
+Provides:       bundled(golang(k8s.io/klog/v2)) = v2.2.0
+Provides:       bundled(golang(k8s.io/utils)) = 2df71ebbae66f39338aed4cd0bb82d2212ee33cc
+Provides:       bundled(golang(sigs.k8s.io/structured-merge-diff/v3)) = v3.0.0
+Provides:       bundled(golang(sigs.k8s.io/yaml)) = v1.2.0
 
 
 %description
@@ -145,31 +156,31 @@ low-level storage and network attachments, etc.
 
 
 %prep
-%autosetup
+%autosetup -p1
+# Used only for generation:
+rm -rf cmd/protoc-gen-gogoctrd
 
 
 %build
 %gobuildroot
 export LDFLAGS="-X %{goipath}/version.Version=%{version}"
-%gobuild -o _bin/containerd %{goipath}/cmd/containerd
-%gobuild -o _bin/containerd-shim %{goipath}/cmd/containerd-shim
-%gobuild -o _bin/containerd-shim-runc-v1 %{goipath}/cmd/containerd-shim-runc-v1
-%gobuild -o _bin/ctr %{goipath}/cmd/ctr
+for cmd in cmd/* ; do
+  %gobuild -o _bin/$(basename $cmd) %{goipath}/$cmd
+done
 mkdir _man
-go-md2man -in docs/man/containerd.1.md -out _man/containerd.1
-go-md2man -in docs/man/containerd-config.1.md -out _man/containerd-config.1
-go-md2man -in docs/man/ctr.1.md -out _man/ctr.1
+go-md2man -in docs/man/containerd-config.8.md -out _man/containerd-config.8
 go-md2man -in docs/man/containerd-config.toml.5.md -out _man/containerd-config.toml.5
+_bin/gen-manpages containerd.8 _man
+_bin/gen-manpages ctr.8 _man
+rm _bin/gen-manpages
 
 
 %install
-install -D -p -m 0755 _bin/containerd %{buildroot}%{_bindir}/containerd
-install -D -p -m 0755 _bin/containerd-shim %{buildroot}%{_bindir}/containerd-shim
-install -D -p -m 0755 _bin/containerd-shim-runc-v1 %{buildroot}%{_bindir}/containerd-shim-runc-v1
-install -D -p -m 0755 _bin/ctr %{buildroot}%{_bindir}/ctr
-install -D -p -m 0644 _man/containerd.1 %{buildroot}%{_mandir}/man1/containerd.1
-install -D -p -m 0644 _man/containerd-config.1 %{buildroot}%{_mandir}/man1/containerd-config.1
-install -D -p -m 0644 _man/ctr.1 %{buildroot}%{_mandir}/man1/ctr.1
+install -m 0755 -vd                     %{buildroot}%{_bindir}
+install -m 0755 -vp _bin/* %{buildroot}%{_bindir}/
+install -D -p -m 0644 _man/containerd.8 %{buildroot}%{_mandir}/man1/containerd.8
+install -D -p -m 0644 _man/containerd-config.8 %{buildroot}%{_mandir}/man1/containerd-config.8
+install -D -p -m 0644 _man/ctr.8 %{buildroot}%{_mandir}/man1/ctr.8
 install -D -p -m 0644 _man/containerd-config.toml.5 %{buildroot}%{_mandir}/man5/containerd-config.toml.5
 install -D -p -m 0644 %{S:1} %{buildroot}%{_unitdir}/containerd.service
 install -D -p -m 0644 %{S:2} %{buildroot}%{_sysconfdir}/containerd/config.toml
@@ -177,7 +188,7 @@ install -D -p -m 0644 %{S:2} %{buildroot}%{_sysconfdir}/containerd/config.toml
 
 %if %{with tests}
 %check
-%gochecks
+%gochecks -d . -d mount -t snapshots
 %endif
 
 
@@ -194,15 +205,13 @@ install -D -p -m 0644 %{S:2} %{buildroot}%{_sysconfdir}/containerd/config.toml
 
 
 %files
-%license LICENSE
-%doc README.md
-%{_bindir}/containerd
-%{_bindir}/containerd-shim
-%{_bindir}/containerd-shim-runc-v1
-%{_bindir}/ctr
-%{_mandir}/man1/containerd.1*
-%{_mandir}/man1/containerd-config.1*
-%{_mandir}/man1/ctr.1*
+%license LICENSE NOTICE
+%doc docs PLUGINS.md ROADMAP.md RUNC.md SCOPE.md code-of-conduct.md BUILDING.md
+%doc README.md RELEASES.md
+%{_bindir}/*
+%{_mandir}/man1/containerd.8*
+%{_mandir}/man1/containerd-config.8*
+%{_mandir}/man1/ctr.8*
 %{_mandir}/man5/containerd-config.toml.5*
 %{_unitdir}/containerd.service
 %dir %{_sysconfdir}/containerd
@@ -210,6 +219,9 @@ install -D -p -m 0644 %{S:2} %{buildroot}%{_sysconfdir}/containerd/config.toml
 
 
 %changelog
+* Fri Oct 16 2020 Nicolas Trangez <nicolas.trangez@scality.com> - 1.4.1-1
+- Update to 1.4.1, based on containerd-1.4.1-1.fc34
+
 * Mon Apr 6 2020 Nicolas Trangez <nicolas.trangez@scality.com> - 1.2.13-2
 - Enable seccomp support
 

--- a/scripts/backup.sh.in
+++ b/scripts/backup.sh.in
@@ -186,8 +186,11 @@ backup_etcd() {
     crictl exec -i "$etcd_container" sh -c "${cmd[*]}"
 
     local -r rootfs_v1="/run/containerd/io.containerd.runtime.v1.linux/k8s.io/${etcd_container}/rootfs"
+    local -r rootfs_v2="/run/containerd/io.containerd.runtime.v2.task/k8s.io/${etcd_container}/rootfs"
     local rootfs=''
-    if test -d "${rootfs_v1}"; then
+    if test -d "${rootfs_v2}"; then
+        rootfs="${rootfs_v2}"
+    elif test -d "${rootfs_v1}"; then
         rootfs="${rootfs_v1}"
     else
         die "Unable to find etcd container rootfs"

--- a/scripts/backup.sh.in
+++ b/scripts/backup.sh.in
@@ -184,8 +184,22 @@ backup_etcd() {
         --state Running)"
     echo "Running '${cmd[*]}' in etcd container $etcd_container"
     crictl exec -i "$etcd_container" sh -c "${cmd[*]}"
+
+    local -r rootfs_v1="/run/containerd/io.containerd.runtime.v1.linux/k8s.io/${etcd_container}/rootfs"
+    local rootfs=''
+    if test -d "${rootfs_v1}"; then
+        rootfs="${rootfs_v1}"
+    else
+        die "Unable to find etcd container rootfs"
+    fi
+
+    local -r snapshot_file="${rootfs}/${etcd_snapshot}"
+    if ! test -f "${snapshot_file}"; then
+        die "etcd snapshot file not found"
+    fi
+
     _save_cp \
-        "/run/containerd/io.containerd.runtime.v1.linux/k8s.io/${etcd_container}/rootfs/${etcd_snapshot}" \
+        "${snapshot_file}" \
         "${BACKUP_DIR}/etcd_snapshot"
 }
 

--- a/scripts/backup.sh.in
+++ b/scripts/backup.sh.in
@@ -201,6 +201,8 @@ backup_etcd() {
     _save_cp \
         "${snapshot_file}" \
         "${BACKUP_DIR}/etcd_snapshot"
+
+    rm "${snapshot_file}"
 }
 
 create_archive() {


### PR DESCRIPTION
Changes, including the patch, based on `containerd-1.4.1-1.fc34`. Still
using the RHEL7/EPEL way of packaging Go projects.
 
Closes: #2855
See: https://github.com/scality/metalk8s/issues/2855

### TODO
- [x] Changelog
- [ ] Should we set `Vendor` and/or a particular string in `Release`?