### PR TITLE
salt: Add function to sort using a cmp function

### DIFF
--- a/salt/_modules/metalk8s.py
+++ b/salt/_modules/metalk8s.py
@@ -2,6 +2,7 @@
 '''
 Module for handling MetalK8s specific calls.
 '''
+import functools
 import logging
 import os.path
 import re
@@ -343,3 +344,14 @@ def format_slots(data):
             )
 
     return data
+
+
+def cmp_sorted(*args, **kwargs):
+    """Helper to sort a list using a function to compare (as `cmp` in Python2)
+
+    Useful when we want to sort a list in Jinja
+    """
+    if 'cmp' in kwargs:
+        kwargs['key'] = functools.cmp_to_key(kwargs.pop('cmp'))
+
+    return sorted(*args, **kwargs)

--- a/salt/tests/unit/modules/test_metalk8s.py
+++ b/salt/tests/unit/modules/test_metalk8s.py
@@ -307,3 +307,18 @@ class Metalk8sTestCase(TestCase, LoaderModuleMockMixin):
                     metalk8s.format_slots(data),
                     result
                 )
+
+    @parameterized.expand([
+        param([3, 5, 2, -4], [-4, 2, 3, 5]),
+        param([3, 5, 2, -4], [5, 3, 2, -4], reverse=True),
+        param([3, 5, 2, -4], [5, 3, 2, -4], cmp=lambda a, b: -1 if a > b else 1),
+        param([3, 5, 2, -4], [2, 3, -4, 5], key=abs)
+    ])
+    def test_cmp_sorted(self, obj, result, **kwargs):
+        """
+        Tests the return of `cmp_sorted` function
+        """
+        self.assertEqual(
+            metalk8s.cmp_sorted(obj, **kwargs),
+            result
+        )


### PR DESCRIPTION
**Component**:

'salt'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

Migration to Python3

NOTE: Put this function in development/2.6 so that it can be used during downgrade from 2.7.x to 2.6.x and avoid some "hack" in the salt downgrade orchestrate

**Summary**:

In python3 `sorted` and `sort` function do not support `cmp` function
compare to python2 that does (but it's easily doable using
`functools.cmp_to_key`).
For Jinja in Salt states it's useful function so add a salt module to
do this `sorted` using a `cmp` function same as it was done in Python2

---

