### PR TITLE
ci: Run all buildbot workers with Python 3

### DIFF
--- a/eve/workers/docker-centos7/Dockerfile
+++ b/eve/workers/docker-centos7/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-ARG BUILDBOT_VERSION=0.9.12
+ARG BUILDBOT_VERSION=2.0.1
 
 ENV LANG=en_US.utf8
 
@@ -11,12 +11,12 @@ RUN yum install -y --setopt=skip_missing_names_on_install=False \
     && yum install -y --setopt=skip_missing_names_on_install=False \
     gcc \
     sudo \
-    python-devel \
-    python-pip \
+    python36 \
+    python36-pip \
     git \
     && adduser -u 1042 --home /home/eve eve \
     && chown -R eve:eve /home/eve \
-    && pip install buildbot-worker==${BUILDBOT_VERSION}
+    && python3.6 -m pip install buildbot-worker==${BUILDBOT_VERSION}
 
 # Add eve to sudoers.
 RUN echo "eve ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/eve

--- a/eve/workers/pod-builder/Dockerfile
+++ b/eve/workers/pod-builder/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-ARG BUILDBOT_VERSION=0.9.12
+ARG BUILDBOT_VERSION=2.0.1
 
 WORKDIR /home/eve/workspace
 
@@ -13,8 +13,6 @@ RUN yum install -y --setopt=skip_missing_names_on_install=False \
     gcc \
     hardlink \
     make \
-    python-devel \
-    python-pip \
     python36 \
     python36-devel \
     python36-pip \
@@ -25,7 +23,7 @@ RUN yum install -y --setopt=skip_missing_names_on_install=False \
     docker-ce-cli-18.09.6 \
     && adduser -u 1042 --home /home/eve eve --groups docker \
     && chown eve:eve /home/eve/workspace \
-    && pip install buildbot-worker==${BUILDBOT_VERSION}
+    && python3.6 -m pip install buildbot-worker==${BUILDBOT_VERSION}
 
 # Add eve to sudoers.
 RUN echo "eve ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/eve

--- a/eve/workers/pod-example-solution-builder/Dockerfile
+++ b/eve/workers/pod-example-solution-builder/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-ARG BUILDBOT_VERSION=0.9.12
+ARG BUILDBOT_VERSION=2.0.1
 ARG OPERATOR_SDK_VERSION=v0.17.0
 
 WORKDIR /home/eve/workspace
@@ -15,10 +15,11 @@ RUN yum install -y --setopt=skip_missing_names_on_install=False \
     gcc \
     hardlink \
     make \
+    python36 \
+    python36-devel \
+    python36-pip \
     genisoimage \
     golang \
-    python-devel \
-    python-pip \
     skopeo \
     yum-utils \
     docker-ce-cli-18.09.6 \
@@ -30,7 +31,7 @@ RUN yum install -y --setopt=skip_missing_names_on_install=False \
     && adduser -u 1042 --home /home/eve eve --groups docker \
     && mkdir -p /home/eve/.cache /home/eve/go \
     && chown eve:eve /home/eve/workspace /home/eve/.cache /home/eve/go \
-    && pip install buildbot-worker==${BUILDBOT_VERSION} pyyaml
+    && python3.6 -m pip install buildbot-worker==${BUILDBOT_VERSION} pyyaml
 
 # Add eve to sudoers.
 RUN echo "eve ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/eve

--- a/eve/workers/pod-linter/Dockerfile
+++ b/eve/workers/pod-linter/Dockerfile
@@ -1,7 +1,7 @@
 # CI lint container - Fedora for recent ShellCheck version
 FROM fedora:32
 
-ARG BUILDBOT_VERSION=0.9.12
+ARG BUILDBOT_VERSION=2.0.1
 ARG GO_VERSION=1.13.10
 ARG OPERATOR_SDK_VERSION=v0.17.0
 
@@ -21,12 +21,13 @@ RUN dnf install -y git \
   python-pip \
   python3 \
   python3-devel \
+  python3-pip \
   ShellCheck \
   && dnf clean all \
   && adduser -u 1042 --home /home/eve eve \
   && chown -R eve:eve /home/eve \
-  && pip install tox \
-  && pip install buildbot-worker==${BUILDBOT_VERSION}
+  && pip3 install tox \
+  && pip3 install buildbot-worker==${BUILDBOT_VERSION}
 
 # Add eve to sudoers.
 RUN echo "eve ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/eve

--- a/eve/workers/pod-unit-tests/salt/Dockerfile
+++ b/eve/workers/pod-unit-tests/salt/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-ARG BUILDBOT_VERSION=0.9.12
+ARG BUILDBOT_VERSION=2.0.1
 
 ENV LANG=en_US.utf8
 
@@ -19,8 +19,10 @@ RUN yum install -y --setopt=skip_missing_names_on_install=False \
     git \
     && adduser -u 1042 --home /home/eve eve \
     && chown -R eve:eve /home/eve \
-    && pip install buildbot-worker==${BUILDBOT_VERSION} \
-    && python3.6 -m pip install six==1.14.0 tox==3.14.3
+    && python3.6 -m pip install \
+       buildbot-worker==${BUILDBOT_VERSION} \
+       six==1.14.0 \
+       tox==3.14.3
 
 # Add eve to sudoers.
 RUN echo "eve ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/eve

--- a/eve/workers/pod-unit-tests/storage-operator/Dockerfile
+++ b/eve/workers/pod-unit-tests/storage-operator/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-ARG BUILDBOT_VERSION=0.9.12
+ARG BUILDBOT_VERSION=2.0.1
 ARG GO_VERSION=1.13.10
 ARG OPERATOR_SDK_VERSION=v0.17.0
 
@@ -14,13 +14,14 @@ RUN yum install -y --setopt=skip_missing_names_on_install=False \
     gcc \
     sudo \
     make \
-    python-devel \
-    python-pip \
+    python36 \
+    python36-devel \
+    python36-pip \
     hg \
     git \
     && adduser -u 1042 --home /home/eve eve \
     && chown -R eve:eve /home/eve \
-    && pip install buildbot-worker==${BUILDBOT_VERSION}
+    && python3.6 -m pip install buildbot-worker==${BUILDBOT_VERSION}
 
 # Add eve to sudoers.
 RUN echo "eve ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/eve

--- a/eve/workers/pod-unit-tests/ui/Dockerfile
+++ b/eve/workers/pod-unit-tests/ui/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-ARG BUILDBOT_VERSION=0.9.12
+ARG BUILDBOT_VERSION=2.0.1
 
 ENV LANG=en_US.utf8
 
@@ -12,13 +12,14 @@ RUN yum install -y --setopt=skip_missing_names_on_install=False \
     && yum install -y --setopt=skip_missing_names_on_install=False \
     gcc \
     sudo \
-    python-devel \
-    python-pip \
+    python36 \
+    python36-devel \
+    python36-pip \
     git \
     nodejs \
     && adduser -u 1042 --home /home/eve eve \
     && chown -R eve:eve /home/eve \
-    && pip install buildbot-worker==${BUILDBOT_VERSION}
+    && python3.6 -m pip install buildbot-worker==${BUILDBOT_VERSION}
 
 # Add eve to sudoers.
 RUN echo "eve ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/eve


### PR DESCRIPTION
Installing `buildbot-worker==2.0.1` with pip using Python 2 fails,
because of a transitive dependency (namely, `idna`) which is only
expressed with a `>=` constraint, and for which recent versions have
dropped support of Python 2.