### PR TITLE
charts,build: Bump Dex image to 2.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@
 - Bump `fluent-bit` chart to 2.0.1 and `loki` chart to 2.1.0
   (PR [#2946](https://github.com/scality/metalk8s/pull/2946))
 
-- Bump `dex` version to 2.24.0 (PR [#2942](https://github.com/scality/metalk8s/pull/2942))
+- [#2985](https://github.com/scality/metalk8s/issues/2985) - Bump `dex` version
+  to 2.27.0 (PR [#2990](https://github.com/scality/metalk8s/pull/2990))
 
 - Replace the prometheus-operator chart by the kube-prometheus-stack one and
   bump the version to 12.2.3.

--- a/buildchain/buildchain/constants.py
+++ b/buildchain/buildchain/constants.py
@@ -19,7 +19,7 @@ CMD_WIDTH : int = 14
 # URLs of the main container repositories.
 CALICO_REPOSITORY               : str = 'docker.io/calico'
 COREOS_REPOSITORY               : str = 'quay.io/coreos'
-DEX_REPOSITORY                  : str = 'quay.io/dexidp'
+DEX_REPOSITORY                  : str = 'docker.io/dexidp'
 DOCKER_REPOSITORY               : str = 'docker.io/library'
 GOOGLE_REPOSITORY               : str = 'k8s.gcr.io'
 GRAFANA_REPOSITORY              : str = 'docker.io/grafana'

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -106,8 +106,8 @@ CONTAINER_IMAGES : Tuple[Image, ...] = (
     ),
     Image(
         name='dex',
-        version='v2.24.0',
-        digest='sha256:c9b7f6d0d9539bc648e278d64de46eb45f8d1e984139f934ae26694fe7de6077',
+        version='v2.27.0',
+        digest='sha256:ff94efdd1ec68f43e01b39a2d11a73961b1cf73860515893118af731551f1939',
     ),
     Image(
         name='etcd',

--- a/charts/dex.yaml
+++ b/charts/dex.yaml
@@ -1,5 +1,10 @@
 image: '__image__(dex)'
 
+# NOTE: We do not use the new Helm3 chart for the moment as it's not yet part
+# of stable repo, but since Dex 2.24 is affected by CVE (CVE-2020-15216) use
+# the newest 2.27 image even if we still use the deprecated chart
+imageTag: 'v2.27.0'
+
 nodeSelector:
   node-role.kubernetes.io/infra: ''
 

--- a/salt/metalk8s/addons/dex/deployed/chart.sls
+++ b/salt/metalk8s/addons/dex/deployed/chart.sls
@@ -136,7 +136,7 @@ spec:
         - serve
         - /etc/dex/cfg/config.yaml
         env: []
-        image: {% endraw -%}{{ build_image_name("dex", False) }}{%- raw %}:v2.24.0
+        image: {% endraw -%}{{ build_image_name("dex", False) }}{%- raw %}:v2.27.0
         imagePullPolicy: IfNotPresent
         name: main
         ports:


### PR DESCRIPTION
**Component**:

'dex'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

#2985 

**Summary**:

Because of "CVE-2020-15216" we need to use a newer Dex image, note that
at this time no stable repo exists for Dex helm3 chart so we still use
the deprecated chart where we only bump the Dex image version

---

Fixes: #2985 
