### PR TITLE
 salt/etcd: Increase number of check attempts

### DIFF
--- a/salt/_states/metalk8s.py
+++ b/salt/_states/metalk8s.py
@@ -135,11 +135,11 @@ def static_pod_managed(
             return _error(ret, "Unable to manage file: {}".format(exc))
 
 
-def module_run(name, attemps=1, sleep_time=10, **kwargs):
+def module_run(name, attempts=1, sleep_time=10, **kwargs):
     """Classic module.run with a retry logic as it's buggy in salt version
     https://github.com/saltstack/salt/issues/44639
     """
-    retry = attemps
+    retry = attempts
     ret = {"name": name, "changes": {}, "result": False, "comment": ""}
     while retry > 0 and not ret["result"]:
         try:

--- a/salt/metalk8s/orchestrate/etcd.sls
+++ b/salt/metalk8s/orchestrate/etcd.sls
@@ -51,7 +51,7 @@ Deploy etcd {{ node }} to {{ dest_version }}:
 Check etcd cluster health for {{ node }}:
   metalk8s.module_run:
     - metalk8s_etcd.check_etcd_health: []
-    - attemps: 5
+    - attempts: 5
     - require:
       - salt: Deploy etcd {{ node }} to {{ dest_version }}
 

--- a/salt/metalk8s/orchestrate/etcd.sls
+++ b/salt/metalk8s/orchestrate/etcd.sls
@@ -51,7 +51,9 @@ Deploy etcd {{ node }} to {{ dest_version }}:
 Check etcd cluster health for {{ node }}:
   metalk8s.module_run:
     - metalk8s_etcd.check_etcd_health: []
-    - attempts: 5
+    # Wait at most (31 - 1) * 10s = 300s = 5mn
+    - attempts: 31
+    - sleep_time: 10
     - require:
       - salt: Deploy etcd {{ node }} to {{ dest_version }}
 

--- a/salt/metalk8s/orchestrate/register_etcd.sls
+++ b/salt/metalk8s/orchestrate/register_etcd.sls
@@ -22,6 +22,8 @@ Check etcd cluster health:
   metalk8s.module_run:
     - metalk8s_etcd.check_etcd_health:
       - minion_id: {{ nodename }}
-    - attempts: 5
+    # Wait at most (31 - 1) * 10s = 300s = 5mn
+    - attempts: 31
+    - sleep_time: 10
     - require:
       - metalk8s_etcd: Register host as part of etcd cluster

--- a/salt/metalk8s/orchestrate/register_etcd.sls
+++ b/salt/metalk8s/orchestrate/register_etcd.sls
@@ -22,6 +22,6 @@ Check etcd cluster health:
   metalk8s.module_run:
     - metalk8s_etcd.check_etcd_health:
       - minion_id: {{ nodename }}
-    - attemps: 5
+    - attempts: 5
     - require:
       - metalk8s_etcd: Register host as part of etcd cluster


### PR DESCRIPTION
When checking the cluster health after some live reconfiguration of the
etcd cluster, we were only attempting the check 5 times, with 10s of
sleep time between each. This totals to a 40s window during which things
need to stabilize, which, given the sensitivity of etcd, can be too
short.

We increase drastically the number of attempts to 31, so the maximum
period we will wait amounts to 5 minutes. This may be slightly high when
some real issue exists, but it gives us some headroom, and is much
better than failing because we're too optimistic.
