### PR TITLE
changelog: Add missing entries for 2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Release 2.6.1 (development in progress)
 
+### Features Added
+- [#2919](https://github.com/scality/metalk8s/issues/2919) - [UI] Ability to
+  sort in Nodes list (PR [#2926](https://github.com/scality/metalk8s/pull/2926))
+
+### Enhancements
+- [UI] Upgrade React to 17.0.1
+  (PR [#2926](https://github.com/scality/metalk8s/pull/2926))
+
+### Bug Fixes
+- [#2949](https://github.com/scality/metalk8s/issues/2949) - [UI] Handle
+  terminating environments and improve SaltAPI error handling
+  (PR [#2954](https://github.com/scality/metalk8s/pull/2954))
+
 ## Release 2.6.0
 
 ### Breaking changes


### PR DESCRIPTION
Even if we don't release this version yet, changes should be listed in
the appropriate section and merged in the same branch.