### PR TITLE
[UI] Polish UI and Bugfixes

### DIFF
--- a/ui/cypress/integration/sidebar.spec.js
+++ b/ui/cypress/integration/sidebar.spec.js
@@ -13,7 +13,7 @@ describe('Sidebar', () => {
 
   // TODO: Remove the interaction from the E2E test as much as possible
   it('brings me to the monitoring page', () => {
-    cy.get('[data-cy="sidebar_item_monitoring"]').click();
+    cy.get('[data-cy="sidebar_item_alerts"]').click();
 
     cy.get('@historyPush').should('be.calledWith', '/');
   });

--- a/ui/src/components/CommonLayoutStyle.js
+++ b/ui/src/components/CommonLayoutStyle.js
@@ -119,3 +119,30 @@ export const MetricsActionContainer = styled.div`
     background-color: ${(props) => props.theme.brand.info};
   }
 `;
+
+export const GraphsContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: ${padding.small};
+
+  .sc-vegachart svg {
+    background-color: inherit !important;
+  }
+`;
+
+export const RowGraphContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+`;
+
+export const GraphTitle = styled.div`
+  font-size: ${fontSize.small};
+  font-weight: ${fontWeight.bold};
+  color: ${(props) => props.theme.brand.textSecondary};
+  padding: ${padding.small} 0 0 ${padding.larger};
+`;
+
+export const GraphWrapper = styled.div`
+  padding-left: 0px;
+`;

--- a/ui/src/components/CommonLayoutStyle.js
+++ b/ui/src/components/CommonLayoutStyle.js
@@ -96,3 +96,24 @@ export const TableHeader = styled.th`
     }
   }
 `;
+
+export const MetricsActionContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  padding: ${padding.large} ${padding.base};
+
+  .sc-dropdown {
+    padding-left: 25px;
+  }
+
+  .sc-dropdown > div {
+    background-color: ${(props) => props.theme.brand.primary};
+    border: 1px solid ${(props) => props.theme.brand.borderLight}
+    border-radius: 3px;
+  }
+
+  .sc-button {
+    background-color: ${(props) => props.theme.brand.info};
+  }
+`;

--- a/ui/src/components/CommonLayoutStyle.js
+++ b/ui/src/components/CommonLayoutStyle.js
@@ -55,7 +55,6 @@ export const PageContentContainer = styled.div`
 export const NodeTab = styled.div`
   background-color: ${(props) => props.theme.brand.primary};
   color: ${(props) => props.theme.brand.textPrimary};
-  padding-top: ${padding.base};
   padding-bottom: ${padding.base};
   height: calc(100vh - 172px);
   overflow: scroll;
@@ -75,7 +74,6 @@ export const VolumeTab = styled.div`
   overflow: scroll;
   height: calc(100vh - 174px);
   color: ${(props) => props.theme.brand.textPrimary};
-  padding-top: ${padding.base};
   padding-bottom: ${padding.base};
 `;
 
@@ -101,7 +99,11 @@ export const MetricsActionContainer = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: flex-end;
-  padding: ${padding.large} ${padding.base};
+  padding: ${padding.base} ${padding.base};
+  position: sticky;
+  top: 0px;
+  z-index: 100;
+  background-color: ${(props) => props.theme.brand.primary};
 
   .sc-dropdown {
     padding-left: 25px;

--- a/ui/src/components/NodePageAlertsTab.js
+++ b/ui/src/components/NodePageAlertsTab.js
@@ -68,6 +68,10 @@ const TitleContainer = styled.div`
   display: flex;
   justify-content: space-between;
   padding: ${padding.large} ${padding.base} 0 ${padding.larger};
+  position: sticky;
+  top: 0px;
+  z-index: 100;
+  background-color: ${(props) => props.theme.brand.primary};
 `;
 
 const NodePageAlertsTab = (props) => {

--- a/ui/src/components/NodePageAlertsTab.js
+++ b/ui/src/components/NodePageAlertsTab.js
@@ -15,6 +15,11 @@ import { NodeTab } from './CommonLayoutStyle';
 import { STATUS_WARNING, STATUS_CRITICAL } from '../constants';
 import { intl } from '../translations/IntlGlobalProvider';
 
+// Overriding overflow for the Tab since the table components has inner scroll
+const NodeAlertsTab = styled(NodeTab)`
+  overflow: hidden;
+`;
+
 const ActiveAlertsTableContainer = styled.div`
   color: ${(props) => props.theme.brand.textPrimary};
   padding: 1rem;
@@ -68,10 +73,6 @@ const TitleContainer = styled.div`
   display: flex;
   justify-content: space-between;
   padding: ${padding.large} ${padding.base} 0 ${padding.larger};
-  position: sticky;
-  top: 0px;
-  z-index: 100;
-  background-color: ${(props) => props.theme.brand.primary};
 `;
 
 const NodePageAlertsTab = (props) => {
@@ -227,7 +228,7 @@ const NodePageAlertsTab = (props) => {
   );
 
   return (
-    <NodeTab>
+    <NodeAlertsTab>
       <TitleContainer>
         <ActiveAlertsText theme={theme}>
           {intl.translate('active_alert')}
@@ -237,7 +238,7 @@ const NodePageAlertsTab = (props) => {
       <ActiveAlertsTableContainer>
         <Table columns={columns} data={activeAlertListData} />
       </ActiveAlertsTableContainer>
-    </NodeTab>
+    </NodeAlertsTab>
   );
 };
 

--- a/ui/src/components/NodePageOverviewTab.js
+++ b/ui/src/components/NodePageOverviewTab.js
@@ -45,7 +45,7 @@ const NodeNameContainer = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 0 ${padding.larger} ${padding.large};
+  padding: ${padding.large} 0 ${padding.larger} ${padding.large};
 `;
 
 const NodeNameStatusContainer = styled.div``;

--- a/ui/src/components/NodePageVolumesTab.js
+++ b/ui/src/components/NodePageVolumesTab.js
@@ -19,8 +19,16 @@ import {
 import VolumeListTable from '../components/VolumeListTable';
 import { getVolumeListData } from '../services/NodeVolumesUtils';
 import { useRefreshEffect } from '../services/utils';
-import { fontSize } from '@scality/core-ui/dist/style/theme';
-import { NodeTab } from './CommonLayoutStyle';
+import { fontSize, padding } from '@scality/core-ui/dist/style/theme';
+
+// Custom Volumes styling instead of the CommonLayout one because the volumes table component has inner scroll
+export const NodesVolumesTab = styled.div`
+  background-color: ${(props) => props.theme.brand.primary};
+  color: ${(props) => props.theme.brand.textPrimary};
+  padding-bottom: ${padding.base};
+  height: calc(100vh - 172px);
+  overflow: hidden;
+`;
 
 const TabContent = styled.div`
   height: 78vh;
@@ -56,7 +64,7 @@ const NodePageVolumesTab = (props) => {
   }, [dispatch]);
 
   return (
-    <NodeTab>
+    <NodesVolumesTab>
       <TabContent>
         <VolumeListTable
           volumeListData={volumeListData}
@@ -65,7 +73,7 @@ const NodePageVolumesTab = (props) => {
           nodeName={name}
         ></VolumeListTable>
       </TabContent>
-    </NodeTab>
+    </NodesVolumesTab>
   );
 };
 

--- a/ui/src/components/NodePageVolumesTab.js
+++ b/ui/src/components/NodePageVolumesTab.js
@@ -19,14 +19,11 @@ import {
 import VolumeListTable from '../components/VolumeListTable';
 import { getVolumeListData } from '../services/NodeVolumesUtils';
 import { useRefreshEffect } from '../services/utils';
-import { fontSize, padding } from '@scality/core-ui/dist/style/theme';
+import { fontSize } from '@scality/core-ui/dist/style/theme';
+import { NodeTab } from './CommonLayoutStyle';
 
-// Custom Volumes styling instead of the CommonLayout one because the volumes table component has inner scroll
-export const NodesVolumesTab = styled.div`
-  background-color: ${(props) => props.theme.brand.primary};
-  color: ${(props) => props.theme.brand.textPrimary};
-  padding-bottom: ${padding.base};
-  height: calc(100vh - 172px);
+// Overriding overflow for the Tab since the table components has inner scroll
+export const NodesVolumesTab = styled(NodeTab)`
   overflow: hidden;
 `;
 

--- a/ui/src/components/VolumeAlertsTab.js
+++ b/ui/src/components/VolumeAlertsTab.js
@@ -14,6 +14,11 @@ import { useTable } from 'react-table';
 import { intl } from '../translations/IntlGlobalProvider';
 import { VolumeTab } from './CommonLayoutStyle';
 
+// Overriding overflow for the Tab since the table components has inner scroll
+const VolumeAlertTab = styled(VolumeTab)`
+  overflow: hidden;
+`;
+
 const ActiveAlertsCardContainer = styled.div`
   margin: ${padding.small};
   padding: ${padding.small};
@@ -26,10 +31,6 @@ const ActiveAlertsTitle = styled.div`
   padding: ${padding.small} 0 0 ${padding.large};
   display: flex;
   justify-content: space-between;
-  position: sticky;
-  top: 0px;
-  z-index: 100;
-  background-color: ${(props) => props.theme.brand.primary};
 `;
 
 const ActiveAlertsTableContainer = styled.div`
@@ -253,7 +254,7 @@ const ActiveAlertsCard = (props) => {
   );
 
   return (
-    <VolumeTab>
+    <VolumeAlertTab>
       <ActiveAlertsCardContainer>
         <ActiveAlertsTitle>
           <div>{intl.translate('active_alert')}</div>
@@ -266,7 +267,7 @@ const ActiveAlertsCard = (props) => {
           <Table columns={columns} data={activeAlertListData} />
         </ActiveAlertsTableContainer>
       </ActiveAlertsCardContainer>
-    </VolumeTab>
+    </VolumeAlertTab>
   );
 };
 

--- a/ui/src/components/VolumeAlertsTab.js
+++ b/ui/src/components/VolumeAlertsTab.js
@@ -26,6 +26,10 @@ const ActiveAlertsTitle = styled.div`
   padding: ${padding.small} 0 0 ${padding.large};
   display: flex;
   justify-content: space-between;
+  position: sticky;
+  top: 0px;
+  z-index: 100;
+  background-color: ${(props) => props.theme.brand.primary};
 `;
 
 const ActiveAlertsTableContainer = styled.div`

--- a/ui/src/components/VolumeListTable.js
+++ b/ui/src/components/VolumeListTable.js
@@ -57,6 +57,11 @@ const VolumeListContainer = styled.div`
       width: 120px;
       height: 10px;
     }
+
+    thead tr[role='row'] {
+      border-bottom: 1px solid ${(props) => props.theme.brand.border};
+    }
+
     tr {
       :last-child {
         td {

--- a/ui/src/components/VolumeListTable.js
+++ b/ui/src/components/VolumeListTable.js
@@ -236,7 +236,7 @@ function Table({
 
         if (size1 && size2) {
           return allSizeUnitsToBytes(size1) - allSizeUnitsToBytes(size2);
-        }
+        } else return !size1 ? -1 : 1;
       },
       status: (row1, row2) => {
         const weights = {};

--- a/ui/src/components/VolumeListTable.js
+++ b/ui/src/components/VolumeListTable.js
@@ -544,7 +544,7 @@ const VolumeListTable = (props) => {
   );
   const nodeCol = { Header: 'Node', accessor: 'node' };
   if (isNodeColumn) {
-    columns.splice(1, 0, nodeCol);
+    columns.splice(2, 0, nodeCol);
   }
 
   // handle the row selection by updating the URL

--- a/ui/src/components/VolumeMetricsTab.js
+++ b/ui/src/components/VolumeMetricsTab.js
@@ -31,37 +31,13 @@ import {
   queryTimeSpansCodes,
 } from '../constants';
 import { intl } from '../translations/IntlGlobalProvider';
-import { VolumeTab } from './CommonLayoutStyle';
+import { VolumeTab, MetricsActionContainer } from './CommonLayoutStyle';
 
 const MetricGraphCardContainer = styled.div`
   min-height: 270px;
 
   .sc-vegachart svg {
     background-color: inherit !important;
-  }
-`;
-
-const MetricGraphTitle = styled.div`
-  color: ${(props) => props.theme.brand.textPrimary};
-  font-size: ${fontSize.base};
-  font-weight: ${fontWeight.bold};
-  padding: ${padding.small};
-  display: flex;
-  flex-direction: row-reverse;
-  padding: ${padding.large} ${padding.base};
-
-  .sc-dropdown {
-    padding-left: 25px;
-  }
-  
-  .sc-dropdown > div {
-    background-color: ${(props) => props.theme.brand.primary};
-    border: 1px solid ${(props) => props.theme.brand.borderLight}
-    border-radius: 3px;
-  }
-  
-  .sc-button {
-    background-color: ${(props) => props.theme.brand.info};
   }
 `;
 
@@ -360,15 +336,7 @@ const MetricsTab = (props) => {
   return (
     <VolumeTab>
       <MetricGraphCardContainer>
-        <MetricGraphTitle>
-          {volumeCondition === VOLUME_CONDITION_LINK && (
-            <Dropdown
-              items={metricsTimeSpanDropdownItems}
-              text={metricsTimeSpan}
-              size="small"
-              data-cy="metrics_timespan_selection"
-            />
-          )}
+        <MetricsActionContainer>
           {config.api?.url_grafana && volumeNamespace && volumePVCName && (
             <Button
               text={intl.translate('advanced_metrics')}
@@ -382,7 +350,15 @@ const MetricsTab = (props) => {
               data-cy="advanced_metrics_volume_detailed"
             />
           )}
-        </MetricGraphTitle>
+          {volumeCondition === VOLUME_CONDITION_LINK && (
+            <Dropdown
+              items={metricsTimeSpanDropdownItems}
+              text={metricsTimeSpan}
+              size="small"
+              data-cy="metrics_timespan_selection"
+            />
+          )}
+        </MetricsActionContainer>
         {volumeCondition === VOLUME_CONDITION_LINK ? (
           <GraphsContainer>
             <RowGraphContainer>

--- a/ui/src/components/VolumeMetricsTab.js
+++ b/ui/src/components/VolumeMetricsTab.js
@@ -7,14 +7,11 @@ import {
   fetchVolumeStatsAction,
   updateVolumeStatsAction,
 } from '../ducks/app/monitoring';
-import {
-  fontSize,
-  padding,
-  fontWeight,
-} from '@scality/core-ui/dist/style/theme';
+import { fontSize, padding } from '@scality/core-ui/dist/style/theme';
 import {
   addMissingDataPoint,
   fromUnixTimestampToDate,
+  useDynamicChartSize,
 } from '../services/utils';
 import { yAxisUsage, yAxisWriteRead } from './LinechartSpec';
 import {
@@ -31,41 +28,17 @@ import {
   queryTimeSpansCodes,
 } from '../constants';
 import { intl } from '../translations/IntlGlobalProvider';
-import { VolumeTab, MetricsActionContainer } from './CommonLayoutStyle';
+import {
+  VolumeTab,
+  MetricsActionContainer,
+  GraphsContainer,
+  RowGraphContainer,
+  GraphTitle,
+  GraphWrapper,
+} from './CommonLayoutStyle';
 
 const MetricGraphCardContainer = styled.div`
   min-height: 270px;
-
-  .sc-vegachart svg {
-    background-color: inherit !important;
-  }
-`;
-
-const GraphsContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  padding-left: ${padding.small};
-`;
-
-const RowGraphContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  padding-left: 3px;
-`;
-
-const GraphTitle = styled.div`
-  font-size: ${fontSize.small};
-  font-weight: ${fontWeight.bold};
-  color: ${(props) => props.theme.brand.textSecondary};
-  padding: ${padding.small} 0 0 ${padding.larger};
-`;
-
-const LeftGraphContainer = styled.div`
-  padding-left: 0px;
-`;
-
-const RightGraphContainer = styled.div`
-  padding-left: ${padding.large};
 `;
 
 // No data rendering should be extracted to an common style
@@ -97,6 +70,7 @@ const MetricsTab = (props) => {
     (state) => state.app.monitoring.volumeStats.metricsTimeSpan,
   );
   const config = useSelector((state) => state.config);
+  const [graphWidth, graphHeight] = useDynamicChartSize('graph_container');
 
   // write the selected timespan in URL
   const writeUrlTimeSpan = (timespan) => {
@@ -360,9 +334,9 @@ const MetricsTab = (props) => {
           )}
         </MetricsActionContainer>
         {volumeCondition === VOLUME_CONDITION_LINK ? (
-          <GraphsContainer>
+          <GraphsContainer id="graph_container">
             <RowGraphContainer>
-              <LeftGraphContainer>
+              <GraphWrapper>
                 <GraphTitle>USAGE (%)</GraphTitle>
                 {volumeUsageData?.length > 0 ? (
                   <LineChart
@@ -371,15 +345,15 @@ const MetricsTab = (props) => {
                     xAxis={xAxis}
                     yAxis={yAxisUsage}
                     color={colorUsage}
-                    width={window.innerWidth / 4 - 110}
-                    height={window.innerHeight / 6 - 30}
+                    width={graphWidth}
+                    height={graphHeight}
                     tooltip={false}
                   />
                 ) : (
                   <NoDataGraphText>No available usage data</NoDataGraphText>
                 )}
-              </LeftGraphContainer>
-              <RightGraphContainer>
+              </GraphWrapper>
+              <GraphWrapper>
                 <GraphTitle>LATENCY (µs) </GraphTitle>
                 {volumeLatencyData?.length > 0 ? (
                   <LineChart
@@ -388,17 +362,17 @@ const MetricsTab = (props) => {
                     xAxis={xAxis}
                     yAxis={yAxisWriteRead}
                     color={colors}
-                    width={window.innerWidth / 4 - 110}
-                    height={window.innerHeight / 6 - 30}
+                    width={graphWidth}
+                    height={graphHeight}
                     tooltip={false}
                   />
                 ) : (
                   <NoDataGraphText>No available latency data</NoDataGraphText>
                 )}
-              </RightGraphContainer>
+              </GraphWrapper>
             </RowGraphContainer>
             <RowGraphContainer>
-              <LeftGraphContainer>
+              <GraphWrapper>
                 <GraphTitle>THROUGHPUT (MB/s)</GraphTitle>
                 {volumeThroughputData?.length > 0 ? (
                   <LineChart
@@ -407,8 +381,8 @@ const MetricsTab = (props) => {
                     xAxis={xAxis}
                     yAxis={yAxisWriteRead}
                     color={colors}
-                    width={window.innerWidth / 4 - 110}
-                    height={window.innerHeight / 6 - 30}
+                    width={graphWidth}
+                    height={graphHeight}
                     tooltip={false}
                   />
                 ) : (
@@ -416,8 +390,8 @@ const MetricsTab = (props) => {
                     No available throughput data
                   </NoDataGraphText>
                 )}
-              </LeftGraphContainer>
-              <RightGraphContainer>
+              </GraphWrapper>
+              <GraphWrapper>
                 <GraphTitle>IOPS</GraphTitle>
                 {volumeIOPSData?.length > 0 ? (
                   <LineChart
@@ -426,14 +400,14 @@ const MetricsTab = (props) => {
                     xAxis={xAxis}
                     yAxis={yAxisWriteRead}
                     color={colors}
-                    width={window.innerWidth / 4 - 110}
-                    height={window.innerHeight / 6 - 30}
+                    width={graphWidth}
+                    height={graphHeight}
                     tooltip={false}
                   />
                 ) : (
                   <NoDataGraphText>No available IOPS data</NoDataGraphText>
                 )}
-              </RightGraphContainer>
+              </GraphWrapper>
             </RowGraphContainer>
           </GraphsContainer>
         ) : (

--- a/ui/src/components/VolumeMetricsTab.js
+++ b/ui/src/components/VolumeMetricsTab.js
@@ -338,7 +338,7 @@ const MetricsTab = (props) => {
             <RowGraphContainer>
               <GraphWrapper>
                 <GraphTitle>USAGE (%)</GraphTitle>
-                {volumeUsageData?.length > 0 ? (
+                {volumeUsageData?.length > 0 && graphWidth ? (
                   <LineChart
                     id={'volume_usage_id'}
                     data={volumeUsageData}
@@ -355,7 +355,7 @@ const MetricsTab = (props) => {
               </GraphWrapper>
               <GraphWrapper>
                 <GraphTitle>LATENCY (µs) </GraphTitle>
-                {volumeLatencyData?.length > 0 ? (
+                {volumeLatencyData?.length > 0 && graphWidth ? (
                   <LineChart
                     id={'volume_latency_id'}
                     data={volumeLatencyData}
@@ -374,7 +374,7 @@ const MetricsTab = (props) => {
             <RowGraphContainer>
               <GraphWrapper>
                 <GraphTitle>THROUGHPUT (MB/s)</GraphTitle>
-                {volumeThroughputData?.length > 0 ? (
+                {volumeThroughputData?.length > 0 && graphWidth ? (
                   <LineChart
                     id={'volume_throughput_id'}
                     data={volumeThroughputData}
@@ -393,7 +393,7 @@ const MetricsTab = (props) => {
               </GraphWrapper>
               <GraphWrapper>
                 <GraphTitle>IOPS</GraphTitle>
-                {volumeIOPSData?.length > 0 ? (
+                {volumeIOPSData?.length > 0 && graphWidth ? (
                   <LineChart
                     id={'volume_IOPS_id'}
                     data={volumeIOPSData}

--- a/ui/src/components/VolumeOverviewTab.js
+++ b/ui/src/components/VolumeOverviewTab.js
@@ -35,7 +35,7 @@ const VolumeInformation = styled.div`
 
 const VolumeTitleSection = styled.div`
   color: ${(props) => props.theme.brand.textPrimary};
-  padding: 0 0 ${padding.larger} ${padding.large};
+  padding: ${padding.large} 0 ${padding.larger} ${padding.large};
   display: flex;
   justify-content: space-between;
 `;

--- a/ui/src/containers/Layout.js
+++ b/ui/src/containers/Layout.js
@@ -55,7 +55,7 @@ const Layout = (props) => {
     'data-cy-state-isexpanded': sidebar.expanded,
     actions: [
       {
-        label: intl.translate('monitoring'),
+        label: intl.translate('alerts'),
         icon: <i className="fas fa-desktop" />,
         onClick: () => {
           history.push('/');
@@ -65,7 +65,7 @@ const Layout = (props) => {
           exact: true,
           strict: true,
         }),
-        'data-cy': 'sidebar_item_monitoring',
+        'data-cy': 'sidebar_item_alerts',
       },
       {
         label: intl.translate('nodes'),

--- a/ui/src/containers/NodePageMetricsTab.js
+++ b/ui/src/containers/NodePageMetricsTab.js
@@ -286,7 +286,7 @@ const NodePageMetricsTab = (props) => {
         <RowGraphContainer>
           <GraphWrapper>
             <GraphTitle>CPU USAGE (%)</GraphTitle>
-            {nodeStatsData['cpuUsage'].length !== 0 ? (
+            {nodeStatsData['cpuUsage'].length !== 0 && graphWidth ? (
               <LineChart
                 id={'node_cpu_usage_id'}
                 data={nodeStatsData['cpuUsage']}
@@ -304,7 +304,7 @@ const NodePageMetricsTab = (props) => {
           </GraphWrapper>
           <GraphWrapper>
             <GraphTitle>CPU SYSTEM LOAD (%)</GraphTitle>
-            {nodeStatsData['systemLoad'].length !== 0 ? (
+            {nodeStatsData['systemLoad'].length !== 0 && graphWidth ? (
               <LineChart
                 id={'node_system_load_id'}
                 data={nodeStatsData['systemLoad']}
@@ -324,7 +324,7 @@ const NodePageMetricsTab = (props) => {
         <RowGraphContainer>
           <GraphWrapper>
             <GraphTitle>MEMORY (%)</GraphTitle>
-            {nodeStatsData['memory'].length !== 0 ? (
+            {nodeStatsData['memory'].length !== 0 && graphWidth ? (
               <LineChart
                 id={'node_memory_id'}
                 data={nodeStatsData['memory']}
@@ -342,7 +342,7 @@ const NodePageMetricsTab = (props) => {
           </GraphWrapper>
           <GraphWrapper>
             <GraphTitle>IOPS</GraphTitle>
-            {iopsData.length !== 0 ? (
+            {iopsData.length !== 0 && graphWidth ? (
               <LineChart
                 id={'node_IOPS_id'}
                 data={iopsData}
@@ -363,7 +363,7 @@ const NodePageMetricsTab = (props) => {
         <RowGraphContainer>
           <GraphWrapper>
             <GraphTitle>CONTROL PLANE BANDWIDTH (MB)</GraphTitle>
-            {controlPlaneNetworkBandwidthData.length !== 0 ? (
+            {controlPlaneNetworkBandwidthData.length !== 0 && graphWidth ? (
               <LineChart
                 id={'node_control_plane_bandwidth_id'}
                 data={controlPlaneNetworkBandwidthData}
@@ -381,7 +381,7 @@ const NodePageMetricsTab = (props) => {
           </GraphWrapper>
           <GraphWrapper>
             <GraphTitle>WORKLOAD PLANE BANDWIDTH (MB)</GraphTitle>
-            {workloadPlaneNetworkBandwidthData.length !== 0 ? (
+            {workloadPlaneNetworkBandwidthData.length !== 0 && graphWidth ? (
               <LineChart
                 id={'node_workload_plane_bandwidth_id'}
                 data={workloadPlaneNetworkBandwidthData}

--- a/ui/src/containers/NodePageMetricsTab.js
+++ b/ui/src/containers/NodePageMetricsTab.js
@@ -2,11 +2,7 @@ import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useHistory } from 'react-router';
 import styled from 'styled-components';
-import {
-  fontSize,
-  padding,
-  fontWeight,
-} from '@scality/core-ui/dist/style/theme';
+import { padding } from '@scality/core-ui/dist/style/theme';
 import { LineChart, Loader, Dropdown, Button } from '@scality/core-ui';
 import { updateNodeStatsFetchArgumentAction } from '../ducks/app/monitoring';
 import {
@@ -18,11 +14,16 @@ import {
 import {
   NodeTab,
   MetricsActionContainer,
+  GraphsContainer,
+  RowGraphContainer,
+  GraphTitle,
+  GraphWrapper,
 } from '../components/CommonLayoutStyle';
 import {
   addMissingDataPoint,
   fromUnixTimestampToDate,
   useQuery,
+  useDynamicChartSize,
 } from '../services/utils';
 import {
   LAST_SEVEN_DAYS,
@@ -38,35 +39,6 @@ import {
   PORT_NODE_EXPORTER,
 } from '../constants';
 import { intl } from '../translations/IntlGlobalProvider';
-
-const GraphsContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  height: 78vh;
-  // Change the background color of to primary, should change it in core-ui.
-  .sc-vegachart > svg {
-    background-color: ${(props) => props.theme.brand.primary} !important;
-  }
-`;
-
-const GraphTitle = styled.div`
-  font-size: ${fontSize.small};
-  font-weight: ${fontWeight.bold};
-  color: ${(props) => props.theme.brand.textSecondary};
-  padding: ${padding.small} 0 0 ${padding.larger};
-`;
-
-const RowGraphContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-around;
-  padding-left: 3px;
-`;
-
-const Graph = styled.div`
-  min-width: 308px;
-  padding-right: 40px;
-`;
 
 const LoaderContainer = styled(Loader)`
   padding-left: ${padding.larger};
@@ -99,6 +71,7 @@ const NodePageMetricsTab = (props) => {
   const metricsTimeSpan = useSelector(
     (state) => state.app.monitoring.nodeStats.metricsTimeSpan,
   );
+  const [graphWidth, graphHeight] = useDynamicChartSize('graph_container');
 
   // To redirect to the right Node(Detailed) dashboard in Grafana
   const unameInfos = useSelector((state) => state.app.monitoring.unameInfo);
@@ -309,9 +282,9 @@ const NodePageMetricsTab = (props) => {
           />
         </DropdownContainer>
       </MetricsActionContainer>
-      <GraphsContainer>
+      <GraphsContainer id="graph_container">
         <RowGraphContainer>
-          <Graph>
+          <GraphWrapper>
             <GraphTitle>CPU USAGE (%)</GraphTitle>
             {nodeStatsData['cpuUsage'].length !== 0 ? (
               <LineChart
@@ -320,16 +293,16 @@ const NodePageMetricsTab = (props) => {
                 xAxis={xAxis}
                 yAxis={yAxisUsage}
                 color={colorUsage}
-                width={window.innerWidth / 4 - 60}
-                height={window.innerHeight / 6 - 30}
+                width={graphWidth}
+                height={graphHeight}
                 tooltip={false}
                 lineConfig={lineConfig}
               />
             ) : (
               <LoaderContainer size="small"></LoaderContainer>
             )}
-          </Graph>
-          <Graph>
+          </GraphWrapper>
+          <GraphWrapper>
             <GraphTitle>CPU SYSTEM LOAD (%)</GraphTitle>
             {nodeStatsData['systemLoad'].length !== 0 ? (
               <LineChart
@@ -338,18 +311,18 @@ const NodePageMetricsTab = (props) => {
                 xAxis={xAxis}
                 yAxis={yAxis}
                 color={colorSystemLoad}
-                width={window.innerWidth / 4 - 60}
-                height={window.innerHeight / 6 - 30}
+                width={graphWidth}
+                height={graphHeight}
                 tooltip={false}
                 lineConfig={lineConfig}
               />
             ) : (
               <LoaderContainer size="small"></LoaderContainer>
             )}
-          </Graph>
+          </GraphWrapper>
         </RowGraphContainer>
         <RowGraphContainer>
-          <Graph>
+          <GraphWrapper>
             <GraphTitle>MEMORY (%)</GraphTitle>
             {nodeStatsData['memory'].length !== 0 ? (
               <LineChart
@@ -358,16 +331,16 @@ const NodePageMetricsTab = (props) => {
                 xAxis={xAxis}
                 yAxis={yAxisUsage}
                 color={colorMemory}
-                width={window.innerWidth / 4 - 60}
-                height={window.innerHeight / 6 - 30}
+                width={graphWidth}
+                height={graphHeight}
                 tooltip={false}
                 lineConfig={lineConfig}
               />
             ) : (
               <LoaderContainer size="small"></LoaderContainer>
             )}
-          </Graph>
-          <Graph>
+          </GraphWrapper>
+          <GraphWrapper>
             <GraphTitle>IOPS</GraphTitle>
             {iopsData.length !== 0 ? (
               <LineChart
@@ -376,19 +349,19 @@ const NodePageMetricsTab = (props) => {
                 xAxis={xAxis}
                 yAxis={yAxisWriteRead}
                 color={colorsWriteRead}
-                width={window.innerWidth / 4 - 60}
-                height={window.innerHeight / 6 - 30}
+                width={graphWidth}
+                height={graphHeight}
                 tooltip={false}
                 lineConfig={lineConfig}
               />
             ) : (
               <LoaderContainer size="small"></LoaderContainer>
             )}
-          </Graph>
+          </GraphWrapper>
         </RowGraphContainer>
 
         <RowGraphContainer>
-          <Graph>
+          <GraphWrapper>
             <GraphTitle>CONTROL PLANE BANDWIDTH (MB)</GraphTitle>
             {controlPlaneNetworkBandwidthData.length !== 0 ? (
               <LineChart
@@ -397,16 +370,16 @@ const NodePageMetricsTab = (props) => {
                 xAxis={xAxis}
                 yAxis={yAxisInOut}
                 color={colorsInOut}
-                width={window.innerWidth / 4 - 60}
-                height={window.innerHeight / 6 - 30}
+                width={graphWidth}
+                height={graphHeight}
                 tooltip={false}
                 lineConfig={lineConfig}
               />
             ) : (
               <LoaderContainer size="small"></LoaderContainer>
             )}
-          </Graph>
-          <Graph>
+          </GraphWrapper>
+          <GraphWrapper>
             <GraphTitle>WORKLOAD PLANE BANDWIDTH (MB)</GraphTitle>
             {workloadPlaneNetworkBandwidthData.length !== 0 ? (
               <LineChart
@@ -415,15 +388,15 @@ const NodePageMetricsTab = (props) => {
                 xAxis={xAxis}
                 yAxis={yAxisInOut}
                 color={colorsInOut}
-                width={window.innerWidth / 4 - 60}
-                height={window.innerHeight / 6 - 30}
+                width={graphWidth}
+                height={graphHeight}
                 tooltip={false}
                 lineConfig={lineConfig}
               />
             ) : (
               <LoaderContainer size="small"></LoaderContainer>
             )}
-          </Graph>
+          </GraphWrapper>
         </RowGraphContainer>
       </GraphsContainer>
     </NodeTab>

--- a/ui/src/containers/NodePageMetricsTab.js
+++ b/ui/src/containers/NodePageMetricsTab.js
@@ -15,7 +15,10 @@ import {
   yAxisWriteRead,
   yAxisInOut,
 } from '../components/LinechartSpec';
-import { NodeTab } from '../components/CommonLayoutStyle';
+import {
+  NodeTab,
+  MetricsActionContainer,
+} from '../components/CommonLayoutStyle';
 import {
   addMissingDataPoint,
   fromUnixTimestampToDate,
@@ -68,17 +71,6 @@ const Graph = styled.div`
 
 const LoaderContainer = styled(Loader)`
   padding-left: ${padding.larger};
-`;
-
-const ActionContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-end;
-  padding: ${padding.large} ${padding.base};
-
-  .sc-button {
-    background-color: ${(props) => props.theme.brand.info};
-  }
 `;
 
 const DropdownContainer = styled.div`
@@ -297,7 +289,7 @@ const NodePageMetricsTab = (props) => {
 
   return (
     <NodeTab>
-      <ActionContainer>
+      <MetricsActionContainer>
         <Button
           text={intl.translate('advanced_metrics')}
           variant={'base'}
@@ -317,7 +309,7 @@ const NodePageMetricsTab = (props) => {
             data-cy="metrics_timespan_selection"
           />
         </DropdownContainer>
-      </ActionContainer>
+      </MetricsActionContainer>
       <GraphsContainer>
         <RowGraphContainer>
           <Graph>

--- a/ui/src/containers/NodePageMetricsTab.js
+++ b/ui/src/containers/NodePageMetricsTab.js
@@ -42,7 +42,6 @@ import { intl } from '../translations/IntlGlobalProvider';
 const GraphsContainer = styled.div`
   display: flex;
   flex-direction: column;
-  overflow-y: auto;
   height: 78vh;
   // Change the background color of to primary, should change it in core-ui.
   .sc-vegachart > svg {

--- a/ui/src/services/utils.js
+++ b/ui/src/services/utils.js
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useLocation, useHistory } from 'react-router-dom';
 import { createSelector } from 'reselect';
@@ -402,4 +402,20 @@ export const useTableSortURLSync = (sorted, desc, data) => {
       history.replace(`?${query.toString()}`);
     }
   }, [sorted, desc, data.length, history]);
+};
+
+/*
+ ** Custom hook to define chart dimension based on their container
+ ** This calculates the width for rows of 2 charts
+ ** Takes container id as a param and returns [ width, heigth ]
+ */
+export const useDynamicChartSize = (container_id) => {
+  const graphsContainerWidth = document.getElementById(container_id)
+    ?.offsetWidth;
+  const [graphWidth, setGraphWidth] = useState(0);
+  useEffect(() => {
+    if (graphsContainerWidth) setGraphWidth(graphsContainerWidth / 2 - 50);
+  }, [graphsContainerWidth]);
+
+  return [graphWidth, window.innerHeight / 6 - 30];
 };


### PR DESCRIPTION
**Component**:
ui, volumes, nodes, sidebar

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

- [Improvement]We want to keep the time selector and advanced metrics button always visible in the tabs when we scroll down.
- [Improvement] We can still improve the Volume Page Metrics tab, in order to fully use the empty space (Please refer to the Node Page Metrics tab, maybe we should generalize the common styles).
- [Improvement] Add a separation line in the volume table between Header and content rows
- [Bug] In Volume Page, the Node Name should come after Volume Name
- [Improvement] Rename the overview page to Alerts in the sidebar
- [Bug] When sorting by size in the volume list, we should take into consideration Unknown.

**Acceptance criteria**: 
- The time selector stays visible on metrics tab when the user scrolls down
- The Charts are now taking the available space in metrics tabs and the layout is more coherent between the Volumes and Nodes pages
- The node column is now after the name column on Volumes table
- Overview is renamed to alerts in the sidebar
- Sorting by size on Volumes table is now working as expected


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #2917

<!-- If you want to refer to an issue while not closing it, use:


-->
