### PR TITLE
UI - Bugfixes multi nodes - high availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Bump Kubernetes version to 1.21.4
   (PR[#3495](https://github.com/scality/metalk8s/pull/3495))
 
+- Fix UI issues in multi nodes environment when a node
+  is unavailable (PR[#3521](https://github.com/scality/metalk8s/pull/3521))
+
 ## Release 2.10.2
 ### Bug fixes
 - Fix the link to documentation from the UI navigation bar

--- a/ui/src/components/NodePageOverviewTab.js
+++ b/ui/src/components/NodePageOverviewTab.js
@@ -195,7 +195,7 @@ const NodePageOverviewTab = (props) => {
             <CircleStatus status={currentNode?.health?.health}></CircleStatus>
             <NodeName>{name}</NodeName>
           </div>
-          {currentNodeReturnByK8S?.status === API_STATUS_UNKNOWN ? (
+          {currentNodeReturnByK8S?.status === API_STATUS_UNKNOWN && !currentNodeReturnByK8S.internalIP ? (
             !currentNodeReturnByK8S?.deploying ? (
               <DeployButton
                 text={intl.formatMessage({ id: 'deploy' })}

--- a/ui/src/components/NodePageVolumesTab.js
+++ b/ui/src/components/NodePageVolumesTab.js
@@ -38,7 +38,7 @@ const NodePageVolumesTab = (props) => {
   const { name } = useParams();
   const dispatch = useDispatch();
 
-  const volumeListData = useVolumesWithAlerts();
+  const volumeListData = useVolumesWithAlerts(name);
 
   useRefreshEffect(refreshVolumesAction, stopRefreshVolumesAction);
   useRefreshEffect(

--- a/ui/src/containers/NodePageRSP.js
+++ b/ui/src/containers/NodePageRSP.js
@@ -123,10 +123,13 @@ const NodePageRSP = (props) => {
 
   const alertList = useAlerts({
     alertname: NODE_ALERTS_GROUP,
-    instance: `${instanceIP}:${PORT_NODE_EXPORTER}`,
   });
 
-  const alertsNode = (alertList && alertList.alerts) || [];
+  const alertsNode = ((alertList && alertList.alerts) || []).filter(
+    (alert) =>
+      alert.labels.instance === `${instanceIP}:${PORT_NODE_EXPORTER}` ||
+      alert.labels.node === name,
+  );
 
   const isHealthTabActive = location.pathname.endsWith('/overview');
   const isAlertsTabActive = location.pathname.endsWith('/alerts');


### PR DESCRIPTION
**Component**:

UI

**Context**: 

When a nodes is unavailable the UI reported wrong / incomplete information.
 - All the volumes where listed for all the nodes instead of filtering only the volumes of the selected node in the volumes tab of node detail pane
 - The deploy button was displayed when a node is unavailable but has already been deployed
 - An incorrect node status (unknown) was reported in the node table when a node is unavailable
