### PR TITLE
Build: Fix deps issue in python linting for Salt

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,3 @@
 # Format all Python files with black
 d66ec12cd2854e286253012a1954bba6b3c653b4
+69c71596307c14a80cd604db5d38ee3c410e17ca

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
         name: Lint Salt
         # Linting for salt files only in directory "salt/_<module>/<module_name>.py"
         files: salt/_.*/.*\.py
-        additional_dependencies: ['saltpylint==2020.9.28']
+        additional_dependencies: ['saltpylint==2020.9.28', 'six==1.15.0']
         args:
           - --rcfile=salt/.pylintrc
           - --ignore=metalk8s_package_manager_apt.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,14 @@ repos:
     hooks:
       - id: black
         name: Formatting Python
+      - id: black
+        # We want this hook to be part of "pylint" so that if we run
+        # `pre-commit run pylint` we include this hook
+        alias: pylint
+        name: Checking Python formatting
+        args:
+          - --check
+          - --diff
 
   - repo: https://github.com/pycqa/pylint
     rev: pylint-2.6.0

--- a/buildchain/buildchain/format.py
+++ b/buildchain/buildchain/format.py
@@ -55,7 +55,7 @@ def format_python() -> types.TaskDict:
         "name": "python",
         "title": utils.title_with_subtask_name("FORMAT"),
         "doc": format_python.__doc__,
-        "actions": [["tox", "-e", "format-python"]],
+        "actions": [["tox", "-e", "lint", "black"]],
         "file_dep": python_files,
     }
 

--- a/salt/_modules/metalk8s.py
+++ b/salt/_modules/metalk8s.py
@@ -151,20 +151,23 @@ def _get_archive_info(info):
 def archive_info_from_product_txt(archive):
     if os.path.isdir(archive):
         info = archive_info_from_tree(archive)
-        info.update({
-            'iso': None,
-            'path': archive,
-        })
+        info.update(
+            {
+                "iso": None,
+                "path": archive,
+            }
+        )
     elif os.path.isfile(archive):
         info = archive_info_from_iso(archive)
-        info.update({
-            'iso': archive,
-            'path': '/srv/scality/metalk8s-{0}'.format(info['version']),
-        })
+        info.update(
+            {
+                "iso": archive,
+                "path": "/srv/scality/metalk8s-{0}".format(info["version"]),
+            }
+        )
     else:
         raise CommandExecutionError(
-            'Invalid archive path {0}, should be an iso or a directory.'
-            .format(archive)
+            "Invalid archive path {0}, should be an iso or a directory.".format(archive)
         )
 
     return info
@@ -235,22 +238,23 @@ def get_archives(archives=None):
     res = {}
     for archive in archives:
         info = archive_info_from_product_txt(archive)
-        env_name = 'metalk8s-{0}'.format(info['version'])
+        env_name = "metalk8s-{0}".format(info["version"])
 
         # Raise if we have 2 archives with the same version
         if env_name in res:
             error_msg = []
             for dup_version in (res[env_name], info):
-                if dup_version['iso']:
-                    path = dup_version['iso']
-                    kind = 'ISO'
+                if dup_version["iso"]:
+                    path = dup_version["iso"]
+                    kind = "ISO"
                 else:
-                    path = dup_version['path']
-                    kind = 'directory'
+                    path = dup_version["path"]
+                    kind = "directory"
                 error_msg.append("{0} ({1})".format(path, kind))
             raise CommandExecutionError(
-                'Two archives have the same version "{0}":\n- {1}'
-                .format(info['version'], "\n- ".join(error_msg))
+                'Two archives have the same version "{0}":\n- {1}'.format(
+                    info["version"], "\n- ".join(error_msg)
+                )
             )
 
         res.update({env_name: info})
@@ -645,12 +649,10 @@ def get_from_map(value, saltenv=None):
 
 def _read_bootstrap_config():
     try:
-        with salt.utils.files.fopen(BOOTSTRAP_CONFIG, 'r') as fd:
+        with salt.utils.files.fopen(BOOTSTRAP_CONFIG, "r") as fd:
             config = salt.utils.yaml.safe_load(fd)
     except IOError as exc:
-        msg = 'Failed to load bootstrap config file at "{}"'.format(
-            BOOTSTRAP_CONFIG
-        )
+        msg = 'Failed to load bootstrap config file at "{}"'.format(BOOTSTRAP_CONFIG)
         raise CommandExecutionError(message=msg) from exc
 
     return config
@@ -658,12 +660,10 @@ def _read_bootstrap_config():
 
 def _write_bootstrap_config(config):
     try:
-        with salt.utils.files.fopen(BOOTSTRAP_CONFIG, 'w') as fd:
+        with salt.utils.files.fopen(BOOTSTRAP_CONFIG, "w") as fd:
             salt.utils.yaml.safe_dump(config, fd, default_flow_style=False)
     except Exception as exc:
-        msg = 'Failed to write bootstrap config file at "{}"'.format(
-            BOOTSTRAP_CONFIG
-        )
+        msg = 'Failed to write bootstrap config file at "{}"'.format(BOOTSTRAP_CONFIG)
         raise CommandExecutionError(message=msg) from exc
 
 
@@ -675,15 +675,15 @@ def configure_archive(archive, remove=False):
 
     if remove:
         try:
-            config['archives'].remove(archive)
+            config["archives"].remove(archive)
             msg = "removed from bootstrap configuration"
         except ValueError:
             msg = "already absent in bootstrap configuration"
     else:
-        if archive in config['archives']:
+        if archive in config["archives"]:
             msg = "already present in bootstrap configuration"
         else:
-            config['archives'].append(archive)
+            config["archives"].append(archive)
             msg = "added to bootstrap configuration"
 
     _write_bootstrap_config(config)

--- a/salt/tests/unit/modules/test_metalk8s.py
+++ b/salt/tests/unit/modules/test_metalk8s.py
@@ -224,7 +224,7 @@ class Metalk8sTestCase(TestCase, mixins.LoaderModuleMockMixin):
         result,
         invalid_path=False,
         raises=False,
-        pillar_archives=None
+        pillar_archives=None,
     ):
         """
         Tests the return of `get_archives` function
@@ -240,17 +240,14 @@ class Metalk8sTestCase(TestCase, mixins.LoaderModuleMockMixin):
 
         pillar_dict = {"metalk8s": {}}
         if pillar_archives is not None:
-            pillar_dict['metalk8s']['archives'] = pillar_archives
+            pillar_dict["metalk8s"]["archives"] = pillar_archives
 
-        with patch(
-            "metalk8s.archive_info_from_product_txt", infos_mock
-        ), patch.dict(metalk8s.__pillar__, pillar_dict):
+        with patch("metalk8s.archive_info_from_product_txt", infos_mock), patch.dict(
+            metalk8s.__pillar__, pillar_dict
+        ):
             if raises:
                 self.assertRaisesRegex(
-                    CommandExecutionError,
-                    result,
-                    metalk8s.get_archives,
-                    archives
+                    CommandExecutionError, result, metalk8s.get_archives, archives
                 )
             else:
                 self.assertEqual(metalk8s.get_archives(archives), result)
@@ -523,49 +520,52 @@ class Metalk8sTestCase(TestCase, mixins.LoaderModuleMockMixin):
                     compile_template_mock.call_args[1],
                     **expected_args,
                 ),
-                compile_template_mock.call_args[1]
+                compile_template_mock.call_args[1],
             )
 
-    @utils.parameterized_from_cases(
-        YAML_TESTS_CASES["archive_info_from_product_txt"]
-    )
-    def test_archive_info_from_product_txt(self, archive, info, result,
-            is_file=False, is_dir=False, raises=False):
+    @utils.parameterized_from_cases(YAML_TESTS_CASES["archive_info_from_product_txt"])
+    def test_archive_info_from_product_txt(
+        self, archive, info, result, is_file=False, is_dir=False, raises=False
+    ):
         info_mock = MagicMock(return_value=info)
 
-        with patch("os.path.isdir", MagicMock(return_value=is_dir)), \
-                patch("os.path.isfile", MagicMock(return_value=is_file)), \
-                patch("metalk8s.archive_info_from_tree", info_mock), \
-                patch("metalk8s.archive_info_from_iso", info_mock):
+        with patch("os.path.isdir", MagicMock(return_value=is_dir)), patch(
+            "os.path.isfile", MagicMock(return_value=is_file)
+        ), patch("metalk8s.archive_info_from_tree", info_mock), patch(
+            "metalk8s.archive_info_from_iso", info_mock
+        ):
             if raises:
                 self.assertRaisesRegex(
                     CommandExecutionError,
                     result,
                     metalk8s.archive_info_from_product_txt,
-                    archive
+                    archive,
                 )
             else:
                 self.assertEqual(
-                    metalk8s.archive_info_from_product_txt(archive),
-                    result
+                    metalk8s.archive_info_from_product_txt(archive), result
                 )
 
-
     @utils.parameterized_from_cases(YAML_TESTS_CASES["configure_archive"])
-    def test_configure_archive(self, archive, result, remove=None, config=None,
-                               invalid_path=False, raises=False):
+    def test_configure_archive(
+        self,
+        archive,
+        result,
+        remove=None,
+        config=None,
+        invalid_path=False,
+        raises=False,
+    ):
         """
         Tests the return of `configure_archive` function
         """
         info_mock = MagicMock()
         if invalid_path:
-            info_mock.side_effect = CommandExecutionError(
-                "Invalid archive path"
-            )
+            info_mock.side_effect = CommandExecutionError("Invalid archive path")
 
-        with patch("metalk8s.archive_info_from_product_txt", info_mock), \
-                patch("metalk8s._read_bootstrap_config", MagicMock(return_value=config)), \
-                patch("metalk8s._write_bootstrap_config", MagicMock()):
+        with patch("metalk8s.archive_info_from_product_txt", info_mock), patch(
+            "metalk8s._read_bootstrap_config", MagicMock(return_value=config)
+        ), patch("metalk8s._write_bootstrap_config", MagicMock()):
             if raises:
                 self.assertRaisesRegex(
                     CommandExecutionError,
@@ -576,22 +576,16 @@ class Metalk8sTestCase(TestCase, mixins.LoaderModuleMockMixin):
                 )
             else:
                 self.assertEqual(
-                    metalk8s.configure_archive(
-                        archive, remove=remove
-                    ),
-                    result
+                    metalk8s.configure_archive(archive, remove=remove), result
                 )
 
-    @parameterized.expand([
-        param(),
-        param(True, "Failed to write bootstrap config file")
-    ])
+    @parameterized.expand(
+        [param(), param(True, "Failed to write bootstrap config file")]
+    )
     def test__write_bootstrap_config(self, raises=False, result=None):
         open_mock = mock_open()
         if raises:
-            open_mock.side_effect = Exception(
-                "A wild exception appears!"
-            )
+            open_mock.side_effect = Exception("A wild exception appears!")
 
         with patch("salt.utils.files.fopen", open_mock):
             if raises:
@@ -599,7 +593,7 @@ class Metalk8sTestCase(TestCase, mixins.LoaderModuleMockMixin):
                     CommandExecutionError,
                     result,
                     metalk8s._write_bootstrap_config,
-                    None
+                    None,
                 )
             else:
                 self.assertEqual(
@@ -607,10 +601,9 @@ class Metalk8sTestCase(TestCase, mixins.LoaderModuleMockMixin):
                     None,
                 )
 
-    @parameterized.expand([
-        param(),
-        param(True, "Failed to load bootstrap config file")
-    ])
+    @parameterized.expand(
+        [param(), param(True, "Failed to load bootstrap config file")]
+    )
     def test__read_bootstrap_config(self, raises=False, result=None):
         open_mock = mock_open(read_data="config")
         if raises:


### PR DESCRIPTION
**Component**:

'build', 'lint'

**Context**: 

Error during pylint check

**Summary**:

- Add `six` dependency in pre-commit pylint hook for Salt
- Format with black python file not yet "well formatted"
- Enforce black formatting as part of `pylint` target
- Fix invliad `format:python` entry in doit

---

