### PR TITLE
salt: Convert `datetime` from `managedFields` from storage classes in pillar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 ## Release 2.10.4 (in development)
+## Bug fixes
+
+- [#3564](https://github.com/scality/metalk8s/issues/3564) - Fix a bug that
+  prevents running salt states using salt-ssh if the target node has some
+  MetalK8s volumes
+  (PR[#3566](https://github.com/scality/metalk8s/pull/3566))
+
 ## Release 2.10.3
 ### Enhancements
 

--- a/salt/_pillar/metalk8s_nodes.py
+++ b/salt/_pillar/metalk8s_nodes.py
@@ -84,6 +84,9 @@ def get_storage_classes(kubeconfig=None):
         storageclass["metadata"]["deletion_timestamp"] = iso_timestamp_converter(
             storageclass["metadata"]["deletion_timestamp"]
         )
+        for managed_field in storageclass["metadata"]["managed_fields"]:
+            managed_field["time"] = iso_timestamp_converter(managed_field["time"])
+
         storage_classes[storageclass["metadata"]["name"]] = storageclass
 
     return storage_classes

--- a/tests/post/features/salt_ssh.feature
+++ b/tests/post/features/salt_ssh.feature
@@ -1,0 +1,6 @@
+@post @ci @local @saltssh
+Feature: saltssh
+    Scenario: salt-ssh state work on every non-bootstrap nodes
+        Given the Kubernetes API is available
+        And we are on a multi node cluster
+        Then we are able to run 'metalk8s.node.grains' using salt-ssh on non-bootstrap nodes

--- a/tests/post/steps/test_salt_ssh.py
+++ b/tests/post/steps/test_salt_ssh.py
@@ -1,0 +1,41 @@
+import json
+
+import pytest
+from pytest_bdd import scenario, then, parsers
+
+from tests import utils
+
+
+@scenario(
+    "../features/salt_ssh.feature", "salt-ssh state work on every non-bootstrap nodes"
+)
+def test_salt_ssh_state(host):
+    pass
+
+
+@then(parsers.parse("we are able to run '{state}' using salt-ssh on non-{role} nodes"))
+def run_state_salt_ssh(host, k8s_client, ssh_config, version, state, role):
+    minions = [
+        node.metadata.name
+        for node in k8s_client.list_node(
+            label_selector=f"node-role.kubernetes.io/{role}!="
+        ).items
+    ]
+    command = [
+        "salt-ssh",
+        "-L",
+        ",".join(minions),
+        "state.sls",
+        state,
+        "saltenv=metalk8s-{}".format(version),
+        "--out=json",
+    ]
+
+    state_outputs = json.loads(utils.run_salt_command(host, command, ssh_config).stdout)
+
+    for minion, ret in state_outputs.items():
+        assert isinstance(ret, dict), f"Error on {minion}: {ret}"
+        for state_name, state_result in ret.items():
+            assert state_result[
+                "result"
+            ], f"Error on {minion}: state {state_name}: {state_result['comment']}"


### PR DESCRIPTION
**Component**:

'salt'

**Context**: 

#3564 

**Summary**:

We store volumes and storage classes in the salt pillar that contains
some `datetime` python objects and `datetime` objects cannot be rendered
to json using "classic" `json.dump`.
This means that salt-ssh command that relies on the pillar (like salt
states) crash if some volume is deployed on the target node

---

Fixes: #3564
