### PR TITLE
ci: Fix NodeAffinity deletion and bump restore eve timeout

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -2418,7 +2418,7 @@ stages:
           # NOTE: Increase timeout as restore may take some time
           # Since we use pytest we do not have any output until restore totaly
           # finished
-          timeout: 1800
+          timeout: 2700
           env:
             <<: *_env_bastion_tests
             PYTEST_FILTERS: "restore"

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -1916,7 +1916,7 @@ stages:
           command: |
             ssh -F ssh_config bootstrap <<ENDSSH
             for ns in \$(sudo kubectl get ns --kubeconfig=/etc/kubernetes/admin.conf -o jsonpath='{.items[*].metadata.name}'); do
-                node_aff_pods=\$(sudo kubectl get pods --kubeconfig=/etc/kubernetes/admin.conf -n "\$ns" | grep NodeAffinity | awk '{print \$1}' | tr \\n ' ')
+                node_aff_pods=\$(sudo kubectl get pods --kubeconfig=/etc/kubernetes/admin.conf -n "\$ns" | grep NodeAffinity | awk '{print \$1}' | tr \\\n ' ')
                 if [ "\$node_aff_pods" ]; then
                     sudo kubectl delete pods --kubeconfig=/etc/kubernetes/admin.conf -n "\$ns" \$node_aff_pods
                 fi


### PR DESCRIPTION
**Component**:

'ci'

**Context**: 

Some flakies on post-merge

**Summary**:

- Fix the NodeAffinity pod deletion in the snapshot restore tests in CI
- Bump eve timeout for restore tests

---

