### PR TITLE
packages: Handle fs.may_detach_mounts sysctl for containerd

### DIFF
--- a/buildchain/buildchain/packaging.py
+++ b/buildchain/buildchain/packaging.py
@@ -311,6 +311,7 @@ CONTAINERD_RPM = _rpm_package(
         Path('0001-Revert-commit-for-Windows-metrics.patch'),
         Path('containerd.service'),
         Path('containerd.toml'),
+        Path('60-containerd.conf'),
         Path('containerd-{}.tar.gz'.format(versions.CONTAINERD_VERSION)),
     ],
 )

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -21,7 +21,7 @@ CALICO_VERSION     : str = '3.17.0'
 K8S_VERSION        : str = '1.18.16'
 SALT_VERSION       : str = '3002.5'
 CONTAINERD_VERSION : str = '1.4.3'
-CONTAINERD_RELEASE : str = '1.el7'
+CONTAINERD_RELEASE : str = '2.el7'
 
 def load_version_information() -> None:
     """Load version information from `VERSION`."""

--- a/packages/redhat/60-containerd.conf
+++ b/packages/redhat/60-containerd.conf
@@ -1,0 +1,9 @@
+# Starting with EL7.4, this knob should be set to '1' on hosts where container
+# runtimes are being used. Docker seems to set this from inside the daemon,
+# containerd doesn't.
+# Some pointers:
+# - https://github.com/scality/metalk8s/issues/3211
+# - https://access.redhat.com/solutions/5430091
+# - https://github.com/containerd/containerd/issues/3667#issuecomment-802373736
+# - https://github.com/cri-o/cri-o/pull/4210
+fs.may_detach_mounts = 1

--- a/packages/redhat/containerd.spec
+++ b/packages/redhat/containerd.spec
@@ -32,13 +32,14 @@ go build -compiler gc -tags="rpm_crashtraceback ${BUILDTAGS:-seccomp}" -ldflags 
 
 
 Name:           containerd
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        An industry-standard container runtime
 License:        ASL 2.0
 URL:            https://containerd.io
 Source0:        %{gosource}
 Source1:        containerd.service
 Source2:        containerd.toml
+Source3:        60-containerd.conf
 # Carve out code requiring github.com/Microsoft/hcsshim
 Patch0:         0001-Revert-commit-for-Windows-metrics.patch
 
@@ -184,6 +185,7 @@ install -D -p -m 0644 _man/ctr.8 %{buildroot}%{_mandir}/man1/ctr.8
 install -D -p -m 0644 _man/containerd-config.toml.5 %{buildroot}%{_mandir}/man5/containerd-config.toml.5
 install -D -p -m 0644 %{S:1} %{buildroot}%{_unitdir}/containerd.service
 install -D -p -m 0644 %{S:2} %{buildroot}%{_sysconfdir}/containerd/config.toml
+install -D -p -m 0644 %{S:3} %{buildroot}%{_sysctldir}/60-containerd.conf
 
 
 %if %{with tests}
@@ -194,6 +196,7 @@ install -D -p -m 0644 %{S:2} %{buildroot}%{_sysconfdir}/containerd/config.toml
 
 %post
 %systemd_post containerd.service
+%sysctl_apply 60-containerd.conf
 
 
 %preun
@@ -216,9 +219,13 @@ install -D -p -m 0644 %{S:2} %{buildroot}%{_sysconfdir}/containerd/config.toml
 %{_unitdir}/containerd.service
 %dir %{_sysconfdir}/containerd
 %config(noreplace) %{_sysconfdir}/containerd/config.toml
+%{_sysctldir}/60-containerd.conf
 
 
 %changelog
+* Fri Mar 19 2021 Nicolas Trangez <nicolas.trangez@scality.com> - 1.4.3-2
+- Configure 'fs.may_detach_mounts' sysctl to be '1'
+
 * Tue Dec 1 2020 Nicolas Trangez <nicolas.trangez@scality.com> - 1.4.3-1
 - Latest upstream
 


### PR DESCRIPTION
On EL7.4, a new sysctl, `fs.may_detach_mounts`, was added which should
be enabled on hosts where container runtimes are being used (it's off
by default for backwards compatibility). Docker sets this as part of
the daemon startup process, `containerd` (and `cri-o`) don't. We've
seen the netns cleanup issue resulting from this not being set in the
past in various deployments.

Adding a `sysctl.d` drop-in to set the value as part of the containerd
RPM we build should fix this.

Fixes: https://github.com/scality/metalk8s/issues/3211
See: https://access.redhat.com/solutions/5430091
See: https://github.com/containerd/containerd/issues/3667#issuecomment-802373736
See: https://github.com/cri-o/cri-o/pull/4210