### PR TITLE
buildchain,ui,deployment: use `nginx-alpine`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@
   completions for the `kubectl` command are now provided when `kubectl` is installed
   (PR [#3039](https://github.com/scality/metalk8s/pull/3039))
 
+- Use the [Alpine Linux](https://alpinelinux.org)-based version of the
+  [nginx](https://nginx.org) [container image](https://hub.docker.com/_/nginx),
+  reducing disk space used by the ISO and in image caches
+  (PR [#3047](https://github.com/scality/metalk8s/pull/3047))
+
 ### Bug fixes
 - [#3022](https://github.com/scality/metalk8s/issues/3022) - Ensure salt-master
   container can start at reboot even if local salt-minion is down

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -59,7 +59,7 @@ CENTOS_BASE_IMAGE : str = 'docker.io/centos'
 CENTOS_BASE_IMAGE_SHA256 : str = \
     '6ae4cddb2b37f889afd576a17a5286b311dcbf10a904409670827f6f9b50065e'
 
-NGINX_IMAGE_VERSION   : str = '1.15.8'
+NGINX_IMAGE_VERSION   : str = '1.19.6-alpine'
 NODEJS_IMAGE_VERSION  : str = '10.16.0'
 
 # Current build IDs, to be augmented whenever we rebuild the corresponding
@@ -151,7 +151,7 @@ CONTAINER_IMAGES : Tuple[Image, ...] = (
     Image(
         name='nginx',
         version=NGINX_IMAGE_VERSION,
-        digest='sha256:f09fe80eb0e75e97b04b9dfb065ac3fda37a8fac0161f42fca1e6fe4d0977c80',
+        digest='sha256:629df02b47c8733258baf6663e308a86cd23f80247d35407022c35fd91a50ea3',
     ),
     Image(
         name='nginx-ingress-controller',


### PR DESCRIPTION
Instead of using the 'standard' `docker.io/nginx` version, use the
`-alpine` variant (and use a newer version).

Rationale is to reduce the size of the ISO we ship, since we're not
using any fancy `nginx` features in the first place, as well as space
consumed by images pulled by `containerd`.

Results (`du -s ...` of the directories):

```
$ cat before
1613124	_build/root/
1323720	_build/root/images/
43716	_build/root/images/nginx
110292	_build/root/images/nginx-1.15.8.tar
61460	_build/root/images/metalk8s-ui

$ cat after
1456000	_build/root/
1166600	_build/root/images/
9520	_build/root/images/nginx
23312	_build/root/images/nginx-1.19.6-alpine.tar
25516	_build/root/images/metalk8s-ui
```

Or, a total reduction of +- 154MB.