### PR TITLE
Revert "eve: Deactivate minor version downgrade on this branch" dev/2.8

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -859,9 +859,7 @@ stages:
           name: Trigger upgrade and downgrade test stages simultaneously
           stage_names:
             - single-node-upgrade-centos
-            # NOTE: Deactivate minor downgrade on this branch
-            # See: https://github.com/scality/metalk8s/issues/1750
-            #- single-node-downgrade-centos
+            - single-node-downgrade-centos
           waitForFinish: True
 
   create-upload-testrail-objects:
@@ -1758,9 +1756,7 @@ stages:
           stage_names:
             - snapshot-single-node-upgrades
             - snapshot-multi-node-upgrades
-            # NOTE: Deactivate minor downgrade on this branch
-            # See: https://github.com/scality/metalk8s/issues/1750
-            #- single-node-downgrade-promoted-centos
+            - single-node-downgrade-promoted-centos
 
   snapshot-single-node-upgrades:
     # NOTE: This stage just set `environment_type` property to


### PR DESCRIPTION
It's not needed since patch version downgrade is supported by etcd, so
we support downgrade from etcd 3.4.13 to 3.4.3

This reverts commit a325e622b495214cc8be134e0490d309b65f14f0.