### PR TITLE
scripts: Fix downgrade when `force` not set

### DIFF
--- a/scripts/downgrade.sh.in
+++ b/scripts/downgrade.sh.in
@@ -124,7 +124,7 @@ launch_downgrade () {
     "${SALT_MASTER_CALL[@]}" salt-run state.orchestrate \
         metalk8s.orchestrate.downgrade \
         saltenv="$SALTENV" \
-        "${FORCE:+pillar={'metalk8s': {'downgrade': {'enabled': true\}\}\}}"
+        ${FORCE:+pillar="{'metalk8s': {'downgrade': {'enabled': true}}}"}
 }
 
 downgrade_bootstrap () {


### PR DESCRIPTION
Move quote inside the bash expansion instead of outside so that if
`FORCE` environment variable is not set we do not have a remaining `""`

Fixes: #2909 
