### PR TITLE
tests/post: Reduce some flakiness

### DIFF
--- a/docs/operation/account_administration/user_authentication_and_identity_management.rst
+++ b/docs/operation/account_administration/user_authentication_and_identity_management.rst
@@ -96,12 +96,26 @@ the following steps from the bootstrap node.
 
 #. Apply your changes.
 
-   .. parsed-literal::
+   #. Update Dex deployment.
 
-      root\@bootstrap $ kubectl exec -n kube-system -c salt-master \\
-                         --kubeconfig /etc/kubernetes/admin.conf \\
-                         salt-master-bootstrap -- salt-run state.sls \\
-                         metalk8s.addons.dex.deployed saltenv=metalk8s-|version|
+      .. parsed-literal::
+
+         root\@bootstrap $ kubectl exec -n kube-system -c salt-master \\
+                           --kubeconfig /etc/kubernetes/admin.conf \\
+                           salt-master-bootstrap -- salt-run state.sls \\
+                           metalk8s.addons.dex.deployed \\
+                           saltenv=metalk8s-|version|
+
+   #. Update Grafana configuration (so this new user is recognized as a
+      Grafana admin user).
+
+      .. parsed-literal::
+
+         root\@bootstrap $ kubectl exec -n kube-system -c salt-master \\
+                           --kubeconfig /etc/kubernetes/admin.conf \\
+                           salt-master-bootstrap -- salt-run state.sls \\
+                           metalk8s.addons.prometheus-operator.deployed \\
+                           saltenv=metalk8s-|version|
 
 #. Bind the user to an existing (Cluster) Role using
    :ref:`a ClusterRoleBlinding <bind-user-to-role>`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import json
 import pathlib
 import re
 import requests.exceptions
+import time
 
 import kubernetes
 import pytest
@@ -243,14 +244,6 @@ def ssh_config(request):
     return request.config.getoption("--ssh-config")
 
 
-@pytest.fixture(scope="function")
-def request_retry_session(request):
-    # Callers can inject arguments using `pytest.mark.parametrize`
-    params = getattr(request, "param", {})
-
-    return utils.requests_retry_session(**params)
-
-
 @pytest.fixture
 def prometheus_api(control_plane_ip):
     return utils.PrometheusApi(control_plane_ip, CONTROL_PLANE_INGRESS_PORT)
@@ -336,30 +329,79 @@ def check_resource_list(host, resource, namespace):
 
 
 @then(
-    parsers.parse(
-        "we are able to login to Dex as '{username}' using password '{password}'"
-    )
+    parsers.re(
+        r"^we are (?P<should_fail>(?:not )?)able to login to Dex "
+        r"as '(?P<username>[^']+)' using password '(?P<password>[^']+)'$"
+    ),
+    converters=dict(should_fail=lambda s: s == "not "),
 )
-def dex_successful_login(username, password, control_plane_ip, request_retry_session):
-
-    response = _dex_login(username, password, control_plane_ip, request_retry_session)
-    assert response.text is not None
-    assert response.status_code == 303
-    assert response.headers.get("location") is not None
-
-
-@then(
-    parsers.parse(
-        "we are not able to login to Dex " "as '{username}' using password '{password}'"
+def dex_login(username, password, should_fail, control_plane_ip):
+    session = utils.requests_retry_session(
+        # Both Dex and the ingress controller may fail with one of the following codes
+        status_forcelist=(500, 502, 503, 504),
+        retries=10,
+        backoff_factor=2,
     )
-)
-def dex_failed_login(username, password, control_plane_ip, request_retry_session):
-    response = _dex_login(username, password, control_plane_ip, request_retry_session)
-    assert response.text is not None
-    assert response.status_code == 200
-    # 'Invalid Email Address and password' is found in reponse text
-    assert "Invalid Email Address and password" in response.text
-    assert response.headers.get("locaction") is None
+    ingress_url = "https://{}:{}".format(control_plane_ip, CONTROL_PLANE_INGRESS_PORT)
+
+    get_auth_start = time.time()
+    try:
+        auth_page = session.post(
+            ingress_url + "/oidc/auth?",
+            data={
+                "response_type": "id_token",
+                "client_id": "metalk8s-ui",
+                "scope": "openid audience:server:client_id:oidc-auth-client",
+                "redirect_uri": ingress_url + "/oauth2/callback",
+                "nonce": "nonce",
+            },
+            verify=False,
+        )
+    except requests.exceptions.ConnectionError as exc:
+        pytest.fail("Failed to retrieve Dex authentication page: {}".format(exc))
+
+    get_auth_duration = time.time() - get_auth_start
+    if auth_page.status_code != 200:
+        pytest.fail(
+            f"Failed to retrieve Dex authentication page after {get_auth_duration:.1f} "
+            f"seconds [status={auth_page.status_code}]:\n{auth_page.text}"
+        )
+
+    # The response is an HTML form (for display in a browser)
+    auth_form = auth_page.text
+
+    # The form action looks like:
+    # <a href="/oidc/auth/local?req=ovc5qdll5zznlubewjok266rl" target="_self">
+    next_path_match = re.search(r'href=[\'"](?P<next_path>/oidc/\S+)[\'"] ', auth_form)
+    assert (
+        next_path_match is not None
+    ), "Could not find an anchor with `href='/oidc/...'` in Dex response:\n{}".format(
+        auth_form
+    )
+    next_path = next_path_match.group("next_path")
+
+    try:
+        auth_response = session.post(
+            ingress_url + next_path,
+            data={"login": username, "password": password},
+            verify=False,
+            allow_redirects=False,
+        )
+    except requests.exceptions.ConnectionError as exc:
+        pytest.fail(
+            "Failed when authenticating to Dex through '{}': {}".format(
+                ingress_url + next_path, exc
+            )
+        )
+
+    assert auth_response.text is not None
+    if should_fail:
+        assert auth_response.status_code == 200
+        assert "Invalid Email Address and password" in auth_response.text
+        assert auth_response.headers.get("location") is None
+    else:
+        assert auth_response.status_code == 303
+        assert auth_response.headers.get("location") is not None
 
 
 @then(parsers.parse('node "{node_name}" is a member of etcd cluster'))
@@ -382,49 +424,6 @@ def _verify_kubeapi_service(host):
         res = host.run(cmd)
         if res.rc != 0:
             pytest.fail(res.stderr)
-
-
-def _dex_login(username, password, control_plane_ip, request_retry_session):
-    """Login to Dex and return the result"""
-    try:
-        response = request_retry_session.post(
-            "https://{}:{}/oidc/auth?".format(
-                control_plane_ip, CONTROL_PLANE_INGRESS_PORT
-            ),
-            data={
-                "response_type": "id_token",
-                "client_id": "metalk8s-ui",
-                "scope": "openid audience:server:client_id:oidc-auth-client",
-                "redirect_uri": "https://{}:{}/oauth2/callback".format(
-                    control_plane_ip, CONTROL_PLANE_INGRESS_PORT
-                ),
-                "nonce": "nonce",
-            },
-            verify=False,
-        )
-    except requests.exceptions.ConnectionError as exc:
-        pytest.fail("Dex authentication request failed with error: {}".format(exc))
-
-    auth_request = response.text  # response is an html form
-    # form action looks like:
-    # <a href="/oidc/auth/local?req=ovc5qdll5zznlubewjok266rl" target="_self">
-    reqpath = re.search(r'href=[\'"](?P<reqpath>/oidc/\S+)[\'"] ', auth_request).group(
-        "reqpath"
-    )
-
-    try:
-        result = requests.post(
-            "https://{}:{}{}".format(
-                control_plane_ip, CONTROL_PLANE_INGRESS_PORT, reqpath
-            ),
-            data={"login": username, "password": password},
-            verify=False,
-            allow_redirects=False,
-        )
-    except requests.exceptions.ConnectionError as exc:
-        pytest.fail("Unable to login: {}".format(exc))
-
-    return result
 
 
 def etcdctl(k8s_client, command, ssh_config):

--- a/tests/post/features/service_configuration.feature
+++ b/tests/post/features/service_configuration.feature
@@ -7,6 +7,7 @@ Feature: Cluster and Services Configurations
         And we have a 'metalk8s-dex-config' CSC in namespace 'metalk8s-auth'
         When we update the CSC 'spec.deployment.replicas' to '3'
         And we apply the 'metalk8s.addons.dex.deployed' state
+        And we wait for the rollout of 'deploy/dex' in namespace 'metalk8s-auth' to complete
         Then we have '3' at 'status.available_replicas' for 'dex' Deployment in namespace 'metalk8s-auth'
 
     Scenario: Update Admin static user password
@@ -16,6 +17,7 @@ Feature: Cluster and Services Configurations
         # Update password to "new-password"
         When we update the CSC 'spec.config.staticPasswords.0.hash' to '$2y$14$pDe0vj917rR3XJQ5iEZvhuSGoWkZg2/qBN/mMLqwFSz9S7EYcbIpO'
         And we apply the 'metalk8s.addons.dex.deployed' state
+        And we wait for the rollout of 'deploy/dex' in namespace 'metalk8s-auth' to complete
         Then we have 2 running pod labeled 'app.kubernetes.io/name=dex' in namespace 'metalk8s-auth'
         And we are not able to login to Dex as 'admin@metalk8s.invalid' using password 'password'
         And we are able to login to Dex as 'admin@metalk8s.invalid' using password 'new-password'

--- a/tests/post/features/service_configuration.feature
+++ b/tests/post/features/service_configuration.feature
@@ -6,6 +6,7 @@ Feature: Cluster and Services Configurations
         And we have 2 running pod labeled 'app.kubernetes.io/name=dex' in namespace 'metalk8s-auth'
         And we have a 'metalk8s-dex-config' CSC in namespace 'metalk8s-auth'
         When we update the CSC 'spec.deployment.replicas' to '3'
+        And we apply the 'metalk8s.addons.dex.deployed' state
         Then we have '3' at 'status.available_replicas' for 'dex' Deployment in namespace 'metalk8s-auth'
 
     Scenario: Update Admin static user password
@@ -14,6 +15,7 @@ Feature: Cluster and Services Configurations
         # NOTE: Consider that admin user is the first static user configured.
         # Update password to "new-password"
         When we update the CSC 'spec.config.staticPasswords.0.hash' to '$2y$14$pDe0vj917rR3XJQ5iEZvhuSGoWkZg2/qBN/mMLqwFSz9S7EYcbIpO'
+        And we apply the 'metalk8s.addons.dex.deployed' state
         Then we have 2 running pod labeled 'app.kubernetes.io/name=dex' in namespace 'metalk8s-auth'
         And we are not able to login to Dex as 'admin@metalk8s.invalid' using password 'password'
         And we are able to login to Dex as 'admin@metalk8s.invalid' using password 'new-password'
@@ -23,4 +25,5 @@ Feature: Cluster and Services Configurations
         And pods with label 'app=prometheus' are 'Ready'
         And we have a 'metalk8s-prometheus-config' CSC in namespace 'metalk8s-monitoring'
         When we update the CSC 'spec.rules.node_exporter.node_filesystem_space_filling_up.warning.hours' to '48'
+        And we apply the 'metalk8s.addons.prometheus-operator.deployed' state
         Then we have an alert rule 'NodeFilesystemSpaceFillingUp' in group 'node-exporter' with severity 'warning' and 'annotations.summary' equal to 'Filesystem is predicted to run out of space within the next 48 hours.'

--- a/tests/post/steps/test_service_configuration.py
+++ b/tests/post/steps/test_service_configuration.py
@@ -69,7 +69,12 @@ def csc(host, ssh_config, version, k8s_client, name, namespace):
 def update_csc(csc, path, value):
     csc_content = csc.get()
     utils.set_dict_element(csc_content, path, value)
-    csc.update(csc_content)
+    csc.update(csc_content, apply_config=False)
+
+
+@when(parsers.parse("we apply the '{state}' state"))
+def apply_csc(csc, state):
+    csc.apply(state)
 
 
 # }}}
@@ -202,11 +207,11 @@ class ClusterServiceConfiguration:
 
         return self.csc
 
-    def apply(self):
+    def apply(self, state="metalk8s.deployed"):
         cmd = [
             "salt-run",
             "state.sls",
-            "metalk8s.deployed",
+            state,
             "saltenv=metalk8s-{}".format(self.version),
             "--log-level=warning",
             "--out=json",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -100,6 +100,7 @@ def requests_retry_session(
         connect=retries,
         backoff_factor=backoff_factor,
         status_forcelist=status_forcelist,
+        method_whitelist=method_whitelist,
     )
     adapter = HTTPAdapter(max_retries=retry)
     session.mount("http://", adapter)


### PR DESCRIPTION
**docs, tests: Apply specific '.deployed' states**

When changing the CSC ConfigMap of a component we were often running
the whole `metalk8s.deployed` state.
We now document which state to run for each specific component, and
ensure the tests are following this documentation.

---

**tests: Clean-up Dex-related tests**

Mainly remove the `request_retry_session` fixture and replace it with
direct calls to `utils.request_retry_session` when needed, so one can
adjust the expected error codes and the number of retries depending on
the use-case.
Adding `502` and `504` to the list of expected error codes, and bumping
retries from 3 to 5, for all requests specifically targeted at Dex.

---

**tests: Wait for rollout of CSC changes to complete**

Not waiting was leading to some flaky issues where the expected changes
were not yet propagated to the tested service, hence breaking the test.
