### PR TITLE
salt: Use slot to write beacon configuration

### DIFF
--- a/salt/metalk8s/beacon/certificates.sls
+++ b/salt/metalk8s/beacon/certificates.sls
@@ -63,7 +63,7 @@ Add beacon for kubeconfig expiration:
 Write beacons configuration:
   file.managed:
     - name: /etc/salt/minion.d/beacons.conf
-    - contents: {{ salt['beacons.list']() | json }}
+    - contents: __slot__:salt:beacons.list()
 {%- else %}
 No certificate or kubeconfig to watch for this node:
   test.nop


### PR DESCRIPTION
**Component**:
salt

**Context**: 
We were using Jinja to render the content of the beacons configuration file, but this Jinja
is rendered before the beacons are actually configured, so it fails the first time.

**Summary**:
We now use the slot mechanism to call the `beacons.list` module after the runtime configuration is applied.

**Acceptance criteria**:
No errors related to `beacons.conf` file in the log during installation.