### PR TITLE
eve: Use `yum clean all` instead of setup proxy cache

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -21,11 +21,12 @@ models:
         git clone "https://github.com/scality/metalk8s" --branch "%(prop:branch)s"
       workdir: build/eve/workers/openstack-terraform/terraform/
       haltOnFailure: true
-  - ShellCommand: &setup_cache
-      name: Setup proxy cache
-      command: >
-          curl -s http://proxy-cache/setup.sh | sudo sh &&
-          . /usr/local/bin/use_scality_proxy_cache
+  - ShellCommand: &yum_clean_all
+      # Eve cache the workers, so time to time yum repositories definition are
+      # really outdated, to avoid this, just do a `yum clean all` when starting a
+      # worker
+      name: Clean local yum cache
+      command: sudo yum clean all && sudo rm -rf /var/cache/yum
       haltOnFailure: true
   - SetProperty: &set_premerge_url
       name: Set premerge artifacts private_url as Property
@@ -973,7 +974,7 @@ stages:
             <<: *_env_final_status_artifact_failed
             <<: *_build_metalk8s_junit_info
             STEP_NAME: build
-      - ShellCommand: *setup_cache
+      - ShellCommand: *yum_clean_all
       - ShellCommand: *build_all
       - ShellCommand:
           <<: *copy_artifacts
@@ -1008,7 +1009,7 @@ stages:
     worker: *build_worker
     steps:
       - ShellCommand: *wait_for_docker
-      - ShellCommand: *setup_cache
+      - ShellCommand: *yum_clean_all
       - Git: *git_pull
       - ShellCommand:
           <<: *add_final_status_artifact_failed
@@ -1055,7 +1056,6 @@ stages:
             <<: *_env_final_status_artifact_failed
             <<: *_build_docs_junit_info
             STEP_NAME: docs
-      - ShellCommand: *setup_cache
       - ShellCommand:
           name: Build documentation for ReadTheDocs
           env:
@@ -1121,7 +1121,7 @@ stages:
             <<: *_env_final_status_artifact_failed
             <<: *_lint_junit_info
             STEP_NAME: lint
-      - ShellCommand: *setup_cache
+      - ShellCommand: *yum_clean_all
       - ShellCommand:
           name: Run all linting targets
           command: source /etc/profile && ./doit.sh lint
@@ -1158,7 +1158,7 @@ stages:
             <<: *_env_final_status_artifact_failed
             <<: *_integration_tests_ui_junit_info
             STEP_NAME: integration_tests_ui
-      - ShellCommand: *setup_cache
+      - ShellCommand: *yum_clean_all
       - ShellCommand:
           name: Install Cypress and its dependencies
           workdir: build/ui
@@ -1250,7 +1250,7 @@ stages:
             <<: *_env_final_status_artifact_failed
             <<: *_unit-test_ui_junit_info
             STEP_NAME: unit_tests_ui
-      - ShellCommand: *setup_cache
+      - ShellCommand: *yum_clean_all
       - ShellCommand:
           name: Install UI dependencies
           workdir: build/ui
@@ -1306,7 +1306,7 @@ stages:
             <<: *_env_final_status_artifact_failed
             <<: *_unit-test_storage_operator_junit_info
             STEP_NAME: unit_tests_storage_operator
-      - ShellCommand: *setup_cache
+      - ShellCommand: *yum_clean_all
       - ShellCommand:
           name: Run all storage-operator unit tests
           workdir: build/storage-operator
@@ -1342,7 +1342,7 @@ stages:
             <<: *_env_final_status_artifact_failed
             <<: *_unit-test_salt_junit_info
             STEP_NAME: unit_tests_salt
-      - ShellCommand: *setup_cache
+      - ShellCommand: *yum_clean_all
       - ShellCommand:
           name: Run all salt unit tests
           command: tox -e unit-tests
@@ -1375,7 +1375,7 @@ stages:
             <<: *_env_final_status_artifact_failed
             <<: *_downgrade_minor_single-node_junit_info
             STEP_NAME: single-node-downgrade-centos
-      - ShellCommand: *setup_cache
+      - ShellCommand: *yum_clean_all
       - ShellCommand: *ssh_ip_setup
       # --- Get ISO for version N ---
       - ShellCommand: *retrieve_iso_checksum
@@ -1489,7 +1489,7 @@ stages:
             <<: *_env_final_status_artifact_failed
             <<: *_upgrade_minor_single-node_junit_info
             STEP_NAME: single-node-upgrade-centos
-      - ShellCommand: *setup_cache
+      - ShellCommand: *yum_clean_all
       - ShellCommand: *ssh_ip_setup
       # --- Get ISO for version N ---
       - ShellCommand: *retrieve_iso_checksum
@@ -1596,7 +1596,7 @@ stages:
             <<: *_env_final_status_artifact_failed
             <<: *_install_single-node_junit_info
             STEP_NAME: "single-node-install-%(prop:os:-centos-7)s"
-      - ShellCommand: *setup_cache
+      - ShellCommand: *yum_clean_all
       - ShellCommand: *ssh_ip_setup
       - ShellCommand: *retrieve_iso
       - ShellCommand: *retrieve_iso_checksum
@@ -1819,7 +1819,7 @@ stages:
             <<: *_env_final_status_artifact_failed
             <<: *_snapshot_upgrade_junit_info
             STEP_NAME: "%(prop:environment_type)s-%(prop:environment_name)s-upgrade-%(prop:promoted_version_type:-unknown)s-%(prop:os:-centos-7)s"
-      - ShellCommand: *setup_cache
+      - ShellCommand: *yum_clean_all
       - ShellCommand: *ssh_ip_setup
       # --- Get ISO for version N ---
       - ShellCommand: *retrieve_iso
@@ -1924,7 +1924,7 @@ stages:
             <<: *_env_final_status_artifact_failed
             <<: *_downgrade_promoted_single-node_junit_info
             STEP_NAME: "single-node-downgrade-%(prop:promoted_version_type)s-centos"
-      - ShellCommand: *setup_cache
+      - ShellCommand: *yum_clean_all
       - ShellCommand: *ssh_ip_setup
       # --- Get ISO for version N ---
       - ShellCommand: *retrieve_iso
@@ -2023,7 +2023,7 @@ stages:
             <<: *_env_final_status_artifact_failed
             <<: *_install_multi-node_junit_info
             STEP_NAME: "multiple-nodes-%(prop:os:-centos-7)s"
-      - ShellCommand: *setup_cache
+      - ShellCommand: *yum_clean_all
       - ShellCommand: *ssh_ip_setup
       - ShellCommand: *retrieve_iso
       - ShellCommand: *retrieve_iso_checksum
@@ -2196,7 +2196,7 @@ stages:
             <<: *_env_final_status_artifact_failed
             <<: *_bootstrap_restore_junit_info
             STEP_NAME: bootstrap-restore
-      - ShellCommand: *setup_cache
+      - ShellCommand: *yum_clean_all
       - ShellCommand: *ssh_ip_setup
       - ShellCommand: *retrieve_iso
       - ShellCommand: *retrieve_iso_checksum
@@ -2372,7 +2372,7 @@ stages:
             <<: *_env_final_status_artifact_failed
             <<: *_solutions_single-node_junit_info
             STEP_NAME: single-node-solutions
-      - ShellCommand: *setup_cache
+      - ShellCommand: *yum_clean_all
       - ShellCommand: *ssh_ip_setup
       - ShellCommand: *retrieve_iso
       - ShellCommand: *retrieve_iso_checksum


### PR DESCRIPTION
**Component**:

'ci'

**Context**: 

Failure when setting proxy cache

**Summary**:

Eve already setup the proxy cache for every worker, so it's not needed
to do it manually in the `eve/main.yml`. But eve also cache workers so
from time to time the repositories definition are outdated, to avoid that
kind of issue just do a `yum clean all` when we start the eve worker


---

