### PR TITLE
Ensure containerd is ready before importing container image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@
   volumes are all provisioned on reboot
   (PR [#2936](https://github.com/scality/metalk8s/pull/2936))
 
+- Make sure container engine is ready before trying to import container images
+  (PR [#3020](https://github.com/scality/metalk8s/pull/3020))
+
 ## Release 2.6.1 (in development)
 
 ### Features Added

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -450,7 +450,9 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/container-engine/containerd/files/50-metalk8s.conf.j2'),
     Path('salt/metalk8s/container-engine/containerd/init.sls'),
     Path('salt/metalk8s/container-engine/containerd/installed.sls'),
+    Path('salt/metalk8s/container-engine/containerd/running.sls'),
     Path('salt/metalk8s/container-engine/init.sls'),
+    Path('salt/metalk8s/container-engine/running.sls'),
 
     Path('salt/metalk8s/defaults.yaml'),
     Path('salt/metalk8s/deployed.sls'),

--- a/salt/_modules/cri.py
+++ b/salt/_modules/cri.py
@@ -192,3 +192,20 @@ def component_is_running(name):
         log.error('Failed to list pods')
         return False
     return len(salt.utils.json.loads(out['stdout'])['items']) != 0
+
+
+def ready(timeout=10):
+    '''Wait for container engine to be ready.
+
+    .. note::
+
+        This uses the :command:`crictl version` command, which should be
+        configured correctly on the system, e.g. in :file:`/etc/crictl.yaml`.
+
+    timeout
+        time, in seconds, to wait for container engine to respond
+    '''
+    cmd = 'crictl --timeout={0}s version'.format(timeout)
+    log.debug('Checking for container engine to be ready using: %s', cmd)
+
+    return __salt__['cmd.retcode'](cmd) == 0

--- a/salt/metalk8s/container-engine/containerd/configured.sls
+++ b/salt/metalk8s/container-engine/containerd/configured.sls
@@ -2,17 +2,7 @@
 
 include:
   - .installed
-
-Start and enable containerd:
-  service.running:
-    - name: containerd
-    - enable: True
-    - init_delay: 2
-    - require:
-      - metalk8s_package_manager: Install containerd
-    - watch:
-      - file: Configure registry IP in containerd conf
-      - file: Create containerd service drop-in
+  - .running
 
 Inject pause image:
   # The `containerd` states require the `cri` module, which requires `crictl`
@@ -22,7 +12,7 @@ Inject pause image:
     - unless: >-
         ctr -n k8s.io image ls -q | grep k8s.gcr.io/pause | grep 3\\.1
     - require:
-      - service: Start and enable containerd
+      - sls: metalk8s.container-engine.containerd.running
   containerd.image_managed:
     - name: k8s.gcr.io/pause:3.1
     - archive_path: /tmp/pause-3.1.tar

--- a/salt/metalk8s/container-engine/containerd/running.sls
+++ b/salt/metalk8s/container-engine/containerd/running.sls
@@ -1,0 +1,21 @@
+# NOTE: This state just ensure containerd running and "ready"
+# To restart containerd you need to use a `watch_in` in another state 
+# that include this one
+# ```
+# - watch_in:
+#   - service: Ensure containerd running
+# ```
+
+Ensure containerd running:
+  service.running:
+    - name: containerd
+    - enable: True
+    - init_delay: 2
+
+Ensure containerd is ready:
+  test.configurable_test_state:
+    - changes: False
+    - result: __slot__:salt:cri.ready()
+    - comment: Ran 'cri.ready'
+    - require:
+      - service: Ensure containerd running

--- a/salt/metalk8s/container-engine/running.sls
+++ b/salt/metalk8s/container-engine/running.sls
@@ -1,0 +1,20 @@
+{%- from "metalk8s/map.jinja" import kubelet with context %}
+
+{%- if kubelet.container_engine %}
+
+# NOTE: This state just ensure that the container engine is running and ready
+
+include:
+  - .{{ kubelet.container_engine }}.running
+
+Container engine is ready:
+  test.succeed_without_changes:
+    - require:
+      - sls: metalk8s.container-engine.{{ kubelet.container_engine }}.running
+
+{%- else %}
+
+No container engine to check:
+  test.succeed_without_changes
+
+{%- endif %}

--- a/salt/metalk8s/repo/installed.sls
+++ b/salt/metalk8s/repo/installed.sls
@@ -18,11 +18,14 @@
 
 include:
   - .configured
+  - metalk8s.container-engine.running
 
 Inject nginx image:
   containerd.image_managed:
     - name: {{ image_fullname }}
     - archive_path: {{ archives[saltenv].path }}/images/{{ image_name }}-{{ image_version }}.tar
+    - require:
+      - sls: metalk8s.container-engine.running
 
 Install repositories manifest:
   metalk8s.static_pod_managed:

--- a/salt/tests/unit/modules/test_cri.py
+++ b/salt/tests/unit/modules/test_cri.py
@@ -191,3 +191,15 @@ class CriTestCase(TestCase, mixins.LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=cmd)
         with patch.dict(cri.__salt__, {'cmd.run_all': mock_cmd}):
             self.assertEqual(cri.component_is_running('my_comp'), result)
+
+    @parameterized.expand([
+        (0, True),
+        (1, False)
+    ])
+    def test_ready(self, retcode, result):
+        """
+        Tests the return of `ready` function
+        """
+        mock_cmd = MagicMock(return_value=retcode)
+        with patch.dict(cri.__salt__, {'cmd.retcode': mock_cmd}):
+            self.assertEqual(cri.ready(), result)


### PR DESCRIPTION
**Component**:

'salt'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

Time to time importing of pause image fail because containerd just get upgraded and not fully restarted

```
         ID: Inject pause image
    Function: containerd.image_managed
        Name: k8s.gcr.io/pause:3.1
      Result: False
     Comment: Failed to import archive: time="2021-01-08T10:22:26+01:00" level=debug msg="unpacking 1 images"
     Started: 10:22:26.698077
    Duration: 168.411 ms
     Changes: 
```

**Summary**:

- Add a salt module to check for container engine to be ready (using `crictl version`)
- Make sure container engine is ready before importing pause image
- Make sure container engine is ready before importing nginx image


---
