### PR TITLE
ui: Fix salt may return false when fetching IP interfaces

### DIFF
--- a/ui/src/containers/NodePage.js
+++ b/ui/src/containers/NodePage.js
@@ -4,14 +4,12 @@ import { refreshNodesAction, stopRefreshNodesAction } from '../ducks/app/nodes';
 import { useRefreshEffect } from '../services/utils';
 import NodePageContent from './NodePageContent';
 import { PageContainer } from '../components/style/CommonLayoutStyle';
-import { fetchNodesIPsInterfaceAction } from '../ducks/app/nodes';
 import { fetchAlertsAlertmanagerAction } from '../ducks/app/alerts';
 import { getNodeListData } from '../services/NodeUtils';
 
 const NodePage = (props) => {
   const dispatch = useDispatch();
   useEffect(() => {
-    dispatch(fetchNodesIPsInterfaceAction());
     dispatch(fetchAlertsAlertmanagerAction());
   }, [dispatch]);
   useRefreshEffect(refreshNodesAction, stopRefreshNodesAction);

--- a/ui/src/ducks/app/nodes.test.js
+++ b/ui/src/ducks/app/nodes.test.js
@@ -11,6 +11,7 @@ import {
   CREATE_NODE_FAILED,
   clusterVersionSelector,
   nodesRefreshingSelector,
+  fetchNodesIPsInterface,
 } from './nodes';
 import { allJobsSelector } from './salt';
 import {
@@ -127,6 +128,7 @@ describe('`fetchNodes` saga', () => {
     expect(_gen.next().value).toEqual(
       put({ type: UPDATE_NODES, payload: { isLoading: false } }),
     );
+    expect(_gen.next().value).toEqual(call(fetchNodesIPsInterface));
     expect(_gen.next().done).toBe(true);
   };
 

--- a/ui/src/services/NodeUtils.js
+++ b/ui/src/services/NodeUtils.js
@@ -12,6 +12,7 @@ import {
   API_STATUS_DEPLOYING,
 } from '../constants';
 import { compareHealth } from './utils';
+import type { IPInterfaces } from './salt/api';
 
 const METALK8S_CONTROL_PLANE_IP = 'metalk8s:control_plane_ip';
 const METALK8S_WORKLOAD_PLANE_IP = 'metalk8s:workload_plane_ip';
@@ -141,7 +142,19 @@ export const getNodeListData = createSelector(
 //   control_plane: { ip: '10.0.1.42', interface: 'eth1'}
 //   workload_plane: { ip: '10.100.0.2', interface: 'eth3'},
 // }
-export const nodesCPWPIPsInterface = (IPsInterfacesObject) => {
+export const nodesCPWPIPsInterface = (
+  IPsInterfacesObject: IPInterfaces | boolean,
+): {
+  control_plane: { ip: string, interface: string },
+  workload_plane: { ip: string, interface: string },
+} => {
+  if (!IPsInterfacesObject) {
+    return {
+      control_plane: { ip: '', interface: '' },
+      workload_plane: { ip: '', interface: '' },
+    };
+  }
+  
   return {
     controlPlane: {
       ip: IPsInterfacesObject[METALK8S_CONTROL_PLANE_IP],

--- a/ui/src/services/NodeUtils.js
+++ b/ui/src/services/NodeUtils.js
@@ -139,22 +139,22 @@ export const getNodeListData = createSelector(
 // }
 // Return
 // {
-//   control_plane: { ip: '10.0.1.42', interface: 'eth1'}
-//   workload_plane: { ip: '10.100.0.2', interface: 'eth3'},
+//   controlPlane: { ip: '10.0.1.42', interface: 'eth1'}
+//   workloadPlane: { ip: '10.100.0.2', interface: 'eth3'},
 // }
 export const nodesCPWPIPsInterface = (
   IPsInterfacesObject: IPInterfaces | boolean,
 ): {
-  control_plane: { ip: string, interface: string },
-  workload_plane: { ip: string, interface: string },
+  controlPlane: { ip: string, interface: string },
+  workloadPlane: { ip: string, interface: string },
 } => {
   if (!IPsInterfacesObject) {
     return {
-      control_plane: { ip: '', interface: '' },
-      workload_plane: { ip: '', interface: '' },
+      controlPlane: { ip: '', interface: '' },
+      workloadPlane: { ip: '', interface: '' },
     };
   }
-  
+
   return {
     controlPlane: {
       ip: IPsInterfacesObject[METALK8S_CONTROL_PLANE_IP],

--- a/ui/src/services/salt/api.js
+++ b/ui/src/services/salt/api.js
@@ -1,3 +1,5 @@
+//@flow
+import { User } from 'oidc-client';
 import ApiClient from '../ApiClient';
 
 let saltApiClient = null;
@@ -6,7 +8,7 @@ export function getClient() {
   return saltApiClient;
 }
 
-export function initialize(apiUrl) {
+export function initialize(apiUrl: string) {
   saltApiClient = new ApiClient({ apiUrl });
 }
 
@@ -23,8 +25,11 @@ export type SaltToken = {
   ],
 };
 
-export function authenticate(user): Promise<SaltToken> {
-  var payload = {
+export async function authenticate(user: User): Promise<SaltToken> {
+  if (!saltApiClient) {
+    throw new Error('Salt api client should be defined.');
+  }
+  const payload = {
     eauth: 'kubernetes_rbac',
     username: `oidc:${user.profile.email}`,
     token: user.id_token,
@@ -32,7 +37,10 @@ export function authenticate(user): Promise<SaltToken> {
   return saltApiClient.post('/login', payload);
 }
 
-export async function deployNode(node, version) {
+export async function deployNode(node: string, version: string) {
+  if (!saltApiClient) {
+    throw new Error('Salt api client should be defined.');
+  }
   return saltApiClient.post('/', {
     client: 'runner_async',
     fun: 'state.orchestrate',
@@ -44,7 +52,10 @@ export async function deployNode(node, version) {
   });
 }
 
-export async function printJob(jid) {
+export async function printJob(jid: string) {
+  if (!saltApiClient) {
+    throw new Error('Salt api client should be defined.');
+  }
   return saltApiClient.post('/', {
     client: 'runner',
     fun: 'jobs.print_job',
@@ -52,7 +63,10 @@ export async function printJob(jid) {
   });
 }
 
-export async function prepareEnvironment(environment, version) {
+export async function prepareEnvironment(environment: string, version: string) {
+  if (!saltApiClient) {
+    throw new Error('Salt api client should be defined.');
+  }
   return saltApiClient.post('/', {
     client: 'runner_async',
     fun: 'state.orchestrate',
@@ -64,7 +78,17 @@ export async function prepareEnvironment(environment, version) {
   });
 }
 
-export async function getNodesIPsInterfaces() {
+export type IPInterfaces = {
+  'metalk8s:control_plane_ip': string,
+  'metalk8s:workload_plane_ip': string,
+  ip_interfaces: { [interface: string]: string[] },
+};
+export async function getNodesIPsInterfaces(): Promise<{
+  return: [{ [nodeName: string]: boolean | IPInterfaces }],
+}> {
+  if (!saltApiClient) {
+    throw new Error('Salt api client should be defined.');
+  }
   return saltApiClient.post('/', {
     client: 'local',
     tgt: '*',

--- a/ui/src/services/salt/api.js
+++ b/ui/src/services/salt/api.js
@@ -83,7 +83,9 @@ export type IPInterfaces = {
   'metalk8s:workload_plane_ip': string,
   ip_interfaces: { [interface: string]: string[] },
 };
-export async function getNodesIPsInterfaces(): Promise<{
+export async function getNodesIPsInterfaces(
+  nodeNames: string[],
+): Promise<{
   return: [{ [nodeName: string]: boolean | IPInterfaces }],
 }> {
   if (!saltApiClient) {
@@ -91,7 +93,8 @@ export async function getNodesIPsInterfaces(): Promise<{
   }
   return saltApiClient.post('/', {
     client: 'local',
-    tgt: '*',
+    tgt: nodeNames.join(','),
+    tgt_type: 'list',
     fun: 'grains.item',
     arg: [
       'metalk8s:control_plane_ip',


### PR DESCRIPTION
**Component**:

ui

**Context**: 

When a cluster goes into an incorrect state, salt API may sends `false` when requesting IP interfaces of nodes which then prevent the UI to display the nodes.

**Acceptance criteria**: 

The UI should display the nodes even if we can't fetch their IPs.
