### PR TITLE
Alerts without a "message" annotation don't show meaningful details in MetalK8s UI

### DIFF
--- a/tests/post/steps/test_monitoring.py
+++ b/tests/post/steps/test_monitoring.py
@@ -252,7 +252,8 @@ def check_deployed_rules(host, prometheus_api):
             # For now, we only need alerting rules
             if rule['type'] == "alerting":
                 message = rule['annotations'].get('message') or \
-                    rule['annotations'].get('summary')
+                    rule['annotations'].get('summary') or \
+                    rule['annotations'].get('description')
                 fixup_alerting_rule = {
                     'name': rule['name'],
                     'severity': rule['labels']['severity'],

--- a/ui/src/components/VolumeAlertsTab.js
+++ b/ui/src/components/VolumeAlertsTab.js
@@ -100,7 +100,7 @@ const ActiveAlertsCard = (props) => {
       return {
         name: alert.labels.alertname,
         severity: alert.labels.severity,
-        alert_description: alert.annotations.message,
+        alert_description: alert.annotations.description || alert.annotations.summary || alert.annotations.message,
         active_since: alert.startsAt,
       };
     }) ?? [];

--- a/ui/src/components/VolumeAlertsTab.js
+++ b/ui/src/components/VolumeAlertsTab.js
@@ -109,7 +109,7 @@ const ActiveAlertsCard = (props) => {
        name: alert.labels.alertname,
        severity: alert.labels.severity,
        alert_description: alert_description,
-       active_since: alert.activeAt,
+       active_since: alert.startsAt,
      };
      return alertData;
     }) ?? [];

--- a/ui/src/components/VolumeAlertsTab.js
+++ b/ui/src/components/VolumeAlertsTab.js
@@ -97,12 +97,21 @@ const ActiveAlertsCard = (props) => {
 
   let activeAlertListData =
     alertlist?.map((alert) => {
-      return {
-        name: alert.labels.alertname,
-        severity: alert.labels.severity,
-        alert_description: alert.annotations.message,
-        active_since: alert.startsAt,
-      };
+     var alert_description = "";
+     if (alert.annotations.description) {
+       alert_description = alert.annotations.description;
+     } else if (alert.annotations.summary) {
+       alert_description = alert.annotations.summary;
+     } else {
+       alert_description = alert.annotations.message;
+     }
+     var alertData = {
+       name: alert.labels.alertname,
+       severity: alert.labels.severity,
+       alert_description: alert_description,
+       active_since: alert.activeAt,
+     };
+     return alertData;
     }) ?? [];
 
   if (activeAlertListData && selectedFilter)

--- a/ui/src/components/VolumeAlertsTab.js
+++ b/ui/src/components/VolumeAlertsTab.js
@@ -97,21 +97,12 @@ const ActiveAlertsCard = (props) => {
 
   let activeAlertListData =
     alertlist?.map((alert) => {
-     var alert_description = "";
-     if (alert.annotations.description) {
-       alert_description = alert.annotations.description;
-     } else if (alert.annotations.summary) {
-       alert_description = alert.annotations.summary;
-     } else {
-       alert_description = alert.annotations.message;
-     }
-     var alertData = {
-       name: alert.labels.alertname,
-       severity: alert.labels.severity,
-       alert_description: alert_description,
-       active_since: alert.startsAt,
-     };
-     return alertData;
+      return {
+        name: alert.labels.alertname,
+        severity: alert.labels.severity,
+        alert_description: alert.annotations.description || alert.annotations.summary || alert.annotations.message,
+        active_since: alert.startsAt,
+      };
     }) ?? [];
 
   if (activeAlertListData && selectedFilter)

--- a/ui/src/containers/ClusterMonitoring.js
+++ b/ui/src/containers/ClusterMonitoring.js
@@ -181,7 +181,7 @@ const ClusterMonitoring = (props) => {
         name: alert.labels.alertname,
         severity: alert.labels.severity,
         message: message,
-        activeAt: alert.activeAt,
+        activeAt: alert.startsAt,
       };
       return alertData;
     });

--- a/ui/src/containers/ClusterMonitoring.js
+++ b/ui/src/containers/ClusterMonitoring.js
@@ -172,7 +172,7 @@ const ClusterMonitoring = (props) => {
       return {
         name: alert.labels.alertname,
         severity: alert.labels.severity,
-        message: alert.annotations.message,
+        message: alert.annotations.description || alert.annotations.summary || alert.annotations.message,
         activeAt: alert.startsAt,
       };
     });

--- a/ui/src/containers/ClusterMonitoring.js
+++ b/ui/src/containers/ClusterMonitoring.js
@@ -169,12 +169,21 @@ const ClusterMonitoring = (props) => {
   const alertsList = alerts.list
     .filter((alert) => alert.state !== 'pending')
     .map((alert) => {
-      return {
+      var message = "";
+      if (alert.annotations.description) {
+        message = alert.annotations.description;
+      } else if (alert.annotations.summary) {
+        message = alert.annotations.summary;
+      } else {
+        message = alert.annotations.message;
+      }
+      var alertData = {
         name: alert.labels.alertname,
         severity: alert.labels.severity,
-        message: alert.annotations.message,
-        activeAt: alert.startsAt,
+        message: message,
+        activeAt: alert.activeAt,
       };
+      return alertData;
     });
 
   const checkControlPlaneStatus = (jobCount) =>

--- a/ui/src/containers/ClusterMonitoring.js
+++ b/ui/src/containers/ClusterMonitoring.js
@@ -169,21 +169,12 @@ const ClusterMonitoring = (props) => {
   const alertsList = alerts.list
     .filter((alert) => alert.state !== 'pending')
     .map((alert) => {
-      var message = "";
-      if (alert.annotations.description) {
-        message = alert.annotations.description;
-      } else if (alert.annotations.summary) {
-        message = alert.annotations.summary;
-      } else {
-        message = alert.annotations.message;
-      }
-      var alertData = {
+      return {
         name: alert.labels.alertname,
         severity: alert.labels.severity,
-        message: message,
+        message: alert.annotations.description || alert.annotations.summary || alert.annotations.message,
         activeAt: alert.startsAt,
       };
-      return alertData;
     });
 
   const checkControlPlaneStatus = (jobCount) =>


### PR DESCRIPTION
**Component**:

ui, tests

**Context**: 
https://github.com/scality/metalk8s/issues/2994

**Summary**:
Changes made to display alert message on UI when prometheus alerts annotation have any of description, summary or message field. Currently blank alert message shown for many of prometheus alerts in metalk8s UI.

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
