### PR TITLE
salt: Use `systemd` cgroupdriver instead of `cgroupfs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@
   Calico version from 3.17.0 to 3.19.0
   (PR [#](https://github.com/scality/metalk8s/pull/))
 
+- [#3366](https://github.com/scality/metalk8s/issues/3366) - Use
+  `systemd` cgroupDriver for Kubelet and containerd
+  (PR[#3377](https://github.com/scality/metalk8s/pull/3377))
+
 ### Breaking changes
 
 - [#2199](https://github.com/scality/metalk8s/issues/2199) - Prometheus label

--- a/salt/metalk8s/container-engine/containerd/installed.sls
+++ b/salt/metalk8s/container-engine/containerd/installed.sls
@@ -99,8 +99,15 @@ Configure registry IP in containerd conf:
     - name: /etc/containerd/config.toml
     - makedirs: true
     - contents: |
-        [plugins.cri.registry.mirrors."{{ repo.registry_endpoint }}"]
+        version = 2
+
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ repo.registry_endpoint }}"]
         endpoint = ["http://{{ registry_ip }}:{{ registry_port }}"]
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+        runtime_type = "io.containerd.runc.v2"
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+        SystemdCgroup = true
 
         [debug]
         level = "{{ 'debug' if metalk8s.debug else 'info' }}"

--- a/salt/metalk8s/kubernetes/kubelet/standalone.sls
+++ b/salt/metalk8s/kubernetes/kubelet/standalone.sls
@@ -24,6 +24,7 @@ Create kubelet service environment file:
       {%- endfor %}
           node-ip: {{ grains['metalk8s']['control_plane_ip'] }}
           hostname-override: {{ grains['id'] }}
+          cgroup-driver: systemd
           v: {{ 2 if metalk8s.debug else 0 }}
     - require:
       - metalk8s_package_manager: Install kubelet
@@ -55,8 +56,7 @@ Create kubelet config file:
           webhook:
             cacheAuthorizedTTL: 0s
             cacheUnauthorizedTTL: 0s
-        # NOTE: we use cgroupfs for the moment
-        # cgroupDriver: systemd
+        cgroupDriver: systemd
         clusterDNS:
           - {{ cluster_dns_ip }}
         clusterDomain: cluster.local
@@ -83,7 +83,6 @@ Create kubelet config file:
         volumeStatsAggPeriod: 0s
       # }
         address: {{ grains['metalk8s']['control_plane_ip'] }}
-        cgroupDriver: cgroupfs
         rotateCertificates: false
         port: 10250
 {%- for key, value in kubelet.config.items() %}


### PR DESCRIPTION
**Component**:

'salt', 'kubelet', 'containerd'

**Context**: 

#3366

**Summary**:

To match recommendation from Kubernetes/kubeadm, change the
`cgroupDriver` from Kubelet to `systemd` and update containerd config
file accordingly

Sees: https://kubernetes.io/docs/setup/production-environment/container-runtimes/#containerd-systemd

**Acceptance criteria**: 

- Install: OK
- Upgrade: OK 
- Downgrade: OK

This change only implies all containers to restart but that kind of behavior is already handled by the upgrade/downgrade process

---

Fixes: #3366 