### PR TITLE
shell: Add defaultDexConnector option to automatically trigger login on a predefined Dex connector

### DIFF
--- a/shell-ui/src/initFederation/ConfigurationProviders.js
+++ b/shell-ui/src/initFederation/ConfigurationProviders.js
@@ -28,7 +28,8 @@ export type OIDCConfig = {
   clientId: string,
   responseType: string,
   scopes: string,
-  providerLogout?: boolean
+  providerLogout?: boolean,
+  defaultDexConnector?: string,
 };
 
 type RuntimeWebFinger = {


### PR DESCRIPTION
**Component**:

shell

**Context**: 

Dex is providing the possibility to use several connectors to federate OIDC providers. However under some conditions we may need to force the usage of a specific connector.

**Summary**:

This PR add a `defaultDexConnector` option to enable this.

This option can be added to the auth section of micro application `runtime-app-configuration`.
It intercept the `authorization_endpoint` of the oidc web finger and append it the `connector_id` query parameter.

The connector choice can be forced by adding the `displayLoginChoice` query parameter to the current URL.
This enable to maintain UI login possible when the default connector is unavailable.

Additionaly as Dex is not supporting `end_session_endpoint` the logout is reviewed to clean the cookies of the
domain and clearing the localStorage entries of oidc client when `providerLogout` is set to true.

**Acceptance criteria**: 

We shall be able to login directly using the default dex connector when the property is defined
