### PR TITLE
build, packages: bump `containerd` to 1.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
 ## Release 2.11.0 (in development)
+### Enhancements
+- Bump `containerd` version to 1.4.8 (PR [#3466](https://github.com/scality/metalk8s/pull/3466)).
 
 ## Release 2.10.1 (in development)
 

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -21,7 +21,7 @@ Image = namedtuple("Image", ("name", "version", "digest"))
 CALICO_VERSION: str = "3.19.1"
 K8S_VERSION: str = "1.21.3"
 SALT_VERSION: str = "3002.6"
-CONTAINERD_VERSION: str = "1.4.3"
+CONTAINERD_VERSION: str = "1.4.8"
 SOS_VERSION: str = "< 4.0"
 
 CALICO_RELEASE: str = "1"

--- a/packages/redhat/common/containerd.spec
+++ b/packages/redhat/common/containerd.spec
@@ -1,5 +1,5 @@
 %global goipath github.com/containerd/containerd
-Version:        1.4.3
+Version:        1.4.8
 
 %if %{defined fedora}
 %gometa
@@ -232,6 +232,9 @@ install -D -p -m 0644 %{S:3} %{buildroot}%{_sysctldir}/60-containerd.conf
 
 
 %changelog
+* Thu Jul 29 2021 Nicolas Trangez <nicolas.trangez@scality.com> - 1.4.8-1
+- Latest upstream
+
 * Fri Mar 19 2021 Nicolas Trangez <nicolas.trangez@scality.com> - 1.4.3-3
 - Only configure 'fs.may_detach_mounts' on EL7
 


### PR DESCRIPTION
Latest release in the 1.4 series, including `runc` 1.0.0.