### PR TITLE
CI: Properly handle 404 when retrieving ISOs, sleep a bit after etcd node deletion in Bootstrap restore

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -2335,7 +2335,8 @@ stages:
             --cert /etc/kubernetes/pki/etcd/server.crt
             --key /etc/kubernetes/pki/etcd/server.key
             --cacert /etc/kubernetes/pki/etcd/ca.crt
-            member remove %(prop:bootstrap_etcd_member_id)s\"
+            member remove %(prop:bootstrap_etcd_member_id)s\" &&
+            sleep 10
           workdir: build/eve/workers/openstack-terraform/terraform/
           haltOnFailure: true
       - ShellCommand:

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -251,7 +251,16 @@ models:
           if [ $(( $i % 10 )) -eq 1 ]; then
             echo "Attempt $i out of ${MAX_ATTEMPTS}"
           fi
-          curl -L -s -XGET -o "${out_path}" "${in_url}" && exit
+          status_code=$(curl -L -s -XGET -o "${out_path}" "${in_url}" --write-out "%{http_code}")
+          case "$status_code" in
+              200)
+                  exit
+                  ;;
+              404)
+                  echo "Could not retrieve $FILE_SOURCE: $status_code" >&2
+                  exit 1
+                  ;;
+          esac
           sleep 2
         done
         echo "Could not retrieve $FILE_SOURCE after $MAX_ATTEMPTS attempts" >&2


### PR DESCRIPTION
**Component**:

'internal', 'ci'

**Context**: 

Improve CI behavior

**Summary**:

- Properly handle 404 when retrieving ISO images in the CI
- Sleep a bit after etcd node deletion in Bootstrap restore in the CI

Should avoid: 

```
Error from server: rpc error: code = Unavailable desc = transport is closing
```

---