### PR TITLE
salt: Check Service CIDR has a route declared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@
   services already started on the machine before doing all the installation
   (PR [#3069](https://github.com/scality/metalk8s/pull/3069))
 
+- [kubernetes/kubernetes#57534](https://github.com/kubernetes/kubernetes/issues/57534) -
+  Check if a route exists for the Service IPs CIDR
+  (PR [#3076](https://github.com/scality/metalk8s/pull/3076))
+
 ### Bug fixes
 - [#3022](https://github.com/scality/metalk8s/issues/3022) - Ensure salt-master
   container can start at reboot even if local salt-minion is down

--- a/salt/tests/unit/modules/files/test_metalk8s_checks.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_checks.yaml
@@ -310,36 +310,26 @@ route_exists:
   # 1. Success: Nominal (default route)
   - &route_exists_nominal
     destination: 10.96.0.0/12
-    get_route_ret:
-      gateway: &default_gw "10.10.0.1"
-      interface: &default_iface eth0
-      destination: 10.96.0.0/32
-      source: "10.10.1.2"
     routes_ret:
       - &default_route
         addr_family: inet
         destination: "0.0.0.0"
         flags: UG
-        gateway: *default_gw
-        interface: *default_iface
+        gateway: "10.10.0.1"
+        interface: eth0
         netmask: "0.0.0.0"
 
   # 2. Success: Nominal (dedicated dummy route)
   - <<: *route_exists_nominal
-    get_route_ret:
-      gateway: *default_gw
-      interface: dummy0
-      destination: 10.96.0.0/32
-      source: "10.10.1.2"
     routes_ret:
       - <<: *default_route
         interface: dummy0
         destination: "10.96.0.0"
         netmask: "255.240.0.0"
 
-  # 3. Error: Failure to get route
+  # 3. Error: No route exists
   - <<: *route_exists_nominal
-    get_route_ret: Some error when getting route
+    routes_ret: []
     error: No route exists for 10.96.0.0/12
 
   # 4. Error: Route found is too small

--- a/salt/tests/unit/modules/files/test_metalk8s_checks.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_checks.yaml
@@ -1,33 +1,67 @@
 node:
-  # 1. Everything fine
-  - packages_ret: True
+  # 1. Success: Nominal
+  - &node_nominal
+    packages_ret: True
     services_ret: True
+    route_exists_ret: True
+    pillar:
+      networks:
+        service: 10.96.0.0/16
     result: True
 
-  # 2. Error with packages
-  - packages_ret: "Package abcd got an error because of banana"
-    services_ret: True
+  # 2. Success: Service CIDR from command-line
+  - <<: *node_nominal
+    pillar: {}
+    service_cidr: 10.96.0.0/16
+
+  # 3. Error: Packages
+  - &node_packages_error
+    <<: *node_nominal
+    packages_ret: "Package abcd got an error because of banana"
     expect_raise: True
     result: "Node my_node_1: Package abcd got an error because of banana"
-  # 2. bis (no raises)
-  - packages_ret: "Package toto got an error :)"
-    services_ret: True
+  - <<: *node_packages_error
     raises: False
-    result: "Node my_node_1: Package toto got an error :)"
+    expect_raise: False
 
-  # 3. Error with services
+  # 4. Error: Services
   - packages_ret: True
     services_ret: "Service abcd got an error because of penguin"
     expect_raise: True
     result: "Node my_node_1: Service abcd got an error because of penguin"
 
-  # 4. Error with services and packages
-  - packages_ret: "Package abcd got an error because of banana"
+  # 5. Error: Route for Service CIDR
+  - <<: *node_nominal
+    route_exists_ret: No route exists for banana
+    expect_raise: True
+    # NOTE: We shorten the exception message for ease of use as a regex.
+    result: >-
+      Node my_node_1: Invalid networks:service CIDR - No route exists for
+      banana.
+  - <<: *node_nominal
+    raises: False
+    route_exists_ret: No route exists for banana
+    result: >-
+      Node my_node_1: Invalid networks:service CIDR - No route exists for
+      banana. Please make sure to have either a default route or a dummy
+      interface and route for this range (for details, see
+      https://github.com/kubernetes/kubernetes/issues/57534#issuecomment-527653412).
+
+  # 6. Error: Combined errors
+  - <<: *node_nominal
+    packages_ret: "Package abcd got an error because of banana"
     services_ret: "Service abcd got an error because of penguin"
     expect_raise: True
     result: |-
       Node my_node_1: Package abcd got an error because of banana
       Service abcd got an error because of penguin
+  - <<: *node_nominal
+    packages_ret: "Package abcd got an error because of banana"
+    route_exists_ret: "No route exists for penguin"
+    expect_raise: True
+    result: |-
+      Node my_node_1: Package abcd got an error because of banana
+      Invalid networks:service CIDR - No route exists for penguin
 
 packages:
   # 1. Success: No conflicting packages to check
@@ -271,3 +305,8 @@ sysctl:
       net.ipv4.ip_forward: '0'
     result: 'Incorrect value for .*'
     raises: True
+
+route_exists:
+  - destination: 10.96.0.0/16
+  - destination: 10.96.0.0/16
+    error: No route exists for 10.96.0.0/16

--- a/salt/tests/unit/modules/files/test_metalk8s_checks.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_checks.yaml
@@ -6,13 +6,13 @@ node:
     route_exists_ret: True
     pillar:
       networks:
-        service: 10.96.0.0/16
+        service: 10.96.0.0/12
     result: True
 
   # 2. Success: Service CIDR from command-line
   - <<: *node_nominal
     pillar: {}
-    service_cidr: 10.96.0.0/16
+    service_cidr: 10.96.0.0/12
 
   # 3. Error: Packages
   - &node_packages_error
@@ -307,6 +307,47 @@ sysctl:
     raises: True
 
 route_exists:
-  - destination: 10.96.0.0/16
-  - destination: 10.96.0.0/16
-    error: No route exists for 10.96.0.0/16
+  # 1. Success: Nominal (default route)
+  - &route_exists_nominal
+    destination: 10.96.0.0/12
+    get_route_ret:
+      gateway: &default_gw "10.10.0.1"
+      interface: &default_iface eth0
+      destination: 10.96.0.0/32
+      source: "10.10.1.2"
+    routes_ret:
+      - &default_route
+        addr_family: inet
+        destination: "0.0.0.0"
+        flags: UG
+        gateway: *default_gw
+        interface: *default_iface
+        netmask: "0.0.0.0"
+
+  # 2. Success: Nominal (dedicated dummy route)
+  - <<: *route_exists_nominal
+    get_route_ret:
+      gateway: *default_gw
+      interface: dummy0
+      destination: 10.96.0.0/32
+      source: "10.10.1.2"
+    routes_ret:
+      - <<: *default_route
+        interface: dummy0
+        destination: "10.96.0.0"
+        netmask: "255.240.0.0"
+
+  # 3. Error: Failure to get route
+  - <<: *route_exists_nominal
+    get_route_ret: Some error when getting route
+    error: No route exists for 10.96.0.0/12
+
+  # 4. Error: Route found is too small
+  - <<: *route_exists_nominal
+    routes_ret:
+      - <<: *default_route
+        destination: "10.96.0.0"
+        netmask: "255.255.0.0"  # It's a /16 i.s.o. a /12
+    error: >-
+      A route was found for 10.96.0.0, but it does not match the full
+      destination network 10.96.0.0/12

--- a/salt/tests/unit/modules/test_metalk8s_checks.py
+++ b/salt/tests/unit/modules/test_metalk8s_checks.py
@@ -162,22 +162,14 @@ class Metalk8sChecksTestCase(TestCase, mixins.LoaderModuleMockMixin):
         self,
         destination,
         error=None,
-        get_route_ret=None,
         routes_ret=None,
     ):
         """
         Tests the return of `route_exists` function
         """
-        def _network_get_route(dest):
-            if isinstance(get_route_ret, dict):
-                return get_route_ret
-            raise AttributeError(get_route_ret)
-
-        network_get_route_mock = MagicMock(side_effect=_network_get_route)
         network_routes_mock = MagicMock(return_value=routes_ret)
 
         patch_dict = {
-            'network.get_route': network_get_route_mock,
             'network.routes': network_routes_mock,
         }
 

--- a/salt/tests/unit/modules/test_metalk8s_checks.py
+++ b/salt/tests/unit/modules/test_metalk8s_checks.py
@@ -158,19 +158,27 @@ class Metalk8sChecksTestCase(TestCase, mixins.LoaderModuleMockMixin):
                 )
 
     @utils.parameterized_from_cases(YAML_TESTS_CASES["route_exists"])
-    def test_route_exists(self, destination, error=None):
+    def test_route_exists(
+        self,
+        destination,
+        error=None,
+        get_route_ret=None,
+        routes_ret=None,
+    ):
         """
         Tests the return of `route_exists` function
         """
         def _network_get_route(dest):
-            if error is None:
-                return
-            raise AttributeError('Could not find a route')
+            if isinstance(get_route_ret, dict):
+                return get_route_ret
+            raise AttributeError(get_route_ret)
 
         network_get_route_mock = MagicMock(side_effect=_network_get_route)
+        network_routes_mock = MagicMock(return_value=routes_ret)
 
         patch_dict = {
-            'network.get_route': network_get_route_mock
+            'network.get_route': network_get_route_mock,
+            'network.routes': network_routes_mock,
         }
 
         with patch.dict(metalk8s_checks.__salt__, patch_dict):


### PR DESCRIPTION
**Component**: salt, kubernetes, networking

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**:

When deploying some control plane services in the cluster (e.g. calico), we let such services interact with `kube-apiserver` using its Service IP (10.96.0.1 by default).
However, the resolution of such virtual IPs, emulated using `iptables` (through `kube-proxy`), requires at a minimum that a route exists for the Service CIDR (a default route also works).
We add a check to the `metalk8s_checks.node` helper, to have it run before bootstrap and expansion.

See: kubernetes/kubernetes#57534

**Summary**:

- First check implemented using `network.get_route` Salt execution method
- Re-worked to handle systems where kernel refuses network ranges (strict netlink validation)
- Removed initial implementation, simply read through the entire routing table

**Acceptance criteria**:

- CI keeps passing
- Installing on a system without a route set for the configured `networks:service` range should bail out (both in bootstrap and expansion), similarly to checks from #3050 or #3069