### PR TITLE
Force sos dependency on an older version

### DIFF
--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -22,6 +22,7 @@ K8S_VERSION        : str = '1.18.16'
 SALT_VERSION       : str = '3002.6'
 CONTAINERD_VERSION : str = '1.4.3'
 CONTAINERD_RELEASE : str = '2.el7'
+SOS_VERSION        : str = '< 4.0'
 
 def load_version_information() -> None:
     """Load version information from `VERSION`."""
@@ -331,7 +332,8 @@ PACKAGES: Dict[str, Tuple[PackageVersion, ...]] = {
         PackageVersion(name='runc'),
         PackageVersion(name='salt-minion', version=SALT_VERSION),
         PackageVersion(name='socat'),
-        PackageVersion(name='sos'),  # TODO download built package dependencies
+        # TODO download built package dependencies
+        PackageVersion(name='sos', version=SOS_VERSION),
         PackageVersion(name='util-linux'),
         PackageVersion(name='xfsprogs'),
     ),

--- a/packages/redhat/metalk8s-sosreport.spec
+++ b/packages/redhat/metalk8s-sosreport.spec
@@ -5,7 +5,8 @@ Summary: 	Metalk8s SOS report custom plugins
 
 
 Requires: python >= 2.6, python < 2.8
-Requires: sos >= 3.1
+# Does not work with 4.0.0 and later
+Requires: sos >= 3.1, sos < 4.0
 # NameError on FileNotFoundError in sos 3.5 python2.7
 Conflicts: sos = 3.5
 

--- a/packages/redhat/yum_repositories/saltstack.repo
+++ b/packages/redhat/yum_repositories/saltstack.repo
@@ -1,6 +1,6 @@
 [saltstack]
 name=SaltStack repo for RHEL/CentOS $releasever
-baseurl=https://repo.saltstack.com/py3/redhat/$releasever/$basearch/archive/@SALT_VERSION@
+baseurl=https://repo.saltproject.io/py3/redhat/$releasever/$basearch/archive/@SALT_VERSION@
 enabled=1
 gpgcheck=1
-gpgkey=https://repo.saltstack.com/py3/redhat/$releasever/$basearch/archive/@SALT_VERSION@/SALTSTACK-GPG-KEY.pub
+gpgkey=https://repo.saltproject.io/py3/redhat/$releasever/$basearch/archive/@SALT_VERSION@/SALTSTACK-GPG-KEY.pub

--- a/salt/_modules/metalk8s_package_manager_yum.py
+++ b/salt/_modules/metalk8s_package_manager_yum.py
@@ -167,9 +167,15 @@ def check_pkg_availability(pkgs_info, exclude=None):
         List of package to exclude (e.g.: containerd.io)
     '''
     for name, info in pkgs_info.items():
-        pkg_name = name
         if info.get('version'):
-            pkg_name += '-' + str(info['version'])
+            pkg_version = str(info["version"])
+            pkg_name = "{}{}{}".format(
+                name,
+                "-" if pkg_version[0].isdigit() else " ",
+                pkg_version
+            )
+        else:
+            pkg_name = name
 
         cmd = [
             'yum', 'install', pkg_name,
@@ -185,8 +191,9 @@ def check_pkg_availability(pkgs_info, exclude=None):
 
         if ret['retcode'] != 0:
             raise CommandExecutionError(
-                'Check availability of package {} failed: {}'.format(
+                'Check availability of package {} failed:\n{}\n{}'.format(
                     pkg_name,
-                    ret['stdout']
+                    ret['stdout'],
+                    ret['stderr'],
                 )
             )

--- a/salt/tests/unit/modules/files/test_metalk8s_package_manager_yum.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_package_manager_yum.yaml
@@ -159,14 +159,20 @@ check_pkg_availability:
   - pkgs_info:
       nonexistent_pkg: {}
     yum_install_retcode: 1
-    raise_msg: "Check availability of package nonexistent_pkg failed: Oh ! No ! An ErRoR"
+    raise_msg: |-
+      Check availability of package nonexistent_pkg failed:
+      Some output
+      Oh ! No ! An ErRoR
 
   # check 1 package not available with version - error when retrieving it
   - pkgs_info:
       nonexistent_pkg:
         version: "3.11.12"
     yum_install_retcode: 1
-    raise_msg: "Check availability of package nonexistent_pkg-3.11.12 failed: Oh ! No ! An ErRoR"
+    raise_msg: |-
+      Check availability of package nonexistent_pkg-3.11.12 failed:
+      Some output
+      Oh ! No ! An ErRoR
 
   # check 3 package (2 available, 1 not available) - error when retrieving it
   - pkgs_info:
@@ -177,4 +183,12 @@ check_pkg_availability:
         version: null
     yum_install_retcode:
       nonexistent_pkg: 1
-    raise_msg: "Check availability of package nonexistent_pkg failed: Oh ! No ! An ErRoR"
+    raise_msg: |-
+      Check availability of package nonexistent_pkg failed:
+      Some output
+      Oh ! No ! An ErRoR
+
+  # check 1 package with a version constraint
+  - pkgs_info:
+      my_package:
+        version: "< 3.11.12"

--- a/salt/tests/unit/modules/test_metalk8s_package_manager_yum.py
+++ b/salt/tests/unit/modules/test_metalk8s_package_manager_yum.py
@@ -153,7 +153,8 @@ class Metalk8sPackageManagerYumTestCase(TestCase, mixins.LoaderModuleMockMixin):
                 out_kwargs['retcode'] = yum_install_retcode.get(command[2], 0)
 
             if out_kwargs.get('retcode'):
-                out_kwargs['stdout'] = 'Oh ! No ! An ErRoR'
+                out_kwargs['stdout'] = "Some output"
+                out_kwargs['stderr'] = 'Oh ! No ! An ErRoR'
 
             return utils.cmd_output(**out_kwargs)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -297,7 +297,7 @@ def count_running_pods(
     if node:
         error_msg += "on node '{node}'".format(node=node)
 
-    utils.retry(_check_pods_count, times=20, wait=3, error_msg=error_msg)
+    utils.retry(_check_pods_count, times=40, wait=3, error_msg=error_msg)
 
 
 _COUNT_RUNNING_PODS_PARSER = parsers.re(


### PR DESCRIPTION
**Component**: packages

**Context**: 
Ci builds no longer work because metalk8s-sosreport package is not compatible with latest 4.0.0 sos package

**Summary**:
For now, we stick to a version before 4.0.0 as it is not compatible with this one.
But, this is more a workaround to fix the CI for now as we may want to be compatible with the latest sos versions.

**Acceptance criteria**: 
Green build

---

See: #3387