### PR TITLE
salt: Add `bash-completion` for `kubectl`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - Bump etcd version to 3.4.13-0 (PR[#3008](https://github.com/scality/metalk8s/pull/3008))
 
+- [#2996](https://github.com/scality/metalk8s/issues/2996) - The `bash-completion`
+  completions for the `kubectl` command are now provided when `kubectl` is installed
+  (PR [#3039](https://github.com/scality/metalk8s/pull/3039))
+
 ## Release 2.7.0 (in development)
 ### Enhancements
 - Bump Kubernetes version to 1.18.13 (PR[#2973](https://github.com/scality/metalk8s/pull/2973))

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -465,6 +465,7 @@ SALT_FILES : Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path('salt/metalk8s/sreport/init.sls'),
     Path('salt/metalk8s/sreport/installed.sls'),
 
+    Path('salt/metalk8s/kubectl/configured.sls'),
     Path('salt/metalk8s/kubectl/init.sls'),
     Path('salt/metalk8s/kubectl/installed.sls'),
 

--- a/salt/metalk8s/kubectl/configured.sls
+++ b/salt/metalk8s/kubectl/configured.sls
@@ -1,0 +1,14 @@
+include:
+  - .installed
+
+Create kubectl bash completion file:
+  file.managed:
+    - name: /etc/bash_completion.d/kubectl
+    - contents: __slot__:salt:cmd.run('kubectl completion bash')
+    - makedirs: True
+    - dir_mode: 755
+    - mode: 644
+    - user: root
+    - group: root
+    - require:
+      - metalk8s_package_manager: Install kubectl

--- a/salt/metalk8s/kubectl/init.sls
+++ b/salt/metalk8s/kubectl/init.sls
@@ -5,7 +5,8 @@
 # ================
 #
 # * installed   -> Ensure kubectl is installed
+# * configured  -> Configure bash completion for kubectl
 #
 
 include:
-  - .installed
+  - .configured


### PR DESCRIPTION
**Component**:

'salt', 'kubectl'

**Context**: 

#2996 

**Summary**:

Add a `/etc/bash_completion.d/kubectl` file for completion in bash for
kubectl command


---

Fixes: #2996
