### PR TITLE
salt: Disable 'RemoveSelfLink' feature gate

### DIFF
--- a/salt/metalk8s/kubernetes/apiserver/installed.sls
+++ b/salt/metalk8s/kubernetes/apiserver/installed.sls
@@ -96,6 +96,7 @@ Create kube-apiserver Pod manifest:
           - --oidc-groups-claim=groups
           - '"--oidc-groups-prefix=oidc:"'
           - --v={{ 2 if metalk8s.debug else 0 }}
+          - --feature-gates=RemoveSelfLink=false
         requested_cpu: 250m
         volumes:
           - path: {{ encryption_k8s_path }}


### PR DESCRIPTION
The feature in k-a responsible for adding `selfLink` to all objects is
disabled by default in K8s 1.20+. However, this may break a bunch of
applications, including KubeDB operators.

We disable the feature gate until controlling feature gates is exposed
in a cleaner fashion.

See: kubernetes/enhancements#1164
