### PR TITLE
Allow defining an explicit `docker build` context instead of a directory

### DIFF
--- a/buildchain/buildchain/builder.py
+++ b/buildchain/buildchain/builder.py
@@ -16,7 +16,7 @@ from buildchain.targets.local_image import LocalImage  # Avoid circular importâ€
 
 def task__build_builder() -> Iterator[types.TaskDict]:
     """Build the builder containers."""
-    for builder in _BUILDERS:
+    for builder in BUILDERS:
         yield builder.task
 
 
@@ -93,7 +93,7 @@ UI_BUILDER : LocalImage = _builder_image(
 )
 
 
-_BUILDERS : Tuple[LocalImage, ...] = (
+BUILDERS : Tuple[LocalImage, ...] = (
     RPM_BUILDER,
     DEB_BUILDER,
     DOC_BUILDER,

--- a/buildchain/buildchain/docker_command.py
+++ b/buildchain/buildchain/docker_command.py
@@ -122,13 +122,19 @@ def task_error(
 })
 def docker_build(image: 'LocalImage') -> None:
     """Build a Docker image using Docker API."""
-    DOCKER_CLIENT.images.build(
+    kwargs = dict(
         tag=image.tag,
-        path=str(image.build_context),
-        dockerfile=str(image.dockerfile),
         buildargs=image.build_args,
         forcerm=True,
     )
+    if image.custom_context:
+        kwargs["fileobj"] = image.build_context.build_tar()
+        kwargs["custom_context"] = True
+    else:
+        kwargs["path"] = str(image.build_context)
+        kwargs["dockerfile"] = str(image.dockerfile)
+
+    DOCKER_CLIENT.images.build(**kwargs)
 
 
 class DockerRun:

--- a/buildchain/buildchain/image.py
+++ b/buildchain/buildchain/image.py
@@ -32,14 +32,13 @@ Overview:
 import datetime
 from typing import Any, Dict, Iterator, List, Tuple
 
+from buildchain import builder
 from buildchain import config
 from buildchain import constants
-from buildchain import coreutils
 from buildchain import targets
 from buildchain import types
 from buildchain import utils
 from buildchain import versions
-from buildchain import ROOT
 
 
 def task_images() -> types.TaskDict:
@@ -69,9 +68,17 @@ def task__image_pull() -> Iterator[types.TaskDict]:
 
 
 def task__image_build() -> Iterator[types.TaskDict]:
-    """Download the container images."""
+    """Build the container images."""
     for image in TO_BUILD:
         yield image.task
+
+
+def task__image_calc_build_deps() -> Iterator[types.TaskDict]:
+    """Compute dependencies from the Dockerfile of locally built images."""
+    for image in TO_BUILD:
+        yield image.calc_deps_task
+    for builder_image in builder.BUILDERS:
+        yield builder_image.calc_deps_task
 
 
 def task__image_dedup_layers() -> types.TaskDict:
@@ -238,13 +245,6 @@ TO_BUILD : Tuple[targets.LocalImage, ...] = (
         build_args={
             'NGINX_IMAGE_VERSION': versions.NGINX_IMAGE_VERSION,
         },
-        file_dep=(
-            list(coreutils.ls_files_rec(constants.UI_BUILD_ROOT)) +
-            list(coreutils.ls_files_rec(constants.DOCS_BUILD_ROOT)) +
-            [
-                config.BUILD_ROOT/'metalk8s-ui-nginx.conf'
-            ]
-        ),
         task_dep=['ui', 'doc'],
     ),
     _local_image(
@@ -260,9 +260,6 @@ TO_BUILD : Tuple[targets.LocalImage, ...] = (
             'SALT_VERSION': versions.SALT_VERSION,
             'KUBERNETES_VERSION': versions.K8S_VERSION,
         },
-        file_dep=[
-            ROOT/'images'/'metalk8s-utils'/'configure-repos.sh',
-        ],
     ),
     _operator_image(
         name='storage-operator',

--- a/buildchain/buildchain/image.py
+++ b/buildchain/buildchain/image.py
@@ -241,7 +241,15 @@ TO_BUILD : Tuple[targets.LocalImage, ...] = (
     ),
     _local_image(
         name='metalk8s-ui',
-        build_context=config.BUILD_ROOT,
+        build_context=targets.ExplicitContext(
+            dockerfile=constants.ROOT/"images/metalk8s-ui/Dockerfile",
+            base_dir=config.BUILD_ROOT,
+            contents=[
+                constants.UI_BUILD_ROOT.relative_to(config.BUILD_ROOT),
+                constants.DOCS_BUILD_ROOT.relative_to(config.BUILD_ROOT),
+                "metalk8s-ui-nginx.conf",
+            ],
+        ),
         build_args={
             'NGINX_IMAGE_VERSION': versions.NGINX_IMAGE_VERSION,
         },

--- a/buildchain/buildchain/targets/__init__.py
+++ b/buildchain/buildchain/targets/__init__.py
@@ -8,7 +8,7 @@ from buildchain.targets.base import Target, AtomicTarget, CompositeTarget
 from buildchain.targets.checksum import Sha256Sum
 from buildchain.targets.directory import Mkdir
 from buildchain.targets.file_tree import FileTree
-from buildchain.targets.local_image import LocalImage
+from buildchain.targets.local_image import LocalImage, ExplicitContext
 from buildchain.targets.operator_image import OperatorImage
 from buildchain.targets.package import Package, RPMPackage, DEBPackage
 from buildchain.targets.remote_image import (
@@ -28,7 +28,7 @@ __all__ = [
     'Sha256Sum',
     'Mkdir',
     'FileTree',
-    'LocalImage',
+    'LocalImage', 'ExplicitContext',
     'OperatorImage',
     'Package', 'RPMPackage', 'DEBPackage',
     'ImageSaveFormat', 'RemoteImage', 'SaveAsLayers', 'SaveAsTar',

--- a/buildchain/buildchain/targets/base.py
+++ b/buildchain/buildchain/targets/base.py
@@ -12,6 +12,7 @@ from typing import List, Optional, Sequence
 from buildchain import types
 
 
+# pylint: disable=too-many-instance-attributes
 class Target:
     """Base class for target that generate tasks."""
 
@@ -20,6 +21,7 @@ class Target:
         targets: Optional[Sequence[Path]]=None,
         file_dep: Optional[Sequence[Path]]=None,
         task_dep: Optional[Sequence[str]]=None,
+        calc_dep: Optional[Sequence[str]]=None,
         basename: Optional[str]=None,
         task_name: Optional[str]=None,
         uptodate: Optional[Sequence[types.UpToDateCheck]]=None,
@@ -38,6 +40,7 @@ class Target:
         self._targets  = targets or []
         self._file_dep = file_dep or []
         self._task_dep = task_dep or []
+        self._calc_dep = calc_dep or []
         self._basename = basename
         self._task_name = task_name
         self._uptodate = uptodate or []
@@ -46,6 +49,7 @@ class Target:
     targets   = property(operator.attrgetter('_targets'))
     file_dep  = property(operator.attrgetter('_file_dep'))
     task_dep  = property(operator.attrgetter('_task_dep'))
+    calc_dep  = property(operator.attrgetter('_calc_dep'))
     task_name = property(operator.attrgetter('_task_name'))
     uptodate  = property(operator.attrgetter('_uptodate'))
 
@@ -62,6 +66,7 @@ class Target:
             'targets': self.targets.copy(),
             'file_dep': self.file_dep.copy(),
             'task_dep': self.task_dep.copy(),
+            'calc_dep': self.calc_dep.copy(),
             'uptodate': self.uptodate.copy(),
             'clean': True
         }


### PR DESCRIPTION
**Component**: build

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: See #3271

**Summary**:

- Fix an issue with dependency checking for `LocalImage` targets, and replace this check with a dynamic calculation of these dependencies.
- Introduce an `ExplicitContext` object to prepare a tar archive in memory before sending it as a build context to Docker client.

**Acceptance criteria**: Builds still pass, no flakiness is observed on `_image_build:metalk8s-ui`.


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #3271

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
