### PR TITLE
eve: Properly handle multi pods in NodeAffinity in the same ns

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -1916,7 +1916,7 @@ stages:
             ssh -F ssh_config bootstrap <<ENDSSH
             for ns in \$(sudo kubectl get ns --kubeconfig=/etc/kubernetes/admin.conf -o jsonpath='{.items[*].metadata.name}'); do
                 node_aff_pods=\$(sudo kubectl get pods --kubeconfig=/etc/kubernetes/admin.conf -n "\$ns" | grep NodeAffinity | awk '{print \$1}' | tr \\n ' ')
-                if [ \$node_aff_pods ]; then
+                if [ "\$node_aff_pods" ]; then
                     sudo kubectl delete pods --kubeconfig=/etc/kubernetes/admin.conf -n "\$ns" \$node_aff_pods
                 fi
             done


### PR DESCRIPTION
In snapshot upgrade we need to delete NodeAffinity pods but several pods
can be in the same namespace and then the `node_aff_pods` variable
contains multiple pods separated by the space so we need to quote it in
the if to avoid
```
-bash: line 3: [: too many arguments
```

Sees: 27adae15d