### PR TITLE
salt: Fix Dex upgrade from <2.10.0

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -225,6 +225,7 @@ SALT_FILES: Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path("salt/metalk8s/addons/dex/config/dex.yaml.j2"),
     Path("salt/metalk8s/addons/dex/deployed/chart.sls"),
     Path("salt/metalk8s/addons/dex/deployed/init.sls"),
+    Path("salt/metalk8s/addons/dex/deployed/pre-upgrade.sls"),
     Path("salt/metalk8s/addons/dex/deployed/namespace.sls"),
     Path("salt/metalk8s/addons/dex/deployed/secret.sls"),
     Path("salt/metalk8s/addons/dex/deployed/service-configuration.sls"),

--- a/salt/metalk8s/addons/dex/deployed/init.sls
+++ b/salt/metalk8s/addons/dex/deployed/init.sls
@@ -16,5 +16,6 @@ include:
 - .theme-configmap
 - .service-configuration
 - .secret
+- .pre-upgrade
 - .chart
 - .clusterrolebinding

--- a/salt/metalk8s/addons/dex/deployed/pre-upgrade.sls
+++ b/salt/metalk8s/addons/dex/deployed/pre-upgrade.sls
@@ -1,0 +1,31 @@
+{#- With new Dex Helm chart the Deployment label selector changed but this field
+    is immutable so we need to remove the deployment in order to be able to deploy
+    the new one #}
+{#- NOTE: This can be removed in development/2.11 #}
+
+{%- set dex_deploy = salt.metalk8s_kubernetes.get_object(
+        kind='Deployment',
+        apiVersion='apps/v1',
+        name='dex',
+        namespace='metalk8s-auth'
+    ) %}
+
+{#- Only remove it `if current_version < 2.10.0` #}
+
+{%- if dex_deploy and
+       salt.pkg.version_cmp(
+         dex_deploy['metadata']['labels']['metalk8s.scality.com/version'],
+        '2.10.0'
+      ) == -1 %}
+
+Delete old Dex Deployment:
+  metalk8s_kubernetes.object_absent:
+    - name: dex
+    - namespace: metalk8s-auth
+    - kind: Deployment
+    - apiVersion: apps/v1
+    - wait:
+        attempts: 10
+        sleep: 10
+
+{%- endif %}

--- a/salt/metalk8s/orchestrate/downgrade/init.sls
+++ b/salt/metalk8s/orchestrate/downgrade/init.sls
@@ -113,6 +113,33 @@ Deploy Kubernetes service config objects:
   - require_in:
     - salt: Deploy Kubernetes objects
 
+{#- With new Dex Helm chart the Deployment label selector changed but this field
+    is immutable so we need to remove the deployment in order to be able to deploy
+    the new one #}
+{#- NOTE: This can be removed in development/2.11 #}
+{#- NOTE: We do this here as we want this Dex service to be unavaible the least time
+    and since we are in downgrade we do not manage the Dex salt states #}
+
+{#- Only remove it `if dest_version < 2.10.0` #}
+
+{%- if salt.pkg.version_cmp(dest_version, '2.10.0') == -1 %}
+
+Delete Dex Deployment:
+  metalk8s_kubernetes.object_absent:
+    - name: dex
+    - namespace: metalk8s-auth
+    - kind: Deployment
+    - apiVersion: apps/v1
+    - wait:
+        attempts: 10
+        sleep: 10
+    - require:
+      - salt: Deploy Kubernetes service config objects
+    - require_in:
+      - salt: Deploy Kubernetes objects
+
+{%- endif %}
+
 Deploy Kubernetes objects:
   salt.runner:
     - name: state.orchestrate

--- a/salt/tests/unit/formulas/data/kubernetes/base.yaml
+++ b/salt/tests/unit/formulas/data/kubernetes/base.yaml
@@ -445,3 +445,9 @@ items: []
 apiVersion: monitoring.coreos.com/v1
 objectKind: PrometheusRule
 items: []
+
+---
+# Default deployment list (empty)
+apiVersion: apps/v1
+objectKind: Deployment
+items: []


### PR DESCRIPTION
Since Dex chart migration changed the Label selector of Dex deployment
and Label selector is immutable we need to remove the Dex deployment
before being able to create the new one.
We also want the time with Dex service unavailable to be as short as
possible

Refs: #3427 