### PR TITLE
salt: Support `127.0.0.1` hostPort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 
 ## Release 2.9.3 (in development)
+## Enhancements
+- Allow hostPort on 127.0.0.1
+  (PR[#3396](https://github.com/scality/metalk8s/pull/3396))
 
 ## Release 2.9.2
 ### Bug fixes

--- a/salt/metalk8s/kubernetes/cni/calico/configured.sls
+++ b/salt/metalk8s/kubernetes/cni/calico/configured.sls
@@ -63,7 +63,7 @@ Create CNI calico configuration file:
             snat: true
             capabilities:
               portMappings: true
-            conditionsV4: ["-d", "{{ grains.metalk8s.workload_plane_ip }}/32"]
+            conditionsV4: ["-d", "{{ grains.metalk8s.workload_plane_ip }}/32,127.0.0.1/32"]
           # Note: Calico upstream enables the `bandwidth` CNI plugin by default.
           # However, this plugin (executable) is not available in the CNI RPM
           # package we currently install. Hence, not enabling this functionality


### PR DESCRIPTION
**Component**:

'salt'

**Context**: 

Support `127.0.0.1` as hostPort

**Summary**:

Before this commit we only support hostPort on workloadPlane IP, this
commit also add `127.0.0.1` as supported hostPort

NOTE: It's needed for Kubernetes conformance tests for Kubernetes 1.20+

---

