### PR TITLE
salt: Minor downgrade do not need to be disabled on 2.7

### DIFF
--- a/salt/metalk8s/defaults.yaml
+++ b/salt/metalk8s/defaults.yaml
@@ -7,7 +7,7 @@ metalk8s:
     # (e.g. downgrade of etcd), prior to downgrading the cluster.
     # The downgrade can still be forced setting `metalk8s.downgrade.enabled`
     # to `True` in the pillar.
-    enabled: false
+    enabled: true
 
 kubernetes:
   cluster: kubernetes


### PR DESCRIPTION
In a previous commit minor downgrade get disabled for 2.6 but it
shouldn't be disabled on 2.7, this commit just re-enable minor version
downgrade support in 2.7
