### PR TITLE
Explicitly mention that Metalk8s 1.x is no longer maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,5 @@ tox -e docs
 
 ---
 
-MetalK8s version 1 is still maintained in this repository. See the
-`development/1.*` branches, e. g.
-[MetalK8s 1.3](https://github.com/scality/metalk8s/tree/development/1.3) in the
-same repository.
+MetalK8s version 1 is still hosted in this repository but is no longer maintained.
+The last release is [MetalK8s 1.3](https://github.com/scality/metalk8s/tree/development/1.3).


### PR DESCRIPTION
**Component**:
Docs
<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
Metalk8s 1.x
**Summary**:
v 1.x is no longer maintained, better mention it
