### PR TITLE
Launch multi node upgrade tests in ci

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -1617,7 +1617,26 @@ stages:
             TF_VAR_rhsm_username: "%(secret:rhel_ci_login)s"
             TF_VAR_rhsm_password: "%(secret:rhel_ci_password)s"
       # --- Wait for all pods to be running ---
-      - ShellCommand: *wait_pods_running_ssh
+      - ShellCommand:
+          <<: *wait_pods_running_ssh
+          # NOTE: Do not use `wait_pods_running_ssh` directly as we need to
+          # have a workaround to make sure all PVs are well recreated by
+          # storage operator
+          # Check https://github.com/scality/metalk8s/issues/2726
+          # As workaround if `wait_pods_status` failed just restart salt-minion
+          # everywhere and `wait_pods_status` again
+          command: >
+            git checkout "%(prop:branch)s" &&
+            scp -F ssh_config "%(prop:builddir)s/build/eve/wait_pods_status.sh" bootstrap:/tmp/ &&
+            ssh -F ssh_config bootstrap sudo bash -c "
+            /tmp/wait_pods_status.sh --sleep-time 5 --stabilization-time 30 --status Running
+            --retry 30 || (crictl exec -it
+            \$(sudo crictl ps -q --label io.kubernetes.pod.namespace=kube-system
+            --label io.kubernetes.container.name=salt-master --state Running)
+            salt '*' cmd.run_bg 'salt-call --local service.restart salt-minion' &&
+            sleep 10 &&
+            /tmp/wait_pods_status.sh --sleep-time 5 --stabilization-time 30 --status Running
+            --retry 30)"
       # --- We do not need to Test promoted version ---
       # --- Upgrade to version N ---
       - ShellCommand: *copy_iso_bootstrap_ssh

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -1532,6 +1532,7 @@ stages:
           doStepIf: "%(prop:minor_present)s"
           stage_names:
             - snapshot-single-node-upgrades
+            - snapshot-multi-node-upgrades
             # Cannot downgrade from a 3.4 etcd cluster to 3.3
             #- single-node-downgrade-promoted-centos
 
@@ -1550,6 +1551,22 @@ stages:
           stage_names:
             - snapshot-simple-environment-upgrade
 
+  snapshot-multi-node-upgrades:
+    # NOTE: This stage just set `environment_type` property to
+    # `multi node` and trigger all upgrade multi nodes stages
+    worker:
+      type: local
+    steps:
+      - SetProperty:
+          name: Set environment type to multi node
+          property: environment_type
+          value: multi node
+      - TriggerStages:
+          name: Trigger multi-node upgrade stages
+          stage_names:
+            - snapshot-3-nodes-upgrade
+
+
   snapshot-simple-environment-upgrade:
     # NOTE: This stage just set `environment_name` property to
     # `simple environment` and trigger the real upgrade tests
@@ -1562,6 +1579,25 @@ stages:
           value: simple environment
       - TriggerStages:
           name: Trigger simple environment upgrade stage
+          stage_names:
+            - snapshot-upgrade
+
+  snapshot-3-nodes-upgrade:
+    # NOTE: This stage just set `environment_name` property to
+    # `simple environment` and trigger the real upgrade tests
+    worker:
+      type: local
+    steps:
+      - SetProperty:
+          name: Set nodes count to 2 (bootstrap + 2 nodes)
+          property: nodes_count
+          value: "2"
+      - SetProperty:
+          name: Set environment name to 3 nodes
+          property: environment_name
+          value: "3 nodes"
+      - TriggerStages:
+          name: Trigger 3 node upgrade stage
           stage_names:
             - snapshot-upgrade
 

--- a/eve/wait_pods_status.sh
+++ b/eve/wait_pods_status.sh
@@ -117,4 +117,8 @@ done
 echo "Pods are still not $STATUS after $RETRY retries in" \
      "$SECONDS seconds!"
 
+kubectl get pods "$NAMESPACE" \
+    --field-selector="status.phase!=$STATUS" \
+    --kubeconfig="$KUBECONFIG"
+
 exit 1


### PR DESCRIPTION
**Component**:

'build', 'tests', 'lifecycle'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

#1128 

**Summary**:

- Backport fb2b5a4
- Add a workaround for #2726 in snapshot upgrade stage
- Add 3 nodes snapshot upgrade tests in CI

---

Fixes: #1128 
