### PR TITLE
tests: Raise volume client retry delay to 4s

### DIFF
--- a/tests/kube_utils.py
+++ b/tests/kube_utils.py
@@ -253,7 +253,7 @@ class Client(abc.ABC):
 class VolumeClient(Client):
     def __init__(self, k8s_client, ssh_config):
         super().__init__(
-            k8s_client, kind='Volume', retry_count=30, retry_delay=2
+            k8s_client, kind='Volume', retry_count=30, retry_delay=4
         )
         self._ssh_config = ssh_config
         self._group="storage.metalk8s.scality.com"


### PR DESCRIPTION
**Component**: tests

**Context**: 
Some volume tests are flaky because we probably do not wait enough time.  

**Summary**:
We double the delay between each try (4s instead of 2s), so we wait 2 min in total.

**Acceptance criteria**: At least no flakies on volume tests. :)