### PR TITLE
[UI] Fix volume sorting/ auto-select

### DIFF
--- a/ui/src/components/VolumeListTable.js
+++ b/ui/src/components/VolumeListTable.js
@@ -302,6 +302,11 @@ function Table({
       if (sorted) {
         sorted ? query.set('sort', sorted) : query.delete('sort');
         desc ? query.set('desc', desc) : query.delete('desc');
+        // Remove the default sorting `sort=health` from the query string
+        if (sorted === 'health' && desc === false) {
+          query.delete('sort');
+          query.delete('desc');
+        }
       } else if (!sorted && querySort) {
         query.delete('sort');
         query.delete('desc');

--- a/ui/src/containers/VolumePage.js
+++ b/ui/src/containers/VolumePage.js
@@ -92,7 +92,7 @@ const VolumePage = (props) => {
 
   // If data has been retrieved and no volume is selected yet we select the first one
   useEffect(() => {
-    if (volumeListData.length && !currentVolumeName) {
+    if (volumeListData[0]?.volumeAlertsRetrieved && !currentVolumeName) {
       history.replace({
         pathname: `/volumes/${volumeListData[0]?.name}/overview`,
         search: query.toString(),

--- a/ui/src/containers/VolumePage.js
+++ b/ui/src/containers/VolumePage.js
@@ -80,6 +80,12 @@ const VolumePage = (props) => {
     (state) => state.app.volumes.currentVolumeObject,
   );
   const pVList = useSelector((state) => state.app.volumes.pVList);
+
+  /*
+   ** The PVCs list is used to check when the alerts will be mapped to the corresponding volumes
+   ** in order to auto select the volume when all the data are there.
+   */
+  const pVCList = useSelector((state) => state?.app?.volumes?.pVCList);
   const alerts = useSelector((state) => state.app.alerts);
 
   const volumeStats = useSelector(
@@ -92,13 +98,18 @@ const VolumePage = (props) => {
 
   // If data has been retrieved and no volume is selected yet we select the first one
   useEffect(() => {
-    if (volumeListData[0]?.volumeAlertsRetrieved && !currentVolumeName) {
+    if (
+      volumeListData[0]?.name &&
+      alerts.list?.length &&
+      pVCList.length &&
+      !currentVolumeName
+    ) {
       history.replace({
         pathname: `/volumes/${volumeListData[0]?.name}/overview`,
         search: query.toString(),
       });
     }
-  }, [volumeListData, currentVolumeName, query, history]);
+  }, [volumeListData, currentVolumeName, query, history, alerts.list, pVCList]);
 
   return (
     <PageContainer>

--- a/ui/src/services/NodeVolumesUtils.js
+++ b/ui/src/services/NodeVolumesUtils.js
@@ -244,6 +244,7 @@ export const getVolumeListData = createSelector(
       return {
         name: volume?.metadata?.name,
         node: volume?.spec?.nodeName,
+        volumeAlertsRetrieved :  alerts?.list && pVCList.length,
         usage:
           volumeUsedCurrent && volumeCapacityCurrent
             ? (

--- a/ui/src/services/NodeVolumesUtils.js
+++ b/ui/src/services/NodeVolumesUtils.js
@@ -244,7 +244,6 @@ export const getVolumeListData = createSelector(
       return {
         name: volume?.metadata?.name,
         node: volume?.spec?.nodeName,
-        volumeAlertsRetrieved :  alerts?.list && pVCList.length,
         usage:
           volumeUsedCurrent && volumeCapacityCurrent
             ? (


### PR DESCRIPTION
**Component**:
ui,volumes
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
There were some sorting issues on the Volumes list sorting (see #2920 )

- The auto-selected volume was not always the first one after health sorting
- The default sort sometime appeared in the URL

**Summary**:
Added a flag property to only auto-select when PVCs and Alerts are retrieved.
Removed URL sort when default sorted.

**Acceptance criteria**: 

The volumes list components waits for alerts data to be retrieved before auto-selecting the first volume.
The default sort does not appear in the URL anymore.


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2920 

<!-- If you want to refer to an issue while not closing it, use:


-->
