### PR TITLE
Fix the CPU Usage expression that causes negative values during the platform's upgrade

### DIFF
--- a/ui/src/ducks/app/monitoring.js
+++ b/ui/src/ducks/app/monitoring.js
@@ -703,7 +703,7 @@ export function* fetchNodeStats() {
     Math.round(currentTime.getTime() / 1000) - sampleDuration;
   const startingTimeISO = new Date(startingTimestamp * 1000).toISOString();
 
-  const cpuUsageQuery = `(((count(count(node_cpu_seconds_total{instance=~"${instanceIP}:${PORT_NODE_EXPORTER}"}) by (cpu))) - avg(sum by (mode)(irate(node_cpu_seconds_total{mode='idle',instance=~"${instanceIP}:${PORT_NODE_EXPORTER}"}[5m])))) * 100) / count(count(node_cpu_seconds_total{instance=~"${instanceIP}:${PORT_NODE_EXPORTER}"}) by (cpu))`;
+  const cpuUsageQuery = `100 - (avg by (instance) (irate(node_cpu_seconds_total{mode="idle",instance=~"${instanceIP}:${PORT_NODE_EXPORTER}"}[5m])) * 100)`;
   const systemLoadQuery = `avg(node_load1{instance=~"${instanceIP}:${PORT_NODE_EXPORTER}"}) / count(count(node_cpu_seconds_total{instance=~"${instanceIP}:${PORT_NODE_EXPORTER}"}) by (cpu)) * 100`;
   const memoryQuery = `sum(100 - ((node_memory_MemAvailable_bytes{instance=~"${instanceIP}:${PORT_NODE_EXPORTER}"} * 100) / node_memory_MemTotal_bytes{instance=~"${instanceIP}:${PORT_NODE_EXPORTER}"}))`;
   const iopsReadQuery = `sum(irate(node_disk_reads_completed_total{instance=~"${instanceIP}:${PORT_NODE_EXPORTER}"}[5m])) by (instance)`;


### PR DESCRIPTION
**Component**: ui, monitoring

**Context**: 
The previous CPU Usage Expression causes a negative value during the platform's upgrade.
![image](https://user-images.githubusercontent.com/18453133/107074713-65ecf100-67e9-11eb-867f-9b2581a31cf3.png)

By comparing the old and new expression, we discovered the two expressions have almost the same value, the only difference is during the time of upgrade. 

**Summary**:
Note this PR only fix the expression that is used by UI to fetch the data for CPU Usage. 
However, the Grafana dash still uses the wrong expression. We need to fix it.
![image](https://user-images.githubusercontent.com/18453133/107075523-823d5d80-67ea-11eb-81c5-287e8953ffc7.png)

**Acceptance criteria**: 


---


<!-- If you want to refer to an issue while not closing it, use:

See: #3080

-->
