### PR TITLE
[UI] bump core ui to resolve memory leaks in vega chart component

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -2843,8 +2843,8 @@
       }
     },
     "@scality/core-ui": {
-      "version": "github:scality/core-ui#3a7cd45a477af2111655f5d3e8fbb52845a560c1",
-      "from": "github:scality/core-ui#3a7cd45"
+      "version": "github:scality/core-ui#273996b92544aba0d6369f52d33fc0a77d78de28",
+      "from": "github:scality/core-ui#v0.6.1"
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "4.2.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.7.2",
     "@kubernetes/client-node": "github:scality/kubernetes-client-javascript.git#browser-0.10.2-62-g61d8543",
-    "@scality/core-ui": "github:scality/core-ui.git#3a7cd45",
+    "@scality/core-ui": "github:scality/core-ui.git#v0.6.1",
     "axios": "^0.18.0",
     "formik": "2.2.5",
     "lodash.isempty": "^4.4.0",


### PR DESCRIPTION
**Component**:

VegaChart

See: https://github.com/scality/core-ui/issues/214