### PR TITLE
Etcd upgrade do not stop on first failure in 2.7.0-dev+

### DIFF
--- a/salt/metalk8s/orchestrate/etcd.sls
+++ b/salt/metalk8s/orchestrate/etcd.sls
@@ -1,3 +1,7 @@
+# This orchestrate is used to do a rolling upgrade or downgrade of the etcd
+# cluster, that's why this orchestrate need to be backward compatible with
+# latest MetalK8s minor version
+
 {%- set dest_version = pillar.metalk8s.cluster_version %}
 {%- set etcd_nodes = salt.metalk8s.minions_by_role('etcd') %}
 

--- a/salt/metalk8s/orchestrate/etcd.sls
+++ b/salt/metalk8s/orchestrate/etcd.sls
@@ -40,7 +40,10 @@ Deploy etcd {{ node }} to {{ dest_version }}:
     - require:
       - salt: Check pillar on {{ node }}
       - module: Check etcd cluster health
-  {%- if previous_node is defined %}
+  {%- if loop.previtem is defined %}
+      - metalk8s: Check etcd cluster health for {{ loop.previtem }}
+  {%- elif previous_node is defined %}
+  {#- NOTE: This can be removed in `development/2.8` #}
       - metalk8s: Check etcd cluster health for {{ previous_node }}
   {%- endif %}
 
@@ -51,6 +54,7 @@ Check etcd cluster health for {{ node }}:
     - require:
       - salt: Deploy etcd {{ node }} to {{ dest_version }}
 
+  {#- NOTE: This can be removed in `development/2.8` #}
   {#- Ugly but needed since we have jinja2.7 (`loop.previtem` added in 2.10) #}
   {%- set previous_node = node %}
 


### PR DESCRIPTION
**Component**:

'salt', 'lifecycle'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

When upgrading etcd cluster, the salt orchestrate do not stop after first node failure

**Summary**:

- Add `loop.previtem` in the etcd orchestrate since "old logic" using a variable in for loop does not work with newer version part of Salt Python3 3002.2
- Add a warning comment for developer in etcd orchestrate

---