### PR TITLE
salt,charts: Set Alertmanager Secret name

### DIFF
--- a/charts/kube-prometheus-stack.yaml
+++ b/charts/kube-prometheus-stack.yaml
@@ -57,6 +57,8 @@ alertmanager:
   # config: '__var_tojson__(alertmanager.spec.notification.config)'
 
     useExistingSecret: true
+    secrets:
+      - alertmanager-prometheus-operator-alertmanager
 
 prometheusOperator:
   tls:

--- a/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
@@ -53847,6 +53847,8 @@ spec:
   replicas: {% endraw -%}{{ alertmanager.spec.deployment.replicas }}{%- raw %}
   retention: 120h
   routePrefix: /
+  secrets:
+  - alertmanager-prometheus-operator-alertmanager
   securityContext:
     fsGroup: 2000
     runAsGroup: 2000


### PR DESCRIPTION
**Component**: salt, charts, monitoring

**Context**: 
Alertmanager configuration customization was not working anymore because of a change in how the operator behaves, we now need to tell the operator which Secrets we want Alertmanager to use (the one rendered by CSC).

**Summary**:

**Acceptance criteria**: 
We should probably add some tests to ensure such case can't happen again.

---

Closes: #3134