### PR TITLE
Add custom metalk8s_network.routes execution module

### DIFF
--- a/salt/_modules/metalk8s_checks.py
+++ b/salt/_modules/metalk8s_checks.py
@@ -408,7 +408,7 @@ def route_exists(destination, raises=True):
     error = None
     route_exists = False
 
-    all_routes = __salt__["network.routes"](family="inet")
+    all_routes = __salt__["metalk8s_network.routes"]()
 
     for route in all_routes:
         # Check if our destination network is fully included in this route.

--- a/salt/tests/unit/modules/files/test_metalk8s_network.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_network.yaml
@@ -37,3 +37,49 @@ get_listening_processes:
         127.0.0.1:
           pid: 123
           name: likely-something
+
+routes:
+  # 0. Default route
+  - ip_route_output: |-
+      default via 10.200.0.1 dev eth0
+    result:
+      - &default_route
+        addr_family: inet
+        destination: 0.0.0.0
+        flags: UG
+        gateway: 10.200.0.1
+        interface: eth0
+        netmask: 0.0.0.0
+  # 1. A simple route
+  - ip_route_output: |-
+      10.200.0.0/16 dev eth0 proto kernel scope link src 10.200.2.41
+    result:
+      - &simple_route
+        addr_family: inet
+        destination: 10.200.0.0
+        flags: U
+        gateway: 0.0.0.0
+        interface: eth0
+        netmask: 255.255.0.0
+  # 2. A blackhole route
+  - ip_route_output: |-
+      blackhole 10.233.162.0/26 proto bird
+    result: []
+  # 3. Multiple routes
+  - ip_route_output: |-
+      default via 10.200.0.1 dev eth0
+      10.200.0.0/16 dev eth0 proto kernel scope link src 10.200.2.41
+      blackhole 10.233.162.0/26 proto bird
+    result:
+      - *default_route
+      - *simple_route
+  # 4. No routes
+  - ip_route_output: ''
+    result: []
+  # 5. Unsupported type or format
+  - ip_route_output: |-
+      banana route via foo
+      this is not a valid input
+      10.200.0.0/16 dev eth0 proto kernel scope link src 10.200.2.41
+    result:
+      - *simple_route

--- a/salt/tests/unit/modules/test_metalk8s_checks.py
+++ b/salt/tests/unit/modules/test_metalk8s_checks.py
@@ -193,7 +193,7 @@ class Metalk8sChecksTestCase(TestCase, mixins.LoaderModuleMockMixin):
         network_routes_mock = MagicMock(return_value=routes_ret)
 
         patch_dict = {
-            "network.routes": network_routes_mock,
+            "metalk8s_network.routes": network_routes_mock,
         }
 
         with patch.dict(metalk8s_checks.__salt__, patch_dict):


### PR DESCRIPTION
**Component**: salt, tests

**Context**:
We rely on the Salt `network.routes` execution module to retrieve the routes during pre-check to ensure a route exists for a specific destination (or at least a default route).
The issue is that this module is bugged and fails when there is a blackhole route defined, which is our case, since Calico defines one.

**Summary**:
We implement a basic version of the `network.routes` module, fixing the blackhole issue and only keeping what we really need.

**Acceptance criteria**:
Unit tests are OK and `salt-call metalk8s_network.routes` returns the list of routes without crashing when a blackhole route is defined and there is no `net-tools` package installed

---

Closes: #3349