### PR TITLE
Fix snapshot generation in CI

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -715,6 +715,20 @@ models:
         --solution "$SOLUTION_NAME" --version "$SOLUTION_VERSION"
       workdir: build/eve/workers/openstack-terraform/terraform/
       haltOnFailure: true
+  - ShellCommand: &wait_for_solution_operator
+      doStepIf: "%(prop:install_solution:-false)s"
+      name: Wait for Solution Operator to become ready
+      env:
+        ENVIRONMENT_NAME: "%(prop:solution_env_name:-example-environment)s"
+        SOLUTION_NAME: "%(prop:solution_name:-example-solution)s"
+      command: >
+        ssh -F ssh_config bootstrap
+        sudo kubectl --kubeconfig /etc/kubernetes/admin.conf
+        wait pods --namespace "$ENVIRONMENT_NAME"
+        --selector "app.kubernetes.io/name=$SOLUTION_NAME-operator"
+        --for condition=Ready
+      workdir: build/eve/workers/openstack-terraform/terraform/
+      haltOnFailure: true
 
   # --- Previous version (for Upgrade/Downgrade) ---
   - Git: &git_pull_prev
@@ -1634,6 +1648,7 @@ stages:
       - ShellCommand: *create_solution_env
       - ShellCommand: *untaint_bootstrap
       - ShellCommand: *deploy_solution
+      - ShellCommand: *wait_for_solution_operator
     # }}}
       - ShellCommand: *wait_pods_stable_ssh
       - ShellCommand: *git_pull_ssh
@@ -2135,6 +2150,7 @@ stages:
       - ShellCommand: *create_solution_env
       - ShellCommand: *untaint_bootstrap
       - ShellCommand: *deploy_solution
+      - ShellCommand: *wait_for_solution_operator
     # }}}
       - ShellCommand: *wait_pods_stable_ssh
       - ShellCommand: &multi_node_fast_tests

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -604,7 +604,7 @@ models:
       doStepIf: "%(prop:generate_snapshot:-false)s"
       env:
         <<: *_env_terraform
-        SNAPSHOT_NAME: "%(prop:metalk8s_version)s-%(prop:os:-centos-7)s-%(prop:environment_type)s-%(prop:environment_name)s"
+        SNAPSHOT_NAME: "metalk8s-%(prop:metalk8s_version)s-%(prop:os:-centos-7)s-%(prop:environment_type)s-%(prop:environment_name)s"
       command: ./generate_snapshot.sh
       workdir: build/eve/workers/openstack-terraform/terraform/
       haltOnFailure: true

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -688,6 +688,18 @@ models:
         create-env --name "$ENVIRONMENT_NAME"
       workdir: build/eve/workers/openstack-terraform/terraform/
       haltOnFailure: true
+  - ShellCommand: &untaint_bootstrap
+      doStepIf: "%(prop:install_solution:-false)s"
+      name: Untaint Bootstrap before deploying a Solution
+      env:
+        NODE_NAME: "bootstrap"
+      command: |
+        ssh -F ssh_config bootstrap <<ENDSSH
+        sudo kubectl --kubeconfig /etc/kubernetes/admin.conf \
+        patch node "$NODE_NAME" --patch '{"spec": {"taints": []}}'
+        ENDSSH
+      workdir: build/eve/workers/openstack-terraform/terraform/
+      haltOnFailure: true
   - ShellCommand: &deploy_solution
       doStepIf: "%(prop:install_solution:-false)s"
       name: Deploy Solution
@@ -1620,6 +1632,7 @@ stages:
       - ShellCommand: *import_solution
       - ShellCommand: *activate_solution
       - ShellCommand: *create_solution_env
+      - ShellCommand: *untaint_bootstrap
       - ShellCommand: *deploy_solution
     # }}}
       - ShellCommand: *wait_pods_stable_ssh
@@ -2120,6 +2133,7 @@ stages:
       - ShellCommand: *import_solution
       - ShellCommand: *activate_solution
       - ShellCommand: *create_solution_env
+      - ShellCommand: *untaint_bootstrap
       - ShellCommand: *deploy_solution
     # }}}
       - ShellCommand: *wait_pods_stable_ssh

--- a/eve/workers/openstack-terraform/requirements.sh
+++ b/eve/workers/openstack-terraform/requirements.sh
@@ -15,7 +15,8 @@ yum install -y "${PACKAGES[@]}"
 
 yum clean all
 
-sudo -u eve pip3.6 install --user tox python-openstackclient
+sudo -u eve python3.6 -m pip install --user --upgrade pip
+sudo -u eve python3.6 -m pip install --user tox python-openstackclient
 
 sudo -u eve mkdir -p /home/eve/.ssh/
 sudo -u eve ssh-keygen -t rsa -b 4096 -N '' -f /home/eve/.ssh/terraform


### PR DESCRIPTION
**Component**: ci

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 2.7.1 release process - could not generate snapshots (and when it ended up working, they were not valid for post-merge tests, at least in single node)

**Summary**:

- Upgrade pip to latest before install `python-openstackclient`
- Add `metalk8s-` prefix to generated snapshots
- Untaint Bootstrap node before deploying a Solution operator
- Check that the Solution operator is ready after deployment

**Acceptance criteria**:

- Can generate snapshots
- Can use said snapshots in post-merge
