### PR TITLE
salt: Add kubelet_scrape_timeout to configure kubelet service monitor scrape timeout

### DIFF
--- a/charts/kube-prometheus-stack.yaml
+++ b/charts/kube-prometheus-stack.yaml
@@ -244,3 +244,7 @@ kubeControllerManager:
   serviceMonitor:
     https: true
     insecureSkipVerify: true
+
+kubelet:
+  serviceMonitor:
+    scrapeTimeout: "__var__(prometheus.spec.config.serviceMonitor.kubelet.scrapeTimeout)"

--- a/docs/operation/cluster_and_service_configuration.rst
+++ b/docs/operation/cluster_and_service_configuration.rst
@@ -328,6 +328,37 @@ Both size and time based retentions can be activated at the same time.
 
 Then :ref:`apply the configuration<csc-prometheus-apply-cfg>`.
 
+Set Kubelet metrics scrape tiemout
+""""""""""""""""""""""""""""""""""
+
+In some cases (e.g. when using a lot of sparse loop devices), the kubelet
+metrics endpoint can be very slow to answer and the Prometheus' default 10s
+scrape timeout may not be sufficient.
+To avoid timeouts and thus losing metrics, you can customize the scrape
+timeout as follows:
+
+
+.. code-block:: yaml
+
+   ---
+   apiVersion: v1
+   kind: ConfigMap
+   metadata:
+     name: metalk8s-prometheus-config
+     namespace: metalk8s-monitoring
+   data:
+     config.yaml: |-
+       apiVersion: addons.metalk8s.scality.com
+       kind: PrometheusConfig
+       spec:
+         config:
+           serviceMonitor:
+             kubelet:
+               scrapeTimeout: 30s
+
+Then :ref:`apply the configuration<csc-prometheus-apply-cfg>`.
+
+
 Predefined Alert Rules Customization
 """"""""""""""""""""""""""""""""""""
 

--- a/salt/metalk8s/addons/prometheus-operator/config/prometheus.yaml
+++ b/salt/metalk8s/addons/prometheus-operator/config/prometheus.yaml
@@ -11,6 +11,9 @@ spec:
     retention_time: "10d"
     retention_size: "0"  # "0" to disable size-based retention
     enable_admin_api: false
+    serviceMonitor:
+      kubelet:
+        scrapeTimeout: 10s
   rules:
     node_exporter:
       node_filesystem_space_filling_up:

--- a/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
@@ -60866,6 +60866,7 @@ spec:
       - __metrics_path__
       targetLabel: metrics_path
     scheme: https
+    scrapeTimeout: {% endraw -%}{{ prometheus.spec.config.serviceMonitor.kubelet.scrapeTimeout }}{%- raw %}
     tlsConfig:
       caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
       insecureSkipVerify: true


### PR DESCRIPTION
**Component**:

salt

**Context**: 

When using a bunch of sparseloopdevice kubelet metrics endpoint may spend
a lot of time to retrieve volumes metrics. In such situation the default
10s scrape timeout of Prometheus is not enough as the metrics endpoint may
take longer to answer.

To avoid losing data in such situations, we enabled customization of kubelet
scarpe timeout.