### PR TITLE
Sparse loop device provisioning with systemd units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
   more robust about static pod restart and improve user experience
   (PR [#2928](https://github.com/scality/metalk8s/pull/2928))
 
+- [#2726](https://github.com/scality/metalk8s/issues/2726) - Ensure sparse loop
+  volumes are all provisioned on reboot
+  (PR [#2936](https://github.com/scality/metalk8s/pull/2936))
+
 ## Release 2.6.1 (in development)
 
 ## Release 2.6.0

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -651,7 +651,8 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/volumes/init.sls'),
     Path('salt/metalk8s/volumes/prepared/init.sls'),
     Path('salt/metalk8s/volumes/prepared/installed.sls'),
-    Path('salt/metalk8s/volumes/provisioned/init.sls'),
+    Path('salt/metalk8s/volumes/prepared/files/metalk8s-sparse-volume@.service'),
+    Path('salt/metalk8s/volumes/prepared/files/sparse_volume_cleanup.py'),
     Path('salt/metalk8s/volumes/unprepared/init.sls'),
 
     Path('salt/_auth/kubernetes_rbac.py'),

--- a/salt/_states/metalk8s_volumes.py
+++ b/salt/_states/metalk8s_volumes.py
@@ -51,43 +51,6 @@ def present(name):
     return ret
 
 
-def provisioned(name):
-    """Provision the given volume.
-
-    Args:
-        name (str): Volume name
-
-    Returns:
-        dict: state return value
-    """
-    ret = {'name': name, 'changes': {}, 'result': False, 'comment': ''}
-    # Idempotence.
-    if __salt__['metalk8s_volumes.is_provisioned'](name):
-        ret['result'] = True
-        ret['comment'] = 'Storage for volume {} already provisioned.'\
-            .format(name)
-        return ret
-    # Dry-run.
-    if __opts__['test']:
-        ret['changes'][name] = 'Provisioned'
-        ret['result'] = None
-        ret['comment'] = 'Storage for volume {} is going to be provisioned.'\
-            .format(name)
-        return ret
-    # Let's go for real.
-    try:
-        __salt__['metalk8s_volumes.provision'](name)
-    except CommandExecutionError as exn:
-        ret['result'] = False
-        ret['comment'] = 'Storage provisioning for volume {} failed: {}.'\
-            .format(name, exn)
-    else:
-        ret['changes'][name] = 'Provisioned'
-        ret['result'] = True
-        ret['comment'] = 'Storage provisioned for volume {}.'.format(name)
-    return ret
-
-
 def prepared(name):
     """Prepare the given volume.
 

--- a/salt/metalk8s/salt/minion/files/minion-99-metalk8s.conf.j2
+++ b/salt/metalk8s/salt/minion/files/minion-99-metalk8s.conf.j2
@@ -10,8 +10,3 @@ use_superseded:
 log_level_logfile: {{ 'debug' if debug else 'info' }}
 
 saltenv: {{ saltenv }}
-
-# Prepare volume at startup (required for loop devices persistency).
-startup_states: sls
-sls_list:
-  - /metalk8s/volumes/provisioned

--- a/salt/metalk8s/volumes/prepared/files/metalk8s-sparse-volume@.service
+++ b/salt/metalk8s/volumes/prepared/files/metalk8s-sparse-volume@.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Setup MetalK8s sparse loop volume %I
+RequiresMountsFor=/var/lib/metalk8s/storage/sparse
+AssertFileNotEmpty=/var/lib/metalk8s/storage/sparse/%i
+
+[Service]
+Type=oneshot
+ExecStart=/bin/flock --exclusive --wait 10 /var/lock/metalk8s-sparse-volume.lock \
+             /sbin/losetup --find --partscan "/var/lib/metalk8s/storage/sparse/%i"
+ExecStop=/usr/local/libexec/metalk8s-sparse-volume-cleanup "%i"
+TimeoutStartSec=10
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/salt/metalk8s/volumes/prepared/files/sparse_volume_cleanup.py
+++ b/salt/metalk8s/volumes/prepared/files/sparse_volume_cleanup.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python2
+"""Script for cleaning up MetalK8s sparse loop volumes.
+
+Handle discovery of the device through a Volume's UUID, and then detach the
+device using the right `ioctl`.
+"""
+
+from __future__ import print_function
+import argparse
+import errno
+import fcntl
+import os
+import stat
+import sys
+
+
+def parse_args(args=None):
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        prog='metalk8s-sparse-volume-cleanup',
+        description='Cleanup MetalK8s sparse loop volumes',
+    )
+
+    parser.add_argument(
+        'volume_id',
+        help='UUID of the MetalK8s Volume object',
+    )
+
+    return parser.parse_args(args=args)
+
+
+SPARSE_FILES_DIR = '/var/lib/metalk8s/storage/sparse'
+
+
+def check_sparse_file(volume_id):
+    """Check if the sparse file exists for this volume ID."""
+    sparse_file_path = os.path.join(SPARSE_FILES_DIR, volume_id)
+    if not os.path.isfile(sparse_file_path):
+        raise Error(
+            "Sparse file {} does not exist for volume '{}'".format(
+                sparse_file_path, volume_id
+            ),
+            exit_code=errno.ENOENT
+        )
+
+
+def find_device(volume_id):
+    """Find the device provisioned for this volume ID.
+
+    SparseLoopDevice volumes are either:
+    - formatted, with the volume ID set in the file-system annotations
+    - raw, in which case the device is partitioned and the first partition
+      is labeled with the volume ID
+    """
+    for _get_device in [device_by_uuid, device_from_part_uuid]:
+        device_path = _get_device(volume_id)
+        if device_path is not None:
+            break
+    else:
+        raise Error(
+            "Device for volume '{}' was not found".format(volume_id),
+            exit_code=errno.ENOENT,
+        )
+
+    if not is_loop_device(device_path):
+        raise Error(
+            "{} (found for volume '{}') is not a loop device".format(
+                device_path, volume_id
+            ),
+            exit_code=errno.EINVAL,
+        )
+
+    return device_path
+
+
+# https://github.com/torvalds/linux/blob/master/include/uapi/linux/loop.h#L110
+LOOP_CLR_FD = 0x4C01
+
+
+def cleanup(volume_id):
+    """Clean up a sparse volume's loop device.
+
+    This function will bail out if a corresponding loop device cannot be
+    found.
+    """
+    device_path = find_device(volume_id)
+
+    print("Detaching loop device '{}' for volume '{}'".format(
+        device_path, volume_id
+    ))
+
+    device_handle = os.open(device_path, os.O_RDONLY)
+    try:
+        fcntl.ioctl(device_handle, LOOP_CLR_FD, 0)
+    except IOError as exn:
+        if exn.errno != errno.ENXIO:
+            raise Error(
+                "Unexpected error when trying to free device {}: {}".format(
+                    device_path, str(exn)
+                ),
+                exit_code=exn.errno,
+            )
+        print("Device already freed")
+    finally:
+        os.close(device_handle)
+
+    print("Loop device for volume '{}' was successfully detached".format(
+        volume_id
+    ))
+
+
+def main():
+    """Main "routine" of this script."""
+    args = parse_args()
+
+    check_sparse_file(args.volume_id)
+    cleanup(args.volume_id)
+
+
+# Helpers {{{
+# Error handling {{{
+
+def die(message, exit_code=1):
+    """Print a message to the standard error stream, and exit."""
+    print(message, file=sys.stderr)
+    sys.stderr.flush()
+    sys.exit(exit_code)
+
+
+class Error(Exception):
+    """Base-class for errors raised by methods from this module."""
+    def __init__(self, message, *args, exit_code=1):
+        super(Error, self).__init__(self, message, *args)
+        self.message = message
+        self.exit_code = exit_code
+
+
+# }}}
+# Loop device discovery {{{
+
+def device_by_uuid(volume_id):
+    """Find a device by file-system UUID."""
+    path_by_uuid = os.path.join("/dev/disk/by-uuid", volume_id)
+    if not os.path.exists(path_by_uuid):
+        return None
+
+    return os.path.realpath(path_by_uuid)
+
+
+def device_from_part_uuid(volume_id):
+    """Find a device from its first partition UUID."""
+    path_by_partuuid = os.path.join("/dev/disk/by-partuuid", volume_id)
+    if not os.path.exists(path_by_partuuid):
+        return None
+
+    partition_name = os.path.basename(os.path.realpath(path_by_partuuid))
+    device_link = os.path.join("/sys/class/block", partition_name, os.pardir)
+    device_name = os.path.basename(os.path.realpath(device_link))
+    return os.path.join("/dev", device_name)
+
+
+# }}}
+
+# https://github.com/torvalds/linux/blob/master/Documentation/admin-guide/devices.txt#L191
+LOOP_MAJOR = 7
+
+
+def is_loop_device(path):
+    """Check if the provided path is a real loop device."""
+    device_stat = os.stat(path)
+    return stat.S_ISBLK(device_stat.st_mode) \
+        and (os.major(device_stat.st_rdev) == LOOP_MAJOR)
+
+
+# }}}
+
+if __name__ == '__main__':
+    try:
+        main()
+    except Error as exc:
+        die(exc.message, exit_code=exc.exit_code)
+    except Exception as exc:  # pylint: disable=broad-except
+        die('Unhandled exception when cleaning up volume: {!s}'.format(exc))

--- a/salt/metalk8s/volumes/prepared/installed.sls
+++ b/salt/metalk8s/volumes/prepared/installed.sls
@@ -17,3 +17,9 @@ Install gdisk:
   {{ pkg_installed('gdisk') }}
     - require:
       - test: Repositories configured
+
+# Needed by the sparse volume cleanup script
+Ensure Python 2 is available:
+  test.fail_without_changes:
+    - comment: Could not find a working Python 2 installation
+    - unless: /usr/bin/env python2 --version

--- a/salt/metalk8s/volumes/provisioned/init.sls
+++ b/salt/metalk8s/volumes/provisioned/init.sls
@@ -1,8 +1,0 @@
-{%- for volume in pillar.metalk8s.volumes.keys() %}
-
-Provision backing storage for {{ volume }}:
-  metalk8s_volumes.provisioned:
-    - name: {{ volume }}
-    - parallel: True
-
-{%- endfor %}

--- a/salt/metalk8s/volumes/unprepared/init.sls
+++ b/salt/metalk8s/volumes/unprepared/init.sls
@@ -1,19 +1,28 @@
 {%- set volumes = pillar.metalk8s.volumes %}
-{%- set volume  = pillar.get('volume', '') %}
+{%- set volume_name  = pillar.get('volume', '') %}
+{%- set to_remove = volumes.get(volume_name) %}
 
+{%- if to_remove is not none %}
+  {%- if 'sparseLoopDevice' in to_remove.spec %}
+Disable systemd provisioning of loop device for {{ volume_name }}:
+  service.dead:
+    - name: metalk8s-sparse-volume@{{ to_remove.metadata.uid }}
+    - enable: false
+    - require_in:
+      - metalk8s_volumes: Clean up backing storage for {{ volume_name }}
 
-{%- if volume in volumes.keys() %}
-Clean up backing storage for {{ volume }}:
+  {%- endif %}
+Clean up backing storage for {{ volume_name }}:
   metalk8s_volumes.removed:
-    - name: {{ volume }}
+    - name: {{ volume_name }}
 {%- else %}
 
-{%- do salt.log.warning('Volume ' ~ volume ~ ' not found in pillar') -%}
+{%- do salt.log.warning('Volume ' ~ volume_name ~ ' not found in pillar') -%}
 
-Volume {{ volume }} not found in pillar:
+Volume {{ volume_name }} not found in pillar:
   test.configurable_test_state:
-    - name: {{ volume }}
+    - name: {{ volume_name }}
     - changes: False
     - result: True
-    - comment: Volume {{ volume }} not found in pillar
+    - comment: Volume {{ volume_name }} not found in pillar
 {%- endif %}

--- a/salt/tests/unit/modules/files/test_metalk8s_volumes.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_volumes.yaml
@@ -465,127 +465,6 @@ create:
     pillar_volumes: *volumes_details
     raise_msg: unsupported Volume type for Volume my-invalid-type-volume
 
-is_provisioned:
-  ## SPARSE volume
-  # sparse file associated with a loop device
-  - name: my-sparse-volume
-    pillar_volumes: *volumes_details
-    losetup_output: |
-      /dev/loop3: [64769]:41159 (/var/lib/metalk8s/storage/sparse/f1d78810-3787-4ca4-b712-50a269e42560)
-    result: True
-
-  # sparse file not associated with any device
-  - name: my-sparse-volume
-    pillar_volumes: *volumes_details
-    losetup_output: |
-    result: False
-
-  # error when checking sparse file association
-  - name: my-sparse-volume
-    pillar_volumes: *volumes_details
-    raises: True
-    result: "error while trying to run `losetup --associated /var/lib/metalk8s/storage/sparse/f1d78810-3787-4ca4-b712-50a269e42560`: An error has occurred"
-
-  ## SPARSE block volume
-  # sparse file associated with a loop device
-  - name: my-sparse-block-volume
-    pillar_volumes: *volumes_details
-    losetup_output: |
-      /dev/loop4: [64769]:41159 (/var/lib/metalk8s/storage/sparse/8474cda7-0dbe-40fc-9842-3cb0404a725a)
-    result: True
-
-  # sparse file not associated with any device
-  - name: my-sparse-block-volume
-    pillar_volumes: *volumes_details
-    losetup_output: |
-    result: False
-
-  # error when checking sparse file association
-  - name: my-sparse-block-volume
-    pillar_volumes: *volumes_details
-    raises: True
-    result: "error while trying to run `losetup --associated /var/lib/metalk8s/storage/sparse/8474cda7-0dbe-40fc-9842-3cb0404a725a`: An error has occurred"
-
-  ## RAW BLOCK DEVICE volume
-  # raw block device always provisioned (nothing to provision)
-  - name: my-raw-block-device-volume
-    pillar_volumes: *volumes_details
-    result: True
-
-  ## RAW BLOCK DEVICE block disk volume
-  # raw block device always provisioned (nothing to provision)
-  - name: my-raw-block-device-block-disk-volume
-    pillar_volumes: *volumes_details
-    result: True
-
-  ## RAW BLOCK DEVICE block partition volume
-  # raw block device always provisioned (nothing to provision)
-  - name: my-raw-block-device-block-partition-volume
-    pillar_volumes: *volumes_details
-    result: True
-
-  ## RAW BLOCK DEVICE block lvm volume
-  # raw block device always provisioned (nothing to provision)
-  - name: my-raw-block-device-block-lvm-volume
-    pillar_volumes: *volumes_details
-    result: True
-
-  ## Invalid volumes
-  # specified volume is not in the pillar
-  - name: unknown-volume
-    pillar_volumes: *volumes_details
-    raises: True
-    result: volume unknown-volume not found in pillar
-
-provision:
-  ## SPARSE volume
-  # provision a sparse file with a loop device
-  - name: my-sparse-volume
-    pillar_volumes: *volumes_details
-    losetup_output: |
-
-  # error when searching a loop device for the sparse file
-  - name: my-sparse-volume
-    pillar_volumes: *volumes_details
-    raise_msg: "error while trying to run `losetup --find /var/lib/metalk8s/storage/sparse/f1d78810-3787-4ca4-b712-50a269e42560`: An error has occurred"
-
-  ## SPARSE block volume
-  # provision a sparse file with a loop device
-  - name: my-sparse-block-volume
-    pillar_volumes: *volumes_details
-    losetup_output: |
-
-  # error when searching a loop device for the sparse file
-  - name: my-sparse-block-volume
-    pillar_volumes: *volumes_details
-    raise_msg: "error while trying to run `losetup --find --partscan /var/lib/metalk8s/storage/sparse/8474cda7-0dbe-40fc-9842-3cb0404a725a`: An error has occurred"
-
-  ## RAW BLOCK DEVICE volume
-  # nothing to provision for raw block device
-  - name: my-raw-block-device-volume
-    pillar_volumes: *volumes_details
-
-  ## RAW BLOCK DEVICE block disk volume
-  # nothing to provision for raw block device
-  - name: my-raw-block-device-block-disk-volume
-    pillar_volumes: *volumes_details
-
-  ## RAW BLOCK DEVICE block partition volume
-  # nothing to provision for raw block device
-  - name: my-raw-block-device-block-partition-volume
-    pillar_volumes: *volumes_details
-
-  ## RAW BLOCK DEVICE block lvm volume
-  # nothing to provision for raw block device
-  - name: my-raw-block-device-block-lvm-volume
-    pillar_volumes: *volumes_details
-
-  ## Invalid volumes
-  # specified volume is not in the pillar
-  - name: unknown-volume
-    pillar_volumes: *volumes_details
-    raise_msg: volume unknown-volume not found in pillar
-
 is_prepared:
   ## SPARSE volume
   # sparse volume already prepared - right UUID
@@ -789,17 +668,9 @@ is_cleaned_up:
     pillar_volumes: *volumes_details
     result: True
 
-  # sparse file exists and associated with a loop device
+  # sparse file exists
   - name: my-sparse-volume
     pillar_volumes: *volumes_details
-    is_provisioned: True
-    exists: True
-    result: False
-
-  # sparse file exists but not associated with any device
-  - name: my-sparse-volume
-    pillar_volumes: *volumes_details
-    is_provisioned: False
     exists: True
     result: False
 
@@ -809,17 +680,9 @@ is_cleaned_up:
     pillar_volumes: *volumes_details
     result: True
 
-  # sparse file exists and associated with a loop device
+  # sparse file exists
   - name: my-sparse-block-volume
     pillar_volumes: *volumes_details
-    is_provisioned: True
-    exists: True
-    result: False
-
-  # sparse file exists but not associated with any device
-  - name: my-sparse-block-volume
-    pillar_volumes: *volumes_details
-    is_provisioned: False
     exists: True
     result: False
 
@@ -871,12 +734,6 @@ clean_up:
     remove_error: "An error has occurred during remove"
     raise_msg: "An error has occurred during remove"
 
-  # error when running ioctl on the sparse file
-  - name: my-sparse-volume
-    pillar_volumes: *volumes_details
-    ioctl_error: "An error has occurred during ioctl"
-    raise_msg: "An error has occurred during ioctl"
-
   ## SPARSE block volume
   # clean up a sparse file
   - name: my-sparse-block-volume
@@ -892,12 +749,6 @@ clean_up:
     pillar_volumes: *volumes_details
     remove_error: "An error has occurred during remove"
     raise_msg: "An error has occurred during remove"
-
-  # error when running ioctl on the sparse file
-  - name: my-sparse-block-volume
-    pillar_volumes: *volumes_details
-    ioctl_error: "An error has occurred during ioctl"
-    raise_msg: "An error has occurred during ioctl"
 
   ## RAW BLOCK DEVICE volume
   # nothing to clean up for raw block device

--- a/salt/tests/unit/modules/test_metalk8s_volumes.py
+++ b/salt/tests/unit/modules/test_metalk8s_volumes.py
@@ -112,100 +112,6 @@ class Metalk8sVolumesTestCase(TestCase, LoaderModuleMockMixin):
                 # This function does not return anything
                 metalk8s_volumes.create(name)
 
-    @utils.parameterized_from_cases(YAML_TESTS_CASES["is_provisioned"])
-    def test_is_provisioned(self, name, result, raises=False,
-                            pillar_volumes=None, losetup_output=None):
-        """
-        Tests the return of `is_provisioned` function
-        """
-        pillar_dict = {
-            'metalk8s': {
-                'volumes': pillar_volumes or {}
-            }
-        }
-
-        if losetup_output is None:
-            losetup_cmd_kwargs = {
-                'retcode': 1,
-                'stderr': 'An error has occurred'
-            }
-        else:
-            losetup_cmd_kwargs = {
-                'stdout': losetup_output
-            }
-
-        salt_dict = {
-            'cmd.run_all': MagicMock(
-                return_value=utils.cmd_output(**losetup_cmd_kwargs)
-            )
-        }
-
-        # Glob is used only for lvm, let simulate that we have 2 lvm volume
-        glob_mock = MagicMock(return_value=["/dev/dm-1", "/dev/dm-2"])
-
-        with patch.dict(metalk8s_volumes.__pillar__, pillar_dict), \
-                patch.dict(metalk8s_volumes.__salt__, salt_dict), \
-                patch("metalk8s_volumes.device_name", device_name_mock), \
-                patch("glob.glob", glob_mock):
-            if raises:
-                self.assertRaisesRegexp(
-                    Exception,
-                    result,
-                    metalk8s_volumes.is_provisioned,
-                    name
-                )
-            else:
-                self.assertEqual(
-                    metalk8s_volumes.is_provisioned(name),
-                    result
-                )
-
-    @utils.parameterized_from_cases(YAML_TESTS_CASES["provision"])
-    def test_provision(self, name, raise_msg=False,
-                       pillar_volumes=None, losetup_output=None):
-        """
-        Tests the return of `provision` function
-        """
-        pillar_dict = {
-            'metalk8s': {
-                'volumes': pillar_volumes or {}
-            }
-        }
-
-        if losetup_output is None:
-            losetup_cmd_kwargs = {
-                'retcode': 1,
-                'stderr': 'An error has occurred'
-            }
-        else:
-            losetup_cmd_kwargs = {
-                'stdout': losetup_output
-            }
-
-        salt_dict = {
-            'cmd.run_all': MagicMock(
-                return_value=utils.cmd_output(**losetup_cmd_kwargs)
-            )
-        }
-
-        # Glob is used only for lvm, let simulate that we have 2 lvm volume
-        glob_mock = MagicMock(return_value=["/dev/dm-1", "/dev/dm-2"])
-
-        with patch.dict(metalk8s_volumes.__pillar__, pillar_dict), \
-                patch.dict(metalk8s_volumes.__salt__, salt_dict), \
-                patch("metalk8s_volumes.device_name", device_name_mock), \
-                patch("glob.glob", glob_mock):
-            if raise_msg:
-                self.assertRaisesRegexp(
-                    Exception,
-                    raise_msg,
-                    metalk8s_volumes.provision,
-                    name
-                )
-            else:
-                # This function does not return anything
-                metalk8s_volumes.provision(name)
-
     @utils.parameterized_from_cases(YAML_TESTS_CASES["is_prepared"])
     def test_is_prepared(self, name, result, raises=False,
                          uuid_return=None, device_name_return=True,
@@ -318,8 +224,7 @@ class Metalk8sVolumesTestCase(TestCase, LoaderModuleMockMixin):
 
     @utils.parameterized_from_cases(YAML_TESTS_CASES["is_cleaned_up"])
     def test_is_cleaned_up(self, name, result, raises=False,
-                           is_provisioned=False, exists=False,
-                           pillar_volumes=None):
+                           exists=False, pillar_volumes=None):
         """
         Tests the return of `is_cleaned_up` function
         """
@@ -334,11 +239,7 @@ class Metalk8sVolumesTestCase(TestCase, LoaderModuleMockMixin):
 
         with patch.dict(metalk8s_volumes.__pillar__, pillar_dict), \
                 patch.object(metalk8s_volumes.SparseLoopDevice,
-                             'is_provisioned',
-                             is_provisioned), \
-                patch.object(metalk8s_volumes.SparseLoopDevice,
-                             'exists',
-                             exists), \
+                             'exists', exists), \
                 patch("metalk8s_volumes.device_name", device_name_mock), \
                 patch("glob.glob", glob_mock):
             if raises:
@@ -356,7 +257,7 @@ class Metalk8sVolumesTestCase(TestCase, LoaderModuleMockMixin):
 
     @utils.parameterized_from_cases(YAML_TESTS_CASES["clean_up"])
     def test_clean_up(self, name, raise_msg=False, pillar_volumes=None,
-                      remove_error=None, ioctl_error=None):
+                      remove_error=None):
         """
         Tests the return of `clean_up` function
         """
@@ -372,19 +273,9 @@ class Metalk8sVolumesTestCase(TestCase, LoaderModuleMockMixin):
                 remove_error = [remove_error]
             remove_mock.side_effect = OSError(*remove_error)
 
-        ioctl_mock = MagicMock()
-        if ioctl_error:
-            ioctl_mock.side_effect = IOError(ioctl_error)
-
-        # Glob is used only for lvm, let simulate that we have 2 lvm volume
-        glob_mock = MagicMock(return_value=["/dev/dm-1", "/dev/dm-2"])
-
         with patch.dict(metalk8s_volumes.__pillar__, pillar_dict), \
                 patch("metalk8s_volumes.device_name", device_name_mock), \
-                patch("glob.glob", glob_mock), \
-                patch("os.open", MagicMock()), \
-                patch("os.remove", remove_mock), \
-                patch("fcntl.ioctl", ioctl_mock):
+                patch("os.remove", remove_mock):
             if raise_msg:
                 self.assertRaisesRegexp(
                     Exception,

--- a/tox.ini
+++ b/tox.ini
@@ -92,14 +92,28 @@ commands =
 
 [testenv:lint-python]
 description =
-    Lint Python files using pylint and mypy (buildchain-related files only for
-    now).
+    Lint Python files using pylint and mypy.
 deps =
     -r{toxinidir}/buildchain/requirements-{env:OSTYPE}.txt
     -r{toxinidir}/buildchain/requirements-dev.txt
 commands =
-    pylint        buildchain/dodo.py buildchain/buildchain packages/debian/download_packages.py
-    mypy --strict buildchain/dodo.py buildchain/buildchain packages/debian/download_packages.py
+    bash -c " \
+        py3_files=( \
+            buildchain/dodo.py \
+            buildchain/buildchain \
+            packages/debian/download_packages.py \
+        ); \
+        py2_files=( \
+            salt/metalk8s/volumes/prepared/files/sparse_volume_cleanup.py \
+        ); \
+        pylint $\{py2_files[@]\} $\{py3_files[@]\}; PYLINT_RC=$?; \
+        mypy --strict $\{py3_files[@]\}; MYPY_RC=$?; \
+        if [[ $PYLINT_RC -gt 0 || $MYPY_RC -gt 0 ]]; then \
+            echo Failed: pylint [$PYLINT_RC] - mypy [$MYPY_RC]; exit 1; \
+        else \
+            echo Success!; \
+        fi \
+    "
 
 [testenv:lint-shell]
 description =


### PR DESCRIPTION
**Component**: salt, storage

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**:

The previous approach was relying entirely on Salt (through our custom
`metalk8s_volumes` execution/state module) to manage provisioning and
cleanup of loop devices (on sparse files).
The issues arise when (re)booting a node:
- Salt minion has to execute a startup state, which may come in when
kube-apiserver is not (yet) available
- `losetup --find` calls, with the version available for CentOS 7, are
not atomic, so we may lose some devices if we have too many (re-running
the state manually is the current workaround)

**Summary**:

To fix these, we introduce two main changes:
- management of loop devices is delegated to systemd; using a unit
template file, we define a service per volume (passing the Volume's UUID
as a parameter), which will provision and attach the device on start,
and detach it on stop
- `losetup --find` invocations from these units is made sequential by
using an exclusive lockfile (this is not perfect, but avoids the need to
re-implement the command ourselves to include the fix from higher
versions of `losetup`)

Note that we cannot simply use `losetup --detach` in the unit template,
because sparse volumes may not always be discovered from the same path:
- either the volume is formatted, and we can find it in
/dev/disk/by-uuid/
- or it's kept raw, so we only have the UUID in the partition table, and
we can discover the device through /dev/disk/by-partuuid/

**Acceptance criteria**:

- CI keeps working (provisioning and cleanup of loop devices is tested)
- (manual) can reboot a node with many sparse loop volumes (10+) and have them all in `losetup -l` after

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2726

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
