### PR TITLE
salt: Add Node status precheck for Upgrade and Downgrade

### DIFF
--- a/salt/metalk8s/orchestrate/downgrade/precheck.sls
+++ b/salt/metalk8s/orchestrate/downgrade/precheck.sls
@@ -73,4 +73,27 @@ Unable to compare version for node {{ node }}, version_cmp {{ dest_version }} {{
 
   {%- endif %}
 
+  {#- Check Kubernetes node object status (should be Ready) #}
+  {%- set node_obj = salt.metalk8s_kubernetes.get_object(kind='Node', apiVersion='v1', name=node) %}
+  {%- set condition = node_obj['status']['conditions'] | selectattr('type', 'equalto', 'Ready') | first %} 
+
+  {%- if condition['status'] != 'True' %}
+
+Node {{ node }} is not Ready - {{ condition['reason'] }}:
+  test.fail_without_changes
+
+  {%- else %}
+
+Node {{ node }} is Ready:
+  test.succeed_without_changes
+
+  {%- endif %}
+
+  {#- Check Salt communication with this Node #}
+Ensure {{ node }} salt-minion running and reachable:
+  salt.function:
+    - name: test.ping
+    - tgt: {{ node }}
+    - timeout: 10
+
 {%- endfor %}


### PR DESCRIPTION
**Component**:

'salt', 'lifecycle'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

#2894 

**Summary**:

Before starting an upgrade or downgrade we need to make sure all nodes are
Ready and salt-minion running and reachable, so add this checks in
`precheck` states of Upgrade and Downgrade

**Acceptance criteria**: 

Status:
- `bootstrap` salt-minion process stopped
- `worker-0` kubelet stopped
- `not-installed-node` just get created and never deployed

Result:

```
# /srv/scality/metalk8s-2.6.0-dev/upgrade.sh 
> Getting cluster version 2.6.0-dev... done [0s]
> Performing Pre-Upgrade checks... fail [25s]

Failure while running step 'Performing Pre-Upgrade checks'

Command: precheck_upgrade

Output:

<< BEGIN >>
[...]
bootstrap_master:
----------
          ID: Correct saltenv "metalk8s-2.6.0-dev" for upgrade to "2.6.0-dev"
    Function: test.succeed_without_changes
      Result: True
     Comment: Success!
     Started: 11:01:02.632072
    Duration: 0.879 ms
     Changes:   
----------
[...]
----------
          ID: Node worker-0 is not Ready - NodeStatusUnknown
    Function: test.fail_without_changes
      Result: False
     Comment: Failure!
     Started: 11:01:02.967216
    Duration: 0.954 ms
     Changes:   
----------
[...]
----------
          ID: Ensure bootstrap salt-minion running and reachable
    Function: salt.function
        Name: test.ping
      Result: False
     Comment: 
     Started: 11:01:04.294297
    Duration: 20211.215 ms
     Changes:   
----------
[...]
----------
          ID: Node not-installed-node is not Ready - NodeStatusNeverUpdated
    Function: test.fail_without_changes
      Result: False
     Comment: Failure!
     Started: 11:01:25.178010
    Duration: 0.626 ms
     Changes:   
----------
          ID: Ensure not-installed-node salt-minion running and reachable
    Function: salt.function
        Name: test.ping
      Result: False
     Comment: 
     Started: 11:01:25.178858
    Duration: 49.211 ms
     Changes:   

Summary for bootstrap_master
-------------
Succeeded: 24 (changed=7)
Failed:     4
-------------
Total states run:     28
Total run time:   22.584 s
time="2020-10-29T11:02:04Z" level=fatal msg="execing command in container failed: command terminated with exit code 1"
<< END >>

This script will now exit
```

---

Fixes: #2894
