### PR TITLE
grafana: Fix logs dashboard for Grafana 8

### DIFF
--- a/charts/logs-dashboard.json
+++ b/charts/logs-dashboard.json
@@ -1165,6 +1165,11 @@
         "label": null,
         "multi": true,
         "name": "level",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
         "options": [
           {
             "selected": true,


### PR DESCRIPTION
**Component**:

grafana

**Context**: 

On Grafana 8 the logs dashboard was broken and displayed the following message :

```
Templating init failed Cannot read property 'value' of undefined
```

This is due to a missing `current` section in the dashboard template. 

**Summary**:

This PR add the missing section.