### PR TITLE
[ci] Fix post merge multi node upgrade and certificate renewal

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -2047,7 +2047,14 @@ stages:
             <<: *_env_provision_volumes
             PRODUCT_MOUNT: "/srv/scality/metalk8s-%(prop:metalk8s_version)s"
             PRODUCT_TXT: "/srv/scality/metalk8s-%(prop:metalk8s_version)s/product.txt"
-      - ShellCommand: *wait_pods_stable_ssh
+      - ShellCommand:
+          <<: *wait_pods_stable_ssh
+          env:
+            <<: *_env_wait_pods_stable_ssh
+            # NOTE: We increase stabilization time after upgrade it may take some
+            # time to stabilize (e.g.: Rolling update of some DaemonSet that may take
+            # some times, especially in multi node context)
+            STABILIZATION_TIME: "240"
       # --- Test version N ---
       - ShellCommand: *git_pull_ssh
       - ShellCommand:

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -2078,7 +2078,7 @@ stages:
           name: Certificates expiration beacons test
           command: |
               scp -F ssh_config %(prop:builddir)s/build/tests/test-certificates-beacon.sh bootstrap:
-              ssh -F ssh_config bootstrap "sudo ./test-certificates-beacon.sh /var/tmp/metalk8s"
+              ssh -F ssh_config bootstrap "sudo ./test-certificates-beacon.sh /srv/scality/metalk8s-%(prop:metalk8s_version)s"
           workdir: *terraform_workdir
           haltOnFailure: true
           doStepIf: "%(prop:check_certs_renewal:-false)s"

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -1992,6 +1992,17 @@ stages:
             <<: *_env_terraform
             TF_VAR_restore_env: "%(prop:product_promoted_version)s-%(prop:os:-centos-7)s-%(prop:environment_type)s-%(prop:environment_name)s"
       # --- Wait for all pods to be running ---
+      - ShellCommand:
+          name: Ensure all Salt minion running
+          command: |
+            ssh -F ssh_config bootstrap <<ENDSSH
+            for _ in \$(seq 10); do
+                sudo crictl exec \$(sudo crictl ps --label="io.kubernetes.container.name=salt-master" -q) salt '*' test.ping && exit 0
+                sleep 5
+            done
+            ENDSSH
+          workdir: *terraform_workdir
+          haltOnFailure: true
       - ShellCommand: *wait_pods_stable_ssh
       - ShellCommand:
           # NOTE: We remove all "NodeAffinity" pods as, when restoring an environment


### PR DESCRIPTION
**Component**:

'ci'

**Context**: 

- The test after a multi node upgrade was broken because of nginx ingress upgrade and change from `cgroupfs` to `systemd` for containers and kubelet, nginx pods get time to be updated and make the test after upgrade fail
- Certificate renewal was broken due to an invalid ISO mountpoint path

**Summary**:

- Reduce flakiness when restoring VM (`test.ping` all salt minion)
- Increase stabilization time as `nginx-ingress` pod take a lot of time to restart one by one after the upgrade
- Use the right ISO mountpoint for the certificate tests

---
