### PR TITLE
Restore CI in offline mode

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -597,6 +597,8 @@ models:
         TF_VAR_rhsm_username: "%(secret:rhel_ci_login)s"
         TF_VAR_rhsm_password: "%(secret:rhel_ci_password)s"
         TF_VAR_debug: "%(prop:metalk8s_debug:-false)s"
+        TF_VAR_offline: "%(prop:offline:-true)s"
+        TF_VAR_use_proxy: "%(prop:use_proxy:-true)s"
         MAX_RETRIES: "3"
       workdir: build/eve/workers/openstack-terraform/terraform/
       haltOnFailure: true
@@ -1641,6 +1643,17 @@ stages:
           name: Set OS property to rhel-8
           property: os
           value: "rhel-8"
+      # FIXME: We disable offline mode for RHEL as it does not work for now,
+      # there are some certificates issues when trying to reach RedHat
+      # repositories through the company proxy.
+      - SetProperty:
+          name: Set offline property to false
+          property: offline
+          value: "false"
+      - SetProperty:
+          name: Set use_proxy property to false
+          property: use_proxy
+          value: "false"
       - TriggerStages:
           name: Trigger single-node-install with os set to rhel-8
           stage_names:

--- a/eve/workers/openstack-terraform/terraform/.gitignore
+++ b/eve/workers/openstack-terraform/terraform/.gitignore
@@ -1,0 +1,4 @@
+.terraform
+.terraform.tfstate*
+ssh_config
+terraform.tfstate*

--- a/eve/workers/openstack-terraform/terraform/common.tf
+++ b/eve/workers/openstack-terraform/terraform/common.tf
@@ -23,6 +23,11 @@ variable "nodes_count" {
   default = "2"
 }
 
+variable "offline" {
+  type    = bool
+  default = true
+}
+
 resource "random_string" "current" {
   length  = 5
   special = false

--- a/eve/workers/openstack-terraform/terraform/common.tf
+++ b/eve/workers/openstack-terraform/terraform/common.tf
@@ -25,7 +25,22 @@ variable "nodes_count" {
 
 variable "offline" {
   type    = bool
-  default = true
+  default = false
+}
+
+variable "use_proxy" {
+  type    = bool
+  default = false
+}
+
+variable "proxy_host" {
+  type    = string
+  default = "proxy-cache"
+}
+
+variable "proxy_port" {
+  type    = string
+  default = "3128"
 }
 
 resource "random_string" "current" {

--- a/eve/workers/openstack-terraform/terraform/network.tf
+++ b/eve/workers/openstack-terraform/terraform/network.tf
@@ -63,13 +63,42 @@ resource "openstack_networking_secgroup_rule_v2" "ingress_ingress" {
   security_group_id = openstack_networking_secgroup_v2.ingress.id
 }
 
-resource "openstack_networking_secgroup_rule_v2" "ingress_egress" {
-  direction         = "egress"
-  ethertype         = "IPv4"
-  remote_group_id   = openstack_networking_secgroup_v2.ingress.id
-  security_group_id = openstack_networking_secgroup_v2.ingress.id
-}
-
 resource "openstack_networking_secgroup_v2" "open_egress" {
   name                 = "${local.prefix}-open-egress"
+}
+
+resource "openstack_networking_secgroup_v2" "egress" {
+  name                 = "${local.prefix}-egress"
+  delete_default_rules = var.offline
+}
+
+resource "openstack_networking_secgroup_rule_v2" "egress_egress" {
+  direction         = "egress"
+  ethertype         = "IPv4"
+  remote_group_id   = openstack_networking_secgroup_v2.egress.id
+  security_group_id = openstack_networking_secgroup_v2.egress.id
+}
+
+# Allow DNS queries to go out, especially because SSHd is doing
+# reverse DNS on incoming IPs, otherwise it could really slow down
+# connections
+resource "openstack_networking_secgroup_rule_v2" "egress_dns" {
+  direction         = "egress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 53
+  port_range_max    = 53
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.egress.id
+}
+
+# Used by cloud-init to retrieve SSH keys during VM deployment
+resource "openstack_networking_secgroup_rule_v2" "egress_metadata" {
+  direction         = "egress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 80
+  port_range_max    = 80
+  remote_ip_prefix  = "169.254.169.254/32"
+  security_group_id = openstack_networking_secgroup_v2.egress.id
 }

--- a/eve/workers/openstack-terraform/terraform/nodes.tf
+++ b/eve/workers/openstack-terraform/terraform/nodes.tf
@@ -170,8 +170,8 @@ resource "openstack_compute_instance_v2" "bootstrap" {
   }
 
   provisioner "remote-exec" {
-    when = "destroy"
-    on_failure = "continue"
+    when = destroy
+    on_failure = continue
     inline = [
       "case '${var.os}' in rhel-*) sudo subscription-manager unregister;; esac"
     ]
@@ -260,8 +260,8 @@ resource "openstack_compute_instance_v2" "nodes" {
   }
 
   provisioner "remote-exec" {
-    when = "destroy"
-    on_failure = "continue"
+    when = destroy
+    on_failure = continue
     inline = [
       "case '${var.os}' in rhel-*) sudo subscription-manager unregister;; esac"
     ]

--- a/eve/workers/openstack-terraform/terraform/nodes.tf
+++ b/eve/workers/openstack-terraform/terraform/nodes.tf
@@ -5,6 +5,7 @@ resource "openstack_networking_port_v2" "bastion_public" {
   network_id          = data.openstack_networking_network_v2.default_network.id
   security_group_ids  = [
     openstack_networking_secgroup_v2.ingress.id,
+    openstack_networking_secgroup_v2.egress.id,
     openstack_networking_secgroup_v2.open_egress.id
   ]
 }
@@ -99,7 +100,7 @@ resource "openstack_networking_port_v2" "bootstrap_public" {
   network_id          = data.openstack_networking_network_v2.default_network.id
   security_group_ids  = [
     openstack_networking_secgroup_v2.ingress.id,
-    openstack_networking_secgroup_v2.open_egress.id
+    openstack_networking_secgroup_v2.egress.id
   ]
 }
 
@@ -185,7 +186,7 @@ resource "openstack_networking_port_v2" "nodes_public" {
   network_id          = data.openstack_networking_network_v2.default_network.id
   security_group_ids  = [
     openstack_networking_secgroup_v2.ingress.id,
-    openstack_networking_secgroup_v2.open_egress.id
+    openstack_networking_secgroup_v2.egress.id
   ]
   count               = var.nodes_count
 }

--- a/eve/workers/openstack-terraform/terraform/nodes.tf
+++ b/eve/workers/openstack-terraform/terraform/nodes.tf
@@ -68,6 +68,16 @@ resource "openstack_compute_instance_v2" "bastion" {
     ]
   }
 
+  # Configure HTTP proxy for yum repositories
+  # We also use the proxy on the bastion, even if it has an access to the
+  # Internet, to benefit from the cache.
+  provisioner "remote-exec" {
+    inline = [
+      "if [ '${var.use_proxy}' = 'true' ]; then sudo chmod +x scripts/proxy-setup.sh; fi",
+      "if [ '${var.use_proxy}' = 'true' ]; then sudo scripts/proxy-setup.sh '${var.proxy_host}' '${var.proxy_port}'; fi"
+    ]
+  }
+
   # Install Cypress requirements
   provisioner "remote-exec" {
     inline = [
@@ -162,6 +172,14 @@ resource "openstack_compute_instance_v2" "bootstrap" {
     ]
   }
 
+  # Configure HTTP proxy for yum repositories
+  provisioner "remote-exec" {
+    inline = [
+      "if [ '${var.use_proxy}' = 'true' ]; then sudo chmod +x scripts/proxy-setup.sh; fi",
+      "if [ '${var.use_proxy}' = 'true' ]; then sudo scripts/proxy-setup.sh '${var.proxy_host}' '${var.proxy_port}'; fi"
+    ]
+  }
+
   # Register RHSM if OS = rhel
   provisioner "remote-exec" {
     inline = [
@@ -249,6 +267,14 @@ resource "openstack_compute_instance_v2" "nodes" {
       "sudo scripts/network.sh eth1",
       "sudo scripts/network.sh eth2",
       "sudo systemctl restart network || sudo systemctl restart NetworkManager"
+    ]
+  }
+
+  # Configure HTTP proxy for yum repositories
+  provisioner "remote-exec" {
+    inline = [
+      "if [ '${var.use_proxy}' = 'true' ]; then sudo chmod +x scripts/proxy-setup.sh; fi",
+      "if [ '${var.use_proxy}' = 'true' ]; then sudo scripts/proxy-setup.sh '${var.proxy_host}' '${var.proxy_port}'; fi"
     ]
   }
 

--- a/eve/workers/openstack-terraform/terraform/scripts/proxy-setup.sh
+++ b/eve/workers/openstack-terraform/terraform/scripts/proxy-setup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -euo pipefail
+
+PROXY_HOST=${1:-}
+PROXY_PORT=${2:-3128}
+PROXY_URL=http://$PROXY_HOST:$PROXY_PORT
+PROXY_CA_URL=https://eve.devsca.com/vault/v1/release_engineering_root_CA_prod/cert/ca
+PROXY_CA_PATH=/etc/pki/ca-trust/source/anchors/scality_internal_ca.crt
+
+
+if ! [[ $PROXY_HOST ]]; then
+    echo "No proxy host provided, exiting"
+    exit
+fi
+
+if ! [ -f /etc/redhat-release ]; then
+    echo "The proxy script only handle RedHat family dists."
+    exit 1
+fi
+
+curl -skx "$PROXY_URL" -L "$PROXY_CA_URL" \
+    | sed -e 's/.*"certificate":"\(.*\)","revocation_time".*/\1/' \
+          -e 's/\\n/\n/g' \
+    > "$PROXY_CA_PATH"
+
+update-ca-trust force-enable
+update-ca-trust extract
+
+yum-config-manager --save --setopt proxy="$PROXY_URL"


### PR DESCRIPTION
**Component**: ci

**Context**:
We found some bug lately (#3120), not catched by the CI, because we're no longer testing in offline environments since #1928.

**Summary**:
Restore the offline mode by configuring some security groups on Openstack and using a proxy for the YUM repositories.

**Acceptance criteria**: 