### PR TITLE
Bootstrap restore: Fix few issues

### DIFF
--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -166,6 +166,19 @@ bootstrap_file_is_present() {
     fi
 }
 
+check_ca_minion() {
+    # NOTE: Today using bootstrap script, bootstrap node is also the CA
+    # minion, so check for minion id equal to CA minion
+    minion_id="$("$SALT_CALL" --out txt --local grains.get id | cut -c 8-)"
+    ca_minion="$("$SALT_CALL" --out txt --local pillar.get metalk8s:ca:minion | cut -c 8-)"
+    if [ "$minion_id" != "$ca_minion" ]; then
+        echo "CA minion \"$ca_minion\" from bootstrap configuration is not equal" \
+             "to the local minion ID \"$minion_id\", you need to change" \
+             "the local minion ID, or update the bootstrap configuration." >&2
+        return 1
+    fi
+}
+
 
 main() {
     run "Determine the OS" determine_os
@@ -182,6 +195,7 @@ main() {
     run "Installing mandatory packages" install_packages "${PACKAGES[@]}"
     run "Configuring Salt minion to run in local mode" configure_salt_minion_local_mode
     run "Ensure archive is available" ensure_archives_mounted
+    run "Checking CA minion" check_ca_minion
     run "Checking local node" check_local_node
 
     orchestrate_bootstrap

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -63,12 +63,6 @@ declare -a PACKAGES=(
 # shellcheck disable=SC1090
 . "$BASE_DIR"/common.sh
 
-ensure_archives_mounted() {
-    "${SALT_CALL}" --local --state-output=mixed --retcode-passthrough \
-        state.sls metalk8s.archives.mounted \
-        saltenv=metalk8s-@@VERSION pillarenv=metalk8s-@@VERSION
-}
-
 orchestrate_bootstrap() {
     # Grains must be set (in `/etc/salt/grains`) *before* invoking `salt-call`,
     # otherwise grains set during execution won't be taken into account

--- a/scripts/common.sh.in
+++ b/scripts/common.sh.in
@@ -353,6 +353,12 @@ configure_salt_minion_local_mode() {
         pillar="{'metalk8s': {'archives': '$BASE_DIR'}}" saltenv=base
 }
 
+ensure_archives_mounted() {
+    "${SALT_CALL}" --local --state-output=mixed --retcode-passthrough \
+        state.sls metalk8s.archives.mounted \
+        saltenv=metalk8s-@@VERSION
+}
+
 check_local_node() {
     "$SALT_CALL" --local --retcode-passthrough metalk8s_checks.node \
         saltenv=metalk8s-@@VERSION

--- a/scripts/common.sh.in
+++ b/scripts/common.sh.in
@@ -354,17 +354,6 @@ configure_salt_minion_local_mode() {
 }
 
 check_local_node() {
-    # NOTE: Today using bootstrap script, bootstrap node is also the CA
-    # minion, so check for minion id equal to CA minion
-    minion_id="$("$SALT_CALL" --out txt --local grains.get id | cut -c 8-)"
-    ca_minion="$("$SALT_CALL" --out txt --local pillar.get metalk8s:ca:minion | cut -c 8-)"
-    if [ "$minion_id" != "$ca_minion" ]; then
-        echo "CA minion \"$ca_minion\" from bootstrap configuration is not equal" \
-            "to the local minion ID \"$minion_id\", you need to change" \
-            "the local minion ID, or update the bootstrap configuration." 1>&2
-        return 1
-    fi
-
     "$SALT_CALL" --local --retcode-passthrough metalk8s_checks.node \
         saltenv=metalk8s-@@VERSION
 }

--- a/scripts/restore.sh.in
+++ b/scripts/restore.sh.in
@@ -340,9 +340,11 @@ run "Stopping Salt minion service" stop_salt_minion_service
 run "Configuring local repositories" configure_repositories
 run "Installing mandatory packages" install_packages "${PACKAGES[@]}"
 run "Configuring Salt minion to run in local mode" configure_salt_minion_local_mode
-run "Checking local node" check_local_node
 
 run "Restoring MetalK8s configurations" restore_metalk8s_conf
+
+run "Checking local node" check_local_node
+
 run "Restoring CAs certificates and keys" restore_cas
 run "Configuring salt-master" configure_salt_master
 run "Pushing CAs to salt mine" push_cas

--- a/scripts/restore.sh.in
+++ b/scripts/restore.sh.in
@@ -342,6 +342,7 @@ run "Installing mandatory packages" install_packages "${PACKAGES[@]}"
 run "Configuring Salt minion to run in local mode" configure_salt_minion_local_mode
 
 run "Restoring MetalK8s configurations" restore_metalk8s_conf
+run "Ensure archive is available" ensure_archives_mounted
 
 run "Checking local node" check_local_node
 


### PR DESCRIPTION
**Component**:

'script'

**Context**: 

- Restore always fail as we check CA minion when bootstrap config not yet restored
```
CA minion "" from bootstrap configuration is not equal to the local minion ID "<minion_id>", you need to change the local minion ID, or update the bootstrap configuration.
```
- We always check for default service CIDR in the restore script (because we check before restoring the bootstrap config)

**Summary**:

- Move the CA minion check directly in the bootstrap script. We do not want to check for CA minion in the restore script as, today, we always update the bootstrap config to set CA minion to the local minion id. And also one day, especially in the restore context, CA minion may be different from the bootstrap minion
- Restore the bootstrap config before calling "check local node" in the restore script
- Make sure the archive is mounted in restore script (sees e173f8bdf0f79614efd670b8065f1e2484a81581)

---
