### PR TITLE
MetalK8s UI: Redirect to dashboard page as root

### DIFF
--- a/ui/src/components/DashboardAlerts.js
+++ b/ui/src/components/DashboardAlerts.js
@@ -103,8 +103,8 @@ const DashboardAlerts = () => {
           </BadgesContainer>
           <Link
             onClick={() => {
-              history.push('/alerts');
               openLink(alertView);
+              history.replace('/alerts');
             }}
             data-testid="view-all-link"
           >

--- a/ui/src/components/DashboardInventory.js
+++ b/ui/src/components/DashboardInventory.js
@@ -24,6 +24,7 @@ import {
   useHighestSeverityAlerts,
   highestAlertToStatus,
 } from '../containers/AlertProvider';
+import { useHistory } from 'react-router';
 
 const InventoryContainer = styled.div`
   padding: 0px ${spacing.sp2};
@@ -87,7 +88,7 @@ const DashboardInventory = () => {
   const { data: nodesCount } = useQuery(
     getNodesCountQuery(config || '', token),
   );
-
+  const history = useHistory();
   return (
     <InventoryContainer>
       <PageSubtitle aria-label="inventory">
@@ -100,6 +101,9 @@ const DashboardInventory = () => {
             headerBackgroundColor="backgroundLevel1"
             bodyBackgroundColor="backgroundLevel2"
             aria-label="nodes"
+            onClick={() => {
+              history.push('/nodes');
+            }}
           >
             <Card.Header>
               <div>{intl.formatMessage({ id: 'nodes' })}</div>
@@ -126,6 +130,9 @@ const DashboardInventory = () => {
             headerBackgroundColor="backgroundLevel1"
             bodyBackgroundColor="backgroundLevel2"
             aria-label="volumes"
+            onClick={() => {
+              history.push('/volumes');
+            }}
           >
             <Card.Header>
               <div>{intl.formatMessage({ id: 'volumes' })}</div>

--- a/ui/src/containers/Layout.js
+++ b/ui/src/containers/Layout.js
@@ -122,7 +122,7 @@ const Layout = () => {
           <PrivateRoute
             exact
             path="/"
-            component={() => <Redirect to="/nodes" />}
+            component={() => <Redirect to="/dashboard" />}
           />
           <PrivateRoute exact path="/nodes/create" component={NodeCreateForm} />
           <PrivateRoute


### PR DESCRIPTION
**Component**: UI

**Context**: 
- We should be able to redirect to /dashboard when the root is /
- Go to the Node and Volume page when click on the inventory card in dashboard page

**Summary**:

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
