### PR TITLE
salt: Set salt-master timeout to 10 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@
 - Fix invalid return of Success when `wait_minions` runner fails
   (PR [#3031](https://github.com/scality/metalk8s/pull/3031))
 
+- Improve the robustness of salt orchestrate execution
+  (PR [#3033](https://github.com/scality/metalk8s/pull/3033))
+
 ## Release 2.6.1 (in development)
 
 ### Features Added

--- a/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
+++ b/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
@@ -2,6 +2,8 @@ interface: {{ salt_ip }}
 
 log_level: {{ 'debug' if debug else 'info' }}
 
+timeout: 10
+
 peer:
   .*:
     - x509.sign_remote_certificate


### PR DESCRIPTION
**Component**:

'salt'

**Context**: 

Time to time we get some failure during orchestrate execution.

For example, if pillar calculation take too much time when executing a salt states on a salt-minion we may get an error:
```
During handling of the above exception, another exception occurred:
              
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/salt/state.py", line 2154, in call
    *cdata["args"], **cdata["kwargs"]
  File "/usr/lib/python3.6/site-packages/salt/loader.py", line 2106, in wrapper
    return f(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/states/saltmod.py", line 322, in state
    cmd_ret = __salt__["saltutil.cmd"](tgt, fun, **cmd_kw)
  File "/usr/lib/python3.6/site-packages/salt/modules/saltutil.py", line 1657, in cmd
    fcn_ret = _exec(client, tgt, fun, arg, timeout, tgt_type, ret, kwarg, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/modules/saltutil.py", line 1609, in _exec
    for ret_comp in _cmd(**cmd_kwargs):
  File "/usr/lib/python3.6/site-packages/salt/client/__init__.py", line 868, in cmd_iter
    **kwargs
  File "/usr/lib/python3.6/site-packages/salt/client/__init__.py", line 1207, in get_iter_returns
    jid, list(minions - found), "list", **kwargs
  File "/usr/lib/python3.6/site-packages/salt/client/__init__.py", line 254, in gather_job_info
    **kwargs
  File "/usr/lib/python3.6/site-packages/salt/client/__init__.py", line 361, in run_job
    raise SaltClientError(general_exception)
salt.exceptions.SaltClientError: Salt request timed out. The master is not responding. You may need to run your command with `--async` in order to bypass the congested event bus. With `--async`, the CLI tool will print the job id (jid) and exit immediately without listening for responses. You can then use `salt-run jobs.lookup_jid` to look up the results of the job in the job cache later.
```

Also if for whatever reason a salt-minion is not able to send an event to a job before timeout we get an error
```
----------
          ID: <state id>
    Function: salt.state
      Result: False
     Comment: Run failed on minions: <minion id>
     Started: 17:13:27.036267
    Duration: 2313.207 ms
     Changes:   
              <minion id>:
                  False
```

**Summary**:

By default salt master timeout is set to 5 seconds, and time to time
it's not sufficient, as pillar compute may take some time and also it
happens that some time a salt-minion take a bit of time to answer a job
listing when executing a salt states


---
