### PR TITLE
ci/build: Workaround GKE issue with TCPMSS

### DIFF
--- a/eve/workers/pod-builder/pod.yaml
+++ b/eve/workers/pod-builder/pod.yaml
@@ -4,6 +4,18 @@ kind: Pod
 metadata:
   name: build-pod
 spec:
+  initContainers:
+    - name: workaround
+      image: k8s.gcr.io/build-image/debian-iptables-amd64:buster-v1.6.7
+      command:
+        - sh
+        - -c
+        - "iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu"
+      securityContext:
+        capabilities:
+          add:
+            - NET_ADMIN
+        privileged: true
   containers:
     - name: build-worker
       image: {{ images['docker-builder'] }}

--- a/eve/workers/pod-builder/pod.yaml
+++ b/eve/workers/pod-builder/pod.yaml
@@ -40,7 +40,7 @@ spec:
         - name: worker-workspace
           mountPath: /home/eve/workspace
     - name: platform-dind-daemon
-      image: docker:19.03.2-dind
+      image: docker:20.10.8-dind
       resources:
         requests:
           cpu: "3"


### PR DESCRIPTION
An issue in our CI cluster seems to require this workaround to avoid
connectivity issues towards the Fastly CDN used by some of our
dependencies.

Also bump `dind` (Docker in Docker) sidecar to `20.10.8`.