### PR TITLE
salt: Avoid duplicating static pod manifests

### DIFF
--- a/salt/_states/metalk8s.py
+++ b/salt/_states/metalk8s.py
@@ -1,28 +1,38 @@
 """Custom states for MetalK8s."""
 
+import logging
 import time
+import traceback
 import re
+
+from salt.ext import six
 
 
 __virtualname__ = "metalk8s"
+log = logging.getLogger(__name__)
 
 
 def __virtual__():
     return __virtualname__
 
 
+def _error(ret, err_msg):
+    ret["result"] = False
+    ret["comment"] = err_msg
+    return ret
+
+
 def static_pod_managed(name,
                        source,
                        config_files=None,
                        config_files_opt=None,
-                       context=None,
-                       **kwargs):
+                       context=None):
     """Simple helper to edit a static Pod manifest if configuration changes.
 
     Expects the template to use:
     - `config_digest` variable and store it in the `metadata.annotations`
       section, with the key `metalk8s.scality.com/config-digest`.
-    - `metalk8s_version` variabble and store it in the `metadata.labels`
+    - `metalk8s_version` variable and store it in the `metadata.labels`
       section, with the key `metalk8s.scality.com/version`.
 
     name:
@@ -41,21 +51,42 @@ def static_pod_managed(name,
 
     context:
         Context to use to render the source template.
-
-    kwargs:
-        Any arguments supported by `file.managed` are supported.
     """
+    ret = {"changes": {}, "comment": "", "name": name, "result": True}
+
+    if not name:
+        return _error(ret, "Manifest file name is required")
+
+    if not isinstance(source, six.text_type):
+        return _error(ret, "Source must be a single string")
+
     if not config_files:
         config_files = []
 
     for config_file in config_files_opt or []:
         if __salt__["file.file_exists"](config_file):
             config_files.append(config_file)
+        else:
+            log.debug(
+                "Ignoring optional config file %s: file does not exist",
+                config_file
+            )
 
-    config_file_digests = [
-        __salt__["hashutil.digest_file"](config_file, checksum="sha256")
-        for config_file in config_files
-    ]
+    config_file_digests = []
+    for config_file in config_files:
+        try:
+            digest = __salt__["hashutil.digest_file"](
+                config_file, checksum="sha256"
+            )
+        except CommandExecutionError as exc:
+            return _error(
+                ret,
+                "Unable to compute digest of config file {}: {}".format(
+                    config_file, exc
+                )
+            )
+        config_file_digests.append(digest)
+
     config_digest = __salt__["hashutil.md5_digest"](
         "-".join(config_file_digests)
     )
@@ -63,21 +94,52 @@ def static_pod_managed(name,
     match = re.search(r'metalk8s-(?P<version>.+)$', __env__)
     metalk8s_version = match.group('version') if match else "unknown"
 
-    return __states__["file.managed"](
-        name,
-        source,
-        template=kwargs.pop("template", "jinja"),
-        user=kwargs.pop("user", "root"),
-        group=kwargs.pop("group", "root"),
-        mode=kwargs.pop("mode", "0600"),
-        makedirs=kwargs.pop("makedirs", False),
-        backup=kwargs.pop("backup", False),
-        context=dict(
-            context or {},
-            config_digest=config_digest, metalk8s_version=metalk8s_version
-        ),
-        **kwargs
+    context_ = dict(
+        context or {},
+        config_digest=config_digest, metalk8s_version=metalk8s_version
     )
+
+    if __opts__["test"]:
+        log.warning("Test functionality is not yet implemented.")
+        ret["comment"] = (
+            "The manifest {} is in the correct state (supposedly)."
+        ).format(name)
+        return ret
+
+    # Gather the source file from the server
+    try:
+        source_filename, source_sum, comment_ = __salt__["file.get_managed"](
+            name,
+            template="jinja",
+            source=source,
+            source_hash="",
+            source_hash_name=None,
+            user="root",
+            group="root",
+            mode="0600",
+            attrs=None,
+            saltenv=__env__,
+            context=context_,
+            defaults=None,
+        )
+    except Exception as exc:  # pylint: disable=broad-except
+        log.debug(traceback.format_exc())
+        return _error(ret, "Unable to get managed file: {}".format(exc))
+
+    if comment_:
+        return _error(ret, comment_)
+    else:
+        try:
+            return __salt__["metalk8s.manage_static_pod_manifest"](
+                name,
+                source_filename,
+                source,
+                source_sum,
+                saltenv=__env__,
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            log.debug(traceback.format_exc())
+            return _error(ret, "Unable to manage file: {}".format(exc))
 
 
 def module_run(name, attemps=1, sleep_time=10, **kwargs):

--- a/salt/tests/unit/modules/files/test_metalk8s.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s.yaml
@@ -328,3 +328,112 @@ format_slots:
       my_mod.my_fun: null
     raises: True
     result: "Unable to compute slot '__slot__:salt:my_mod.my_fun\\(\\)': An error has occurred"
+
+manage_static_pod_manifest:
+  # Nominal: pre-cached source
+  - name: &manifest_name /etc/kubernetes/manifests/my-pod.yaml
+    source: &manifest_source salt://my/state/files/my-pod-manifest.yaml.j2
+    pre_cached_source: True
+    result: &manifest_nominal_result_no_changes
+      name: *manifest_name
+      changes: {}
+      comment: >-
+        File /etc/kubernetes/manifests/my-pod.yaml is in the correct state
+      result: True
+  # Nominal: source not in cache
+  - name: *manifest_name
+    source: *manifest_source
+    result: *manifest_nominal_result_no_changes
+  # Nominal: cached hash mismatch
+  - name: *manifest_name
+    source: *manifest_source
+    pre_cached_source: True
+    cached_hash_mismatch: True
+    result: *manifest_nominal_result_no_changes
+  # Nominal: target is a link
+  - name: *manifest_name
+    source: *manifest_source
+    target_links_to: /some/other/path.yaml
+    result: *manifest_nominal_result_no_changes
+  # Nominal: target hash mismatch
+  - name: *manifest_name
+    source: *manifest_source
+    target_hash_mismatch: True
+    result: &manifest_nominal_result_updated
+      <<: *manifest_nominal_result_no_changes
+      changes:
+        diff: Some diff
+      comment: >-
+        File /etc/kubernetes/manifests/my-pod.yaml updated
+  # Nominal: target hash + perms/owner mismatch
+  - name: *manifest_name
+    source: *manifest_source
+    target_hash_mismatch: True
+    target_stats:
+      mode: '0644'
+      user: my-user
+      group: my-group
+    result:
+      <<: *manifest_nominal_result_updated
+      changes:
+        diff: Some diff
+        user: root
+        group: root
+        mode: '0600'
+  # Nominal: new file
+  - name: *manifest_name
+    source: *manifest_source
+    target_exists: False
+    result:
+      <<: *manifest_nominal_result_updated
+      changes:
+        diff: New file
+  # Nominal: obfuscate templates
+  - name: *manifest_name
+    source: *manifest_source
+    obfuscate_templates: True
+    target_hash_mismatch: True
+    result:
+      <<: *manifest_nominal_result_updated
+      changes:
+        diff: <Obfuscated Template>
+  # Nominal: file.get_diff failure
+  - name: *manifest_name
+    source: *manifest_source
+    get_diff_error: Failed to compute diff
+    target_hash_mismatch: True
+    result:
+      <<: *manifest_nominal_result_updated
+      changes:
+        diff: Failed to compute diff
+  # Nominal: test mode
+  - name: *manifest_name
+    source: *manifest_source
+    target_hash_mismatch: True
+    opts:
+      test: True
+    result:
+      <<: *manifest_nominal_result_updated
+      comment: >-
+        File /etc/kubernetes/manifests/my-pod.yaml would be updated
+  # Error: missing source
+  - name: *manifest_name
+    error: Must provide a source
+  # Error: target directory does not exist
+  - name: *manifest_name
+    source: *manifest_source
+    target_dir_exists: False
+    error: Target directory /etc/kubernetes/manifests does not exist
+  # Error: source could not be cached
+  - name: *manifest_name
+    source: *manifest_source
+    cache_file_ret: False
+    error: >-
+      Source file 'salt://my/state/files/my-pod-manifest.yaml.j2' not found
+  # Error: copy error
+  - name: *manifest_name
+    source: *manifest_source
+    target_exists: False
+    atomic_copy_raises: Could not copy!
+    error: >-
+      Failed to commit change: Could not copy!


### PR DESCRIPTION
When using `metalk8s.static_pod_managed`, we call `file.managed` behind
the scenes. This state does a lot of magic, including creating a
temporary file with the new contents before replacing the old file.
This temp file gets created **in the same directory** as the managed
file by default, so it gets picked up by `kubelet` as if it were
another static Pod to manage. If the replacement occurs too late,
`kubelet` may have already created another Pod for the temp file, and
may not be able to "remember" the old Pod, hence not cleaning it up.
This results in "rogue containers", which can create issues (e.g.
preventing new containers from binding some ports on the host).

This commit reimplements the 'file.managed' state in a minimal fashion,
to ensure the temporary file used for making an "atomic replace" is
ignored by kubelet. Note that it requires us to also reimplement the
'file.manage_file' execution function, since it always relies on the
existing "atomic copy" operation from `salt.utils.files.copyfile`.

Fixes: #2840