### PR TITLE
ci: Fix mismatch in "publish" stage names

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -881,9 +881,9 @@ stages:
             - bootstrap-restore
           haltOnFailure: true
       - TriggerStages:
-          name: Trigger publish-images stage
+          name: Trigger publish stage
           stage_names:
-            - publish-images
+            - publish
           haltOnFailure: true
           doStepIf: "%(prop:publish_images:-false)s"
       - ShellCommand: *add_final_status_artifact_success


### PR DESCRIPTION
See: #3406

NOTE: we can't use it anyway, but this mismatch currently breaks all post-merge runs.