### PR TITLE
ui: Disable terser parallelism

### DIFF
--- a/ui/config-overrides.js
+++ b/ui/config-overrides.js
@@ -27,9 +27,19 @@ const setWebpackPerformance = () => (config) => {
   return config;
 };
 
+/**
+ * After getting a lot of OOM issues while building the UI, we disabled terser parallelism
+ * Refs: https://github.com/timarney/react-app-rewired/issues/391#issuecomment-571954944
+ */
+const terserDisableParallelism = () => config => {
+  config.optimization.minimizer[0].parallel=false;
+  return config;
+};
+
 module.exports = override(
   useBabelRc(),
   useEslintRc(),
   addWebpackPlugin(new CompressionPlugin()),
   setWebpackPerformance(),
+  terserDisableParallelism()
 );


### PR DESCRIPTION
In order to fix a frequent OOM issue in the CI, I tried to disable terser parallelism

Refs:  https://github.com/timarney/react-app-rewired/issues/391#issuecomment-571954944

**Component**:

ui, build

**Context**: 

Lot of OOM issues in the CI
