### PR TITLE
eve: Add label role node when untaint node

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -671,7 +671,9 @@ models:
       command: |
         ssh -F ssh_config bootstrap <<ENDSSH
         sudo kubectl --kubeconfig /etc/kubernetes/admin.conf \
-        patch node "$NODE_NAME" --patch '{"spec": {"taints": []}}'
+        patch node "$NODE_NAME" --patch '{"spec": {"taints": []}}' &&
+        sudo kubectl --kubeconfig /etc/kubernetes/admin.conf \
+        label node --overwrite  "$NODE_NAME" "node-role.kubernetes.io/node="
         ENDSSH
       workdir: build/eve/workers/openstack-terraform/terraform/
       haltOnFailure: true


### PR DESCRIPTION
Add the role label "node" to the node when untaint so that if we re-run
bootstrap we do not add taints again