### PR TITLE
Bump Grafana image to 8.0.6-ubuntu

### DIFF
--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -122,8 +122,8 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     ),
     Image(
         name="grafana",
-        version="8.0.1",
-        digest="sha256:1c3e2fc7896adf9e33be5d062c08066087cb556f63b0a95f8aefe92bd37a6f38",
+        version="8.0.6-ubuntu",
+        digest="sha256:e37d12f5772727d6f20a427a68dbcc53b6398931db5d3715baf852b96c18946e",
     ),
     Image(
         name="k8s-sidecar",

--- a/charts/kube-prometheus-stack.yaml
+++ b/charts/kube-prometheus-stack.yaml
@@ -143,6 +143,7 @@ grafana:
 
   image:
     repository: '__image__(grafana)'
+    tag: '8.0.6-ubuntu'
 
   sidecar:
     image:

--- a/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
@@ -20422,7 +20422,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 8.0.1
+    app.kubernetes.io/version: 8.0.6-ubuntu
     helm.sh/chart: grafana-6.13.0
     heritage: metalk8s
   name: prometheus-operator-grafana
@@ -20680,7 +20680,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 8.0.1
+    app.kubernetes.io/version: 8.0.6-ubuntu
     helm.sh/chart: grafana-6.13.0
     heritage: metalk8s
   name: prometheus-operator-grafana
@@ -20782,7 +20782,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 8.0.1
+    app.kubernetes.io/version: 8.0.6-ubuntu
     helm.sh/chart: grafana-6.13.0
     heritage: metalk8s
   name: prometheus-operator-grafana
@@ -20811,7 +20811,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 8.0.1
+    app.kubernetes.io/version: 8.0.6-ubuntu
     helm.sh/chart: grafana-6.13.0
     heritage: metalk8s
   name: prometheus-operator-grafana-config-dashboards
@@ -20853,7 +20853,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 8.0.1
+    app.kubernetes.io/version: 8.0.6-ubuntu
     helm.sh/chart: grafana-6.13.0
     heritage: metalk8s
   name: prometheus-operator-grafana
@@ -56507,7 +56507,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 8.0.1
+    app.kubernetes.io/version: 8.0.6-ubuntu
     helm.sh/chart: grafana-6.13.0
     heritage: metalk8s
   name: prometheus-operator-grafana-clusterrole
@@ -56967,7 +56967,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 8.0.1
+    app.kubernetes.io/version: 8.0.6-ubuntu
     helm.sh/chart: grafana-6.13.0
     heritage: metalk8s
   name: prometheus-operator-grafana-clusterrolebinding
@@ -57154,7 +57154,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 8.0.1
+    app.kubernetes.io/version: 8.0.6-ubuntu
     helm.sh/chart: grafana-6.13.0
     heritage: metalk8s
   name: prometheus-operator-grafana
@@ -57203,7 +57203,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 8.0.1
+    app.kubernetes.io/version: 8.0.6-ubuntu
     helm.sh/chart: grafana-6.13.0
     heritage: metalk8s
   name: prometheus-operator-grafana
@@ -57250,7 +57250,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 8.0.1
+    app.kubernetes.io/version: 8.0.6-ubuntu
     helm.sh/chart: grafana-6.13.0
     heritage: metalk8s
   name: prometheus-operator-grafana
@@ -57644,7 +57644,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 8.0.1
+    app.kubernetes.io/version: 8.0.6-ubuntu
     helm.sh/chart: grafana-6.13.0
     heritage: metalk8s
   name: prometheus-operator-grafana
@@ -57665,8 +57665,8 @@ spec:
           apiVersion="v1", namespace="metalk8s-monitoring", name="prometheus-operator-grafana",
           path="data:grafana.ini")
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/sc-dashboard-provider-config: a173a86f2a73a38694f15b1c29166d2f21d5fe505644c17bc48414e0431618ee
-        checksum/secret: 3a961265bddf6e6e02f7b3d81656b4762b8a5c8e56e6d8ce0bc7eb6dd2fe83e6
+        checksum/sc-dashboard-provider-config: 1fb938ae203ab04abaec138541fafa99df99f419c7c1567c8573f1cb0e9a487c
+        checksum/secret: 81a974a3dea4b80cdc27cccd08b7648f4175ec54526ce15faffd35b6535e0967
       labels:
         app.kubernetes.io/instance: prometheus-operator
         app.kubernetes.io/name: grafana
@@ -57707,7 +57707,7 @@ spec:
           value: /var/lib/grafana/plugins
         - name: GF_PATHS_PROVISIONING
           value: /etc/grafana/provisioning
-        image: {% endraw -%}{{ build_image_name("grafana", False) }}{%- raw %}:8.0.1
+        image: {% endraw -%}{{ build_image_name("grafana", False) }}{%- raw %}:8.0.6-ubuntu
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
@@ -57954,7 +57954,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 8.0.1
+    app.kubernetes.io/version: 8.0.6-ubuntu
     helm.sh/chart: grafana-6.13.0
     heritage: metalk8s
   name: prometheus-operator-grafana


### PR DESCRIPTION
We moved to Ubuntu-based image because the Alpine-based image
handle DNS SERVFAIL errors poorly.

Grafana image tag set to 8.0.6-ubuntu then
```
./charts/render.py prometheus-operator \
      charts/kube-prometheus-stack.yaml \
      charts/kube-prometheus-stack/ \
      --namespace metalk8s-monitoring \
      --service-config grafana \
      metalk8s-grafana-config \
      metalk8s/addons/prometheus-operator/config/grafana.yaml \
      metalk8s-monitoring \
      --service-config prometheus \
      metalk8s-prometheus-config \
      metalk8s/addons/prometheus-operator/config/prometheus.yaml \
      metalk8s-monitoring \
      --service-config alertmanager \
      metalk8s-alertmanager-config \
      metalk8s/addons/prometheus-operator/config/alertmanager.yaml \
      metalk8s-monitoring \
      --service-config dex \
      metalk8s-dex-config \
      metalk8s/addons/dex/config/dex.yaml.j2 metalk8s-auth \
      --drop-prometheus-rules charts/drop-prometheus-rules.yaml \
      > salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
```

Refs: #3480

**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

**Summary**:

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #3480

<!-- If you want to refer to an issue while not closing it, use:

See: #3480

-->
