### PR TITLE
[UI] Use new core UI components

### DIFF
--- a/ui/cypress/integration/node/nodetabs.spec.js
+++ b/ui/cypress/integration/node/nodetabs.spec.js
@@ -65,9 +65,7 @@ describe('Node page alerts tab', () => {
       cy.stubHistory();
       cy.get('[data-cy="alert_filter"]').click();
 
-      cy.get('.sc-dropdown .trigger .menu-item')
-        .contains('li', severity.name)
-        .click();
+      cy.get('.sc-healthselector .trigger li').contains(severity.name).click();
       cy.get('@historyPush').should(
         'be.calledWith',
         `/nodes/master-0/alerts?severity=${severity.value}`,

--- a/ui/cypress/integration/volume/volumetabs.spec.js
+++ b/ui/cypress/integration/volume/volumetabs.spec.js
@@ -61,9 +61,7 @@ describe('Volume page alerts tab', () => {
     it(`adds the filter of ${severity.value}`, () => {
       cy.get('[data-cy="alert_filter"]').click();
       cy.stubHistory();
-      cy.get('.sc-dropdown .trigger .menu-item')
-        .contains('li', severity.name)
-        .click();
+      cy.get('.sc-healthselector .trigger li').contains(severity.name).click();
       cy.get('@historyPush').should(
         'be.calledWith',
         `/volumes/master-0-alertmanager/alerts?severity=${severity.value}`,

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -2933,8 +2933,8 @@
       }
     },
     "@scality/core-ui": {
-      "version": "github:scality/core-ui#2c243cc89c135985f6a4ff3a8c5cbfd817a5d0c1",
-      "from": "github:scality/core-ui#v0.10.0"
+      "version": "github:scality/core-ui#dce199471969bd7cbe30486efdafe7731ed62c40",
+      "from": "github:scality/core-ui#v0.10.2"
     },
     "@sinonjs/commons": {
       "version": "1.8.2",

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.7.2",
     "@kubernetes/client-node": "github:scality/kubernetes-client-javascript.git#browser-0.10.2-63-g579d066",
-    "@scality/core-ui": "github:scality/core-ui.git#v0.10.0",
+    "@scality/core-ui": "github:scality/core-ui.git#v0.10.2",
     "axios": "^0.21.1",
     "formik": "2.2.5",
     "jest-environment-jsdom-sixteen": "^1.0.3",

--- a/ui/src/components/ActiveAlertsFilters.js
+++ b/ui/src/components/ActiveAlertsFilters.js
@@ -1,36 +1,12 @@
 import React from 'react';
-import styled from 'styled-components';
-import { Dropdown } from '@scality/core-ui';
+import { Healthselector } from '@scality/core-ui';
 import { useHistory, useRouteMatch } from 'react-router';
 import { useQuery } from '../services/utils';
-import { padding } from '@scality/core-ui/dist/style/theme';
-import { STATUS_WARNING, STATUS_CRITICAL } from '../constants.js';
-
-export const FilterIcon = styled.i`
-  color: ${(props) => {
-    const theme = props.theme.brand;
-    let color = theme.textPrimary;
-
-    switch (props.status) {
-      case STATUS_WARNING:
-        color = theme.warning;
-        break;
-      case STATUS_CRITICAL:
-        color = theme.danger;
-        break;
-      default:
-        color = theme.textPrimary;
-    }
-    return color;
-  }};
-  padding: ${padding.smaller};
-`;
-
-export const ActiveAlertsFilterWrapper = styled.div`
-  .sc-dropdown > div {
-    background-color: ${(props) => props.theme.brand.info};
-  }
-`;
+import {
+  STATUS_WARNING,
+  STATUS_CRITICAL,
+  STATUS_HEALTH,
+} from '../constants.js';
 
 const ActiveAlertsFilter = (props) => {
   const history = useHistory();
@@ -41,66 +17,39 @@ const ActiveAlertsFilter = (props) => {
   let items = [
     {
       label: 'All',
-      value: 'all',
       onClick: () => {
         query.delete('severity');
         history.push(`${match.url}?${query.toString()}`);
       },
-      iconCode: '',
-      'data-cy': 'severity_all',
+      selected: !selectedFilter,
     },
     {
-      label: 'Critical',
-      value: STATUS_CRITICAL,
+      label: 'Health',
       onClick: () => {
-        query.set('severity', STATUS_CRITICAL);
+        query.set('severity', STATUS_HEALTH);
         history.push(`${match.url}?${query.toString()}`);
       },
-      iconCode: 'fas fa-times-circle',
-      'data-cy': 'severity_critical',
+      selected: selectedFilter === STATUS_HEALTH,
     },
     {
       label: 'Warning',
-      value: STATUS_WARNING,
       onClick: () => {
         query.set('severity', STATUS_WARNING);
         history.push(`${match.url}?${query.toString()}`);
       },
-      iconCode: 'fas fa-exclamation-triangle',
-      'data-cy': 'severity_warning',
+      selected: selectedFilter === STATUS_WARNING,
+    },
+    {
+      label: 'Critical',
+      onClick: () => {
+        query.set('severity', STATUS_CRITICAL);
+        history.push(`${match.url}?${query.toString()}`);
+      },
+      selected: selectedFilter === STATUS_CRITICAL,
     },
   ];
 
-  const dropDownLabel = (() => {
-    if (!selectedFilter) return items[0].label;
-
-    const item = items.find((item) => item.value === selectedFilter);
-    return (
-      <span>
-        {item.value !== 'all' && (
-          <FilterIcon status={item.value} className={item.iconCode} />
-        )}
-        {item.label}
-      </span>
-    );
-  })();
-
-  if (selectedFilter) {
-    items = items.filter((item) => item.value !== selectedFilter);
-  } else {
-    items.splice(0, 1);
-  }
-
-  return (
-    <ActiveAlertsFilterWrapper>
-      <Dropdown
-        items={items}
-        text={dropDownLabel}
-        size="small"
-        data-cy="alert_filter"
-      />
-    </ActiveAlertsFilterWrapper>
-  );
+  return <Healthselector items={items} data-cy="alert_filter" />;
 };
 
 export default ActiveAlertsFilter;

--- a/ui/src/components/LinechartSpec.js
+++ b/ui/src/components/LinechartSpec.js
@@ -65,6 +65,7 @@ export const getTooltipConfig = (
           title: 'Date',
         },
       ],
+      color: {},
     },
     selection: {
       hover: {

--- a/ui/src/components/LinechartSpec.js
+++ b/ui/src/components/LinechartSpec.js
@@ -1,3 +1,4 @@
+//@flow
 export const yAxisUsage = [
   {
     field: 'y',
@@ -39,7 +40,9 @@ export const yAxisInOut = [
   },
 ];
 
-export const getTooltipConfig = (fields) => {
+export const getTooltipConfig = (
+  fields: { field: string, type: string, title: string, format: string }[],
+) => {
   const tooltipConfigBase = {
     transform: [{ pivot: 'type', value: 'y', groupby: ['date'] }],
     mark: 'rule',
@@ -75,7 +78,6 @@ export const getTooltipConfig = (fields) => {
     },
   };
   if (fields.length) {
-    fields = fields.filter((item) => !!item);
     const newFields = [...tooltipConfigBase.encoding.tooltip, ...fields];
     const newConfig = Object.assign({}, tooltipConfigBase);
     newConfig.encoding.tooltip = newFields;

--- a/ui/src/components/LinechartSpec.js
+++ b/ui/src/components/LinechartSpec.js
@@ -62,7 +62,6 @@ export const getTooltipConfig = (fields) => {
           title: 'Date',
         },
       ],
-      color: { legend: null },
     },
     selection: {
       hover: {
@@ -75,9 +74,12 @@ export const getTooltipConfig = (fields) => {
       },
     },
   };
-
-  const newFields = [...tooltipConfigBase.encoding.tooltip, ...fields];
-  const newConfig = Object.assign({}, tooltipConfigBase);
-  newConfig.encoding.tooltip = newFields;
-  return newConfig;
+  if (fields.length) {
+    fields = fields.filter((item) => !!item);
+    const newFields = [...tooltipConfigBase.encoding.tooltip, ...fields];
+    const newConfig = Object.assign({}, tooltipConfigBase);
+    newConfig.encoding.tooltip = newFields;
+    return newConfig;
+  }
+  return tooltipConfigBase;
 };

--- a/ui/src/containers/CreateVolume.js
+++ b/ui/src/containers/CreateVolume.js
@@ -172,15 +172,6 @@ const CheckboxContainer = styled.div`
   }
 `;
 
-const InputNumberComponentStyle = styled.input`
-  width: 60px;
-  height: 25px;
-  border: solid 1px ${(props) => props.theme.brand.border};
-  border-radius: 4px;
-  background-color: ${(props) => props.theme.brand.primary};
-  color: ${(props) => props.theme.brand.textPrimary};
-`;
-
 const MultiCreationFormContainer = styled.div`
   padding-left: ${padding.base};
   display: flex;
@@ -707,8 +698,7 @@ const CreateVolume = (props) => {
                               >
                                 {intl.translate('number_volume_create')}
                               </span>
-                              {/* TODO: Generalize the number input component to core-ui. */}
-                              <InputNumberComponentStyle
+                              <Input
                                 type="number"
                                 name="numberOfVolumes"
                                 value={values.numberOfVolumes}

--- a/ui/src/containers/Layout.js
+++ b/ui/src/containers/Layout.js
@@ -51,6 +51,7 @@ const Layout = (props) => {
 
   const sidebarConfig = {
     onToggleClick: toggleSidebar,
+    hoverable: true,
     expanded: sidebar.expanded,
     'data-cy-state-isexpanded': sidebar.expanded,
     actions: [

--- a/ui/src/containers/NodePageMetricsTab.js
+++ b/ui/src/containers/NodePageMetricsTab.js
@@ -1,6 +1,6 @@
 //@flow
 import React from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router';
 import styled from 'styled-components';
 import { padding } from '@scality/core-ui/dist/style/theme';
@@ -79,10 +79,10 @@ const NodePageMetricsTab = ({
   avgStats: MonitoringMetrics,
 }) => {
   const dispatch = useDispatch();
-  const theme = useSelector((state) => state.config.theme);
+  const theme = useTypedSelector((state) => state.config.theme);
   const history = useHistory();
   const query = useQuery();
-  const config = useSelector((state) => state.config);
+  const api = useTypedSelector((state) => state.config.api);
   const metricsTimeSpan = useTypedSelector(
     (state) => state.app.monitoring.nodeStats.metricsTimeSpan,
   );
@@ -505,17 +505,18 @@ const NodePageMetricsTab = ({
             }}
           />
         </ToggleContainer>
-        <Button
-          text={intl.translate('advanced_metrics')}
-          variant={'base'}
-          onClick={() => {}}
-          icon={<i className="fas fa-external-link-alt" />}
-          size={'small'}
-          href={`${config.api.url_grafana}/dashboard/db/nodes-detailed?var-DS_PROMETHEUS=Prometheus&var-job=node-exporter&var-name=${hostnameLabel}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          data-cy="advanced_metrics_node_detailed"
-        />
+        {api && api.url_grafana && (
+          <Button
+            text={intl.translate('advanced_metrics')}
+            variant={'base'}
+            icon={<i className="fas fa-external-link-alt" />}
+            size={'small'}
+            href={`${api.url_grafana}/dashboard/db/nodes-detailed?var-DS_PROMETHEUS=Prometheus&var-job=node-exporter&var-name=${hostnameLabel}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            data-cy="advanced_metrics_node_detailed"
+          />
+        )}
         <Dropdown
           items={metricsTimeSpanDropdownItems}
           text={metricsTimeSpan}
@@ -527,7 +528,7 @@ const NodePageMetricsTab = ({
         <RowGraphContainer>
           <GraphWrapper>
             <GraphTitle>CPU Usage (%)</GraphTitle>
-            {nodeStatsData['cpuUsage'].length !== 0 && graphWidth ? (
+            {nodeStatsData['cpuUsage'].length && graphWidth ? (
               <LineChart
                 id={'node_cpu_usage_id'}
                 data={cpuData}
@@ -549,7 +550,7 @@ const NodePageMetricsTab = ({
           </GraphWrapper>
           <GraphWrapper>
             <GraphTitle>CPU System Load (%)</GraphTitle>
-            {nodeStatsData['systemLoad'].length !== 0 && graphWidth ? (
+            {nodeStatsData['systemLoad'].length && graphWidth ? (
               <LineChart
                 id={'node_system_load_id'}
                 data={systemLoadData}
@@ -573,7 +574,7 @@ const NodePageMetricsTab = ({
         <RowGraphContainer>
           <GraphWrapper>
             <GraphTitle>Memory (%)</GraphTitle>
-            {nodeStatsData['memory'].length !== 0 && graphWidth ? (
+            {nodeStatsData['memory'].length && graphWidth ? (
               <LineChart
                 id={'node_memory_id'}
                 data={memoryData}
@@ -595,7 +596,7 @@ const NodePageMetricsTab = ({
           </GraphWrapper>
           <GraphWrapper>
             <GraphTitle>IOPS</GraphTitle>
-            {iopsData.length !== 0 && graphWidth ? (
+            {iopsData.length && graphWidth ? (
               <LineChart
                 id={'node_IOPS_id'}
                 data={iopsData}
@@ -620,7 +621,7 @@ const NodePageMetricsTab = ({
         <RowGraphContainer>
           <GraphWrapper>
             <GraphTitle>Control Plane Bandwidth (MB/s)</GraphTitle>
-            {controlPlaneNetworkBandwidthData.length !== 0 && graphWidth ? (
+            {controlPlaneNetworkBandwidthData.length && graphWidth ? (
               <LineChart
                 id={'node_control_plane_bandwidth_id'}
                 data={controlPlaneNetworkBandwidthData}
@@ -642,7 +643,7 @@ const NodePageMetricsTab = ({
           </GraphWrapper>
           <GraphWrapper>
             <GraphTitle>Workload Plane Bandwidth (MB/s)</GraphTitle>
-            {workloadPlaneNetworkBandwidthData.length !== 0 && graphWidth ? (
+            {workloadPlaneNetworkBandwidthData.length && graphWidth ? (
               <LineChart
                 id={'node_workload_plane_bandwidth_id'}
                 data={workloadPlaneNetworkBandwidthData}

--- a/ui/src/containers/NodePageMetricsTab.js
+++ b/ui/src/containers/NodePageMetricsTab.js
@@ -96,7 +96,7 @@ const NodePageMetricsTab = ({
   const unameInfos = useTypedSelector(
     (state) => state.app.monitoring.unameInfo,
   );
-  const hostnameLabel = unameInfos?.find(
+  const hostnameLabel = unameInfos.find(
     (unameInfo) =>
       unameInfo?.metric?.instance === `${instanceIP}:${PORT_NODE_EXPORTER}`,
   )?.metric?.nodename;
@@ -190,58 +190,58 @@ const NodePageMetricsTab = ({
   }, {});
 
   let cpuData = nodeStatsData['cpuUsage'];
-  if (showAvg) cpuData = cpuData.concat(avgStatsData['cpuUsage']);
-  const tooltipConfigCPU = getTooltipConfig([
+  let systemLoadData = nodeStatsData['systemLoad'];
+  let memoryData = nodeStatsData['memory'];
+  // Combine the read/write, in/out into one dataset
+  let iopsData = nodeStatsData['iopsRead'].concat(nodeStatsData['iopsWrite']);
+  let controlPlaneNetworkBandwidthData = nodeStatsData[
+    'controlPlaneNetworkBandwidthIn'
+  ].concat(nodeStatsData['controlPlaneNetworkBandwidthOut']);
+  let workloadPlaneNetworkBandwidthData = nodeStatsData[
+    'workloadPlaneNetworkBandwidthIn'
+  ].concat(nodeStatsData['workloadPlaneNetworkBandwidthOut']);
+
+  if (showAvg) {
+    cpuData = cpuData.concat(avgStatsData['cpuUsage']);
+    systemLoadData = systemLoadData.concat(avgStatsData['systemLoad']);
+    memoryData = memoryData.concat(avgStatsData['memory']);
+    iopsData = iopsData
+      .concat(avgStatsData['iopsRead'])
+      .concat(avgStatsData['iopsWrite']);
+    controlPlaneNetworkBandwidthData = controlPlaneNetworkBandwidthData
+      .concat(avgStatsData['controlPlaneNetworkBandwidthIn'])
+      .concat(avgStatsData['controlPlaneNetworkBandwidthOut']);
+    workloadPlaneNetworkBandwidthData = workloadPlaneNetworkBandwidthData
+      .concat(avgStatsData['workloadPlaneNetworkBandwidthIn'])
+      .concat(avgStatsData['workloadPlaneNetworkBandwidthOut']);
+  }
+
+  // Tooltip Custom Spec
+  const ttpCPUSpec = [
     {
       field: 'CPU Usage',
       type: 'quantitative',
       title: `CPU Usage - ${nodeName}`,
       format: '.1f',
     },
-    showAvg && {
-      field: 'cluster avg',
-      type: 'quantitative',
-      title: `CPU Usage - ${intl.translate('cluster_avg')}`,
-      format: '.1f',
-    },
-  ]);
-
-  let systemLoadData = nodeStatsData['systemLoad'];
-  if (showAvg)
-    systemLoadData = systemLoadData.concat(avgStatsData['systemLoad']);
-  const tooltipConfigSystemLoad = getTooltipConfig([
+  ];
+  const ttpSystemLoadSpec = [
     {
       field: 'System Load',
       type: 'quantitative',
       title: `System Load - ${nodeName}`,
       format: '.1f',
     },
-    showAvg && {
-      field: 'cluster avg',
-      type: 'quantitative',
-      title: `System Load - ${intl.translate('cluster_avg')}`,
-      format: '.1f',
-    },
-  ]);
-
-  let memoryData = nodeStatsData['memory'];
-  if (showAvg) memoryData = memoryData.concat(avgStatsData['memory']);
-  const tooltipConfigMemory = getTooltipConfig([
+  ];
+  const ttpMemorySpec = [
     {
       field: 'Memory',
       type: 'quantitative',
       title: `Memory - ${nodeName}`,
       format: '.1f',
     },
-    showAvg && {
-      field: 'cluster avg',
-      type: 'quantitative',
-      title: `Memory - ${intl.translate('cluster_avg')}`,
-      format: '.1f',
-    },
-  ]);
-
-  const tooltipConfigIops = getTooltipConfig([
+  ];
+  const ttpIOPSSpec = [
     {
       field: `Read`,
       type: 'quantitative',
@@ -254,27 +254,8 @@ const NodePageMetricsTab = ({
       title: `Write - ${nodeName}`,
       format: '.1f',
     },
-    showAvg && {
-      field: 'read avg',
-      type: 'quantitative',
-      title: `Read - ${intl.translate('cluster_avg')}`,
-      format: '.1f',
-    },
-    showAvg && {
-      field: 'write avg',
-      type: 'quantitative',
-      title: `Write - ${intl.translate('cluster_avg')}`,
-      format: '.1f',
-    },
-  ]);
-  // Combine the read/write, in/out into one dataset
-  let iopsData = nodeStatsData['iopsRead'].concat(nodeStatsData['iopsWrite']);
-  if (showAvg)
-    iopsData = iopsData
-      .concat(avgStatsData['iopsRead'])
-      .concat(avgStatsData['iopsWrite']);
-
-  const tooltipConfigInOut = getTooltipConfig([
+  ];
+  const ttpInOutSpec = [
     {
       field: 'In',
       type: 'quantitative',
@@ -287,35 +268,60 @@ const NodePageMetricsTab = ({
       title: `Out - ${nodeName}`,
       format: '.1f',
     },
-    showAvg && {
-      field: 'in avg',
+  ];
+  if (showAvg) {
+    ttpCPUSpec.push({
+      field: 'cluster avg',
       type: 'quantitative',
-      title: `In - ${intl.translate('cluster_avg')}`,
+      title: `CPU Usage - ${intl.translate('cluster_avg')}`,
       format: '.1f',
-    },
-    showAvg && {
-      field: 'out avg',
+    });
+    ttpSystemLoadSpec.push({
+      field: 'cluster avg',
       type: 'quantitative',
-      title: `Out - ${intl.translate('cluster_avg')}`,
+      title: `System Load - ${intl.translate('cluster_avg')}`,
       format: '.1f',
-    },
-  ]);
-
-  let controlPlaneNetworkBandwidthData = nodeStatsData[
-    'controlPlaneNetworkBandwidthIn'
-  ].concat(nodeStatsData['controlPlaneNetworkBandwidthOut']);
-  if (showAvg)
-    controlPlaneNetworkBandwidthData = controlPlaneNetworkBandwidthData
-      .concat(avgStatsData['controlPlaneNetworkBandwidthIn'])
-      .concat(avgStatsData['controlPlaneNetworkBandwidthOut']);
-
-  let workloadPlaneNetworkBandwidthData = nodeStatsData[
-    'workloadPlaneNetworkBandwidthIn'
-  ].concat(nodeStatsData['workloadPlaneNetworkBandwidthOut']);
-  if (showAvg)
-    workloadPlaneNetworkBandwidthData = workloadPlaneNetworkBandwidthData
-      .concat(avgStatsData['workloadPlaneNetworkBandwidthIn'])
-      .concat(avgStatsData['workloadPlaneNetworkBandwidthOut']);
+    });
+    ttpMemorySpec.push({
+      field: 'cluster avg',
+      type: 'quantitative',
+      title: `Memory - ${intl.translate('cluster_avg')}`,
+      format: '.1f',
+    });
+    ttpIOPSSpec.push(
+      {
+        field: 'read avg',
+        type: 'quantitative',
+        title: `Read - ${intl.translate('cluster_avg')}`,
+        format: '.1f',
+      },
+      {
+        field: 'write avg',
+        type: 'quantitative',
+        title: `Write - ${intl.translate('cluster_avg')}`,
+        format: '.1f',
+      },
+    );
+    ttpInOutSpec.push(
+      {
+        field: 'in avg',
+        type: 'quantitative',
+        title: `In - ${intl.translate('cluster_avg')}`,
+        format: '.1f',
+      },
+      {
+        field: 'out avg',
+        type: 'quantitative',
+        title: `Out - ${intl.translate('cluster_avg')}`,
+        format: '.1f',
+      },
+    );
+  }
+  const tooltipConfigCPU = getTooltipConfig(ttpCPUSpec);
+  const tooltipConfigSystemLoad = getTooltipConfig(ttpSystemLoadSpec);
+  const tooltipConfigMemory = getTooltipConfig(ttpMemorySpec);
+  const tooltipConfigIops = getTooltipConfig(ttpIOPSSpec);
+  const tooltipConfigInOut = getTooltipConfig(ttpInOutSpec);
 
   const xAxis = {
     field: 'date',
@@ -358,7 +364,6 @@ const NodePageMetricsTab = ({
 
   // the `read` and `out` should be the same color
   // the `write` and `in` should be the same color
-
   const colorCPU = {
     field: 'type',
     type: 'nominal',

--- a/ui/src/containers/NodePageMetricsTab.js
+++ b/ui/src/containers/NodePageMetricsTab.js
@@ -260,13 +260,13 @@ const NodePageMetricsTab = ({
       field: 'In',
       type: 'quantitative',
       title: `In - ${nodeName}`,
-      format: '.1f',
+      format: '.2f',
     },
     {
       field: 'Out',
       type: 'quantitative',
       title: `Out - ${nodeName}`,
-      format: '.1f',
+      format: '.2f',
     },
   ];
   if (showAvg) {
@@ -307,13 +307,13 @@ const NodePageMetricsTab = ({
         field: 'in avg',
         type: 'quantitative',
         title: `In - ${intl.translate('cluster_avg')}`,
-        format: '.1f',
+        format: '.2f',
       },
       {
         field: 'out avg',
         type: 'quantitative',
         title: `Out - ${intl.translate('cluster_avg')}`,
-        format: '.1f',
+        format: '.2f',
       },
     );
   }


### PR DESCRIPTION
**Component**:
ui, sidebar, inputs, alerts

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

We want to use the new Core-UI components. #3060 

**Summary**:
* Replaced ActiveAlertsFilters by core-ui's HealthSelector.
* Made Sidebar hoverable.
* #3060 also mentions number inputs but those work without any adaptations

**Important** : For this to work we need this fix (https://github.com/scality/core-ui/pull/234) to be included in the core-ui version used by metalk8s.

**Acceptance criteria**: 
* Sidebar is now hoverable
* Number inputs are working
* Alerts are filtered through the Healthselector component


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #3060 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
