### PR TITLE
[UI] Apply util functions for the existing alert related components

### DIFF
--- a/ui/cypress/fixtures/kubernetes/nodes.json
+++ b/ui/cypress/fixtures/kubernetes/nodes.json
@@ -2687,9 +2687,9 @@
           "node-role.kubernetes.io/infra": "",
           "node-role.kubernetes.io/master": ""
         },
-        "name": "yanjin-test",
+        "name": "test",
         "resourceVersion": "20123936",
-        "selfLink": "/api/v1/nodes/yanjin-test",
+        "selfLink": "/api/v1/nodes/test",
         "uid": "c27b42b0-cd4c-459b-b31e-dc99d05be722"
       },
       "spec": {

--- a/ui/cypress/integration/node/nodelist.spec.js
+++ b/ui/cypress/integration/node/nodelist.spec.js
@@ -10,11 +10,8 @@ describe('Node list', () => {
     cy.stubHistory();
 
     cy.fixture('kubernetes/nodes.json').then((nodes) => {
-      // It may break when we implement sorting for the nodes
-      cy.location('pathname').should(
-        'eq',
-        `/nodes/${nodes.items[0].metadata.name}/overview`,
-      );
+      // With sorting implemented, node "test" is in unknown state hence should be the first on the nodelist.
+      cy.location('pathname').should('eq', `/nodes/test/overview`);
     });
   });
 
@@ -59,7 +56,7 @@ describe('Node list', () => {
   it(`keeps warning severity for the alert while searching the node`, () => {
     cy.visit('/nodes/master-0/alerts?severity=warning');
     cy.stubHistory();
-  
+
     cy.get('[data-cy="node_list_search"]').type('hello');
     cy.get('@historyPush').should(
       'be.calledWithExactly',

--- a/ui/cypress/integration/volume/volumelist.spec.js
+++ b/ui/cypress/integration/volume/volumelist.spec.js
@@ -6,6 +6,9 @@ beforeEach(() => {
 // Navigation tests
 describe('Volume list', () => {
   it('brings me to the overview tab of the unhealthy volume', () => {
+    // Specify a fake now timestamp to make sure the alert is active.
+    const now = new Date('2020-11-09T08:33:26.330Z').getTime();
+    cy.clock(now);
     // Note that:
     // If we visit() in beforeEach, make sure we don't visit() again within each test case, or it may create issues with the test
     // (some network requests would be interrupted) - see 07a34b5 (#2891)

--- a/ui/src/components/NodePartitionTable.js
+++ b/ui/src/components/NodePartitionTable.js
@@ -17,6 +17,7 @@ import {
   NODE_FILESYSTEM_ALMOST_OUTOF_SPACE,
   NODE_FILESYSTEM_FILES_FILLINGUP,
   NODE_FILESYSTEM_ALMOST_OUTOF_FILES,
+  PORT_NODE_EXPORTER,
 } from '../constants';
 import { intl } from '../translations/IntlGlobalProvider';
 
@@ -104,15 +105,17 @@ const LoaderContainer = styled.div`
 
 const NodePartitionTable = ({ instanceIP }: { instanceIP: string }) => {
   const theme = useTheme();
-  const { data: alertNF } = useAlerts({
+  const alertList = useAlerts({
     alertname: [
       NODE_FILESYSTEM_SPACE_FILLINGUP,
       NODE_FILESYSTEM_ALMOST_OUTOF_SPACE,
       NODE_FILESYSTEM_FILES_FILLINGUP,
       NODE_FILESYSTEM_ALMOST_OUTOF_FILES,
     ],
+    instance: `${instanceIP}:${PORT_NODE_EXPORTER}`,
   });
 
+  const alertNF = alertList && alertList.alerts;
   const { data: partitions, status } = useQuery(
     ['nodeDevices', instanceIP],
     useCallback(
@@ -134,7 +137,10 @@ const NodePartitionTable = ({ instanceIP }: { instanceIP: string }) => {
             );
           }
         }),
-      [alertNF, instanceIP],
+      // disable the eslint checking because it requires `alertNF` to be in the dependency list,
+      // and since react is not performing a deep comparison, so useCallback would be recalled everytime useAlerts refetch the alerts.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [instanceIP, JSON.stringify(alertNF)],
     ),
   );
 

--- a/ui/src/components/NodePartitionTable.test.js
+++ b/ui/src/components/NodePartitionTable.test.js
@@ -4,14 +4,18 @@ import { screen } from '@testing-library/react';
 import { setupServer } from 'msw/node';
 import { rest } from 'msw';
 import NodePartitionTable from './NodePartitionTable';
-import { waitForLoadingToFinish, render } from './__TEST__/util';
+import {
+  waitForLoadingToFinish,
+  render,
+  FAKE_CONTROL_PLANE_IP,
+} from './__TEST__/util';
 import { initialize as initializeProm } from '../services/prometheus/api';
 import { initialize as initializeAM } from '../services/alertmanager/api';
 import { initialize as initializeLoki } from '../services/loki/api';
 
 const server = setupServer(
   rest.get(
-    'http://192.168.1.18:8443/api/prometheus/api/v1/query',
+    `http://${FAKE_CONTROL_PLANE_IP}:8443/api/prometheus/api/v1/query`,
     (req, res, ctx) => {
       const result = {
         status: 'success',
@@ -42,7 +46,7 @@ const server = setupServer(
   ),
 
   rest.get(
-    'http://192.168.1.18:8443/api/alertmanager/api/v2/alerts',
+    `http://${FAKE_CONTROL_PLANE_IP}:8443/api/alertmanager/api/v2/alerts`,
     (req, res, ctx) => {
       const alerts = [
         {
@@ -54,11 +58,13 @@ const server = setupServer(
             summary: 'Filesystem has less than 5% space left.',
           },
           /*
-          We want to have an active alert, meaning the current time should be in between `startsAt` and `endsAt`.
-          Since we can't spyon the `activeOn` in getHealthStatus(). If we use ```endsAt: new Date().toISOString()```, there will be slightly bwtween the two current time.
+          We want to have an active alert triggered, meaning the current time should be in between `startsAt` and `endsAt`.
+          Since we can't spy on the `activeOn` in getHealthStatus(). If we use ```endsAt: new Date().toISOString()```, there will be a slightly difference between the two current times.
           Hence, here we add one day to make sure the alert is active.
           */
-          endsAt: new Date(new Date().getTime() + 86400000).toISOString(),
+          endsAt: new Date(
+            new Date().getTime() + 1000 * 60 * 60 * 24,
+          ).toISOString(),
           fingerprint: '37b2591ac3cdb320',
           receivers: [
             {
@@ -106,9 +112,9 @@ describe('the system partition table', () => {
 
     // use fake timers to let react query retry immediately after promise failure
     jest.useFakeTimers();
-    initializeProm('http://192.168.1.18:8443/api/prometheus');
-    initializeAM('http://192.168.1.18:8443/api/alertmanager');
-    initializeLoki('http://192.168.1.18:8443/api/loki');
+    initializeProm(`http://${FAKE_CONTROL_PLANE_IP}:8443/api/prometheus`);
+    initializeAM(`http://${FAKE_CONTROL_PLANE_IP}:8443/api/alertmanager`);
+    initializeLoki(`http://${FAKE_CONTROL_PLANE_IP}:8443/api/loki`);
 
     const { getByLabelText } = render(
       <NodePartitionTable instanceIP={'192.168.1.29'} />,
@@ -131,19 +137,19 @@ describe('the system partition table', () => {
   test('handles server error', async () => {
     // S
     jest.useFakeTimers();
-    initializeProm('http://192.168.1.18:8443/api/prometheus');
-    initializeAM('http://192.168.1.18:8443/api/alertmanager');
+    initializeProm(`http://${FAKE_CONTROL_PLANE_IP}:8443/api/prometheus`);
+    initializeAM(`http://${FAKE_CONTROL_PLANE_IP}:8443/api/alertmanager`);
 
     // override the default route with error status
     server.use(
       rest.get(
-        'http://192.168.1.18:8443/api/prometheus/api/v1/query',
+        `http://${FAKE_CONTROL_PLANE_IP}:8443/api/prometheus/api/v1/query`,
         (req, res, ctx) => {
           return res(ctx.status(500));
         },
       ),
       rest.get(
-        'http://192.168.1.18:8443/api/alertmanager/api/v2/alerts',
+        `http://${FAKE_CONTROL_PLANE_IP}:8443/api/alertmanager/api/v2/alerts`,
         (req, res, ctx) => {
           return res(ctx.status(500));
         },

--- a/ui/src/components/__TEST__/util.js
+++ b/ui/src/components/__TEST__/util.js
@@ -62,3 +62,6 @@ export * from '@testing-library/react';
 
 // override render method
 export { customRender as render };
+
+// use this fake control to initialize the APIs and retrieve the data from the APIs.
+export const FAKE_CONTROL_PLANE_IP = 'fake.control.plane.ip.invalid';

--- a/ui/src/components/__TEST__/util.js
+++ b/ui/src/components/__TEST__/util.js
@@ -3,6 +3,8 @@ import { ThemeProvider } from 'styled-components';
 import { render } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { screen, waitForElementToBeRemoved } from '@testing-library/react';
+import AlertProvider from '../../containers/AlertProvider';
+import AlertHistoryProvider from '../../containers/AlertHistoryProvider';
 
 export const waitForLoadingToFinish = () =>
   waitForElementToBeRemoved(
@@ -43,7 +45,11 @@ const AllTheProviders = ({ children }) => {
   };
   return (
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider theme={theme}>{children}</ThemeProvider>
+      <AlertProvider>
+        <AlertHistoryProvider>
+          <ThemeProvider theme={theme}>{children}</ThemeProvider>
+        </AlertHistoryProvider>
+      </AlertProvider>
     </QueryClientProvider>
   );
 };

--- a/ui/src/containers/AlertHistoryProvider.js
+++ b/ui/src/containers/AlertHistoryProvider.js
@@ -1,0 +1,32 @@
+import React, { createContext, useContext } from 'react';
+import { useQuery } from 'react-query';
+import { getLast7DaysAlerts } from '../services/loki/api';
+import { filterAlerts } from '../services/alertUtils';
+
+const AlertHistoryContext = createContext(null);
+
+export function useHistoryAlerts(filters?: FilterLabels) {
+  const query = useContext(AlertHistoryContext);
+  if (query.status === 'success') {
+    return {
+      ...query,
+      data: filterAlerts(query.data, filters),
+    };
+  }
+  return query;
+}
+
+const AlertHistoryProvider = ({ children }) => {
+  const query = useQuery('alertsHistory', () =>
+    getLast7DaysAlerts().then((data) => {
+      return data;
+    }),
+  );
+
+  return (
+    <AlertHistoryContext.Provider value={{ ...query }}>
+      {children}
+    </AlertHistoryContext.Provider>
+  );
+};
+export default AlertHistoryProvider;

--- a/ui/src/containers/AlertHistoryProvider.js
+++ b/ui/src/containers/AlertHistoryProvider.js
@@ -1,27 +1,29 @@
+//@flow
 import React, { createContext, useContext } from 'react';
 import { useQuery } from 'react-query';
 import { getLast7DaysAlerts } from '../services/loki/api';
 import { filterAlerts } from '../services/alertUtils';
+import type { FilterLabels } from '../services/alertUtils';
 
-const AlertHistoryContext = createContext(null);
+const AlertHistoryContext = createContext<null>(null);
 
 export function useHistoryAlerts(filters?: FilterLabels) {
   const query = useContext(AlertHistoryContext);
-  if (query.status === 'success') {
+  if (!query) {
+    throw new Error(
+      'The useHistoryAlerts hook can only be used within AlertHistoryProvider.',
+    );
+  } else if (query.status === 'success') {
     return {
       ...query,
-      data: filterAlerts(query.data, filters),
+      alerts: filterAlerts(query.data, filters),
     };
   }
   return query;
 }
 
-const AlertHistoryProvider = ({ children }) => {
-  const query = useQuery('alertsHistory', () =>
-    getLast7DaysAlerts().then((data) => {
-      return data;
-    }),
-  );
+const AlertHistoryProvider = ({ children }: any) => {
+  const query = useQuery('alertsHistory', () => getLast7DaysAlerts());
 
   return (
     <AlertHistoryContext.Provider value={{ ...query }}>

--- a/ui/src/containers/AlertProvider.js
+++ b/ui/src/containers/AlertProvider.js
@@ -1,0 +1,32 @@
+import React, { createContext, useContext } from 'react';
+import { useQuery } from 'react-query';
+import { getAlerts } from '../services/alertmanager/api';
+import { filterAlerts } from '../services/alertUtils';
+
+const AlertContext = createContext(null);
+
+export function useAlerts(filters: FilterLabels) {
+  const query = useContext(AlertContext);
+  if (query.status === 'success') {
+    return {
+      ...query,
+      data: filterAlerts(query.data, filters),
+    };
+  }
+  return query;
+}
+
+const AlertProvider = ({ children }) => {
+  const query = useQuery('activeAlerts', () =>
+    getAlerts().then((data) => {
+      return data;
+    }),
+  );
+
+  return (
+    <AlertContext.Provider value={{ ...query }}>
+      {children}
+    </AlertContext.Provider>
+  );
+};
+export default AlertProvider;

--- a/ui/src/containers/AlertProvider.js
+++ b/ui/src/containers/AlertProvider.js
@@ -1,6 +1,7 @@
 //@flow
 import React, { createContext, useContext } from 'react';
 import { useQuery } from 'react-query';
+import { Loader } from '@scality/core-ui';
 import { getAlerts } from '../services/alertmanager/api';
 import { filterAlerts } from '../services/alertUtils';
 import type { FilterLabels } from '../services/alertUtils';
@@ -27,11 +28,17 @@ const AlertProvider = ({ children }: any) => {
     // refetch the alerts every 10 seconds
     refetchInterval: 10000,
   });
-
-  return (
-    <AlertContext.Provider value={{ ...query }}>
-      {children}
-    </AlertContext.Provider>
-  );
+  if (query.status === 'loading') {
+    return (
+      <AlertContext.Provider value={{ ...query }}>
+        <Loader size="massive" centered={true} aria-label="loading" />
+      </AlertContext.Provider>
+    );
+  } else
+    return (
+      <AlertContext.Provider value={{ ...query }}>
+        {children}
+      </AlertContext.Provider>
+    );
 };
 export default AlertProvider;

--- a/ui/src/containers/AlertProvider.js
+++ b/ui/src/containers/AlertProvider.js
@@ -1,27 +1,32 @@
+//@flow
 import React, { createContext, useContext } from 'react';
 import { useQuery } from 'react-query';
 import { getAlerts } from '../services/alertmanager/api';
 import { filterAlerts } from '../services/alertUtils';
+import type { FilterLabels } from '../services/alertUtils';
 
-const AlertContext = createContext(null);
+const AlertContext = createContext<null>(null);
 
 export function useAlerts(filters: FilterLabels) {
   const query = useContext(AlertContext);
-  if (query.status === 'success') {
+  if (!query) {
+    throw new Error(
+      'The useAlerts hook can only be used within AlertProvider.',
+    );
+  } else if (query.status === 'success') {
     return {
       ...query,
-      data: filterAlerts(query.data, filters),
+      alerts: filterAlerts(query.data, filters),
     };
   }
   return query;
 }
 
-const AlertProvider = ({ children }) => {
-  const query = useQuery('activeAlerts', () =>
-    getAlerts().then((data) => {
-      return data;
-    }),
-  );
+const AlertProvider = ({ children }: any) => {
+  const query = useQuery('activeAlerts', () => getAlerts(), {
+    // refetch the alerts every 10 seconds
+    refetchInterval: 10000,
+  });
 
   return (
     <AlertContext.Provider value={{ ...query }}>

--- a/ui/src/containers/App.js
+++ b/ui/src/containers/App.js
@@ -6,6 +6,8 @@ import { IntlProvider, addLocaleData } from 'react-intl';
 import locale_en from 'react-intl/locale-data/en';
 import locale_fr from 'react-intl/locale-data/fr';
 import { QueryClient, QueryClientProvider } from 'react-query';
+import AlertProvider from './AlertProvider';
+import AlertHistoryProvider from './AlertHistoryProvider';
 import translations_en from '../translations/en';
 import translations_fr from '../translations/fr';
 import { Loader } from '@scality/core-ui';
@@ -23,26 +25,28 @@ const messages = {
 addLocaleData([...locale_en, ...locale_fr]);
 
 const App = (props) => {
-  const { language, api, theme } = useSelector(
-    (state) => state.config,
-  );
+  const { language, api, theme } = useSelector((state) => state.config);
   const dispatch = useDispatch();
 
   useEffect(() => {
     document.title = messages[language].product_name;
     dispatch(fetchConfigAction());
-    dispatch(setInitialLanguageAction());// todo removes this once the navbar provides it 
+    dispatch(setInitialLanguageAction()); // todo removes this once the navbar provides it
     dispatch(initToggleSideBarAction());
     // eslint-disable-next-line
   }, []);
 
   return api && theme ? (
     <QueryClientProvider client={queryClient}>
-        <IntlProvider locale={language} messages={messages[language]}>
-          <IntlGlobalProvider>
-            <Layout />
-          </IntlGlobalProvider>
-        </IntlProvider>
+      <AlertProvider>
+        <AlertHistoryProvider>
+          <IntlProvider locale={language} messages={messages[language]}>
+            <IntlGlobalProvider>
+              <Layout />
+            </IntlGlobalProvider>
+          </IntlProvider>
+        </AlertHistoryProvider>
+      </AlertProvider>
     </QueryClientProvider>
   ) : (
     <Loader size="massive" centered={true} />

--- a/ui/src/containers/NodePageRSP.js
+++ b/ui/src/containers/NodePageRSP.js
@@ -35,7 +35,7 @@ import {
   NODE_ALERTS_GROUP,
   PORT_NODE_EXPORTER,
 } from '../constants';
-import { filterAlerts } from '../services/alertUtils';
+import { useAlerts } from '../containers/AlertProvider';
 import { intl } from '../translations/IntlGlobalProvider';
 import { useTypedSelector } from '../hooks';
 
@@ -120,12 +120,13 @@ const NodePageRSP = (props) => {
     showAvg,
   ]);
 
-  // Filter alerts for the specific node, base on the InstaceIP and Alert Name
-  const alerts = useSelector((state) => state.app.alerts.list);
-  const alertsNode = filterAlerts(alerts, {
+  const alertList = useAlerts({
     alertname: NODE_ALERTS_GROUP,
     instance: `${instanceIP}:${PORT_NODE_EXPORTER}`,
   });
+
+  const alertsNode = alertList && alertList.alerts;
+
   const isHealthTabActive = location.pathname.endsWith('/overview');
   const isAlertsTabActive = location.pathname.endsWith('/alerts');
   const isMetricsTabActive = location.pathname.endsWith('/metrics');

--- a/ui/src/containers/NodePageRSP.js
+++ b/ui/src/containers/NodePageRSP.js
@@ -35,6 +35,7 @@ import {
   NODE_ALERTS_GROUP,
   PORT_NODE_EXPORTER,
 } from '../constants';
+import { filterAlerts } from '../services/alertUtils';
 import { intl } from '../translations/IntlGlobalProvider';
 import { useTypedSelector } from '../hooks';
 
@@ -121,13 +122,10 @@ const NodePageRSP = (props) => {
 
   // Filter alerts for the specific node, base on the InstaceIP and Alert Name
   const alerts = useSelector((state) => state.app.alerts.list);
-  const alertsNode =
-    alerts?.filter(
-      (alert) =>
-        NODE_ALERTS_GROUP.includes(alert?.labels?.alertname) &&
-        `${instanceIP}:${PORT_NODE_EXPORTER}` === alert?.labels?.instance,
-    ) ?? [];
-
+  const alertsNode = filterAlerts(alerts, {
+    alertname: NODE_ALERTS_GROUP,
+    instance: `${instanceIP}:${PORT_NODE_EXPORTER}`,
+  });
   const isHealthTabActive = location.pathname.endsWith('/overview');
   const isAlertsTabActive = location.pathname.endsWith('/alerts');
   const isMetricsTabActive = location.pathname.endsWith('/metrics');

--- a/ui/src/containers/VolumePageContent.js
+++ b/ui/src/containers/VolumePageContent.js
@@ -15,7 +15,7 @@ import {
   PORT_NODE_EXPORTER,
 } from '../constants';
 import { computeVolumeGlobalStatus } from '../services/NodeVolumesUtils';
-import { filterAlerts } from '../services/alertUtils';
+import { useAlerts } from '../containers/AlertProvider';
 import {
   LeftSideInstanceList,
   NoInstanceSelectedContainer,
@@ -101,9 +101,8 @@ const VolumePageContent = (props) => {
       pod.volumes.find((volume) => volume.persistentVolumeClaim === PVCName),
     );
 
-  // get the alert
-  const alertlist =
-    PVCName && filterAlerts(alerts.list, { persistentvolumeclaim: PVCName });
+  const alertsVolume = useAlerts({ persistentvolumeclaim: PVCName });
+  const alertlist = alertsVolume && alertsVolume.data;
 
   // prepare the data for <PerformanceGraphCard>
   const deviceName = volume?.status?.deviceName;

--- a/ui/src/containers/VolumePageContent.js
+++ b/ui/src/containers/VolumePageContent.js
@@ -15,6 +15,7 @@ import {
   PORT_NODE_EXPORTER,
 } from '../constants';
 import { computeVolumeGlobalStatus } from '../services/NodeVolumesUtils';
+import { filterAlerts } from '../services/alertUtils';
 import {
   LeftSideInstanceList,
   NoInstanceSelectedContainer,
@@ -102,10 +103,7 @@ const VolumePageContent = (props) => {
 
   // get the alert
   const alertlist =
-    PVCName &&
-    alerts?.list?.filter(
-      (alert) => alert.labels.persistentvolumeclaim === PVCName,
-    );
+    PVCName && filterAlerts(alerts.list, { persistentvolumeclaim: PVCName });
 
   // prepare the data for <PerformanceGraphCard>
   const deviceName = volume?.status?.deviceName;

--- a/ui/src/ducks/config.js
+++ b/ui/src/ducks/config.js
@@ -9,6 +9,7 @@ import * as ApiK8s from '../services/k8s/api';
 import * as ApiSalt from '../services/salt/api';
 import * as ApiPrometheus from '../services/prometheus/api';
 import * as ApiAlertmanager from '../services/alertmanager/api';
+import * as ApiLoki from '../services/loki/api';
 import { EN_LANG, FR_LANG, LANGUAGE } from '../constants';
 
 import { authenticateSaltApi } from './login';
@@ -93,7 +94,10 @@ export function updateLanguageAction(language: string) {
   return { type: UPDATE_LANGUAGE, payload: language };
 }
 
-export function updateAPIConfigAction(payload: { id_token: string, token_type: string }) {
+export function updateAPIConfigAction(payload: {
+  id_token: string,
+  token_type: string,
+}) {
   return { type: UPDATE_API_CONFIG, payload };
 }
 
@@ -133,6 +137,7 @@ export function* fetchConfig(): Generator<Effect, void, Result<Config>> {
     yield call(ApiSalt.initialize, result.url_salt);
     yield call(ApiPrometheus.initialize, result.url_prometheus);
     yield call(ApiAlertmanager.initialize, result.url_alertmanager);
+    yield call(ApiLoki.initialize, result.url_loki);
   }
 }
 

--- a/ui/src/ducks/config.test.js
+++ b/ui/src/ducks/config.test.js
@@ -26,6 +26,7 @@ import * as ApiK8s from '../services/k8s/api';
 import * as ApiSalt from '../services/salt/api';
 import * as ApiPrometheus from '../services/prometheus/api';
 import * as ApiAlertmanager from '../services/alertmanager/api';
+import * as ApiLoki from '../services/loki/api';
 
 it('update the theme state and logo path when fetchTheme', () => {
   const gen = fetchTheme();
@@ -64,6 +65,7 @@ it('update the config state when fetchConfig', () => {
     url_salt: 'http://172.21.254.13:4507',
     url_prometheus: 'http://172.21.254.46:30222',
     url_alertmanager: 'http://172.21.254.46:8443',
+    url_loki: 'http://172.21.254.46:8080',
   };
 
   expect(gen.next(result).value).toEqual(call(fetchTheme));
@@ -82,6 +84,10 @@ it('update the config state when fetchConfig', () => {
 
   expect(gen.next(result).value).toEqual(
     call(ApiAlertmanager.initialize, 'http://172.21.254.46:8443'),
+  );
+
+  expect(gen.next(result).value).toEqual(
+    call(ApiLoki.initialize, 'http://172.21.254.46:8080'),
   );
 
   expect(gen.next().done).toEqual(true);

--- a/ui/src/services/alertUtils.js
+++ b/ui/src/services/alertUtils.js
@@ -10,7 +10,7 @@ import type { StreamValue } from './loki/api';
 import { compareHealth } from './utils';
 
 export type Health = 'healthy' | 'warning' | 'critical' | 'none';
-type FilterLabels = {
+export type FilterLabels = {
   [labelName: string]: string | string[],
   parents?: string[],
   selectors?: string[],

--- a/ui/src/services/alertUtils.js
+++ b/ui/src/services/alertUtils.js
@@ -74,7 +74,7 @@ export const removeWarningAlerts = (alerts: Alert[]): Alert[] => {
 // Sort the alerts base on the `severity`
 export const sortAlerts = (alerts: Alert[]): Alert[] => {
   return alerts.sort(function (a, b) {
-    return compareHealth(a.labels.severity, b.labels.severity);
+    return compareHealth(b.labels.severity, a.labels.severity);
   });
 };
 

--- a/ui/src/services/alertUtils.js
+++ b/ui/src/services/alertUtils.js
@@ -153,6 +153,7 @@ export const filterAlerts = (
   alerts: Alert[],
   filters?: FilterLabels,
 ): Alert[] => {
+  if (!alerts) return [];
   if (!filters) {
     return alerts;
   }

--- a/ui/src/services/api.js
+++ b/ui/src/services/api.js
@@ -51,6 +51,7 @@ export type Config = {
   url_grafana: string,
   url_doc: string,
   url_alertmanager: string,
+  url_loki: string,
   flags?: [],
   url_navbar: string,
   url_navbar_config: string,


### PR DESCRIPTION
**Component**: ui, loki

**Context**: 
Apply the `filtersAlerts` to the existing alert/health related component.

**Summary**:
The component(NodePartitionsTable) fetches alerts by react-query could benefit from the useAlerts() hook. 
For the rest components, we still retrieve the alerts by selectors and then apply the util function. 

Set up Loki service to retrieve the alert from Loki API tested by Alexandre's platform.

**Acceptance criteria**: 
UI should work as before.

