### PR TITLE
UI/bugfix: The health status of the unbound volume should be NONE

### DIFF
--- a/ui/src/components/DashboardMetrics.js
+++ b/ui/src/components/DashboardMetrics.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 import { useQuery } from 'react-query';
 import { Button } from '@scality/core-ui';
 import { padding } from '@scality/core-ui/dist/style/theme';
@@ -8,7 +8,6 @@ import { useIntl } from 'react-intl';
 
 import { fetchConfig } from '../services/api';
 import {
-  useTypedSelector,
   useNodes,
   useMetricsTimeSpan,
   useNodeAddressesSelector,
@@ -92,7 +91,7 @@ export const colorRange = [
 ];
 
 const DashboardMetrics = () => {
-  const theme = useTypedSelector((state) => state.config.theme);
+  const theme = useTheme();
   const nodeAddresses = useNodeAddressesSelector(useNodes());
   const [metricsTimeSpan] = useMetricsTimeSpan();
   const intl = useIntl();

--- a/ui/src/components/VolumeMetricsTab.js
+++ b/ui/src/components/VolumeMetricsTab.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { useHistory } from 'react-router';
 import { useDispatch, useSelector } from 'react-redux';
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 import { LineChart, Dropdown, Button } from '@scality/core-ui';
 import {
   fetchVolumeStatsAction,
@@ -66,7 +66,7 @@ const MetricsTab = (props) => {
   const history = useHistory();
   const intl = useIntl();
   const query = new URLSearchParams(history?.location?.search);
-  const theme = useSelector((state) => state.config.theme);
+  const theme = useTheme();
   const metricsTimeSpan = useSelector(
     (state) => state.app.monitoring.volumeStats.metricsTimeSpan,
   );

--- a/ui/src/components/VolumeOverviewTab.js
+++ b/ui/src/components/VolumeOverviewTab.js
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import { useHistory } from 'react-router';
 import { FormattedDate, FormattedTime } from 'react-intl';
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 import {
   fontSize,
   padding,
@@ -160,7 +160,7 @@ const VolumeDetailCard = (props) => {
   const location = useLocation();
   const intl = useIntl();
   const query = new URLSearchParams(location.search);
-  const theme = useSelector((state) => state.config.theme);
+  const theme = useTheme();
 
   const deleteVolume = (deleteVolumeName) =>
     dispatch(deleteVolumeAction(deleteVolumeName));

--- a/ui/src/hooks.js
+++ b/ui/src/hooks.js
@@ -10,6 +10,8 @@ import {
   queryTimeSpansCodes,
   REFRESH_METRICS_GRAPH,
   SAMPLE_DURATION_LAST_TWENTY_FOUR_HOURS,
+  VOLUME_CONDITION_LINK,
+  STATUS_NONE,
 } from './constants';
 import { compareHealth, useURLQuery } from './services/utils';
 import type { V1NodeList } from '@kubernetes/client-node';
@@ -128,6 +130,7 @@ export const useVolumesWithAlerts = (nodeName?: string) => {
   const volumeListData = useTypedSelector((state) =>
     getVolumeListData(state, null, nodeName),
   );
+
   //This forces alerts to have been fetched at least once (watchdog alert should be present)
   // before rendering volume list
   // TODO enhance this using useAlerts status
@@ -136,12 +139,15 @@ export const useVolumesWithAlerts = (nodeName?: string) => {
     const volumeAlerts = filterAlerts(alerts, {
       persistentvolumeclaim: volume.persistentvolumeclaim,
     });
+    // For the unbound volume, the health status should be none.
+    const isVolumeBound = volume.status === VOLUME_CONDITION_LINK;
     const volumeHealth = getHealthStatus(volumeAlerts);
     return {
       ...volume,
-      health: volumeHealth,
+      health: isVolumeBound ? volumeHealth : STATUS_NONE,
     };
   });
+
   volumeListWithStatus.sort((volumeA, volumeB) =>
     compareHealth(volumeB.health, volumeA.health),
   );


### PR DESCRIPTION
**Component**: ui, monitoring

**Context**: 
To fix Two small bugs introduced in the module federation PR.

**Summary**:

**Acceptance criteria**: 
- For those volumes who are not bound, the health status should be NONE.  
- The `theme` should be retrieved from `useTheme()`

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
