### PR TITLE
scripts/upgrade: Bump timeout for static pod restart

### DIFF
--- a/scripts/upgrade.sh.in
+++ b/scripts/upgrade.sh.in
@@ -151,7 +151,7 @@ upgrade_local_engines () {
     )
     for container in "${containers_to_check[@]}"; do
         "${SALT_CALL}" --local --retcode-passthrough cri.wait_container \
-            name="$container" state=running timeout=120 || return 1
+            name="$container" state=running timeout=180 || return 1
     done
 }
 


### PR DESCRIPTION
Time to time it may take a bit of time for all static pods to restart
properly, in order to avoid some flakiness during upgrade process, bump
a bit the timeout waiting for static pod to restart after kubelet
upgrade