### PR TITLE
scripts: Ensure archive is mounted before bootstrap

### DIFF
--- a/docs/installation/bootstrap.rst
+++ b/docs/installation/bootstrap.rst
@@ -9,7 +9,10 @@ Preparation
    from the Scality repositories.
 
 #. Download the MetalK8s ISO file on the machine that will host the bootstrap
-   node. Mount this ISO file at the specific following path:
+   node. Mount this ISO file at the path of your choice (we will use
+   ``/srv/scality/metalk8s-|version|`` for the rest of this guide, as this is
+   where the ISO will be mounted automatically after running the bootstrap
+   script):
 
    .. parsed-literal::
 

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -247,8 +247,11 @@ models:
       timeout: 2400
   - ShellCommand: &copy_iso_bootstrap_ssh
       name: Copy ISO to bootstrap node
+      env: &_env_copy_iso_bootstrap_ssh
+        DEST: ''
       command: >
-        scp -F ssh_config "%(prop:builddir)s/build/metalk8s.iso" bootstrap:
+        scp -F ssh_config "%(prop:builddir)s/build/metalk8s.iso"
+        bootstrap:"$DEST"
       workdir: build/eve/workers/openstack-terraform/terraform/
       haltOnFailure: true
   - ShellCommand: &create_mountpoint
@@ -273,9 +276,12 @@ models:
         "/srv/scality/metalk8s-${PRODUCT_VERSION}"
   - ShellCommand: &mount_iso_ssh
       name: Mount ISO image in bootstrap node
+      env: &_env_mount_iso_ssh
+        ARCHIVE: metalk8s.iso
+        MOUNTPOINT: /var/tmp/metalk8s
       command: >
         ssh -F ssh_config bootstrap
-        sudo mount -o loop metalk8s.iso /var/tmp/metalk8s
+        sudo mount -o loop ${ARCHIVE} ${MOUNTPOINT}
       workdir: build/eve/workers/openstack-terraform/terraform/
       haltOnFailure: true
   - ShellCommand: &set_bootstrap_minion_id_ssh
@@ -316,8 +322,9 @@ models:
       haltOnFailure: true
   - ShellCommand: &bootstrap_config_ssh
       name: Create bootstrap configuration file on bootstrap
-      env:
+      env: &_env_bootstrap_config_ssh
         DEBUG: "%(prop:metalk8s_debug:-false)s"
+        ARCHIVE: /var/tmp/metalk8s
       command: |
         ssh -F ssh_config bootstrap "
         sudo bash << EOF
@@ -333,7 +340,7 @@ models:
         ca:
           minion: \"bootstrap\"
         archives:
-          - \"/var/tmp/metalk8s\"
+          - \"${ARCHIVE}\"
         debug: ${DEBUG}
         END
         EOF"
@@ -1829,11 +1836,32 @@ stages:
               scp -F ssh_config -3 bastion:.ssh/bastion bootstrap:./         &&
               ssh -F ssh_config bootstrap "sudo cp bastion /etc/metalk8s/pki/"
           workdir: build/eve/workers/openstack-terraform/terraform/
+          haltOnFailure: true
       - ShellCommand: *set_bootstrap_minion_id_ssh
-      - ShellCommand: *bootstrap_config_ssh
-      - ShellCommand: *copy_iso_bootstrap_ssh
+      - ShellCommand:
+          name: Create /archives directory
+          command: >
+            ssh -F ssh_config bootstrap '
+              sudo mkdir /archives && sudo chown $USER: /archives
+            '
+          workdir: build/eve/workers/openstack-terraform/terraform/
+          haltOnFailure: true
+      - ShellCommand:
+          <<: *bootstrap_config_ssh
+          env:
+            <<: *_env_bootstrap_config_ssh
+            ARCHIVE: /archives/metalk8s.iso
+      - ShellCommand:
+          <<: *copy_iso_bootstrap_ssh
+          env:
+            <<: *_env_copy_iso_bootstrap_ssh
+            DEST: /archives/metalk8s.iso
       - ShellCommand: *create_mountpoint_ssh
-      - ShellCommand: *mount_iso_ssh
+      - ShellCommand:
+          <<: *mount_iso_ssh
+          env:
+            <<: *_env_mount_iso_ssh
+            ARCHIVE: /archives/metalk8s.iso
       - ShellCommand: *run_bootstrap_ssh
       - ShellCommand: &install_kubectl_bootstrap_ssh
           name: Install kubectl on the boostrap node

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -63,6 +63,12 @@ declare -a PACKAGES=(
 # shellcheck disable=SC1090
 . "$BASE_DIR"/common.sh
 
+ensure_archives_mounted() {
+    "${SALT_CALL}" --local --state-output=mixed --retcode-passthrough \
+        state.sls metalk8s.archives.mounted \
+        saltenv=metalk8s-@@VERSION pillarenv=metalk8s-@@VERSION
+}
+
 orchestrate_bootstrap() {
     # Grains must be set (in `/etc/salt/grains`) *before* invoking `salt-call`,
     # otherwise grains set during execution won't be taken into account
@@ -171,6 +177,7 @@ main() {
     run "Stopping Salt minion service" stop_salt_minion_service
     run "Installing mandatory packages" install_packages "${PACKAGES[@]}"
     run "Configuring Salt minion to run in local mode" configure_salt_minion_local_mode
+    run "Ensure archive is available" ensure_archives_mounted
 
     orchestrate_bootstrap
 


### PR DESCRIPTION
In cases where the initial archive is not mounted at
/srv/scality/metalk8s-<version>, bootstrap will fail to install packages
due to files not being found at the expected path. The required state to
mount archives at their expected path is only called after, in
`metalk8s.roles.bootstrap`.
We add a simple method in the bootstrap script to execute
`metalk8s.archives.mounted` before actually installing anything.

We also update documentation to reflect this (no path explicitly
required), and the multiple-nodes-centos BootstrapConfig to validate the
new behaviour works.

Fixes: #2864