### PR TITLE
UI : 3256 Dashboard inventory panel

### DIFF
--- a/ui/src/components/DashboardInventory.js
+++ b/ui/src/components/DashboardInventory.js
@@ -1,0 +1,153 @@
+//@flow
+
+import React from 'react';
+import { useQuery } from 'react-query';
+import styled, { css } from 'styled-components';
+import { Card, Loader } from '@scality/core-ui';
+import {
+  spacing,
+  fontSize,
+  fontWeight,
+} from '@scality/core-ui/dist/style/theme';
+
+import { useIntl } from 'react-intl';
+import { PageSubtitle } from '../components/style/CommonLayoutStyle';
+import { STATUS_WARNING, STATUS_CRITICAL } from '../constants';
+import { useTypedSelector } from '../hooks';
+import {
+  getNodesCountQuery,
+  getVolumesCountQuery,
+} from '../services/platformlibrary/k8s.js';
+import {
+  useAlertLibrary,
+  useHighestSeverityAlerts,
+  highestAlertToStatus,
+} from '../containers/AlertProvider';
+
+const InventoryContainer = styled.div`
+  padding: 0px ${spacing.sp2};
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+`;
+
+const CardsWrapper = styled.div`
+  display: flex;
+  justify-content: space-around;
+  font-size: ${fontSize.base};
+  margin: ${spacing.sp4} 0px;
+`;
+
+const InventoryIcon = styled.i`
+  font-size: ${fontSize.larger};
+  margin-right: ${spacing.sp4};
+  ${(props) => {
+    switch (props.status) {
+      case STATUS_WARNING:
+        return css`
+          color: ${props.theme.statusWarning};
+        `;
+      case STATUS_CRITICAL:
+        return css`
+          color: ${props.theme.statusCritical};
+        `;
+
+      default:
+        return css`
+          color: ${props.theme.statusHealthy};
+        `;
+    }
+  }}
+`;
+
+const InventoryValue = styled.span`
+  font-size: ${fontSize.larger};
+  font-weight: ${fontWeight.bold};
+`;
+
+const DashboardInventory = () => {
+  const intl = useIntl();
+  const alertsLibrary = useAlertLibrary();
+  const nodesAlerts = useHighestSeverityAlerts(
+    alertsLibrary.getNodesAlertSelectors(),
+  );
+  const nodesStatus = highestAlertToStatus(nodesAlerts);
+  const volumesAlerts = useHighestSeverityAlerts(
+    alertsLibrary.getVolumesAlertSelectors(),
+  );
+  const volumesStatus = highestAlertToStatus(volumesAlerts);
+  const token = useTypedSelector((state) => state.oidc?.user?.token);
+  const config = useTypedSelector((state) => state.config.api?.url);
+
+  const { data: volumesCount } = useQuery(
+    getVolumesCountQuery(config || '', token),
+  );
+
+  const { data: nodesCount } = useQuery(
+    getNodesCountQuery(config || '', token),
+  );
+
+  return (
+    <InventoryContainer>
+      <PageSubtitle aria-label="inventory">
+        {intl.formatMessage({ id: 'inventory' })}
+      </PageSubtitle>
+      <CardsWrapper>
+        {(nodesCount || nodesCount === 0) && nodesStatus ? (
+          <Card
+            width="46%"
+            headerBackgroundColor="backgroundLevel1"
+            bodyBackgroundColor="backgroundLevel2"
+            aria-label="nodes"
+          >
+            <Card.Header>
+              <div>{intl.formatMessage({ id: 'nodes' })}</div>
+            </Card.Header>
+            <Card.BodyContainer>
+              <Card.Body>
+                <InventoryIcon
+                  className="fas fa-server"
+                  status={nodesStatus}
+                  aria-label={nodesStatus}
+                />
+                <InventoryValue aria-label={`${nodesCount} nodes`}>
+                  {nodesCount}
+                </InventoryValue>
+              </Card.Body>
+            </Card.BodyContainer>
+          </Card>
+        ) : (
+          <Loader aria-label="loading" />
+        )}
+        {(volumesCount || volumesCount === 0) && volumesStatus ? (
+          <Card
+            width="46%"
+            headerBackgroundColor="backgroundLevel1"
+            bodyBackgroundColor="backgroundLevel2"
+            aria-label="volumes"
+          >
+            <Card.Header>
+              <div>{intl.formatMessage({ id: 'volumes' })}</div>
+            </Card.Header>
+            <Card.BodyContainer>
+              <Card.Body>
+                <InventoryIcon
+                  className="fas fa-hdd"
+                  status={volumesStatus}
+                  aria-label={volumesStatus}
+                />
+                <InventoryValue aria-label={`${volumesCount} volumes`}>
+                  {volumesCount}
+                </InventoryValue>
+              </Card.Body>
+            </Card.BodyContainer>
+          </Card>
+        ) : (
+          <Loader aria-label="loading" />
+        )}
+      </CardsWrapper>
+    </InventoryContainer>
+  );
+};
+
+export default DashboardInventory;

--- a/ui/src/components/DashboardInventory.test.js
+++ b/ui/src/components/DashboardInventory.test.js
@@ -1,0 +1,140 @@
+//@flow
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { setupServer } from 'msw/node';
+import { rest } from 'msw';
+import DashboardInventory from './DashboardInventory';
+import {
+  waitForLoadingToFinish,
+  render,
+  FAKE_CONTROL_PLANE_IP,
+} from './__TEST__/util';
+import type { Alert } from '../services/alertUtils';
+import { useHighestSeverityAlerts } from '../containers/AlertProvider';
+import {
+  getNodesCountQuery,
+  getVolumesCountQuery,
+} from '../services/platformlibrary/k8s.js';
+
+const alertsCritical = [
+  {
+    id: 'alert1',
+    severity: 'critical',
+  },
+];
+const alertsWarning = [
+  {
+    id: 'alert2',
+    severity: 'warning',
+  },
+];
+const noAlerts = [];
+
+jest.mock('../services/platformlibrary/k8s.js', () => ({
+  __esModule: true, // Allows for the "default" import to work in the Mock injection
+  default: ({ children }) => <>{children}</>,
+  getNodesCountQuery: jest.fn(),
+  getVolumesCountQuery: jest.fn(),
+}));
+
+jest.mock('../containers/AlertProvider', () => ({
+  __esModule: true,
+  default: ({ children }) => <>{children}</>,
+  useHighestSeverityAlerts: jest.fn(),
+  useAlertLibrary: () => ({
+    getNodesAlertSelectors: () => {},
+    getVolumesAlertSelectors: () => {},
+  }),
+  highestAlertToStatus: (alerts?: Alert[]): string => {
+    return (alerts?.[0] && ((alerts[0].severity: any): string)) || 'healthy';
+  },
+}));
+
+describe('the dashboard inventory panel', () => {
+  beforeAll(() => {
+    // Have to any type jest.fn function to avoid Flow warning for mockImplementation()
+    (getVolumesCountQuery: any).mockImplementation(() => ({
+      queryKey: 'countVolumes',
+      queryFn: () => 4,
+    }));
+    (getNodesCountQuery: any).mockImplementation(() => ({
+      queryKey: 'countNodes',
+      queryFn: () => 6,
+    }));
+  });
+
+  test('displays the inventory card and nodes/volumes counts', async () => {
+    // Render
+    render(<DashboardInventory />);
+
+    // Loading
+    await waitForLoadingToFinish();
+
+    // Verify
+    expect(screen.getByLabelText('inventory')).toBeInTheDocument();
+    expect(screen.getByLabelText('nodes')).toBeInTheDocument();
+    expect(screen.getByLabelText('volumes')).toBeInTheDocument();
+    expect(screen.getByLabelText('6 nodes')).toBeInTheDocument();
+    expect(screen.getByLabelText('4 volumes')).toBeInTheDocument();
+  });
+
+  test('displays properly the status CRITICAL for nodes and volumes', async () => {
+    // Have to any type jest.fn function to avoid Flow warning for mockImplementation()
+    (useHighestSeverityAlerts: any).mockImplementation(() => alertsCritical);
+
+    // Render
+    render(<DashboardInventory />);
+
+    // Loading
+    await waitForLoadingToFinish();
+
+    // Verify
+    expect(screen.getAllByLabelText('critical').length).toEqual(2);
+  });
+
+  test('displays properly the status WARNING for nodes and volumes', async () => {
+    // Have to any type jest.fn function to avoid Flow warning for mockImplementation()
+    (useHighestSeverityAlerts: any).mockImplementation(() => alertsWarning);
+
+    // Render
+    render(<DashboardInventory />);
+
+    // Loading
+    await waitForLoadingToFinish();
+
+    // Verify
+    expect(screen.getAllByLabelText('warning').length).toEqual(2);
+  });
+
+  test('displays properly the status HEALTHY for nodes and volumes', async () => {
+    // Have to any type jest.fn function to avoid Flow warning for mockImplementation()
+    (useHighestSeverityAlerts: any).mockImplementation(() => noAlerts);
+
+    // Render
+    render(<DashboardInventory />);
+
+    // Loading
+    await waitForLoadingToFinish();
+
+    // Verify
+    expect(screen.getAllByLabelText('healthy').length).toEqual(2);
+  });
+
+  test('displays the loader if the query does not return a result', async () => {
+    // Have to any type jest.fn function to avoid Flow warning for mockImplementation()
+    (getVolumesCountQuery: any).mockImplementation(() => ({
+      queryKey: 'countVolumes',
+      queryFn: () => {},
+    }));
+    (getNodesCountQuery: any).mockImplementation(() => ({
+      queryKey: 'countNodes',
+      queryFn: () => {},
+    }));
+
+    // Render
+    render(<DashboardInventory />);
+
+    // Verify
+    expect(screen.getAllByLabelText('loading').length).toEqual(2);
+  });
+});

--- a/ui/src/containers/AlertProvider.js
+++ b/ui/src/containers/AlertProvider.js
@@ -3,16 +3,31 @@ import React, { type Node } from 'react';
 import { useIntl } from 'react-intl';
 import { useTypedSelector } from '../hooks';
 import { ErrorBoundary } from 'react-error-boundary';
-import type { FilterLabels } from '../services/alertUtils';
+import type { FilterLabels, Alert } from '../services/alertUtils';
 import { ErrorPage500 } from '@scality/core-ui';
 import {
   ComponentWithFederatedImports,
   FederatedComponent,
 } from '@scality/module-federation';
+import { STATUS_HEALTH } from '../constants';
+
+export type Status = 'healthy' | 'warning' | 'critical';
 
 const alertGlobal = {};
 export const useAlerts = (filters: FilterLabels) => {
   return alertGlobal.hooks.useAlerts(filters);
+};
+
+export const useHighestSeverityAlerts = (filters: FilterLabels) => {
+  return alertGlobal.hooks.useHighestSeverityAlerts(filters);
+};
+
+export const useAlertLibrary = () => {
+  return alertGlobal.hooks;
+};
+
+export const highestAlertToStatus = (alerts?: Alert[]): Status => {
+  return (alerts?.[0] && ((alerts[0].severity: any): Status)) || STATUS_HEALTH;
 };
 
 const InternalAlertProvider = ({

--- a/ui/src/containers/DashboardPage.js
+++ b/ui/src/containers/DashboardPage.js
@@ -4,6 +4,7 @@ import { useHistory } from 'react-router';
 import { UseQueryOptions } from 'react-query';
 import styled from 'styled-components';
 import DashboardMetrics from '../components/DashboardMetrics';
+import DashboardInventory from '../components/DashboardInventory';
 import { padding } from '@scality/core-ui/dist/style/theme';
 import { Dropdown } from '@scality/core-ui';
 
@@ -30,7 +31,7 @@ const DashboardGrid = styled.div`
 
   > div {
     background-color: ${(props) => {
-      return props.theme.backgroundLevel2;
+      return props.theme.backgroundLevel3;
     }};
     color: ${(props) => props.theme.textPrimary};
     padding: 2px ${padding.smaller};
@@ -40,6 +41,7 @@ const DashboardGrid = styled.div`
   }
   .health {
     grid-area: health;
+    background-color: ${(props) => props.theme.backgroundLevel2};
   }
   .inventory {
     grid-area: inventory;
@@ -152,7 +154,9 @@ const DashboardPage = (props: {}) => {
         />
       </div>
       <div className="health">Global Health</div>
-      <div className="inventory">Inventory</div>
+      <div className="inventory">
+        <DashboardInventory />
+      </div>
       <div className="network">Network</div>
       <div className="metrics">
         <DashboardMetrics />

--- a/ui/src/services/graphUtils.js
+++ b/ui/src/services/graphUtils.js
@@ -19,6 +19,7 @@ export const formatNodesPromRangeForChart = (
     if (
       result[index] &&
       result[index].status === 'success' &&
+      result[index].data.result[0] &&
       result[index].data.result[0].values.length
     ) {
       const matrixResult: RangeMatrixResult = result[index].data;

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -165,5 +165,6 @@
   "dashboard": "Dashboard",
   "required_fields": "* Required fields",
   "salt_login_error_title": "An error occurred when authenticating on salt API",
-  "salt_login_error_message": "Some features of the UI may not work as expected (cluster expansion and displaying nodes IPs). Please try to logout and login again or contact your support if this error persist."
+  "salt_login_error_message": "Some features of the UI may not work as expected (cluster expansion and displaying nodes IPs). Please try to logout and login again or contact your support if this error persist.",
+  "inventory": "Inventory"
 }

--- a/ui/src/translations/fr.json
+++ b/ui/src/translations/fr.json
@@ -165,6 +165,6 @@
   "dashboard": "Dashboard",
   "required_fields": "* Champs requis",
   "salt_login_error_title": "L'authentification aupres de Salt a échoué",
-  "salt_login_error_message": "Certaines fonctionalité de l'interface peuvent ne pas fonctionner (deploiement d'un nouveau node ou affichage des IPs d'un node). Veuillez essayer de vous deconnecter et de vous reconnecter, ou si l'erreur persiste merci de bien vouloir contacter votre support."
-
+  "salt_login_error_message": "Certaines fonctionalité de l'interface peuvent ne pas fonctionner (deploiement d'un nouveau node ou affichage des IPs d'un node). Veuillez essayer de vous deconnecter et de vous reconnecter, ou si l'erreur persiste merci de bien vouloir contacter votre support.",
+  "inventory": "Inventaire"
 }


### PR DESCRIPTION
**Component**:
dashboard, inventory

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**:  We want to add an inventory card to the dashboard page

**Summary**: The card displays the volume and node counts and their status

![Screenshot 2021-06-16 at 16 21 40](https://user-images.githubusercontent.com/3480526/122237167-66944300-cebf-11eb-8e30-1503364941f3.png)

**Please note that as of today to make it work you will need to use the last core-ui version not the one defined in package.json. Will update the version here when core-ui tabs issue will be fixed **

**Acceptance criteria**:  #3256 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #3256 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
