### PR TITLE
salt: Create `/var/run/salt` directory in salt-master manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 
 - Bump etcd version to 3.4.13-0 (PR[#3008](https://github.com/scality/metalk8s/pull/3008))
 
+### Bug fixes
+- [#3022](https://github.com/scality/metalk8s/issues/3022) - Ensure salt-master
+  container can start at reboot even if local salt-minion is down
+  (PR [#3041](https://github.com/scality/metalk8s/pull/3041))
+
 ## Release 2.7.0 (in development)
 ### Enhancements
 - Bump Kubernetes version to 1.18.13 (PR[#2973](https://github.com/scality/metalk8s/pull/2973))

--- a/salt/metalk8s/salt/master/files/salt-master-manifest.yaml.j2
+++ b/salt/metalk8s/salt/master/files/salt-master-manifest.yaml.j2
@@ -118,7 +118,7 @@ spec:
     - name: run
       hostPath:
         path: '/var/run/salt'
-        type: Directory
+        type: DirectoryOrCreate
     {%- for env, archive in archives.items() | sort(attribute='0') %}
     - name: states-{{ env | replace('.', '-') }}
       hostPath:


### PR DESCRIPTION
**Component**:

'salt'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

#3022 

**Summary**:

Salt process create a `/var/run/salt` directory at startup this
directory is shared between salt-master container and salt-minion
running on the host so it's mounted in the container, since this
directory does not exists at system boot we need to use
`DirectoryOrCreate` so that salt-master does not need salt-minion to
start before being able to start

---

Fixes: #3022
