### PR TITLE
Alerts without a "message" annotation don't show meaningful details in MetalK8s UI

### DIFF
--- a/tests/post/steps/test_monitoring.py
+++ b/tests/post/steps/test_monitoring.py
@@ -252,7 +252,8 @@ def check_deployed_rules(host, prometheus_api):
             # For now, we only need alerting rules
             if rule['type'] == "alerting":
                 message = rule['annotations'].get('message') or \
-                    rule['annotations'].get('summary')
+                    rule['annotations'].get('summary') or \
+                    rule['annotations'].get('description')
                 fixup_alerting_rule = {
                     'name': rule['name'],
                     'severity': rule['labels']['severity'],

--- a/ui/src/components/VolumeAlertsTab.js
+++ b/ui/src/components/VolumeAlertsTab.js
@@ -100,7 +100,7 @@ const ActiveAlertsCard = (props) => {
       return {
         name: alert.labels.alertname,
         severity: alert.labels.severity,
-        alert_description: alert.annotations.message,
+        alert_description: alert.annotations.description || alert.annotations.summary || alert.annotations.message,
         active_since: alert.startsAt,
       };
     }) ?? [];

--- a/ui/src/containers/ClusterMonitoring.js
+++ b/ui/src/containers/ClusterMonitoring.js
@@ -172,7 +172,7 @@ const ClusterMonitoring = (props) => {
       return {
         name: alert.labels.alertname,
         severity: alert.labels.severity,
-        message: alert.annotations.message,
+        message: alert.annotations.description || alert.annotations.summary || alert.annotations.message,
         activeAt: alert.startsAt,
       };
     });


### PR DESCRIPTION
Component:

ui, tests

Context:
#2994

Summary:
Changes made to display alert message on UI when prometheus alerts annotation have any of description, summary or message field. Currently blank alert message shown for many of prometheus alerts in metalk8s UI.

**Acceptance criteria**: 

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
