### PR TITLE
Bump pause image to 3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
 ## Release 2.7.2 (in development)
+### Bug fixes
+- Embed `pause` image version 3.2 instead of 3.1 needed for MetalK8s to work
+  offline (needed by containerd version superior to 1.4.0)
+  (PR [#3120](https://github.com/scality/metalk8s/pull/3120))
 
 ## Release 2.7.1
 ### Bug fixes

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -170,8 +170,8 @@ CONTAINER_IMAGES : Tuple[Image, ...] = (
     ),
     Image(
         name='pause',
-        version='3.1',
-        digest='sha256:da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e',
+        version='3.2',
+        digest='sha256:80d28bedfe5dec59da9ebf8e6260224ac9008ab5c11dbbe16ee3ba3e4439ac2c',
     ),
     Image(
         name='prometheus',

--- a/salt/_states/containerd.py
+++ b/salt/_states/containerd.py
@@ -60,7 +60,9 @@ def image_managed(name, archive_path=None):
             })
             return ret
 
-        result = __salt__['containerd.load_cri_image'](path=archive_path)
+        real_archive_path = __salt__['cp.cache_file'](archive_path, __env__)
+
+        result = __salt__['containerd.load_cri_image'](path=real_archive_path)
         # ctr can fail to load the image and exit silently
         if result['retcode'] == 0 and __salt__['cri.available'](name):
             ret['changes'].update({

--- a/salt/metalk8s/container-engine/containerd/configured.sls
+++ b/salt/metalk8s/container-engine/containerd/configured.sls
@@ -1,21 +1,16 @@
 {% from "metalk8s/map.jinja" import metalk8s with context %}
+{%- from "metalk8s/map.jinja" import repo with context %}
 
 include:
   - .installed
   - .running
 
+{%- set pause_version = repo.images.pause.version %}
+
 Inject pause image:
   # The `containerd` states require the `cri` module, which requires `crictl`
-  file.managed:
-    - name: /tmp/pause-3.1.tar
-    - source: salt://{{ slspath }}/files/pause-3.1.tar
-    - unless: >-
-        ctr -n k8s.io image ls -q | grep k8s.gcr.io/pause | grep 3\\.1
-    - require:
-      - sls: metalk8s.container-engine.containerd.running
   containerd.image_managed:
-    - name: k8s.gcr.io/pause:3.1
-    - archive_path: /tmp/pause-3.1.tar
+    - name: k8s.gcr.io/pause:{{ pause_version }}
+    - archive_path: salt://{{ slspath }}/files/pause-{{ pause_version }}.tar
     - require:
-      - file: Inject pause image
       - metalk8s_package_manager: Install and configure cri-tools


### PR DESCRIPTION
**Component**:

'salt'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

Invalid pause image version injected in containerd

**Summary**:

- Rewrite a bit the pause injection
- Bump pause image to 3.2

---
