### PR TITLE
salt: Ensure we do not have multi cidr for Control Plane with MetalLB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
 - Fix UI issues in multi nodes environment when a node
   is unavailable (PR[#3521](https://github.com/scality/metalk8s/pull/3521))
 
+## Bug fixes
+
+- Enforce a single subnet for control plane when using a
+  MetalLB-managed VIP for Ingress
+  (PR [#3533](https://github.com/scality/metalk8s/pull/3533))
+
 ## Release 2.10.2
 ### Bug fixes
 - Fix the link to documentation from the UI navigation bar

--- a/salt/_pillar/metalk8s.py
+++ b/salt/_pillar/metalk8s.py
@@ -94,13 +94,18 @@ def _load_networks(config_data):
     # MetalLB disabled by default
     networks_data["controlPlane"].setdefault("metalLB", {}).setdefault("enabled", False)
 
-    if networks_data["controlPlane"]["metalLB"]["enabled"] and not networks_data[
-        "controlPlane"
-    ].get("ingress", {}).get("ip"):
-        errors.append(
-            "'ip' for 'ingress' in 'controlPlane' network is mandatory when 'metalLB'"
-            "is enabled"
-        )
+    if networks_data["controlPlane"]["metalLB"]["enabled"]:
+        if not networks_data["controlPlane"].get("ingress", {}).get("ip"):
+            errors.append(
+                "'ip' for 'ingress' in 'controlPlane' network is mandatory when "
+                "'metalLB' is enabled"
+            )
+        if len(networks_data["controlPlane"]["cidr"]) > 1:
+            errors.append(
+                "Enabling 'metalLB' requires a single 'cidr' in "
+                "'controlPlane' network, see "
+                "https://github.com/scality/metalk8s/issues/3502"
+            )
 
     if errors:
         return __utils__["pillar_utils.errors_to_dict"](errors)


### PR DESCRIPTION
Today we do not support multiple subnets for the Control Plane network when
MetalLB is enabled, so this commit check that it's not the case

See: #3502