### PR TITLE
Improve robustness of salt-master and upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
 ## Release 2.7.2 (in development)
+### Enhancements
+- Improve Salt master and cluster upgrade stability in slow environments
+  (PR [#3125](https://github.com/scality/metalk8s/pull/3125))
+
 ### Bug fixes
 - Embed `pause` image version 3.2 instead of 3.1 needed for MetalK8s to work
   offline (needed by containerd version superior to 1.4.0)

--- a/salt/_modules/cri.py
+++ b/salt/_modules/cri.py
@@ -6,6 +6,7 @@ import re
 import logging
 import time
 
+from salt.exceptions import CommandExecutionError
 import salt.utils.json
 
 
@@ -165,15 +166,25 @@ def wait_container(name, state, timeout=60, delay=5):
     if state is not None:
         opts += " --state {0}".format(state)
 
+    last_error = None
     for _ in range(0, timeout, delay):
         out = __salt__['cmd.run_all']('crictl ps -q {0}'.format(opts))
 
-        if out['retcode'] == 0 and out['stdout']:
-            return True
+        if out["retcode"] == 0:
+            if out["stdout"]:
+                return True
+            last_error = "No container found"
+        else:
+            last_error = out["stderr"] or out["stdout"]
+
         time.sleep(delay)
-    else:
-        log.error('Failed to find container "%s" in state "%s"', name, state)
-        return False
+
+    error_msg = 'Failed to find container "{}"'.format(name)
+    if state is not None:
+        error_msg += ' in state "{}"'.format(state)
+    error_msg += ": {}".format(last_error)
+
+    raise CommandExecutionError(error_msg)
 
 
 def component_is_running(name):

--- a/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
+++ b/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
@@ -3,6 +3,8 @@ interface: {{ salt_ip }}
 log_level: {{ 'debug' if debug else 'info' }}
 
 timeout: 20
+sock_pool_size: 15
+worker_threads: 10
 
 peer:
   .*:

--- a/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
+++ b/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
@@ -2,7 +2,7 @@ interface: {{ salt_ip }}
 
 log_level: {{ 'debug' if debug else 'info' }}
 
-timeout: 10
+timeout: 20
 
 peer:
   .*:

--- a/salt/tests/unit/modules/test_cri.py
+++ b/salt/tests/unit/modules/test_cri.py
@@ -151,29 +151,76 @@ class CriTestCase(TestCase, mixins.LoaderModuleMockMixin):
                     'crictl exec {} my command '.format(stdout_ps)
                 )
 
-    @parameterized.expand([
-        (None, 6, 0, "292c3b07b", True),
-        (None, 6, 0, "", False),
-        (None, 6, 1, "Error occurred", False),
-        ("running", 6, 0, "292c3b07b", True),
-        ("running", 6, 0, "", False),
-        ("running", 6, 1, "Error occurred", False)
-    ])
-    def test_wait_container(self, state, timeout, retcode, stdout, result):
+    @parameterized.expand(
+        [
+            # Success: Found one container
+            (None, 6, 0, "292c3b07b", True),
+            # Failure: Container does not exist
+            (
+                None,
+                6,
+                0,
+                "",
+                'Failed to find container "my_cont": No container found',
+                True,
+            ),
+            # Failure: Error occurred when executing crictl command
+            (
+                None,
+                6,
+                1,
+                "Error occurred",
+                'Failed to find container "my_cont": Error occurred',
+                True,
+            ),
+            # Success: Found one running container
+            ("running", 6, 0, "292c3b07b", True),
+            # Failure: Container does not exist or is not running
+            (
+                "running",
+                6,
+                0,
+                "",
+                'Failed to find container "my_cont" in state "running": No container found',
+                True,
+            ),
+            # Failure: Error occurred when executing crictl command
+            (
+                "running",
+                6,
+                1,
+                "Error occurred",
+                'Failed to find container "my_cont" in state "running": Error occurred',
+                True,
+            ),
+        ]
+    )
+    def test_wait_container(
+        self, state, timeout, retcode, stdout, result, raises=False
+    ):
         """
         Tests the return of `wait_container` function
         """
         cmd = utils.cmd_output(retcode=retcode, stdout=stdout)
         mock_cmd = MagicMock(return_value=cmd)
-        with patch.dict(cri.__salt__, {'cmd.run_all': mock_cmd}), \
-                patch("time.sleep", MagicMock()):
-            self.assertEqual(cri.wait_container(
-                "my_cont",
-                state=state, timeout=timeout
-            ), result)
-            cmd_call = (
-                'crictl ps -q --label io.kubernetes.container.name="my_cont"'
-            )
+
+        with patch.dict(cri.__salt__, {"cmd.run_all": mock_cmd}), patch(
+            "time.sleep", MagicMock()
+        ):
+            if raises:
+                self.assertRaisesRegex(
+                    Exception,
+                    result,
+                    cri.wait_container,
+                    "my_cont",
+                    state=state,
+                    timeout=timeout,
+                )
+            else:
+                self.assertEqual(
+                    cri.wait_container("my_cont", state=state, timeout=timeout), result
+                )
+            cmd_call = 'crictl ps -q --label io.kubernetes.container.name="my_cont"'
             if state:
                 cmd_call += " --state {}".format(state)
             mock_cmd.assert_called_with(cmd_call)

--- a/scripts/upgrade.sh.in
+++ b/scripts/upgrade.sh.in
@@ -151,7 +151,7 @@ upgrade_local_engines () {
     )
     for container in "${containers_to_check[@]}"; do
         "${SALT_CALL}" --local --retcode-passthrough cri.wait_container \
-            name="$container" state=running || return 1
+            name="$container" state=running timeout=120 || return 1
     done
 }
 

--- a/scripts/upgrade.sh.in
+++ b/scripts/upgrade.sh.in
@@ -135,12 +135,24 @@ upgrade_local_engines () {
     repo_endpoint="$($SALT_CALL pillar.get \
         metalk8s:endpoints:repositories --out txt | cut -d' ' -f2- )"
 
-    # NOTE: Sleep a bit at the end so that salt-master container properly stop
-    #       before going to the next step
+    # NOTE: Sleep a bit at the end so that container properly stop before
+    #       going to the next step
     "${SALT_CALL}" --local --retcode-passthrough state.sls sync_mods="all" \
         metalk8s.kubernetes.kubelet.standalone saltenv="$SALTENV" \
         pillar="{'metalk8s': {'endpoints': {'salt-master': $saltmaster_endpoint, \
         'repositories': $repo_endpoint}}}" && sleep 20
+
+    # List of containers that need to be running to continue the upgrade
+    local -a containers_to_check=(
+        'repositories'
+        'salt-master'
+        'kube-apiserver'
+        'etcd'
+    )
+    for container in "${containers_to_check[@]}"; do
+        "${SALT_CALL}" --local --retcode-passthrough cri.wait_container \
+            name="$container" state=running || return 1
+    done
 }
 
 upgrade_nodes () {


### PR DESCRIPTION
**Component**:

'salt', 'lifecycle'

**Context**: 

Upgrade get a lot of flakies on environment that are a bit slow

**Summary**:

- Backport https://github.com/scality/metalk8s/commit/9ee0c533d4336edabc5832f2351240cd8995c99b
- Bump timeout waiting for containers after local container engine upgrade from 60s to 120s
- Backport https://github.com/scality/metalk8s/commit/73835bef88a38db53330cb825c0d69e543386603
- Increase Salt master `sock_pool_size` (from 1 to 15) and `worker_threads` (from 5 to 10)

---
