### PR TITLE
Fix mark-control-plane and upgrade script

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -1220,7 +1220,7 @@ stages:
           command: >
             sudo bash
             /srv/scality/metalk8s-%(prop:metalk8s_version)s/upgrade.sh
-            --destination-version "%(prop:metalk8s_version)s" --verbose
+            --verbose
           haltOnFailure: true
       - ShellCommand: *provision_prometheus_volumes
       - ShellCommand: *wait_pods_running
@@ -1564,7 +1564,7 @@ stages:
           command: >
             sudo bash
             /srv/scality/metalk8s-%(prop:metalk8s_version)s/upgrade.sh
-            --destination-version %(prop:metalk8s_version)s --verbose
+            --verbose
           haltOnFailure: true
       - ShellCommand: *provision_prometheus_volumes
       - ShellCommand: *wait_pods_running

--- a/salt/metalk8s/kubernetes/mark-control-plane/files/bootstrap_node_update.yaml.j2.in
+++ b/salt/metalk8s/kubernetes/mark-control-plane/files/bootstrap_node_update.yaml.j2.in
@@ -14,6 +14,14 @@
 {%- if 'node-role.kubernetes.io/node' not in node_obj['metadata'].get('labels', {}) %}
   {%- set node_taints = node_obj['spec'].get('taints') | default([], True) %}
 
+  {#- Convert all `time_added` key to string as datetime cannot be serialized
+      as JSON automatically #}
+  {%- for taint in node_taints %}
+    {%- if 'time_added' in taint %}
+      {%- do taint.update({'time_added': taint['time_added'] | date_format("%Y-%m-%dT%H:%M:%SZ")}) %}
+    {%- endif %}
+  {%- endfor %}
+
   {%- for key_taint in ['node-role.kubernetes.io/bootstrap', 'node-role.kubernetes.io/infra'] %}
     {#- Only add taints if not present #}
     {%- if not (node_taints | selectattr('key', 'equalto', key_taint) | list) %}

--- a/scripts/upgrade.sh.in
+++ b/scripts/upgrade.sh.in
@@ -82,7 +82,8 @@ upgrade_bootstrap () {
         saltenv="$SALTENV"
 
     "${SALT_CALL}" --local --retcode-passthrough state.sls sync_mods="all" \
-        metalk8s.roles.bootstrap.components saltenv="$SALTENV" \
+        "['metalk8s.roles.bootstrap.components', 'metalk8s.container-engine']" \
+        saltenv="$SALTENV" \
         pillar="{'metalk8s': {'endpoints': {'salt-master': $saltmaster_endpoint, \
         'repositories': $repo_endpoint}}}"
 }


### PR DESCRIPTION
**Component**:

'salt', 'scripts', 'lifecycle'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

#2886 #2889 

**Summary**:

- Fix 'mark-control-plane' state when taints exist with `timeAdded`
- Fix upgrade script so that we upgrade containerd on bootstrap before calling highstate through crictl in salt-master container
- Fix upgrade test in CI (remove `destination-version` as it does not longer exists in upgrade script

**Acceptance criteria**: 

Working:
- [x] Bootstrap restore in CI
- [x] Upgrade in CI

---

Closes: #2886 #2889 
