### PR TITLE
eve: Disable terraform plugins verification

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -545,7 +545,7 @@ models:
       name: Init terraform
       command: |-
         for try in $(seq 1 $MAX_RETRIES); do
-          if terraform init; then
+          if terraform init --verify-plugins=false; then
             break
           elif [ $try -lt $MAX_RETRIES ]; then
             rm -rf .terraform/


### PR DESCRIPTION
Due to a bug in gpg signature for openstack terraform plugins, disable
plugins verification for now
This commit should really be reverted ASAP !