### PR TITLE
[UI] Remove hard loading state  and AlertHistoryProvider

### DIFF
--- a/ui/src/components/NodePartitionTable.js
+++ b/ui/src/components/NodePartitionTable.js
@@ -116,7 +116,7 @@ const NodePartitionTable = ({ instanceIP }: { instanceIP: string }) => {
   });
 
   const alertNF = alertList && alertList.alerts;
-  const { data: partitions, status } = useQuery(
+  const { data: nodeFSResult, status } = useQuery(
     ['nodeDevices', instanceIP],
     useCallback(
       () =>
@@ -130,19 +130,23 @@ const NodePartitionTable = ({ instanceIP }: { instanceIP: string }) => {
             nodeFSUsageResult.data.resultType === 'vector' &&
             nodeFSSizeResult.data.resultType === 'vector'
           ) {
-            return getNodePartitionsTableData(
-              nodeFSUsageResult.data.result,
-              nodeFSSizeResult.data.result,
-              alertNF,
-            );
+            return {
+              nodeFSUsage: nodeFSUsageResult.data.result,
+              nodeFSSize: nodeFSSizeResult.data.result,
+            };
           }
         }),
-      // disable the eslint checking because it requires `alertNF` to be in the dependency list,
-      // and since react is not performing a deep comparison, so useCallback would be recalled everytime useAlerts refetch the alerts.
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      [instanceIP, JSON.stringify(alertNF)],
+      [instanceIP],
     ),
   );
+
+  let partitions = [];
+  if (status === 'success')
+    partitions = getNodePartitionsTableData(
+      nodeFSResult.nodeFSUsage,
+      nodeFSResult.nodeFSSize,
+      alertNF,
+    );
 
   const {
     getTableProps,

--- a/ui/src/components/__TEST__/util.js
+++ b/ui/src/components/__TEST__/util.js
@@ -4,7 +4,6 @@ import { render } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { screen, waitForElementToBeRemoved } from '@testing-library/react';
 import AlertProvider from '../../containers/AlertProvider';
-import AlertHistoryProvider from '../../containers/AlertHistoryProvider';
 
 export const waitForLoadingToFinish = () =>
   waitForElementToBeRemoved(
@@ -46,9 +45,7 @@ const AllTheProviders = ({ children }) => {
   return (
     <QueryClientProvider client={queryClient}>
       <AlertProvider>
-        <AlertHistoryProvider>
-          <ThemeProvider theme={theme}>{children}</ThemeProvider>
-        </AlertHistoryProvider>
+        <ThemeProvider theme={theme}>{children}</ThemeProvider>
       </AlertProvider>
     </QueryClientProvider>
   );

--- a/ui/src/containers/AlertHistoryProvider.js
+++ b/ui/src/containers/AlertHistoryProvider.js
@@ -22,7 +22,9 @@ export function useHistoryAlerts(filters?: FilterLabels) {
 }
 
 const AlertHistoryProvider = ({ children }: any) => {
-  const query = useQuery('alertsHistory', () => getLast7DaysAlerts());
+  const query = useQuery('alertsHistory', () => getLast7DaysAlerts(), {
+    initialData: [],
+  });
 
   return (
     <AlertHistoryContext.Provider value={{ ...query }}>

--- a/ui/src/containers/AlertProvider.js
+++ b/ui/src/containers/AlertProvider.js
@@ -26,6 +26,8 @@ const AlertProvider = ({ children }: any) => {
   const query = useQuery('activeAlerts', () => getAlerts(), {
     // refetch the alerts every 10 seconds
     refetchInterval: 10000,
+    // avoid stucking at the hard loading state before alertmanager is ready
+    initialData: [],
   });
   if (query.status === 'loading') {
     return (

--- a/ui/src/containers/App.js
+++ b/ui/src/containers/App.js
@@ -8,7 +8,6 @@ import locale_en from 'react-intl/locale-data/en';
 import locale_fr from 'react-intl/locale-data/fr';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import AlertProvider from './AlertProvider';
-import AlertHistoryProvider from './AlertHistoryProvider';
 import translations_en from '../translations/en';
 import translations_fr from '../translations/fr';
 import { Loader } from '@scality/core-ui';
@@ -45,16 +44,14 @@ const App = () => {
   return status === 'success' && api && theme ? (
     <QueryClientProvider client={queryClient}>
       <AlertProvider>
-        <AlertHistoryProvider>
-          <IntlProvider
-            locale={language}
-            messages={messages[language.toUpperCase()]}
-          >
-            <IntlGlobalProvider>
-              <Layout />
-            </IntlGlobalProvider>
-          </IntlProvider>
-        </AlertHistoryProvider>
+        <IntlProvider
+          locale={language}
+          messages={messages[language.toUpperCase()]}
+        >
+          <IntlGlobalProvider>
+            <Layout />
+          </IntlGlobalProvider>
+        </IntlProvider>
       </AlertProvider>
     </QueryClientProvider>
   ) : (


### PR DESCRIPTION
**Component**: ui

**Context**: 
We decided to add the loader to AlertProvider when the query is in loading status.
But the issue is, when the alertmanager is not ready, we would be stuck at the loading status for a while. 
  ```js
  if (query.status === 'loading') {
    return (
      <AlertContext.Provider value={{ ...query }}>
        <Loader size="massive" centered={true} aria-label="loading" />
      </AlertContext.Provider>
    );
  } else
```

**Summary**:
A solution is to add an empty array as an initialData to skip the initial loading state!
https://react-query.tanstack.com/guides/initial-query-data

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
