### PR TITLE
build: Add missing gdisk package in versions.json

### DIFF
--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -328,6 +328,7 @@ PACKAGES: Dict[str, Any] = {
         PackageVersion(name="e2fsprogs"),
         PackageVersion(name="ebtables"),
         PackageVersion(name="ethtool"),
+        PackageVersion(name="gdisk"),
         PackageVersion(name="genisoimage"),
         PackageVersion(name="iproute"),
         PackageVersion(name="iptables"),


### PR DESCRIPTION
**Component**: build

**Context**: 
We install this package in Salt formulas but we were not referencing it in `buildchain/buildchain/versions.py`

**Summary**:

**Acceptance criteria**: 


---

Closes: #3122
