### PR TITLE
ci/ui-integration: Increase app wait timeout

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -1107,13 +1107,14 @@ stages:
               attempts=0
               until curl -Isfo /dev/null http://localhost:80/; do
                 (( attempts++ ))
-                if [ $attempts -gt 40 ]; then
-                  >&2 echo "Failed to reach application after 2 minutes"
+                if [ $attempts -gt 100 ]; then
+                  >&2 echo "Failed to reach application after 5 minutes"
                   exit 1
                 fi
                 sleep 3
               done
             '
+          haltOnFailure: true
       - ShellCommand:
           name: Run all UI integration tests
           workdir: build/ui


### PR DESCRIPTION
Before starting the Cypress test suite, we try to reach the sidecar
container running the application under test.
This timeout was set to 2 minutes, which sometimes fails (because things
are too slow; we can know this by seeing the Cypress suite succeeding
after such timeout). We bump it to 5 minutes.
We also ensure such timeouts will prevent the suite from being executed
further.