### PR TITLE
salt: Wait properly after apiserver restart

### DIFF
--- a/salt/metalk8s/kubernetes/apiserver/installed.sls
+++ b/salt/metalk8s/kubernetes/apiserver/installed.sls
@@ -111,10 +111,27 @@ Create kube-apiserver Pod manifest:
       - file: Ensure SA pub key is present
       - file: Ensure Ingress CA cert is present
 
-Make sure kube-apiserver container is up:
-  module.wait:
+Delay after apiserver pod deployment:
+  module.run:
+    - test.sleep:
+      - length: 10
+    - onchanges:
+      - metalk8s: Create kube-apiserver Pod manifest
+
+Make sure kube-apiserver container is up and ready:
+  module.run:
     - cri.wait_container:
       - name: kube-apiserver
       - state: running
-    - watch:
+    - onchanges:
       - metalk8s: Create kube-apiserver Pod manifest
+    - require:
+      - module: Delay after apiserver pod deployment
+  http.wait_for_successful_query:
+    - name: https://127.0.0.1:6443/healthz
+    - verify_ssl: True
+    - ca_bundle: /etc/kubernetes/pki/ca.crt
+    - status: 200
+    - match: 'ok'
+    - require:
+      - module: Make sure kube-apiserver container is up and ready


### PR DESCRIPTION
**Component**:

'salt', 'lifecycle'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

Failure during single node upgrade because apiserver not properly ready.

**Summary**:

When updating the apiserver manifest, apiserver container will be
restarted by kubelet, so wait a bit before checking that apiserver
container is properly running and ready

---
