### PR TITLE
ui: Fix configuration when changing the basePath and fix permissions management in the navbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@
 
 - Bump Node.js version to 14.16.0 (PR[#3214](https://github.com/scality/metalk8s/pull/3214))
 
+- Introduces a `shell-ui` project that groups various UI components to be reused by
+solutions UIs (PR[#3106](https://github.com/scality/metalk8s/pull/3106))
+
+- Move the navbar component to `shell-ui` to enable its reuse by solutions UIs
+(PR[#3110](https://github.com/scality/metalk8s/pull/3110))
+
+- Add a static user/groups mapping configuration as part of `shell-ui` configuration to 
+allow solutions UIs displaying features according to some user groups
+(PR[#3154](https://github.com/scality/metalk8s/pull/3154))
+
 ## Release 2.8.1 (in development)
 ### Enhancements
 

--- a/docs/operation/cluster_and_service_configuration.rst
+++ b/docs/operation/cluster_and_service_configuration.rst
@@ -39,7 +39,7 @@ The default configuration values for Dex are specified below:
 
 .. literalinclude:: ../../salt/metalk8s/addons/dex/config/dex.yaml.j2
    :language: yaml
-   :lines: 3-42,45-
+   :lines: 14-42,45-
 
 See :ref:`csc-dex-customization` for Dex configuration customizations.
 

--- a/salt/metalk8s/addons/dex/config/dex.yaml.j2
+++ b/salt/metalk8s/addons/dex/config/dex.yaml.j2
@@ -1,5 +1,16 @@
 #!jinja|yaml
 
+{%- set metalk8s_ui_defaults = salt.slsutil.renderer(
+        'salt://metalk8s/addons/ui/config/metalk8s-ui-config.yaml', saltenv=saltenv
+    )
+%}
+
+{%- set metalk8s_ui_config = salt.metalk8s_service_configuration.get_service_conf(
+        'metalk8s-ui', 'metalk8s-ui-config', metalk8s_ui_defaults
+    )
+%}
+
+
 # Defaults for configuration of Dex (OIDC)
 apiVersion: addons.metalk8s.scality.com/v1alpha2
 kind: DexConfig
@@ -54,7 +65,7 @@ spec:
     - id: metalk8s-ui
       name: MetalK8s UI
       redirectURIs:
-      - https://{{ grains.metalk8s.control_plane_ip }}:8443/
+      - https://{{ grains.metalk8s.control_plane_ip }}:8443/{{ metalk8s_ui_config.spec.basePath.lstrip('/') }}
       secret: ybrMJpVMQxsiZw26MhJzCjA2ut
     - id: grafana-ui
       name: Grafana UI

--- a/salt/metalk8s/addons/ui/config/metalk8s-shell-ui-config.yaml.j2
+++ b/salt/metalk8s/addons/ui/config/metalk8s-shell-ui-config.yaml.j2
@@ -2,6 +2,15 @@
 
 {%- set dex_defaults = salt.slsutil.renderer('salt://metalk8s/addons/dex/config/dex.yaml.j2', saltenv=saltenv) %}
 {%- set dex = salt.metalk8s_service_configuration.get_service_conf('metalk8s-auth', 'metalk8s-dex-config', dex_defaults) %}
+{%- set metalk8s_ui_defaults = salt.slsutil.renderer(
+        'salt://metalk8s/addons/ui/config/metalk8s-ui-config.yaml', saltenv=saltenv
+    )
+%}
+
+{%- set metalk8s_ui_config = salt.metalk8s_service_configuration.get_service_conf(
+        'metalk8s-ui', 'metalk8s-ui-config', metalk8s_ui_defaults
+    )
+%}
 
 {%- set normalized_base_path = metalk8s_ui_config.spec.basePath.strip('/') %}
 
@@ -14,7 +23,7 @@ kind: ShellUIConfig
 spec:
   oidc:
     providerUrl: "/oidc"
-    redirectUrl: "https://{{ grains.metalk8s.control_plane_ip }}:8443/"
+    redirectUrl: "https://{{ grains.metalk8s.control_plane_ip }}:8443/{{ metalk8s_ui_config.spec.basePath.lstrip('/') }}"
     clientId: "metalk8s-ui"
     responseType: "id_token"
     scopes: "openid profile email groups offline_access audience:server:client_id:oidc-auth-client"

--- a/salt/metalk8s/addons/ui/config/metalk8s-shell-ui-config.yaml.j2
+++ b/salt/metalk8s/addons/ui/config/metalk8s-shell-ui-config.yaml.j2
@@ -3,6 +3,11 @@
 {%- set dex_defaults = salt.slsutil.renderer('salt://metalk8s/addons/dex/config/dex.yaml.j2', saltenv=saltenv) %}
 {%- set dex = salt.metalk8s_service_configuration.get_service_conf('metalk8s-auth', 'metalk8s-dex-config', dex_defaults) %}
 
+{%- set normalized_base_path = metalk8s_ui_config.spec.basePath.strip('/') %}
+
+{%- set metalk8s_ui_url = "https://" ~ grains.metalk8s.control_plane_ip ~
+                          ":8443" ~ ('/' ~ normalized_base_path if normalized_base_path else '') ~ '/' %}
+
 # Defaults for shell UI configuration
 apiVersion: addons.metalk8s.scality.com/v1alpha1
 kind: ShellUIConfig
@@ -25,17 +30,16 @@ spec:
   canChangeTheme: false
   options:
     main:
-      "https://{{ grains.metalk8s.control_plane_ip }}:8443/":
+      "{{ metalk8s_ui_url }}":
         en: "Platform"
         fr: "Plateforme"
         groups: [metalk8s:admin]
-        activeIfMatches: "https://{{ grains.metalk8s.control_plane_ip }}:8443/(?!alerts).*"
-      "https://{{ grains.metalk8s.control_plane_ip }}:8443/alerts":
+        activeIfMatches: "{{ metalk8s_ui_url }}(?!alerts|docs).*"
+      "{{ metalk8s_ui_url }}alerts":
         en: "Alerts"
         fr: "Alertes"
         groups: [metalk8s:admin]
     subLogin:
-      "https://{{ grains.metalk8s.control_plane_ip }}:8443/docs":
+      "{{ metalk8s_ui_url }}docs":
         en: "Documentation"
         fr: "Documentation"
-      

--- a/salt/metalk8s/addons/ui/deployed/ingress.sls
+++ b/salt/metalk8s/addons/ui/deployed/ingress.sls
@@ -87,28 +87,30 @@ metadata:
     heritage: metalk8s
   annotations:
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    nginx.ingress.kubernetes.io/rewrite-target: '/$2'
+    nginx.ingress.kubernetes.io/use-regex: 'true'
     kubernetes.io/ingress.class: "nginx-control-plane"
 spec:
   rules:
   - http:
       paths:
-      - path: {{ metalk8s_ui_config.spec.basePath }}
+      - path: {{ metalk8s_ui_config.spec.basePath }}(/|$)(.*)
         backend:
           serviceName: metalk8s-ui
           servicePort: 80
-      - path: /config.json
+      - path: /()(config\.json)
         backend:
           serviceName: metalk8s-ui
           servicePort: 80
-      - path: /brand
+      - path: /()(brand.*)
         backend:
           serviceName: metalk8s-ui
           servicePort: 80
-      - path: /static
+      - path: /()(static.*)
         backend:
           serviceName: metalk8s-ui
           servicePort: 80
-      - path: /manifest.json
+      - path: /()(manifest\.json)
         backend:
           serviceName: metalk8s-ui
           servicePort: 80

--- a/salt/metalk8s/addons/ui/deployed/ingress.sls
+++ b/salt/metalk8s/addons/ui/deployed/ingress.sls
@@ -10,6 +10,9 @@
     )
 %}
 
+{%- set stripped_base_path = metalk8s_ui_config.spec.basePath.strip('/') %}
+{%- set normalized_base_path = '/' ~ stripped_base_path %}
+
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
@@ -87,30 +90,21 @@ metadata:
     heritage: metalk8s
   annotations:
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
-    nginx.ingress.kubernetes.io/rewrite-target: '/$2'
-    nginx.ingress.kubernetes.io/use-regex: 'true'
     kubernetes.io/ingress.class: "nginx-control-plane"
 spec:
   rules:
   - http:
       paths:
-      - path: {{ metalk8s_ui_config.spec.basePath }}(/|$)(.*)
+{% for path in [
+    "/brand",
+    "/config.json",
+    "/manifest.json",
+    "/shell",
+    "/static",
+    normalized_base_path
+] %}
+      - path: {{ path }}
         backend:
           serviceName: metalk8s-ui
           servicePort: 80
-      - path: /()(config\.json)
-        backend:
-          serviceName: metalk8s-ui
-          servicePort: 80
-      - path: /()(brand.*)
-        backend:
-          serviceName: metalk8s-ui
-          servicePort: 80
-      - path: /()(static.*)
-        backend:
-          serviceName: metalk8s-ui
-          servicePort: 80
-      - path: /()(manifest\.json)
-        backend:
-          serviceName: metalk8s-ui
-          servicePort: 80
+{% endfor %}

--- a/salt/metalk8s/addons/ui/deployed/ui.sls.in
+++ b/salt/metalk8s/addons/ui/deployed/ui.sls.in
@@ -26,6 +26,9 @@ include:
     )
 %}
 
+{%- set stripped_base_path = metalk8s_ui_config.spec.basePath.strip('/') %}
+{%- set normalized_base_path = '/' ~ stripped_base_path %}
+
 Create metalk8s-ui deployment:
   metalk8s_kubernetes.object_present:
     - name: salt://{{ slspath }}/files/metalk8s-ui-deployment.yaml.j2
@@ -69,7 +72,7 @@ Create metalk8s-ui ConfigMap:
               "url_alertmanager": "/api/alertmanager",
               "url_navbar": "/shell/solution-ui-navbar.@@ShellUIVersion.js",
               "url_navbar_config": "/shell/config.json",
-              "ui_base_path": "{{ metalk8s_ui_config.spec.basePath }}"
+              "ui_base_path": "{{ normalized_base_path }}"
             }
 
 Create shell-ui ConfigMap:

--- a/shell-ui/babel.config.js
+++ b/shell-ui/babel.config.js
@@ -1,16 +1,36 @@
-if (process.env.NODE_ENV === "test") {
+if (process.env.NODE_ENV === 'test') {
   module.exports = {
-    "presets": ["@babel/preset-env", "@babel/preset-flow", ["@babel/preset-react", {
-        "runtime": "automatic"
-      }]],
-      "plugins": ["@babel/plugin-transform-modules-commonjs"]
-  }
+    presets: [
+      '@babel/preset-env',
+      '@babel/preset-flow',
+      [
+        '@babel/preset-react',
+        {
+          runtime: 'automatic',
+        },
+      ],
+    ],
+    plugins: ['@babel/plugin-transform-modules-commonjs'],
+  };
 } else {
   module.exports = {
-    "presets": ["@babel/preset-env", "@babel/preset-flow", ["@babel/preset-react", {
-        "runtime": "automatic"
-      }]]
-  }
-  
+    plugins: [
+      [
+        'babel-plugin-styled-components',
+        {
+          namespace: 'shell-ui',
+        },
+      ],
+    ],
+    presets: [
+      '@babel/preset-env',
+      '@babel/preset-flow',
+      [
+        '@babel/preset-react',
+        {
+          runtime: 'automatic',
+        },
+      ],
+    ],
+  };
 }
-

--- a/shell-ui/package.json
+++ b/shell-ui/package.json
@@ -20,6 +20,7 @@
     "@testing-library/user-event": "^13.0.10",
     "babel-jest": "^26.6.3",
     "babel-loader": "^8.2.2",
+    "babel-plugin-styled-components": "^1.12.0",
     "css-loader": "^5.0.1",
     "flow-bin": "^0.143.1",
     "html-webpack-plugin": "^4.5.1",

--- a/shell-ui/src/auth/permissionUtils.js
+++ b/shell-ui/src/auth/permissionUtils.js
@@ -11,7 +11,7 @@ export const isEntryAccessibleByTheUser = (
   userGroups: string[],
 ): boolean => {
   return (
-    pathDescription.groups?.every((group) => userGroups.includes(group)) ??
+    pathDescription.groups?.some((group) => userGroups.includes(group)) ??
     true
   );
 };


### PR DESCRIPTION
**Component**:

salt, ui

**Context**: 

When deploying the UI on another path than `/` the shell-ui config couldn't be fetched.

Also this PR brings a fix for the shell-ui which was checking if the user have all the groups instead of a single one to enable access to an entry.