### PR TITLE
salt: Start salt-minion if not yet started as part of state

### DIFF
--- a/salt/metalk8s/salt/minion/installed.sls
+++ b/salt/metalk8s/salt/minion/installed.sls
@@ -14,8 +14,14 @@ Install salt-minion:
     - watch_in:
       - cmd: Restart salt-minion
 
-Enable Salt minion:
-  service.enabled:
+Start and enable Salt minion:
+  # NOTE: We use `service.running` but do not put any `watch` as
+  # we do not want this state to restart salt-minion process just
+  # start it if not yet started and enable the service
+  service.running:
     - name: salt-minion
+    - enable: True
     - require:
       - metalk8s_package_manager: Install salt-minion
+    - require_in:
+      - cmd: Restart salt-minion


### PR DESCRIPTION
Before this commit, if for some reason salt-minion is not started and
the configuration file is in the expected state when we call the salt minion SLS
the salt-minion service will not be started.
NOTE: This happens when you re-launch the bootstrap script for example

So make sure we always ensure that the salt-minion process is running
