### PR TITLE
Feature/3266 apply error pages

### DIFF
--- a/shell-ui/src/navbar/Navbar.spec.js
+++ b/shell-ui/src/navbar/Navbar.spec.js
@@ -45,8 +45,8 @@ const server = setupServer(
 );
 
 function mockOidcReact() {
-  const {jest} = require('@jest/globals');
-  
+  const { jest } = require('@jest/globals');
+
   const original = jest.requireActual('oidc-react');
   return {
     ...original, //Pass down all the exported objects
@@ -58,8 +58,8 @@ function mockOidcReact() {
           name: 'user',
         },
       },
-    })
-  }
+    }),
+  };
 }
 jest.mock('oidc-react', () => mockOidcReact());
 
@@ -110,7 +110,7 @@ describe('navbar', () => {
         return res(ctx.status(500));
       }),
     );
-    
+
     render(
       <solutions-navbar
         oidc-provider-url="https://mocked.ingress/oidc"
@@ -124,9 +124,7 @@ describe('navbar', () => {
     //E
     await waitForLoadingToFinish();
     //V
-    expect(
-      screen.queryByText(/Failed to load navbar configuration/i),
-    ).toBeInTheDocument();
+    expect(screen.queryByText('Unexpected Error')).toBeInTheDocument();
   });
 
   it('should display expected selected menu when it matches by exact loaction (default behavior)', async () => {
@@ -250,7 +248,6 @@ describe('navbar', () => {
 
     mockOIDCProvider();
 
-
     render(
       <solutions-navbar
         oidc-provider-url="https://mocked.ingress/oidc"
@@ -278,7 +275,6 @@ describe('navbar', () => {
     //S
 
     mockOIDCProvider();
-
 
     render(
       <solutions-navbar

--- a/shell-ui/src/navbar/index.js
+++ b/shell-ui/src/navbar/index.js
@@ -1,5 +1,5 @@
 //@flow
-import React, { useEffect, useLayoutEffect, useRef } from 'react';
+import React, { useLayoutEffect } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import reactToWebComponent from 'react-to-webcomponent';
@@ -11,12 +11,12 @@ import { LoadingNavbar, Navbar } from './NavBar';
 import { UserDataListener } from './UserDataListener';
 import { logOut } from './auth/logout';
 import { prefetch } from 'quicklink';
-import { defaultTheme } from '@scality/core-ui/dist/style/theme';
 import { LanguageProvider } from './lang';
-import { ThemeProvider, useThemeName } from './theme';
+import { ThemeProvider } from './theme';
 import { useFavicon } from './favicon';
 import { version } from '../../package.json';
 import "./library";
+import ErrorPage500 from '@scality/core-ui/dist/components/error-pages/ErrorPage500.component';
 
 export type PathDescription = {
   en: string,
@@ -123,7 +123,7 @@ const SolutionsNavbar = ({
     default:
       return <LoadingNavbar logo={logos.dark || `/brand/assets/logo-dark.svg`} />;
     case 'error':
-      return <>Failed to load navbar configuration</>; // TODO redirects to a beautiful error page
+      return ReactDOM.render(<ErrorPage500 data-cy='sc-error-page500'/>, document.body);
     case 'success': {
       const userManager = new UserManager({
         authority: oidcProviderUrl || config.oidc?.providerUrl,

--- a/ui/cypress/fixtures/config.json
+++ b/ui/cypress/fixtures/config.json
@@ -1,12 +1,13 @@
 {
-    "url": "/api/kubernetes",
-    "url_salt": "/api/salt",
-    "url_prometheus": "/api/prometheus",
-    "url_grafana": "/grafana",
-    "url_doc": "/docs",
-    "url_alertmanager": "/api/alertmanager",
-    "url_navbar": "/shell/solution-ui-navbar.1.0.0.js",
-    "url_alerts": "/shell/alerts.1.0.0.js",
-    "alerts_lib_version": "1.0.0",
-    "url_navbar_config": "/shell/config.json"
+  "url": "/api/kubernetes",
+  "url_salt": "/api/salt",
+  "url_prometheus": "/api/prometheus",
+  "url_grafana": "/grafana",
+  "url_doc": "/docs",
+  "url_alertmanager": "/api/alertmanager",
+  "url_navbar": "/shell/solution-ui-navbar.1.0.0.js",
+  "url_alerts": "/shell/alerts.1.0.0.js",
+  "alerts_lib_version": "1.0.0",
+  "url_navbar_config": "/shell/config.json",
+  "url_support": "https://support.com"
 }

--- a/ui/cypress/integration/error-pages.spec.js
+++ b/ui/cypress/integration/error-pages.spec.js
@@ -1,0 +1,95 @@
+describe('Error Pages Navigation', () => {
+  beforeEach(() => {
+    cy.setupMocks();
+    cy.login();
+  });
+
+  it('redirects me to 404 error page if route not found', () => {
+    cy.visit('/undefined-route-that-doesnt-exists');
+    cy.stubHistory();
+
+    cy.get('[data-cy="sc-error-page404"]').contains(
+      'Error: this page does not exist',
+    );
+  });
+});
+
+describe('Error Pages Custom config', () => {
+  beforeEach(() => {
+    cy.setupMocks(null);
+    cy.login();
+  });
+
+  it('redirects me to 500 - fetch config results in internal error', () => {
+    cy.route2('GET', '/config.json', {
+      fixture: 'config.json',
+      statusCode: 500,
+    });
+    cy.visit('/');
+    cy.stubHistory();
+    cy.get('[data-cy="sc-error-page500"]').contains('Unexpected Error');
+  });
+
+  it('redirects me to 500 in case of wrong url_alerts config', () => {
+    let url_support = 'https://mysupportlink.com';
+    cy.fixture('config.json').then((config) => {
+      config.url_support = url_support;
+      // must be a fake url
+      // otherwise in CI nginx which is served with a try files rule, will return a html with successful response code
+      config.url_alerts = 'http://invalid/url';
+      cy.route2('GET', '/config.json', config);
+    });
+
+    // alerts page will throw an error if it has failed
+    // we must catch it on cypress
+    cy.on('uncaught:exception', () => false);
+
+    cy.visit('/');
+    cy.stubHistory();
+
+    cy.get('[data-cy="sc-error-page500"]').contains('Unexpected Error');
+
+    if (url_support) {
+      cy.get('.sc-error-page500 * a')
+        .should('have.attr', 'href')
+        .and('include', url_support);
+    }
+  });
+});
+
+describe('Error Pages Auth failure', () => {
+  beforeEach(() => {
+    cy.setupMocks();
+    cy.badLogin();
+  });
+
+  it('redirects me to auth error page in case of auth failure', () => {
+    cy.visit('/alerts');
+    cy.stubHistory();
+
+    cy.get('[data-cy="sc-error-pageauth"]').contains('Authenticating...');
+  });
+});
+
+describe('Error Pages Navbar failure', () => {
+  beforeEach(() => {
+    cy.setupMocks('config.json', null);
+    cy.login();
+  });
+
+  it('redirects to 500 error page in case of navbar fail to load', () => {
+    cy.fixture('shell-config.json').then((config) => {
+      config.options = null;
+      cy.route2('GET', '/shell/config.json', config);
+    });
+
+    // internal navbar will throw an error if the shell-ui navbar has failed
+    // we must catch it on cypress
+    cy.on('uncaught:exception', () => false);
+
+    cy.visit('/');
+    cy.stubHistory();
+
+    cy.get('[data-cy="sc-error-page500"]').contains('Unexpected Error');
+  });
+});

--- a/ui/public/config.json
+++ b/ui/public/config.json
@@ -1,13 +1,14 @@
 {
-    "url": "https://{ip}:8443/api/kubernetes",
-    "url_salt": "https://{ip}:8443/api/salt",
-    "url_prometheus": "https://{ip}:8443/api/prometheus",
-    "url_grafana": "https://{ip}:8443/grafana",
-    "url_doc": "https://{ip}:8443/docs",
-    "url_alertmanager": "https://{ip}:8443/api/alertmanager",
-    "flags": [],
-    "url_navbar": "/shell/solution-ui-navbar.1.0.0.js",
-    "url_alerts": "/shell/alerts.1.0.0.js",
-    "url_navbar_config": "/shell/config.json",
-    "alerts_lib_version": "1.0.0"
+  "url": "https://{ip}:8443/api/kubernetes",
+  "url_salt": "https://{ip}:8443/api/salt",
+  "url_prometheus": "https://{ip}:8443/api/prometheus",
+  "url_grafana": "https://{ip}:8443/grafana",
+  "url_doc": "https://{ip}:8443/docs",
+  "url_alertmanager": "https://{ip}:8443/api/alertmanager",
+  "flags": [],
+  "url_navbar": "/shell/solution-ui-navbar.1.0.0.js",
+  "url_alerts": "/shell/alerts.1.0.0.js",
+  "url_navbar_config": "/shell/config.json",
+  "alerts_lib_version": "1.0.0",
+  "url_support": "https://github.com/scality/metalk8s/discussions/new"
 }

--- a/ui/src/components/Navbar.js
+++ b/ui/src/components/Navbar.js
@@ -72,6 +72,14 @@ function useNavbarVersion(navbarRef: { current: NavbarWebComponent | null }): st
 function useLoginEffect(navbarRef: { current: NavbarWebComponent | null }, version: string | null) {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const dispatch = useDispatch();
+  const user = useTypedSelector((state) => state.oidc?.user);
+  const userStoredInRedux = useRef(false);
+
+  useEffect(() => {
+    if (user) {
+      userStoredInRedux.current = true;
+    }
+  }, [!!user])
 
   useEffect(() => {
     if (!navbarRef.current || !version) {
@@ -103,7 +111,7 @@ function useLoginEffect(navbarRef: { current: NavbarWebComponent | null }, versi
     };
   }, [navbarRef, version, dispatch]);
 
-  return { isAuthenticated };
+  return { isAuthenticated: isAuthenticated && userStoredInRedux.current };
 }
 
 function useLanguageEffect(navbarRef: { current: NavbarWebComponent | null }, version: string | null) {

--- a/ui/src/components/Navbar.js
+++ b/ui/src/components/Navbar.js
@@ -4,6 +4,7 @@ import { useTypedSelector } from '../hooks';
 import { setThemeAction, updateAPIConfigAction, setLanguageAction } from '../ducks/config';
 import { useDispatch } from 'react-redux';
 import { ErrorBoundary } from 'react-error-boundary';
+import { ErrorPage500 } from '@scality/core-ui';
 
 function useWebComponent(src?: string, customElementName: string) {
   const [hasFailed, setHasFailed] = useState(false);
@@ -31,7 +32,7 @@ function useWebComponent(src?: string, customElementName: string) {
   }, [src]);
 
   if (hasFailed) {
-    throw new Error(`Failed to load component ${customElementName}`);
+    throw new Error(`Failed to load component ${ customElementName }`);
   }
 }
 
@@ -49,8 +50,8 @@ function useNavbarVersion(navbarRef: { current: NavbarWebComponent | null }): st
 
     const onReady = (evt: Event) => {
       // $flow-disable-line
-      setVersion(evt.detail.version)
-    }
+      setVersion(evt.detail.version);
+    };
 
     navbarElement.addEventListener(
       'ready',
@@ -63,7 +64,7 @@ function useNavbarVersion(navbarRef: { current: NavbarWebComponent | null }): st
         onReady,
       );
     };
-  }, [navbarRef])
+  }, [navbarRef]);
 
   return version;
 }
@@ -187,19 +188,15 @@ function useLogoutEffect(
   }, [navbarRef, !user, isAuthenticated]);
 }
 
-function ErrorFallback({ error, resetErrorBoundary }) {
-  //Todo redirect to a beautiful error page
-  return (
-    <div role="alert">
-      <p>Something went wrong:</p>
-      <pre>{error.message}</pre>
-    </div>
-  );
+function ErrorFallback() {
+  const { language, api } = useTypedSelector((state) => state.config);
+  const url_support = api?.url_support;
+  return <ErrorPage500 data-cy='sc-error-page500' locale={ language } supportLink={ url_support }/>;
 }
 
 export function Navbar() {
   return (
-    <ErrorBoundary FallbackComponent={ErrorFallback}>
+    <ErrorBoundary FallbackComponent={ ErrorFallback }>
       <InternalNavbar />
     </ErrorBoundary>
   );
@@ -226,7 +223,7 @@ function InternalNavbar() {
         // $flow-disable-line -- flow considers solutions-navbar as a row HTMLElement, TODO find if it is possible to extends JSX flow native definitions with custom element types
         navbarRef
       }
-      config-url={navbarConfigUrl}
+      config-url={ navbarConfigUrl }
     />
   );
 }

--- a/ui/src/containers/AlertProvider.js
+++ b/ui/src/containers/AlertProvider.js
@@ -11,6 +11,7 @@ import { useQuery } from 'react-query';
 import { useTypedSelector } from '../hooks';
 import { ErrorBoundary } from 'react-error-boundary';
 import type { FilterLabels } from '../services/alertUtils';
+import { ErrorPage500 } from '@scality/core-ui';
 
 export const useAlerts = (filters: FilterLabels) => {
   const alertsVersion = useTypedSelector(
@@ -24,10 +25,10 @@ export const useAlerts = (filters: FilterLabels) => {
 
 /**
  * This hook dynamically load Alert library.
- * 
+ *
  * It first creates a script entry if none exists referring the given library src
  *  and then initiates the library by calling `createAlertContext`
- * 
+ *
  * @param {string} src library bundle url
  * @param {string?} version library version
  */
@@ -89,14 +90,10 @@ const InternalAlertProvider = ({ children }: { children: Node }): Node => {
   return <>{children}</>;
 };
 
-function ErrorFallback({ error, resetErrorBoundary }) {
-  //Todo redirect to a beautiful error page
-  return (
-    <div role="alert">
-      <p>Something went wrong:</p>
-      <pre>{error.message}</pre>
-    </div>
-  );
+function ErrorFallback() {
+  const { language, api } = useTypedSelector((state) => state.config);
+  const url_support = api?.url_support;
+  return <ErrorPage500 data-cy='sc-error-page500' locale={ language } supportLink={ url_support }/>;
 }
 
 const AlertProvider = ({ children }: { children: Node }): Node => {

--- a/ui/src/containers/Layout.js
+++ b/ui/src/containers/Layout.js
@@ -2,13 +2,14 @@
 import React, { useCallback, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { ThemeProvider } from 'styled-components';
-import { matchPath, RouteProps } from 'react-router';
+import { matchPath, RouteProps, Route, Redirect } from 'react-router';
 import { useHistory, useLocation, Switch } from 'react-router-dom';
 import {
   Layout as CoreUILayout,
   Notifications,
   Loader,
   ScrollbarWrapper,
+  ErrorPage404,
 } from '@scality/core-ui';
 import { intl } from '../translations/IntlGlobalProvider';
 import { toggleSideBarAction } from '../ducks/app/layout';
@@ -30,14 +31,13 @@ const AlertPage = React.lazy(() => import('./AlertPage'));
 
 const Layout = () => {
   const sidebar = useTypedSelector((state) => state.app.layout.sidebar);
-  const { theme } = useTypedSelector((state) => state.config);
+  const { theme, language } = useTypedSelector((state) => state.config);
   const notifications = useTypedSelector(
     (state) => state.app.notifications.list,
   );
 
   const isUserLoaded = useTypedSelector((state) => !!state.oidc?.user);
   const api = useTypedSelector((state) => state.config.api);
-
   const dispatch = useDispatch();
 
   const removeNotification = (uid) => dispatch(removeNotificationAction(uid));
@@ -136,6 +136,11 @@ const Layout = () => {
               <Switch>
                 <PrivateRoute
                   exact
+                  path="/"
+                  component={() => <Redirect to="/nodes" />}
+                />
+                <PrivateRoute
+                  exact
                   path="/nodes/create"
                   component={NodeCreateForm}
                 />
@@ -160,6 +165,14 @@ const Layout = () => {
                     component={DashboardPage}
                   />
                 )}
+                <Route
+                  component={() => (
+                    <ErrorPage404
+                      data-cy="sc-error-page404"
+                      locale={language}
+                    />
+                  )}
+                />
               </Switch>
             </Suspense>
           </AlertProvider>

--- a/ui/src/containers/PrivateRoute.js
+++ b/ui/src/containers/PrivateRoute.js
@@ -1,14 +1,24 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { Route } from 'react-router-dom';
+import { ErrorPageAuth } from '@scality/core-ui';
+import { useTypedSelector } from '../hooks';
 
-const PrivateRoute = ({ component, ...rest }) => {
+const PrivateRoute = ({ component, location, ...rest }) => {
+  const { language, api } = useTypedSelector((state) => state.config);
+  const url_support = api?.url_support;
   const authenticated = useSelector((state) => !!state.oidc.user);
 
-  if (!authenticated) {
-    return <>You are not authenticated</>;//todo display a nicer message here
-  } else {
+  if (authenticated) {
     return <Route {...rest} component={component} />;
+  } else {
+    return (
+      <ErrorPageAuth
+        data-cy="sc-error-pageauth"
+        supportLink={url_support}
+        locale={language}
+      />
+    );
   }
 };
 

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -12,6 +12,7 @@ import sagas from './ducks/sagas';
 import { createBrowserHistory } from 'history';
 import { useTypedSelector } from './hooks';
 import { setHistory as setReduxHistory } from './ducks/history';
+import { ErrorPage500 } from '@scality/core-ui';
 
 const composeEnhancers =
   typeof window === 'object' && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
@@ -26,31 +27,35 @@ if (window.Cypress) window.__store__ = store;
 
 sagaMiddleware.run(sagas);
 
-const RouterWithBaseName = ({children}) => {
-  const configStatus = useTypedSelector(state => state.config.status);
-  const basename = useTypedSelector(state => state.config.api?.ui_base_path);
+const RouterWithBaseName = ({ children }) => {
+  const configStatus = useTypedSelector((state) => state.config.status);
+  const basename = useTypedSelector((state) => state.config.api?.ui_base_path);
   const [history, setHistory] = useState(createBrowserHistory({}));
   const dispatch = useDispatch();
-  useLayoutEffect(() =>{
+  useLayoutEffect(() => {
     if (basename) {
-      const historyWithBasename = createBrowserHistory({basename});
+      const historyWithBasename = createBrowserHistory({ basename });
       setHistory(historyWithBasename);
       if (window.Cypress) window.__history__ = historyWithBasename;
       dispatch(setReduxHistory(historyWithBasename));
     }
     if (window.Cypress) window.__history__ = history;
   }, [basename]);
- 
+
   if (configStatus === 'error') {
-    return <>An error occurred, please try to refresh the page</>//Todo display an error page
+    return <ErrorPage500 data-cy="sc-error-page500" />;
   }
 
   if (configStatus === 'idle' || configStatus === 'loading') {
-    return <>{children}</>
+    return <>{children}</>;
   }
 
-  return <Router key={basename} history={history}>{children}</Router>
-}
+  return (
+    <Router key={basename} history={history}>
+      {children}
+    </Router>
+  );
+};
 
 ReactDOM.render(
   <Provider store={store}>

--- a/ui/src/services/api.js
+++ b/ui/src/services/api.js
@@ -48,6 +48,7 @@ export type Config = {
   ui_base_path?: string,
   url_alerts: string,
   alerts_lib_version: string,
+  url_support?: string,
 };
 
 export function fetchConfig(): Promise<Config> {


### PR DESCRIPTION
**Component**: ui, errorpages

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**:  #3266 
We want to add error pages to metalK8S.

**Summary**:
This adds :
* a 404 page to undefined routes.
* a 500 page when the config file is not found/valid
* a 500 page on Navbar fail
* an Auth error page when the user is not authenticated




---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #3266 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
