### PR TITLE
ci: Bump timeout for nginx ingress tests + remove "NodeAffinity" pods in Ci

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -1873,8 +1873,7 @@ stages:
             ssh -F ssh_config bootstrap 'sudo bash -c "
             kubectl --kubeconfig=/etc/kubernetes/admin.conf
             wait pods --for=condition=Ready --all --all-namespaces
-            --field-selector=status.phase!=Succeeded"
-            --timeout=120s'
+            --field-selector=status.phase!=Succeeded"'
           workdir: build/eve/workers/openstack-terraform/terraform/
           haltOnFailure: true
       # --- We do not need to Test promoted version ---

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -1866,6 +1866,21 @@ stages:
       # --- Wait for all pods to be running ---
       - ShellCommand: *wait_pods_stable_ssh
       - ShellCommand:
+          # NOTE: We remove all "NodeAffinity" pods as, when restoring an environment
+          # from time to time we get some pods stuck in "NodeAffinity"
+          name: Remove pods stuck in NodeAffinity
+          command: |
+            ssh -F ssh_config bootstrap <<ENDSSH
+            for ns in \$(sudo kubectl get ns --kubeconfig=/etc/kubernetes/admin.conf -o jsonpath='{.items[*].metadata.name}'); do
+                node_aff_pods=\$(sudo kubectl get pods --kubeconfig=/etc/kubernetes/admin.conf -n "\$ns" | grep NodeAffinity | awk '{print \$1}' | tr \\n ' ')
+                if [ \$node_aff_pods ]; then
+                    sudo kubectl delete pods --kubeconfig=/etc/kubernetes/admin.conf -n "\$ns" \$node_aff_pods
+                fi
+            done
+            ENDSSH
+          workdir: build/eve/workers/openstack-terraform/terraform/
+          haltOnFailure: true
+      - ShellCommand:
           # NOTE: we ignore Succeeded pods which were scheduled by Jobs, since
           # their Ready condition is False
           name: Ensure all pods are running

--- a/tests/post/steps/test_authentication.py
+++ b/tests/post/steps/test_authentication.py
@@ -90,7 +90,7 @@ def check_cp_ingress_pod_and_container(request, host, k8s_client, control_plane_
 
     utils.retry(
         _wait_for_ingress_pod_and_container,
-        times=10,
+        times=24,
         wait=5,
         name="wait for pod labeled '{}'".format(label),
     )


### PR DESCRIPTION
**Component**:

'tests', 'ci'

**Context**: 

From time to time we get flakies during upgrade tests when the platform is a bit slow

**Summary**:

- Increase timeout to wait for ingress pods to be ready in tests
- Delete "NodeAffinity" pods when restoring a snapshot in CI

---
