### PR TITLE
Bump Kubernetes version to 1.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Bump Kubernetes version to 1.22.1
   (PR[#3525](https://github.com/scality/metalk8s/pull/3525))
 
+- Bump etcd version to 3.5.0-0
+  (PR[#3525](https://github.com/scality/metalk8s/pull/3525))
+
 - Bump `containerd` version to 1.4.8 (PR [#3466](https://github.com/scality/metalk8s/pull/3466)).
 
 - Bump Calico version to 3.20.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ## Release 2.11.0 (in development)
 ### Enhancements
 
+- Bump Kubernetes version to 1.22.1
+  (PR[#3525](https://github.com/scality/metalk8s/pull/3525))
+
 - Bump `containerd` version to 1.4.8 (PR [#3466](https://github.com/scality/metalk8s/pull/3466)).
 
 - Bump Calico version to 3.20.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Bump etcd version to 3.5.0-0
   (PR[#3525](https://github.com/scality/metalk8s/pull/3525))
 
+- Bump CoreDNS version to v1.8.4
+  (PR[#3525](https://github.com/scality/metalk8s/pull/3525))
+
 - Bump `containerd` version to 1.4.8 (PR [#3466](https://github.com/scality/metalk8s/pull/3466)).
 
 - Bump Calico version to 3.20.0

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -117,8 +117,8 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     ),
     Image(
         name="etcd",
-        version="3.4.13-0",
-        digest="sha256:4ad90a11b55313b182afc186b9876c8e891531b8db4c9bf1541953021618d0e2",
+        version="3.5.0-0",
+        digest="sha256:9ce33ba33d8e738a5b85ed50b5080ac746deceed4a7496c550927a7a19ca3b6d",
     ),
     Image(
         name="grafana",

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -107,8 +107,8 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     ),
     Image(
         name="coredns",
-        version="v1.8.0",
-        digest="sha256:cc8fb77bc2a0541949d1d9320a641b82fd392b0d3d8145469ca4709ae769980e",
+        version="v1.8.4",
+        digest="sha256:6e5a02c21641597998b4be7cb5eb1e7b02c0d8d23cce4dd09f4682d463798890",
     ),
     Image(
         name="dex",

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -19,7 +19,7 @@ Image = namedtuple("Image", ("name", "version", "digest"))
 # Project-wide versions {{{
 
 CALICO_VERSION: str = "3.20.0"
-K8S_VERSION: str = "1.21.4"
+K8S_VERSION: str = "1.22.1"
 SALT_VERSION: str = "3002.7"
 CONTAINERD_VERSION: str = "1.4.8"
 SOS_VERSION: str = "< 4.0"
@@ -133,22 +133,22 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     Image(
         name="kube-apiserver",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:a12a4347573b16ba925bf3c2154b9155faa7796d35016d0e194f3ffce93435dc",
+        digest="sha256:6862d5a70cea8f3ef49213d6a36b7bfbbf90f99fb37f7124505be55f0ef51364",
     ),
     Image(
         name="kube-controller-manager",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:2f8234e1d386faa415090c381edc55a473b355ba79ef71c7851f89041b294d56",
+        digest="sha256:3e4274dee8a122bdd5e3f3db6b1eb8db59404deda2bf1adb0fec1da5dd95400a",
     ),
     Image(
         name="kube-proxy",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:bebf88332fc0e5648795fd7f0b57c4d39b901878e56d7cbd940ff9bd20d2a027",
+        digest="sha256:efcf1d5fb2fc95d28841f534f1385a4884230c7c876fb1b7cf66d2777ad6dc56",
     ),
     Image(
         name="kube-scheduler",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:650b648d881c672e7541227ad3ef9ff107e24d565a66feec95ca089b027c0b18",
+        digest="sha256:e1a999694bf4b9198bc220216680ef651fabe406445a93c2d354f9dd7e53c1fd",
     ),
     Image(
         name="kube-state-metrics",

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -945,7 +945,9 @@ stages:
           name: Trigger upgrade and downgrade test stages simultaneously
           stage_names:
             - single-node-upgrade-centos
-            - single-node-downgrade-centos
+            # NOTE: Deactivate minor downgrade on this branch
+            # See: https://github.com/scality/metalk8s/issues/1750
+            #- single-node-downgrade-centos
           waitForFinish: true
 
   create-upload-testrail-objects:
@@ -1900,7 +1902,9 @@ stages:
           stage_names:
             - snapshot-single-node-upgrades
             - snapshot-multi-node-upgrades
-            - single-node-downgrade-promoted-centos
+            # NOTE: Deactivate minor downgrade on this branch
+            # See: https://github.com/scality/metalk8s/issues/1750
+            #- single-node-downgrade-promoted-centos
 
   snapshot-single-node-upgrades:
     # NOTE: This stage just set `environment_type` property to

--- a/salt/metalk8s/addons/logging/fluent-bit/deployed/configmap.sls
+++ b/salt/metalk8s/addons/logging/fluent-bit/deployed/configmap.sls
@@ -28,7 +28,7 @@ Create fluent-bit ConfigMap:
         data:
           fluent-bit.conf: |-
             [SERVICE]
-                HTTP_Server    On
+                HTTP_Server    Off
                 HTTP_Listen    0.0.0.0
                 HTTP_PORT      2020
                 Flush          1

--- a/salt/metalk8s/defaults.yaml
+++ b/salt/metalk8s/defaults.yaml
@@ -7,7 +7,7 @@ metalk8s:
     # (e.g. downgrade of etcd), prior to downgrading the cluster.
     # The downgrade can still be forced setting `metalk8s.downgrade.enabled`
     # to `True` in the pillar.
-    enabled: true
+    enabled: false
 
 kubernetes:
   cluster: kubernetes

--- a/salt/metalk8s/kubernetes/apiserver/installed.sls
+++ b/salt/metalk8s/kubernetes/apiserver/installed.sls
@@ -74,7 +74,6 @@ Create kube-apiserver Pod manifest:
           - --etcd-certfile={{ certificates.client.files['apiserver-etcd'].path }}
           - --etcd-keyfile=/etc/kubernetes/pki/apiserver-etcd-client.key
           - --etcd-servers={{ etcd_servers | join(",") }}
-          - --insecure-port=0
           - --kubelet-client-certificate={{ certificates.client.files['apiserver-kubelet'].path }}
           - --kubelet-client-key=/etc/kubernetes/pki/apiserver-kubelet-client.key
           - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname

--- a/salt/metalk8s/kubernetes/coredns/deployed.sls
+++ b/salt/metalk8s/kubernetes/coredns/deployed.sls
@@ -25,7 +25,9 @@ Create coredns ConfigMap:
                   ttl 30
                 }
                 prometheus :9153
-                forward . /etc/resolv.conf
+                forward . /etc/resolv.conf {
+                  max_concurrent 1000
+                }
                 cache 30
                 loop
                 reload
@@ -65,12 +67,15 @@ Create coredns service:
           - name: dns
             port: 53
             protocol: UDP
+            targetPort: 53
           - name: dns-tcp
             port: 53
             protocol: TCP
+            targetPort: 53
           - name: metrics
             port: 9153
             protocol: TCP
+            targetPort: 9153
     - require:
       - metalk8s_kubernetes: Create coredns deployment
 
@@ -107,6 +112,13 @@ Create coredns cluster role:
           - nodes
           verbs:
           - get
+        - apiGroups:
+          - discovery.k8s.io
+          resources:
+          - endpointslices
+          verbs:
+          - list
+          - watch
 
 Create coredns cluster role binding:
   metalk8s_kubernetes.object_present:

--- a/salt/metalk8s/kubernetes/etcd/installed.sls
+++ b/salt/metalk8s/kubernetes/etcd/installed.sls
@@ -112,7 +112,7 @@ Waiting for etcd running:
       - {{ certificates.server.files.etcd.path }}
       - /etc/kubernetes/pki/etcd/server.key
     - status: 200
-    - match: '{"health":"true"}'
+    - match: '{"health":"true","reason":""}'
     - require:
       - module: Delay after etcd pod deployment
 

--- a/salt/metalk8s/kubernetes/scheduler/installed.sls
+++ b/salt/metalk8s/kubernetes/scheduler/installed.sls
@@ -26,7 +26,6 @@ Create kube-scheduler Pod manifest:
           - --leader-elect=true
           - --port=0
         # }
-          - --bind-address={{ grains['metalk8s']['control_plane_ip'] }}
           - --v={{ 2 if metalk8s.debug else 0 }}
         requested_cpu: 100m
         ports:


### PR DESCRIPTION
- Disable `HTTP_Server` for fluent-bit because it does not work with Kubernetes 1.22 for the moment (see https://github.com/fluent/fluent-bit/issues/4063)
- Bump Kubernetes to 1.22.1
- Remove duplicate argument for kube-scheduler
- Bump etcd to 3.5.0-0 (as it's the version used by kubeadm 1.22)
- Bump CoreDNS to v1.8.4 (as it's the version used by kubeadm 1.22)

NOTE: We also disable downgrade to minor version (2.10.X) as etcd get bumped and cannot be downgraded automatically (see #1750)