### PR TITLE
charts,salt,build: Bump NGINX Ingress chart to 3.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,10 +37,9 @@
    - prometheus-operator to v0.48.1
   (PR[#3422](https://github.com/scality/metalk8s/pull/3422))
 
-- [#3279](https://github.com/scality/metalk8s/issues/3279) - Bump
-  ingress-nginx chart version from 3.13.0 to 3.30.0
-  nginx-ingress-controller image has been bump accordingly from v0.41.2
-  to v0.46.0 (PR[#3371](https://github.com/scality/metalk8s/pull/3371))
+- Bump ingress-nginx chart version to 3.34.0
+  nginx-ingress-controller image has been bump accordingly to v0.47.0
+  (PR[#34381](https://github.com/scality/metalk8s/pull/3438))
 
 - Bump Calico version to 3.19.1
   (PR [#3430](https://github.com/scality/metalk8s/pull/3430))

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -162,8 +162,8 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     ),
     Image(
         name="nginx-ingress-controller",
-        version="v0.46.0",
-        digest="sha256:52f0058bed0a17ab0fb35628ba97e8d52b5d32299fbc03cc0f6c7b9ff036b61a",
+        version="v0.47.0",
+        digest="sha256:a1e4efc107be0bb78f32eaec37bef17d7a0c81bec8066cdf2572508d21351d0b",
     ),
     Image(
         name="nginx-ingress-defaultbackend-amd64",

--- a/charts/ingress-nginx/CHANGELOG.md
+++ b/charts/ingress-nginx/CHANGELOG.md
@@ -2,10 +2,25 @@
 
 This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 3.34.0
+
+- [7256] https://github.com/kubernetes/ingress-nginx/pull/7256 Add namespace field in the namespace scoped resource templates
+
+### 3.33.0
+
+- [7164] https://github.com/kubernetes/ingress-nginx/pull/7164 Update nginx to v1.20.1
+
+### 3.32.0
+
+- [7117] https://github.com/kubernetes/ingress-nginx/pull/7117 Add annotations for HPA
+
+### 3.31.0
+
+- [7137] https://github.com/kubernetes/ingress-nginx/pull/7137 Add support for custom probes
+
 ### 3.30.0
 
 - [#7092](https://github.com/kubernetes/ingress-nginx/pull/7092) Removes the possibility of using localhost in ExternalNames as endpoints
-
 
 ### 3.29.0
 

--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -1,8 +1,8 @@
 annotations:
   artifacthub.io/changes: |
-    - Removes the possibility of using localhost in ExternalNames as endpoints
+    - Add namespace field in the namespace scoped resource templates
 apiVersion: v2
-appVersion: 0.46.0
+appVersion: 0.47.0
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer
 home: https://github.com/kubernetes/ingress-nginx
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
@@ -16,4 +16,4 @@ name: ingress-nginx
 sources:
 - https://github.com/kubernetes/ingress-nginx
 type: application
-version: 3.30.0
+version: 3.34.0

--- a/charts/ingress-nginx/templates/_helpers.tpl
+++ b/charts/ingress-nginx/templates/_helpers.tpl
@@ -122,3 +122,13 @@ Check the ingress controller version tag is at most three versions behind the la
 {{- fail "Controller container image tag should be 0.27.0 or higher" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+IngressClass parameters.
+*/}}
+{{- define "ingressClass.parameters" -}}
+  {{- if .Values.controller.ingressClassResource.parameters -}}
+          parameters:
+{{ toYaml .Values.controller.ingressClassResource.parameters | indent 4}}
+  {{ end }}
+{{- end -}}

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "ingress-nginx.fullname" . }}-admission-create
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -33,7 +34,7 @@ spec:
       containers:
         - name: create
           {{- with .Values.controller.admissionWebhooks.patch.image }}
-          image: "{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
+          image: "{{- if .repository -}}{{ .repository }}{{ else }}{{ .registry }}/{{ .image }}{{- end -}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
           {{- end }}
           imagePullPolicy: {{ .Values.controller.admissionWebhooks.patch.image.pullPolicy }}
           args:

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "ingress-nginx.fullname" . }}-admission-patch
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -33,7 +34,7 @@ spec:
       containers:
         - name: patch
           {{- with .Values.controller.admissionWebhooks.patch.image }}
-          image: "{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
+          image: "{{- if .repository -}}{{ .repository }}{{ else }}{{ .registry }}/{{ .image }}{{- end -}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
           {{- end }}
           imagePullPolicy: {{ .Values.controller.admissionWebhooks.patch.image.pullPolicy }}
           args:

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/role.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name:  {{ include "ingress-nginx.fullname" . }}-admission
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/rolebinding.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/rolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "ingress-nginx.fullname" . }}-admission
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/serviceaccount.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "ingress-nginx.fullname" . }}-admission
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/charts/ingress-nginx/templates/controller-configmap-addheaders.yaml
+++ b/charts/ingress-nginx/templates/controller-configmap-addheaders.yaml
@@ -6,5 +6,6 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
   name: {{ include "ingress-nginx.fullname" . }}-custom-add-headers
+  namespace: {{ .Release.Namespace }}
 data: {{ toYaml .Values.controller.addHeaders | nindent 2 }}
 {{- end }}

--- a/charts/ingress-nginx/templates/controller-configmap-proxyheaders.yaml
+++ b/charts/ingress-nginx/templates/controller-configmap-proxyheaders.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
   name: {{ include "ingress-nginx.fullname" . }}-custom-proxy-headers
+  namespace: {{ .Release.Namespace }}
 data:
 {{- if .Values.controller.proxySetHeaders }}
 {{ toYaml .Values.controller.proxySetHeaders | indent 2 }}

--- a/charts/ingress-nginx/templates/controller-configmap-tcp.yaml
+++ b/charts/ingress-nginx/templates/controller-configmap-tcp.yaml
@@ -9,5 +9,6 @@ metadata:
   annotations: {{ toYaml .Values.controller.tcp.annotations | nindent 4 }}
 {{- end }}
   name: {{ include "ingress-nginx.fullname" . }}-tcp
+  namespace: {{ .Release.Namespace }}
 data: {{ tpl (toYaml .Values.tcp) . | nindent 2 }}
 {{- end }}

--- a/charts/ingress-nginx/templates/controller-configmap-udp.yaml
+++ b/charts/ingress-nginx/templates/controller-configmap-udp.yaml
@@ -9,5 +9,6 @@ metadata:
   annotations: {{ toYaml .Values.controller.udp.annotations | nindent 4 }}
 {{- end }}
   name: {{ include "ingress-nginx.fullname" . }}-udp
+  namespace: {{ .Release.Namespace }}
 data: {{ tpl (toYaml .Values.udp) . | nindent 2 }}
 {{- end }}

--- a/charts/ingress-nginx/templates/controller-configmap.yaml
+++ b/charts/ingress-nginx/templates/controller-configmap.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations: {{ toYaml .Values.controller.configAnnotations | nindent 4 }}
 {{- end }}
   name: {{ include "ingress-nginx.controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 data:
 {{- if .Values.controller.addHeaders }}
   add-headers: {{ .Release.Namespace }}/{{ include "ingress-nginx.fullname" . }}-custom-add-headers

--- a/charts/ingress-nginx/templates/controller-daemonset.yaml
+++ b/charts/ingress-nginx/templates/controller-daemonset.yaml
@@ -10,6 +10,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
   name: {{ include "ingress-nginx.controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   {{- if .Values.controller.annotations }}
   annotations: {{ toYaml .Values.controller.annotations | nindent 4 }}
   {{- end }}
@@ -26,10 +27,10 @@ spec:
   template:
     metadata:
     {{- if .Values.controller.podAnnotations }}
-      annotations: 
+      annotations:
       {{- range $key, $value := .Values.controller.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
-      {{- end }}      
+      {{- end }}
     {{- end }}
       labels:
         {{- include "ingress-nginx.selectorLabels" . | nindent 8 }}
@@ -62,9 +63,9 @@ spec:
     {{- end }}
     {{- end }}
       containers:
-        - name: controller
+        - name: {{ .Values.controller.containerName }}
           {{- with .Values.controller.image }}
-          image: "{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
+          image: "{{- if .repository -}}{{ .repository }}{{ else }}{{ .registry }}/{{ .image }}{{- end -}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
           {{- end }}
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
         {{- if .Values.controller.lifecycle }}
@@ -139,26 +140,11 @@ spec:
           {{- if .Values.controller.extraEnvs }}
             {{- toYaml .Values.controller.extraEnvs | nindent 12 }}
           {{- end }}
-          livenessProbe:
-            httpGet:
-              path: {{ .Values.controller.healthCheckPath }}
-              port: {{ .Values.controller.livenessProbe.port }}
-              scheme: HTTP
-            initialDelaySeconds: {{ .Values.controller.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.controller.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.controller.livenessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.controller.livenessProbe.successThreshold }}
-            failureThreshold: {{ .Values.controller.livenessProbe.failureThreshold }}
-          readinessProbe:
-            httpGet:
-              path: {{ .Values.controller.healthCheckPath }}
-              port: {{ .Values.controller.readinessProbe.port }}
-              scheme: HTTP
-            initialDelaySeconds: {{ .Values.controller.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.controller.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.controller.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.controller.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.controller.readinessProbe.failureThreshold }}
+          {{- if .Values.controller.startupProbe }}
+          startupProbe: {{ toYaml .Values.controller.startupProbe | nindent 12 }}
+          {{- end }}
+          livenessProbe: {{ toYaml .Values.controller.livenessProbe | nindent 12 }}
+          readinessProbe: {{ toYaml .Values.controller.readinessProbe | nindent 12 }}
           ports:
           {{- range $key, $value := .Values.controller.containerPort }}
             - name: {{ $key }}

--- a/charts/ingress-nginx/templates/controller-deployment.yaml
+++ b/charts/ingress-nginx/templates/controller-deployment.yaml
@@ -10,6 +10,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
   name: {{ include "ingress-nginx.controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   {{- if .Values.controller.annotations }}
   annotations: {{ toYaml .Values.controller.annotations | nindent 4 }}
   {{- end }}
@@ -30,7 +31,7 @@ spec:
   template:
     metadata:
     {{- if .Values.controller.podAnnotations }}
-      annotations: 
+      annotations:
       {{- range $key, $value := .Values.controller.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
@@ -66,9 +67,9 @@ spec:
     {{- end }}
     {{- end }}
       containers:
-        - name: controller
+        - name: {{ .Values.controller.containerName }}
           {{- with .Values.controller.image }}
-          image: "{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
+          image: "{{- if .repository -}}{{ .repository }}{{ else }}{{ .registry }}/{{ .image }}{{- end -}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
           {{- end }}
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
         {{- if .Values.controller.lifecycle }}
@@ -139,27 +140,12 @@ spec:
           {{- end }}
           {{- if .Values.controller.extraEnvs }}
             {{- toYaml .Values.controller.extraEnvs | nindent 12 }}
+          {{- end }}          
+          {{- if .Values.controller.startupProbe }}
+          startupProbe: {{ toYaml .Values.controller.startupProbe | nindent 12 }}
           {{- end }}
-          livenessProbe:
-            httpGet:
-              path: {{ .Values.controller.healthCheckPath }}
-              port: {{ .Values.controller.livenessProbe.port }}
-              scheme: HTTP
-            initialDelaySeconds: {{ .Values.controller.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.controller.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.controller.livenessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.controller.livenessProbe.successThreshold }}
-            failureThreshold: {{ .Values.controller.livenessProbe.failureThreshold }}
-          readinessProbe:
-            httpGet:
-              path: {{ .Values.controller.healthCheckPath }}
-              port: {{ .Values.controller.readinessProbe.port }}
-              scheme: HTTP
-            initialDelaySeconds: {{ .Values.controller.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.controller.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.controller.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.controller.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.controller.readinessProbe.failureThreshold }}
+          livenessProbe: {{ toYaml .Values.controller.livenessProbe | nindent 12 }}
+          readinessProbe: {{ toYaml .Values.controller.readinessProbe | nindent 12 }}
           ports:
           {{- range $key, $value := .Values.controller.containerPort }}
             - name: {{ $key }}

--- a/charts/ingress-nginx/templates/controller-hpa.yaml
+++ b/charts/ingress-nginx/templates/controller-hpa.yaml
@@ -4,10 +4,15 @@
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
+  annotations:
+  {{- with .Values.controller.autoscaling.annotations }}
+  {{- toYaml . | trimSuffix "\n" | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
   name: {{ include "ingress-nginx.controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/ingress-nginx/templates/controller-ingressclass.yaml
+++ b/charts/ingress-nginx/templates/controller-ingressclass.yaml
@@ -1,0 +1,23 @@
+{{- if and (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) (.Values.controller.ingressClassResource.enabled) -}}
+{{- if and (semverCompare "=1.18-0" .Capabilities.KubeVersion.GitVersion)  }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
+apiVersion: networking.k8s.io/v1
+{{- end }}
+kind: IngressClass
+metadata:
+  labels:
+    {{- include "ingress-nginx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: controller
+    {{- with .Values.controller.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ .Values.controller.ingressClass }}
+{{- if .Values.controller.ingressClassResource.default }}
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: "true"
+{{- end }}
+spec:
+  controller: k8s.io/ingress-nginx
+  {{ template "ingressClass.parameters" . }}
+{{- end }}

--- a/charts/ingress-nginx/templates/controller-poddisruptionbudget.yaml
+++ b/charts/ingress-nginx/templates/controller-poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-{{- if or (and .Values.controller.autoscaling.enabled (gt (.Values.controller.autoscaling.minReplicas | int) 1)) (gt (.Values.controller.replicaCount | int) 1) -}}
+{{- if or (and .Values.controller.autoscaling.enabled (gt (.Values.controller.autoscaling.minReplicas | int) 1)) (and (not .Values.controller.autoscaling.enabled) (gt (.Values.controller.replicaCount | int) 1)) }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -6,6 +6,7 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
   name: {{ include "ingress-nginx.controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/charts/ingress-nginx/templates/controller-role.yaml
+++ b/charts/ingress-nginx/templates/controller-role.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
   name: {{ include "ingress-nginx.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:
       - ""

--- a/charts/ingress-nginx/templates/controller-rolebinding.yaml
+++ b/charts/ingress-nginx/templates/controller-rolebinding.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
   name: {{ include "ingress-nginx.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/ingress-nginx/templates/controller-service-internal.yaml
+++ b/charts/ingress-nginx/templates/controller-service-internal.yaml
@@ -13,6 +13,7 @@ metadata:
     {{- toYaml .Values.controller.service.labels | nindent 4 }}
   {{- end }}
   name: {{ include "ingress-nginx.controller.fullname" . }}-internal
+  namespace: {{ .Release.Namespace }}
 spec:
   type: "{{ .Values.controller.service.type }}"
 {{- if .Values.controller.service.internal.loadBalancerIP }}

--- a/charts/ingress-nginx/templates/controller-service-metrics.yaml
+++ b/charts/ingress-nginx/templates/controller-service-metrics.yaml
@@ -12,6 +12,7 @@ metadata:
     {{- toYaml .Values.controller.metrics.service.labels | nindent 4 }}
   {{- end }}
   name: {{ include "ingress-nginx.controller.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace }}
 spec:
   type: {{ .Values.controller.metrics.service.type }}
 {{- if .Values.controller.metrics.service.clusterIP }}

--- a/charts/ingress-nginx/templates/controller-service-webhook.yaml
+++ b/charts/ingress-nginx/templates/controller-service-webhook.yaml
@@ -9,6 +9,7 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
   name: {{ include "ingress-nginx.controller.fullname" . }}-admission
+  namespace: {{ .Release.Namespace }}
 spec:
   type: {{ .Values.controller.admissionWebhooks.service.type }}
 {{- if .Values.controller.admissionWebhooks.service.clusterIP }}

--- a/charts/ingress-nginx/templates/controller-service.yaml
+++ b/charts/ingress-nginx/templates/controller-service.yaml
@@ -13,6 +13,7 @@ metadata:
     {{- toYaml .Values.controller.service.labels | nindent 4 }}
   {{- end }}
   name: {{ include "ingress-nginx.controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   type: {{ .Values.controller.service.type }}
 {{- if .Values.controller.service.clusterIP }}

--- a/charts/ingress-nginx/templates/controller-serviceaccount.yaml
+++ b/charts/ingress-nginx/templates/controller-serviceaccount.yaml
@@ -6,5 +6,6 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
   name: {{ template "ingress-nginx.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/charts/ingress-nginx/templates/default-backend-deployment.yaml
+++ b/charts/ingress-nginx/templates/default-backend-deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: default-backend
   name: {{ include "ingress-nginx.defaultBackend.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:
@@ -39,7 +40,7 @@ spec:
       containers:
         - name: {{ template "ingress-nginx.name" . }}-default-backend
           {{- with .Values.defaultBackend.image }}
-          image: "{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
+          image: "{{- if .repository -}}{{ .repository }}{{ else }}{{ .registry }}/{{ .image }}{{- end -}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
           {{- end }}
           imagePullPolicy: {{ .Values.defaultBackend.image.pullPolicy }}
         {{- if .Values.defaultBackend.extraArgs }}

--- a/charts/ingress-nginx/templates/default-backend-hpa.yaml
+++ b/charts/ingress-nginx/templates/default-backend-hpa.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: default-backend
   name: {{ template "ingress-nginx.defaultBackend.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/ingress-nginx/templates/default-backend-poddisruptionbudget.yaml
+++ b/charts/ingress-nginx/templates/default-backend-poddisruptionbudget.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: default-backend
   name: {{ include "ingress-nginx.defaultBackend.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/charts/ingress-nginx/templates/default-backend-role.yaml
+++ b/charts/ingress-nginx/templates/default-backend-role.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: default-backend
   name: {{ include "ingress-nginx.fullname" . }}-backend
+  namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:      [{{ template "podSecurityPolicy.apiGroup" . }}]
     resources:      ['podsecuritypolicies']

--- a/charts/ingress-nginx/templates/default-backend-rolebinding.yaml
+++ b/charts/ingress-nginx/templates/default-backend-rolebinding.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: default-backend
   name: {{ include "ingress-nginx.fullname" . }}-backend
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/ingress-nginx/templates/default-backend-service.yaml
+++ b/charts/ingress-nginx/templates/default-backend-service.yaml
@@ -9,6 +9,7 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: default-backend
   name: {{ include "ingress-nginx.defaultBackend.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   type: {{ .Values.defaultBackend.service.type }}
 {{- if .Values.defaultBackend.service.clusterIP }}

--- a/charts/ingress-nginx/templates/default-backend-serviceaccount.yaml
+++ b/charts/ingress-nginx/templates/default-backend-serviceaccount.yaml
@@ -6,5 +6,6 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: default-backend
   name: {{ template "ingress-nginx.defaultBackend.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 automountServiceAccountToken: {{ .Values.defaultBackend.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -10,9 +10,13 @@
 controller:
   name: controller
   image:
-    repository: k8s.gcr.io/ingress-nginx/controller
-    tag: "v0.46.0"
-    digest: sha256:52f0058bed0a17ab0fb35628ba97e8d52b5d32299fbc03cc0f6c7b9ff036b61a
+    registry: k8s.gcr.io
+    image: ingress-nginx/controller
+    # for backwards compatibility consider setting the full image url via the repository value below
+    # use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
+    # repository:
+    tag: "v0.47.0"
+    digest: sha256:a1e4efc107be0bb78f32eaec37bef17d7a0c81bec8066cdf2572508d21351d0b
     pullPolicy: IfNotPresent
     # www-data -> uid 101
     runAsUser: 101
@@ -20,6 +24,9 @@ controller:
 
   # Use an existing PSP instead of creating one
   existingPsp: ""
+
+  # Configures the controller container name
+  containerName: controller
 
   # Configures the ports the nginx-controller listens on
   containerPort:
@@ -72,6 +79,17 @@ controller:
   ## Name of the ingress class to route through this controller
   ##
   ingressClass: nginx
+
+  # This section refers to the creation of the IngressClass resource
+  # IngressClass resources are supported since k8s >= 1.18
+  ingressClassResource:
+    enabled: false
+    default: false
+
+    # Parameters is a link to a custom resource containing additional
+    # configuration for the controller. This is optional if the controller
+    # does not require extra parameters.
+    parameters: {}
 
   # labels to add to the pod container metadata
   podLabels: {}
@@ -248,20 +266,40 @@ controller:
   ## Liveness and readiness probe values
   ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   ##
+  # startupProbe:
+  #   httpGet:
+  #     # should match container.healthCheckPath
+  #     path: "/healthz"
+  #     port: 10254
+  #     scheme: HTTP
+  #   initialDelaySeconds: 5
+  #   periodSeconds: 5
+  #   timeoutSeconds: 2
+  #   successThreshold: 1
+  #   failureThreshold: 5
   livenessProbe:
+    httpGet:
+      # should match container.healthCheckPath
+      path: "/healthz"
+      port: 10254
+      scheme: HTTP
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 1
+    successThreshold: 1
     failureThreshold: 5
-    initialDelaySeconds: 10
-    periodSeconds: 10
-    successThreshold: 1
-    timeoutSeconds: 1
-    port: 10254
   readinessProbe:
-    failureThreshold: 3
+    httpGet:
+      # should match container.healthCheckPath
+      path: "/healthz"
+      port: 10254
+      scheme: HTTP
     initialDelaySeconds: 10
     periodSeconds: 10
-    successThreshold: 1
     timeoutSeconds: 1
-    port: 10254
+    successThreshold: 1
+    failureThreshold: 3
+
 
   # Path of the health check endpoint. All requests received on the port defined by
   # the healthz-port parameter are forwarded internally to this path.
@@ -491,7 +529,11 @@ controller:
     patch:
       enabled: true
       image:
-        repository: docker.io/jettech/kube-webhook-certgen
+        registry: docker.io
+        image: jettech/kube-webhook-certgen
+        # for backwards compatibility consider setting the full image url via the repository value below
+        # use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
+        # repository:
         tag: v1.5.1
         pullPolicy: IfNotPresent
       ## Provide a priority class name to the webhook patching job
@@ -608,7 +650,11 @@ defaultBackend:
 
   name: defaultbackend
   image:
-    repository: k8s.gcr.io/defaultbackend-amd64
+    registry: k8s.gcr.io
+    image: defaultbackend-amd64
+    # for backwards compatibility consider setting the full image url via the repository value below
+    # use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
+    # repository:
     tag: "1.5"
     pullPolicy: IfNotPresent
     # nobody user -> uid 65534
@@ -700,6 +746,7 @@ defaultBackend:
   #    emptyDir: {}
 
   autoscaling:
+    annotations: {}
     enabled: false
     minReplicas: 1
     maxReplicas: 2

--- a/salt/metalk8s/addons/nginx-ingress-control-plane/deployed/chart-daemonset.sls
+++ b/salt/metalk8s/addons/nginx-ingress-control-plane/deployed/chart-daemonset.sls
@@ -16,8 +16,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -32,8 +32,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx-control-plane-controller
   namespace: metalk8s-ingress
@@ -46,8 +46,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -117,8 +117,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -140,8 +140,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -227,8 +227,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -250,8 +250,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx-control-plane-controller-metrics
   namespace: metalk8s-ingress
@@ -276,8 +276,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx-control-plane-controller
   namespace: metalk8s-ingress
@@ -305,8 +305,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx-control-plane-controller
   namespace: metalk8s-ingress
@@ -346,7 +346,7 @@ spec:
         - name: LD_PRELOAD
           value: /usr/local/lib/libmimalloc.so
         image: '{%- endraw -%}{{ build_image_name("nginx-ingress-controller", False)
-          }}{%- raw -%}:v0.46.0'
+          }}{%- raw -%}:v0.47.0'
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -424,8 +424,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
     metalk8s.scality.com/monitor: ''
   name: ingress-nginx-control-plane-controller

--- a/salt/metalk8s/addons/nginx-ingress-control-plane/deployed/chart-deployment.sls
+++ b/salt/metalk8s/addons/nginx-ingress-control-plane/deployed/chart-deployment.sls
@@ -15,8 +15,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx-control-plane-controller
   namespace: metalk8s-ingress
@@ -38,8 +38,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -54,8 +54,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx-control-plane-backend
   namespace: metalk8s-ingress
@@ -70,8 +70,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx-control-plane-controller
   namespace: metalk8s-ingress
@@ -84,8 +84,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -155,8 +155,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -178,8 +178,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -265,8 +265,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -288,8 +288,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx-control-plane-controller-metrics
   namespace: metalk8s-ingress
@@ -314,8 +314,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx-control-plane-controller
   namespace: metalk8s-ingress
@@ -342,8 +342,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx-control-plane-defaultbackend
   namespace: metalk8s-ingress
@@ -368,8 +368,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx-control-plane-controller
   namespace: metalk8s-ingress
@@ -412,7 +412,7 @@ spec:
               fieldPath: metadata.namespace
         - name: LD_PRELOAD
           value: /usr/local/lib/libmimalloc.so
-        image: {% endraw -%}{{ build_image_name("nginx-ingress-controller", False) }}{%- raw %}:v0.46.0
+        image: {% endraw -%}{{ build_image_name("nginx-ingress-controller", False) }}{%- raw %}:v0.47.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -488,8 +488,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx-control-plane-defaultbackend
   namespace: metalk8s-ingress
@@ -568,8 +568,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
     metalk8s.scality.com/monitor: ''
   name: ingress-nginx-control-plane-controller

--- a/salt/metalk8s/addons/nginx-ingress/deployed/chart.sls
+++ b/salt/metalk8s/addons/nginx-ingress/deployed/chart.sls
@@ -16,8 +16,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx
   namespace: metalk8s-ingress
@@ -32,8 +32,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx-backend
   namespace: metalk8s-ingress
@@ -48,8 +48,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx-controller
   namespace: metalk8s-ingress
@@ -62,8 +62,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx
   namespace: metalk8s-ingress
@@ -133,8 +133,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx
   namespace: metalk8s-ingress
@@ -156,8 +156,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx
   namespace: metalk8s-ingress
@@ -243,8 +243,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx
   namespace: metalk8s-ingress
@@ -266,8 +266,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx-controller-metrics
   namespace: metalk8s-ingress
@@ -292,8 +292,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx-controller
   namespace: metalk8s-ingress
@@ -322,8 +322,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx-defaultbackend
   namespace: metalk8s-ingress
@@ -348,8 +348,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx-controller
   namespace: metalk8s-ingress
@@ -390,7 +390,7 @@ spec:
         - name: LD_PRELOAD
           value: /usr/local/lib/libmimalloc.so
         image: '{%- endraw -%}{{ build_image_name("nginx-ingress-controller", False)
-          }}{%- raw -%}:v0.46.0'
+          }}{%- raw -%}:v0.47.0'
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -464,8 +464,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
   name: ingress-nginx-defaultbackend
   namespace: metalk8s-ingress
@@ -542,8 +542,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.46.0
-    helm.sh/chart: ingress-nginx-3.30.0
+    app.kubernetes.io/version: 0.47.0
+    helm.sh/chart: ingress-nginx-3.34.0
     heritage: metalk8s
     metalk8s.scality.com/monitor: ''
   name: ingress-nginx-controller


### PR DESCRIPTION
Bump ingress-nginx chart version to 3.34.0 nginx-ingress-controller image has been bump accordingly to v0.47.0