### PR TITLE
charts,salt,build,tests: Bump Dex chart to v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   nginx-ingress-controller image has been bumped accordingly to v1.0.0
   (PR[#3518](https://github.com/scality/metalk8s/pull/3518))
 
+- Bump Dex chart version to v0.6.3, Dex image has been bumped accordingly
+  to v2.30.0
+  (PR[#3519](https://github.com/scality/metalk8s/pull/3519))
+
 - [#3487](https://github.com/scality/metalk8s/issues/3487) - Make Salt
   Kubernetes execution module more flexible relying on `DynamicClient`
   from `python-kubernetes`

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -112,8 +112,8 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     ),
     Image(
         name="dex",
-        version="v2.28.1",
-        digest="sha256:5e88f2205de172b60fd7af23ac92f34321688a83de9f7de7c9a6f394f6950877",
+        version="v2.30.0",
+        digest="sha256:63fc6ee14bcf1868ebfba90885aec76597e0f27bc8e89d1fd238b1f2ee3dea6e",
     ),
     Image(
         name="etcd",

--- a/charts/dex.yaml
+++ b/charts/dex.yaml
@@ -51,7 +51,7 @@ volumeMounts:
   - name: https-tls
     mountPath: /etc/dex/tls/https/server
   - name: dex-login
-    mountPath: /web/themes/scality
+    mountPath: /srv/dex/web/themes/scality
   - name: nginx-ingress-ca-cert
     mountPath: /etc/ssl/certs/nginx-ingress-ca.crt
     subPath: ca.crt

--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,11 +1,12 @@
 annotations:
   artifacthub.io/changes: |
-    - Added support for priority class name
+    - kind: added
+      description: "`clusterIP` value to control the IP when using ClusterIP service type"
   artifacthub.io/images: |
     - name: dex
-      image: ghcr.io/dexidp/dex:v2.28.1
+      image: ghcr.io/dexidp/dex:v2.30.0
 apiVersion: v2
-appVersion: 2.28.1
+appVersion: 2.30.0
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable
   connectors.
 home: https://dexidp.io/
@@ -25,4 +26,4 @@ sources:
 - https://github.com/dexidp/dex
 - https://github.com/dexidp/helm-charts/tree/master/charts/dex
 type: application
-version: 0.4.0
+version: 0.6.3

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -1,6 +1,6 @@
 # dex
 
-![version: 0.4.0](https://img.shields.io/badge/version-0.4.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.28.1](https://img.shields.io/badge/app%20version-2.28.1-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
+![version: 0.6.3](https://img.shields.io/badge/version-0.6.3-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.30.0](https://img.shields.io/badge/app%20version-2.30.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
 
 OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
 
@@ -140,6 +140,7 @@ ingress:
 | securityContext | object | `{}` | Container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1) for details. |
 | service.annotations | object | `{}` | Annotations to be added to the service. |
 | service.type | string | `"ClusterIP"` | Kubernetes [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types). |
+| service.clusterIP | string | `""` | Internal cluster service IP (when applicable) |
 | service.ports.http.port | int | `5556` | HTTP service port |
 | service.ports.http.nodePort | int | `nil` | HTTP node port (when applicable) |
 | service.ports.https.port | int | `5554` | HTTPS service port |

--- a/charts/dex/ci/no-config-secret.yaml
+++ b/charts/dex/ci/no-config-secret.yaml
@@ -1,0 +1,10 @@
+config:
+  issuer: https://my-issuer.com
+
+  storage:
+    type: memory
+
+  enablePasswordDB: true
+
+configSecret:
+  create: false

--- a/charts/dex/templates/deployment.yaml
+++ b/charts/dex/templates/deployment.yaml
@@ -14,9 +14,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{ if .Values.configSecret.create }}
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       {{- end }}
       labels:
         {{- include "dex.selectorLabels" . | nindent 8 }}

--- a/charts/dex/templates/service.yaml
+++ b/charts/dex/templates/service.yaml
@@ -10,8 +10,8 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
-  {{- if hasKey .Values.service "clusterIP" }}
-  clusterIP: {{ .Values.service.clusterIP | quote }}
+  {{- with .Values.service.clusterIP }}
+  clusterIP: {{ . }}
   {{- end }}
   ports:
     - name: http

--- a/charts/dex/templates/tests/no-config-secret.yaml
+++ b/charts/dex/templates/tests/no-config-secret.yaml
@@ -1,10 +1,12 @@
-{{- if .Values.configSecret.create -}}
+{{- if not .Values.configSecret.create -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "dex.configSecretName" . }}
+  name: {{ include "dex.configSecretName" . }}-test-no-create
   labels:
     {{- include "dex.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
 type: Opaque
 data:
   config.yaml: {{ .Values.config | toYaml | b64enc | quote }}

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -122,6 +122,9 @@ service:
   # -- Kubernetes [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types).
   type: ClusterIP
 
+  # -- Internal cluster service IP (when applicable)
+  clusterIP: ""
+
   ports:
     http:
       # -- HTTP service port

--- a/charts/render.py
+++ b/charts/render.py
@@ -346,6 +346,7 @@ def main():
         "--values",
         args.values,
         "--include-crds",
+        "--skip-tests",
         args.path,
     ]
 

--- a/salt/metalk8s/addons/dex/config/dex.yaml.j2
+++ b/salt/metalk8s/addons/dex/config/dex.yaml.j2
@@ -39,6 +39,7 @@ spec:
       tlsKey: /etc/dex/tls/https/server/tls.key
 
     frontend:
+      dir: /srv/dex/web/
       theme: scality
       issuer: MetalK8s
 

--- a/salt/metalk8s/addons/dex/deployed/chart.sls
+++ b/salt/metalk8s/addons/dex/deployed/chart.sls
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.28.1
-    helm.sh/chart: dex-0.4.0
+    app.kubernetes.io/version: 2.30.0
+    helm.sh/chart: dex-0.6.3
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -28,8 +28,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.28.1
-    helm.sh/chart: dex-0.4.0
+    app.kubernetes.io/version: 2.30.0
+    helm.sh/chart: dex-0.6.3
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -55,8 +55,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.28.1
-    helm.sh/chart: dex-0.4.0
+    app.kubernetes.io/version: 2.30.0
+    helm.sh/chart: dex-0.6.3
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -77,8 +77,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.28.1
-    helm.sh/chart: dex-0.4.0
+    app.kubernetes.io/version: 2.30.0
+    helm.sh/chart: dex-0.6.3
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -113,8 +113,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.28.1
-    helm.sh/chart: dex-0.4.0
+    app.kubernetes.io/version: 2.30.0
+    helm.sh/chart: dex-0.6.3
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -147,7 +147,7 @@ spec:
         env:
         - name: KUBERNETES_POD_NAMESPACE
           value: metalk8s-auth
-        image: {% endraw -%}{{ build_image_name("dex", False) }}{%- raw %}:v2.28.1
+        image: {% endraw -%}{{ build_image_name("dex", False) }}{%- raw %}:v2.30.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -176,7 +176,7 @@ spec:
           readOnly: true
         - mountPath: /etc/dex/tls/https/server
           name: https-tls
-        - mountPath: /web/themes/scality
+        - mountPath: /srv/dex/web/themes/scality
           name: dex-login
         - mountPath: /etc/ssl/certs/nginx-ingress-ca.crt
           name: nginx-ingress-ca-cert
@@ -217,8 +217,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.28.1
-    helm.sh/chart: dex-0.4.0
+    app.kubernetes.io/version: 2.30.0
+    helm.sh/chart: dex-0.6.3
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -365,9 +365,9 @@ def dex_login(username, password, should_fail, control_plane_ingress_ep):
     )
     get_auth_start = time.time()
     try:
-        auth_page = session.post(
-            control_plane_ingress_ep + "/oidc/auth?",
-            data={
+        auth_page = session.get(
+            control_plane_ingress_ep + "/oidc/auth/local?",
+            params={
                 "response_type": "id_token",
                 "client_id": "metalk8s-ui",
                 "scope": "openid audience:server:client_id:oidc-auth-client",
@@ -390,11 +390,11 @@ def dex_login(username, password, should_fail, control_plane_ingress_ep):
     auth_form = auth_page.text
 
     # The form action looks like:
-    # <a href="/oidc/auth/local?req=ovc5qdll5zznlubewjok266rl" target="_self">
-    next_path_match = re.search(r'href=[\'"](?P<next_path>/oidc/\S+)[\'"] ', auth_form)
+    # <form method="post" action="/oidc/auth/local/login?back=&amp;amp;state=ABCD">
+    next_path_match = re.search(r'action=[\'"](?P<next_path>/oidc/\S+)[\'"]', auth_form)
     assert (
         next_path_match is not None
-    ), "Could not find an anchor with `href='/oidc/...'` in Dex response:\n{}".format(
+    ), "Could not find an anchor with `action='/oidc/...'` in Dex response:\n{}".format(
         auth_form
     )
     next_path = next_path_match.group("next_path")


### PR DESCRIPTION
In order to use new v1 APIVersion for CRD creation of Dex, bump Dex
chart version (v0.6.3) and Dex container image (v2.30.0)

Since the default directory used for Dex frontend template changed, it also
change the directory for Scality theme.

The way to authenticate to Dex changed a bit as well that's why some
changes were needed in the tests.

---

NOTE: Let's wait for https://github.com/scality/metalk8s/pull/3518 to be merged first as we will have conflict in changelog