### PR TITLE
Salt runner `wait_minions` report False positif

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@
 - Make sure container engine is ready before trying to import container images
   (PR [#3020](https://github.com/scality/metalk8s/pull/3020))
 
+- Fix invalid return of Success when `wait_minions` runner fails
+  (PR [#3031](https://github.com/scality/metalk8s/pull/3031))
+
 ## Release 2.6.1 (in development)
 
 ### Features Added

--- a/salt/_runners/metalk8s_saltutil.py
+++ b/salt/_runners/metalk8s_saltutil.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import logging
 import time
 
+from salt.exceptions import CommandExecutionError
 import salt.client
 import salt.utils.extmods
 
@@ -64,10 +65,7 @@ def wait_minions(tgt='*', retry=10):
             )
         )
         log.error(error_message)
-        return {
-            'result': False,
-            'error': error_message
-        }
+        raise CommandExecutionError(error_message)
 
     # Waiting for running states to complete
     state_running = client.cmd(tgt, 'saltutil.is_running', arg=['state.*'])
@@ -108,19 +106,10 @@ def wait_minions(tgt='*', retry=10):
             )
         )
         log.error(error_message)
-        return {
-            'result': False,
-            'error': error_message
-        }
+        raise CommandExecutionError(error_message)
 
-    return {
-        'result': True,
-        'comment':
-            'All minions matching "{}" responded and finished startup '
-            'state: {}'.format(
-                tgt, ', '.join(minions)
-            )
-    }
+    return 'All minions matching "{}" responded and finished startup ' \
+           'state: {}'.format(tgt, ', '.join(minions))
 
 
 def orchestrate_show_sls(mods,

--- a/salt/_runners/metalk8s_saltutil.py
+++ b/salt/_runners/metalk8s_saltutil.py
@@ -56,11 +56,11 @@ def wait_minions(tgt='*', retry=10):
         error_message = (
             'Minion{plural} failed to respond after {retry} retries: {minions}'
         ).format(
-            plural='s' if len(minions) > 1 else '',
+            plural='s' if len(minions or {}) > 1 else '',
             retry=retry,
             minions=', '.join(
                 minion
-                for minion, status in (minions or {}).items()
+                for minion, status in (minions or {tgt: False}).items()
                 if not status
             )
         )


### PR DESCRIPTION
**Component**:

'salt'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

```
              ----------
                        ID: Wait minion available
                  Function: salt.runner
                      Name: metalk8s_saltutil.wait_minions
                    Result: True
                   Comment: Runner function 'metalk8s_saltutil.wait_minions' executed.
                   Started: 18:35:17.972072
                  Duration: 109595.07 ms
                   Changes:   
                            ----------
                            return:
                                ----------
                                error:
                                    Minion failed to respond after 10 retries: node-1
                                result:
                                    False
              ----------
```

**Summary**:

Do not use `result: False` in salt runner as it will not report the failure in the state, instead raise an exception in the runner module

---

