### PR TITLE
Improvement/2792 nodes volumes tables edge cases

### DIFF
--- a/ui/src/components/EmptyState.js
+++ b/ui/src/components/EmptyState.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useHistory } from 'react-router';
+import { Button } from '@scality/core-ui';
+import { padding } from '@scality/core-ui/dist/style/theme';
+
+export const EmptyStateWrapper = styled.div`
+  color: ${(props) => props.theme.brand.textSecondary};
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  padding-top: 10%;
+`;
+
+export const BigText = styled.h3`
+  text-align: center;
+  margin: 0px;
+`;
+
+export const EmptyStateRow = styled.div`
+  display: flex;
+  justify-content: space-around;
+  margin-bottom: ${padding.larger};
+`;
+
+export const ActionWrapper = styled.div`
+  display: flex;
+  justify-content: space-around;
+`;
+
+export const IconWrapper = styled.div`
+  background-color: ${(props) => props.theme.brand.borderLight};
+  color: ${(props) => props.theme.brand.background}
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 100%;
+  width: 150px;
+  height: 150px;
+
+  i {
+    &.fas {
+      font-size: 4.5em;
+    }
+  }
+`;
+
+const EmptyState = (props) => {
+  const { label, link } = props;
+  const history = useHistory();
+
+  return (
+    <EmptyStateWrapper>
+      <EmptyStateRow>
+        <IconWrapper>
+          <i className="fas fa-server"></i>
+        </IconWrapper>
+      </EmptyStateRow>
+      <EmptyStateRow>
+        <BigText>A list of {`${label}s`} will appear here</BigText>
+      </EmptyStateRow>
+      <EmptyStateRow>
+        <BigText>
+          There are no {`${label}s`} created yet, let's create your first{' '}
+          {label}.
+        </BigText>
+      </EmptyStateRow>
+      <ActionWrapper>
+        <Button
+          text={`Create ${label}`}
+          size="large"
+          icon={<i className="fas fa-plus"></i>}
+          type="button"
+          variant="secondary"
+          onClick={() => history.push(link)}
+        />
+      </ActionWrapper>
+    </EmptyStateWrapper>
+  );
+};
+
+export default EmptyState;

--- a/ui/src/components/EmptyState.js
+++ b/ui/src/components/EmptyState.js
@@ -46,14 +46,14 @@ export const IconWrapper = styled.div`
 `;
 
 const EmptyState = (props) => {
-  const { label, link } = props;
+  const { label, link, icon } = props;
   const history = useHistory();
 
   return (
     <EmptyStateWrapper>
       <EmptyStateRow>
         <IconWrapper>
-          <i className="fas fa-server"></i>
+          <i className={`fas ${icon}`}></i>
         </IconWrapper>
       </EmptyStateRow>
       <EmptyStateRow>

--- a/ui/src/components/NodeListTable.js
+++ b/ui/src/components/NodeListTable.js
@@ -338,6 +338,25 @@ function Table({ columns, data, rowClicked, theme, selectedNodeName }) {
           })}
         </thead>
         <Body {...getTableBodyProps()}>
+          {rows.length === 0 ? (
+            <HeadRow
+              style={{
+                width: '100%',
+                paddingTop: padding.base,
+                height: '60px',
+              }}
+            >
+              <td
+                style={{
+                  textAlign: 'center',
+                  background: theme.brand.primary,
+                }}
+              >
+                {intl.translate('no_node_found')}
+              </td>
+            </HeadRow>
+          ) : null}
+
           {rows.map((row, i) => {
             prepareRow(row);
             return (

--- a/ui/src/components/VolumeListTable.js
+++ b/ui/src/components/VolumeListTable.js
@@ -376,7 +376,7 @@ function Table({
                   background: theme.brand.primary,
                 }}
               >
-                No Volume
+                {intl.translate('no_volume_found')}
               </td>
             </HeadRow>
           ) : null}

--- a/ui/src/containers/NodePage.js
+++ b/ui/src/containers/NodePage.js
@@ -24,6 +24,7 @@ const NodePage = (props) => {
 
   const theme = useSelector((state) => state.config.theme);
   const nodeTableData = useSelector((state) => getNodeListData(state, props));
+  const nodesLoading = useSelector((state) => state.app.nodes.isLoading);
   const alerts = useSelector((state) => state.app.alerts);
 
   return (
@@ -41,7 +42,11 @@ const NodePage = (props) => {
           ]}
         />
       </BreadcrumbContainer>
-      <NodePageContent nodeTableData={nodeTableData} alerts={alerts} />
+      <NodePageContent
+        nodeTableData={nodeTableData}
+        alerts={alerts}
+        loading={nodesLoading}
+      />
     </PageContainer>
   );
 };

--- a/ui/src/containers/NodePageContent.js
+++ b/ui/src/containers/NodePageContent.js
@@ -45,7 +45,7 @@ const NodePageContent = (props) => {
   return (
     <PageContentContainer>
       {!nodeTableData.length && firstLoading ? (
-        <EmptyState label={'Node'} link="/nodes/create" />
+        <EmptyState label={'Node'} link="/nodes/create" icon="fa-server" />
       ) : (
         <Fragment>
           <LeftSideInstanceList>

--- a/ui/src/containers/NodePageContent.js
+++ b/ui/src/containers/NodePageContent.js
@@ -21,7 +21,7 @@ const NodePageContent = (props) => {
   const { nodeTableData, alerts, loading } = props;
   const { path } = useRouteMatch();
   const [defaultSelectNodeName, setDefaultSelectNodeName] = useState(null);
-  const [firstLoading, setFirstLoading] = useState(false);
+  const [isFirstLoadingDone, setIsFirstLoadingDone] = useState(false);
   const previousLoading = usePrevious(loading);
 
   /*
@@ -29,8 +29,9 @@ const NodePageContent = (props) => {
    ** This allow us to check if we need to display EmptyState or not
    */
   useEffect(() => {
-    if (previousLoading && !loading && !firstLoading) setFirstLoading(true);
-  }, [previousLoading, loading, firstLoading]);
+    if (previousLoading && !loading && !isFirstLoadingDone)
+      setIsFirstLoadingDone(true);
+  }, [previousLoading, loading, isFirstLoadingDone]);
 
   useRefreshEffect(refreshAlertManagerAction, stopRefreshAlertManagerAction);
   useRefreshEffect(refreshNodesAction, stopRefreshNodesAction);
@@ -44,7 +45,7 @@ const NodePageContent = (props) => {
 
   return (
     <PageContentContainer>
-      {!nodeTableData.length && firstLoading ? (
+      {!nodeTableData.length && isFirstLoadingDone ? (
         <EmptyState label={'Node'} link="/nodes/create" icon="fa-server" />
       ) : (
         <Fragment>

--- a/ui/src/containers/NodePageContent.js
+++ b/ui/src/containers/NodePageContent.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, Fragment } from 'react';
 import { Route, useRouteMatch, Switch, Redirect } from 'react-router-dom';
 import { refreshNodesAction, stopRefreshNodesAction } from '../ducks/app/nodes';
 import {
@@ -7,18 +7,30 @@ import {
 } from '../ducks/app/alerts';
 import { useRefreshEffect } from '../services/utils';
 import NodeListTable from '../components/NodeListTable';
+import EmptyState from '../components/EmptyState';
 import NodePageRSP from './NodePageRSP';
 import {
   LeftSideInstanceList,
   PageContentContainer,
   RightSidePanel,
 } from '../components/CommonLayoutStyle';
+import { usePrevious } from '../services/utils';
 
 // <NodePageContent> get the current selected node and pass it to <NodeListTable> and <NodePageRSP>
 const NodePageContent = (props) => {
-  const { nodeTableData, alerts } = props;
+  const { nodeTableData, alerts, loading } = props;
   const { path } = useRouteMatch();
   const [defaultSelectNodeName, setDefaultSelectNodeName] = useState(null);
+  const [firstLoading, setFirstLoading] = useState(false);
+  const previousLoading = usePrevious(loading);
+
+  /*
+   ** Used to determine if a first loading has happened
+   ** This allow us to check if we need to display EmptyState or not
+   */
+  useEffect(() => {
+    if (previousLoading && !loading && !firstLoading) setFirstLoading(true);
+  }, [previousLoading, loading, firstLoading]);
 
   useRefreshEffect(refreshAlertManagerAction, stopRefreshAlertManagerAction);
   useRefreshEffect(refreshNodesAction, stopRefreshNodesAction);
@@ -32,29 +44,37 @@ const NodePageContent = (props) => {
 
   return (
     <PageContentContainer>
-      <LeftSideInstanceList>
-        <NodeListTable nodeTableData={nodeTableData} />
-      </LeftSideInstanceList>
-      <RightSidePanel>
-        <Switch>
-          {/* Auto select the first node in the list */}
-          <Route
-            exact
-            path={`${path}`}
-            render={() =>
-              defaultSelectNodeName && (
-                <Redirect to={`${path}/${defaultSelectNodeName}/overview`} />
-              )
-            }
-          ></Route>
-          <Route
-            path={`${path}/:name`}
-            render={() => {
-              return <NodePageRSP nodeTableData={nodeTableData} />;
-            }}
-          ></Route>
-        </Switch>
-      </RightSidePanel>
+      {!nodeTableData.length && firstLoading ? (
+        <EmptyState label={'Node'} link="/nodes/create" />
+      ) : (
+        <Fragment>
+          <LeftSideInstanceList>
+            <NodeListTable nodeTableData={nodeTableData} />
+          </LeftSideInstanceList>
+          <RightSidePanel>
+            <Switch>
+              {/* Auto select the first node in the list */}
+              <Route
+                exact
+                path={`${path}`}
+                render={() =>
+                  defaultSelectNodeName && (
+                    <Redirect
+                      to={`${path}/${defaultSelectNodeName}/overview`}
+                    />
+                  )
+                }
+              ></Route>
+              <Route
+                path={`${path}/:name`}
+                render={() => {
+                  return <NodePageRSP nodeTableData={nodeTableData} />;
+                }}
+              ></Route>
+            </Switch>
+          </RightSidePanel>
+        </Fragment>
+      )}
     </PageContentContainer>
   );
 };

--- a/ui/src/containers/NodePageRSP.js
+++ b/ui/src/containers/NodePageRSP.js
@@ -26,7 +26,7 @@ import NodePageMetricsTab from './NodePageMetricsTab';
 import NodePageVolumesTab from '../components/NodePageVolumesTab';
 import NodePagePodsTab from '../components/NodePagePodsTab';
 import NodePageDetailsTab from '../components/NodeDetailsTab';
-import { TextBadge } from '../components/CommonLayoutStyle';
+import { TextBadge, NoInstanceSelected } from '../components/CommonLayoutStyle';
 import {
   queryTimeSpansCodes,
   NODE_ALERTS_GROUP,
@@ -107,6 +107,7 @@ const NodePageRSP = (props) => {
     nodes?.find((node) => node.name === name)?.internalIP ?? '';
   const controlPlaneInterface = nodesIPsInfo[name]?.controlPlane?.interface;
   const workloadPlaneInterface = nodesIPsInfo[name]?.workloadPlane?.interface;
+  const currentNode = nodeTableData?.find((node) => node.name.name === name);
 
   useEffect(() => {
     dispatch(
@@ -197,7 +198,7 @@ const NodePageRSP = (props) => {
     },
   ];
 
-  return (
+  return name && currentNode ? (
     <NodePageRSPContainer>
       <Tabs items={items}>
         <Switch>
@@ -241,6 +242,12 @@ const NodePageRSP = (props) => {
         </Switch>
       </Tabs>
     </NodePageRSPContainer>
+  ) : (
+    <NoInstanceSelected>
+      {name
+        ? `Node ${name} ${intl.translate('not_found')}`
+        : intl.translate('no_node_selected')}
+    </NoInstanceSelected>
   );
 };
 

--- a/ui/src/containers/VolumePage.js
+++ b/ui/src/containers/VolumePage.js
@@ -76,7 +76,7 @@ const VolumePage = (props) => {
   const node = useSelector((state) => makeGetNodeFromUrl(state, props));
   const nodes = useSelector((state) => state.app.nodes.list);
   const volumes = useSelector((state) => state.app.volumes.list);
-  const volumesLoading = useSelector((state) => state.app.volumes.loading);
+  const volumesLoading = useSelector((state) => state.app.volumes.isLoading);
   const currentVolumeObject = useSelector(
     (state) => state.app.volumes.currentVolumeObject,
   );

--- a/ui/src/containers/VolumePage.js
+++ b/ui/src/containers/VolumePage.js
@@ -76,6 +76,7 @@ const VolumePage = (props) => {
   const node = useSelector((state) => makeGetNodeFromUrl(state, props));
   const nodes = useSelector((state) => state.app.nodes.list);
   const volumes = useSelector((state) => state.app.volumes.list);
+  const volumesLoading = useSelector((state) => state.app.volumes.loading);
   const currentVolumeObject = useSelector(
     (state) => state.app.volumes.currentVolumeObject,
   );
@@ -136,6 +137,7 @@ const VolumePage = (props) => {
         alerts={alerts}
         volumeStats={volumeStats}
         currentVolumeObject={currentVolumeObject}
+        loading={volumesLoading}
       ></VolumeContent>
     </PageContainer>
   );

--- a/ui/src/containers/VolumePageContent.js
+++ b/ui/src/containers/VolumePageContent.js
@@ -233,7 +233,11 @@ const VolumePageContent = (props) => {
   return (
     <VolumePageContentContainer>
       {!volumeListData.length && firstLoading ? (
-        <EmptyState label={'Volume'} link="/volumes/createVolume" />
+        <EmptyState
+          label={'Volume'}
+          link="/volumes/createVolume"
+          icon="fa-database"
+        />
       ) : (
         <Fragment>
           <LeftSideInstanceList>

--- a/ui/src/containers/VolumePageContent.js
+++ b/ui/src/containers/VolumePageContent.js
@@ -84,7 +84,7 @@ const VolumePageContent = (props) => {
   const location = useLocation();
   const match = useRouteMatch();
   const query = new URLSearchParams(location.search);
-  const [firstLoading, setFirstLoading] = useState(false);
+  const [isFirstLoadingDone, setIsFirstLoadingDone] = useState(false);
   const previousLoading = usePrevious(loading);
 
   const theme = useSelector((state) => state.config.theme);
@@ -227,12 +227,13 @@ const VolumePageContent = (props) => {
    ** This allow us to check if we need to display EmptyState or not
    */
   useEffect(() => {
-    if (previousLoading && !loading && !firstLoading) setFirstLoading(true);
-  }, [previousLoading, loading, firstLoading]);
+    if (previousLoading && !loading && !isFirstLoadingDone)
+      setIsFirstLoadingDone(true);
+  }, [previousLoading, loading, isFirstLoadingDone]);
 
   return (
     <VolumePageContentContainer>
-      {!volumeListData.length && firstLoading ? (
+      {!volumeListData.length && isFirstLoadingDone ? (
         <EmptyState
           label={'Volume'}
           link="/volumes/createVolume"

--- a/ui/src/containers/VolumePageContent.js
+++ b/ui/src/containers/VolumePageContent.js
@@ -1,4 +1,5 @@
-import React from 'react';
+/* eslint no-unused-vars: 0 */
+import React, { Fragment, useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 import { useHistory, useLocation, useRouteMatch } from 'react-router';
@@ -10,6 +11,7 @@ import VolumeOverviewTab from '../components/VolumeOverviewTab';
 import VolumeAlertsTab from '../components/VolumeAlertsTab';
 import VolumeMetricsTab from '../components/VolumeMetricsTab';
 import VolumeDetailsTab from '../components/VolumeDetailsTab';
+import EmptyState from '../components/EmptyState';
 import {
   SPARSE_LOOP_DEVICE,
   RAW_BLOCK_DEVICE,
@@ -24,6 +26,7 @@ import {
   RightSidePanel,
 } from '../components/CommonLayoutStyle';
 import { intl } from '../translations/IntlGlobalProvider';
+import { usePrevious } from '../services/utils';
 
 const VolumePageContentContainer = styled.div`
 display: flex;
@@ -74,12 +77,15 @@ const VolumePageContent = (props) => {
     alerts,
     volumeStats,
     currentVolumeObject,
+    loading,
   } = props;
 
   const history = useHistory();
   const location = useLocation();
   const match = useRouteMatch();
   const query = new URLSearchParams(location.search);
+  const [firstLoading, setFirstLoading] = useState(false);
+  const previousLoading = usePrevious(loading);
 
   const theme = useSelector((state) => state.config.theme);
 
@@ -216,102 +222,122 @@ const VolumePageContent = (props) => {
     },
   ];
 
+  /*
+   ** Used to determine if a first loading has happened
+   ** This allow us to check if we need to display EmptyState or not
+   */
+  useEffect(() => {
+    if (previousLoading && !loading && !firstLoading) setFirstLoading(true);
+  }, [previousLoading, loading, firstLoading]);
+
   return (
     <VolumePageContentContainer>
-      <LeftSideInstanceList>
-        <VolumeListTable
-          volumeListData={volumeListData}
-          nodeName={node?.name}
-          volumeName={currentVolumeName}
-          isSearchBar={true}
-          isNodeColumn={true}
-        ></VolumeListTable>
-      </LeftSideInstanceList>
-
-      {currentVolumeName && volume ? (
-        <RightSidePanel>
-          <Tabs activeColor={theme.brand.primary} items={tabsItems}>
-            <Switch>
-              <Route
-                path={`${match.url}/overview`}
-                render={() => (
-                  <VolumeOverviewTab
-                    name={currentVolumeName}
-                    nodeName={volume?.spec?.nodeName}
-                    storage={
-                      pV?.spec?.capacity?.storage ?? intl.translate('unknown')
-                    }
-                    status={volumeStatus ?? intl.translate('unknown')}
-                    storageClassName={volume?.spec?.storageClassName}
-                    creationTimestamp={volume?.metadata?.creationTimestamp}
-                    volumeType={
-                      volume?.spec?.rawBlockDevice
-                        ? RAW_BLOCK_DEVICE
-                        : SPARSE_LOOP_DEVICE
-                    }
-                    usedPodName={
-                      UsedPod ? UsedPod?.name : intl.translate('not_used')
-                    }
-                    devicePath={
-                      volume?.spec?.rawBlockDevice?.devicePath ??
-                      intl.translate('not_applicable')
-                    }
-                    volumeUsagePercentage={currentVolume?.usage}
-                    volumeUsageBytes={currentVolume?.usageRawData ?? 0}
-                    storageCapacity={
-                      volumeListData?.find(
-                        (vol) => vol.name === currentVolumeName,
-                      ).storageCapacity
-                    }
-                    health={
-                      volumeListData?.find(
-                        (vol) => vol.name === currentVolumeName,
-                      ).health
-                    }
-                    condition={currentVolume.status}
-                    // the delete button inside the volume detail card should know that which volume is the first one
-                    volumeListData={volumeListData}
-                    pVList={pVList}
-                    alertlist={alertlist}
-                  />
-                )}
-              />
-              <Route
-                path={`${match.url}/alerts`}
-                render={() => (
-                  <VolumeAlertsTab alertlist={alertlist} PVCName={PVCName} />
-                )}
-              />
-              <Route
-                path={`${match.url}/metrics`}
-                render={() => (
-                  <VolumeMetricsTab
-                    volumeName={currentVolumeName}
-                    volumeMetricGraphData={volumeMetricGraphData}
-                    // the volume condition compute base on the `status` and `bound/unbound`
-                    volumeCondition={currentVolume.status}
-                    volumePVCName={PVCName}
-                    volumeNamespace={PVCNamespace}
-                  />
-                )}
-              />
-              <Route
-                path={`${match.url}/details`}
-                render={() => (
-                  <VolumeDetailsTab currentVolumeObject={currentVolumeObject} />
-                )}
-              />
-            </Switch>
-          </Tabs>
-        </RightSidePanel>
+      {!volumeListData.length && firstLoading ? (
+        <EmptyState label={'Volume'} link="/volumes/createVolume" />
       ) : (
-        <NoInstanceSelectedContainer>
-          <NoInstanceSelected>
-            {currentVolumeName
-              ? `Volume ${currentVolumeName} ${intl.translate('not_found')}`
-              : intl.translate('no_volume_selected')}
-          </NoInstanceSelected>
-        </NoInstanceSelectedContainer>
+        <Fragment>
+          <LeftSideInstanceList>
+            <VolumeListTable
+              volumeListData={volumeListData}
+              nodeName={node?.name}
+              volumeName={currentVolumeName}
+              isSearchBar={true}
+              isNodeColumn={true}
+            ></VolumeListTable>
+          </LeftSideInstanceList>
+
+          {currentVolumeName && volume ? (
+            <RightSidePanel>
+              <Tabs activeColor={theme.brand.primary} items={tabsItems}>
+                <Switch>
+                  <Route
+                    path={`${match.url}/overview`}
+                    render={() => (
+                      <VolumeOverviewTab
+                        name={currentVolumeName}
+                        nodeName={volume?.spec?.nodeName}
+                        storage={
+                          pV?.spec?.capacity?.storage ??
+                          intl.translate('unknown')
+                        }
+                        status={volumeStatus ?? intl.translate('unknown')}
+                        storageClassName={volume?.spec?.storageClassName}
+                        creationTimestamp={volume?.metadata?.creationTimestamp}
+                        volumeType={
+                          volume?.spec?.rawBlockDevice
+                            ? RAW_BLOCK_DEVICE
+                            : SPARSE_LOOP_DEVICE
+                        }
+                        usedPodName={
+                          UsedPod ? UsedPod?.name : intl.translate('not_used')
+                        }
+                        devicePath={
+                          volume?.spec?.rawBlockDevice?.devicePath ??
+                          intl.translate('not_applicable')
+                        }
+                        volumeUsagePercentage={currentVolume?.usage}
+                        volumeUsageBytes={currentVolume?.usageRawData ?? 0}
+                        storageCapacity={
+                          volumeListData?.find(
+                            (vol) => vol.name === currentVolumeName,
+                          ).storageCapacity
+                        }
+                        health={
+                          volumeListData?.find(
+                            (vol) => vol.name === currentVolumeName,
+                          ).health
+                        }
+                        condition={currentVolume.status}
+                        // the delete button inside the volume detail card should know that which volume is the first one
+                        volumeListData={volumeListData}
+                        pVList={pVList}
+                        alertlist={alertlist}
+                      />
+                    )}
+                  />
+                  <Route
+                    path={`${match.url}/alerts`}
+                    render={() => (
+                      <VolumeAlertsTab
+                        alertlist={alertlist}
+                        PVCName={PVCName}
+                      />
+                    )}
+                  />
+                  <Route
+                    path={`${match.url}/metrics`}
+                    render={() => (
+                      <VolumeMetricsTab
+                        volumeName={currentVolumeName}
+                        volumeMetricGraphData={volumeMetricGraphData}
+                        // the volume condition compute base on the `status` and `bound/unbound`
+                        volumeCondition={currentVolume.status}
+                        volumePVCName={PVCName}
+                        volumeNamespace={PVCNamespace}
+                      />
+                    )}
+                  />
+                  <Route
+                    path={`${match.url}/details`}
+                    render={() => (
+                      <VolumeDetailsTab
+                        currentVolumeObject={currentVolumeObject}
+                      />
+                    )}
+                  />
+                </Switch>
+              </Tabs>
+            </RightSidePanel>
+          ) : (
+            <NoInstanceSelectedContainer>
+              <NoInstanceSelected>
+                {currentVolumeName
+                  ? `Volume ${currentVolumeName} ${intl.translate('not_found')}`
+                  : intl.translate('no_volume_selected')}
+              </NoInstanceSelected>
+            </NoInstanceSelectedContainer>
+          )}
+        </Fragment>
       )}
     </VolumePageContentContainer>
   );

--- a/ui/src/containers/VolumePageContent.js
+++ b/ui/src/containers/VolumePageContent.js
@@ -307,7 +307,9 @@ const VolumePageContent = (props) => {
       ) : (
         <NoInstanceSelectedContainer>
           <NoInstanceSelected>
-            {intl.translate('no_volume_selected')}
+            {currentVolumeName
+              ? `Volume ${currentVolumeName} ${intl.translate('not_found')}`
+              : intl.translate('no_volume_selected')}
           </NoInstanceSelected>
         </NoInstanceSelectedContainer>
       )}

--- a/ui/src/services/utils.js
+++ b/ui/src/services/utils.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { useLocation, useHistory } from 'react-router-dom';
 import { createSelector } from 'reselect';
@@ -418,4 +418,17 @@ export const useDynamicChartSize = (container_id) => {
   }, [graphsContainerWidth]);
 
   return [graphWidth, window.innerHeight / 6 - 30];
+};
+
+/*
+ ** Hook to store previous value of a given variable
+ ** Used to compare prev and next props or equivalent
+ */
+export const usePrevious = (value) => {
+  const ref = useRef();
+  // Store current value in ref
+  useEffect(() => {
+    ref.current = value;
+  }, [value]); // Only re-run if value changes
+  return ref.current;
 };

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -72,6 +72,7 @@
   "creationTime": "Creation Time",
   "create_new_volume": "Create Volume",
   "no_volume_found": "No volumes found",
+  "no_node_found": "No nodes found",
   "no_searched_volume_found": "No volumes matching the search",
   "volume_type": "Type",
   "volume_size": "Volume Capacity",

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -71,7 +71,7 @@
   "storageClass": "Storage Class",
   "creationTime": "Creation Time",
   "create_new_volume": "Create Volume",
-  "no_volume_found": "No volumes on this node",
+  "no_volume_found": "No volumes found",
   "no_searched_volume_found": "No volumes matching the search",
   "volume_type": "Type",
   "volume_size": "Volume Capacity",

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -174,5 +174,6 @@
   "overview": "Overview",
   "volume_usage": "Volume Usage",
   "usage": "Usage",
-  "error_volume_details": "Volume details request has failed."
+  "error_volume_details": "Volume details request has failed.",
+  "not_found": "not found."
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -72,6 +72,7 @@
   "creationTime": "Date de Création",
   "create_new_volume": "Créer Volume",
   "no_volume_found": "Aucun volume",
+  "no_node_found": "Aucun nœud",
   "no_searched_volume_found": "Aucun volume correspondant à la recherche",
   "volume_type": "Type de Volume",
   "volume_size": "Capacité du volume",

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -174,5 +174,6 @@
   "overview": "Aperçu",
   "volume_usage": "Utilisation du Volume",
   "usage": "Utilisation",
-  "error_volume_details": "Échec de la récuperation des details du volume."
+  "error_volume_details": "Échec de la récuperation des details du volume.",
+  "not_found": "introuvable."
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -71,7 +71,7 @@
   "storageClass": "Classe de Stockage",
   "creationTime": "Date de Création",
   "create_new_volume": "Créer Volume",
-  "no_volume_found": "Aucun volume sur ce nœud",
+  "no_volume_found": "Aucun volume",
   "no_searched_volume_found": "Aucun volume correspondant à la recherche",
   "volume_type": "Type de Volume",
   "volume_size": "Capacité du volume",


### PR DESCRIPTION
**Component**: ui, nodes, volumes, emptystate

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
This adresses the issues described in #2792 .

**Summary**:

- Both nodes and volumes table have appropriate message when no data matches the filters.
- If an non-existing volumes/node is specified in the URL the right panel displays and appropriate message
- If no nodes/volumes exist at all the page displays an "EmptyState" component that guides the user to create his first node/volume. (the component has dynamic link and icon to be re-used in both pages) : 

![metalk8s-empty-demo](https://user-images.githubusercontent.com/3480526/101656956-a0cde500-3a43-11eb-8cb7-c03f9f54f10e.gif)


**Acceptance criteria**: 
The issues described in #2792 are fixed.


---

<!-- Declare one or more issues to close once this PR gets merged -->


<!-- If you want to refer to an issue while not closing it, use:

See: #2792 

-->
