### PR TITLE
calico: Update to Calico 3.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - [#2203](https://github.com/scality/metalk8s/issues/2203) - Migrate Salt to Python3
   and bump to version 3002.2 (PR [#2839](https://github.com/scality/metalk8s/pull/2839))
 
+- Bump `calico` version to 3.17.0 (PR [#2943](https://github.com/scality/metalk8s/pull/2943))
+
 ### Bug fixes
 
 - [#2908](https://github.com/scality/metalk8s/issues/2908) - Make upgrade script

--- a/buildchain/buildchain/constants.py
+++ b/buildchain/buildchain/constants.py
@@ -17,7 +17,7 @@ from buildchain import config
 CMD_WIDTH : int = 14
 
 # URLs of the main container repositories.
-CALICO_REPOSITORY             : str = 'quay.io/calico'
+CALICO_REPOSITORY             : str = 'docker.io/calico'
 COREOS_REPOSITORY             : str = 'quay.io/coreos'
 DEX_REPOSITORY                : str = 'quay.io/dexidp'
 DOCKER_REPOSITORY             : str = 'docker.io/library'

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -17,7 +17,7 @@ Image = namedtuple('Image', ('name', 'version', 'digest'))
 
 # Project-wide versions {{{
 
-CALICO_VERSION     : str = '3.16.1'
+CALICO_VERSION     : str = '3.17.0'
 K8S_VERSION        : str = '1.18.12'
 SALT_VERSION       : str = '3002.2'
 CONTAINERD_VERSION : str = '1.4.1'
@@ -87,12 +87,12 @@ CONTAINER_IMAGES : Tuple[Image, ...] = (
     Image(
         name='calico-node',
         version=_version_prefix(CALICO_VERSION),
-        digest='sha256:8f7ae199f9f00e03527c515008aa1dbc21f8a27eaefe4b00ca789f732b0f0aef',
+        digest='sha256:92227666988edccd1222d463173489fd656c5a37b8dedab0dadfbc22a471893a',
     ),
     Image(
         name='calico-kube-controllers',
         version=_version_prefix(CALICO_VERSION),
-        digest='sha256:04bba565d9e133ce7c8184d3b08fab09df061b7fb5936b08c5d12cc9e56a3799',
+        digest='sha256:78a6e7648e22b2c87fcc06db610d753e49c6f9b3cf622ab23fdc3a63c1563fc8',
     ),
     Image(
         name='configmap-reload',

--- a/packages/redhat/calico-cni-plugin.spec
+++ b/packages/redhat/calico-cni-plugin.spec
@@ -6,12 +6,12 @@
 
 %ifarch x86_64
 %global built_arch              amd64
-%global calico_sha256           baa67cb9fbceb2aebebd6b14e12d448c89dcf694f32b5f450ffd8b780fb3d18d
-%global calico_ipam_sha256      baa67cb9fbceb2aebebd6b14e12d448c89dcf694f32b5f450ffd8b780fb3d18d
+%global calico_sha256           9325d1ead70f2afb9222da64f0c7eaa1f3c5f68763241d6b07cff3a853b783f2
+%global calico_ipam_sha256      9325d1ead70f2afb9222da64f0c7eaa1f3c5f68763241d6b07cff3a853b783f2
 %endif
 
 Name:           calico-cni-plugin
-Version:        3.16.1
+Version:        3.17.0
 Release:        1%{?dist}
 Summary:        Calico CNI plugin
 
@@ -49,6 +49,9 @@ install -p -m 755 %{SOURCE2} %{buildroot}/opt/cni/bin/calico-ipam
 %doc README.md
 
 %changelog
+* Wed Nov 25 2020 Teddy Andrieux <teddy.andrieux@scality.com> - 3.17.0-1
+- Version bump
+
 * Thu Oct 1 2020 Teddy Andrieux <teddy.andrieux@scality.com> - 3.16.1-1
 - Version bump
 

--- a/salt/_utils/kubernetes_utils.py
+++ b/salt/_utils/kubernetes_utils.py
@@ -321,6 +321,11 @@ if HAS_LIBS:
         ),
         # }}}
         # /apis/policy/v1beta1/ {{{
+        ('policy/v1beta1', 'PodDisruptionBudget'): KindInfo(
+            model=k8s_client.V1beta1PodDisruptionBudget,
+            api_cls=k8s_client.PolicyV1beta1Api,
+            name='namespaced_pod_disruption_budget',
+        ),
         ('policy/v1beta1', 'PodSecurityPolicy'): KindInfo(
             model=k8s_client.PolicyV1beta1PodSecurityPolicy,
             api_cls=k8s_client.PolicyV1beta1Api,


### PR DESCRIPTION
Deployment manifest updated based on upstream from
https://docs.projectcalico.org/v3.17/manifests/calico.yaml.

And Calico binaries sha256 updated from
https://github.com/projectcalico/cni-plugin/releases/tag/v3.17.0

---