### PR TITLE
salt: Do not restart `salt-minion` process in background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Release 2.7.1 (in development)
 
+### Bug fixes
+- Fix a bug where salt-minion process not get properly restarted
+  (PR [#3059](https://github.com/scality/metalk8s/pull/3059))
+
 ## Release 2.7.0
 ### Features Added
 - [#2964](https://github.com/scality/metalk8s/issues/2964) - [UI] Ability to

--- a/salt/metalk8s/salt/minion/running.sls
+++ b/salt/metalk8s/salt/minion/running.sls
@@ -1,7 +1,6 @@
 Restart salt-minion:
   cmd.wait:
     - name: 'salt-call --local service.restart salt-minion > /dev/null'
-    - bg: true
 
 Wait until salt-minion restarted:
   test.configurable_test_state:


### PR DESCRIPTION
**Component**:

'salt'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

It happen time to time, especially during upgrade when reconfiguring the salt-minion process on a node, the salt-minion do not restart properly so we end the upgrade with a salt-minion process stopped
With in log `An instance already running`

**Summary**:

Time to time when restarting the salt-minion process, restart take a bit
of time (more than 10s) so we have 2 salt command trying to start the
salt-minion process at the same time and sometime it happens that at the
end the salt-minion is not running at all `An instance is already running`.
Because the `salt-call --local service.restart salt-minion` first try to
restart the salt-minion process and then `service.running` seems to
happen when salt-minion process is actually not yet restarted.
To fix do not call the `service.restart` command in background so that
we wait for this to finish before running the `service.running` state.
NOTE: That this `bg: True` is not needed here since anyway in this SLS
we wait for the salt-minion process to restart