### PR TITLE
Improve buildchain verbosity and readability

### DIFF
--- a/buildchain/buildchain/action.py
+++ b/buildchain/buildchain/action.py
@@ -1,0 +1,36 @@
+# coding: utf-8
+"""Implement custom actions used by doit tasks"""
+
+from pathlib import Path
+from typing import Any, Callable, List, Optional, Union
+
+import doit  # type: ignore
+
+
+class CmdActionOnFailure(doit.action.CmdAction):  # type: ignore
+    """Wrapper around CmdAction allowing to pass a callable run if action fails"""
+
+    def __init__(
+        self,
+        action: Union[str, List[Union[str, Path]], Callable[..., Optional[Any]]],
+        task: Optional[doit.task.Task] = None,
+        save_out: Optional[str] = None,
+        shell: bool = True,
+        encoding: str = "utf-8",
+        decode_error: str = "replace",
+        buffering: int = 0,
+        on_failure: Optional[Callable[..., None]] = None,
+        **pkwargs: Any
+    ):
+        super().__init__(
+            action, task, save_out, shell, encoding, decode_error, buffering, **pkwargs
+        )
+        self.on_failure = on_failure
+
+    def execute(
+        self, out: Any = None, err: Any = None
+    ) -> doit.exceptions.CatchedException:
+        failure = super().execute(out, err)
+        if failure and self.on_failure:
+            self.on_failure()
+        return failure

--- a/buildchain/buildchain/docker_command.py
+++ b/buildchain/buildchain/docker_command.py
@@ -63,11 +63,18 @@ def build_error_handler(build_error: BuildError) -> str:
         if "stream" in item:
             line = item["stream"]
         elif "status" in item:
-            line = "{}: {}/{}".format(
-                item["status"],
-                item["progressDetail"]["current"],
-                item["progressDetail"]["total"],
-            )
+            try:
+                line = "{0}: ".format(item["id"])
+            except KeyError:
+                line = ""
+            line += item["status"]
+            try:
+                line += ": {0}/{1}\x1b[1K\r".format(
+                    item["progressDetail"]["current"],
+                    item["progressDetail"]["total"],
+                )
+            except KeyError:
+                line += "\n"
         elif "error" in item:
             line = item["error"]
         else:

--- a/buildchain/buildchain/docker_command.py
+++ b/buildchain/buildchain/docker_command.py
@@ -74,8 +74,7 @@ def build_error_handler(build_error: BuildError) -> str:
             line = "buildchain: Unknown build log entry {}".format(str(item))
         output_lines.append(line)
 
-    log = "".join(output_lines)
-    return "{}:\n{}".format(str(build_error), log)
+    return "".join(output_lines)
 
 
 def container_error_handler(container_error: ContainerError) -> str:

--- a/buildchain/dodo.py
+++ b/buildchain/dodo.py
@@ -66,7 +66,7 @@ class CustomReporter(doit.reporter.JsonReporter):  # type: ignore
                     self.tag["failed"], task.title(), time_elapsed
                 )
             )
-            self._write_failure(result)
+            self._write_failure(result, task.verbosity > 1, task.verbosity > 0)
 
     def add_success(self, task: doit.task.Task) -> None:
         """Called when execution finishes successfully"""
@@ -78,6 +78,7 @@ class CustomReporter(doit.reporter.JsonReporter):  # type: ignore
                     self.tag["success"], task.title(), time_elapsed
                 )
             )
+            self._write_task_output(task, task.verbosity > 1, task.verbosity > 0)
 
     def skip_uptodate(self, task: doit.task.Task) -> None:
         """Called when a task is skipped (up-to-date)."""
@@ -111,13 +112,7 @@ class CustomReporter(doit.reporter.JsonReporter):  # type: ignore
             show_out = task.verbosity < 2 or self.failure_verbosity == 2
             if show_err or show_out:
                 self._write(failure_header)
-            if show_err:
-                self._write_failure(result)
-                err = "".join([action.err for action in task.actions if action.err])
-                self._write("{} <stderr>:\n{}\n".format(task.name, err))
-            if show_out:
-                out = "".join([action.out for action in task.actions if action.out])
-                self._write("{} <stdout>:\n{}\n".format(task.name, out))
+            self._write_failure(result, show_out, show_err)
 
         if self.runtime_errors:
             self._write(failure_header)
@@ -134,14 +129,31 @@ class CustomReporter(doit.reporter.JsonReporter):  # type: ignore
     def _write(self, text: str) -> None:
         self.outstream.write(text)
 
-    def _write_failure(self, result: Dict[str, Any]) -> None:
-        self._write(
-            "{} - taskid:{}\n".format(
-                result["exception"].get_name(), result["task"].name
+    def _write_task_output(
+        self, task: doit.task.Task, show_out: bool, show_err: bool
+    ) -> None:
+        if show_out:
+            out = "".join([action.out for action in task.actions if action.out])
+            if out:
+                self._write("{0} <stdout>:\n{1}\n".format(task.name, out))
+        if show_err:
+            err = "".join([action.err for action in task.actions if action.err])
+            if err:
+                self._write("{0} <stderr>:\n{1}\n".format(task.name, err))
+
+    def _write_failure(
+        self, result: Dict[str, Any], show_out: bool, show_err: bool
+    ) -> None:
+        task = result["task"]
+        if show_err:
+            self._write(
+                "{0} - taskid:{1}\n{2}\n".format(
+                    result["exception"].get_name(),
+                    task.name,
+                    result["exception"].get_msg(),
+                )
             )
-        )
-        self._write(result["exception"].get_msg())
-        self._write("\n")
+        self._write_task_output(task, show_out, show_err)
 
 
 DOIT_CONFIG = {

--- a/buildchain/dodo.py
+++ b/buildchain/dodo.py
@@ -31,18 +31,26 @@ from buildchain.vagrant import *
 class CustomReporter(doit.reporter.JsonReporter):  # type: ignore
     """A custom reporter that display a JSON object for each task."""
 
+    tag = {
+        "started": "\033[1;33mSTARTED\033[0m  ",
+        "success": "\033[1;32mSUCCESS\033[0m  ",
+        "failed": "\033[1;31mFAILED\033[0m   ",
+        "skipped": "\033[1;34mSKIPPED\033[0m  ",
+        "ignored": "\033[1;35mIGNORED\033[0m  ",
+    }
     desc = "console, display the execution of each task, generate a build log"
 
     def __init__(self, outstream: TextIO, options: Dict[str, Any]):
         super().__init__(outstream, options)
         self.failures: List[Dict[str, Any]] = []
         self.runtime_errors: List[str] = []
+        self.failure_verbosity: int = options.get("failure_verbosity", 0)
 
     def execute_task(self, task: doit.task.Task) -> None:
         """Called when a task is executed."""
         super().execute_task(task)
         if task.actions:  # Ignore tasks that do not define actions.
-            self._write(".  {}\n".format(task.title()))
+            self._write("{}{}\n".format(self.tag["started"], task.title()))
 
     def add_failure(
         self, task: doit.task.Task, exception: doit.exceptions.CatchedException
@@ -51,16 +59,35 @@ class CustomReporter(doit.reporter.JsonReporter):  # type: ignore
         super().add_failure(task, exception)
         result = {"task": task, "exception": exception}
         self.failures.append(result)
+        if task.actions:
+            time_elapsed = self.t_results[task.name].to_dict()["elapsed"] or 0
+            self._write(
+                "{}{} [{:.0f}s]\n".format(
+                    self.tag["failed"], task.title(), time_elapsed
+                )
+            )
+            self._write_failure(result)
+
+    def add_success(self, task: doit.task.Task) -> None:
+        """Called when execution finishes successfully"""
+        super().add_success(task)
+        if task.actions:
+            time_elapsed = self.t_results[task.name].to_dict()["elapsed"]
+            self._write(
+                "{}{} [{:.0f}s]\n".format(
+                    self.tag["success"], task.title(), time_elapsed
+                )
+            )
 
     def skip_uptodate(self, task: doit.task.Task) -> None:
         """Called when a task is skipped (up-to-date)."""
         super().skip_uptodate(task)
-        self._write("-- {}\n".format(task.title()))
+        self._write("{}{}\n".format(self.tag["skipped"], task.title()))
 
     def skip_ignore(self, task: doit.task.Task) -> None:
         """Called when a task is skipped (ignored)."""
         super().skip_ignore(task)
-        self._write("!! {}\n".format(task.title()))
+        self._write("{}{}\n".format(self.tag["ignored"], task.title()))
 
     def cleanup_error(self, exception: doit.exceptions.CatchedException) -> None:
         """Error during cleanup."""
@@ -80,13 +107,16 @@ class CustomReporter(doit.reporter.JsonReporter):  # type: ignore
             # Makes no sense to print output if task was not executed.
             if not task.executed:
                 continue
-            self._write(failure_header)
-            self._write_failure(result)
-            err = "".join([action.err for action in task.actions if action.err])
-            if err:
+            show_err = task.verbosity < 1 or self.failure_verbosity > 0
+            show_out = task.verbosity < 2 or self.failure_verbosity == 2
+            if show_err or show_out:
+                self._write(failure_header)
+            if show_err:
+                self._write_failure(result)
+                err = "".join([action.err for action in task.actions if action.err])
                 self._write("{} <stderr>:\n{}\n".format(task.name, err))
-            out = "".join([action.out for action in task.actions if action.out])
-            if out:
+            if show_out:
+                out = "".join([action.out for action in task.actions if action.out])
                 self._write("{} <stdout>:\n{}\n".format(task.name, out))
 
         if self.runtime_errors:
@@ -94,6 +124,7 @@ class CustomReporter(doit.reporter.JsonReporter):  # type: ignore
             self._write("Execution aborted.\n")
             self._write("\n".join(self.runtime_errors))
             self._write("\n")
+
         # Generate the build log.
         build_log = constants.ROOT / "build.log"
         with build_log.open("w", encoding="utf-8") as fp:

--- a/buildchain/dodo.py
+++ b/buildchain/dodo.py
@@ -51,7 +51,6 @@ class CustomReporter(doit.reporter.JsonReporter):  # type: ignore
         super().add_failure(task, exception)
         result = {"task": task, "exception": exception}
         self.failures.append(result)
-        self._write_failure(result)
 
     def skip_uptodate(self, task: doit.task.Task) -> None:
         """Called when a task is skipped (up-to-date)."""
@@ -84,9 +83,11 @@ class CustomReporter(doit.reporter.JsonReporter):  # type: ignore
             self._write(failure_header)
             self._write_failure(result)
             err = "".join([action.err for action in task.actions if action.err])
-            self._write("{} <stderr>:\n{}\n".format(task.name, err))
+            if err:
+                self._write("{} <stderr>:\n{}\n".format(task.name, err))
             out = "".join([action.out for action in task.actions if action.out])
-            self._write("{} <stdout>:\n{}\n".format(task.name, out))
+            if out:
+                self._write("{} <stdout>:\n{}\n".format(task.name, out))
 
         if self.runtime_errors:
             self._write(failure_header)

--- a/buildchain/platform-requirements.txt
+++ b/buildchain/platform-requirements.txt
@@ -1,7 +1,3 @@
 # Note: these come from 'buildchain/platform-requirements.txt'
-macfsevents==0.8.1; sys_platform=="darwin" \
-    --hash=sha256:1324b66b356051de662ba87d84f73ada062acd42b047ed1246e60a449f833e10 \
-     # via doit
-pyinotify==0.9.6; sys_platform=="linux" \
-    --hash=sha256:9c998a5d7606ca835065cdabc013ae6c66eb9ea76a00a1e3bc6e0cfe2b4f71f4 \
-     # via doit
+macfsevents==0.8.1; sys_platform=="darwin"  # via doit
+pyinotify==0.9.6; sys_platform=="linux"     # via doit

--- a/buildchain/requirements.in
+++ b/buildchain/requirements.in
@@ -1,4 +1,4 @@
 -c platform-requirements.txt
-doit ~= 0.32.0
+git+git://github.com/pydoit/doit.git@baa3713bb0f3230e1bcbfe956a1dd01fd27ebed9#egg=doit
 docker ~= 4.1.0
 PyYAML ~= 5.3.1

--- a/buildchain/requirements.txt
+++ b/buildchain/requirements.txt
@@ -4,64 +4,17 @@
 #
 #    tox -e pip-compile
 #
-certifi==2020.12.5 \
-    --hash=sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c \
-    --hash=sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830 \
-    # via requests
-chardet==4.0.0 \
-    --hash=sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa \
-    --hash=sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5 \
-    # via requests
-cloudpickle==1.6.0 \
-    --hash=sha256:3a32d0eb0bc6f4d0c57fbc4f3e3780f7a81e6fee0fa935072884d58ae8e1cc7c \
-    --hash=sha256:9bc994f9e9447593bd0a45371f0e7ac7333710fcf64a4eb9834bf149f4ef2f32 \
-    # via doit
-docker==4.1.0 \
-    --hash=sha256:6e06c5e70ba4fad73e35f00c55a895a448398f3ada7faae072e2bb01348bafc1 \
-    --hash=sha256:8f93775b8bdae3a2df6bc9a5312cce564cade58d6555f2c2570165a1270cd8a7 \
-    # via -r /home/nicolas/Projects/metalk8s/buildchain/requirements.in
-doit==0.32.0 \
-    --hash=sha256:323d0411e50a0babb945e2a639aa6e633fbb84a9f98086df0c880e739237750c \
-    # via -r /home/nicolas/Projects/metalk8s/buildchain/requirements.in
-idna==2.10 \
-    --hash=sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6 \
-    --hash=sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0 \
-    # via requests
-pyyaml==5.3.1 \
-    --hash=sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97 \
-    --hash=sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76 \
-    --hash=sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2 \
-    --hash=sha256:6034f55dab5fea9e53f436aa68fa3ace2634918e8b5994d82f3621c04ff5ed2e \
-    --hash=sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648 \
-    --hash=sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf \
-    --hash=sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f \
-    --hash=sha256:7739fc0fa8205b3ee8808aea45e968bc90082c10aef6ea95e855e10abf4a37b2 \
-    --hash=sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee \
-    --hash=sha256:ad9c67312c84def58f3c04504727ca879cb0013b2517c85a9a253f0cb6380c0a \
-    --hash=sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d \
-    --hash=sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c \
-    --hash=sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a \
-    # via -r /home/nicolas/Projects/metalk8s/buildchain/requirements.in
-requests==2.25.1 \
-    --hash=sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804 \
-    --hash=sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e \
-    # via docker
-six==1.15.0 \
-    --hash=sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259 \
-    --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced \
-    # via docker, websocket-client
-urllib3==1.26.4 \
-    --hash=sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df \
-    --hash=sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937 \
-    # via requests
-websocket-client==0.58.0 \
-    --hash=sha256:44b5df8f08c74c3d82d28100fdc81f4536809ce98a17f0757557813275fbb663 \
-    --hash=sha256:63509b41d158ae5b7f67eb4ad20fecbb4eee99434e73e140354dc3ff8e09716f \
-    # via docker
+certifi==2020.12.5        # via requests
+chardet==4.0.0            # via requests
+cloudpickle==1.6.0        # via doit
+docker==4.1.0             # via -r /home/alexandre/work/scm/metalk8s/worktrees/improvement/3217-buildchain-verbosity/buildchain/requirements.in
+git+git://github.com/pydoit/doit.git@baa3713bb0f3230e1bcbfe956a1dd01fd27ebed9#egg=doit  # via -r /home/alexandre/work/scm/metalk8s/worktrees/improvement/3217-buildchain-verbosity/buildchain/requirements.in
+idna==2.10                # via requests
+pyyaml==5.3.1             # via -r /home/alexandre/work/scm/metalk8s/worktrees/improvement/3217-buildchain-verbosity/buildchain/requirements.in
+requests==2.25.1          # via docker
+six==1.15.0               # via docker, websocket-client
+urllib3==1.26.4           # via requests
+websocket-client==0.58.0  # via docker
 # Note: these come from 'buildchain/platform-requirements.txt'
-macfsevents==0.8.1; sys_platform=="darwin" \
-    --hash=sha256:1324b66b356051de662ba87d84f73ada062acd42b047ed1246e60a449f833e10 \
-     # via doit
-pyinotify==0.9.6; sys_platform=="linux" \
-    --hash=sha256:9c998a5d7606ca835065cdabc013ae6c66eb9ea76a00a1e3bc6e0cfe2b4f71f4 \
-     # via doit
+macfsevents==0.8.1; sys_platform=="darwin"  # via doit
+pyinotify==0.9.6; sys_platform=="linux"     # via doit

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -85,7 +85,9 @@ models:
       # There are 3 CPUs available for Docker, and 1 for `doit` in the Pod.
       # Given the network IO-bound nature of some of the build steps, and
       # most build steps running in Docker, set concurrency to 4.
-      command: source /etc/profile && ./doit.sh -n 4
+      command: >
+        source /etc/profile &&
+        ./doit.sh -n 4 --verbosity 2 --failure-verbosity 2
       usePTY: true
       haltOnFailure: true
   - ShellCommand: &ssh_ip_setup

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ setenv =
 commands =
     bash -c ' \
         pip-compile \
-            --emit-index-url --emit-trusted-host --annotate --generate-hashes \
+            --emit-index-url --emit-trusted-host --annotate \
             --allow-unsafe \
             {posargs:--upgrade} \
             -o "{toxinidir}/buildchain/requirements.tmp" \


### PR DESCRIPTION
**Component**: buildchain

**Context**:
In the buildchain, we are actually missing some output for debugging purposes and some output are not really readable.
We also do not have timers to see the time taken by each step.

**Summary**:
* Clean up the docker build//run output on failure (make it more readable)
* Add timer for each step

I still need to basically pipe every logs to a file.

**Acceptance criteria**: 

---

Closes: #3217