### PR TITLE
[UI] Bugfix no banner display for no prom volume provision

### DIFF
--- a/ui/src/ducks/app/monitoring.js
+++ b/ui/src/ducks/app/monitoring.js
@@ -333,7 +333,9 @@ function getClusterQueryStatus(result) {
 }
 
 export function* handlePrometheusError(clusterHealth, result) {
-  if (result.error.response) {
+  // TODO:
+  // Type result argument to something similar to {error: {response?: AxiosResponse} } to simplify optional chaining use here.
+  if (result?.error?.response?.status < 500) {
     yield put(setPrometheusApiAvailable(true));
     clusterHealth.error = `Prometheus - ${result.error.response.statusText}`;
   } else {

--- a/ui/src/ducks/app/monitoring.test.js
+++ b/ui/src/ducks/app/monitoring.test.js
@@ -346,7 +346,9 @@ it('should set cluster error if a query failed', () => {
 });
 
 it('should handlePrometheusError when prometheus is up', () => {
-  const result = { error: { response: { statusText: 'Bad Request' } } };
+  const result = {
+    error: { response: { statusText: 'Bad Request', status: 400 } },
+  };
   const gen = handlePrometheusError({}, result);
   expect(gen.next().value).toEqual(
     put({


### PR DESCRIPTION
**Component**: ui, bug

**Context**: 
When we deploy a fresh bootstrap node, before provisioning the volume
for prometheus, we can't see the banner to guide you to provision the
volume from the deployed UI (not from local dev environment)

**Summary**:
The root cause is how do we handle the prometheus error. The logic is
correct, we first check if there error from prometheus API, if no, we go
to check the deployment.

However, we can't tell the status of the HTTP request by just check if
`result.error.response` exist. It exists for all the out of 2XX
response. So we should check the response status instead of.

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
