### PR TITLE
Migrate APIService from `apiregistration.k8s.io/v1beta1` to `apiregistration.k8s.io/v1`

### DIFF
--- a/charts/render.py
+++ b/charts/render.py
@@ -318,6 +318,9 @@ def main():
         "--values",
         args.values,
         "--include-crds",
+        "--api-versions",
+        # Used by APIService (available since Kubernetes 1.10)
+        "apiregistration.k8s.io/v1",
         args.path,
     ]
 

--- a/salt/metalk8s/addons/prometheus-adapter/deployed/chart.sls
+++ b/salt/metalk8s/addons/prometheus-adapter/deployed/chart.sls
@@ -435,7 +435,7 @@ spec:
       - emptyDir: {}
         name: tmp
 ---
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   labels:
@@ -458,7 +458,7 @@ spec:
   version: v1beta1
   versionPriority: 100
 ---
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   labels:


### PR DESCRIPTION
`APIServic€` from  `apiregistration.k8s.io/v1beta1` get removed in
Kubernetes 1.22