### PR TITLE
build,packages,salt: Update Calico to 3.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Bump `containerd` version to 1.4.8 (PR [#3466](https://github.com/scality/metalk8s/pull/3466)).
 
+- Bump Calico version to 3.20.0
+  (PR[#3527](https://github.com/scality/metalk8s/pull/3527))
+
 - Bump ingress-nginx chart version to 4.0.1
   nginx-ingress-controller image has been bumped accordingly to v1.0.0
   (PR[#3518](https://github.com/scality/metalk8s/pull/3518))

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -18,7 +18,7 @@ Image = namedtuple("Image", ("name", "version", "digest"))
 
 # Project-wide versions {{{
 
-CALICO_VERSION: str = "3.19.1"
+CALICO_VERSION: str = "3.20.0"
 K8S_VERSION: str = "1.21.4"
 SALT_VERSION: str = "3002.7"
 CONTAINERD_VERSION: str = "1.4.8"
@@ -98,12 +98,12 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     Image(
         name="calico-node",
         version=_version_prefix(CALICO_VERSION),
-        digest="sha256:bc4a631d553b38fdc169ea4cb8027fa894a656e80d68d513359a4b9d46836b55",
+        digest="sha256:7f9aa7e31fbcea7be64b153f8bcfd494de023679ec10d851a05667f0adb42650",
     ),
     Image(
         name="calico-kube-controllers",
         version=_version_prefix(CALICO_VERSION),
-        digest="sha256:904458fe1bd56f995ef76e2c4d9a6831c506cc80f79e8fc0182dc059b1db25a4",
+        digest="sha256:a850ce8daa84433a5641900693b0f8bc8e5177a4aa4cac8cf4b6cd8c24fd9886",
     ),
     Image(
         name="coredns",

--- a/packages/redhat/common/calico-cni-plugin.spec
+++ b/packages/redhat/common/calico-cni-plugin.spec
@@ -6,12 +6,12 @@
 
 %ifarch x86_64
 %global built_arch              amd64
-%global calico_sha256           08786c58ad05bdd274ac4433e522853a08ade0cf2ca6e3cbfb5b4adb52bd303a
-%global calico_ipam_sha256      08786c58ad05bdd274ac4433e522853a08ade0cf2ca6e3cbfb5b4adb52bd303a
+%global calico_sha256           3a8b8e80599597bed8a4c10a43bad6424c2f3d8c00b3bb26f1268a0cae2a60da
+%global calico_ipam_sha256      3a8b8e80599597bed8a4c10a43bad6424c2f3d8c00b3bb26f1268a0cae2a60da
 %endif
 
 Name:           calico-cni-plugin
-Version:        3.19.1
+Version:        3.20.0
 Release:        1%{?dist}
 Summary:        Calico CNI plugin
 
@@ -49,6 +49,9 @@ install -p -m 755 %{SOURCE2} %{buildroot}/opt/cni/bin/calico-ipam
 %doc README.md
 
 %changelog
+* Wed Sep 8 2021 Teddy Andrieux <teddy.andrieux@scality.com> - 3.20.0.1-1
+- Version bump
+
 * Tue Jun 29 2021 Teddy Andrieux <teddy.andrieux@scality.com> - 3.19.1-1
 - Version bump
 


### PR DESCRIPTION
3.20.0 Calico release note https://docs.projectcalico.org/release-notes/#v3200

Calico binaries sha256 updated from:
  https://github.com/projectcalico/cni-plugin/releases/tag/v3.20.0

Images bumped with:
  docker.io/calico/node:v3.20.0
  docker.io/calico/kube-controllers:v3.20.0

Manifest updated based on upstream from:
  https://docs.projectcalico.org/v3.20/manifests/calico.yaml