### PR TITLE
[UI] Nodes sorting

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -2894,6 +2894,16 @@
         "loader-utils": "^1.2.3"
       }
     },
+    "@testing-library/react-hooks": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-3.4.2.tgz",
+      "integrity": "sha512-RfPG0ckOzUIVeIqlOc1YztKgFW+ON8Y5xaSPbiBkfj9nMkkiLhLeBXT5icfPX65oJV/zCZu4z8EVnUc6GY9C5A==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.5.4",
+        "@types/testing-library__react-hooks": "^3.4.0"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.10",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.10.tgz",
@@ -3012,10 +3022,43 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
+    "@types/prop-types": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+      "dev": true
+    },
     "@types/q": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
+    },
+    "@types/react": {
+      "version": "16.9.56",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.56.tgz",
+      "integrity": "sha512-gIkl4J44G/qxbuC6r2Xh+D3CGZpJ+NdWTItAPmZbR5mUS+JQ8Zvzpl0ea5qT/ZT3ZNTUcDKUVqV3xBE8wv/DyQ==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
+          "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ==",
+          "dev": true
+        }
+      }
+    },
+    "@types/react-test-renderer": {
+      "version": "16.9.3",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-16.9.3.tgz",
+      "integrity": "sha512-wJ7IlN5NI82XMLOyHSa+cNN4Z0I+8/YaLl04uDgcZ+W+ExWCmCiVTLT/7fRNqzy4OhStZcUwIqLNF7q+AdW43Q==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
     },
     "@types/request": {
       "version": "2.48.5",
@@ -3038,6 +3081,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw=="
+    },
+    "@types/testing-library__react-hooks": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.4.1.tgz",
+      "integrity": "sha512-G4JdzEcq61fUyV6wVW9ebHWEiLK2iQvaBuCHHn9eMSbZzVh4Z4wHnUGIvQOYCCYeu5DnUtFyNYuAAgbSaO/43Q==",
+      "dev": true,
+      "requires": {
+        "@types/react-test-renderer": "*"
+      }
     },
     "@types/tough-cookie": {
       "version": "4.0.0",
@@ -15027,10 +15079,50 @@
         "react-transition-group": "^4.3.0"
       }
     },
+    "react-shallow-renderer": {
+      "version": "16.14.1",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz",
+      "integrity": "sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0"
+      }
+    },
     "react-table": {
       "version": "7.5.1",
       "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.5.1.tgz",
       "integrity": "sha512-rprrUElCqvj79lyY2XbUoYLzwA5Mm4CGS8ElQ8OyzocvmkvCcmunvvfbpIg9Jm9HnMBjVZcVyPFPZ1BFelIBKw=="
+    },
+    "react-test-renderer": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
+      "integrity": "sha512-/dRae3mj6aObwkjCcxZPlxDFh73XZLgvwhhyON2haZGUEhiaY5EjfAdw+d/rQmlcFwdTpMXCSGVk374QbCTlrA==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.1",
+        "react-is": "^17.0.1",
+        "react-shallow-renderer": "^16.13.1",
+        "scheduler": "^0.20.1"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "17.0.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+          "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
+          "dev": true
+        },
+        "scheduler": {
+          "version": "0.20.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.1.tgz",
+          "integrity": "sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
+      }
     },
     "react-textarea-autosize": {
       "version": "6.1.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -4019,7 +4019,8 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "string_decoder": {
           "version": "1.1.1",
@@ -14535,13 +14536,12 @@
       }
     },
     "react": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
-      "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.1.tgz",
+      "integrity": "sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==",
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
+        "object-assign": "^4.1.1"
       }
     },
     "react-app-polyfill": {
@@ -18947,7 +18947,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "optional": true
         },
         "string_decoder": {
           "version": "1.1.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,7 +12,7 @@
     "lodash.sortby": "^4.7.0",
     "oidc-client": "^1.8.0",
     "polished": "3.4.1",
-    "react": "^16.8.1",
+    "react": "^17.0.1",
     "react-debounce-input": "3.2.2",
     "react-dom": "^16.8.1",
     "react-intl": "^2.8.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -69,6 +69,7 @@
     "@babel/plugin-proposal-optional-chaining": "^7.2.0",
     "@babel/preset-flow": "^7.0.0",
     "@redux-saga/testing-utils": "^1.0.2",
+    "@testing-library/react-hooks": "^3.4.2",
     "babel-eslint": "10.1.0",
     "compression-webpack-plugin": "^6.0.0",
     "customize-cra": "^0.4.1",
@@ -79,6 +80,7 @@
     "flow-bin": "^0.107.0",
     "jest-junit": "^7.0.0",
     "react-app-rewired": "^2.1.3",
+    "react-test-renderer": "^17.0.1",
     "source-map-explorer": "^2.0.1"
   },
   "cypress-cucumber-preprocessor": {

--- a/ui/src/components/CommonLayoutStyle.js
+++ b/ui/src/components/CommonLayoutStyle.js
@@ -78,3 +78,21 @@ export const VolumeTab = styled.div`
   padding-top: ${padding.base};
   padding-bottom: ${padding.base};
 `;
+
+export const SortCaretWrapper = styled.span`
+  padding-left: ${padding.smaller};
+  position: absolute;
+`;
+
+export const SortIncentive = styled.span`
+  position: absolute;
+  display: none;
+`;
+
+export const TableHeader = styled.th`
+  &:hover {
+    ${SortIncentive} {
+      display: block;
+    }
+  }
+`;

--- a/ui/src/components/NodeListTable.js
+++ b/ui/src/components/NodeListTable.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router';
 import { useLocation, useRouteMatch } from 'react-router-dom';
@@ -20,7 +20,7 @@ import {
   SortIncentive,
   TableHeader,
 } from './CommonLayoutStyle';
-import { compareHealth } from '../services/utils';
+import { compareHealth, useTableSortURLSync } from '../services/utils';
 import {
   API_STATUS_READY,
   API_STATUS_NOT_READY,
@@ -203,7 +203,6 @@ function GlobalFilter({
 }
 
 function Table({ columns, data, rowClicked, theme, selectedNodeName }) {
-  const history = useHistory();
   const query = useQuery();
   const querySearch = query.get('search');
   const querySort = query.get('sort');
@@ -283,27 +282,7 @@ function Table({ columns, data, rowClicked, theme, selectedNodeName }) {
     ?.id;
   const desc = headerGroups[0].headers.find((item) => item.isSorted === true)
     ?.isSortedDesc;
-  useEffect(() => {
-    // Creating a local query instance to avoid having it in the useEffect dependencies and creating infinite loops on search change
-    const query = new URLSearchParams(window.location.search);
-    const querySort = query.get('sort');
-    const queryDesc = query.get('desc');
-    if (data.length && (sorted !== querySort || desc !== queryDesc)) {
-      if (sorted) {
-        sorted ? query.set('sort', sorted) : query.delete('sort');
-        desc ? query.set('desc', desc) : query.delete('desc');
-        // Remove the default sorting `sort=health` from the query string
-        if (sorted === 'health' && desc === false) {
-          query.delete('sort');
-          query.delete('desc');
-        }
-      } else if (!sorted && querySort) {
-        query.delete('sort');
-        query.delete('desc');
-      }
-      history.replace(`?${query.toString()}`);
-    }
-  }, [sorted, desc, history, data.length]);
+  useTableSortURLSync(sorted, desc, data);
 
   return (
     <>

--- a/ui/src/components/NodeListTable.js
+++ b/ui/src/components/NodeListTable.js
@@ -67,7 +67,7 @@ const NodeListContainer = styled.div`
 
     td {
       margin: 0;
-      padding: 0.5rem;
+      padding: ${padding.smaller};
       text-align: left;
 
       :last-child {
@@ -236,6 +236,11 @@ function Table({ columns, data, rowClicked, theme, selectedNodeName }) {
           weights[row1?.values?.status?.status] -
           weights[row2?.values?.status?.status]
         );
+      },
+      name: (row1, row2) => {
+        const a = row1?.values?.name?.name;
+        const b = row2.values?.name?.name;
+        return a.toLowerCase().localeCompare(b.toLowerCase());
       },
     };
   }, []);
@@ -418,7 +423,7 @@ const NodeListTable = (props) => {
       {
         Header: 'Health',
         accessor: 'health',
-        cellStyle: { textAlign: 'center', width: '50px' },
+        cellStyle: { textAlign: 'center', width: '70px' },
         Cell: (cellProps) => {
           const { health } = cellProps.value;
           return <CircleStatus status={health} />;
@@ -429,6 +434,7 @@ const NodeListTable = (props) => {
         Header: 'Name',
         accessor: 'name',
         cellStyle: { width: '180px' },
+        sortType: 'name',
       },
       {
         Header: 'Roles',

--- a/ui/src/components/NodeListTable.js
+++ b/ui/src/components/NodeListTable.js
@@ -21,6 +21,12 @@ import {
   TableHeader,
 } from './CommonLayoutStyle';
 import { compareHealth } from '../services/utils';
+import {
+  API_STATUS_READY,
+  API_STATUS_NOT_READY,
+  API_STATUS_UNKNOWN,
+  API_STATUS_DEPLOYING,
+} from '../constants';
 
 const NodeListContainer = styled.div`
   color: ${(props) => props.theme.brand.textPrimary};
@@ -217,6 +223,18 @@ function Table({ columns, data, rowClicked, theme, selectedNodeName }) {
         return compareHealth(
           row2?.values?.health?.health,
           row1?.values?.health?.health,
+        );
+      },
+      status: (row1, row2) => {
+        const weights = {};
+        weights[API_STATUS_READY] = 3;
+        weights[API_STATUS_NOT_READY] = 2;
+        weights[API_STATUS_DEPLOYING] = 1;
+        weights[API_STATUS_UNKNOWN] = 0;
+
+        return (
+          weights[row1?.values?.status?.status] -
+          weights[row2?.values?.status?.status]
         );
       },
     };
@@ -422,7 +440,6 @@ const NodeListTable = (props) => {
         cellStyle: { textAlign: 'center', width: '80px' },
         Cell: (cellProps) => {
           const { statusTextColor, computedStatus } = cellProps.value;
-          console.log(computedStatus);
           return computedStatus.map((status) => {
             return (
               <StatusText key={status} textColor={statusTextColor}>
@@ -431,6 +448,7 @@ const NodeListTable = (props) => {
             );
           });
         },
+        sortType: 'status',
       },
     ],
     [],

--- a/ui/src/components/VolumeListTable.js
+++ b/ui/src/components/VolumeListTable.js
@@ -302,6 +302,11 @@ function Table({
       if (sorted) {
         sorted ? query.set('sort', sorted) : query.delete('sort');
         desc ? query.set('desc', desc) : query.delete('desc');
+        // Remove the default sorting `sort=health` from the query string
+        if (sorted === 'health' && desc === false) {
+          query.delete('sort');
+          query.delete('desc');
+        }
       } else if (!sorted && querySort) {
         query.delete('sort');
         query.delete('desc');

--- a/ui/src/components/VolumeListTable.js
+++ b/ui/src/components/VolumeListTable.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router';
 import { useLocation } from 'react-router-dom';
@@ -28,6 +28,7 @@ import {
   allSizeUnitsToBytes,
   compareHealth,
   formatSizeForDisplay,
+  useTableSortURLSync,
 } from '../services/utils';
 import {
   SortCaretWrapper,
@@ -280,27 +281,7 @@ function Table({
     ?.id;
   const desc = headerGroups[0].headers.find((item) => item.isSorted === true)
     ?.isSortedDesc;
-  useEffect(() => {
-    // Creating a local query instance to avoid having it in the useEffect dependencies and creating infinite loops on search change
-    const query = new URLSearchParams(window.location.search);
-    const querySort = query.get('sort');
-    const queryDesc = query.get('desc');
-    if (data.length && (sorted !== querySort || desc !== queryDesc)) {
-      if (sorted) {
-        sorted ? query.set('sort', sorted) : query.delete('sort');
-        desc ? query.set('desc', desc) : query.delete('desc');
-        // Remove the default sorting `sort=health` from the query string
-        if (sorted === 'health' && desc === false) {
-          query.delete('sort');
-          query.delete('desc');
-        }
-      } else if (!sorted && querySort) {
-        query.delete('sort');
-        query.delete('desc');
-      }
-      history.replace(`?${query.toString()}`);
-    }
-  }, [sorted, desc, history, data.length]);
+  useTableSortURLSync(sorted, desc, data);
 
   return (
     <>

--- a/ui/src/components/VolumeListTable.js
+++ b/ui/src/components/VolumeListTable.js
@@ -29,6 +29,11 @@ import {
   compareHealth,
   formatSizeForDisplay,
 } from '../services/utils';
+import {
+  SortCaretWrapper,
+  SortIncentive,
+  TableHeader,
+} from './CommonLayoutStyle';
 
 const VolumeListContainer = styled.div`
   color: ${(props) => props.theme.brand.textPrimary};
@@ -138,24 +143,6 @@ const TooltipContent = styled.div`
   color: ${(props) => props.theme.brand.textSecondary};
   font-weight: ${fontWeight.bold};
   min-width: 60px;
-`;
-
-const SortCaretWrapper = styled.span`
-  padding-left: ${padding.smaller};
-  position: absolute;
-`;
-
-const SortIncentive = styled.span`
-  position: absolute;
-  display: none;
-`;
-
-const TableHeader = styled.th`
-  &:hover {
-    ${SortIncentive} {
-      display: block;
-    }
-  }
 `;
 
 function GlobalFilter({

--- a/ui/src/constants.js
+++ b/ui/src/constants.js
@@ -13,6 +13,7 @@ export const STATUS_HEALTH = 'health';
 export const API_STATUS_READY = 'ready';
 export const API_STATUS_NOT_READY = 'not_ready';
 export const API_STATUS_UNKNOWN = 'unknown';
+export const API_STATUS_DEPLOYING = 'deploying';
 
 export const STATUS_BOUND = 'Bound';
 export const STATUS_PENDING = 'Pending';

--- a/ui/src/containers/NodePage.js
+++ b/ui/src/containers/NodePage.js
@@ -24,6 +24,7 @@ const NodePage = (props) => {
 
   const theme = useSelector((state) => state.config.theme);
   const nodeTableData = useSelector((state) => getNodeListData(state, props));
+  const alerts = useSelector((state) => state.app.alerts);
 
   return (
     <PageContainer>
@@ -40,7 +41,7 @@ const NodePage = (props) => {
           ]}
         />
       </BreadcrumbContainer>
-      <NodePageContent nodeTableData={nodeTableData}></NodePageContent>
+      <NodePageContent nodeTableData={nodeTableData} alerts={alerts} />
     </PageContainer>
   );
 };

--- a/ui/src/containers/NodePageContent.js
+++ b/ui/src/containers/NodePageContent.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Route, useRouteMatch, Switch, Redirect } from 'react-router-dom';
 import { refreshNodesAction, stopRefreshNodesAction } from '../ducks/app/nodes';
 import {
@@ -16,12 +16,19 @@ import {
 
 // <NodePageContent> get the current selected node and pass it to <NodeListTable> and <NodePageRSP>
 const NodePageContent = (props) => {
-  const { nodeTableData } = props;
+  const { nodeTableData, alerts } = props;
   const { path } = useRouteMatch();
-  const defaultSelectNodeName = nodeTableData[0]?.name?.name;
+  const [defaultSelectNodeName, setDefaultSelectNodeName] = useState(null);
 
   useRefreshEffect(refreshAlertManagerAction, stopRefreshAlertManagerAction);
   useRefreshEffect(refreshNodesAction, stopRefreshNodesAction);
+
+  // Making sure the alerts have been retrieved (mandatory for health sorting) before selecting the first node
+  useEffect(() => {
+    if (alerts.list.length && !defaultSelectNodeName) {
+      setDefaultSelectNodeName(nodeTableData[0]?.name?.name);
+    }
+  }, [alerts, nodeTableData, defaultSelectNodeName]);
 
   return (
     <PageContentContainer>

--- a/ui/src/containers/VolumePage.js
+++ b/ui/src/containers/VolumePage.js
@@ -92,7 +92,7 @@ const VolumePage = (props) => {
 
   // If data has been retrieved and no volume is selected yet we select the first one
   useEffect(() => {
-    if (volumeListData.length && !currentVolumeName) {
+    if (volumeListData[0]?.volumeAlertsRetrieved && !currentVolumeName) {
       history.replace({
         pathname: `/volumes/${volumeListData[0]?.name}/overview`,
         search: query.toString(),

--- a/ui/src/containers/VolumePage.js
+++ b/ui/src/containers/VolumePage.js
@@ -80,6 +80,12 @@ const VolumePage = (props) => {
     (state) => state.app.volumes.currentVolumeObject,
   );
   const pVList = useSelector((state) => state.app.volumes.pVList);
+
+  /*
+   ** The PVCs list is used to check when the alerts will be mapped to the corresponding volumes
+   ** in order to auto select the volume when all the data are there.
+   */
+  const pVCList = useSelector((state) => state?.app?.volumes?.pVCList);
   const alerts = useSelector((state) => state.app.alerts);
 
   const volumeStats = useSelector(
@@ -92,13 +98,18 @@ const VolumePage = (props) => {
 
   // If data has been retrieved and no volume is selected yet we select the first one
   useEffect(() => {
-    if (volumeListData[0]?.volumeAlertsRetrieved && !currentVolumeName) {
+    if (
+      volumeListData[0]?.name &&
+      alerts.list?.length &&
+      pVCList.length &&
+      !currentVolumeName
+    ) {
       history.replace({
         pathname: `/volumes/${volumeListData[0]?.name}/overview`,
         search: query.toString(),
       });
     }
-  }, [volumeListData, currentVolumeName, query, history]);
+  }, [volumeListData, currentVolumeName, query, history, alerts.list, pVCList]);
 
   return (
     <PageContainer>

--- a/ui/src/services/NodeUtils.js
+++ b/ui/src/services/NodeUtils.js
@@ -6,7 +6,10 @@ import {
   STATUS_WARNING,
   STATUS_HEALTH,
   STATUS_NONE,
+  API_STATUS_READY,
+  API_STATUS_NOT_READY,
   API_STATUS_UNKNOWN,
+  API_STATUS_DEPLOYING,
 } from '../constants';
 
 const METALK8S_CONTROL_PLANE_IP = 'metalk8s:control_plane_ip';
@@ -64,25 +67,25 @@ export const getNodeListData = createSelector(
         // "yellow" when status.conditions['Ready'] == True and some other conditions are true
         // "red" when status.conditions['Ready'] == False
         // "grey" when there is no status.conditions
-        if (node?.status === 'ready' && node?.conditions.length === 0) {
+        if (node?.status === API_STATUS_READY && node?.conditions.length === 0) {
           statusTextColor = brand?.healthy;
-          computedStatus.push('ready');
-        } else if (node?.status === 'ready' && node?.conditions.length !== 0) {
+          computedStatus.push(API_STATUS_READY);
+        } else if (node?.status === API_STATUS_READY && node?.conditions.length !== 0) {
           statusTextColor = brand?.warning;
           nodes.conditions.map((cond) => {
             return computedStatus.push(cond);
           });
         } else if (node.deploying && node.status === API_STATUS_UNKNOWN) {
           statusTextColor = brand?.textSecondary;
-          computedStatus.push('deploying');
+          computedStatus.push(API_STATUS_DEPLOYING);
           health = STATUS_NONE;
-        } else if (node?.status !== 'ready') {
+        } else if (node?.status !== API_STATUS_READY) {
           statusTextColor = brand?.critical;
-          computedStatus.push('not_ready');
+          computedStatus.push(API_STATUS_NOT_READY);
           health = STATUS_NONE;
         } else {
           statusTextColor = brand?.textSecondary;
-          computedStatus.push('unknown');
+          computedStatus.push(API_STATUS_UNKNOWN);
           health = STATUS_NONE;
         }
 

--- a/ui/src/services/NodeUtils.js
+++ b/ui/src/services/NodeUtils.js
@@ -11,6 +11,7 @@ import {
   API_STATUS_UNKNOWN,
   API_STATUS_DEPLOYING,
 } from '../constants';
+import { compareHealth } from './utils';
 
 const METALK8S_CONTROL_PLANE_IP = 'metalk8s:control_plane_ip';
 const METALK8S_WORKLOAD_PLANE_IP = 'metalk8s:workload_plane_ip';
@@ -28,7 +29,7 @@ export const getNodeListData = createSelector(
   brandSelector,
   alertsSelector,
   (nodes, nodeIPsInfo, brand, alerts) => {
-    return (
+    const mapped =
       nodes?.map((node) => {
         const IPsInfo = nodeIPsInfo?.[node.name];
         let statusTextColor, health;
@@ -67,10 +68,16 @@ export const getNodeListData = createSelector(
         // "yellow" when status.conditions['Ready'] == True and some other conditions are true
         // "red" when status.conditions['Ready'] == False
         // "grey" when there is no status.conditions
-        if (node?.status === API_STATUS_READY && node?.conditions.length === 0) {
+        if (
+          node?.status === API_STATUS_READY &&
+          node?.conditions.length === 0
+        ) {
           statusTextColor = brand?.healthy;
           computedStatus.push(API_STATUS_READY);
-        } else if (node?.status === API_STATUS_READY && node?.conditions.length !== 0) {
+        } else if (
+          node?.status === API_STATUS_READY &&
+          node?.conditions.length !== 0
+        ) {
           statusTextColor = brand?.warning;
           nodes.conditions.map((cond) => {
             return computedStatus.push(cond);
@@ -110,7 +117,10 @@ export const getNodeListData = createSelector(
             warningAlertsCounter,
           },
         };
-      }) ?? []
+      }) ?? [];
+
+    return mapped.sort((a, b) =>
+      compareHealth(b.health.health, a.health.health),
     );
   },
 );

--- a/ui/src/services/NodeVolumesUtils.js
+++ b/ui/src/services/NodeVolumesUtils.js
@@ -244,6 +244,7 @@ export const getVolumeListData = createSelector(
       return {
         name: volume?.metadata?.name,
         node: volume?.spec?.nodeName,
+        volumeAlertsRetrieved :  alerts?.list && pVCList.length,
         usage:
           volumeUsedCurrent && volumeCapacityCurrent
             ? (

--- a/ui/src/services/NodeVolumesUtils.js
+++ b/ui/src/services/NodeVolumesUtils.js
@@ -244,7 +244,6 @@ export const getVolumeListData = createSelector(
       return {
         name: volume?.metadata?.name,
         node: volume?.spec?.nodeName,
-        volumeAlertsRetrieved :  alerts?.list && pVCList.length,
         usage:
           volumeUsedCurrent && volumeCapacityCurrent
             ? (

--- a/ui/src/services/utils.js
+++ b/ui/src/services/utils.js
@@ -377,9 +377,9 @@ export const formatSizeForDisplay = (value) => {
 };
 
 /*
-** Custom hook that stores table sorting choice in the URL queries
-** Defaults to health sorting (used on Nodes and Volumes tables)
-*/
+ ** Custom hook that stores table sorting choice in the URL queries
+ ** Defaults to health sorting (used on Nodes and Volumes tables)
+ */
 export const useTableSortURLSync = (sorted, desc, data) => {
   const history = useHistory();
   useEffect(() => {
@@ -401,5 +401,5 @@ export const useTableSortURLSync = (sorted, desc, data) => {
       }
       history.replace(`?${query.toString()}`);
     }
-  }, [sorted, desc, data.length]);
+  }, [sorted, desc, data.length, history]);
 };

--- a/ui/src/services/utils.js
+++ b/ui/src/services/utils.js
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useHistory } from 'react-router-dom';
 import { createSelector } from 'reselect';
 import sortByArray from 'lodash.sortby';
 import { intl } from '../translations/IntlGlobalProvider';
@@ -374,4 +374,32 @@ export const compareHealth = (status1, status2) => {
 // Adds a space between size value and its unit since the API returns this as a string
 export const formatSizeForDisplay = (value) => {
   return value.replace(/^(\d+)(\D+)$/, '$1 $2');
+};
+
+/*
+** Custom hook that stores table sorting choice in the URL queries
+** Defaults to health sorting (used on Nodes and Volumes tables)
+*/
+export const useTableSortURLSync = (sorted, desc, data) => {
+  const history = useHistory();
+  useEffect(() => {
+    const query = new URLSearchParams(window.location.search);
+    const querySort = query.get('sort');
+    const queryDesc = query.get('desc');
+    if (data.length && (sorted !== querySort || desc !== queryDesc)) {
+      if (sorted) {
+        sorted ? query.set('sort', sorted) : query.delete('sort');
+        desc ? query.set('desc', desc) : query.delete('desc');
+        // Remove the default sorting `sort=health` from the query string
+        if (sorted === 'health' && desc === false) {
+          query.delete('sort');
+          query.delete('desc');
+        }
+      } else if (!sorted && querySort) {
+        query.delete('sort');
+        query.delete('desc');
+      }
+      history.replace(`?${query.toString()}`);
+    }
+  }, [sorted, desc, data.length]);
 };


### PR DESCRIPTION
**Component**:
ui, nodes

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
We want to be able to sort the Nodes table like the Volumes table.

**Summary**:
I used the same sorting logic (leveraging react-table's sorting abilities). 
I extracted the URL sync code to its custom hook and the Table sorting components to the Common layout file to avoid code redundancy between the two views.
Update:
- Introduce hook test libray 
- Bump React version to the latest v17.0.1

**Acceptance criteria**: 
Clicking on a column header on the Nodes table sorts the data according to what is specified in #2919 .
Loading the page with a sorting specified in the URL sorts the data accordingly.


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2919 

<!-- If you want to refer to an issue while not closing it, use:


-->
