### PR TITLE
tests: Remove unneeded assertion for ssh_config

### DIFF
--- a/tests/kube_utils.py
+++ b/tests/kube_utils.py
@@ -100,8 +100,6 @@ def get_pods(
         field_selector.append('status.phase={}'.format(state))
 
     if node:
-        assert ssh_config is not None, \
-            'Must provide an `ssh_config` if searching per Node'
         nodename = utils.get_node_name(node, ssh_config)
         field_selector.append('spec.nodeName={}'.format(nodename))
 


### PR DESCRIPTION
In a06bda1, we made the `ssh_config` argument to `kube_utils.get_pods`
optional, and added an assertion that it was never set to `None` if the
`node` argument was set (as it is used to compute the actual node name
from the SSH config file host).
However, the `utils.get_node_name` method already handles a `None`
ssh_config, so this assertion actually breaks behaviour when no
`ssh_config` is passed to pytest.

This reverts this change, which should fix tests run with `tox -e
tests-local`.