### PR TITLE
salt: Install `lvm2` on every machines

### DIFF
--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -345,6 +345,7 @@ PACKAGES: Dict[str, Any] = {
         PackageVersion(name="iproute"),
         PackageVersion(name="iptables"),
         PackageVersion(name="kubernetes-cni"),
+        PackageVersion(name="lvm2"),
         PackageVersion(name="m2crypto"),
         PackageVersion(name="python36-psutil"),
         PackageVersion(name="python36-pyOpenSSL"),

--- a/salt/metalk8s/volumes/installed.sls
+++ b/salt/metalk8s/volumes/installed.sls
@@ -18,6 +18,11 @@ Install gdisk:
     - require:
       - test: Repositories configured
 
+Install lvm2:
+  {{ pkg_installed('lvm2') }}
+    - require:
+      - test: Repositories configured
+
 # Needed by the sparse volume cleanup script
 Ensure Python 3 is available:
   test.fail_without_changes:


### PR DESCRIPTION
Since we have a new volume type `LVMLogicalVolume` that use lvm,
install the needed package on every machines as part of MetalK8s

Fixes: #3270
