### PR TITLE
[tests] Add volume creation tests for RawBlock and LVM LV volumes

### DIFF
--- a/tests/post/features/volume.feature
+++ b/tests/post/features/volume.feature
@@ -35,6 +35,31 @@ Feature: Volume management
         And the PersistentVolume 'test-volume1-sparse' does not exist
         And the backing storage for Volume 'test-volume1-sparse' is deleted
 
+    Scenario: Test volume creation (rawBlockDevice)
+        Given the Kubernetes API is available
+        And a device exists
+        When I create the following Volume:
+            apiVersion: storage.metalk8s.scality.com/v1alpha1
+            kind: Volume
+            metadata:
+              name: test-volume1-rawblock
+            spec:
+              nodeName: bootstrap
+              storageClassName: metalk8s
+              rawBlockDevice:
+                devicePath: {device_path}
+              template:
+                metadata:
+                  labels:
+                    random-key: random-value
+        Then the Volume 'test-volume1-rawblock' is 'Available'
+        And the PersistentVolume 'test-volume1-rawblock' has size '{device_size}'
+        And the PersistentVolume 'test-volume1-rawblock' has label 'random-key' with value 'random-value'
+        And the Volume 'test-volume1-rawblock' has device name '{device_name}'
+        When I delete the Volume 'test-volume1-rawblock'
+        Then the Volume 'test-volume1-rawblock' does not exist
+        And the backing storage for Volume 'test-volume1-rawblock' still exists
+
     Scenario: Test PersistentVolume protection
         Given a Volume 'test-volume3' exist
         When I delete the PersistentVolume 'test-volume3'
@@ -170,13 +195,30 @@ Feature: Volume management
             apiVersion: storage.metalk8s.scality.com/v1alpha1
             kind: Volume
             metadata:
-              name: test-volume12
+              name: test-volume12-loop
             spec:
               nodeName: bootstrap
               storageClassName: metalk8s
               mode: Block
               sparseLoopDevice:
                 size: 10Gi
-        Then the Volume 'test-volume12' is 'Available'
-        And the PersistentVolume 'test-volume12' has size '10Gi'
-        And the backing storage for Volume 'test-volume12' is created
+        Then the Volume 'test-volume12-loop' is 'Available'
+        And the PersistentVolume 'test-volume12-loop' has size '10Gi'
+        And the backing storage for Volume 'test-volume12-loop' is created
+
+    Scenario: Test volume creation (rawBlockDevice Block mode)
+        Given the Kubernetes API is available
+        And a device exists
+        When I create the following Volume:
+            apiVersion: storage.metalk8s.scality.com/v1alpha1
+            kind: Volume
+            metadata:
+              name: test-volume12-rawblock
+            spec:
+              nodeName: bootstrap
+              storageClassName: metalk8s
+              mode: Block
+              rawBlockDevice:
+                devicePath: {device_path}
+        Then the Volume 'test-volume12-rawblock' is 'Available'
+        And the PersistentVolume 'test-volume12-rawblock' has size '{device_size}'

--- a/tests/post/features/volume.feature
+++ b/tests/post/features/volume.feature
@@ -60,6 +60,34 @@ Feature: Volume management
         Then the Volume 'test-volume1-rawblock' does not exist
         And the backing storage for Volume 'test-volume1-rawblock' still exists
 
+    Scenario: Test volume creation (lvmLogicalVolume)
+        Given the Kubernetes API is available
+        And a LVM VG 'test-vg-1' exists
+        When I create the following Volume:
+            apiVersion: storage.metalk8s.scality.com/v1alpha1
+            kind: Volume
+            metadata:
+              name: test-volume1-lvmlv
+            spec:
+              nodeName: bootstrap
+              storageClassName: metalk8s
+              lvmLogicalVolume:
+                vgName: test-vg-1
+                size: 10Gi
+              template:
+                metadata:
+                  labels:
+                    random-key: random-value
+        Then the Volume 'test-volume1-lvmlv' is 'Available'
+        And the PersistentVolume 'test-volume1-lvmlv' has size '10Gi'
+        And the PersistentVolume 'test-volume1-lvmlv' has label 'random-key' with value 'random-value'
+        And the device '/dev/test-vg-1/test-volume1-lvmlv' exists
+        And the Volume 'test-volume1-lvmlv' has device name 'dm-\d+'
+        When I delete the Volume 'test-volume1-lvmlv'
+        Then the Volume 'test-volume1-lvmlv' does not exist
+        And the device '/dev/test-vg-1/test-volume1-lvmlv' exists
+        And the backing storage for Volume 'test-volume1-lvmlv' still exists
+
     Scenario: Test PersistentVolume protection
         Given a Volume 'test-volume3' exist
         When I delete the PersistentVolume 'test-volume3'
@@ -222,3 +250,22 @@ Feature: Volume management
                 devicePath: {device_path}
         Then the Volume 'test-volume12-rawblock' is 'Available'
         And the PersistentVolume 'test-volume12-rawblock' has size '{device_size}'
+
+    Scenario: Test volume creation (lvmLogicalVolume Block mode)
+        Given the Kubernetes API is available
+        And a LVM VG 'test-vg-12' exists
+        When I create the following Volume:
+            apiVersion: storage.metalk8s.scality.com/v1alpha1
+            kind: Volume
+            metadata:
+              name: test-volume12-lvmlv
+            spec:
+              nodeName: bootstrap
+              storageClassName: metalk8s
+              mode: Block
+              lvmLogicalVolume:
+                vgName: test-vg-12
+                size: 10Gi
+        Then the Volume 'test-volume12-lvmlv' is 'Available'
+        And the PersistentVolume 'test-volume12-lvmlv' has size '10Gi'
+        And the device '/dev/test-vg-12/test-volume12-lvmlv' exists

--- a/tests/post/features/volume.feature
+++ b/tests/post/features/volume.feature
@@ -15,7 +15,7 @@ Feature: Volume management
             apiVersion: storage.metalk8s.scality.com/v1alpha1
             kind: Volume
             metadata:
-              name: test-volume1
+              name: test-volume1-sparse
             spec:
               nodeName: bootstrap
               storageClassName: metalk8s
@@ -25,18 +25,15 @@ Feature: Volume management
                 metadata:
                   labels:
                     random-key: random-value
-        Then the Volume 'test-volume1' is 'Available'
-        And the PersistentVolume 'test-volume1' has size '10Gi'
-        And the PersistentVolume 'test-volume1' has label 'random-key' with value 'random-value'
-        And the Volume 'test-volume1' has device name 'loop\d+'
-        And the backing storage for Volume 'test-volume1' is created
-
-    Scenario: Test volume deletion (sparseLoopDevice)
-        Given a Volume 'test-volume2' exist
-        When I delete the Volume 'test-volume2'
-        Then the Volume 'test-volume2' does not exist
-        And the PersistentVolume 'test-volume2' does not exist
-        And the backing storage for Volume 'test-volume2' is deleted
+        Then the Volume 'test-volume1-sparse' is 'Available'
+        And the PersistentVolume 'test-volume1-sparse' has size '10Gi'
+        And the PersistentVolume 'test-volume1-sparse' has label 'random-key' with value 'random-value'
+        And the Volume 'test-volume1-sparse' has device name 'loop\d+'
+        And the backing storage for Volume 'test-volume1-sparse' is created
+        When I delete the Volume 'test-volume1-sparse'
+        Then the Volume 'test-volume1-sparse' does not exist
+        And the PersistentVolume 'test-volume1-sparse' does not exist
+        And the backing storage for Volume 'test-volume1-sparse' is deleted
 
     Scenario: Test PersistentVolume protection
         Given a Volume 'test-volume3' exist

--- a/tests/post/steps/test_volume.py
+++ b/tests/post/steps/test_volume.py
@@ -45,11 +45,6 @@ def test_volume_creation(host, teardown):
     pass
 
 
-@scenario("../features/volume.feature", "Test volume deletion (sparseLoopDevice)")
-def test_volume_deletion(host, teardown):
-    pass
-
-
 @scenario("../features/volume.feature", "Test PersistentVolume protection")
 def test_pv_protection(host, teardown):
     pass

--- a/tests/post/steps/test_volume.py
+++ b/tests/post/steps/test_volume.py
@@ -141,8 +141,8 @@ def storage_class_exist(name, sc_client):
 
 
 @when(parsers.parse("I create the following Volume:\n{body}"))
-def create_volume(body, volume_client):
-    volume_client.create_from_yaml(body)
+def create_volume(context, body, volume_client):
+    volume_client.create_from_yaml(body.format(**context))
 
 
 @when(parsers.parse("I delete the Volume '{name}'"))
@@ -242,7 +242,9 @@ def check_pv_label(name, key, value, pv_client):
 
 
 @then(parsers.parse("the Volume '{name}' has device name '{value}'"))
-def check_device_name(name, value, volume_client):
+def check_device_name(context, name, value, volume_client):
+    value = value.format(**context)
+
     def _check_device_name():
         volume = volume_client.get(name)
         assert volume is not None, "Volume {} not found".format(name)

--- a/tests/post/steps/test_volume.py
+++ b/tests/post/steps/test_volume.py
@@ -194,11 +194,16 @@ def check_volume_status(context, name, status, volume_client):
 
 @then(parsers.parse("the PersistentVolume '{name}' has size '{size}'"))
 def check_pv_size(name, size, pv_client):
+    # Convert size in bytes
+    size_bytes = _quantity_to_bytes(size)
+
     def _check_pv_size():
         pv = pv_client.get(name)
         assert pv is not None, "PersistentVolume {} not found".format(name)
+        # Check size to the nearest 0.1%
         assert (
-            pv.spec.capacity["storage"] == size
+            abs(_quantity_to_bytes(pv.spec.capacity["storage"]) - size_bytes)
+            < 0.1 * size_bytes / 100
         ), "Unexpected PersistentVolume size: expected {}, got {}".format(
             size, pv.spec.capacity["storage"]
         )

--- a/tests/post/steps/test_volume.py
+++ b/tests/post/steps/test_volume.py
@@ -92,6 +92,13 @@ def test_volume_delete_while_pending(host, teardown):
     pass
 
 
+@scenario(
+    "../features/volume.feature", "Test volume creation (sparseLoopDevice Block mode)"
+)
+def test_volume_creation_loop_block(host, teardown):
+    pass
+
+
 # }}}
 # Given {{{
 

--- a/tests/post/steps/test_volume.py
+++ b/tests/post/steps/test_volume.py
@@ -193,9 +193,9 @@ def check_volume_status(context, name, status, volume_client):
 
 
 @then(parsers.parse("the PersistentVolume '{name}' has size '{size}'"))
-def check_pv_size(name, size, pv_client):
+def check_pv_size(context, name, size, pv_client):
     # Convert size in bytes
-    size_bytes = _quantity_to_bytes(size)
+    size_bytes = _quantity_to_bytes(size.format(**context))
 
     def _check_pv_size():
         pv = pv_client.get(name)


### PR DESCRIPTION
**Component**:

'tests', 'volumes'

**Context**: 

#1804 

**Summary**:

- Fix test for `sparseLoopDevice` mode `block`
- Do not create a new volume just to test volume deletion
- Add tests for  `rawBlockDevice` volume creation (mode `filesystem` and `block`)
- Add tests for `lvmLogicalVolume` volume creation (mode `filesystem` and `block`)

---

Fixes: #1804 
