### PR TITLE
packages: Do not include "base" package in "metalk8s-saltstack" repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@
   package is available in one configured repository
   (PR [#3050](https://github.com/scality/metalk8s/pull/3050))
 
+- [#3075](https://github.com/scality/metalk8s/issues/3075) - Properly install "base"
+  Salt dependencies from "base" RHEL 7 repository
+  (PR [#3083](https://github.com/scality/metalk8s/pull/3083))
+
 ## Release 2.7.1 (in development)
 
 ### Bug fixes

--- a/packages/redhat/common/entrypoint.sh
+++ b/packages/redhat/common/entrypoint.sh
@@ -114,14 +114,17 @@ resolve_dependencies() {
     local -a dependencies=("$@")
 
     for package in "${packages[@]}"; do
-        while read -r dependency repo; do
+        while read -r dependency repo relpath; do
             if [[ $repo =~ $ENABLED_REPOS_RE ]] && \
+               # We exclude all package from "base" directory of Saltstack since those
+               # packages are available in "base" CentOS/RHEL 7 repositories
+               { [[ $repo != "saltstack" ]] || [[ $relpath != base/* ]]; } && \
                ! in_dependencies "$dependency" "${dependencies[@]}"; then
                 dependencies+=("$dependency")
             fi
         done < <(
             repoquery --requires --resolve --recursive \
-                      --queryformat='%{name} %{repoid}' "$package"
+                      --queryformat='%{name} %{repoid} %{relativepath}' "$package"
         )
     done
 


### PR DESCRIPTION
**Component**:

'salt', 'packages'

**Context**: 

#3075 

**Summary**:

In saltstack repository we have a "base" directory containing package
available in RHEL/CentOs 7 "base" repositories, since MetalK8s already
rely on this "base" repository available on the host it does not make
sense to include those package as part of `metalk8s-saltstack`
repository, especially for RedHat that do not have the GPG key for
those "base" packages build by CentOS


---

Fixes: #3075 
