### PR TITLE
shell-ui: Share events and logic with consumers

### DIFF
--- a/shell-ui/src/UserDataListener.js
+++ b/shell-ui/src/UserDataListener.js
@@ -1,7 +1,8 @@
 import { useAuth } from 'oidc-react';
 import { useLayoutEffect } from 'react';
 import { getUserGroups } from './auth/permissionUtils';
-import { AUTHENTICATED_EVENT, SolutionsNavbarProps, type UserGroupsMapping } from './index';
+import { SolutionsNavbarProps, type UserGroupsMapping } from './index';
+import { AUTHENTICATED_EVENT } from './events';
 
 export const UserDataListener = ({
   userGroupsMapping,

--- a/shell-ui/src/UserDataListener.spec.js
+++ b/shell-ui/src/UserDataListener.spec.js
@@ -3,7 +3,7 @@ import { useAuth } from 'oidc-react';
 import { act } from 'react-dom/test-utils';
 
 import StateManager from 'react-select';
-import { AUTHENTICATED_EVENT } from '.';
+import { AUTHENTICATED_EVENT } from './events';
 
 const fakeDataChangedAfterTime = 5;
 const initialUserData = {};

--- a/shell-ui/src/events.js
+++ b/shell-ui/src/events.js
@@ -1,0 +1,5 @@
+const EVENTS_PREFIX = 'solutions-navbar--';
+export const AUTHENTICATED_EVENT: string = EVENTS_PREFIX + 'authenticated';
+export const LANGUAGE_CHANGED_EVENT: string =
+  EVENTS_PREFIX + 'language-changed';
+export const THEME_CHANGED_EVENT: string = EVENTS_PREFIX + 'theme-changed';

--- a/shell-ui/src/index.js
+++ b/shell-ui/src/index.js
@@ -15,12 +15,8 @@ import { defaultTheme } from '@scality/core-ui/dist/style/theme';
 import { LanguageProvider } from './lang';
 import { ThemeProvider, useThemeName } from './theme';
 import { useFavicon } from './favicon';
-
-const EVENTS_PREFIX = 'solutions-navbar--';
-export const AUTHENTICATED_EVENT: string = EVENTS_PREFIX + 'authenticated';
-export const LANGUAGE_CHANGED_EVENT: string =
-  EVENTS_PREFIX + 'language-changed';
-export const THEME_CHANGED_EVENT: string = EVENTS_PREFIX + 'theme-changed';
+import { version } from '../package.json';
+import "./library";
 
 export type PathDescription = {
   en: string,
@@ -234,6 +230,7 @@ class SolutionsNavbarWebComponent extends reactToWebComponent(
   React,
   ReactDOM,
 ) {
+
   constructor() {
     super();
     this.setUserManager = (userManager: UserManager) => {
@@ -251,7 +248,10 @@ class SolutionsNavbarWebComponent extends reactToWebComponent(
     this.logOut = () => {
       logOut(window.userManager);
     };
+
+    this.dispatchEvent(new CustomEvent('ready', {detail: {version}}));
   }
+
 }
 
 customElements.define('solutions-navbar', SolutionsNavbarWebComponent);

--- a/shell-ui/src/lang.js
+++ b/shell-ui/src/lang.js
@@ -3,7 +3,7 @@ import React, { useContext, useState, type Node, useLayoutEffect } from 'react';
 import { IntlProvider } from 'react-intl';
 import translations_en from './translations/en';
 import translations_fr from './translations/fr';
-import { LANGUAGE_CHANGED_EVENT } from '.';
+import { LANGUAGE_CHANGED_EVENT } from './events';
 
 const LanguageContext = React.createContext(null);
 

--- a/shell-ui/src/library.js
+++ b/shell-ui/src/library.js
@@ -1,0 +1,19 @@
+import {
+  AUTHENTICATED_EVENT,
+  LANGUAGE_CHANGED_EVENT,
+  THEME_CHANGED_EVENT,
+} from './events';
+import { version } from '../package.json';
+
+window.shellUINavbar = {
+  ///spread shellUI to keep all versions libraries
+  ...window.shellUINavbar,
+  [version]: {
+    isAuthenticatedEvent: (evt) => evt.detail && evt.detail.profile,
+    events: {
+      AUTHENTICATED_EVENT,
+      LANGUAGE_CHANGED_EVENT,
+      THEME_CHANGED_EVENT,
+    },
+  },
+};

--- a/shell-ui/src/theme.js
+++ b/shell-ui/src/theme.js
@@ -1,7 +1,8 @@
 //@flow
 import React, { useContext, useState, type Node, useLayoutEffect } from 'react';
 import { defaultTheme } from '@scality/core-ui/dist/style/theme';
-import { THEME_CHANGED_EVENT } from '.';
+import { THEME_CHANGED_EVENT } from "./events";
+
 
 type ThemeName = 'dark' | 'light' | 'custom';
 type ThemeContextValues = {

--- a/shell-ui/webpack.config.dev.js
+++ b/shell-ui/webpack.config.dev.js
@@ -1,9 +1,15 @@
 const HtmlWebPackPlugin = require("html-webpack-plugin");
+const path = require("path");
+const {name, version} = require("./package.json");
 const {DefinePlugin} = require("webpack")
 module.exports = {
   mode: "development",
   devtool: "source-map",
   entry: "./index.js",
+  output: {
+    path: path.resolve(__dirname, "build"),
+    filename: `shell/${name}.${version}.js`,
+  },
   module: {
     // ...
     rules: [

--- a/ui/src/components/Navbar.js
+++ b/ui/src/components/Navbar.js
@@ -37,9 +37,8 @@ function useWebComponent(src?: string, customElementName: string) {
 
 type NavbarWebComponent = HTMLElement & { logOut: () => void };
 
-function useLoginEffect(navbarRef: { current: NavbarWebComponent | null }) {
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
-  const dispatch = useDispatch();
+function useNavbarVersion(navbarRef: { current: NavbarWebComponent | null }): string | null {
+  const [version, setVersion] = useState(null);
 
   useEffect(() => {
     if (!navbarRef.current) {
@@ -48,10 +47,40 @@ function useLoginEffect(navbarRef: { current: NavbarWebComponent | null }) {
 
     const navbarElement = navbarRef.current;
 
-    const onAuthenticated = (evt: Event) => {
-      /// flow is not accepting CustomEvent type for listener arguments of {add,remove}EventListener https://github.com/facebook/flow/issues/7179
+    const onReady = (evt: Event) => {
       // $flow-disable-line
-      if (evt.detail && evt.detail.profile) {
+      setVersion(evt.detail.version)
+    }
+
+    navbarElement.addEventListener(
+      'ready',
+      onReady,
+    );
+
+    return () => {
+      navbarElement.removeEventListener(
+        'ready',
+        onReady,
+      );
+    };
+  }, [navbarRef])
+
+  return version;
+}
+
+function useLoginEffect(navbarRef: { current: NavbarWebComponent | null }, version: string | null) {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (!navbarRef.current || !version) {
+      return;
+    }
+
+    const navbarElement = navbarRef.current;
+
+    const onAuthenticated = (evt: Event) => {
+      if (window.shellUINavbar[version].isAuthenticatedEvent(evt)) {
         // $flow-disable-line
         dispatch(updateAPIConfigAction(evt.detail));
         setIsAuthenticated(true);
@@ -61,26 +90,26 @@ function useLoginEffect(navbarRef: { current: NavbarWebComponent | null }) {
     };
 
     navbarElement.addEventListener(
-      'solutions-navbar--authenticated',
+      window.shellUINavbar[version].events.AUTHENTICATED_EVENT,
       onAuthenticated,
     );
 
     return () => {
       navbarElement.removeEventListener(
-        'solutions-navbar--authenticated',
+        window.shellUINavbar[version].events.AUTHENTICATED_EVENT,
         onAuthenticated,
       );
     };
-  }, [navbarRef, dispatch]);
+  }, [navbarRef, version, dispatch]);
 
   return { isAuthenticated };
 }
 
-function useLanguageEffect(navbarRef: { current: NavbarWebComponent | null }) {
+function useLanguageEffect(navbarRef: { current: NavbarWebComponent | null }, version: string | null) {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    if (!navbarRef.current) {
+    if (!navbarRef.current || !version) {
       return;
     }
 
@@ -96,24 +125,24 @@ function useLanguageEffect(navbarRef: { current: NavbarWebComponent | null }) {
     };
 
     navbarElement.addEventListener(
-      'solutions-navbar--language-changed',
+      window.shellUINavbar[version].events.LANGUAGE_CHANGED_EVENT,
       onLanguageChanged,
     );
 
     return () => {
       navbarElement.removeEventListener(
-        'solutions-navbar--language-changed',
+        window.shellUINavbar[version].events.LANGUAGE_CHANGED_EVENT,
         onLanguageChanged,
       );
     };
-  }, [navbarRef, dispatch]);
+  }, [navbarRef, version, dispatch]);
 }
 
-function useThemeEffect(navbarRef: { current: NavbarWebComponent | null }) {
+function useThemeEffect(navbarRef: { current: NavbarWebComponent | null }, version: string | null) {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    if (!navbarRef.current) {
+    if (!navbarRef.current || !version) {
       return;
     }
 
@@ -129,17 +158,17 @@ function useThemeEffect(navbarRef: { current: NavbarWebComponent | null }) {
     };
 
     navbarElement.addEventListener(
-      'solutions-navbar--theme-changed',
+      window.shellUINavbar[version].events.THEME_CHANGED_EVENT,
       onThemeChanged,
     );
 
     return () => {
       navbarElement.removeEventListener(
-        'solutions-navbar--theme-changed',
+        window.shellUINavbar[version].events.THEME_CHANGED_EVENT,
         onThemeChanged,
       );
     };
-  }, [navbarRef, dispatch]);
+  }, [navbarRef, version, dispatch]);
 }
 
 function useLogoutEffect(
@@ -185,10 +214,11 @@ function InternalNavbar() {
 
   const navbarRef = useRef<NavbarWebComponent | null>(null);
 
-  const { isAuthenticated } = useLoginEffect(navbarRef);
+  const version = useNavbarVersion(navbarRef);
+  const { isAuthenticated } = useLoginEffect(navbarRef, version);
   useLogoutEffect(navbarRef, isAuthenticated);
-  useLanguageEffect(navbarRef);
-  useThemeEffect(navbarRef);
+  useLanguageEffect(navbarRef, version);
+  useThemeEffect(navbarRef, version);
 
   return (
     <solutions-navbar


### PR DESCRIPTION
**Component**:

shell-ui

**Context**: 

In order to ease change over time on events name and shell ui shared logic, client apps should be able to import common logic.

**Summary**:

Add a library exposing event names and common logic to window global object. The shared object is namespaced to shell-ui and segregated per version.

**Acceptance criteria**: 

Integration tests
