### PR TITLE
storage-operator: Re generate CRD for Volume using "v1" API

### DIFF
--- a/buildchain/buildchain/codegen.py
+++ b/buildchain/buildchain/codegen.py
@@ -9,7 +9,6 @@ from typing import Callable, Iterator, Tuple
 
 import doit  # type: ignore
 
-from buildchain import config
 from buildchain import constants
 from buildchain import types
 from buildchain import utils
@@ -25,11 +24,8 @@ def codegen_go() -> types.TaskDict:
     """Generate Go code using operator-sdk."""
     cwd = constants.STORAGE_OPERATOR_ROOT
     actions = []
-    for target in ("k8s", "crds"):
-        cmd = " ".join(
-            map(shlex.quote, [config.ExtCommand.OPERATOR_SDK.value, "generate", target])
-        )
-        actions.append(doit.action.CmdAction(cmd, cwd=cwd))
+    for cmd in constants.OPERATOR_SDK_GENERATE_CMDS:
+        actions.append(doit.action.CmdAction(" ".join(map(shlex.quote, cmd)), cwd=cwd))
 
     return {
         "name": "go",

--- a/buildchain/buildchain/constants.py
+++ b/buildchain/buildchain/constants.py
@@ -126,5 +126,10 @@ STORAGE_OPERATOR_SOURCES: FrozenSet[Path] = frozenset(
 )
 GO_SOURCES: FrozenSet[Path] = frozenset(filepath for filepath in ROOT.rglob("*.go"))
 
+OPERATOR_SDK_GENERATE_CMDS: List[List[str]] = [
+    [config.ExtCommand.OPERATOR_SDK.value, "generate", "k8s"],
+    [config.ExtCommand.OPERATOR_SDK.value, "generate", "crds", "--crd-version", "v1"],
+]
+
 # For mypy, see `--no-implicit-reexport` documentation.
 __all__ = ["ROOT"]

--- a/buildchain/buildchain/lint.py
+++ b/buildchain/buildchain/lint.py
@@ -158,8 +158,7 @@ def check_go_codegen() -> Optional[doit.exceptions.TaskError]:
     cwd = constants.STORAGE_OPERATOR_ROOT
     git_diff = [config.ExtCommand.GIT.value, "diff"]
     base = subprocess.check_output(git_diff)
-    for target in ("k8s", "crds"):
-        cmd = [config.ExtCommand.OPERATOR_SDK.value, "generate", target]
+    for cmd in constants.OPERATOR_SDK_GENERATE_CMDS:
         subprocess.check_call(cmd, cwd=cwd)
     current = subprocess.check_output(git_diff)
     # If the diff changed after running the code generation that means that

--- a/storage-operator/deploy/crds/storage.metalk8s.scality.com_volumes_crd.yaml
+++ b/storage-operator/deploy/crds/storage.metalk8s.scality.com_volumes_crd.yaml
@@ -1,17 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: volumes.storage.metalk8s.scality.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.nodeName
-    description: The node on which the volume is available
-    name: Node
-    type: string
-  - JSONPath: .spec.storageClassName
-    description: The storage class of the volume
-    name: StorageClass
-    type: string
   group: storage.metalk8s.scality.com
   names:
     kind: Volume
@@ -19,1167 +10,1189 @@ spec:
     plural: volumes
     singular: volume
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Volume is the Schema for the volumes API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: VolumeSpec defines the desired state of Volume
-          properties:
-            lvmLogicalVolume:
-              properties:
-                size:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  description: Size of the created LVM LogicalVolume backing the PersistentVolume
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-                vgName:
-                  description: Name of the LVM VolumeGroup on the node to create the
-                    LVM LogicalVolume to back the PersistentVolume
-                  type: string
-              required:
-              - size
-              - vgName
-              type: object
-            mode:
-              description: How the volume is intended to be consumed, either Block
-                or Filesystem (default is Filesystem).
-              enum:
-              - Filesystem
-              - Block
-              type: string
-            nodeName:
-              description: Name of the node on which the volume is available.
-              type: string
-            rawBlockDevice:
-              properties:
-                devicePath:
-                  description: Path of the block device on the node to back the PersistentVolume.
-                  type: string
-              required:
-              - devicePath
-              type: object
-            sparseLoopDevice:
-              properties:
-                size:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  description: Size of the generated sparse file backing the PersistentVolume.
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-              required:
-              - size
-              type: object
-            storageClassName:
-              description: Name of the StorageClass that gets assigned to the volume.
-                Also, any mount options are copied from the StorageClass to the PersistentVolume
-                if present.
-              type: string
-            template:
-              description: Template for the underlying PersistentVolume.
-              properties:
-                metadata:
-                  description: Standard object's metadata.
-                  type: object
-                spec:
-                  description: Specification of the Persistent Volume.
-                  properties:
-                    accessModes:
-                      description: 'AccessModes contains all ways the volume can be
-                        mounted. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes'
-                      items:
-                        type: string
-                      type: array
-                    awsElasticBlockStore:
-                      description: 'AWSElasticBlockStore represents an AWS Disk resource
-                        that is attached to a kubelet''s host machine and then exposed
-                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                      properties:
-                        fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
-                          type: string
-                        partition:
-                          description: 'The partition in the volume that you want
-                            to mount. If omitted, the default is to mount by volume
-                            name. Examples: For volume /dev/sda1, you specify the
-                            partition as "1". Similarly, the volume partition for
-                            /dev/sda is "0" (or you can leave the property empty).'
-                          format: int32
-                          type: integer
-                        readOnly:
-                          description: 'Specify "true" to force and set the ReadOnly
-                            property in VolumeMounts to "true". If omitted, the default
-                            is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                          type: boolean
-                        volumeID:
-                          description: 'Unique ID of the persistent disk resource
-                            in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    azureDisk:
-                      description: AzureDisk represents an Azure Data Disk mount on
-                        the host and bind mount to the pod.
-                      properties:
-                        cachingMode:
-                          description: 'Host Caching mode: None, Read Only, Read Write.'
-                          type: string
-                        diskName:
-                          description: The Name of the data disk in the blob storage
-                          type: string
-                        diskURI:
-                          description: The URI the data disk in the blob storage
-                          type: string
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          type: string
-                        kind:
-                          description: 'Expected values Shared: multiple blob disks
-                            per storage account  Dedicated: single blob disk per storage
-                            account  Managed: azure managed data disk (only in managed
-                            availability set). defaults to shared'
-                          type: string
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                      required:
-                      - diskName
-                      - diskURI
-                      type: object
-                    azureFile:
-                      description: AzureFile represents an Azure File Service mount
-                        on the host and bind mount to the pod.
-                      properties:
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                        secretName:
-                          description: the name of secret that contains Azure Storage
-                            Account Name and Key
-                          type: string
-                        secretNamespace:
-                          description: the namespace of the secret that contains Azure
-                            Storage Account Name and Key default is the same as the
-                            Pod
-                          type: string
-                        shareName:
-                          description: Share Name
-                          type: string
-                      required:
-                      - secretName
-                      - shareName
-                      type: object
-                    capacity:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'A description of the persistent volume''s resources
-                        and capacity. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#capacity'
-                      type: object
-                    cephfs:
-                      description: CephFS represents a Ceph FS mount on the host that
-                        shares a pod's lifetime
-                      properties:
-                        monitors:
-                          description: 'Required: Monitors is a collection of Ceph
-                            monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          items:
-                            type: string
-                          type: array
-                        path:
-                          description: 'Optional: Used as the mounted root, rather
-                            than the full Ceph tree, default is /'
-                          type: string
-                        readOnly:
-                          description: 'Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          type: boolean
-                        secretFile:
-                          description: 'Optional: SecretFile is the path to key ring
-                            for User, default is /etc/ceph/user.secret More info:
-                            https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          type: string
-                        secretRef:
-                          description: 'Optional: SecretRef is reference to the authentication
-                            secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          properties:
-                            name:
-                              description: Name is unique within a namespace to reference
-                                a secret resource.
-                              type: string
-                            namespace:
-                              description: Namespace defines the space within which
-                                the secret name must be unique.
-                              type: string
-                          type: object
-                        user:
-                          description: 'Optional: User is the rados user name, default
-                            is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          type: string
-                      required:
-                      - monitors
-                      type: object
-                    cinder:
-                      description: 'Cinder represents a cinder volume attached and
-                        mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                      properties:
-                        fsType:
-                          description: 'Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Examples:
-                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                          type: string
-                        readOnly:
-                          description: 'Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                          type: boolean
-                        secretRef:
-                          description: 'Optional: points to a secret object containing
-                            parameters used to connect to OpenStack.'
-                          properties:
-                            name:
-                              description: Name is unique within a namespace to reference
-                                a secret resource.
-                              type: string
-                            namespace:
-                              description: Namespace defines the space within which
-                                the secret name must be unique.
-                              type: string
-                          type: object
-                        volumeID:
-                          description: 'volume id used to identify the volume in cinder.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    claimRef:
-                      description: 'ClaimRef is part of a bi-directional binding between
-                        PersistentVolume and PersistentVolumeClaim. Expected to be
-                        non-nil when bound. claim.VolumeName is the authoritative
-                        bind between PV and PVC. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#binding'
-                      properties:
-                        apiVersion:
-                          description: API version of the referent.
-                          type: string
-                        fieldPath:
-                          description: 'If referring to a piece of an object instead
-                            of an entire object, this string should contain a valid
-                            JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                            For example, if the object reference is to a container
-                            within a pod, this would take on a value like: "spec.containers{name}"
-                            (where "name" refers to the name of the container that
-                            triggered the event) or if no container name is specified
-                            "spec.containers[2]" (container with index 2 in this pod).
-                            This syntax is chosen only to have some well-defined way
-                            of referencing a part of an object. TODO: this design
-                            is not final and this field is subject to change in the
-                            future.'
-                          type: string
-                        kind:
-                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                          type: string
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                          type: string
-                        namespace:
-                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                          type: string
-                        resourceVersion:
-                          description: 'Specific resourceVersion to which this reference
-                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                          type: string
-                        uid:
-                          description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                          type: string
-                      type: object
-                    csi:
-                      description: CSI represents storage that is handled by an external
-                        CSI driver (Beta feature).
-                      properties:
-                        controllerExpandSecretRef:
-                          description: ControllerExpandSecretRef is a reference to
-                            the secret object containing sensitive information to
-                            pass to the CSI driver to complete the CSI ControllerExpandVolume
-                            call. This is an alpha field and requires enabling ExpandCSIVolumes
-                            feature gate. This field is optional, and may be empty
-                            if no secret is required. If the secret object contains
-                            more than one secret, all secrets are passed.
-                          properties:
-                            name:
-                              description: Name is unique within a namespace to reference
-                                a secret resource.
-                              type: string
-                            namespace:
-                              description: Namespace defines the space within which
-                                the secret name must be unique.
-                              type: string
-                          type: object
-                        controllerPublishSecretRef:
-                          description: ControllerPublishSecretRef is a reference to
-                            the secret object containing sensitive information to
-                            pass to the CSI driver to complete the CSI ControllerPublishVolume
-                            and ControllerUnpublishVolume calls. This field is optional,
-                            and may be empty if no secret is required. If the secret
-                            object contains more than one secret, all secrets are
-                            passed.
-                          properties:
-                            name:
-                              description: Name is unique within a namespace to reference
-                                a secret resource.
-                              type: string
-                            namespace:
-                              description: Namespace defines the space within which
-                                the secret name must be unique.
-                              type: string
-                          type: object
-                        driver:
-                          description: Driver is the name of the driver to use for
-                            this volume. Required.
-                          type: string
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs".
-                          type: string
-                        nodePublishSecretRef:
-                          description: NodePublishSecretRef is a reference to the
-                            secret object containing sensitive information to pass
-                            to the CSI driver to complete the CSI NodePublishVolume
-                            and NodeUnpublishVolume calls. This field is optional,
-                            and may be empty if no secret is required. If the secret
-                            object contains more than one secret, all secrets are
-                            passed.
-                          properties:
-                            name:
-                              description: Name is unique within a namespace to reference
-                                a secret resource.
-                              type: string
-                            namespace:
-                              description: Namespace defines the space within which
-                                the secret name must be unique.
-                              type: string
-                          type: object
-                        nodeStageSecretRef:
-                          description: NodeStageSecretRef is a reference to the secret
-                            object containing sensitive information to pass to the
-                            CSI driver to complete the CSI NodeStageVolume and NodeStageVolume
-                            and NodeUnstageVolume calls. This field is optional, and
-                            may be empty if no secret is required. If the secret object
-                            contains more than one secret, all secrets are passed.
-                          properties:
-                            name:
-                              description: Name is unique within a namespace to reference
-                                a secret resource.
-                              type: string
-                            namespace:
-                              description: Namespace defines the space within which
-                                the secret name must be unique.
-                              type: string
-                          type: object
-                        readOnly:
-                          description: 'Optional: The value to pass to ControllerPublishVolumeRequest.
-                            Defaults to false (read/write).'
-                          type: boolean
-                        volumeAttributes:
-                          additionalProperties:
-                            type: string
-                          description: Attributes of the volume to publish.
-                          type: object
-                        volumeHandle:
-                          description: VolumeHandle is the unique volume name returned
-                            by the CSI volume plugin’s CreateVolume to refer to the
-                            volume on all subsequent calls. Required.
-                          type: string
-                      required:
-                      - driver
-                      - volumeHandle
-                      type: object
-                    fc:
-                      description: FC represents a Fibre Channel resource that is
-                        attached to a kubelet's host machine and then exposed to the
-                        pod.
-                      properties:
-                        fsType:
-                          description: 'Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
-                          type: string
-                        lun:
-                          description: 'Optional: FC target lun number'
-                          format: int32
-                          type: integer
-                        readOnly:
-                          description: 'Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
-                          type: boolean
-                        targetWWNs:
-                          description: 'Optional: FC target worldwide names (WWNs)'
-                          items:
-                            type: string
-                          type: array
-                        wwids:
-                          description: 'Optional: FC volume world wide identifiers
-                            (wwids) Either wwids or combination of targetWWNs and
-                            lun must be set, but not both simultaneously.'
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    flexVolume:
-                      description: FlexVolume represents a generic volume resource
-                        that is provisioned/attached using an exec based plugin.
-                      properties:
-                        driver:
-                          description: Driver is the name of the driver to use for
-                            this volume.
-                          type: string
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". The default filesystem depends on FlexVolume
-                            script.
-                          type: string
-                        options:
-                          additionalProperties:
-                            type: string
-                          description: 'Optional: Extra command options if any.'
-                          type: object
-                        readOnly:
-                          description: 'Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
-                          type: boolean
-                        secretRef:
-                          description: 'Optional: SecretRef is reference to the secret
-                            object containing sensitive information to pass to the
-                            plugin scripts. This may be empty if no secret object
-                            is specified. If the secret object contains more than
-                            one secret, all secrets are passed to the plugin scripts.'
-                          properties:
-                            name:
-                              description: Name is unique within a namespace to reference
-                                a secret resource.
-                              type: string
-                            namespace:
-                              description: Namespace defines the space within which
-                                the secret name must be unique.
-                              type: string
-                          type: object
-                      required:
-                      - driver
-                      type: object
-                    flocker:
-                      description: Flocker represents a Flocker volume attached to
-                        a kubelet's host machine and exposed to the pod for its usage.
-                        This depends on the Flocker control service being running
-                      properties:
-                        datasetName:
-                          description: Name of the dataset stored as metadata -> name
-                            on the dataset for Flocker should be considered as deprecated
-                          type: string
-                        datasetUUID:
-                          description: UUID of the dataset. This is unique identifier
-                            of a Flocker dataset
-                          type: string
-                      type: object
-                    gcePersistentDisk:
-                      description: 'GCEPersistentDisk represents a GCE Disk resource
-                        that is attached to a kubelet''s host machine and then exposed
-                        to the pod. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                      properties:
-                        fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
-                          type: string
-                        partition:
-                          description: 'The partition in the volume that you want
-                            to mount. If omitted, the default is to mount by volume
-                            name. Examples: For volume /dev/sda1, you specify the
-                            partition as "1". Similarly, the volume partition for
-                            /dev/sda is "0" (or you can leave the property empty).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                          format: int32
-                          type: integer
-                        pdName:
-                          description: 'Unique name of the PD resource in GCE. Used
-                            to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                          type: string
-                        readOnly:
-                          description: 'ReadOnly here will force the ReadOnly setting
-                            in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                          type: boolean
-                      required:
-                      - pdName
-                      type: object
-                    glusterfs:
-                      description: 'Glusterfs represents a Glusterfs volume that is
-                        attached to a host and exposed to the pod. Provisioned by
-                        an admin. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
-                      properties:
-                        endpoints:
-                          description: 'EndpointsName is the endpoint name that details
-                            Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                          type: string
-                        endpointsNamespace:
-                          description: 'EndpointsNamespace is the namespace that contains
-                            Glusterfs endpoint. If this field is empty, the EndpointNamespace
-                            defaults to the same namespace as the bound PVC. More
-                            info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                          type: string
-                        path:
-                          description: 'Path is the Glusterfs volume path. More info:
-                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                          type: string
-                        readOnly:
-                          description: 'ReadOnly here will force the Glusterfs volume
-                            to be mounted with read-only permissions. Defaults to
-                            false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                          type: boolean
-                      required:
-                      - endpoints
-                      - path
-                      type: object
-                    hostPath:
-                      description: 'HostPath represents a directory on the host. Provisioned
-                        by a developer or tester. This is useful for single-node development
-                        and testing only! On-host storage is not supported in any
-                        way and WILL NOT WORK in a multi-node cluster. More info:
-                        https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                      properties:
-                        path:
-                          description: 'Path of the directory on the host. If the
-                            path is a symlink, it will follow the link to the real
-                            path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                          type: string
-                        type:
-                          description: 'Type for HostPath Volume Defaults to "" More
-                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                          type: string
-                      required:
-                      - path
-                      type: object
-                    iscsi:
-                      description: ISCSI represents an ISCSI Disk resource that is
-                        attached to a kubelet's host machine and then exposed to the
-                        pod. Provisioned by an admin.
-                      properties:
-                        chapAuthDiscovery:
-                          description: whether support iSCSI Discovery CHAP authentication
-                          type: boolean
-                        chapAuthSession:
-                          description: whether support iSCSI Session CHAP authentication
-                          type: boolean
-                        fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
-                          type: string
-                        initiatorName:
-                          description: Custom iSCSI Initiator Name. If initiatorName
-                            is specified with iscsiInterface simultaneously, new iSCSI
-                            interface <target portal>:<volume name> will be created
-                            for the connection.
-                          type: string
-                        iqn:
-                          description: Target iSCSI Qualified Name.
-                          type: string
-                        iscsiInterface:
-                          description: iSCSI Interface Name that uses an iSCSI transport.
-                            Defaults to 'default' (tcp).
-                          type: string
-                        lun:
-                          description: iSCSI Target Lun number.
-                          format: int32
-                          type: integer
-                        portals:
-                          description: iSCSI Target Portal List. The Portal is either
-                            an IP or ip_addr:port if the port is other than default
-                            (typically TCP ports 860 and 3260).
-                          items:
-                            type: string
-                          type: array
-                        readOnly:
-                          description: ReadOnly here will force the ReadOnly setting
-                            in VolumeMounts. Defaults to false.
-                          type: boolean
-                        secretRef:
-                          description: CHAP Secret for iSCSI target and initiator
-                            authentication
-                          properties:
-                            name:
-                              description: Name is unique within a namespace to reference
-                                a secret resource.
-                              type: string
-                            namespace:
-                              description: Namespace defines the space within which
-                                the secret name must be unique.
-                              type: string
-                          type: object
-                        targetPortal:
-                          description: iSCSI Target Portal. The Portal is either an
-                            IP or ip_addr:port if the port is other than default (typically
-                            TCP ports 860 and 3260).
-                          type: string
-                      required:
-                      - iqn
-                      - lun
-                      - targetPortal
-                      type: object
-                    local:
-                      description: Local represents directly-attached storage with
-                        node affinity
-                      properties:
-                        fsType:
-                          description: Filesystem type to mount. It applies only when
-                            the Path is a block device. Must be a filesystem type
-                            supported by the host operating system. Ex. "ext4", "xfs",
-                            "ntfs". The default value is to auto-select a fileystem
-                            if unspecified.
-                          type: string
-                        path:
-                          description: The full path to the volume on the node. It
-                            can be either a directory or block device (disk, partition,
-                            ...).
-                          type: string
-                      required:
-                      - path
-                      type: object
-                    mountOptions:
-                      description: 'A list of mount options, e.g. ["ro", "soft"].
-                        Not validated - mount will simply fail if one is invalid.
-                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#mount-options'
-                      items:
-                        type: string
-                      type: array
-                    nfs:
-                      description: 'NFS represents an NFS mount on the host. Provisioned
-                        by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                      properties:
-                        path:
-                          description: 'Path that is exported by the NFS server. More
-                            info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                          type: string
-                        readOnly:
-                          description: 'ReadOnly here will force the NFS export to
-                            be mounted with read-only permissions. Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                          type: boolean
-                        server:
-                          description: 'Server is the hostname or IP address of the
-                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                          type: string
-                      required:
-                      - path
-                      - server
-                      type: object
-                    nodeAffinity:
-                      description: NodeAffinity defines constraints that limit what
-                        nodes this volume can be accessed from. This field influences
-                        the scheduling of pods that use this volume.
-                      properties:
-                        required:
-                          description: Required specifies hard node constraints that
-                            must be met.
-                          properties:
-                            nodeSelectorTerms:
-                              description: Required. A list of node selector terms.
-                                The terms are ORed.
-                              items:
-                                description: A null or empty node selector term matches
-                                  no objects. The requirements of them are ANDed.
-                                  The TopologySelectorTerm type implements a subset
-                                  of the NodeSelectorTerm.
-                                properties:
-                                  matchExpressions:
-                                    description: A list of node selector requirements
-                                      by node's labels.
-                                    items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values
-                                            array must be empty. If the operator is
-                                            Gt or Lt, the values array must have a
-                                            single element, which will be interpreted
-                                            as an integer. This array is replaced
-                                            during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    description: A list of node selector requirements
-                                      by node's fields.
-                                    items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values
-                                            array must be empty. If the operator is
-                                            Gt or Lt, the values array must have a
-                                            single element, which will be interpreted
-                                            as an integer. This array is replaced
-                                            during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                type: object
-                              type: array
-                          required:
-                          - nodeSelectorTerms
-                          type: object
-                      type: object
-                    persistentVolumeReclaimPolicy:
-                      description: 'What happens to a persistent volume when released
-                        from its claim. Valid options are Retain (default for manually
-                        created PersistentVolumes), Delete (default for dynamically
-                        provisioned PersistentVolumes), and Recycle (deprecated).
-                        Recycle must be supported by the volume plugin underlying
-                        this PersistentVolume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#reclaiming'
-                      type: string
-                    photonPersistentDisk:
-                      description: PhotonPersistentDisk represents a PhotonController
-                        persistent disk attached and mounted on kubelets host machine
-                      properties:
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          type: string
-                        pdID:
-                          description: ID that identifies Photon Controller persistent
-                            disk
-                          type: string
-                      required:
-                      - pdID
-                      type: object
-                    portworxVolume:
-                      description: PortworxVolume represents a portworx volume attached
-                        and mounted on kubelets host machine
-                      properties:
-                        fsType:
-                          description: FSType represents the filesystem type to mount
-                            Must be a filesystem type supported by the host operating
-                            system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
-                            if unspecified.
-                          type: string
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                        volumeID:
-                          description: VolumeID uniquely identifies a Portworx volume
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    quobyte:
-                      description: Quobyte represents a Quobyte mount on the host
-                        that shares a pod's lifetime
-                      properties:
-                        group:
-                          description: Group to map volume access to Default is no
-                            group
-                          type: string
-                        readOnly:
-                          description: ReadOnly here will force the Quobyte volume
-                            to be mounted with read-only permissions. Defaults to
-                            false.
-                          type: boolean
-                        registry:
-                          description: Registry represents a single or multiple Quobyte
-                            Registry services specified as a string as host:port pair
-                            (multiple entries are separated with commas) which acts
-                            as the central registry for volumes
-                          type: string
-                        tenant:
-                          description: Tenant owning the given Quobyte volume in the
-                            Backend Used with dynamically provisioned Quobyte volumes,
-                            value is set by the plugin
-                          type: string
-                        user:
-                          description: User to map volume access to Defaults to serivceaccount
-                            user
-                          type: string
-                        volume:
-                          description: Volume is a string that references an already
-                            created Quobyte volume by name.
-                          type: string
-                      required:
-                      - registry
-                      - volume
-                      type: object
-                    rbd:
-                      description: 'RBD represents a Rados Block Device mount on the
-                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
-                      properties:
-                        fsType:
-                          description: 'Filesystem type of the volume that you want
-                            to mount. Tip: Ensure that the filesystem type is supported
-                            by the host operating system. Examples: "ext4", "xfs",
-                            "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
-                          type: string
-                        image:
-                          description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: string
-                        keyring:
-                          description: 'Keyring is the path to key ring for RBDUser.
-                            Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: string
-                        monitors:
-                          description: 'A collection of Ceph monitors. More info:
-                            https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          items:
-                            type: string
-                          type: array
-                        pool:
-                          description: 'The rados pool name. Default is rbd. More
-                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: string
-                        readOnly:
-                          description: 'ReadOnly here will force the ReadOnly setting
-                            in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: boolean
-                        secretRef:
-                          description: 'SecretRef is name of the authentication secret
-                            for RBDUser. If provided overrides keyring. Default is
-                            nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          properties:
-                            name:
-                              description: Name is unique within a namespace to reference
-                                a secret resource.
-                              type: string
-                            namespace:
-                              description: Namespace defines the space within which
-                                the secret name must be unique.
-                              type: string
-                          type: object
-                        user:
-                          description: 'The rados user name. Default is admin. More
-                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: string
-                      required:
-                      - image
-                      - monitors
-                      type: object
-                    scaleIO:
-                      description: ScaleIO represents a ScaleIO persistent volume
-                        attached and mounted on Kubernetes nodes.
-                      properties:
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Default is "xfs"
-                          type: string
-                        gateway:
-                          description: The host address of the ScaleIO API Gateway.
-                          type: string
-                        protectionDomain:
-                          description: The name of the ScaleIO Protection Domain for
-                            the configured storage.
-                          type: string
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                        secretRef:
-                          description: SecretRef references to the secret for ScaleIO
-                            user and other sensitive information. If this is not provided,
-                            Login operation will fail.
-                          properties:
-                            name:
-                              description: Name is unique within a namespace to reference
-                                a secret resource.
-                              type: string
-                            namespace:
-                              description: Namespace defines the space within which
-                                the secret name must be unique.
-                              type: string
-                          type: object
-                        sslEnabled:
-                          description: Flag to enable/disable SSL communication with
-                            Gateway, default false
-                          type: boolean
-                        storageMode:
-                          description: Indicates whether the storage for a volume
-                            should be ThickProvisioned or ThinProvisioned. Default
-                            is ThinProvisioned.
-                          type: string
-                        storagePool:
-                          description: The ScaleIO Storage Pool associated with the
-                            protection domain.
-                          type: string
-                        system:
-                          description: The name of the storage system as configured
-                            in ScaleIO.
-                          type: string
-                        volumeName:
-                          description: The name of a volume already created in the
-                            ScaleIO system that is associated with this volume source.
-                          type: string
-                      required:
-                      - gateway
-                      - secretRef
-                      - system
-                      type: object
-                    storageClassName:
-                      description: Name of StorageClass to which this persistent volume
-                        belongs. Empty value means that this volume does not belong
-                        to any StorageClass.
-                      type: string
-                    storageos:
-                      description: 'StorageOS represents a StorageOS volume that is
-                        attached to the kubelet''s host machine and mounted into the
-                        pod More info: https://examples.k8s.io/volumes/storageos/README.md'
-                      properties:
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          type: string
-                        readOnly:
-                          description: Defaults to false (read/write). ReadOnly here
-                            will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                        secretRef:
-                          description: SecretRef specifies the secret to use for obtaining
-                            the StorageOS API credentials.  If not specified, default
-                            values will be attempted.
-                          properties:
-                            apiVersion:
-                              description: API version of the referent.
-                              type: string
-                            fieldPath:
-                              description: 'If referring to a piece of an object instead
-                                of an entire object, this string should contain a
-                                valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                                For example, if the object reference is to a container
-                                within a pod, this would take on a value like: "spec.containers{name}"
-                                (where "name" refers to the name of the container
-                                that triggered the event) or if no container name
-                                is specified "spec.containers[2]" (container with
-                                index 2 in this pod). This syntax is chosen only to
-                                have some well-defined way of referencing a part of
-                                an object. TODO: this design is not final and this
-                                field is subject to change in the future.'
-                              type: string
-                            kind:
-                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                              type: string
-                            namespace:
-                              description: 'Namespace of the referent. More info:
-                                https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                              type: string
-                            resourceVersion:
-                              description: 'Specific resourceVersion to which this
-                                reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                              type: string
-                            uid:
-                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                              type: string
-                          type: object
-                        volumeName:
-                          description: VolumeName is the human-readable name of the
-                            StorageOS volume.  Volume names are only unique within
-                            a namespace.
-                          type: string
-                        volumeNamespace:
-                          description: VolumeNamespace specifies the scope of the
-                            volume within StorageOS.  If no namespace is specified
-                            then the Pod's namespace will be used.  This allows the
-                            Kubernetes name scoping to be mirrored within StorageOS
-                            for tighter integration. Set VolumeName to any name to
-                            override the default behaviour. Set to "default" if you
-                            are not using namespaces within StorageOS. Namespaces
-                            that do not pre-exist within StorageOS will be created.
-                          type: string
-                      type: object
-                    volumeMode:
-                      description: volumeMode defines if a volume is intended to be
-                        used with a formatted filesystem or to remain in raw block
-                        state. Value of Filesystem is implied when not included in
-                        spec. This is a beta feature.
-                      type: string
-                    vsphereVolume:
-                      description: VsphereVolume represents a vSphere volume attached
-                        and mounted on kubelets host machine
-                      properties:
-                        fsType:
-                          description: Filesystem type to mount. Must be a filesystem
-                            type supported by the host operating system. Ex. "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          type: string
-                        storagePolicyID:
-                          description: Storage Policy Based Management (SPBM) profile
-                            ID associated with the StoragePolicyName.
-                          type: string
-                        storagePolicyName:
-                          description: Storage Policy Based Management (SPBM) profile
-                            name.
-                          type: string
-                        volumePath:
-                          description: Path that identifies vSphere volume vmdk
-                          type: string
-                      required:
-                      - volumePath
-                      type: object
-                  type: object
-              type: object
-          required:
-          - nodeName
-          - storageClassName
-          type: object
-        status:
-          description: VolumeStatus defines the observed state of Volume
-          properties:
-            conditions:
-              description: List of conditions through which the Volume has or has
-                not passed.
-              items:
+  versions:
+  - additionalPrinterColumns:
+    - description: The node on which the volume is available
+      jsonPath: .spec.nodeName
+      name: Node
+      type: string
+    - description: The storage class of the volume
+      jsonPath: .spec.storageClassName
+      name: StorageClass
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Volume is the Schema for the volumes API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeSpec defines the desired state of Volume
+            properties:
+              lvmLogicalVolume:
                 properties:
-                  lastTransitionTime:
-                    description: Last time the condition transited from one status
-                      to another (optional).
-                    format: date-time
-                    type: string
-                  lastUpdateTime:
-                    description: Last time the condition was updated (optional).
-                    format: date-time
-                    type: string
-                  message:
-                    description: Human readable message indicating details about last
-                      transition.
-                    type: string
-                  reason:
-                    description: Unique, one-word, CamelCase reason for the condition's
-                      last transition.
-                    enum:
-                    - Pending
-                    - Terminating
-                    - InternalError
-                    - CreationError
-                    - DestructionError
-                    - UnavailableError
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    enum:
-                    - "True"
-                    - "False"
-                    - Unknown
-                    type: string
-                  type:
-                    description: Type of volume condition.
-                    enum:
-                    - Ready
+                  size:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Size of the created LVM LogicalVolume backing the
+                      PersistentVolume
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  vgName:
+                    description: Name of the LVM VolumeGroup on the node to create
+                      the LVM LogicalVolume to back the PersistentVolume
                     type: string
                 required:
-                - status
-                - type
+                - size
+                - vgName
                 type: object
-              type: array
-              x-kubernetes-list-map-keys:
-              - type
-              x-kubernetes-list-type: map
-            deviceName:
-              description: Name of the underlying block device.
-              type: string
-            job:
-              description: Job in progress
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
+              mode:
+                description: How the volume is intended to be consumed, either Block
+                  or Filesystem (default is Filesystem).
+                enum:
+                - Filesystem
+                - Block
+                type: string
+              nodeName:
+                description: Name of the node on which the volume is available.
+                type: string
+              rawBlockDevice:
+                properties:
+                  devicePath:
+                    description: Path of the block device on the node to back the
+                      PersistentVolume.
+                    type: string
+                required:
+                - devicePath
+                type: object
+              sparseLoopDevice:
+                properties:
+                  size:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Size of the generated sparse file backing the PersistentVolume.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                required:
+                - size
+                type: object
+              storageClassName:
+                description: Name of the StorageClass that gets assigned to the volume.
+                  Also, any mount options are copied from the StorageClass to the
+                  PersistentVolume if present.
+                type: string
+              template:
+                description: Template for the underlying PersistentVolume.
+                properties:
+                  metadata:
+                    description: Standard object's metadata.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  spec:
+                    description: Specification of the Persistent Volume.
+                    properties:
+                      accessModes:
+                        description: 'AccessModes contains all ways the volume can
+                          be mounted. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes'
+                        items:
+                          type: string
+                        type: array
+                      awsElasticBlockStore:
+                        description: 'AWSElasticBlockStore represents an AWS Disk
+                          resource that is attached to a kubelet''s host machine and
+                          then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        properties:
+                          fsType:
+                            description: 'Filesystem type of the volume that you want
+                              to mount. Tip: Ensure that the filesystem type is supported
+                              by the host operating system. Examples: "ext4", "xfs",
+                              "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                              TODO: how do we prevent errors in the filesystem from
+                              compromising the machine'
+                            type: string
+                          partition:
+                            description: 'The partition in the volume that you want
+                              to mount. If omitted, the default is to mount by volume
+                              name. Examples: For volume /dev/sda1, you specify the
+                              partition as "1". Similarly, the volume partition for
+                              /dev/sda is "0" (or you can leave the property empty).'
+                            format: int32
+                            type: integer
+                          readOnly:
+                            description: 'Specify "true" to force and set the ReadOnly
+                              property in VolumeMounts to "true". If omitted, the
+                              default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            type: boolean
+                          volumeID:
+                            description: 'Unique ID of the persistent disk resource
+                              in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      azureDisk:
+                        description: AzureDisk represents an Azure Data Disk mount
+                          on the host and bind mount to the pod.
+                        properties:
+                          cachingMode:
+                            description: 'Host Caching mode: None, Read Only, Read
+                              Write.'
+                            type: string
+                          diskName:
+                            description: The Name of the data disk in the blob storage
+                            type: string
+                          diskURI:
+                            description: The URI the data disk in the blob storage
+                            type: string
+                          fsType:
+                            description: Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            type: string
+                          kind:
+                            description: 'Expected values Shared: multiple blob disks
+                              per storage account  Dedicated: single blob disk per
+                              storage account  Managed: azure managed data disk (only
+                              in managed availability set). defaults to shared'
+                            type: string
+                          readOnly:
+                            description: Defaults to false (read/write). ReadOnly
+                              here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                        required:
+                        - diskName
+                        - diskURI
+                        type: object
+                      azureFile:
+                        description: AzureFile represents an Azure File Service mount
+                          on the host and bind mount to the pod.
+                        properties:
+                          readOnly:
+                            description: Defaults to false (read/write). ReadOnly
+                              here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          secretName:
+                            description: the name of secret that contains Azure Storage
+                              Account Name and Key
+                            type: string
+                          secretNamespace:
+                            description: the namespace of the secret that contains
+                              Azure Storage Account Name and Key default is the same
+                              as the Pod
+                            type: string
+                          shareName:
+                            description: Share Name
+                            type: string
+                        required:
+                        - secretName
+                        - shareName
+                        type: object
+                      capacity:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'A description of the persistent volume''s resources
+                          and capacity. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#capacity'
+                        type: object
+                      cephfs:
+                        description: CephFS represents a Ceph FS mount on the host
+                          that shares a pod's lifetime
+                        properties:
+                          monitors:
+                            description: 'Required: Monitors is a collection of Ceph
+                              monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            items:
+                              type: string
+                            type: array
+                          path:
+                            description: 'Optional: Used as the mounted root, rather
+                              than the full Ceph tree, default is /'
+                            type: string
+                          readOnly:
+                            description: 'Optional: Defaults to false (read/write).
+                              ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            type: boolean
+                          secretFile:
+                            description: 'Optional: SecretFile is the path to key
+                              ring for User, default is /etc/ceph/user.secret More
+                              info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            type: string
+                          secretRef:
+                            description: 'Optional: SecretRef is reference to the
+                              authentication secret for User, default is empty. More
+                              info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            properties:
+                              name:
+                                description: Name is unique within a namespace to
+                                  reference a secret resource.
+                                type: string
+                              namespace:
+                                description: Namespace defines the space within which
+                                  the secret name must be unique.
+                                type: string
+                            type: object
+                          user:
+                            description: 'Optional: User is the rados user name, default
+                              is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            type: string
+                        required:
+                        - monitors
+                        type: object
+                      cinder:
+                        description: 'Cinder represents a cinder volume attached and
+                          mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        properties:
+                          fsType:
+                            description: 'Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Examples:
+                              "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                              if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                            type: string
+                          readOnly:
+                            description: 'Optional: Defaults to false (read/write).
+                              ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                            type: boolean
+                          secretRef:
+                            description: 'Optional: points to a secret object containing
+                              parameters used to connect to OpenStack.'
+                            properties:
+                              name:
+                                description: Name is unique within a namespace to
+                                  reference a secret resource.
+                                type: string
+                              namespace:
+                                description: Namespace defines the space within which
+                                  the secret name must be unique.
+                                type: string
+                            type: object
+                          volumeID:
+                            description: 'volume id used to identify the volume in
+                              cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      claimRef:
+                        description: 'ClaimRef is part of a bi-directional binding
+                          between PersistentVolume and PersistentVolumeClaim. Expected
+                          to be non-nil when bound. claim.VolumeName is the authoritative
+                          bind between PV and PVC. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#binding'
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object. TODO: this design
+                              is not final and this field is subject to change in
+                              the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                      csi:
+                        description: CSI represents storage that is handled by an
+                          external CSI driver (Beta feature).
+                        properties:
+                          controllerExpandSecretRef:
+                            description: ControllerExpandSecretRef is a reference
+                              to the secret object containing sensitive information
+                              to pass to the CSI driver to complete the CSI ControllerExpandVolume
+                              call. This is an alpha field and requires enabling ExpandCSIVolumes
+                              feature gate. This field is optional, and may be empty
+                              if no secret is required. If the secret object contains
+                              more than one secret, all secrets are passed.
+                            properties:
+                              name:
+                                description: Name is unique within a namespace to
+                                  reference a secret resource.
+                                type: string
+                              namespace:
+                                description: Namespace defines the space within which
+                                  the secret name must be unique.
+                                type: string
+                            type: object
+                          controllerPublishSecretRef:
+                            description: ControllerPublishSecretRef is a reference
+                              to the secret object containing sensitive information
+                              to pass to the CSI driver to complete the CSI ControllerPublishVolume
+                              and ControllerUnpublishVolume calls. This field is optional,
+                              and may be empty if no secret is required. If the secret
+                              object contains more than one secret, all secrets are
+                              passed.
+                            properties:
+                              name:
+                                description: Name is unique within a namespace to
+                                  reference a secret resource.
+                                type: string
+                              namespace:
+                                description: Namespace defines the space within which
+                                  the secret name must be unique.
+                                type: string
+                            type: object
+                          driver:
+                            description: Driver is the name of the driver to use for
+                              this volume. Required.
+                            type: string
+                          fsType:
+                            description: Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs".
+                            type: string
+                          nodePublishSecretRef:
+                            description: NodePublishSecretRef is a reference to the
+                              secret object containing sensitive information to pass
+                              to the CSI driver to complete the CSI NodePublishVolume
+                              and NodeUnpublishVolume calls. This field is optional,
+                              and may be empty if no secret is required. If the secret
+                              object contains more than one secret, all secrets are
+                              passed.
+                            properties:
+                              name:
+                                description: Name is unique within a namespace to
+                                  reference a secret resource.
+                                type: string
+                              namespace:
+                                description: Namespace defines the space within which
+                                  the secret name must be unique.
+                                type: string
+                            type: object
+                          nodeStageSecretRef:
+                            description: NodeStageSecretRef is a reference to the
+                              secret object containing sensitive information to pass
+                              to the CSI driver to complete the CSI NodeStageVolume
+                              and NodeStageVolume and NodeUnstageVolume calls. This
+                              field is optional, and may be empty if no secret is
+                              required. If the secret object contains more than one
+                              secret, all secrets are passed.
+                            properties:
+                              name:
+                                description: Name is unique within a namespace to
+                                  reference a secret resource.
+                                type: string
+                              namespace:
+                                description: Namespace defines the space within which
+                                  the secret name must be unique.
+                                type: string
+                            type: object
+                          readOnly:
+                            description: 'Optional: The value to pass to ControllerPublishVolumeRequest.
+                              Defaults to false (read/write).'
+                            type: boolean
+                          volumeAttributes:
+                            additionalProperties:
+                              type: string
+                            description: Attributes of the volume to publish.
+                            type: object
+                          volumeHandle:
+                            description: VolumeHandle is the unique volume name returned
+                              by the CSI volume plugin’s CreateVolume to refer to
+                              the volume on all subsequent calls. Required.
+                            type: string
+                        required:
+                        - driver
+                        - volumeHandle
+                        type: object
+                      fc:
+                        description: FC represents a Fibre Channel resource that is
+                          attached to a kubelet's host machine and then exposed to
+                          the pod.
+                        properties:
+                          fsType:
+                            description: 'Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              TODO: how do we prevent errors in the filesystem from
+                              compromising the machine'
+                            type: string
+                          lun:
+                            description: 'Optional: FC target lun number'
+                            format: int32
+                            type: integer
+                          readOnly:
+                            description: 'Optional: Defaults to false (read/write).
+                              ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                            type: boolean
+                          targetWWNs:
+                            description: 'Optional: FC target worldwide names (WWNs)'
+                            items:
+                              type: string
+                            type: array
+                          wwids:
+                            description: 'Optional: FC volume world wide identifiers
+                              (wwids) Either wwids or combination of targetWWNs and
+                              lun must be set, but not both simultaneously.'
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      flexVolume:
+                        description: FlexVolume represents a generic volume resource
+                          that is provisioned/attached using an exec based plugin.
+                        properties:
+                          driver:
+                            description: Driver is the name of the driver to use for
+                              this volume.
+                            type: string
+                          fsType:
+                            description: Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs". The default filesystem depends on FlexVolume
+                              script.
+                            type: string
+                          options:
+                            additionalProperties:
+                              type: string
+                            description: 'Optional: Extra command options if any.'
+                            type: object
+                          readOnly:
+                            description: 'Optional: Defaults to false (read/write).
+                              ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                            type: boolean
+                          secretRef:
+                            description: 'Optional: SecretRef is reference to the
+                              secret object containing sensitive information to pass
+                              to the plugin scripts. This may be empty if no secret
+                              object is specified. If the secret object contains more
+                              than one secret, all secrets are passed to the plugin
+                              scripts.'
+                            properties:
+                              name:
+                                description: Name is unique within a namespace to
+                                  reference a secret resource.
+                                type: string
+                              namespace:
+                                description: Namespace defines the space within which
+                                  the secret name must be unique.
+                                type: string
+                            type: object
+                        required:
+                        - driver
+                        type: object
+                      flocker:
+                        description: Flocker represents a Flocker volume attached
+                          to a kubelet's host machine and exposed to the pod for its
+                          usage. This depends on the Flocker control service being
+                          running
+                        properties:
+                          datasetName:
+                            description: Name of the dataset stored as metadata ->
+                              name on the dataset for Flocker should be considered
+                              as deprecated
+                            type: string
+                          datasetUUID:
+                            description: UUID of the dataset. This is unique identifier
+                              of a Flocker dataset
+                            type: string
+                        type: object
+                      gcePersistentDisk:
+                        description: 'GCEPersistentDisk represents a GCE Disk resource
+                          that is attached to a kubelet''s host machine and then exposed
+                          to the pod. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        properties:
+                          fsType:
+                            description: 'Filesystem type of the volume that you want
+                              to mount. Tip: Ensure that the filesystem type is supported
+                              by the host operating system. Examples: "ext4", "xfs",
+                              "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                              TODO: how do we prevent errors in the filesystem from
+                              compromising the machine'
+                            type: string
+                          partition:
+                            description: 'The partition in the volume that you want
+                              to mount. If omitted, the default is to mount by volume
+                              name. Examples: For volume /dev/sda1, you specify the
+                              partition as "1". Similarly, the volume partition for
+                              /dev/sda is "0" (or you can leave the property empty).
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            format: int32
+                            type: integer
+                          pdName:
+                            description: 'Unique name of the PD resource in GCE. Used
+                              to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            type: string
+                          readOnly:
+                            description: 'ReadOnly here will force the ReadOnly setting
+                              in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            type: boolean
+                        required:
+                        - pdName
+                        type: object
+                      glusterfs:
+                        description: 'Glusterfs represents a Glusterfs volume that
+                          is attached to a host and exposed to the pod. Provisioned
+                          by an admin. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                        properties:
+                          endpoints:
+                            description: 'EndpointsName is the endpoint name that
+                              details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                            type: string
+                          endpointsNamespace:
+                            description: 'EndpointsNamespace is the namespace that
+                              contains Glusterfs endpoint. If this field is empty,
+                              the EndpointNamespace defaults to the same namespace
+                              as the bound PVC. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                            type: string
+                          path:
+                            description: 'Path is the Glusterfs volume path. More
+                              info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                            type: string
+                          readOnly:
+                            description: 'ReadOnly here will force the Glusterfs volume
+                              to be mounted with read-only permissions. Defaults to
+                              false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                            type: boolean
+                        required:
+                        - endpoints
+                        - path
+                        type: object
+                      hostPath:
+                        description: 'HostPath represents a directory on the host.
+                          Provisioned by a developer or tester. This is useful for
+                          single-node development and testing only! On-host storage
+                          is not supported in any way and WILL NOT WORK in a multi-node
+                          cluster. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        properties:
+                          path:
+                            description: 'Path of the directory on the host. If the
+                              path is a symlink, it will follow the link to the real
+                              path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                            type: string
+                          type:
+                            description: 'Type for HostPath Volume Defaults to ""
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                            type: string
+                        required:
+                        - path
+                        type: object
+                      iscsi:
+                        description: ISCSI represents an ISCSI Disk resource that
+                          is attached to a kubelet's host machine and then exposed
+                          to the pod. Provisioned by an admin.
+                        properties:
+                          chapAuthDiscovery:
+                            description: whether support iSCSI Discovery CHAP authentication
+                            type: boolean
+                          chapAuthSession:
+                            description: whether support iSCSI Session CHAP authentication
+                            type: boolean
+                          fsType:
+                            description: 'Filesystem type of the volume that you want
+                              to mount. Tip: Ensure that the filesystem type is supported
+                              by the host operating system. Examples: "ext4", "xfs",
+                              "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                              TODO: how do we prevent errors in the filesystem from
+                              compromising the machine'
+                            type: string
+                          initiatorName:
+                            description: Custom iSCSI Initiator Name. If initiatorName
+                              is specified with iscsiInterface simultaneously, new
+                              iSCSI interface <target portal>:<volume name> will be
+                              created for the connection.
+                            type: string
+                          iqn:
+                            description: Target iSCSI Qualified Name.
+                            type: string
+                          iscsiInterface:
+                            description: iSCSI Interface Name that uses an iSCSI transport.
+                              Defaults to 'default' (tcp).
+                            type: string
+                          lun:
+                            description: iSCSI Target Lun number.
+                            format: int32
+                            type: integer
+                          portals:
+                            description: iSCSI Target Portal List. The Portal is either
+                              an IP or ip_addr:port if the port is other than default
+                              (typically TCP ports 860 and 3260).
+                            items:
+                              type: string
+                            type: array
+                          readOnly:
+                            description: ReadOnly here will force the ReadOnly setting
+                              in VolumeMounts. Defaults to false.
+                            type: boolean
+                          secretRef:
+                            description: CHAP Secret for iSCSI target and initiator
+                              authentication
+                            properties:
+                              name:
+                                description: Name is unique within a namespace to
+                                  reference a secret resource.
+                                type: string
+                              namespace:
+                                description: Namespace defines the space within which
+                                  the secret name must be unique.
+                                type: string
+                            type: object
+                          targetPortal:
+                            description: iSCSI Target Portal. The Portal is either
+                              an IP or ip_addr:port if the port is other than default
+                              (typically TCP ports 860 and 3260).
+                            type: string
+                        required:
+                        - iqn
+                        - lun
+                        - targetPortal
+                        type: object
+                      local:
+                        description: Local represents directly-attached storage with
+                          node affinity
+                        properties:
+                          fsType:
+                            description: Filesystem type to mount. It applies only
+                              when the Path is a block device. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs". The default value is to auto-select a
+                              fileystem if unspecified.
+                            type: string
+                          path:
+                            description: The full path to the volume on the node.
+                              It can be either a directory or block device (disk,
+                              partition, ...).
+                            type: string
+                        required:
+                        - path
+                        type: object
+                      mountOptions:
+                        description: 'A list of mount options, e.g. ["ro", "soft"].
+                          Not validated - mount will simply fail if one is invalid.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#mount-options'
+                        items:
+                          type: string
+                        type: array
+                      nfs:
+                        description: 'NFS represents an NFS mount on the host. Provisioned
+                          by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        properties:
+                          path:
+                            description: 'Path that is exported by the NFS server.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            type: string
+                          readOnly:
+                            description: 'ReadOnly here will force the NFS export
+                              to be mounted with read-only permissions. Defaults to
+                              false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            type: boolean
+                          server:
+                            description: 'Server is the hostname or IP address of
+                              the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            type: string
+                        required:
+                        - path
+                        - server
+                        type: object
+                      nodeAffinity:
+                        description: NodeAffinity defines constraints that limit what
+                          nodes this volume can be accessed from. This field influences
+                          the scheduling of pods that use this volume.
+                        properties:
+                          required:
+                            description: Required specifies hard node constraints
+                              that must be met.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term
+                                    matches no objects. The requirements of them are
+                                    ANDed. The TopologySelectorTerm type implements
+                                    a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      persistentVolumeReclaimPolicy:
+                        description: 'What happens to a persistent volume when released
+                          from its claim. Valid options are Retain (default for manually
+                          created PersistentVolumes), Delete (default for dynamically
+                          provisioned PersistentVolumes), and Recycle (deprecated).
+                          Recycle must be supported by the volume plugin underlying
+                          this PersistentVolume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#reclaiming'
+                        type: string
+                      photonPersistentDisk:
+                        description: PhotonPersistentDisk represents a PhotonController
+                          persistent disk attached and mounted on kubelets host machine
+                        properties:
+                          fsType:
+                            description: Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            type: string
+                          pdID:
+                            description: ID that identifies Photon Controller persistent
+                              disk
+                            type: string
+                        required:
+                        - pdID
+                        type: object
+                      portworxVolume:
+                        description: PortworxVolume represents a portworx volume attached
+                          and mounted on kubelets host machine
+                        properties:
+                          fsType:
+                            description: FSType represents the filesystem type to
+                              mount Must be a filesystem type supported by the host
+                              operating system. Ex. "ext4", "xfs". Implicitly inferred
+                              to be "ext4" if unspecified.
+                            type: string
+                          readOnly:
+                            description: Defaults to false (read/write). ReadOnly
+                              here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          volumeID:
+                            description: VolumeID uniquely identifies a Portworx volume
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      quobyte:
+                        description: Quobyte represents a Quobyte mount on the host
+                          that shares a pod's lifetime
+                        properties:
+                          group:
+                            description: Group to map volume access to Default is
+                              no group
+                            type: string
+                          readOnly:
+                            description: ReadOnly here will force the Quobyte volume
+                              to be mounted with read-only permissions. Defaults to
+                              false.
+                            type: boolean
+                          registry:
+                            description: Registry represents a single or multiple
+                              Quobyte Registry services specified as a string as host:port
+                              pair (multiple entries are separated with commas) which
+                              acts as the central registry for volumes
+                            type: string
+                          tenant:
+                            description: Tenant owning the given Quobyte volume in
+                              the Backend Used with dynamically provisioned Quobyte
+                              volumes, value is set by the plugin
+                            type: string
+                          user:
+                            description: User to map volume access to Defaults to
+                              serivceaccount user
+                            type: string
+                          volume:
+                            description: Volume is a string that references an already
+                              created Quobyte volume by name.
+                            type: string
+                        required:
+                        - registry
+                        - volume
+                        type: object
+                      rbd:
+                        description: 'RBD represents a Rados Block Device mount on
+                          the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                        properties:
+                          fsType:
+                            description: 'Filesystem type of the volume that you want
+                              to mount. Tip: Ensure that the filesystem type is supported
+                              by the host operating system. Examples: "ext4", "xfs",
+                              "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                              TODO: how do we prevent errors in the filesystem from
+                              compromising the machine'
+                            type: string
+                          image:
+                            description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                          keyring:
+                            description: 'Keyring is the path to key ring for RBDUser.
+                              Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                          monitors:
+                            description: 'A collection of Ceph monitors. More info:
+                              https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            items:
+                              type: string
+                            type: array
+                          pool:
+                            description: 'The rados pool name. Default is rbd. More
+                              info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                          readOnly:
+                            description: 'ReadOnly here will force the ReadOnly setting
+                              in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            type: boolean
+                          secretRef:
+                            description: 'SecretRef is name of the authentication
+                              secret for RBDUser. If provided overrides keyring. Default
+                              is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            properties:
+                              name:
+                                description: Name is unique within a namespace to
+                                  reference a secret resource.
+                                type: string
+                              namespace:
+                                description: Namespace defines the space within which
+                                  the secret name must be unique.
+                                type: string
+                            type: object
+                          user:
+                            description: 'The rados user name. Default is admin. More
+                              info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                        required:
+                        - image
+                        - monitors
+                        type: object
+                      scaleIO:
+                        description: ScaleIO represents a ScaleIO persistent volume
+                          attached and mounted on Kubernetes nodes.
+                        properties:
+                          fsType:
+                            description: Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs". Default is "xfs"
+                            type: string
+                          gateway:
+                            description: The host address of the ScaleIO API Gateway.
+                            type: string
+                          protectionDomain:
+                            description: The name of the ScaleIO Protection Domain
+                              for the configured storage.
+                            type: string
+                          readOnly:
+                            description: Defaults to false (read/write). ReadOnly
+                              here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          secretRef:
+                            description: SecretRef references to the secret for ScaleIO
+                              user and other sensitive information. If this is not
+                              provided, Login operation will fail.
+                            properties:
+                              name:
+                                description: Name is unique within a namespace to
+                                  reference a secret resource.
+                                type: string
+                              namespace:
+                                description: Namespace defines the space within which
+                                  the secret name must be unique.
+                                type: string
+                            type: object
+                          sslEnabled:
+                            description: Flag to enable/disable SSL communication
+                              with Gateway, default false
+                            type: boolean
+                          storageMode:
+                            description: Indicates whether the storage for a volume
+                              should be ThickProvisioned or ThinProvisioned. Default
+                              is ThinProvisioned.
+                            type: string
+                          storagePool:
+                            description: The ScaleIO Storage Pool associated with
+                              the protection domain.
+                            type: string
+                          system:
+                            description: The name of the storage system as configured
+                              in ScaleIO.
+                            type: string
+                          volumeName:
+                            description: The name of a volume already created in the
+                              ScaleIO system that is associated with this volume source.
+                            type: string
+                        required:
+                        - gateway
+                        - secretRef
+                        - system
+                        type: object
+                      storageClassName:
+                        description: Name of StorageClass to which this persistent
+                          volume belongs. Empty value means that this volume does
+                          not belong to any StorageClass.
+                        type: string
+                      storageos:
+                        description: 'StorageOS represents a StorageOS volume that
+                          is attached to the kubelet''s host machine and mounted into
+                          the pod More info: https://examples.k8s.io/volumes/storageos/README.md'
+                        properties:
+                          fsType:
+                            description: Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            type: string
+                          readOnly:
+                            description: Defaults to false (read/write). ReadOnly
+                              here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          secretRef:
+                            description: SecretRef specifies the secret to use for
+                              obtaining the StorageOS API credentials.  If not specified,
+                              default values will be attempted.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object
+                                  instead of an entire object, this string should
+                                  contain a valid JSON/Go field access statement,
+                                  such as desiredState.manifest.containers[2]. For
+                                  example, if the object reference is to a container
+                                  within a pod, this would take on a value like: "spec.containers{name}"
+                                  (where "name" refers to the name of the container
+                                  that triggered the event) or if no container name
+                                  is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only
+                                  to have some well-defined way of referencing a part
+                                  of an object. TODO: this design is not final and
+                                  this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info:
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this
+                                  reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                          volumeName:
+                            description: VolumeName is the human-readable name of
+                              the StorageOS volume.  Volume names are only unique
+                              within a namespace.
+                            type: string
+                          volumeNamespace:
+                            description: VolumeNamespace specifies the scope of the
+                              volume within StorageOS.  If no namespace is specified
+                              then the Pod's namespace will be used.  This allows
+                              the Kubernetes name scoping to be mirrored within StorageOS
+                              for tighter integration. Set VolumeName to any name
+                              to override the default behaviour. Set to "default"
+                              if you are not using namespaces within StorageOS. Namespaces
+                              that do not pre-exist within StorageOS will be created.
+                            type: string
+                        type: object
+                      volumeMode:
+                        description: volumeMode defines if a volume is intended to
+                          be used with a formatted filesystem or to remain in raw
+                          block state. Value of Filesystem is implied when not included
+                          in spec. This is a beta feature.
+                        type: string
+                      vsphereVolume:
+                        description: VsphereVolume represents a vSphere volume attached
+                          and mounted on kubelets host machine
+                        properties:
+                          fsType:
+                            description: Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            type: string
+                          storagePolicyID:
+                            description: Storage Policy Based Management (SPBM) profile
+                              ID associated with the StoragePolicyName.
+                            type: string
+                          storagePolicyName:
+                            description: Storage Policy Based Management (SPBM) profile
+                              name.
+                            type: string
+                          volumePath:
+                            description: Path that identifies vSphere volume vmdk
+                            type: string
+                        required:
+                        - volumePath
+                        type: object
+                    type: object
+                type: object
+            required:
+            - nodeName
+            - storageClassName
+            type: object
+          status:
+            description: VolumeStatus defines the observed state of Volume
+            properties:
+              conditions:
+                description: List of conditions through which the Volume has or has
+                  not passed.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transited from one status
+                        to another (optional).
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: Last time the condition was updated (optional).
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      enum:
+                      - Pending
+                      - Terminating
+                      - InternalError
+                      - CreationError
+                      - DestructionError
+                      - UnavailableError
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: Type of volume condition.
+                      enum:
+                      - Ready
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              deviceName:
+                description: Name of the underlying block device.
+                type: string
+              job:
+                description: Job in progress
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/storage-operator/pkg/apis/storage/v1alpha1/volume_types.go
+++ b/storage-operator/pkg/apis/storage/v1alpha1/volume_types.go
@@ -66,9 +66,11 @@ type VolumeSpec struct {
 }
 
 // Describes the PersistentVolume that will be created to back the Volume.
+// +k8s:openapi-gen=true
 type PersistentVolumeTemplateSpec struct {
 	// Standard object's metadata.
 	// +optional
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Metadata metav1.ObjectMeta `json:"metadata,omitempty"`
 	// Specification of the Persistent Volume.
 	// +optional


### PR DESCRIPTION
Since "v1beta1" of CRD is deprecated (and removed in Kubernetes 1.22)
let's generate Volume CRD using "v1"

NOTE: Since fields are pruned with this CRD version we need to disable
pruning on `.spec.template.metadata` since `operator-sdk` generate this
one with no properties

See: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#field-pruning