### PR TITLE
shell: Improve module federation performance

### DIFF
--- a/ui/src/containers/App.js
+++ b/ui/src/containers/App.js
@@ -1,6 +1,4 @@
 //@flow
-import '@fortawesome/fontawesome-free/css/all.css';
-
 import React from 'react';
 import Layout from './Layout';
 


### PR DESCRIPTION
**Component**:

Shell-UI

**Context**: 

When switching between two federated apps in the navbar a loading screen is currently displayed.

![image](https://user-images.githubusercontent.com/75977494/127827785-517ffb97-c785-4cff-a459-68715887f1cb.png)

**Summary**:

Around half of the time of this loading time is dedicated to loading remoteEntry chunk of the federated app. In order to improve navigation performance and reduce loading screen time, in this PR we prefetch remoteEntry chunks of apps for which we display a link in the navbar. The preloading is done in parallel of painting the current page and hence the impact on the app first paint time is negligible.

**Acceptance criteria**: 

Loading screens while browsing federated apps are displayed for a shorter time.
In a dev env, where chunks are not optimised for production, we can see a 2x improvement on time spent on loading screen compared to the previous performance test using production optimised chunks. 

![image](https://user-images.githubusercontent.com/75977494/127830111-519fb80e-3ff6-478a-9734-13fcda14d0e4.png)
