### PR TITLE
[UI] Bugfix the unused volume health status should be none

### DIFF
--- a/ui/src/components/VolumeListTable.js
+++ b/ui/src/components/VolumeListTable.js
@@ -382,7 +382,7 @@ function Table({
               <td
                 style={{
                   textAlign: 'center',
-                  background: theme.brand.primaryDark1,
+                  background: theme.brand.primary,
                 }}
               >
                 No Volume

--- a/ui/src/containers/VolumePageContent.js
+++ b/ui/src/containers/VolumePageContent.js
@@ -188,8 +188,16 @@ const VolumePageContent = (props) => {
     },
     {
       selected: isAlertsPage,
-      title: (<span>{intl.translate('alerts')}<TextBadge>{alertlist?.length}</TextBadge></span>),
-      onClick: () => history.push(`${match.url}/alerts${query.toString() && `?${query.toString()}`}`),
+      title: (
+        <span>
+          {intl.translate('alerts')}
+          {PVCName && <TextBadge>{alertlist?.length}</TextBadge>}
+        </span>
+      ),
+      onClick: () =>
+        history.push(
+          `${match.url}/alerts${query.toString() && `?${query.toString()}`}`,
+        ),
     },
     {
       selected: isMetricsPage,

--- a/ui/src/containers/VolumePageContent.js
+++ b/ui/src/containers/VolumePageContent.js
@@ -20,7 +20,7 @@ import {
   LeftSideInstanceList,
   NoInstanceSelectedContainer,
   NoInstanceSelected,
-  TextBadge
+  TextBadge,
 } from '../components/CommonLayoutStyle';
 import { intl } from '../translations/IntlGlobalProvider';
 
@@ -181,7 +181,10 @@ const VolumePageContent = (props) => {
     {
       selected: isOverviewPage,
       title: intl.translate('overview'),
-      onClick: () => history.push(`${match.url}/overview${query.toString() && `?${query.toString()}`}`),
+      onClick: () =>
+        history.push(
+          `${match.url}/overview${query.toString() && `?${query.toString()}`}`,
+        ),
     },
     {
       selected: isAlertsPage,
@@ -190,13 +193,19 @@ const VolumePageContent = (props) => {
     },
     {
       selected: isMetricsPage,
-      title: (<span>{intl.translate('metrics')}</span>),
-      onClick: () => history.push(`${match.url}/metrics${query.toString() && `?${query.toString()}`}`),
+      title: <span>{intl.translate('metrics')}</span>,
+      onClick: () =>
+        history.push(
+          `${match.url}/metrics${query.toString() && `?${query.toString()}`}`,
+        ),
     },
     {
       selected: isDetailsPage,
-      title: (<span>{intl.translate('details')}</span>),
-      onClick: () => history.push(`${match.url}/details${query.toString() && `?${query.toString()}`}`),
+      title: <span>{intl.translate('details')}</span>,
+      onClick: () =>
+        history.push(
+          `${match.url}/details${query.toString() && `?${query.toString()}`}`,
+        ),
     },
   ];
 
@@ -222,7 +231,9 @@ const VolumePageContent = (props) => {
                   <VolumeOverviewTab
                     name={currentVolumeName}
                     nodeName={volume?.spec?.nodeName}
-                    storage={pV?.spec?.capacity?.storage ?? intl.translate('unknown')}
+                    storage={
+                      pV?.spec?.capacity?.storage ?? intl.translate('unknown')
+                    }
                     status={volumeStatus ?? intl.translate('unknown')}
                     storageClassName={volume?.spec?.storageClassName}
                     creationTimestamp={volume?.metadata?.creationTimestamp}
@@ -231,7 +242,9 @@ const VolumePageContent = (props) => {
                         ? RAW_BLOCK_DEVICE
                         : SPARSE_LOOP_DEVICE
                     }
-                    usedPodName={UsedPod ? UsedPod?.name : intl.translate('not_used')}
+                    usedPodName={
+                      UsedPod ? UsedPod?.name : intl.translate('not_used')
+                    }
                     devicePath={
                       volume?.spec?.rawBlockDevice?.devicePath ??
                       intl.translate('not_applicable')
@@ -239,12 +252,14 @@ const VolumePageContent = (props) => {
                     volumeUsagePercentage={currentVolume?.usage}
                     volumeUsageBytes={currentVolume?.usageRawData ?? 0}
                     storageCapacity={
-                      volumeListData?.find((vol) => vol.name === currentVolumeName)
-                        .storageCapacity
+                      volumeListData?.find(
+                        (vol) => vol.name === currentVolumeName,
+                      ).storageCapacity
                     }
                     health={
-                      volumeListData?.find((vol) => vol.name === currentVolumeName)
-                        .health
+                      volumeListData?.find(
+                        (vol) => vol.name === currentVolumeName,
+                      ).health
                     }
                     condition={currentVolume.status}
                     // the delete button inside the volume detail card should know that which volume is the first one
@@ -257,31 +272,26 @@ const VolumePageContent = (props) => {
               <Route
                 path={`${match.url}/alerts`}
                 render={() => (
-                  <VolumeAlertsTab
-                    alertlist={alertlist}
-                    PVCName={PVCName}
-                  />
+                  <VolumeAlertsTab alertlist={alertlist} PVCName={PVCName} />
                 )}
               />
               <Route
                 path={`${match.url}/metrics`}
                 render={() => (
                   <VolumeMetricsTab
-                  volumeName={currentVolumeName}
-                  volumeMetricGraphData={volumeMetricGraphData}
-                  // the volume condition compute base on the `status` and `bound/unbound`
-                  volumeCondition={currentVolume.status}
-                  volumePVCName={PVCName}
-                  volumeNamespace={PVCNamespace}
+                    volumeName={currentVolumeName}
+                    volumeMetricGraphData={volumeMetricGraphData}
+                    // the volume condition compute base on the `status` and `bound/unbound`
+                    volumeCondition={currentVolume.status}
+                    volumePVCName={PVCName}
+                    volumeNamespace={PVCNamespace}
                   />
                 )}
               />
               <Route
                 path={`${match.url}/details`}
                 render={() => (
-                  <VolumeDetailsTab
-                    currentVolumeObject={currentVolumeObject}
-                  />
+                  <VolumeDetailsTab currentVolumeObject={currentVolumeObject} />
                 )}
               />
             </Switch>

--- a/ui/src/services/NodeVolumesUtils.js
+++ b/ui/src/services/NodeVolumesUtils.js
@@ -217,7 +217,7 @@ export const getVolumeListData = createSelector(
         // compute the volume health based on the severity of the alerts
         // critical => if there is at least one critical
         if (volumeAlerts.length) {
-          volumeHealth = volumeAlerts.find(
+          volumeHealth = volumeAlerts.some(
             (vol) => vol.labels.severity === STATUS_CRITICAL,
           )
             ? STATUS_CRITICAL

--- a/ui/src/services/NodeVolumesUtils.js
+++ b/ui/src/services/NodeVolumesUtils.js
@@ -212,23 +212,23 @@ export const getVolumeListData = createSelector(
           (alert) =>
             alert.labels.persistentvolumeclaim === volumePVC.metadata.name,
         );
-      } else {
-        volumeHealth = STATUS_NONE;
-      }
 
-      // THE RULES TO COMPUTE THE HEALTH
-      // compute the volume health based on the severity of the alerts
-      // critical => if there is at least one critical
-      if (volumeAlerts.length) {
-        volumeHealth = volumeAlerts.find(
-          (vol) => vol.labels.severity === STATUS_CRITICAL,
-        )
-          ? STATUS_CRITICAL
-          : STATUS_WARNING;
-      } else if (volumeComputedCondition === ('exclamation' || 'unlink')) {
-        volumeHealth = STATUS_NONE;
+        // THE RULES TO COMPUTE THE HEALTH
+        // compute the volume health based on the severity of the alerts
+        // critical => if there is at least one critical
+        if (volumeAlerts.length) {
+          volumeHealth = volumeAlerts.find(
+            (vol) => vol.labels.severity === STATUS_CRITICAL,
+          )
+            ? STATUS_CRITICAL
+            : STATUS_WARNING;
+        } else if (volumeComputedCondition === ('exclamation' || 'unlink')) {
+          volumeHealth = STATUS_NONE;
+        } else {
+          volumeHealth = STATUS_HEALTH;
+        }
       } else {
-        volumeHealth = STATUS_HEALTH;
+        volumeHealth = STATUS_NONE;
       }
 
       const instanceIP = nodeList?.find(


### PR DESCRIPTION
**Component**: ui, bugs

**Context**: 
Since the volume is not bound, so we don't have PVC, then no monitoring. So we can't get any alerts, but it doesn't mean it's healthy.

**Summary**:
- Set none health state for the unused volumes (A circle without filled color)
- For unbound volume, display "The volume is not bound yet" in the alerts tab

**Acceptance criteria**: 
![image](https://user-images.githubusercontent.com/18453133/97725944-076bf480-1acf-11eb-8e4f-01f8e3376a41.png)
![image](https://user-images.githubusercontent.com/18453133/97725995-15217a00-1acf-11eb-8d18-aff76e38405d.png)


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2902 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
