### PR TITLE
Revert "salt: Mark our storage class as the default"

### DIFF
--- a/salt/metalk8s/addons/storageclass/deployed.sls
+++ b/salt/metalk8s/addons/storageclass/deployed.sls
@@ -7,8 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/part-of: metalk8s
-  annotations:
-    storageclass.kubernetes.io/is-default-class: 'true'
 provisioner: kubernetes.io/no-provisioner
 reclaimPolicy: Retain
 volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
We won't have a 'default' `StorageClass` at all (cfr. meeting dd.
04/14/21).

This reverts commit b068706cf2411b56a7b1255baf6814ebc0567146.

See: https://github.com/scality/metalk8s/pull/3283
Cc: @gdemonet
Cc: @TeddyAndrieux
Cc: @NickSayer-scality