### PR TITLE
eve: Fix getting of previous minor version to latest tag

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -1882,7 +1882,7 @@ stages:
           command: >
               major=$(echo "%(prop:product_version)s" | cut -d'.' -f1) &&
               minor=$(echo "%(prop:product_version)s" | cut -d'.' -f2) &&
-              git tag --list "$major.$(( $minor-1 )).*" | tail -1
+              git tag --sort=taggerdate --list "$major.$(( $minor-1 )).*" | tail -1
       - SetPropertyFromCommand:
           name: Set the minor version flag
           property: minor_present


### PR DESCRIPTION
In order to use the latest version of the previous minor we use
`git tag` but if we have some "beta" version they will be listed after
the actual GA version. That's why we now sort them by taggerdate so that
we always have the latest tag

```console
$ git tag --list "2.10.*"                  
2.10.0
2.10.0-alpha1
2.10.0-beta1
2.10.0-beta2
2.10.0-beta3
```

```console
$ git tag --list "2.10.*" --sort=taggerdate
2.10.0-alpha1
2.10.0-beta1
2.10.0-beta2
2.10.0-beta3
2.10.0
```