### PR TITLE
Disable Kubelet certificate rotation

### DIFF
--- a/salt/metalk8s/kubernetes/kubelet/installed.sls
+++ b/salt/metalk8s/kubernetes/kubelet/installed.sls
@@ -14,7 +14,7 @@ Install kubelet:
 # status of the kubelet service
 # $ systemctl status kubelet
 # Failed to get properties: Access denied
-# 
+#
 # Workaround: Reload systemctl
 Reload systemctl:
   module.wait:

--- a/salt/metalk8s/kubernetes/kubelet/standalone.sls
+++ b/salt/metalk8s/kubernetes/kubelet/standalone.sls
@@ -106,7 +106,7 @@ Create kubelet config file:
         port: 10250
         registryBurst: 10
         registryPullQPS: 5
-        rotateCertificates: true
+        rotateCertificates: false
         runtimeRequestTimeout: 2m0s
         serializeImagePulls: true
         streamingConnectionIdleTimeout: 4h0m0s

--- a/salt/metalk8s/kubernetes/kubelet/standalone.sls
+++ b/salt/metalk8s/kubernetes/kubelet/standalone.sls
@@ -106,13 +106,15 @@ Create kubelet config file:
         port: 10250
         registryBurst: 10
         registryPullQPS: 5
-        resolvConf: /etc/resolv.conf
         rotateCertificates: true
         runtimeRequestTimeout: 2m0s
         serializeImagePulls: true
         streamingConnectionIdleTimeout: 4h0m0s
         syncFrequency: 1m0s
         volumeStatsAggPeriod: 1m0s
+{%- for key, value in kubelet.config.items() %}
+        {{ key }}: {{ value }}
+{%- endfor %}
     - require:
       - metalk8s_package_manager: Install kubelet
     - watch_in:

--- a/salt/metalk8s/map.jinja
+++ b/salt/metalk8s/map.jinja
@@ -175,17 +175,13 @@
 
 {% set kubelet = salt['grains.filter_by']({
   'Debian': {
-    'service': {
-      'options': {
-        'resolv-conf': '/run/systemd/resolve/resolv.conf'
-      }
+    'config': {
+      'resolvConf': '/run/systemd/resolve/resolv.conf'
     }
   },
   'RedHat': {
-    'service': {
-      'options': {
-        'resolv-conf': '/etc/resolv.conf'
-      }
+    'config': {
+      'resolvConf': '/etc/resolv.conf'
     }
   }
 }, grain='os_family', merge=defaults.get('kubelet')) %}


### PR DESCRIPTION
**Component**: salt

**Context**:
Thanks to #2914 we no longer need Kubelet to handle certificate rotation (anyway it was not working, see comments in #2937 for details).

**Summary**:
- Disable Kubelet certificate rotation
- Not related to the issue, but remove --resolv-conf CLI flag as this is deprecated (and use config file instead) and throws warnings in the kubelet's logs.

**Acceptance criteria**:

---

Closes: #2937