### PR TITLE
Check for valid CA minion at the beginning of the bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@
   MetalK8s UI node page
   (PR [#3045](https://github.com/scality/metalk8s/pull/3045))
 
+- Improve error handling when providing invalid CA minion in Bootstrap
+  configuration file
+  (PR [#3065](https://github.com/scality/metalk8s/pull/3065))
+
 ### Bug fixes
 - [#3022](https://github.com/scality/metalk8s/issues/3022) - Ensure salt-master
   container can start at reboot even if local salt-minion is down

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -170,8 +170,8 @@ bootstrap_file_is_present() {
 main() {
     run "Determine the OS" determine_os
     if [ -z "${PYTHON:-}" ]; then
-	run "Installing Python3 package" install_packages python3
-	PYTHON=${PYTHON:-$(command -v python3)}
+        run "Installing Python3 package" install_packages python3
+        PYTHON=${PYTHON:-$(command -v python3)}
     fi
     run "Checking that BootstrapConfiguration is present" bootstrap_file_is_present
     run "Pre-minion system tests" pre_minion_checks

--- a/scripts/common.sh.in
+++ b/scripts/common.sh.in
@@ -354,6 +354,17 @@ configure_salt_minion_local_mode() {
 }
 
 check_local_node() {
+    # NOTE: Today using bootstrap script, bootstrap node is also the CA
+    # minion, so check for minion id equal to CA minion
+    minion_id="$("$SALT_CALL" --out txt --local grains.get id | cut -c 8-)"
+    ca_minion="$("$SALT_CALL" --out txt --local pillar.get metalk8s:ca:minion | cut -c 8-)"
+    if [ "$minion_id" != "$ca_minion" ]; then
+        echo "CA minion \"$ca_minion\" from bootstrap configuration is not equal" \
+            "to the local minion ID \"$minion_id\", you need to change" \
+            "the local minion ID, or update the bootstrap configuration." 1>&2
+        return 1
+    fi
+
     "$SALT_CALL" --local --retcode-passthrough metalk8s_checks.node \
         saltenv=metalk8s-@@VERSION
 }


### PR DESCRIPTION
**Component**:

'script', 'bootstrap'

**Context**: 

When trying to install the bootstrap node and providing an invalid CA minion in the Bootstrap configuration file. Bootstrap script fail with not clear error about Salt-api unable to starts etc.

**Summary**:

Currently in the bootstrap we use the local node as bootstrap node and
also as CA minion, adding a check to be sure that the minion id provided
in the bootstrap config match the local minion id.
NOTE: This check is only part of the script and not somewhere else in
Salt, the `CA:minion` key inside the bootstrap configuration
is here for being able to install MetalK8s using another Salt minion
as CA (Which is to yet supported by the bootstrap script)

**Acceptance criteria**: 

Output when providing invalid minion id as CA minion in bootstrap configuration

```
# /srv/scality/metalk8s-2.8.0-dev/bootstrap.sh 
> Determine the OS... done [0s]
> Checking that BootstrapConfiguration is present... done [0s]
> Pre-minion system tests... done [0s]
> Configure internal repositories... done [0s]
> Check mandatory packages presence... done [8s]
> Disabling Salt minion service... done [0s]
> Stopping Salt minion service... done [0s]
> Installing mandatory packages... done [0s]
> Configuring Salt minion to run in local mode... done [6s]
> Ensure archive is available... done [2s]
> Checking local node... fail [7s]

Failure while running step 'Checking local node'

Command: check_local_node

Output:

<< BEGIN >>
local:
    True
CA minion "bootstrap" from bootstrap configuration is not equal to the local minion id "test-bootstrap.novalocal", you need to either change the local minion id, either update the bootstrap configuration.
<< END >>

This script will now exit

```

---
