### PR TITLE
salt: Add a check about conflicting services for MetalK8s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@
   configuration file
   (PR [#3065](https://github.com/scality/metalk8s/pull/3065))
 
+- [#3067](https://github.com/scality/metalk8s/issues/3067) - Check for conflicting
+  services already started on the machine before doing all the installation
+  (PR [#3069](https://github.com/scality/metalk8s/pull/3069))
+
 ### Bug fixes
 - [#3022](https://github.com/scality/metalk8s/issues/3022) - Ensure salt-master
   container can start at reboot even if local salt-minion is down

--- a/salt/metalk8s/defaults.yaml
+++ b/salt/metalk8s/defaults.yaml
@@ -36,6 +36,10 @@ kubeadm_preflight:
       - iproute               # provides tc
       - coreutils             # provides touch
 
+# List of services that conflict with MetalK8s installation
+conflicting_services:
+  - firewalld
+
 repo:
   conflicting_packages:
     # List of package that conflict with MetalK8s installation

--- a/salt/metalk8s/orchestrate/deploy_node.sls
+++ b/salt/metalk8s/orchestrate/deploy_node.sls
@@ -1,3 +1,4 @@
+{%- from "metalk8s/map.jinja" import defaults with context %}
 {%- from "metalk8s/map.jinja" import repo with context %}
 
 {%- set node_name = pillar.orchestrate.node_name %}
@@ -26,12 +27,14 @@ Check node:
     - ssh: true
     - roster: kubernetes
     - kwarg:
-        # NOTE: We need to use the `conflicting_packages` from the salt
-        # master since in salt-ssh when running an execution module we cannot
-        # embbed additional files (especially `map.jinja` in this case)
+        # NOTE: We need to use the `conflicting_packages` and `conflicting_services`
+        # from the salt master since in salt-ssh when running an execution module
+        # we cannot embbed additional files (especially `map.jinja` in this case)
         # Sees: https://github.com/saltstack/salt/issues/59314
         conflicting_packages: >-
           {{ repo.conflicting_packages | tojson }}
+        conflicting_services: >-
+          {{ defaults.conflicting_services | tojson }}
     - failhard: true
     - require:
       - metalk8s: Install python36

--- a/salt/tests/unit/modules/files/test_metalk8s_checks.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_checks.yaml
@@ -1,12 +1,33 @@
 node:
+  # 1. Everything fine
   - packages_ret: True
+    services_ret: True
     result: True
+
+  # 2. Error with packages
   - packages_ret: "Package abcd got an error because of banana"
+    services_ret: True
     expect_raise: True
     result: "Node my_node_1: Package abcd got an error because of banana"
+  # 2. bis (no raises)
   - packages_ret: "Package toto got an error :)"
+    services_ret: True
     raises: False
     result: "Node my_node_1: Package toto got an error :)"
+
+  # 3. Error with services
+  - packages_ret: True
+    services_ret: "Service abcd got an error because of penguin"
+    expect_raise: True
+    result: "Node my_node_1: Service abcd got an error because of penguin"
+
+  # 4. Error with services and packages
+  - packages_ret: "Package abcd got an error because of banana"
+    services_ret: "Service abcd got an error because of penguin"
+    expect_raise: True
+    result: |-
+      Node my_node_1: Package abcd got an error because of banana
+      Service abcd got an error because of penguin
 
 packages:
   # 1. Success: No conflicting packages to check
@@ -154,6 +175,82 @@ packages:
     expect_raise: True
     result: |-
       Package my-installed-package-4.5.6 conflicts with MetalK8s installation, please remove it.
+
+services:
+  # 1. Success: No conflicting services to check
+  - conflicting_services: []
+    result: True
+
+  # 2. Success: Conflicting services not installed
+  - conflicting_services:
+      - my-not-started-service
+      - my-not-started-service2
+    service_status_ret:
+      my-not-started-service: False
+      my-not-started-service2: False
+    service_disabled_ret:
+      my-not-started-service: True
+      my-not-started-service2: True
+    result: True
+  # 2. bis
+  - conflicting_services: my-not-started-service
+    service_status_ret:
+      my-not-started-service: False
+    service_disabled_ret:
+      my-not-started-service: True
+    result: True
+
+  # 3. Success: Conflicting service (from map) not started
+  - get_map_ret:
+      conflicting_services:
+        - my-not-started-service
+    service_status_ret:
+      my-not-started-service: False
+    service_disabled_ret:
+      my-not-started-service: True
+    result: True
+
+  # 4. Error: Conflicting service started
+  - conflicting_services:
+      - my-started-service
+      - my-not-started-service
+    service_status_ret:
+      my-started-service: True
+      my-not-started-service: False
+    service_disabled_ret:
+      my-started-service: False
+      my-not-started-service: True
+    expect_raise: True
+    result: |-
+      Service my-started-service conflicts with MetalK8s installation, please stop and disable it.
+  # 4. bis
+  - conflicting_services: my-started-service
+    service_status_ret:
+      my-started-service: True
+    service_disabled_ret:
+      my-started-service: True
+    expect_raise: True
+    result: |-
+      Service my-started-service conflicts with MetalK8s installation, please stop and disable it.
+  # 4. ter (no raise)
+  - conflicting_services: my-started-service
+    raises: False
+    service_status_ret:
+      my-started-service: True
+    service_disabled_ret:
+      my-started-service: True
+    result: |-
+      Service my-started-service conflicts with MetalK8s installation, please stop and disable it.
+
+  # 5. Service stopped but still enabled
+  - conflicting_services: my-enabled-service
+    service_status_ret:
+      my-enabled-service: False
+    service_disabled_ret:
+      my-enabled-service: False
+    expect_raise: True
+    result: |-
+      Service my-enabled-service conflicts with MetalK8s installation, please stop and disable it.
 
 sysctl:
   - params:


### PR DESCRIPTION
**Component**:

'pre-check', 'salt'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

#3067 

**Summary**:

If some service are started on the host where we want to deploy MetalK8s
the installation may not work properly (e.g.: firewalld)
Add a new function to check that those service are not started on the
host before deploying all the MetalK8s components.
NOTE: We do not automatically stop the service from the host since those
services may have been started for good reason, so just ask the user to
remove those packages

**Acceptance criteria**: 

Bootstrap output with firewalld started
```
# /srv/scality/metalk8s-2.8.0-dev/bootstrap.sh 
> Determine the OS... done [0s]
> Checking that BootstrapConfiguration is present... done [0s]
> Pre-minion system tests... done [0s]
> Configure internal repositories... done [0s]
> Check mandatory packages presence... done [3s]
> Disabling Salt minion service... done [0s]
> Stopping Salt minion service... done [0s]
> Installing mandatory packages... done [10s]
> Configuring Salt minion to run in local mode... done [5s]
> Ensure archive is available... done [2s]
> Checking local node... fail [2s]

Failure while running step 'Checking local node'

Command: check_local_node

Output:

<< BEGIN >>
Error running 'metalk8s_checks.node': Node bootstrap: Service firewalld conflicts with MetalK8s installation, please stop and disable it.
<< END >>

This script will now exit
```

Expansion with firewalld started on the new node
```
# crictl exec -it 758110e823084 salt-run state.sls metalk8s.orchestrate.deploy_node saltenv=metalk8s-2.8.0-dev pillar="{'orchestrate': {'node_name': 'node-1'}}"
[...]
bootstrap_master:
----------
[...]
----------
          ID: Check node
    Function: metalk8s.saltutil_cmd
        Name: metalk8s_checks.node
      Result: False
     Comment: Running function metalk8s_checks.node failed on minions: node-1
     Started: 17:36:42.667642
    Duration: 9560.307 ms
     Changes:   
              ----------
              node-1:
                  ----------
                  retcode:
                      1
                  stderr:
                      Error running 'metalk8s_checks.node': Node node-1: Service firewalld conflicts with MetalK8s installation, please stop and disable it.
                  stdout:

Summary for bootstrap_master
------------
Succeeded: 1 (changed=2)
Failed:    1
------------
Total states run:     2
Total run time:  22.045 s

```

---

Fixes: #3067 