### PR TITLE
buildchain: embed ISO MD5 in the generated image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 - Bump etcd version to 3.4.13-0 (PR[#3008](https://github.com/scality/metalk8s/pull/3008))
 
+- [#3026](https://github.com/scality/metalk8s/issues/3026) - Embed a checksum
+  of the data contained in the ISO image inside the ISO so its integrity can be
+  ensured after download, next to or instead of checking the `SHA256SUM` using
+  `checkisomd5` (from [isomd5sum](https://github.com/rhinstaller/isomd5sum))
+  (PR [#3032](https://github.com/scality/metalk8s/pull/3032))
+
 ## Release 2.7.0 (in development)
 ### Enhancements
 - Bump Kubernetes version to 1.18.13 (PR[#2973](https://github.com/scality/metalk8s/pull/2973))

--- a/buildchain/buildchain/config.py
+++ b/buildchain/buildchain/config.py
@@ -52,13 +52,14 @@ VAGRANT_UP_ARGS : Tuple[str, ...] = tuple(shlex.split(
 class ExtCommand(enum.Enum):
     """External commands used by the build chain."""
 
-    GIT          = os.getenv('GIT_BIN',          'git')
-    HARDLINK     = os.getenv('HARDLINK_BIN',     'hardlink')
-    MKISOFS      = os.getenv('MKISOFS_BIN',      'mkisofs')
-    SKOPEO       = os.getenv('SKOPEO_BIN',       'skopeo')
-    VAGRANT      = os.getenv('VAGRANT_BIN',      'vagrant')
-    OPERATOR_SDK = os.getenv('OPERATOR_SDK_BIN', 'operator-sdk')
-    GOFMT        = os.getenv('GOFMT_BIN',        'gofmt')
+    GIT           = os.getenv('GIT_BIN',           'git')
+    HARDLINK      = os.getenv('HARDLINK_BIN',      'hardlink')
+    IMPLANTISOMD5 = os.getenv('IMPLANTISOMD5_BIN', 'implantisomd5')
+    MKISOFS       = os.getenv('MKISOFS_BIN',       'mkisofs')
+    SKOPEO        = os.getenv('SKOPEO_BIN',        'skopeo')
+    VAGRANT       = os.getenv('VAGRANT_BIN',       'vagrant')
+    OPERATOR_SDK  = os.getenv('OPERATOR_SDK_BIN',  'operator-sdk')
+    GOFMT         = os.getenv('GOFMT_BIN',         'gofmt')
 
     @property
     def command_name(self) -> str:

--- a/docs/developer/building/requirements.rst
+++ b/docs/developer/building/requirements.rst
@@ -19,6 +19,9 @@ Mandatory
 - `hardlink <https://jak-linux.org/projects/hardlink/>`_: to de-duplicate images
   layers
 - mkisofs: to create the MetalK8s ISO
+- `implantisomd5` from the
+  `isomd5sum <https://github.com/rhinstaller/isomd5sum>`_ package: to embed an
+  MD5 checksum in the generated ISO, allowing for its integrity to be checked
 
 Optional
 --------

--- a/docs/installation/bootstrap.rst
+++ b/docs/installation/bootstrap.rst
@@ -9,7 +9,10 @@ Preparation
    from the Scality repositories.
 
 #. Download the MetalK8s ISO file on the machine that will host the bootstrap
-   node. Mount this ISO file at the path of your choice (we will use
+   node. Run `checkisomd5 --verbose <path-to-iso>` to validate its integrity
+   (`checkisomd5` is part of the `isomd5sum` package).
+
+#. Mount this ISO file at the path of your choice (we will use
    ``/srv/scality/metalk8s-|version|`` for the rest of this guide, as this is
    where the ISO will be mounted automatically after running the bootstrap
    script):

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -95,7 +95,23 @@ models:
         END
   - ShellCommand: &check_iso_checksum
       name: Check image with checksum
-      command: sha256sum -c SHA256SUM
+      command: |
+        sha256sum -c SHA256SUM
+        # Check the embedded MD5, but only if one is found (i.e.,
+        # MetalK8s >= 2.8)
+        # We optimistically assume the checksum section is always found
+        # within the first 64kB of the ISO, which is not guaranteed. If
+        # this ever becomes an issue in CI, we'll need to find a better way.
+        # Hopefully by then we don't need this check anymore anyway (MetalK8s
+        # >= 2.9).
+        dd if=metalk8s.iso bs=1k count=64 | strings | grep "THIS IS NOT THE SAME AS RUNNING MD5SUM ON THIS ISO"
+        if [ $? -eq 0 ]; then
+          echo "Found signs of an embedded MD5 checksum, validating as well"
+          sudo yum install --assumeyes isomd5sum
+          checkisomd5 metalk8s.iso
+        else
+          echo "No embedded MD5 checksum detected, skipping validation"
+        fi
       haltOnFailure: true
   - Upload: &upload_artifacts
       name: Upload artifacts

--- a/eve/workers/pod-builder/Dockerfile
+++ b/eve/workers/pod-builder/Dockerfile
@@ -12,6 +12,7 @@ RUN yum install -y --setopt=skip_missing_names_on_install=False \
     sudo \
     gcc \
     hardlink \
+    isomd5sum \
     make \
     python36 \
     python36-devel \


### PR DESCRIPTION
The `isomd5sum` tools allow to embed a hash of data sectors found in an
ISO file in an otherwise unused section, hence allowing the integrity of
(the data sectors of) an ISO image to be checked. This is, e.g., also
done for RHEL/CentOS/Fedora ISOs (their integrity can be checked at boot
time).

This commit adds a call to `implantisomd5` at the end of the buildchain,
right after the ISO is created and before its SHA256 is calculated.

Given this, one can run `checkisomd5` on a resulting ISO file after
download to ensure it's not corrupted.

Fixes: #3026
See: https://github.com/scality/metalk8s/issues/3026
See: https://github.com/rhinstaller/isomd5sum