### PR TITLE
Alerts without message annotation no detail in UI 

### DIFF
--- a/eve/workers/pod-integration-tests/ui/worker.Dockerfile
+++ b/eve/workers/pod-integration-tests/ui/worker.Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-ARG BUILDBOT_VERSION=0.9.12
+ARG BUILDBOT_VERSION=2.0.1
 
 ENV LANG=en_US.utf8
 
@@ -16,12 +16,13 @@ RUN yum install -y --setopt=skip_missing_names_on_install=False \
         libXtst* \
         libXScrnSaver* \
         nodejs \
-        python-devel \
-        python-pip \
+        python36 \
+        python36-devel \
+        python36-pip \
         sudo \
         xorg-x11-server-Xvfb
 
-RUN pip install buildbot-worker==${BUILDBOT_VERSION}
+RUN python3.6 -m pip install buildbot-worker==${BUILDBOT_VERSION}
 
 RUN adduser -u 1042 --home /home/eve eve
 RUN echo "eve ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/eve

--- a/tests/post/steps/test_monitoring.py
+++ b/tests/post/steps/test_monitoring.py
@@ -252,7 +252,8 @@ def check_deployed_rules(host, prometheus_api):
             # For now, we only need alerting rules
             if rule['type'] == "alerting":
                 message = rule['annotations'].get('message') or \
-                    rule['annotations'].get('summary')
+                    rule['annotations'].get('summary') or \
+                    rule['annotations'].get('description')
                 fixup_alerting_rule = {
                     'name': rule['name'],
                     'severity': rule['labels']['severity'],

--- a/tools/rule_extractor/rule_extractor.py
+++ b/tools/rule_extractor/rule_extractor.py
@@ -126,7 +126,8 @@ def main():
                 # For now, we only need alerting rules
                 if rule['type'] == "alerting":
                     message = rule['annotations'].get('message') or \
-                        rule['annotations'].get('summary')
+                        rule['annotations'].get('summary') or \
+                        rule['annotations'].get('description')
                     fixup_alerting_rule = {
                         'name': rule['name'],
                         'severity': rule['labels']['severity'],

--- a/ui/src/components/VolumeAlertsTab.js
+++ b/ui/src/components/VolumeAlertsTab.js
@@ -100,7 +100,7 @@ const ActiveAlertsCard = (props) => {
       return {
         name: alert.labels.alertname,
         severity: alert.labels.severity,
-        alert_description: alert.annotations.message,
+        alert_description: alert.annotations.description || alert.annotations.summary || alert.annotations.message,
         active_since: alert.startsAt,
       };
     }) ?? [];

--- a/ui/src/containers/ClusterMonitoring.js
+++ b/ui/src/containers/ClusterMonitoring.js
@@ -172,7 +172,7 @@ const ClusterMonitoring = (props) => {
       return {
         name: alert.labels.alertname,
         severity: alert.labels.severity,
-        message: alert.annotations.message,
+        message: alert.annotations.description || alert.annotations.summary || alert.annotations.message,
         activeAt: alert.startsAt,
       };
     });


### PR DESCRIPTION
originally from https://github.com/scality/metalk8s/pull/3030

> Component:
> 
> ui, tests
> 
> Context:
> #2994
> 
> Summary:
> Changes made to display alert message on UI when prometheus alerts annotation have any of description, summary or message field. Currently blank alert message shown for many of prometheus alerts in metalk8s UI.
> 

Closes: #2994
Closes: #3030