### PR TITLE
repo: Disable repo gpg check for Kubernetes repo

### DIFF
--- a/packages/redhat/yum_repositories/kubernetes.repo
+++ b/packages/redhat/yum_repositories/kubernetes.repo
@@ -3,6 +3,6 @@ name=Kubernetes
 baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
 enabled=1
 gpgcheck=1
-repo_gpgcheck=1
+repo_gpgcheck=0
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
        https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg


### PR DESCRIPTION
Due to a bug on Kubernetes side we cannot check the gpg key for the
repository
Suggested workaround is to disable this repo gpg check especially since
we use "trusted" https endpoints

Sees: https://cloud.google.com/compute/docs/troubleshooting/known-issues#keyexpired
