### PR TITLE
ui: Fix add missing reducer for UPDATE_NODESTATS_FETCH_ARG action

### DIFF
--- a/ui/src/ducks/app/monitoring.js
+++ b/ui/src/ducks/app/monitoring.js
@@ -180,6 +180,11 @@ export default function reducer(state = defaultState, action = {}) {
         ...state,
         volumeCurrentStats: { ...state.volumeCurrentStats, ...action.payload },
       };
+    case UPDATE_NODESTATS_FETCH_ARG:
+      return {
+        ...state,
+        nodeStats: { ...state.nodeStats, ...action.payload },
+      };
     case UPDATE_NODE_UNAME_INFO:
       return {
         ...state,


### PR DESCRIPTION
**Component**:

ui

**Context**: 

Show average button was broken following.

**Summary**:

Adding missing reducer for UPDATE_NODESTATS_FETCH_ARG action solves this.