### PR TITLE
salt: Do not interpolate when parsing sysctl config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 
 ## Release 2.8.1 (in development)
+### Bug fixes
+
+- [#3223](https://github.com/scality/metalk8s/issues/3223) - Prevent failures
+  when some `sysctl` configuration file contains a `%` character
+  (PR [#3224](https://github.com/scality/metalk8s/pull/3224))
 
 ## Release 2.8.0
 ### Enhancements

--- a/salt/_modules/metalk8s_sysctl.py
+++ b/salt/_modules/metalk8s_sysctl.py
@@ -90,7 +90,7 @@ def has_precedence(name, value, config, strict=False):
             )
         )
 
-    parser = configparser.ConfigParser()
+    parser = configparser.ConfigParser(interpolation=None)
     epured_value = " ".join(str(value).split())
 
     for sysctl_file in sysctl_files:

--- a/salt/tests/unit/modules/files/test_metalk8s_sysctl.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_sysctl.yaml
@@ -3,6 +3,7 @@ filesystem_tree:
       net.ipv4.ip_forward=0
   /etc/sysctl.d/99-sysctl.conf: |-
       net.ipv4.ip_forward=1
+      kernel.some-fancy-pattern=%prefix-fancy-value-%suffix
   /etc/sysctl.conf: ""
 
 has_precedence:


### PR DESCRIPTION
Fixes: #3223