### PR TITLE
[UI] Bootstrap the layout of dashboard page

### DIFF
--- a/ui/cypress/integration/e2e/Nodes/steps.js
+++ b/ui/cypress/integration/e2e/Nodes/steps.js
@@ -3,7 +3,7 @@ import { When, Then } from 'cypress-cucumber-preprocessor/steps';
 When('I am on the node page', () => {
   cy.server();
   cy.route('GET', '/api/kubernetes/api/v1/nodes').as('getNodes');
-  cy.get('.sc-sidebar-item').eq(1).click();
+  cy.visit('/nodes');
 });
 
 Then('the bootstrap node appears the node list', () => {

--- a/ui/cypress/integration/e2e/Volumes/steps.js
+++ b/ui/cypress/integration/e2e/Volumes/steps.js
@@ -1,7 +1,7 @@
 import { And, Then, When } from 'cypress-cucumber-preprocessor/steps';
 
 And('I am on the volume creation page', () => {
-  cy.get('.sc-sidebar-item').eq(2).click();
+  cy.visit('/volumes');
   cy.get('[data-cy="create_volume_button"]').click();
 });
 

--- a/ui/public/config.json
+++ b/ui/public/config.json
@@ -5,5 +5,7 @@
     "url_grafana": "https://{ip}:8443/grafana",
     "url_oidc_provider": "https://{ip}:8443/oidc",
     "url_redirect": "http://localhost:3000/oauth2/callback",
-    "url_doc": "https://{ip}:8443/docs"
+    "url_doc": "https://{ip}:8443/docs",
+    "url_alertmanager": "https://{ip}:8443/api/alertmanager",
+    "flags": []
 }

--- a/ui/src/components/LinechartSpec.js
+++ b/ui/src/components/LinechartSpec.js
@@ -65,7 +65,8 @@ export const getTooltipConfig = (
           title: 'Date',
         },
       ],
-      color: {},
+      // Hardcode the color of the rule until we have the design for light mode
+      color: { value: '#ffffff' },
     },
     selection: {
       hover: {

--- a/ui/src/containers/DashboardPage.js
+++ b/ui/src/containers/DashboardPage.js
@@ -1,0 +1,62 @@
+//@flow
+import React from 'react';
+import styled from 'styled-components';
+
+const DashboardGrid = styled.div`
+  display: grid;
+  gap: 8px;
+  grid-template:
+    'health    health   network metrics' 160px
+    'inventory services network metrics' 160px
+    'alerts    services network metrics' auto
+    / 1fr 1fr 1fr 1fr;
+
+  @media (max-width: 1024px) {
+    grid-template:
+      'health    health' 160px
+      'inventory services' 160px
+      'alerts    services' minmax(160px, auto)
+      'network   metrics' auto
+      / 1fr 1fr;
+  }
+
+  height: calc(100vh - 48px - 8px);
+  margin: 0 8px 0 8px;
+
+  div {
+    background-color: ${(props) => props.theme.brand.primary};
+    color: ${(props) => props.theme.brand.textPrimary};
+  }
+  .health {
+    grid-area: health;
+  }
+  .inventory {
+    grid-area: inventory;
+  }
+  .alerts {
+    grid-area: alerts;
+  }
+  .services {
+    grid-area: services;
+  }
+  .network {
+    grid-area: network;
+  }
+  .metrics {
+    grid-area: metrics;
+  }
+`;
+
+const DashboardPage = (props: {}) => {
+  return (
+    <DashboardGrid>
+      <div className="health">Global Health</div>
+      <div className="inventory">Inventory</div>
+      <div className="alerts">Alerts</div>
+      <div className="services">Services</div>
+      <div className="network">Network</div>
+      <div className="metrics">Metrics</div>
+    </DashboardGrid>
+  );
+};
+export default DashboardPage;

--- a/ui/src/services/api.js
+++ b/ui/src/services/api.js
@@ -53,6 +53,7 @@ export type Config = {
   url_redirect: string,
   url_doc: string,
   url_alertmanager: string,
+  flags?: [],
 };
 
 export function fetchTheme(): Promise<WrappedThemes> {

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -185,5 +185,6 @@
   "no_system_partition": "No System Partition",
   "error_system_partitions": "System partitions request has failed.",
   "show_cluster_avg": "Show Cluster Average",
-  "cluster_avg": "Cluster avg"
+  "cluster_avg": "Cluster avg",
+  "dashboard": "Dashboard"
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -185,5 +185,6 @@
   "no_system_partition": "Aucune partition système",
   "error_system_partitions": "Échec de la récupération de la partition système.",
   "show_cluster_avg": "Montrer la moyenne du Cluster",
-  "cluster_avg": "Cluster moy"
+  "cluster_avg": "Cluster moy",
+  "dashboard": "Dashboard"
 }


### PR DESCRIPTION
**Component**: ui

**Context**: 
Bootstrap the layout of the dashboard page, we called it overview page previously.

**Summary**:
- Responsiveness 
  CSS Grid
- Add a feature gate to control access to the dashboard page.
   add `flags: ["dashboard"]` in `config.json` or `ConfigMap` will enable the access. By default, no access.
- We still serve the alert page as the main page, meaning`https://{ip}:8443/` takes us to the alert page.

**Acceptance criteria**: 
Mac 13 inch screen:
![image](https://user-images.githubusercontent.com/18453133/108687237-c1f88a80-74f6-11eb-891d-d1cbf982a939.png)

1024*768
![image](https://user-images.githubusercontent.com/18453133/108689167-09801600-74f9-11eb-8e7b-beb7cf6f3165.png)
![image](https://user-images.githubusercontent.com/18453133/108689965-0f2a2b80-74fa-11eb-86fd-94859e430e10.png)


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #3094 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
