### PR TITLE
salt: Use  `v1` APIVersion instead of `v1beta1` for `Ingress` objects

### DIFF
--- a/charts/dex.yaml
+++ b/charts/dex.yaml
@@ -27,12 +27,13 @@ service:
 
 ingress:
   enabled: true
+  className: "nginx-control-plane"
   annotations:
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-    kubernetes.io/ingress.class: "nginx-control-plane"
   hosts:
     - paths:
       - path: /oidc
+        pathType: Prefix
 
 volumes:
   - name: https-tls

--- a/charts/kube-prometheus-stack.yaml
+++ b/charts/kube-prometheus-stack.yaml
@@ -168,8 +168,8 @@ grafana:
 
   ingress:
     enabled: true
+    ingressClassName: nginx-control-plane
     annotations:
-      kubernetes.io/ingress.class: nginx-control-plane
       nginx.ingress.kubernetes.io/rewrite-target: /$2
     path: /grafana(/|$)(.*)
     hosts:

--- a/charts/render.py
+++ b/charts/render.py
@@ -328,6 +328,13 @@ def main():
     parser.add_argument("path", help="Path to the chart directory")
     args = parser.parse_args()
 
+    api_versions = [
+        # Used by APIService (available since Kubernetes 1.10)
+        "apiregistration.k8s.io/v1",
+        # Available since Kubernetes 1.19
+        "networking.k8s.io/v1/Ingress",
+    ]
+
     command = [
         "helm",
         "template",
@@ -337,12 +344,11 @@ def main():
         "--values",
         args.values,
         "--include-crds",
-        "--api-versions",
-        # Used by APIService (available since Kubernetes 1.10)
-        "apiregistration.k8s.io/v1",
         args.path,
     ]
 
+    for api in api_versions:
+        command.extend(["--api-versions", api])
     if args.kube_version:
         command.extend(["--kube-version", args.kube_version])
 

--- a/salt/metalk8s/addons/dex/deployed/chart.sls
+++ b/salt/metalk8s/addons/dex/deployed/chart.sls
@@ -85,15 +85,18 @@ metadata:
 spec:
   clusterIP: {% endraw -%}{{ salt.metalk8s_network.get_oidc_service_ip() }}{%- raw %}
   ports:
-  - name: http
+  - appProtocol: http
+    name: http
     port: 5556
     protocol: TCP
     targetPort: http
-  - name: https
+  - appProtocol: https
+    name: https
     port: 5554
     protocol: TCP
     targetPort: https
-  - name: telemetry
+  - appProtocol: http
+    name: telemetry
     port: 5558
     protocol: TCP
     targetPort: telemetry
@@ -204,11 +207,10 @@ spec:
           name: nginx-ingress-ca-cert
         name: nginx-ingress-ca-cert
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: nginx-control-plane
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
   labels:
     app.kubernetes.io/instance: dex
@@ -221,13 +223,17 @@ metadata:
   name: dex
   namespace: metalk8s-auth
 spec:
+  ingressClassName: nginx-control-plane
   rules:
   - host: null
     http:
       paths:
       - backend:
-          serviceName: dex
-          servicePort: 5554
+          service:
+            name: dex
+            port:
+              number: 5554
         path: /oidc
+        pathType: Prefix
 
 {% endraw %}

--- a/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
@@ -57731,11 +57731,10 @@ spec:
         key: node-role.kubernetes.io/infra
         operator: Exists
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: nginx-control-plane
     nginx.ingress.kubernetes.io/rewrite-target: /$2
   labels:
     app.kubernetes.io/instance: prometheus-operator
@@ -57748,14 +57747,18 @@ metadata:
   name: prometheus-operator-grafana
   namespace: metalk8s-monitoring
 spec:
+  ingressClassName: nginx-control-plane
   rules:
   - host: null
     http:
       paths:
       - backend:
-          serviceName: prometheus-operator-grafana
-          servicePort: 80
+          service:
+            name: prometheus-operator-grafana
+            port:
+              number: 80
         path: /grafana(/|$)(.*)
+        pathType: Prefix
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: Alertmanager

--- a/salt/metalk8s/addons/ui/deployed/ingress.sls
+++ b/salt/metalk8s/addons/ui/deployed/ingress.sls
@@ -13,7 +13,7 @@
 {%- set stripped_base_path = metalk8s_ui_config.spec.basePath.strip('/') %}
 {%- set normalized_base_path = '/' ~ stripped_base_path %}
 
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: metalk8s-ui-proxies-https
@@ -28,21 +28,27 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: '/$2'
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-    kubernetes.io/ingress.class: "nginx-control-plane"
 spec:
+  ingressClassName: "nginx-control-plane"
   rules:
   - http:
       paths:
       - path: /api/kubernetes(/|$)(.*)
+        pathType: Prefix
         backend:
-          serviceName: kubernetes-api
-          servicePort: 443
+          service:
+            name: kubernetes-api
+            port:
+              number: 443
       - path: /api/salt(/|$)(.*)
+        pathType: Prefix
         backend:
-          serviceName: salt-api
-          servicePort: 4507
+          service:
+            name: salt-api
+            port:
+              number: 4507
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: metalk8s-ui-proxies-http
@@ -54,30 +60,39 @@ metadata:
     app.kubernetes.io/part-of: metalk8s
     heritage: metalk8s
   annotations:
-    kubernetes.io/ingress.class: "nginx-control-plane"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
     nginx.ingress.kubernetes.io/cors-allow-headers: "Access-Control-Allow-Origin"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/rewrite-target: '/$2'
     nginx.ingress.kubernetes.io/use-regex: "true"
 spec:
+  ingressClassName: "nginx-control-plane"
   rules:
   - http:
       paths:
       - path: /api/prometheus(/|$)(.*)
+        pathType: Prefix
         backend:
-          serviceName: prometheus-api
-          servicePort: 9090
+          service:
+            name: prometheus-api
+            port:
+              number: 9090
       - path: /api/alertmanager(/|$)(.*)
+        pathType: Prefix
         backend:
-          serviceName: alertmanager-api
-          servicePort: 9093
+          service:
+            name: alertmanager-api
+            port:
+              number: 9093
       - path: /api/loki(/|$)(.*)
+        pathType: Prefix
         backend:
-          serviceName: loki-api
-          servicePort: 3100
+          service:
+            name: loki-api
+            port:
+              number: 3100
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: metalk8s-ui
@@ -90,9 +105,9 @@ metadata:
     heritage: metalk8s
   annotations:
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
-    kubernetes.io/ingress.class: "nginx-control-plane"
     nginx.ingress.kubernetes.io/rewrite-target: /$1
 spec:
+  ingressClassName: "nginx-control-plane"
   rules:
   - http:
       paths:
@@ -107,16 +122,18 @@ spec:
     "/(" + stripped_base_path + ".*)",
 ] %}
       - path: {{ path }}
+        pathType: Prefix
         backend:
-          serviceName: metalk8s-ui
-          servicePort: 80
+          service:
+            name: metalk8s-ui
+            port:
+              number: 80
 {% endfor %}
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: nginx-control-plane
     nginx.ingress.kubernetes.io/backend-protocol: HTTP
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/rewrite-target: '/docs/$2'
@@ -129,10 +146,14 @@ metadata:
   name: metalk8s-docs
   namespace: metalk8s-ui
 spec:
+  ingressClassName: "nginx-control-plane"
   rules:
   - http:
       paths:
       - path: /docs/{{ stripped_base_path }}(/|$)(.*)
+        pathType: Prefix
         backend:
-          serviceName: metalk8s-ui
-          servicePort: 80
+          service:
+            name: metalk8s-ui
+            port:
+              number: 80


### PR DESCRIPTION
Since `apiVersion` `networking.k8s.io/v1beta1` for Ingress object is deprecated and removed in Kubernetes 1.22 migrate all Ingress object to `networking.k8s.io/v1`