### PR TITLE
charts,salt,build: Bump NGINX Ingress chart to v4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # CHANGELOG
 ## Release 2.11.0 (in development)
 ### Enhancements
+
 - Bump `containerd` version to 1.4.8 (PR [#3466](https://github.com/scality/metalk8s/pull/3466)).
+
+- Bump ingress-nginx chart version to 4.0.1
+  nginx-ingress-controller image has been bumped accordingly to v1.0.0
+  (PR[#3518](https://github.com/scality/metalk8s/pull/3518))
 
 - [#3487](https://github.com/scality/metalk8s/issues/3487) - Make Salt
   Kubernetes execution module more flexible relying on `DynamicClient`

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -162,8 +162,8 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     ),
     Image(
         name="nginx-ingress-controller",
-        version="v0.47.0",
-        digest="sha256:a1e4efc107be0bb78f32eaec37bef17d7a0c81bec8066cdf2572508d21351d0b",
+        version="v1.0.0",
+        digest="sha256:0851b34f69f69352bf168e6ccf30e1e20714a264ab1ecd1933e4d8c0fc3215c6",
     ),
     Image(
         name="nginx-ingress-defaultbackend-amd64",

--- a/charts/ingress-nginx-control-plane-daemonset.yaml
+++ b/charts/ingress-nginx-control-plane-daemonset.yaml
@@ -7,7 +7,9 @@ controller:
 
   electionID: ingress-control-plane-controller-leader
 
-  ingressClass: nginx-control-plane
+  ingressClassResource:
+    name: nginx-control-plane
+    controllerValue: "k8s.io/ingress-nginx-control-plane"
 
   admissionWebhooks:
     enabled: false

--- a/charts/ingress-nginx-control-plane-deployment.yaml
+++ b/charts/ingress-nginx-control-plane-deployment.yaml
@@ -7,7 +7,9 @@ controller:
 
   electionID: ingress-control-plane-controller-leader
 
-  ingressClass: nginx-control-plane
+  ingressClassResource:
+    name: nginx-control-plane
+    controllerValue: "k8s.io/ingress-nginx-control-plane"
 
   admissionWebhooks:
     enabled: false

--- a/charts/ingress-nginx.yaml
+++ b/charts/ingress-nginx.yaml
@@ -6,6 +6,9 @@ controller:
   hostPort:
     enabled: true
 
+  ingressClassResource:
+    default: true
+
   admissionWebhooks:
     enabled: false
 

--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -1,19 +1,22 @@
 annotations:
   artifacthub.io/changes: |
-    - Add namespace field in the namespace scoped resource templates
+    - Support for Ingress object v1 and drop support for v1beta1
+    - Update to go 1.17
+    - Fix some bugs
+  artifacthub.io/prerelease: "false"
 apiVersion: v2
-appVersion: 0.47.0
+appVersion: 1.0.0
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer
 home: https://github.com/kubernetes/ingress-nginx
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
 keywords:
 - ingress
 - nginx
-kubeVersion: '>=1.16.0-0'
+kubeVersion: '>=1.19.0-0'
 maintainers:
 - name: ChiefAlexander
 name: ingress-nginx
 sources:
 - https://github.com/kubernetes/ingress-nginx
 type: application
-version: 3.34.0
+version: 4.0.1

--- a/charts/ingress-nginx/OWNERS
+++ b/charts/ingress-nginx/OWNERS
@@ -1,5 +1,10 @@
+# See the OWNERS docs: https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
+
 approvers:
-  - ChiefAlexander
+- ingress-nginx-helm-maintainers
 
 reviewers:
-  - ChiefAlexander
+- ingress-nginx-helm-reviewers
+
+labels:
+- area/helm

--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -90,9 +90,9 @@ You can add Prometheus annotations to the metrics service using `controller.metr
 
 Previous versions of this chart had a `controller.stats.*` configuration block, which is now obsolete due to the following changes in nginx ingress controller:
 
-- In [0.16.1](https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0161), the vts (virtual host traffic status) dashboard was removed
-- In [0.23.0](https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0230), the status page at port 18080 is now a unix socket webserver only available at localhost.
-  You can use `curl --unix-socket /tmp/nginx-status-server.sock http://localhost/nginx_status` inside the controller container to access it locally, or use the snippet from [nginx-ingress changelog](https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0230) to re-enable the http server
+- In [0.16.1](https://github.com/kubernetes/ingress-nginx/blob/main/Changelog.md#0161), the vts (virtual host traffic status) dashboard was removed
+- In [0.23.0](https://github.com/kubernetes/ingress-nginx/blob/main/Changelog.md#0230), the status page at port 18080 is now a unix socket webserver only available at localhost.
+  You can use `curl --unix-socket /tmp/nginx-status-server.sock http://localhost/nginx_status` inside the controller container to access it locally, or use the snippet from [nginx-ingress changelog](https://github.com/kubernetes/ingress-nginx/blob/main/Changelog.md#0230) to re-enable the http server
 
 ### ExternalDNS Service Configuration
 
@@ -107,7 +107,7 @@ controller:
 
 ### AWS L7 ELB with SSL Termination
 
-Annotate the controller as shown in the [nginx-ingress l7 patch](https://github.com/kubernetes/ingress-nginx/blob/master/deploy/aws/l7/service-l7.yaml):
+Annotate the controller as shown in the [nginx-ingress l7 patch](https://github.com/kubernetes/ingress-nginx/blob/main/deploy/aws/l7/service-l7.yaml):
 
 ```yaml
 controller:
@@ -159,7 +159,7 @@ controller:
       enabled: true
       annotations:
         # Create internal ELB
-        service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+        service.beta.kubernetes.io/aws-load-balancer-internal: "true"
         # Any other annotation can be declared here.
 ```
 

--- a/charts/ingress-nginx/ci/controller-custom-ingressclass-flags.yaml
+++ b/charts/ingress-nginx/ci/controller-custom-ingressclass-flags.yaml
@@ -1,0 +1,7 @@
+controller:
+  watchIngressWithoutClass: true
+  ingressClassResource:
+    name: custom-nginx
+    enabled: true
+    default: true
+    controllerValue: "k8s.io/custom-nginx"

--- a/charts/ingress-nginx/ci/daemonset-customconfig-values.yaml
+++ b/charts/ingress-nginx/ci/daemonset-customconfig-values.yaml
@@ -1,4 +1,8 @@
 controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
   kind: DaemonSet
   admissionWebhooks:
     enabled: false

--- a/charts/ingress-nginx/ci/daemonset-customnodeport-values.yaml
+++ b/charts/ingress-nginx/ci/daemonset-customnodeport-values.yaml
@@ -1,5 +1,9 @@
 controller:
   kind: DaemonSet
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
   admissionWebhooks:
     enabled: false
 

--- a/charts/ingress-nginx/ci/daemonset-headers-values.yaml
+++ b/charts/ingress-nginx/ci/daemonset-headers-values.yaml
@@ -1,5 +1,9 @@
 controller:
   kind: DaemonSet
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
   admissionWebhooks:
     enabled: false
   addHeaders:

--- a/charts/ingress-nginx/ci/daemonset-internal-lb-values.yaml
+++ b/charts/ingress-nginx/ci/daemonset-internal-lb-values.yaml
@@ -1,5 +1,9 @@
 controller:
   kind: DaemonSet
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
   admissionWebhooks:
     enabled: false
   service:
@@ -7,4 +11,4 @@ controller:
     internal:
       enabled: true
       annotations:
-        service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+        service.beta.kubernetes.io/aws-load-balancer-internal: "true"

--- a/charts/ingress-nginx/ci/daemonset-nodeport-values.yaml
+++ b/charts/ingress-nginx/ci/daemonset-nodeport-values.yaml
@@ -1,5 +1,9 @@
 controller:
   kind: DaemonSet
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
   admissionWebhooks:
     enabled: false
   service:

--- a/charts/ingress-nginx/ci/daemonset-podannotations-values.yaml
+++ b/charts/ingress-nginx/ci/daemonset-podannotations-values.yaml
@@ -1,5 +1,9 @@
 controller:
   kind: DaemonSet
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
   admissionWebhooks:
     enabled: false
   metrics:

--- a/charts/ingress-nginx/ci/daemonset-tcp-udp-configMapNamespace-values.yaml
+++ b/charts/ingress-nginx/ci/daemonset-tcp-udp-configMapNamespace-values.yaml
@@ -1,5 +1,9 @@
 controller:
   kind: DaemonSet
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
   admissionWebhooks:
     enabled: false
   service:

--- a/charts/ingress-nginx/ci/daemonset-tcp-udp-values.yaml
+++ b/charts/ingress-nginx/ci/daemonset-tcp-udp-values.yaml
@@ -1,5 +1,9 @@
 controller:
   kind: DaemonSet
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
   admissionWebhooks:
     enabled: false
   service:

--- a/charts/ingress-nginx/ci/daemonset-tcp-values.yaml
+++ b/charts/ingress-nginx/ci/daemonset-tcp-values.yaml
@@ -1,5 +1,9 @@
 controller:
   kind: DaemonSet
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
   admissionWebhooks:
     enabled: false
   service:

--- a/charts/ingress-nginx/ci/deamonset-default-values.yaml
+++ b/charts/ingress-nginx/ci/deamonset-default-values.yaml
@@ -1,5 +1,9 @@
 controller:
   kind: DaemonSet
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
   admissionWebhooks:
     enabled: false
   service:

--- a/charts/ingress-nginx/ci/deamonset-metrics-values.yaml
+++ b/charts/ingress-nginx/ci/deamonset-metrics-values.yaml
@@ -1,5 +1,9 @@
 controller:
   kind: DaemonSet
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
   admissionWebhooks:
     enabled: false
   metrics:

--- a/charts/ingress-nginx/ci/deamonset-psp-values.yaml
+++ b/charts/ingress-nginx/ci/deamonset-psp-values.yaml
@@ -1,5 +1,9 @@
 controller:
   kind: DaemonSet
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
   admissionWebhooks:
     enabled: false
   service:

--- a/charts/ingress-nginx/ci/deamonset-webhook-and-psp-values.yaml
+++ b/charts/ingress-nginx/ci/deamonset-webhook-and-psp-values.yaml
@@ -1,5 +1,9 @@
 controller:
   kind: DaemonSet
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
   admissionWebhooks:
     enabled: true
   service:

--- a/charts/ingress-nginx/ci/deamonset-webhook-values.yaml
+++ b/charts/ingress-nginx/ci/deamonset-webhook-values.yaml
@@ -1,5 +1,9 @@
 controller:
   kind: DaemonSet
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
   admissionWebhooks:
     enabled: true
   service:

--- a/charts/ingress-nginx/ci/deployment-autoscaling-behavior-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-autoscaling-behavior-values.yaml
@@ -1,0 +1,14 @@
+controller:
+  autoscaling:
+    enabled: true
+    behavior:
+      scaleDown:
+        stabilizationWindowSeconds: 300
+        policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 180
+  admissionWebhooks:
+    enabled: false
+  service:
+    type: ClusterIP

--- a/charts/ingress-nginx/ci/deployment-autoscaling-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-autoscaling-values.yaml
@@ -1,4 +1,8 @@
 controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
   autoscaling:
     enabled: true
   admissionWebhooks:

--- a/charts/ingress-nginx/ci/deployment-customconfig-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-customconfig-values.yaml
@@ -1,4 +1,8 @@
 controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
   config:
     use-proxy-protocol: "true"
   admissionWebhooks:

--- a/charts/ingress-nginx/ci/deployment-customnodeport-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-customnodeport-values.yaml
@@ -1,4 +1,8 @@
 controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
   admissionWebhooks:
     enabled: false
   service:

--- a/charts/ingress-nginx/ci/deployment-default-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-default-values.yaml
@@ -1,4 +1,8 @@
 # Left blank to test default values
 controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
   service:
     type: ClusterIP

--- a/charts/ingress-nginx/ci/deployment-headers-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-headers-values.yaml
@@ -1,4 +1,8 @@
 controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
   admissionWebhooks:
     enabled: false
   addHeaders:

--- a/charts/ingress-nginx/ci/deployment-internal-lb-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-internal-lb-values.yaml
@@ -1,4 +1,8 @@
 controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
   admissionWebhooks:
     enabled: false
   service:
@@ -6,4 +10,4 @@ controller:
     internal:
       enabled: true
       annotations:
-        service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+        service.beta.kubernetes.io/aws-load-balancer-internal: "true"

--- a/charts/ingress-nginx/ci/deployment-metrics-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-metrics-values.yaml
@@ -1,4 +1,8 @@
 controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
   admissionWebhooks:
     enabled: false
   metrics:

--- a/charts/ingress-nginx/ci/deployment-nodeport-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-nodeport-values.yaml
@@ -1,4 +1,8 @@
 controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
   admissionWebhooks:
     enabled: false
   service:

--- a/charts/ingress-nginx/ci/deployment-podannotations-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-podannotations-values.yaml
@@ -1,4 +1,8 @@
 controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
   admissionWebhooks:
     enabled: false
   metrics:

--- a/charts/ingress-nginx/ci/deployment-psp-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-psp-values.yaml
@@ -1,4 +1,8 @@
 controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
   service:
     type: ClusterIP
 

--- a/charts/ingress-nginx/ci/deployment-tcp-udp-configMapNamespace-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-tcp-udp-configMapNamespace-values.yaml
@@ -1,4 +1,8 @@
 controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
   admissionWebhooks:
     enabled: false
   service:

--- a/charts/ingress-nginx/ci/deployment-tcp-udp-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-tcp-udp-values.yaml
@@ -1,4 +1,8 @@
 controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
   admissionWebhooks:
     enabled: false
   service:

--- a/charts/ingress-nginx/ci/deployment-tcp-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-tcp-values.yaml
@@ -1,4 +1,8 @@
 controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
   service:
     type: ClusterIP
 

--- a/charts/ingress-nginx/ci/deployment-webhook-and-psp-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-webhook-and-psp-values.yaml
@@ -1,4 +1,8 @@
 controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
   admissionWebhooks:
     enabled: true
   service:

--- a/charts/ingress-nginx/ci/deployment-webhook-resources-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-webhook-resources-values.yaml
@@ -1,0 +1,23 @@
+controller:
+  service:
+    type: ClusterIP
+  admissionWebhooks:
+    enabled: true
+    createSecretJob:
+      resources:
+        limits:
+          cpu: 10m
+          memory: 20Mi
+        requests:
+          cpu: 10m
+          memory: 20Mi
+    patchWebhookJob:
+      resources:
+        limits:
+          cpu: 10m
+          memory: 20Mi
+        requests:
+          cpu: 10m
+          memory: 20Mi
+    patch:
+      enabled: true

--- a/charts/ingress-nginx/ci/deployment-webhook-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-webhook-values.yaml
@@ -1,4 +1,8 @@
 controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
   admissionWebhooks:
     enabled: true
   service:

--- a/charts/ingress-nginx/templates/NOTES.txt
+++ b/charts/ingress-nginx/templates/NOTES.txt
@@ -29,7 +29,7 @@ Get the application URL by running these commands:
 
 An example Ingress that makes use of the controller:
 
-  apiVersion: networking.k8s.io/v1beta1
+  apiVersion: networking.k8s.io/v1
   kind: Ingress
   metadata:
     annotations:

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -47,6 +47,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          {{- if .Values.controller.admissionWebhooks.createSecretJob.resources }}
+          resources: {{ toYaml .Values.controller.admissionWebhooks.createSecretJob.resources | nindent 12 }}
+          {{- end }}
       restartPolicy: OnFailure
       serviceAccountName: {{ include "ingress-nginx.fullname" . }}-admission
     {{- if .Values.controller.admissionWebhooks.patch.nodeSelector }}

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -49,6 +49,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          {{- if .Values.controller.admissionWebhooks.patchWebhookJob.resources }}
+          resources: {{ toYaml .Values.controller.admissionWebhooks.patchWebhookJob.resources | nindent 12 }}
+          {{- end }}
       restartPolicy: OnFailure
       serviceAccountName: {{ include "ingress-nginx.fullname" . }}-admission
     {{- if .Values.controller.admissionWebhooks.patch.nodeSelector }}

--- a/charts/ingress-nginx/templates/admission-webhooks/validating-webhook.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/validating-webhook.yaml
@@ -18,7 +18,7 @@ webhooks:
       - apiGroups:
           - networking.k8s.io
         apiVersions:
-          - v1beta1
+          - v1
         operations:
           - CREATE
           - UPDATE
@@ -28,12 +28,11 @@ webhooks:
     sideEffects: None
     admissionReviewVersions:
       - v1
-      - v1beta1
     clientConfig:
       service:
         namespace: {{ .Release.Namespace | quote }}
         name: {{ include "ingress-nginx.controller.fullname" . }}-admission
-        path: /networking/v1beta1/ingresses
+        path: /networking/v1/ingresses
     {{- if .Values.controller.admissionWebhooks.timeoutSeconds }}
     timeoutSeconds: {{ .Values.controller.admissionWebhooks.timeoutSeconds }}
     {{- end }}

--- a/charts/ingress-nginx/templates/clusterrole.yaml
+++ b/charts/ingress-nginx/templates/clusterrole.yaml
@@ -1,4 +1,10 @@
-{{- if and .Values.rbac.create (not .Values.rbac.scope) -}}
+{{- if .Values.rbac.create }}
+
+{{- if and .Values.rbac.scope (not .Values.controller.scope.enabled) -}}
+  {{ required "Invalid configuration: 'rbac.scope' should be equal to 'controller.scope.enabled' (true/false)." (index (dict) ".") }}
+{{- end }}
+
+{{- if not .Values.rbac.scope -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -42,8 +48,7 @@ rules:
       - list
       - watch
   - apiGroups:
-      - extensions
-      - "networking.k8s.io" # k8s 1.14+
+      - networking.k8s.io
     resources:
       - ingresses
     verbs:
@@ -58,18 +63,19 @@ rules:
       - create
       - patch
   - apiGroups:
-      - extensions
-      - "networking.k8s.io" # k8s 1.14+
+      - networking.k8s.io
     resources:
       - ingresses/status
     verbs:
       - update
   - apiGroups:
-      - "networking.k8s.io" # k8s 1.14+
+      - networking.k8s.io
     resources:
       - ingressclasses
     verbs:
       - get
       - list
       - watch
+{{- end }}
+
 {{- end }}

--- a/charts/ingress-nginx/templates/controller-daemonset.yaml
+++ b/charts/ingress-nginx/templates/controller-daemonset.yaml
@@ -42,6 +42,9 @@ spec:
     {{- if .Values.controller.dnsConfig }}
       dnsConfig: {{ toYaml .Values.controller.dnsConfig | nindent 8 }}
     {{- end }}
+    {{- if .Values.controller.hostname }}
+      hostname: {{ toYaml .Values.controller.hostname | nindent 8 }}
+    {{- end }}
       dnsPolicy: {{ .Values.controller.dnsPolicy }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
@@ -74,22 +77,22 @@ spec:
           args:
             - /nginx-ingress-controller
           {{- if .Values.defaultBackend.enabled }}
-            - --default-backend-service={{ .Release.Namespace }}/{{ include "ingress-nginx.defaultBackend.fullname" . }}
+            - --default-backend-service=$(POD_NAMESPACE)/{{ include "ingress-nginx.defaultBackend.fullname" . }}
           {{- end }}
           {{- if .Values.controller.publishService.enabled }}
             - --publish-service={{ template "ingress-nginx.controller.publishServicePath" . }}
           {{- end }}
             - --election-id={{ .Values.controller.electionID }}
-            - --ingress-class={{ .Values.controller.ingressClass }}
-            - --configmap={{ .Release.Namespace }}/{{ include "ingress-nginx.controller.fullname" . }}
+            - --controller-class={{ .Values.controller.ingressClassResource.controllerValue }}
+            - --configmap={{ default "$(POD_NAMESPACE)" .Values.controller.configMapNamespace }}/{{ include "ingress-nginx.controller.fullname" . }}
           {{- if .Values.tcp }}
-            - --tcp-services-configmap={{ .Release.Namespace }}/{{ include "ingress-nginx.fullname" . }}-tcp
+            - --tcp-services-configmap={{ default "$(POD_NAMESPACE)" .Values.controller.tcp.configMapNamespace }}/{{ include "ingress-nginx.fullname" . }}-tcp
           {{- end }}
           {{- if .Values.udp }}
-            - --udp-services-configmap={{ .Release.Namespace }}/{{ include "ingress-nginx.fullname" . }}-udp
+            - --udp-services-configmap={{ default "$(POD_NAMESPACE)" .Values.controller.udp.configMapNamespace }}/{{ include "ingress-nginx.fullname" . }}-udp
           {{- end }}
           {{- if .Values.controller.scope.enabled }}
-            - --watch-namespace={{ default .Release.Namespace .Values.controller.scope.namespace }}
+            - --watch-namespace={{ default "$(POD_NAMESPACE)" .Values.controller.scope.namespace }}
           {{- end }}
           {{- if and .Values.controller.reportNodeInternalIp .Values.controller.hostNetwork }}
             - --report-node-internal-ip-address={{ .Values.controller.reportNodeInternalIp }}
@@ -107,6 +110,9 @@ spec:
           {{- end }}
           {{- if not (eq .Values.controller.healthCheckPath "/healthz") }}
             - --health-check-path={{ .Values.controller.healthCheckPath }}
+          {{- end }}
+          {{- if .Values.controller.watchIngressWithoutClass }}
+            - --watch-ingress-without-class=true
           {{- end }}
           {{- range $key, $value := .Values.controller.extraArgs }}
             {{- /* Accept keys without values or with false as value */}}

--- a/charts/ingress-nginx/templates/controller-deployment.yaml
+++ b/charts/ingress-nginx/templates/controller-deployment.yaml
@@ -46,6 +46,9 @@ spec:
     {{- if .Values.controller.dnsConfig }}
       dnsConfig: {{ toYaml .Values.controller.dnsConfig | nindent 8 }}
     {{- end }}
+    {{- if .Values.controller.hostname }}
+      hostname: {{ toYaml .Values.controller.hostname | nindent 8 }}
+    {{- end }}
       dnsPolicy: {{ .Values.controller.dnsPolicy }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
@@ -84,13 +87,13 @@ spec:
             - --publish-service={{ template "ingress-nginx.controller.publishServicePath" . }}
           {{- end }}
             - --election-id={{ .Values.controller.electionID }}
-            - --ingress-class={{ .Values.controller.ingressClass }}
-            - --configmap=$(POD_NAMESPACE)/{{ include "ingress-nginx.controller.fullname" . }}
+            - --controller-class={{ .Values.controller.ingressClassResource.controllerValue }}
+            - --configmap={{ default "$(POD_NAMESPACE)" .Values.controller.configMapNamespace }}/{{ include "ingress-nginx.controller.fullname" . }}
           {{- if .Values.tcp }}
-            - --tcp-services-configmap=$(POD_NAMESPACE)/{{ include "ingress-nginx.fullname" . }}-tcp
+            - --tcp-services-configmap={{ default "$(POD_NAMESPACE)" .Values.controller.tcp.configMapNamespace }}/{{ include "ingress-nginx.fullname" . }}-tcp
           {{- end }}
           {{- if .Values.udp }}
-            - --udp-services-configmap=$(POD_NAMESPACE)/{{ include "ingress-nginx.fullname" . }}-udp
+            - --udp-services-configmap={{ default "$(POD_NAMESPACE)" .Values.controller.udp.configMapNamespace }}/{{ include "ingress-nginx.fullname" . }}-udp
           {{- end }}
           {{- if .Values.controller.scope.enabled }}
             - --watch-namespace={{ default "$(POD_NAMESPACE)" .Values.controller.scope.namespace }}
@@ -108,6 +111,9 @@ spec:
           {{- end }}
           {{- if not (eq .Values.controller.healthCheckPath "/healthz") }}
             - --health-check-path={{ .Values.controller.healthCheckPath }}
+          {{- end }}
+          {{- if .Values.controller.watchIngressWithoutClass }}
+            - --watch-ingress-without-class=true
           {{- end }}
           {{- range $key, $value := .Values.controller.extraArgs }}
             {{- /* Accept keys without values or with false as value */}}
@@ -140,7 +146,7 @@ spec:
           {{- end }}
           {{- if .Values.controller.extraEnvs }}
             {{- toYaml .Values.controller.extraEnvs | nindent 12 }}
-          {{- end }}          
+          {{- end }}
           {{- if .Values.controller.startupProbe }}
           startupProbe: {{ toYaml .Values.controller.startupProbe | nindent 12 }}
           {{- end }}

--- a/charts/ingress-nginx/templates/controller-hpa.yaml
+++ b/charts/ingress-nginx/templates/controller-hpa.yaml
@@ -22,9 +22,9 @@ spec:
   maxReplicas: {{ .Values.controller.autoscaling.maxReplicas }}
   metrics:
   {{- with .Values.controller.autoscaling.targetMemoryUtilizationPercentage }}
-  - type: Resource 
-    resource: 
-      name: memory 
+  - type: Resource
+    resource:
+      name: memory
       target:
         type: Utilization
         averageUtilization: {{ . }}
@@ -38,7 +38,11 @@ spec:
         averageUtilization: {{ . }}
   {{- end }}
   {{- with .Values.controller.autoscalingTemplate }}
-{{- toYaml . | nindent 2 }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- with .Values.controller.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/ingress-nginx/templates/controller-ingressclass.yaml
+++ b/charts/ingress-nginx/templates/controller-ingressclass.yaml
@@ -1,9 +1,7 @@
-{{- if and (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) (.Values.controller.ingressClassResource.enabled) -}}
-{{- if and (semverCompare "=1.18-0" .Capabilities.KubeVersion.GitVersion)  }}
-apiVersion: networking.k8s.io/v1beta1
-{{- else }}
+{{- if .Values.controller.ingressClassResource.enabled -}}
+# We don't support namespaced ingressClass yet
+# So a ClusterRole and a ClusterRoleBinding is required
 apiVersion: networking.k8s.io/v1
-{{- end }}
 kind: IngressClass
 metadata:
   labels:
@@ -12,12 +10,12 @@ metadata:
     {{- with .Values.controller.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  name: {{ .Values.controller.ingressClass }}
+  name: {{ .Values.controller.ingressClassResource.name }}
 {{- if .Values.controller.ingressClassResource.default }}
   annotations:
     ingressclass.kubernetes.io/is-default-class: "true"
 {{- end }}
 spec:
-  controller: k8s.io/ingress-nginx
+  controller: {{ .Values.controller.ingressClassResource.controllerValue }}
   {{ template "ingressClass.parameters" . }}
 {{- end }}

--- a/charts/ingress-nginx/templates/controller-poddisruptionbudget.yaml
+++ b/charts/ingress-nginx/templates/controller-poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if or (and .Values.controller.autoscaling.enabled (gt (.Values.controller.autoscaling.minReplicas | int) 1)) (and (not .Values.controller.autoscaling.enabled) (gt (.Values.controller.replicaCount | int) 1)) }}
-apiVersion: policy/v1beta1
+apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version) }}
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/charts/ingress-nginx/templates/controller-role.yaml
+++ b/charts/ingress-nginx/templates/controller-role.yaml
@@ -34,8 +34,7 @@ rules:
       - list
       - watch
   - apiGroups:
-      - extensions
-      - "networking.k8s.io" # k8s 1.14+
+      - networking.k8s.io
     resources:
       - ingresses
     verbs:
@@ -43,14 +42,13 @@ rules:
       - list
       - watch
   - apiGroups:
-      - extensions
-      - "networking.k8s.io" # k8s 1.14+
+      - networking.k8s.io
     resources:
       - ingresses/status
     verbs:
       - update
   - apiGroups:
-      - "networking.k8s.io" # k8s 1.14+
+      - networking.k8s.io
     resources:
       - ingressclasses
     verbs:
@@ -62,7 +60,7 @@ rules:
     resources:
       - configmaps
     resourceNames:
-      - {{ .Values.controller.electionID }}-{{ .Values.controller.ingressClass }}
+      - {{ .Values.controller.electionID }}
     verbs:
       - get
       - update

--- a/charts/ingress-nginx/templates/controller-service-internal.yaml
+++ b/charts/ingress-nginx/templates/controller-service-internal.yaml
@@ -32,6 +32,9 @@ spec:
       port: {{ .Values.controller.service.ports.http }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.http }}
+    {{- if semverCompare ">=1.20" .Capabilities.KubeVersion.Version }}
+      appProtocol: http
+    {{- end }}
     {{- if (and $setNodePorts (not (empty .Values.controller.service.nodePorts.http))) }}
       nodePort: {{ .Values.controller.service.nodePorts.http }}
     {{- end }}
@@ -41,6 +44,9 @@ spec:
       port: {{ .Values.controller.service.ports.https }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.https }}
+    {{- if semverCompare ">=1.20" .Capabilities.KubeVersion.Version }}
+      appProtocol: https
+    {{- end }}
     {{- if (and $setNodePorts (not (empty .Values.controller.service.nodePorts.https))) }}
       nodePort: {{ .Values.controller.service.nodePorts.https }}
     {{- end }}

--- a/charts/ingress-nginx/templates/controller-service-webhook.yaml
+++ b/charts/ingress-nginx/templates/controller-service-webhook.yaml
@@ -28,6 +28,9 @@ spec:
     - name: https-webhook
       port: 443
       targetPort: webhook
+    {{- if semverCompare ">=1.20" .Capabilities.KubeVersion.Version }}
+      appProtocol: https
+    {{- end }}
   selector:
     {{- include "ingress-nginx.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: controller

--- a/charts/ingress-nginx/templates/controller-service.yaml
+++ b/charts/ingress-nginx/templates/controller-service.yaml
@@ -44,6 +44,9 @@ spec:
       port: {{ .Values.controller.service.ports.http }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.http }}
+    {{- if semverCompare ">=1.20" .Capabilities.KubeVersion.Version }}
+      appProtocol: http
+    {{- end }}
     {{- if (and $setNodePorts (not (empty .Values.controller.service.nodePorts.http))) }}
       nodePort: {{ .Values.controller.service.nodePorts.http }}
     {{- end }}
@@ -53,6 +56,9 @@ spec:
       port: {{ .Values.controller.service.ports.https }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.https }}
+    {{- if semverCompare ">=1.20" .Capabilities.KubeVersion.Version }}
+      appProtocol: https
+    {{- end }}
     {{- if (and $setNodePorts (not (empty .Values.controller.service.nodePorts.https))) }}
       nodePort: {{ .Values.controller.service.nodePorts.https }}
     {{- end }}

--- a/charts/ingress-nginx/templates/controller-servicemonitor.yaml
+++ b/charts/ingress-nginx/templates/controller-servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.controller.metrics.enabled .Values.controller.metrics.serviceMonitor.enabled -}}
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.controller.metrics.enabled .Values.controller.metrics.serviceMonitor.enabled -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/ingress-nginx/templates/default-backend-poddisruptionbudget.yaml
+++ b/charts/ingress-nginx/templates/default-backend-poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if or (gt (.Values.defaultBackend.replicaCount | int) 1) (gt (.Values.defaultBackend.autoscaling.minReplicas | int) 1) }}
-apiVersion: policy/v1beta1
+apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version) }}
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/charts/ingress-nginx/templates/default-backend-service.yaml
+++ b/charts/ingress-nginx/templates/default-backend-service.yaml
@@ -29,6 +29,9 @@ spec:
       port: {{ .Values.defaultBackend.service.servicePort }}
       protocol: TCP
       targetPort: http
+    {{- if semverCompare ">=1.20" .Capabilities.KubeVersion.Version }}
+      appProtocol: http
+    {{- end }}
   selector:
     {{- include "ingress-nginx.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: default-backend

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -1,5 +1,5 @@
 ## nginx configuration
-## Ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/index.md
+## Ref: https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/index.md
 ##
 
 ## Overrides for generated resource names
@@ -15,8 +15,8 @@ controller:
     # for backwards compatibility consider setting the full image url via the repository value below
     # use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
     # repository:
-    tag: "v0.47.0"
-    digest: sha256:a1e4efc107be0bb78f32eaec37bef17d7a0c81bec8066cdf2572508d21351d0b
+    tag: "v1.0.0"
+    digest: sha256:0851b34f69f69352bf168e6ccf30e1e20714a264ab1ecd1933e4d8c0fc3215c6
     pullPolicy: IfNotPresent
     # www-data -> uid 101
     runAsUser: 101
@@ -40,7 +40,7 @@ controller:
   ##
   configAnnotations: {}
 
-  # Will add custom headers before sending traffic to backends according to https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers
+  # Will add custom headers before sending traffic to backends according to https://github.com/kubernetes/ingress-nginx/tree/main/docs/examples/customization/custom-headers
   proxySetHeaders: {}
 
   # Will add custom headers before sending response traffic to the client according to: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#add-headers
@@ -48,6 +48,9 @@ controller:
 
   # Optionally customize the pod dnsConfig.
   dnsConfig: {}
+
+  # Optionally customize the pod hostname.
+  hostname: {}
 
   # Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true'.
   # By default, while using host network, name resolution uses the host's DNS. If you wish nginx-controller
@@ -57,6 +60,11 @@ controller:
   # Bare-metal considerations via the host network https://kubernetes.github.io/ingress-nginx/deploy/baremetal/#via-the-host-network
   # Ingress status was blank because there is no Service exposing the NGINX Ingress controller in a configuration using the host network, the default --publish-service flag used in standard cloud setups does not apply
   reportNodeInternalIp: false
+
+  # Process Ingress objects without ingressClass annotation/ingressClassName field
+  # Overrides value for --watch-ingress-without-class flag of the controller binary
+  # Defaults to false
+  watchIngressWithoutClass: false
 
   # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
   # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920
@@ -76,15 +84,13 @@ controller:
   ##
   electionID: ingress-controller-leader
 
-  ## Name of the ingress class to route through this controller
-  ##
-  ingressClass: nginx
-
   # This section refers to the creation of the IngressClass resource
-  # IngressClass resources are supported since k8s >= 1.18
+  # IngressClass resources are supported since k8s >= 1.18 and required since k8s >= 1.19
   ingressClassResource:
-    enabled: false
+    name: nginx
+    enabled: true
     default: false
+    controllerValue: "k8s.io/ingress-nginx"
 
     # Parameters is a link to a custom resource containing additional
     # configuration for the controller. This is optional if the controller
@@ -121,23 +127,23 @@ controller:
   ##
   scope:
     enabled: false
-    namespace: ""   # defaults to .Release.Namespace
+    namespace: ""   # defaults to $(POD_NAMESPACE)
 
   ## Allows customization of the configmap / nginx-configmap namespace
   ##
-  configMapNamespace: ""   # defaults to .Release.Namespace
+  configMapNamespace: ""   # defaults to $(POD_NAMESPACE)
 
   ## Allows customization of the tcp-services-configmap
   ##
   tcp:
-    configMapNamespace: ""   # defaults to .Release.Namespace
+    configMapNamespace: ""   # defaults to $(POD_NAMESPACE)
     ## Annotations to be added to the tcp config configmap
     annotations: {}
 
   ## Allows customization of the udp-services-configmap
   ##
   udp:
-    configMapNamespace: ""   # defaults to .Release.Namespace
+    configMapNamespace: ""   # defaults to $(POD_NAMESPACE)
     ## Annotations to be added to the udp config configmap
     annotations: {}
 
@@ -332,6 +338,19 @@ controller:
     maxReplicas: 11
     targetCPUUtilizationPercentage: 50
     targetMemoryUtilizationPercentage: 50
+    behavior: {}
+      # scaleDown:
+      #   stabilizationWindowSeconds: 300
+      #  policies:
+      #   - type: Pods
+      #     value: 1
+      #     periodSeconds: 180
+      # scaleUp:
+      #   stabilizationWindowSeconds: 300
+      #   policies:
+      #   - type: Pods
+      #     value: 2
+      #     periodSeconds: 60
 
   autoscalingTemplate: []
   # Custom or additional autoscaling metrics
@@ -526,21 +545,35 @@ controller:
       servicePort: 443
       type: ClusterIP
 
+    createSecretJob:
+      resources: {}
+        # limits:
+        #   cpu: 10m
+        #   memory: 20Mi
+        # requests:
+        #   cpu: 10m
+        #   memory: 20Mi
+
+    patchWebhookJob:
+      resources: {}
+
     patch:
       enabled: true
       image:
-        registry: docker.io
-        image: jettech/kube-webhook-certgen
+        registry: k8s.gcr.io
+        image: ingress-nginx/kube-webhook-certgen
         # for backwards compatibility consider setting the full image url via the repository value below
         # use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
         # repository:
-        tag: v1.5.1
+        tag: v1.0
+        digest: sha256:f3b6b39a6062328c095337b4cadcefd1612348fdd5190b1dcbcb9b9e90bd8068
         pullPolicy: IfNotPresent
       ## Provide a priority class name to the webhook patching job
       ##
       priorityClassName: ""
       podAnnotations: {}
-      nodeSelector: {}
+      nodeSelector:
+        kubernetes.io/os: linux
       tolerations: []
       runAsUser: 2000
 
@@ -717,7 +750,8 @@ defaultBackend:
   ## Node labels for default backend pod assignment
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
-  nodeSelector: {}
+  nodeSelector:
+    kubernetes.io/os: linux
 
   ## Annotations to be added to default backend pods
   ##
@@ -770,7 +804,7 @@ defaultBackend:
 
   priorityClassName: ""
 
-## Enable RBAC as per https://github.com/kubernetes/ingress/tree/master/examples/rbac/nginx and https://github.com/kubernetes/ingress/issues/266
+## Enable RBAC as per https://github.com/kubernetes/ingress-nginx/blob/main/docs/deploy/rbac.md and https://github.com/kubernetes/ingress-nginx/issues/266
 rbac:
   create: true
   scope: false
@@ -791,18 +825,18 @@ imagePullSecrets: []
 # - name: secretName
 
 # TCP service key:value pairs
-# Ref: https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/tcp
+# Ref: https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/exposing-tcp-udp-services.md
 ##
 tcp: {}
 #  8080: "default/example-tcp-svc:9000"
 
 # UDP service key:value pairs
-# Ref: https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/udp
+# Ref: https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/exposing-tcp-udp-services.md
 ##
 udp: {}
 #  53: "kube-system/kube-dns:53"
 
 # A base64ed Diffie-Hellman parameter
 # This can be generated with: openssl dhparam 4096 2> /dev/null | base64
-# Ref: https://github.com/krmichel/ingress-nginx/blob/master/docs/examples/customization/ssl-dh-param
+# Ref: https://github.com/kubernetes/ingress-nginx/tree/main/docs/examples/customization/ssl-dh-param
 dhParam:

--- a/charts/render.py
+++ b/charts/render.py
@@ -333,6 +333,8 @@ def main():
         "apiregistration.k8s.io/v1",
         # Available since Kubernetes 1.19
         "networking.k8s.io/v1/Ingress",
+        # Used by ServiceMonitor and other monitoring objects
+        "monitoring.coreos.com/v1",
     ]
 
     command = [

--- a/salt/metalk8s/addons/nginx-ingress-control-plane/deployed/chart-daemonset.sls
+++ b/salt/metalk8s/addons/nginx-ingress-control-plane/deployed/chart-daemonset.sls
@@ -16,8 +16,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -32,8 +32,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx-control-plane-controller
   namespace: metalk8s-ingress
@@ -46,8 +46,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -78,7 +78,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - extensions
   - networking.k8s.io
   resources:
   - ingresses
@@ -94,7 +93,6 @@ rules:
   - create
   - patch
 - apiGroups:
-  - extensions
   - networking.k8s.io
   resources:
   - ingresses/status
@@ -117,8 +115,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -140,8 +138,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -172,7 +170,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - extensions
   - networking.k8s.io
   resources:
   - ingresses
@@ -181,7 +178,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - extensions
   - networking.k8s.io
   resources:
   - ingresses/status
@@ -198,7 +194,7 @@ rules:
 - apiGroups:
   - ''
   resourceNames:
-  - ingress-control-plane-controller-leader-nginx-control-plane
+  - ingress-control-plane-controller-leader
   resources:
   - configmaps
   verbs:
@@ -227,8 +223,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -250,8 +246,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx-control-plane-controller-metrics
   namespace: metalk8s-ingress
@@ -276,8 +272,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx-control-plane-controller
   namespace: metalk8s-ingress
@@ -286,7 +282,8 @@ spec:
   - '{%- endraw -%}{{ salt.metalk8s_network.get_control_plane_ingress_ip() }}{%- raw
     -%}'
   ports:
-  - name: https
+  - appProtocol: https
+    name: https
     port: 8443
     protocol: TCP
     targetPort: https
@@ -305,8 +302,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx-control-plane-controller
   namespace: metalk8s-ingress
@@ -330,8 +327,8 @@ spec:
         - /nginx-ingress-controller
         - --publish-service=$(POD_NAMESPACE)/ingress-nginx-control-plane-controller
         - --election-id=ingress-control-plane-controller-leader
-        - --ingress-class=nginx-control-plane
-        - --configmap=metalk8s-ingress/ingress-nginx-control-plane-controller
+        - --controller-class=k8s.io/ingress-nginx-control-plane
+        - --configmap=$(POD_NAMESPACE)/ingress-nginx-control-plane-controller
         - --default-ssl-certificate=metalk8s-ingress/ingress-control-plane-default-certificate
         - --metrics-per-host=false
         env:
@@ -346,7 +343,7 @@ spec:
         - name: LD_PRELOAD
           value: /usr/local/lib/libmimalloc.so
         image: '{%- endraw -%}{{ build_image_name("nginx-ingress-controller", False)
-          }}{%- raw -%}:v0.47.0'
+          }}{%- raw -%}:v1.0.0'
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -415,6 +412,23 @@ spec:
   updateStrategy:
     type: RollingUpdate
 ---
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx-control-plane
+    app.kubernetes.io/managed-by: salt
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: metalk8s
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
+    heritage: metalk8s
+  name: nginx-control-plane
+  namespace: metalk8s-ingress
+spec:
+  controller: k8s.io/ingress-nginx-control-plane
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -424,8 +438,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
     metalk8s.scality.com/monitor: ''
   name: ingress-nginx-control-plane-controller

--- a/salt/metalk8s/addons/nginx-ingress-control-plane/deployed/chart-deployment.sls
+++ b/salt/metalk8s/addons/nginx-ingress-control-plane/deployed/chart-deployment.sls
@@ -15,8 +15,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx-control-plane-controller
   namespace: metalk8s-ingress
@@ -38,8 +38,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -54,8 +54,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx-control-plane-backend
   namespace: metalk8s-ingress
@@ -70,8 +70,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx-control-plane-controller
   namespace: metalk8s-ingress
@@ -84,8 +84,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -116,7 +116,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - extensions
   - networking.k8s.io
   resources:
   - ingresses
@@ -132,7 +131,6 @@ rules:
   - create
   - patch
 - apiGroups:
-  - extensions
   - networking.k8s.io
   resources:
   - ingresses/status
@@ -155,8 +153,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -178,8 +176,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -210,7 +208,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - extensions
   - networking.k8s.io
   resources:
   - ingresses
@@ -219,7 +216,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - extensions
   - networking.k8s.io
   resources:
   - ingresses/status
@@ -236,7 +232,7 @@ rules:
 - apiGroups:
   - ''
   resourceNames:
-  - ingress-control-plane-controller-leader-nginx-control-plane
+  - ingress-control-plane-controller-leader
   resources:
   - configmaps
   verbs:
@@ -265,8 +261,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -288,8 +284,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx-control-plane-controller-metrics
   namespace: metalk8s-ingress
@@ -314,8 +310,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx-control-plane-controller
   namespace: metalk8s-ingress
@@ -323,7 +319,8 @@ spec:
   externalTrafficPolicy: Local
   loadBalancerIP: {% endraw -%}{{ salt.metalk8s_network.get_control_plane_ingress_ip() }}{%- raw %}
   ports:
-  - name: https
+  - appProtocol: https
+    name: https
     port: 8443
     protocol: TCP
     targetPort: https
@@ -342,14 +339,15 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx-control-plane-defaultbackend
   namespace: metalk8s-ingress
 spec:
   ports:
-  - name: http
+  - appProtocol: http
+    name: http
     port: 80
     protocol: TCP
     targetPort: http
@@ -368,8 +366,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx-control-plane-controller
   namespace: metalk8s-ingress
@@ -397,7 +395,7 @@ spec:
         - --default-backend-service=$(POD_NAMESPACE)/ingress-nginx-control-plane-defaultbackend
         - --publish-service=$(POD_NAMESPACE)/ingress-nginx-control-plane-controller
         - --election-id=ingress-control-plane-controller-leader
-        - --ingress-class=nginx-control-plane
+        - --controller-class=k8s.io/ingress-nginx-control-plane
         - --configmap=$(POD_NAMESPACE)/ingress-nginx-control-plane-controller
         - --default-ssl-certificate=metalk8s-ingress/ingress-control-plane-default-certificate
         - --metrics-per-host=false
@@ -412,7 +410,7 @@ spec:
               fieldPath: metadata.namespace
         - name: LD_PRELOAD
           value: /usr/local/lib/libmimalloc.so
-        image: {% endraw -%}{{ build_image_name("nginx-ingress-controller", False) }}{%- raw %}:v0.47.0
+        image: {% endraw -%}{{ build_image_name("nginx-ingress-controller", False) }}{%- raw %}:v1.0.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -488,8 +486,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx-control-plane-defaultbackend
   namespace: metalk8s-ingress
@@ -545,6 +543,7 @@ spec:
           runAsNonRoot: true
           runAsUser: 65534
       nodeSelector:
+        kubernetes.io/os: linux
         node-role.kubernetes.io/master: ''
       serviceAccountName: ingress-nginx-control-plane-backend
       terminationGracePeriodSeconds: 60
@@ -559,6 +558,23 @@ spec:
         key: node-role.kubernetes.io/infra
         operator: Exists
 ---
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx-control-plane
+    app.kubernetes.io/managed-by: salt
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: metalk8s
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
+    heritage: metalk8s
+  name: nginx-control-plane
+  namespace: metalk8s-ingress
+spec:
+  controller: k8s.io/ingress-nginx-control-plane
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -568,8 +584,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
     metalk8s.scality.com/monitor: ''
   name: ingress-nginx-control-plane-controller

--- a/salt/metalk8s/addons/nginx-ingress/deployed/chart.sls
+++ b/salt/metalk8s/addons/nginx-ingress/deployed/chart.sls
@@ -16,8 +16,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx
   namespace: metalk8s-ingress
@@ -32,8 +32,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx-backend
   namespace: metalk8s-ingress
@@ -48,8 +48,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx-controller
   namespace: metalk8s-ingress
@@ -62,8 +62,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx
   namespace: metalk8s-ingress
@@ -94,7 +94,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - extensions
   - networking.k8s.io
   resources:
   - ingresses
@@ -110,7 +109,6 @@ rules:
   - create
   - patch
 - apiGroups:
-  - extensions
   - networking.k8s.io
   resources:
   - ingresses/status
@@ -133,8 +131,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx
   namespace: metalk8s-ingress
@@ -156,8 +154,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx
   namespace: metalk8s-ingress
@@ -188,7 +186,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - extensions
   - networking.k8s.io
   resources:
   - ingresses
@@ -197,7 +194,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - extensions
   - networking.k8s.io
   resources:
   - ingresses/status
@@ -214,7 +210,7 @@ rules:
 - apiGroups:
   - ''
   resourceNames:
-  - ingress-controller-leader-nginx
+  - ingress-controller-leader
   resources:
   - configmaps
   verbs:
@@ -243,8 +239,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx
   namespace: metalk8s-ingress
@@ -266,8 +262,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx-controller-metrics
   namespace: metalk8s-ingress
@@ -292,18 +288,20 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx-controller
   namespace: metalk8s-ingress
 spec:
   ports:
-  - name: http
+  - appProtocol: http
+    name: http
     port: 80
     protocol: TCP
     targetPort: http
-  - name: https
+  - appProtocol: https
+    name: https
     port: 443
     protocol: TCP
     targetPort: https
@@ -322,14 +320,15 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx-defaultbackend
   namespace: metalk8s-ingress
 spec:
   ports:
-  - name: http
+  - appProtocol: http
+    name: http
     port: 80
     protocol: TCP
     targetPort: http
@@ -348,8 +347,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx-controller
   namespace: metalk8s-ingress
@@ -371,11 +370,11 @@ spec:
       containers:
       - args:
         - /nginx-ingress-controller
-        - --default-backend-service=metalk8s-ingress/ingress-nginx-defaultbackend
+        - --default-backend-service=$(POD_NAMESPACE)/ingress-nginx-defaultbackend
         - --publish-service=$(POD_NAMESPACE)/ingress-nginx-controller
         - --election-id=ingress-controller-leader
-        - --ingress-class=nginx
-        - --configmap=metalk8s-ingress/ingress-nginx-controller
+        - --controller-class=k8s.io/ingress-nginx
+        - --configmap=$(POD_NAMESPACE)/ingress-nginx-controller
         - --default-ssl-certificate=metalk8s-ingress/ingress-workload-plane-default-certificate
         - --metrics-per-host=false
         env:
@@ -390,7 +389,7 @@ spec:
         - name: LD_PRELOAD
           value: /usr/local/lib/libmimalloc.so
         image: '{%- endraw -%}{{ build_image_name("nginx-ingress-controller", False)
-          }}{%- raw -%}:v0.47.0'
+          }}{%- raw -%}:v1.0.0'
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -464,8 +463,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
   name: ingress-nginx-defaultbackend
   namespace: metalk8s-ingress
@@ -522,6 +521,7 @@ spec:
           runAsNonRoot: true
           runAsUser: 65534
       nodeSelector:
+        kubernetes.io/os: linux
         node-role.kubernetes.io/infra: ''
       serviceAccountName: ingress-nginx-backend
       terminationGracePeriodSeconds: 60
@@ -533,6 +533,25 @@ spec:
         key: node-role.kubernetes.io/infra
         operator: Exists
 ---
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: 'true'
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/managed-by: salt
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: metalk8s
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
+    heritage: metalk8s
+  name: nginx
+  namespace: metalk8s-ingress
+spec:
+  controller: k8s.io/ingress-nginx
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -542,8 +561,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 0.47.0
-    helm.sh/chart: ingress-nginx-3.34.0
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: ingress-nginx-4.0.1
     heritage: metalk8s
     metalk8s.scality.com/monitor: ''
   name: ingress-nginx-controller


### PR DESCRIPTION
In order to support the newer Kubernetes version 1.22 we need to bump
the version of NGINX Ingress.

The nginx-ingress-controller image has been bump accordingly to v1.0.0