### PR TITLE
Pre-check Salt minion ID

### DIFF
--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -167,7 +167,6 @@ check_ca_minion() {
     fi
 }
 
-
 main() {
     run "Determine the OS" determine_os
     if [ -z "${PYTHON:-}" ]; then
@@ -181,6 +180,7 @@ main() {
     run "Disabling Salt minion service" disable_salt_minion_service
     run "Stopping Salt minion service" stop_salt_minion_service
     run "Installing mandatory packages" install_packages "${PACKAGES[@]}"
+    run "Checking Salt minion ID" check_minion_id
     run "Configuring Salt minion to run in local mode" configure_salt_minion_local_mode
     run "Ensure archive is available" ensure_archives_mounted
     run "Calculating Salt grains in local mode" set_local_grains

--- a/scripts/common.sh.in
+++ b/scripts/common.sh.in
@@ -191,16 +191,6 @@ install_packages() {
     esac
 }
 
-pre_minion_checks() {
-    test "x$(whoami)" = "xroot" || die "Script must run as root"
-    test -n "${RPM}" || die "rpm not found"
-    test -x "${RPM}" || die "rpm at '${RPM}' is not executable"
-    test -n "${SYSTEMCTL}" || die "systemctl not found"
-    test -x "${SYSTEMCTL}" || die "systemctl at '${SYSTEMCTL}' is not executable"
-    test -n "${YUM}" || die "yum not found"
-    test -x "${YUM}" || die "yum at '${YUM}' is not executable"
-}
-
 disable_salt_minion_service() {
     ${SYSTEMCTL} disable salt-minion.service 2>/dev/null || true
 }

--- a/scripts/common.sh.in
+++ b/scripts/common.sh.in
@@ -370,7 +370,7 @@ get_salt_env() {
 }
 
 get_salt_minion_id() {
-    "$SALT_CALL" --out txt grains.get id | cut -c 8-
+    "$SALT_CALL" --local --out txt grains.get id | cut -c 8-
 }
 
 get_salt_minion_ids() {
@@ -403,4 +403,25 @@ retry() {
     done
 
     echo "$stdout"
+}
+
+check_minion_id() {
+    # Minion ID is used as the Kubernetes Node name, so it must follow the
+    # RFC1123 (https://tools.ietf.org/html/rfc1123).
+    # This means the name must:
+    #   - contain no more than 253 characters
+    #   - contain only lowercase alphanumeric characters, '-' or '.'
+    #   - start with an alphanumeric character
+    #   - end with an alphanumeric character
+    # NB: It is only needed for bootstrap node, as it will be automatically
+    # done by K8s APIServer for expansion, when applying new node manifests.
+    minion_id=$(get_salt_minion_id)
+
+    if ! [[ $minion_id =~ ^(([0-9a-z][0-9a-z.-]{0,251}[0-9a-z])|[0-9a-z])$ ]]; then
+        echo "Invalid Salt minion ID '$minion_id': The ID must be compliant" \
+             "with RFC1123, which means it must contain no more than 253" \
+             "characters, contain only lowercase alphanumeric characters, '-'" \
+             "or '.' and start and end with an alphanumeric character."
+        return 1
+    fi
 }

--- a/scripts/restore.sh.in
+++ b/scripts/restore.sh.in
@@ -335,6 +335,7 @@ run "Disabling Salt minion service" disable_salt_minion_service
 run "Stopping Salt minion service" stop_salt_minion_service
 run "Configuring local repositories" configure_repositories
 run "Installing mandatory packages" install_packages "${PACKAGES[@]}"
+run "Checking Salt minion ID" check_minion_id
 run "Configuring Salt minion to run in local mode" configure_salt_minion_local_mode
 
 run "Restoring MetalK8s configurations" restore_metalk8s_conf


### PR DESCRIPTION
**Component**: scripts, bootstrap

**Context**:
We are using Salt minion ID as Node name, but Node name is more restrictive than minion ID, so we can end up with Node object having an invalid name, which prevents Kubelet from scheduling pods.

**Summary**:
Check that the Salt minion ID is following the RFC1123 and exit early during bootstrap if this is not the case.

**Acceptance criteria**:
Installation must fail if the Salt minion ID is not valid

---

Closes: #3258