### PR TITLE
ui: Fix intl path in redux store

### DIFF
--- a/ui/src/ducks/app/nodes.js
+++ b/ui/src/ducks/app/nodes.js
@@ -258,7 +258,7 @@ export const nodesRefreshingSelector = (state) => state.app.nodes.isRefreshing;
 export const historySelector = (state) => state.history;
 export const isSaltAPIAuthenticatedSelector = (state) => state.login.salt;
 const nodeListSelector = (state) => state.app.nodes.list;
-const intlSelector = (state) => state.app.config.intl;
+const intlSelector = (state) => state.config.intl;
 
 // Sagas
 export function* fetchClusterVersion() {


### PR DESCRIPTION
**Component**:

ui

**Context**: 

Adding and deploying a node from the UI is broken in the 2.10. This is due to a wrong path being used to access internationalised messages in the redux store.

**Summary**:

This PR fix the intl path to retrieve internationalised messages in the redux store.

**Acceptance criteria**: 

The deployment of a node from the UI is again possible

