### PR TITLE
salt: Mark our storage class as the default

### DIFF
--- a/salt/metalk8s/addons/storageclass/deployed.sls
+++ b/salt/metalk8s/addons/storageclass/deployed.sls
@@ -7,6 +7,8 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/part-of: metalk8s
+  annotations:
+    storageclass.kubernetes.io/is-default-class: 'true'
 provisioner: kubernetes.io/no-provisioner
 reclaimPolicy: Retain
 volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
This will allow PVCs without a `storageClassName` specified to match any
PV provisioned with this storage class.