### PR TITLE
ui: Fix a race condition leading to an infinite authentication loop on firefox

### DIFF
--- a/ui/src/components/Navbar.js
+++ b/ui/src/components/Navbar.js
@@ -72,6 +72,14 @@ function useNavbarVersion(navbarRef: { current: NavbarWebComponent | null }): st
 function useLoginEffect(navbarRef: { current: NavbarWebComponent | null }, version: string | null) {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const dispatch = useDispatch();
+  const user = useTypedSelector((state) => state.oidc?.user);
+  const userStoredInRedux = useRef(false);
+
+  useEffect(() => {
+    if (user) {
+      userStoredInRedux.current = true;
+    }
+  }, [!!user])
 
   useEffect(() => {
     if (!navbarRef.current || !version) {
@@ -103,7 +111,7 @@ function useLoginEffect(navbarRef: { current: NavbarWebComponent | null }, versi
     };
   }, [navbarRef, version, dispatch]);
 
-  return { isAuthenticated };
+  return { isAuthenticated: isAuthenticated && userStoredInRedux.current };
 }
 
 function useLanguageEffect(navbarRef: { current: NavbarWebComponent | null }, version: string | null) {


### PR DESCRIPTION
**Component**:

ui

**Context**: 

On firefox a render race condition post authentication was leading to an infinite authentication loop.

**Summary**:

The loop was due to an intermediary render of the navbar before the user being pushed to the redux store resulting in the logout effect being executed with an isAuthenticated flag without user which triggers a logout loop reloading the page, rendering the navbar which trigger a new auth loop and so on...

**Acceptance criteria**: 

The authentication should now work on firefox.

Note for later: we should execute our end to end tests against all the browser that we want to support.