### PR TITLE
Raise timeout for apiserver container status check

### DIFF
--- a/salt/metalk8s/addons/dex/deployed/pre-upgrade.sls
+++ b/salt/metalk8s/addons/dex/deployed/pre-upgrade.sls
@@ -25,7 +25,7 @@ Delete old Dex Deployment:
     - kind: Deployment
     - apiVersion: apps/v1
     - wait:
-        attempts: 10
+        attempts: 20
         sleep: 10
 
 {%- endif %}

--- a/salt/metalk8s/kubernetes/apiserver/installed.sls
+++ b/salt/metalk8s/kubernetes/apiserver/installed.sls
@@ -141,6 +141,7 @@ Make sure kube-apiserver container is up and ready:
     - cri.wait_container:
       - name: kube-apiserver
       - state: running
+      - timeout: 120
     - onchanges:
       - metalk8s: Create kube-apiserver Pod manifest
     - require:


### PR DESCRIPTION
**Component**: salt

**Context**:
On some loaded platforms these checks may fail.

**Summary**:
Raise timeout for apiserver container status check and Dex deployment removal.

**Acceptance criteria**: 