### PR TITLE
CI: Bump some timeouts, ... to reduce flakiness

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -2317,10 +2317,14 @@ stages:
           haltOnFailure: true
       - ShellCommand:
           name: Remove bootstrap node object
-          command: >
-            ssh -F ssh_config node-1
-            sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf delete
-            node --selector="node-role.kubernetes.io/bootstrap"
+          command: |-
+            for _ in $(seq 5); do
+                ssh -F ssh_config node-1 \
+                sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf delete \
+                node --selector="node-role.kubernetes.io/bootstrap" && exit 0
+                sleep 5
+            done
+            exit 1
           workdir: build/eve/workers/openstack-terraform/terraform/
           haltOnFailure: true
       - ShellCommand:

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -1873,7 +1873,8 @@ stages:
             ssh -F ssh_config bootstrap 'sudo bash -c "
             kubectl --kubeconfig=/etc/kubernetes/admin.conf
             wait pods --for=condition=Ready --all --all-namespaces
-            --field-selector=status.phase!=Succeeded"'
+            --field-selector=status.phase!=Succeeded"
+            --timeout=120s'
           workdir: build/eve/workers/openstack-terraform/terraform/
           haltOnFailure: true
       # --- We do not need to Test promoted version ---

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -2312,8 +2312,7 @@ stages:
             --cert /etc/kubernetes/pki/etcd/server.crt
             --key /etc/kubernetes/pki/etcd/server.key
             --cacert /etc/kubernetes/pki/etcd/ca.crt
-            member remove %(prop:bootstrap_etcd_member_id)s\" &&
-            sleep 10
+            member remove %(prop:bootstrap_etcd_member_id)s\"
           workdir: build/eve/workers/openstack-terraform/terraform/
           haltOnFailure: true
       - ShellCommand:

--- a/eve/wait_pods_stable.sh
+++ b/eve/wait_pods_stable.sh
@@ -50,7 +50,7 @@ check_pods_stabilization() {
     [ -z "$(
         timeout "$STABILIZATION_TIME" kubectl get pods --all-namespaces \
             --kubeconfig="$KUBECONFIG" \
-            --watch-only
+            --watch-only 2>&1
     )" ]
 }
 

--- a/tests/post/steps/conftest.py
+++ b/tests/post/steps/conftest.py
@@ -72,7 +72,7 @@ def _check_pods_status(
         name += " with label '{}'".format(label)
 
     # Wait for pod to be in the correct state
-    utils.retry(_wait_for_status, times=12, wait=5, name=name)
+    utils.retry(_wait_for_status, times=24, wait=5, name=name)
 
 
 # }}}


### PR DESCRIPTION
**Component**:

'ci', 'tests'

**Context**: 

We got too many flakies when the platform is a bit slow

**Summary**:

- Increase timeout to wait for a container to be ready in tests
- Retry properly when deleting bootstrap node in bootstrap restore tests (instead of just sleeping before)
- Increase timeout when waiting for pods to be running when restoring a snapshot
- Retry properly in `wait_pods_stable` when apiserver is  not ready

---

