### PR TITLE
salt: Add missing requisite for image injection

### DIFF
--- a/salt/metalk8s/repo/installed.sls
+++ b/salt/metalk8s/repo/installed.sls
@@ -17,12 +17,16 @@
 {%- set image_fullname = docker_repository ~ '/' ~ image_name ~ ':' ~ image_version %}
 
 include:
+  - metalk8s.container-engine.containerd
   - .configured
 
 Inject nginx image:
   containerd.image_managed:
     - name: {{ image_fullname }}
     - archive_path: {{ archives[saltenv].path }}/images/{{ image_name }}-{{ image_version }}.tar
+    - require:
+      - service: Start and enable containerd
+      - metalk8s_package_manager: Install and configure cri-tools
 
 Install repositories manifest:
   metalk8s.static_pod_managed:


### PR DESCRIPTION
**Component**: salt

**Summary**:

The "Inject nginx image" state from `metalk8s.repo.installed` was not
requiring containerd/cri-tools to be available. In case the installation
of containerd failed, we should not try to run this state (because it
will always fail).