### PR TITLE
salt: Add dedicated Ingress for MetalK8s docs

### DIFF
--- a/salt/metalk8s/addons/ui/deployed/ingress.sls
+++ b/salt/metalk8s/addons/ui/deployed/ingress.sls
@@ -108,3 +108,28 @@ spec:
           serviceName: metalk8s-ui
           servicePort: 80
 {% endfor %}
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx-control-plane
+    nginx.ingress.kubernetes.io/backend-protocol: HTTP
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: '/docs/$2'
+  labels:
+    app: metalk8s-docs
+    app.kubernetes.io/managed-by: salt
+    app.kubernetes.io/name: metalk8s-docs
+    app.kubernetes.io/part-of: metalk8s
+    heritage: metalk8s
+  name: metalk8s-docs
+  namespace: metalk8s-ui
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /docs/{{ stripped_base_path }}(/|$)(.*)
+        backend:
+          serviceName: metalk8s-ui
+          servicePort: 80


### PR DESCRIPTION
Adding a `rewrite-target` annotation is needed when the base path is not
/, because NGINX does not know where to find the documentation static
files.

We now always expose MetalK8s docs behind /docs, optionally appending
the configured base path for MetalK8s UI (e.g. /docs/platform).
This will avoid strange conflicts with the behaviour of the current
Ingress when running MetalK8s at a non-root path, because mixing regular
expressions and exact matches does not play well with ingress-nginx.

See: #3254
See: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#use-regex