### PR TITLE
Set fluent-bit memory buffer limit

### DIFF
--- a/salt/metalk8s/addons/logging/fluent-bit/deployed/configmap.sls
+++ b/salt/metalk8s/addons/logging/fluent-bit/deployed/configmap.sls
@@ -46,6 +46,7 @@ Create fluent-bit ConfigMap:
                 Name           systemd
                 Tag            host.*
                 DB             /run/fluent-bit/flb_journal.db
+                Mem_Buf_Limit  5MB
                 Strip_Underscores On
             [FILTER]
                 Name           kubernetes


### PR DESCRIPTION
**Component**: salt

**Context**: 
Sometimes, especially during installation phase, fluent-bit is OOMKilled because it fills up the memory if there is too much data to ingest.

**Summary**:
Set `Mem_Buf_Limit` to 5MB for all `INPUT` plugins.

**Acceptance criteria**: 

---

Closes: #3376