### PR TITLE
ci: Always check embedded MD5 in ISO

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -103,24 +103,10 @@ models:
             ssh eve@$IP
         END
   - ShellCommand: &check_iso_checksum
-      name: Check image with checksum
+      name: Check image with checksums
       command: |
         sha256sum -c SHA256SUM
-        # Check the embedded MD5, but only if one is found (i.e.,
-        # MetalK8s >= 2.8)
-        # We optimistically assume the checksum section is always found
-        # within the first 64kB of the ISO, which is not guaranteed. If
-        # this ever becomes an issue in CI, we'll need to find a better way.
-        # Hopefully by then we don't need this check anymore anyway (MetalK8s
-        # >= 2.9).
-        dd if=metalk8s.iso bs=1k count=64 | strings | grep "THIS IS NOT THE SAME AS RUNNING MD5SUM ON THIS ISO"
-        if [ $? -eq 0 ]; then
-          echo "Found signs of an embedded MD5 checksum, validating as well"
-          sudo yum install --assumeyes isomd5sum
-          checkisomd5 metalk8s.iso
-        else
-          echo "No embedded MD5 checksum detected, skipping validation"
-        fi
+        checkisomd5 metalk8s.iso
       haltOnFailure: true
   - Upload: &upload_artifacts
       name: Upload artifacts
@@ -1738,6 +1724,7 @@ stages:
       type: openstack
       image: CentOS-7-x86_64-GenericCloud-1809.qcow2
       flavor: m1.medium
+      path: eve/workers/openstack-basic
     steps:
       - Git: *git_pull
       - ShellCommand:

--- a/eve/workers/openstack-basic/requirements.sh
+++ b/eve/workers/openstack-basic/requirements.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+## Dependencies ##
+
+PACKAGES=(
+    isomd5sum
+)
+
+yum install -y "${PACKAGES[@]}"
+
+yum clean all

--- a/eve/workers/openstack-single-node/requirements.sh
+++ b/eve/workers/openstack-single-node/requirements.sh
@@ -18,6 +18,7 @@ PACKAGES=(
     gcc-c++
     make
     nodejs
+    isomd5sum
 )
 
 yum install -y "${PACKAGES[@]}"


### PR DESCRIPTION
Since #3032 (merged in 2.8), all our ISOs include an embedded MD5
checksum. We had an empirical check to know whether this checksum was
indeed present, since we also need to verify ISOs from (N-1) when
running upgrade/downgrade tests from version (N).

Now, in 2.9, all ISOs we expect should include this checksum. The
empirical check is no longer needed, and we remove it.
We also add a common `requirements.sh` to install the required package
for openstack workers which were only used to spawn other VMs through
Terraform, since these workers are responsible for validating the
integrity of retrieved artifacts.