### PR TITLE
ui: Remove sorting sync with url for the table in volume tab

### DIFF
--- a/ui/src/components/NodeListTable.js
+++ b/ui/src/components/NodeListTable.js
@@ -258,7 +258,7 @@ function Table({ columns, data, rowClicked, theme, selectedNodeName }) {
       },
     };
   }, []);
-
+  const DEFAULT_SORTING_KEY = 'health';
   const {
     getTableProps,
     getTableBodyProps,
@@ -278,7 +278,7 @@ function Table({ columns, data, rowClicked, theme, selectedNodeName }) {
         globalFilter: querySearch,
         sortBy: [
           {
-            id: querySort || 'health',
+            id: querySort || DEFAULT_SORTING_KEY,
             desc: queryDesc || false,
           },
         ],
@@ -297,7 +297,7 @@ function Table({ columns, data, rowClicked, theme, selectedNodeName }) {
     ?.id;
   const desc = headerGroups[0].headers.find((item) => item.isSorted === true)
     ?.isSortedDesc;
-  useTableSortURLSync(sorted, desc, data);
+  useTableSortURLSync(sorted, desc, data, DEFAULT_SORTING_KEY);
 
   return (
     <>

--- a/ui/src/components/VolumeListTable.js
+++ b/ui/src/components/VolumeListTable.js
@@ -192,6 +192,7 @@ function Table({
     };
   }, []);
 
+  const DEFAULT_SORTING_KEY = 'health';
   const {
     getTableProps,
     getTableBodyProps,
@@ -211,7 +212,7 @@ function Table({
         globalFilter: querySearch,
         sortBy: [
           {
-            id: querySort || 'health',
+            id: querySort || DEFAULT_SORTING_KEY,
             desc: queryDesc || false,
           },
         ],
@@ -231,7 +232,7 @@ function Table({
     ?.id;
   const desc = headerGroups[0].headers.find((item) => item.isSorted === true)
     ?.isSortedDesc;
-  useTableSortURLSync(sorted, desc, data);
+  useTableSortURLSync(sorted, desc, data, DEFAULT_SORTING_KEY);
 
   const RenderRow = React.useCallback(
     ({ index, style }) => {

--- a/ui/src/containers/AlertPage.js
+++ b/ui/src/containers/AlertPage.js
@@ -296,7 +296,7 @@ function ActiveAlertTab({ columns, data, displayLogical, setDisplayLogical }) {
       },
     };
   }, []);
-
+  const DEFAULT_SORTING_KEY = 'severity';
   const {
     getTableProps,
     getTableBodyProps,
@@ -316,7 +316,7 @@ function ActiveAlertTab({ columns, data, displayLogical, setDisplayLogical }) {
         globalFilter: querySearch || undefined,
         sortBy: [
           {
-            id: querySort || 'severity',
+            id: querySort || DEFAULT_SORTING_KEY,
             desc: queryDesc || false,
           },
         ],
@@ -335,7 +335,7 @@ function ActiveAlertTab({ columns, data, displayLogical, setDisplayLogical }) {
     ?.id;
   const desc = headerGroups[0].headers.find((item) => item.isSorted === true)
     ?.isSortedDesc;
-  useTableSortURLSync(sorted, desc, data);
+  useTableSortURLSync(sorted, desc, data, DEFAULT_SORTING_KEY);
 
   return (
     <table {...getTableProps()}>

--- a/ui/src/services/utils.js
+++ b/ui/src/services/utils.js
@@ -375,11 +375,15 @@ export const formatSizeForDisplay = (value) => {
   return value.replace(/^(\d+)(\D+)$/, '$1 $2');
 };
 
-/*
- ** Custom hook that stores table sorting choice in the URL queries
- ** Defaults to health sorting (used on Nodes and Volumes tables)
+/**
+ * Custom hook that stores table sorting choice in the URL queries
+ *
+ * @param {string} sorted
+ * @param {boolean} desc
+ * @param {array} data
+ * @param {string} defaultSortKey default sorting key
  */
-export const useTableSortURLSync = (sorted, desc, data) => {
+export const useTableSortURLSync = (sorted, desc, data, defaultSortKey) => {
   const history = useHistory();
   const location = useLocation();
   useEffect(() => {
@@ -390,8 +394,8 @@ export const useTableSortURLSync = (sorted, desc, data) => {
       if (sorted) {
         sorted ? query.set('sort', sorted) : query.delete('sort');
         desc ? query.set('desc', desc) : query.delete('desc');
-        // Remove the default sorting `sort=health` and `sort=severity` from the query string
-        if ((sorted === 'health' || sorted === 'severity') && desc === false) {
+        // if the current sorting is the default sorting, remove the query parameter
+        if (sorted === defaultSortKey && desc === false) {
           query.delete('sort');
           query.delete('desc');
         }
@@ -409,7 +413,7 @@ export const useTableSortURLSync = (sorted, desc, data) => {
         history.replace(`?${query.toString()}`);
       }
     }
-  }, [sorted, desc, data.length, history, location]);
+  }, [sorted, desc, data.length, history, location, defaultSortKey]);
 };
 
 /*

--- a/ui/src/services/utils.test.js
+++ b/ui/src/services/utils.test.js
@@ -246,44 +246,42 @@ it('should return 1d1m instead of 1d1m1s or 1d1s', () => {
 // Mocking history from react-router to test the URL sync hook
 const mockHistoryReplace = jest.fn();
 jest.mock('react-router-dom', () => {
-  let location = new URL('http://test.test')
+  let location = new URL('http://test.test');
   return {
     ...jest.requireActual('react-router-dom'),
     useHistory: () => ({
       replace: (newLocation) => {
-        location = new URL('http://test.test' + newLocation)
-        mockHistoryReplace(newLocation)
+        location = new URL('http://test.test' + newLocation);
+        mockHistoryReplace(newLocation);
       },
     }),
     useLocation: () => location,
-  }
+  };
 });
 
 describe('useTableSortURLSync hook', () => {
   it('should not set anything in the URL if data is not ready', () => {
-    renderHook(() => useTableSortURLSync('name', false, []));
+    renderHook(() => useTableSortURLSync('name', false, [], 'key'));
     expect(mockHistoryReplace).not.toHaveBeenCalled();
   });
 
   it('should set a name sorting in the URL', () => {
-    renderHook(() => useTableSortURLSync('name', false, ['foo']));
+    renderHook(() => useTableSortURLSync('name', false, ['foo'], 'key'));
     expect(mockHistoryReplace).toHaveBeenCalledWith('?sort=name');
   });
 
   it('should set a status sorting in the URL with a desc parameter', () => {
-    renderHook(() => useTableSortURLSync('status', true, ['foo']));
+    renderHook(() => useTableSortURLSync('status', true, ['foo']), 'key');
     expect(mockHistoryReplace).toHaveBeenCalledWith('?sort=status&desc=true');
   });
 
   it('should clear the URL params if status goes back to default (health)', () => {
     let status = 'status';
-    const { rerender } = renderHook((props) =>{
-      return useTableSortURLSync(status, false, ['foo'])
-    },
-      
-    );
+    const { rerender } = renderHook((props) => {
+      return useTableSortURLSync(status, false, ['foo'], 'health');
+    });
     expect(mockHistoryReplace).toHaveBeenCalledWith('?sort=status');
-    status = 'health'
+    status = 'health';
     rerender();
     expect(mockHistoryReplace).toHaveBeenCalledWith('?');
   });


### PR DESCRIPTION
**Component**: UI

**Context**: 
Given we have two tables with the ability to sort at the same page,
and we use the same query parameter `sort` for both tables, cause a conflict.

We decided to keep the sorting of the table in the volume tab, but it won't
sync with URL.


**Summary**:

**Acceptance criteria**: 

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #3307

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
