### PR TITLE
Upgrade: Wait properly for containers to be "running" after bootstrap kubelet upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@
   Check if a route exists for the Service IPs CIDR
   (PR [#3076](https://github.com/scality/metalk8s/pull/3076))
 
+- Improve the upgrade robustness when the platform is a bit slow
+  (PR [#3105](https://github.com/scality/metalk8s/pull/3105))
+
 ### Bug fixes
 - [#3022](https://github.com/scality/metalk8s/issues/3022) - Ensure salt-master
   container can start at reboot even if local salt-minion is down

--- a/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
+++ b/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
@@ -2,7 +2,7 @@ interface: {{ salt_ip }}
 
 log_level: {{ 'debug' if debug else 'info' }}
 
-timeout: 10
+timeout: 20
 
 peer:
   .*:

--- a/scripts/upgrade.sh.in
+++ b/scripts/upgrade.sh.in
@@ -135,12 +135,24 @@ upgrade_local_engines () {
     repo_endpoint="$($SALT_CALL pillar.get \
         metalk8s:endpoints:repositories --out txt | cut -d' ' -f2- )"
 
-    # NOTE: Sleep a bit at the end so that salt-master container properly stop
-    #       before going to the next step
+    # NOTE: Sleep a bit at the end so that container properly stop before
+    #       going to the next step
     "${SALT_CALL}" --local --retcode-passthrough state.sls sync_mods="all" \
         metalk8s.kubernetes.kubelet.standalone saltenv="$SALTENV" \
         pillar="{'metalk8s': {'endpoints': {'salt-master': $saltmaster_endpoint, \
         'repositories': $repo_endpoint}}}" && sleep 20
+
+    # List of containers that need to be running to continue the upgrade
+    local -a containers_to_check=(
+        'repositories'
+        'salt-master'
+        'kube-apiserver'
+        'etcd'
+    )
+    for container in "${containers_to_check[@]}"; do
+        "${SALT_CALL}" --local --retcode-passthrough cri.wait_container \
+            name="$container" state=running || return 1
+    done
 }
 
 upgrade_nodes () {


### PR DESCRIPTION
**Component**:

'lifecycle'

**Context**: 

Improve robustness of the upgrade script

**Summary**:

After kubelet upgrade all static pod may restart, so we need to wait for
some "useful" pods to be running before going further in the upgrade
process.
NOTE: That before this PR we already sleep 20 seconds, so this commit
only add a proper check after this sleep

---
