### PR TITLE
eve: Use new version of `terraform-snapshot` repo

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -18,7 +18,7 @@ models:
       name: Git pull terraform snapshot
       command: >
         git clone --depth 1 "git@github.com:scality/terraform-snapshot.git"
-        --branch "0.1.0"
+        --branch "0.2.0"
       haltOnFailure: true
   - ShellCommand: &git_pull_ssh
       name: Git pull on bastion


### PR DESCRIPTION
Openstack terraform plugin was broken with terraform 0.12, use version 0.2.0 of `terraform-snapshot` that rely on terraform 0.15