### PR TITLE
salt: Do not consider all ISOs in `/srv/scality` as Solutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@
   Salt dependencies from "base" RHEL 7 repository
   (PR [#3083](https://github.com/scality/metalk8s/pull/3083))
 
+- [#3128](https://github.com/scality/metalk8s/issues/3128) - No longer assume ISOs
+  mounted under `/srv/scality` are Solutions
+  (PR [#3182](https://github.com/scality/metalk8s/pull/3182))
+
 ### Deprecations and Removals
 
 - [#3168](https://github.com/scality/metalk8s/issues/3168) - [UI] Remove the environment page

--- a/salt/tests/unit/modules/files/test_metalk8s_solutions.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_solutions.yaml
@@ -368,6 +368,10 @@ list_available:
   - mountpoints:
       /: {}
       /srv/scality/metalk8s-x.y.z: {}
+      # Ignored as it does not contain any manifests
+      /srv/scality/no-solution:
+        alt_device: /tmp/not-a-solution.iso
+        fstype: iso9660
   # Ok - No mountpoint
   - {}
 

--- a/salt/tests/unit/modules/test_metalk8s_solutions.py
+++ b/salt/tests/unit/modules/test_metalk8s_solutions.py
@@ -267,14 +267,14 @@ class Metalk8sSolutionsTestCase(TestCase, mixins.LoaderModuleMockMixin):
                 self.assertEqual(metalk8s_solutions.manifest_from_iso(path), result)
 
     @utils.parameterized_from_cases(YAML_TESTS_CASES["list_available"])
-    def test_list_available(
-        self, mountpoints=None, archive_infos=None, result=None, raises=False
-    ):
+    def test_list_available(self, mountpoints=None, archive_infos=None, result=None):
         """
         Tests the return of `list_available` function
         """
         mount_active_mock = MagicMock(return_value=mountpoints or {})
         read_solution_manifest_mock = MagicMock(return_value=(None, archive_infos))
+        if archive_infos is None:
+            read_solution_manifest_mock.side_effect = CommandExecutionError("Banana")
 
         salt_dict_patch = {
             "mount.active": mount_active_mock,
@@ -282,14 +282,7 @@ class Metalk8sSolutionsTestCase(TestCase, mixins.LoaderModuleMockMixin):
         with patch.dict(metalk8s_solutions.__salt__, salt_dict_patch), patch(
             "metalk8s_solutions.read_solution_manifest", read_solution_manifest_mock
         ):
-            if raises:
-                self.assertRaisesRegex(
-                    Exception,
-                    'Path has no "product.txt"',
-                    metalk8s_solutions.list_available,
-                )
-            else:
-                self.assertEqual(metalk8s_solutions.list_available(), result or {})
+            self.assertEqual(metalk8s_solutions.list_available(), result or {})
 
     @utils.parameterized_from_cases(YAML_TESTS_CASES["operator_roles_from_manifest"])
     def test_operator_roles_from_manifest(


### PR DESCRIPTION
**Component**:

'salt', 'solutions'
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

#3128 

**Summary**:

Add more check about MetalK8s solutions ISOs, the ISOs mounted in
`/srv/scality` also need to have a `manifests.yaml` with some expected
keys like a good `kind` and `apiVersion`, otherwise the mounted ISO is
ignored and consider as a non-metalk8s mountpoint

---

Fixes: #3128

