### PR TITLE
Attempt to improve some CI reliability

### DIFF
--- a/eve/workers/pod-builder/pod.yaml
+++ b/eve/workers/pod-builder/pod.yaml
@@ -17,10 +17,10 @@ spec:
           # There's a limit of 4 CPUs, so we assign one to `doit`, and 3 to
           # Docker.
           cpu: "1"
-          memory: 2Gi
+          memory: 4Gi
         limits:
           cpu: "1"
-          memory: 2Gi
+          memory: 4Gi
       env:
         - name: DOCKER_HOST
           value: localhost:2375

--- a/tests/post/steps/test_dns.py
+++ b/tests/post/steps/test_dns.py
@@ -31,7 +31,7 @@ def utils_pod(k8s_client, utils_image):
             k8s_client, name=pod_name, namespace="default", state="Running"
         ),
         times=10,
-        wait=5,
+        wait=12,
         name="wait for Pod '{}'".format(pod_name),
     )
 


### PR DESCRIPTION
- Increase memory allocated for the 'build' Pod, to prevent UI build to get OOM killed
- Increase timeout waiting for the DNS test Pod to be created, which tends to time out when set to (only?) 50s. Giving it 2min now :crossed_fingers: 