### PR TITLE
Properly fail if a conflicting package is installed and do not install conflicting packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@
   container can start at reboot even if local salt-minion is down
   (PR [#3041](https://github.com/scality/metalk8s/pull/3041))
 
+- Do not install `containerd.io` instead of `containerd` and `runc` when this
+  package is available in one configured repository
+  (PR [#3050](https://github.com/scality/metalk8s/pull/3050))
+
 ## Release 2.7.0 (in development)
 ### Enhancements
 - Bump Kubernetes version to 1.18.15 (PR[#3035](https://github.com/scality/metalk8s/pull/3035))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
   reducing disk space used by the ISO and in image caches
   (PR [#3047](https://github.com/scality/metalk8s/pull/3047))
 
+- [#2992](https://github.com/scality/metalk8s/issues/2992) - Check for conflicting
+  packages already installed on the machine before doing all the installation
+  (PR [#3050](https://github.com/scality/metalk8s/pull/3050))
+
 ### Bug fixes
 - [#3022](https://github.com/scality/metalk8s/issues/3022) - Ensure salt-master
   container can start at reboot even if local salt-minion is down

--- a/buildchain/buildchain/iso.py
+++ b/buildchain/buildchain/iso.py
@@ -64,9 +64,16 @@ FILE_TREES : Tuple[helper.FileTree, ...] = (
     helper.FileTree(
         basename='_iso_add_tree',
         files=(
-            Path('common.sh'),
             Path('iso-manager.sh'),
             Path('solutions.sh'),
+            helper.TemplateFile(
+                task_name='common.sh',
+                source=constants.ROOT/'scripts'/'common.sh.in',
+                destination=constants.ISO_ROOT/'common.sh',
+                context={'VERSION': versions.VERSION},
+                file_dep=[versions.VERSION_FILE],
+                task_dep=['_iso_mkdir_root'],
+            ),
             helper.TemplateFile(
                 task_name='downgrade.sh',
                 source=constants.ROOT/'scripts'/'downgrade.sh.in',

--- a/salt/_modules/metalk8s_checks.py
+++ b/salt/_modules/metalk8s_checks.py
@@ -12,6 +12,93 @@ def __virtual__():
     return __virtualname__
 
 
+def node(raises=True, **kwargs):
+    """Check if the current Salt-minion match some requirements so that it can
+    be used as a MetalK8s node.
+
+    Arguments:
+        raises (bool): the method will raise if there is any problem.
+    """
+    errors = []
+
+    # Run `packages` check
+    pkg_ret = __salt__['metalk8s_checks.packages'](raises=False, **kwargs)
+    if pkg_ret is not True:
+        errors.append(pkg_ret)
+
+    # Compute return of the function
+    if errors:
+        error_msg = 'Node {}: {}'.format(__grains__['id'], '\n'.join(errors))
+        if raises:
+            raise CheckError(error_msg)
+        return error_msg
+
+    return True
+
+
+def packages(conflicting_packages=None, raises=True, **kwargs):
+    """Check if some conflicting package are installed on the machine,
+    return a string (or raise if `raises` is set to `True`) with the list of
+    conflicting packages.
+
+    Arguments:
+        conflicting_packages (dict): override the list of package that conflict
+            with MetalK8s installation.
+        raises (bool): the method will raise if there is any conflicting
+            package.
+
+    Note: We have some logic in this function, so `conflicting_packages` could
+    be:
+    - a single string `<package_name>` which is the name of the conflicting
+      package (it means we conflict with all versions of this package)
+    - a list `[<package_name1>, <package_name2]` with all conflicting package
+      names (it means we conflict with all versions of those packages)
+    - a dict `{<package1_name>: <package1_versions>, <package2_name>: <package2_versions>}`
+      where `package_versions` could be
+      - `None` mean we conflicting with all versions of this package
+      - A string for a single conflicting version of this package
+      - A list of string for multiple conflicting versions of this package
+    """
+    if conflicting_packages is None:
+        conflicting_packages = __salt__['metalk8s.get_from_map'](
+            'repo', saltenv=kwargs.get('saltenv')
+        )['conflicting_packages']
+
+    if isinstance(conflicting_packages, str):
+        conflicting_packages = {conflicting_packages: None}
+    elif isinstance(conflicting_packages, list):
+        conflicting_packages = {
+            package: None
+            for package in conflicting_packages
+        }
+    errors = []
+
+    installed_packages = __salt__['pkg.list_pkgs'](attr="version")
+    for package, version in conflicting_packages.items():
+        if isinstance(version, str):
+            version = [version]
+        if package in installed_packages:
+            conflicting_versions = set(
+                pkg_info['version']
+                for pkg_info in installed_packages[package]
+            )
+            if version:
+                conflicting_versions.intersection_update(version)
+
+            if conflicting_versions:
+                for ver in sorted(conflicting_versions):
+                    errors.append(
+                        "Package {}-{} conflicts with MetalK8s installation, "
+                        "please remove it.".format(package, ver)
+                    )
+
+    error_msg = '\n'.join(errors)
+    if error_msg and raises:
+        raise CheckError(error_msg)
+
+    return error_msg or True
+
+
 def sysctl(params, raises=True):
     """Check if the given sysctl key-values match the ones in memory and
     return a string (or raise if `raises` is set to `True`) with the list

--- a/salt/metalk8s/defaults.yaml
+++ b/salt/metalk8s/defaults.yaml
@@ -37,6 +37,14 @@ kubeadm_preflight:
       - coreutils             # provides touch
 
 repo:
+  conflicting_packages:
+    # List of package that conflict with MetalK8s installation
+    # <package_name>: [<version1>, <version2>]
+    # Is version list is None then we consider all versions as conflicting
+    docker: null
+    docker-ce: null
+    containerd.io: null
+
   config:
     directory: '/var/lib/metalk8s/repositories/conf.d'
     default: 'default.conf'

--- a/salt/metalk8s/macro.sls
+++ b/salt/metalk8s/macro.sls
@@ -1,5 +1,6 @@
 {%- from "metalk8s/map.jinja" import repo with context %}
 {%- from "metalk8s/map.jinja" import packages with context %}
+{%- from "metalk8s/map.jinja" import package_exclude_list with context %}
 
 {%- macro pkg_installed(name='') -%}
   {%- set package_name = packages.get(name, name) %}
@@ -16,5 +17,9 @@
     - reload_modules: True
     {%- if grains['os_family'].lower() == 'debian' %}
     - refresh: True
+    {%- endif %}
+    {%- if package_exclude_list %}
+    - setopt:
+        - exclude={{ package_exclude_list | join(',') }}
     {%- endif %}
 {%- endmacro -%}

--- a/salt/metalk8s/map.jinja
+++ b/salt/metalk8s/map.jinja
@@ -303,3 +303,29 @@
 {% set certificates = salt['grains.filter_by']({
   'default': {}
 }, merge=defaults.get('certificates')) %}
+
+{#- Compute package exclude list to be used in yum command #}
+{%- set package_exclude_list = [] %}
+{%- if repo.conflicting_packages | is_list %}
+  {#- It's already a list of package name #}
+  {%- do package_exclude_list.extend(repo.conflicting_packages) %}
+{%- elif repo.conflicting_packages is mapping %}
+  {#- It's a dict {"<package_name>": <versions> } #}
+  {%- for p_name, p_versions in repo.conflicting_packages.items() %}
+    {%- if p_versions | is_list %}
+      {#- It's a list of versions for this specific package #}
+      {%- for p_ver in p_versions %}
+        {%- do package_exclude_list.append(p_name ~ '-' ~ p_ver) %}
+      {%- endfor %}
+    {%- elif p_versions %}
+      {#- It's a single version #}
+      {%- do package_exclude_list.append(p_name ~ '-' ~ p_versions) %}
+    {%- else %}
+      {#- No versions specified #}
+      {%- do package_exclude_list.append(p_name) %}
+    {%- endif %}
+  {%- endfor %}
+{%- elif repo.conflicting_packages %}
+  {#- Consider it's a single package name #}
+  {%- do package_exclude_list.append(repo.conflicting_packages) %}
+{%- endif %}

--- a/salt/metalk8s/orchestrate/deploy_node.sls
+++ b/salt/metalk8s/orchestrate/deploy_node.sls
@@ -1,3 +1,5 @@
+{%- from "metalk8s/map.jinja" import repo with context %}
+
 {%- set node_name = pillar.orchestrate.node_name %}
 {%- set run_drain = not pillar.orchestrate.get('skip_draining', False) %}
 {%- set version = pillar.metalk8s.nodes[node_name].version %}
@@ -17,6 +19,23 @@ Install python36:
     - raw_shell: true
     - roster: kubernetes
 
+Check node:
+  metalk8s.saltutil_cmd:
+    - name: metalk8s_checks.node
+    - tgt: {{ node_name }}
+    - ssh: true
+    - roster: kubernetes
+    - kwarg:
+        # NOTE: We need to use the `conflicting_packages` from the salt
+        # master since in salt-ssh when running an execution module we cannot
+        # embbed additional files (especially `map.jinja` in this case)
+        # Sees: https://github.com/saltstack/salt/issues/59314
+        conflicting_packages: >-
+          {{ repo.conflicting_packages | tojson }}
+    - failhard: true
+    - require:
+      - metalk8s: Install python36
+
 Deploy salt-minion on a new node:
   salt.state:
     - ssh: true
@@ -25,6 +44,8 @@ Deploy salt-minion on a new node:
     - saltenv: metalk8s-{{ version }}
     - sls:
       - metalk8s.roles.minion
+    - require:
+      - metalk8s: Check node
 
 Accept key:
   module.run:

--- a/salt/metalk8s/repo/redhat.sls
+++ b/salt/metalk8s/repo/redhat.sls
@@ -1,6 +1,7 @@
 {%- from "metalk8s/map.jinja" import metalk8s with context %}
 {%- from "metalk8s/map.jinja" import packages with context %}
 {%- from "metalk8s/map.jinja" import repo with context %}
+{%- from "metalk8s/map.jinja" import package_exclude_list with context %}
 
 {%- set repo_host = pillar.metalk8s.endpoints['repositories'].ip %}
 {%- set repo_port = pillar.metalk8s.endpoints['repositories'].ports.http %}
@@ -101,6 +102,7 @@ Check packages availability:
   module.wait:
     - metalk8s_package_manager.check_pkg_availability:
       - pkgs_info: {{ repo.packages | tojson }}
+      - exclude: {{ package_exclude_list | tojson }}
     - require_in:
       - test: Repositories configured
 

--- a/salt/tests/unit/modules/files/test_metalk8s_checks.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_checks.yaml
@@ -1,3 +1,160 @@
+node:
+  - packages_ret: True
+    result: True
+  - packages_ret: "Package abcd got an error because of banana"
+    expect_raise: True
+    result: "Node my_node_1: Package abcd got an error because of banana"
+  - packages_ret: "Package toto got an error :)"
+    raises: False
+    result: "Node my_node_1: Package toto got an error :)"
+
+packages:
+  # 1. Success: No conflicting packages to check
+  - conflicting_packages: {}
+    result: True
+
+  # 2. Success: Conflicting packages not installed
+  - conflicting_packages:
+      my-not-installed-package: null
+      my-not-installed-package2: null
+    list_pkgs_ret:
+      my-installed-package:
+        - version: 1.2.3
+    result: True
+  # 2. bis
+  - conflicting_packages: my-not-installed-package
+    list_pkgs_ret:
+      my-installed-package:
+        - version: 1.2.3
+    result: True
+  # 2. ter
+  - conflicting_packages:
+     - my-not-installed-package
+     - my-not-installed-package2
+    list_pkgs_ret:
+      my-installed-package:
+        - version: 1.2.3
+    result: True
+
+  # 3. Success: Conflicting packages (from map) not installed
+  - get_map_ret:
+      conflicting_packages:
+        my-not-installed-package: null
+    list_pkgs_ret:
+      my-installed-package:
+        - version: 1.2.3
+    result: True
+
+  # 4. Success: Conflicting packages in specific version not installed
+  - conflicting_packages:
+      my-installed-package:
+        - 1.2.4
+        - 1.2.5
+    list_pkgs_ret:
+      my-installed-package:
+        - version: 1.2.3
+    result: True
+
+  # 5. Error: Conflicting packages installed
+  - conflicting_packages:
+      my-installed-package: null
+      my-not-installed-package: null
+    list_pkgs_ret:
+      my-installed-package:
+        - version: 1.2.3
+    expect_raise: True
+    result: |-
+      Package my-installed-package-1.2.3 conflicts with MetalK8s installation, please remove it.
+  # 5. bis
+  - conflicting_packages: my-installed-package
+    list_pkgs_ret:
+      my-installed-package:
+        - version: 1.2.3
+    expect_raise: True
+    result: |-
+      Package my-installed-package-1.2.3 conflicts with MetalK8s installation, please remove it.
+  # 5. ter
+  - conflicting_packages:
+      - my-not-installed-package
+      - my-installed-package
+    list_pkgs_ret:
+      my-installed-package:
+        - version: 1.2.3
+    expect_raise: True
+    result: |-
+      Package my-installed-package-1.2.3 conflicts with MetalK8s installation, please remove it.
+
+  # 6. Error: Conflicting packages in specific version installed
+  - conflicting_packages:
+      my-installed-package: 1.2.3
+    list_pkgs_ret:
+      my-installed-package:
+        - version: 1.2.3
+    expect_raise: True
+    result: |-
+      Package my-installed-package-1.2.3 conflicts with MetalK8s installation, please remove it.
+  # 6. bis
+  - conflicting_packages:
+      my-installed-package:
+        - 0.1.3
+        - 1.2.4
+        - 1.2.3
+    list_pkgs_ret:
+      my-installed-package:
+        - version: 1.2.3
+    expect_raise: True
+    result: |-
+      Package my-installed-package-1.2.3 conflicts with MetalK8s installation, please remove it.
+  # 6. ter (no raise)
+  - conflicting_packages:
+      my-installed-package:
+        - 0.1.3
+        - 1.2.4
+        - 1.2.3
+    list_pkgs_ret:
+      my-installed-package:
+        - version: 1.2.3
+    raises: False
+    result: |-
+      Package my-installed-package-1.2.3 conflicts with MetalK8s installation, please remove it.
+
+  # 7. Error: Multiple conflicting package installed
+  - conflicting_packages:
+      my-installed-package1: null
+      my-installed-package2:
+        - 5.6.7
+    list_pkgs_ret:
+      my-installed-package1:
+        - version: 1.2.3
+      my-installed-package2:
+        - version: 5.6.7
+    expect_raise: True
+    result: |-
+      Package my-installed-package1-1.2.3 conflicts with MetalK8s installation, please remove it.
+      Package my-installed-package2-5.6.7 conflicts with MetalK8s installation, please remove it.
+
+  # 8. Error: Multiple package of same version installed
+  - conflicting_packages:
+      my-installed-package: null
+    list_pkgs_ret:
+      my-installed-package:
+        - version: 1.2.3
+        - version: 4.5.6
+    expect_raise: True
+    result: |-
+      Package my-installed-package-1.2.3 conflicts with MetalK8s installation, please remove it.
+      Package my-installed-package-4.5.6 conflicts with MetalK8s installation, please remove it.
+  # 8. bis
+  - conflicting_packages:
+      my-installed-package: 4.5.6
+    list_pkgs_ret:
+      my-installed-package:
+        - version: 1.2.3
+        - version: 4.5.6
+    expect_raise: True
+    result: |-
+      Package my-installed-package-4.5.6 conflicts with MetalK8s installation, please remove it.
+
 sysctl:
   - params:
       net.ipv4.ip_forward: 1

--- a/salt/tests/unit/modules/files/test_metalk8s_package_manager_yum.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_package_manager_yum.yaml
@@ -141,6 +141,9 @@ check_pkg_availability:
   - pkgs_info:
       my_package:
         version: "3.11.12"
+    exclude:
+      - my-excluded-package
+      - my-second-excluded-package-1.2.3
 
   # check 3 package available
   - pkgs_info:
@@ -150,6 +153,7 @@ check_pkg_availability:
         version: null
       my_third_package:
         version: "3.10.5-0.el7"
+    exclude: "my-excluded-package,my-second-excluded-package-1.2.3"
 
   # check 1 package not available - error when retrieving it
   - pkgs_info:

--- a/salt/tests/unit/modules/test_metalk8s_checks.py
+++ b/salt/tests/unit/modules/test_metalk8s_checks.py
@@ -32,6 +32,60 @@ class Metalk8sChecksTestCase(TestCase, mixins.LoaderModuleMockMixin):
         """
         self.assertEqual(metalk8s_checks.__virtual__(), 'metalk8s_checks')
 
+    @utils.parameterized_from_cases(YAML_TESTS_CASES["node"])
+    def test_node(self, packages_ret, result, expect_raise=False, **kwargs):
+        """
+        Tests the return of `node` function
+        """
+        packages_mock = MagicMock(return_value=packages_ret)
+
+        salt_dict = {
+            'metalk8s_checks.packages': packages_mock
+        }
+
+        with patch.dict(metalk8s_checks.__grains__, {'id': 'my_node_1'}), \
+                patch.dict(metalk8s_checks.__salt__, salt_dict):
+            if expect_raise:
+                self.assertRaisesRegex(
+                    CheckError,
+                    result,
+                    metalk8s_checks.node,
+                    **kwargs
+                )
+            else:
+                self.assertEqual(
+                    metalk8s_checks.node(**kwargs),
+                    result
+                )
+
+    @utils.parameterized_from_cases(YAML_TESTS_CASES["packages"])
+    def test_packages(self, result, get_map_ret=None, list_pkgs_ret=None,
+                      expect_raise=False, **kwargs):
+        """
+        Tests the return of `packages` function
+        """
+        get_map_mock = MagicMock(return_value=get_map_ret)
+        list_pkgs_mock = MagicMock(return_value=list_pkgs_ret or {})
+
+        salt_dict = {
+            'metalk8s.get_from_map': get_map_mock,
+            'pkg.list_pkgs': list_pkgs_mock
+        }
+
+        with patch.dict(metalk8s_checks.__salt__, salt_dict):
+            if expect_raise:
+                self.assertRaisesRegex(
+                    CheckError,
+                    result,
+                    metalk8s_checks.packages,
+                    **kwargs
+                )
+            else:
+                self.assertEqual(
+                    metalk8s_checks.packages(**kwargs),
+                    result
+                )
+
     @utils.parameterized_from_cases(YAML_TESTS_CASES["sysctl"])
     def test_sysctl(self, params, data, result, raises=False):
         """

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -182,6 +182,7 @@ main() {
     run "Installing mandatory packages" install_packages "${PACKAGES[@]}"
     run "Configuring Salt minion to run in local mode" configure_salt_minion_local_mode
     run "Ensure archive is available" ensure_archives_mounted
+    run "Checking local node" check_local_node
 
     orchestrate_bootstrap
 

--- a/scripts/common.sh.in
+++ b/scripts/common.sh.in
@@ -353,6 +353,11 @@ configure_salt_minion_local_mode() {
         pillar="{'metalk8s': {'archives': '$BASE_DIR'}}" saltenv=base
 }
 
+check_local_node() {
+    "$SALT_CALL" --local --retcode-passthrough metalk8s_checks.node \
+        saltenv=metalk8s-@@VERSION
+}
+
 get_salt_env() {
     "$SALT_CALL" --out txt slsutil.renderer \
         string="metalk8s-{{ pillar.metalk8s.nodes[grains.id].version }}" \

--- a/scripts/restore.sh.in
+++ b/scripts/restore.sh.in
@@ -340,6 +340,7 @@ run "Stopping Salt minion service" stop_salt_minion_service
 run "Configuring local repositories" configure_repositories
 run "Installing mandatory packages" install_packages "${PACKAGES[@]}"
 run "Configuring Salt minion to run in local mode" configure_salt_minion_local_mode
+run "Checking local node" check_local_node
 
 run "Restoring MetalK8s configurations" restore_metalk8s_conf
 run "Restoring CAs certificates and keys" restore_cas


### PR DESCRIPTION
**Component**:

'salt', 'check', 'deployment'

**Context**: 

#2992 

**Summary**:

- Add an execution module to retrieve value from `map.jinja`
- Check for conflicting package installed during bootstrap and expansion
- Exclude conflicting packages when installing package in salt (e.g: we do not install `containerd.io` instead of `containerd` and `runc`) (NOTE that before this fix when running `containerd` SLS if `containerd.io` is available we install this one instead of `runc` and `containerd`)

**Acceptance criteria**: 

Bootstrap output when docker-ce installed on the host
```
# /srv/scality/metalk8s-2.8.0-dev/bootstrap.sh 
> Determine the OS... done [0s]
> Checking that BootstrapConfiguration is present... done [0s]
> Pre-minion system tests... done [0s]
> Configure internal repositories... done [1s]
> Check mandatory packages presence... done [4s]
> Disabling Salt minion service... done [0s]
> Stopping Salt minion service... done [0s]
> Installing mandatory packages... done [11s]
> Configuring Salt minion to run in local mode... done [6s]
> Ensure archive is available... done [2s]
> Checking local node... fail [2s]

Failure while running step 'Checking local node'

Command: check_local_node

Output:

<< BEGIN >>
Error running 'metalk8s_checks.node': Node bootstrap: Package containerd.io-1.4.3 conflicts with MetalK8s installation, please remove it.
Package docker-ce-20.10.2 conflicts with MetalK8s installation, please remove it.
<< END >>

This script will now exit
```

Expansion output when docker-ce installed on this new node
```
# crictl exec -it 8cf89df3f31ef salt-run state.sls metalk8s.orchestrate.deploy_node saltenv=metalk8s-2.8.0-dev pillar="{'orchestrate': {'node_name': 'node-1'}}"
[...]
bootstrap_master:
[...]
----------
          ID: Check node
    Function: metalk8s.saltutil_cmd
        Name: metalk8s_checks.node
      Result: False
     Comment: Running function metalk8s_checks.node failed on minions: node-1
     Started: 14:45:26.883648
    Duration: 3345.072 ms
     Changes:   
              ----------
              node-1:
                  ----------
                  retcode:
                      1
                  stderr:
                      Error running 'metalk8s_checks.node': Node node-1: Package containerd.io-1.4.3 conflicts with MetalK8s installation, please remove it.
                      Package docker-ce-20.10.2 conflicts with MetalK8s installation, please remove it.
                  stdout:

Summary for bootstrap_master
------------
Succeeded: 1 (changed=2)
Failed:    1
------------
Total states run:     2
Total run time:   5.698 s

```

---

Fixes: #2992 
