### PR TITLE
tests: Fix salt-ssh test for multi node

### DIFF
--- a/tests/post/steps/test_salt_ssh.py
+++ b/tests/post/steps/test_salt_ssh.py
@@ -23,6 +23,7 @@ def run_state_salt_ssh(host, k8s_client, ssh_config, version, state, role):
     ]
     command = [
         "salt-ssh",
+        "--static",
         "-L",
         ",".join(minions),
         "state.sls",


### PR DESCRIPTION
Fix salt-ssh tests so that we can load the salt-ssh output when we run the state
on multiple minions