### PR TITLE
tests: Add retry mechanism when checking certificate renewal

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -2065,6 +2065,7 @@ stages:
               ssh -F ssh_config bootstrap "sudo ./test-certificates-beacon.sh /var/tmp/metalk8s"
           workdir: build/eve/workers/openstack-terraform/terraform/
           haltOnFailure: true
+      - ShellCommand: *wait_pods_stable_ssh
       - ShellCommand:
           <<: *multi_node_fast_tests
           name: Run fast tests on Bastion after certificates renewal


### PR DESCRIPTION
Lower the wait time, but retries 3 times before exiting in error.
In best cases the test is faster, otherwise we wait a little more than before.