### PR TITLE
Certificates beacon no longer check apiserver URL

### DIFF
--- a/salt/_beacons/metalk8s_kubeconfig_info.py
+++ b/salt/_beacons/metalk8s_kubeconfig_info.py
@@ -68,8 +68,6 @@ def beacon(config):
     _config = _flatten_config(config)
 
     ca_minion = __pillar__['metalk8s']['ca']['minion']
-    control_plane_ip = __grains__['metalk8s']['control_plane_ip']
-    apiserver = "https://{0}:6443".format(control_plane_ip)
     b64_ca_cert = __salt__['mine.get'](
         ca_minion, 'kubernetes_root_ca_b64'
     )[ca_minion]
@@ -87,8 +85,7 @@ def beacon(config):
             days_remaining = notify_days
 
         if not __salt__['metalk8s_kubeconfig.validate'](
-                cert_path, b64_ca_cert, apiserver,
-                days_remaining=days_remaining):
+                cert_path, b64_ca_cert, days_remaining=days_remaining):
             log.info(
                 "kubeconfig %s needs to be regenerated", cert_path
             )

--- a/salt/_modules/metalk8s_kubeconfig.py
+++ b/salt/_modules/metalk8s_kubeconfig.py
@@ -16,7 +16,7 @@ def __virtual__():
 
 def validate(filename,
              expected_ca_data,
-             expected_api_server,
+             expected_api_server=None,
              expected_cn=None,
              days_remaining=90):
     """Validate a kubeconfig filename.
@@ -55,7 +55,7 @@ def validate(filename,
     if current_ca_data != expected_ca_data:
         return False
 
-    if current_api_server != expected_api_server:
+    if expected_api_server and current_api_server != expected_api_server:
         return False
 
     # Client Key and certificate verification

--- a/salt/_modules/metalk8s_kubeconfig.py
+++ b/salt/_modules/metalk8s_kubeconfig.py
@@ -15,7 +15,7 @@ def __virtual__():
 
 
 def validate(filename,
-             expected_ca_data,
+             expected_ca_data=None,
              expected_api_server=None,
              expected_cn=None,
              days_remaining=90):
@@ -52,7 +52,7 @@ def validate(filename,
     except (KeyError, IndexError):
         return False
 
-    if current_ca_data != expected_ca_data:
+    if expected_ca_data and current_ca_data != expected_ca_data:
         return False
 
     if expected_api_server and current_api_server != expected_api_server:


### PR DESCRIPTION
**Component**:
salt

**Context**:
In kubeconfig beacon we check for the apiserver URL with a specific hardcoded port (6443) which is not working for some of the kubeconfigs (e.g. calico), thus triggering a certificate renewal every time the beacon run for this certificate (luckily the certificate is not renewed because there is too much days left).

**Summary**:
Make the apiserver check optional in the `metalk8s_kubeconfig.validate()` function and no longer check it in kubeconfig beacon.

**Acceptance criteria**:
to be tested