### PR TITLE
Upgrade: Best effort drain when upgrading single node cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,12 @@
   aggregation of solutions UIs
   (PR[#3414](https://github.com/scality/metalk8s/pull/3414))
 
+### Bug fixes
+- [#3445](https://github.com/scality/metalk8s/issues/3445) - Avoid
+  kube-apiserver timeout during single node cluster upgrade when a
+  lot of pod ran on the node
+  (PR[#3447](https://github.com/scality/metalk8s/pull/3447))
+
 ### Breaking changes
 
 - [#2199](https://github.com/scality/metalk8s/issues/2199) - Prometheus label

--- a/salt/metalk8s/defaults.yaml
+++ b/salt/metalk8s/defaults.yaml
@@ -75,7 +75,7 @@ networks:
         expected: nginx
         description: MetalK8s repository
     master:
-      0.0.0.0:6443:
+      control_plane_ip:6443:
         expected: kube-apiserver
         description: Kubernetes apiserver
       127.0.0.1:7080:

--- a/salt/metalk8s/kubernetes/apiserver-proxy/files/apiserver-proxy.conf.j2
+++ b/salt/metalk8s/kubernetes/apiserver-proxy/files/apiserver-proxy.conf.j2
@@ -26,7 +26,7 @@ events {
 %}
 {%-         if not master_ips and grains.id in masters %}
 {# In case we're bootstrapping, the Mine wouldn't be available #}
-{%-             set apiservers = ["127.0.0.1"] %}
+{%-             set apiservers = [grains['metalk8s']['control_plane_ip']] %}
 {%-         else %}
 {%-             set apiservers = master_ips.values() | sort %}
 {%-         endif %}

--- a/salt/metalk8s/kubernetes/apiserver/installed.sls
+++ b/salt/metalk8s/kubernetes/apiserver/installed.sls
@@ -93,6 +93,7 @@ Create kube-apiserver Pod manifest:
           - --tls-cert-file={{ certificates.server.files.apiserver.path }}
           - --tls-private-key-file=/etc/kubernetes/pki/apiserver.key
         # }
+          - --bind-address={{ host }}
           - --encryption-provider-config={{ encryption_k8s_path }}
           - --cors-allowed-origins=.*
           - --oidc-issuer-url={{ salt.metalk8s_network.get_control_plane_ingress_endpoint() }}/oidc
@@ -145,7 +146,7 @@ Make sure kube-apiserver container is up and ready:
     - require:
       - module: Delay after apiserver pod deployment
   http.wait_for_successful_query:
-    - name: https://127.0.0.1:6443/healthz
+    - name: https://{{ host }}:6443/healthz
     - verify_ssl: True
     - ca_bundle: /etc/kubernetes/pki/ca.crt
     - status: 200

--- a/salt/metalk8s/orchestrate/apiserver.sls
+++ b/salt/metalk8s/orchestrate/apiserver.sls
@@ -34,11 +34,8 @@ Deploy apiserver {{ node }} to {{ dest_version }}:
     - saltenv: metalk8s-{{ dest_version }}
     - require:
       - salt: Check pillar on {{ node }}
-  {%- if previous_node is defined %}
-      - salt: Deploy apiserver {{ previous_node }} to {{ dest_version }}
+  {%- if loop.previtem is defined %}
+      - salt: Deploy apiserver {{ loop.previtem }} to {{ dest_version }}
   {%- endif %}
-
-  {#- Ugly but needed since we have jinja2.7 (`loop.previtem` added in 2.10) #}
-  {%- set previous_node = node %}
 
 {%- endfor %}

--- a/salt/metalk8s/orchestrate/upgrade/pre.sls
+++ b/salt/metalk8s/orchestrate/upgrade/pre.sls
@@ -2,5 +2,28 @@
 # NOTE: This state should be called by salt-master using the saltenv of
 # the destination version (salt-master should have been upgraded)
 
+{%- set cp_nodes = salt.metalk8s.minions_by_role('master') %}
+{%- if cp_nodes|length == 1 %}
+
+# NOTE: Due to a "bug" in kubelet that affect static pod deployment when
+# APIServer is down (See: https://github.com/kubernetes/kubernetes/issues/103658)
+# When all APIServer are down, we want to have as less pod as possible running.
+# That's why, when running in single master node cluster, we first drain the node so
+# that we do not face any issue when upgrading APIServer, etcd or APIServer proxy
+# NOTE2: Since we may not be able to properly drain a node when running in single
+# node cluster, we use "best effort" so that we try to evict as many pods as possible
+
+Best effort drain for {{ cp_nodes[0] }} before upgrade:
+  metalk8s_drain.node_drained:
+    - name: {{ cp_nodes[0] }}
+    - ignore_daemonset: True
+    - delete_local_data: True
+    - force: True
+    - best_effort: True
+
+{%- else %}
+
 Nothing to do before upgrading:
   test.nop: []
+
+{%- endif %}

--- a/salt/tests/unit/modules/files/test_metalk8s_drain.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_drain.yaml
@@ -238,13 +238,27 @@ drain:
       - level: WARNING
         contains: "Deleting pods with local storage: my-pod-with-local-storage"
 
+    # pod managed by unknown controller (evicted, with a warning)
+    - node_name: my-node
+      dataset: unknown-controller-pod
+      pods_to_evict:
+        - my-custom-pod
+      force: true
+      log_lines:
+        - level: WARNING
+          contains: >-
+            Deleting pods not managed by ReplicationController, ReplicaSet,
+            Job, DaemonSet or StatefulSet: my-custom-pod
+
     ## ERROR
     # Daemonset-managed pods
     - node_name: my-node
       dataset: single-daemonset
       pods_to_evict: []
       raises: true
-      raise_msg: "DaemonSet-managed pods: my-daemonset-pod."
+      raise_msg: >-
+        The following are not deletable: DaemonSet-managed pods:
+        my-daemonset-pod.
 
     # Orphaned Daemonset-managed pods
     - node_name: my-node
@@ -253,8 +267,8 @@ drain:
       raises: true
       # FIXME: weird error
       raise_msg: >-
-        Missing controller for pod 'my-namespace/my-daemonset-pod':
-        my-daemonset-pod, my-daemonset-pod.
+        The following are not deletable: Missing controller for pod
+        'my-namespace/my-daemonset-pod': my-daemonset-pod, my-daemonset-pod.
 
     # Other orphaned pods
     - node_name: my-node
@@ -262,8 +276,8 @@ drain:
       pods_to_evict: []
       raises: true
       raise_msg: >-
-        Missing controller for pod 'my-namespace/my-replicaset-pod':
-        my-replicaset-pod.
+        The following are not deletable: Missing controller for pod
+        'my-namespace/my-replicaset-pod': my-replicaset-pod.
 
     # Local storage (evicted, with a warning)
     - node_name: my-node
@@ -271,7 +285,17 @@ drain:
       pods_to_evict:
         - my-pod-with-local-storage
       raises: true
-      raise_msg: "pods with local storage: my-pod-with-local-storage."
+      raise_msg: >-
+        The following are not deletable: pods with local storage:
+        my-pod-with-local-storage.
+
+    # unable to get controller
+    - node_name: my-node
+      dataset: error-getting-controller-pod
+      pods_to_evict:
+        - my-daemonset-pod
+      raises: true
+      raise_msg: "An eRrOr OcCurreD geTting a Penguin"
 
   # Check how eviction is retried on temporary failure
   eviction-retry:
@@ -433,6 +457,17 @@ datasets:
           controller: true
           name: my-daemonset
 
+    unknown-controller-pod: &unknown_controller_pod
+      <<: *base_pod
+      metadata:
+        <<: *base_pod_meta
+        name: my-custom-pod
+        owner_references:
+        - api_version: unkown/v1
+          kind: Unknown
+          controller: true
+          name: my-unknown-controller
+
     common-replicaset: &common_replicaset
       api_version: apps/v1
       kind: ReplicaSet
@@ -511,6 +546,17 @@ datasets:
   orphaned-daemonset-pod:
     <<: *single_daemonset_dataset
     daemonsets: []
+
+  error-getting-controller-pod:
+    <<: *single_daemonset_dataset
+    daemonsets:
+      - <<: *common_daemonset
+        raiseError: "An eRrOr OcCurreD geTting a Penguin"
+
+  unknown-controller-pod:
+    <<: *empty_dataset
+    pods:
+      - *unknown_controller_pod
 
   multiple-pods:
     <<: *single_replicaset_dataset

--- a/salt/tests/unit/modules/files/test_metalk8s_drain.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_drain.yaml
@@ -312,7 +312,7 @@ drain:
     # Retry until eviction isn't locked
     - node_name: my-node
       dataset: blocked-eviction
-      events:
+      events: &blocked_eviction_events
         # evict_pods sleeps 5 seconds between each eviction attempt, so we will
         # try to evict twice with an error, and third attempt will work
         8:
@@ -326,6 +326,13 @@ drain:
             name: my-replicaset-pod
             namespace: my-namespace
       eviction_attempts: 3
+
+    # Best effort do not retry
+    - node_name: my-node
+      dataset: blocked-eviction
+      events: *blocked_eviction_events
+      eviction_attempts: 1
+      best_effort: True
 
   waiting-for-eviction:
     # Instantaneous

--- a/salt/tests/unit/modules/test_metalk8s_drain.py
+++ b/salt/tests/unit/modules/test_metalk8s_drain.py
@@ -291,7 +291,7 @@ class DrainTestCase(TestCase, mixins.LoaderModuleMockMixin):
             if raises:
                 self.assertRaisesRegex(
                     CommandExecutionError,
-                    "The following are not deletable: {}".format(raise_msg),
+                    raise_msg,
                     drainer.run_drain,
                     dry_run=True,
                 )

--- a/scripts/upgrade.sh.in
+++ b/scripts/upgrade.sh.in
@@ -146,13 +146,18 @@ upgrade_local_engines () {
     local -a containers_to_check=(
         'repositories'
         'salt-master'
-        'kube-apiserver'
         'etcd'
+        'kube-apiserver'
     )
     for container in "${containers_to_check[@]}"; do
         "${SALT_CALL}" --local --retcode-passthrough cri.wait_container \
             name="$container" state=running timeout=180 || return 1
     done
+
+    # Make sure apiserver works well
+    "${SALT_CALL}" --local --retcode-passthrough http.wait_for_successful_query \
+        https://127.0.0.1:7443/healthz \
+        verify_ssl=False status=200 match="ok"
 }
 
 upgrade_nodes () {


### PR DESCRIPTION
**Component**:

'lifecycle'

**Context**: 

See: #3445 

**Summary**:

When upgrading a cluster with a single control plane node, first do a "best-effort" drain that will evict all Pods but does not retry if some Pods cannot be evicted instead continue the "classic" upgrade process

NOTE: We do not explicitly uncordon the node at the end, as it's automatically handled by the "deploy_node" orchestrate

---

Fixes: #3445 
