### PR TITLE
fix(CircleStatus): Fix rendering issue for CircleStatus

### DIFF
--- a/ui/src/components/CircleStatus.js
+++ b/ui/src/components/CircleStatus.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import { Icon } from '@scality/core-ui';
 
 import {
   STATUS_WARNING,
@@ -11,74 +11,45 @@ import {
   CIRCLE_DOUBLE_SIZE,
 } from '../constants.js';
 
-export const StatusIcon = styled.i`
-  color: ${(props) => {
-    const theme = props.theme;
-    let color;
-
-    switch (props.status) {
-      case STATUS_SUCCESS:
-        color = theme.statusHealthy;
-        break;
-      case STATUS_WARNING:
-        color = theme.statusWarning;
-        break;
-      case STATUS_CRITICAL:
-        color = theme.statusCritical;
-        break;
-      case STATUS_NONE:
-        color = theme.textTertiary;
-        break;
-      case STATUS_HEALTH:
-        color = theme.statusHealthy;
-        break;
-      default:
-        color = theme.textTertiary;
-    }
-    return color;
-  }};
-`;
+const getStyle = (status) => {
+  switch (status) {
+    case STATUS_SUCCESS:
+    case STATUS_HEALTH:
+      return {
+        name: "Check-circle",
+        color: "statusHealthy"
+      }
+    case STATUS_WARNING:
+      return {
+        name: "Exclamation-circle",
+        color: "statusWarning"
+      }
+    case STATUS_CRITICAL:
+      return {
+        name: "Times-circle",
+        color: "statusCritical"
+      }
+    case STATUS_NONE:
+    default: 
+      return {
+        name: "Dot-circle",
+        color: "infoPrimary"
+      }
+  }
+}
 
 class CircleStatus extends React.Component {
+  shouldComponentUpdate({ status }) {
+    return this.props.status !== status;
+  }
+
   render() {
     const { status, size } = this.props;
-    if (size === undefined || size === CIRCLE_BASE_SIZE) {
-      if (status === STATUS_NONE) {
-        return (
-          <StatusIcon
-            className="far fa-circle"
-            status={status}
-            aria-label={`status ${status}`}
-          />
-        );
-      } else {
-        return (
-          <StatusIcon
-            className="fas fa-circle"
-            status={status}
-            aria-label={`status ${status}`}
-          />
-        );
-      }
-    } else if (size === CIRCLE_DOUBLE_SIZE) {
-      if (status === STATUS_NONE) {
-        return (
-          <StatusIcon
-            className="far fa-circle fa-2x"
-            status={status}
-            aria-label={`status ${status}`}
-          />
-        );
-      } else {
-        return (
-          <StatusIcon
-            className="fas fa-circle fa-2x"
-            status={status}
-            aria-label={`status ${status}`}
-          />
-        );
-      }
-    }
+    const { name, color } = getStyle(status);
+    if (size === undefined || size === CIRCLE_BASE_SIZE || size === CIRCLE_DOUBLE_SIZE)
+      return (
+        <Icon name={name} color={color} size={size === CIRCLE_DOUBLE_SIZE ? "2x" : "1x"}/>
+      );
   }
 }
 

--- a/ui/src/components/CircleStatus.js
+++ b/ui/src/components/CircleStatus.js
@@ -44,7 +44,7 @@ const CircleStatus = React.memo((props) => {
 
   if (size === undefined || size === CIRCLE_BASE_SIZE || size === CIRCLE_DOUBLE_SIZE)
     return (
-      <Icon name={name} color={color} size={size === CIRCLE_DOUBLE_SIZE ? "2x" : "1x"} aria-label={`status ${status}`}/>
+      <Icon name={name} color={color} size={size === CIRCLE_DOUBLE_SIZE ? "2x" : "1x"} ariaLabel={`status ${status}`}/>
     );
 });
 

--- a/ui/src/components/CircleStatus.js
+++ b/ui/src/components/CircleStatus.js
@@ -48,7 +48,7 @@ class CircleStatus extends React.Component {
     const { name, color } = getStyle(status);
     if (size === undefined || size === CIRCLE_BASE_SIZE || size === CIRCLE_DOUBLE_SIZE)
       return (
-        <Icon name={name} color={color} size={size === CIRCLE_DOUBLE_SIZE ? "2x" : "1x"}/>
+        <Icon name={name} color={color} size={size === CIRCLE_DOUBLE_SIZE ? "2x" : "1x"} aria-label={`status ${status}`}/>
       );
   }
 }

--- a/ui/src/components/CircleStatus.js
+++ b/ui/src/components/CircleStatus.js
@@ -38,19 +38,14 @@ const getStyle = (status) => {
   }
 }
 
-class CircleStatus extends React.Component {
-  shouldComponentUpdate({ status }) {
-    return this.props.status !== status;
-  }
+const CircleStatus = React.memo((props) => {
+  const { status, size } = props;
+  const { name, color } = getStyle(status);
 
-  render() {
-    const { status, size } = this.props;
-    const { name, color } = getStyle(status);
-    if (size === undefined || size === CIRCLE_BASE_SIZE || size === CIRCLE_DOUBLE_SIZE)
-      return (
-        <Icon name={name} color={color} size={size === CIRCLE_DOUBLE_SIZE ? "2x" : "1x"} aria-label={`status ${status}`}/>
-      );
-  }
-}
+  if (size === undefined || size === CIRCLE_BASE_SIZE || size === CIRCLE_DOUBLE_SIZE)
+    return (
+      <Icon name={name} color={color} size={size === CIRCLE_DOUBLE_SIZE ? "2x" : "1x"} aria-label={`status ${status}`}/>
+    );
+});
 
 export default CircleStatus;

--- a/ui/src/components/DashboardGlobalHealth.js
+++ b/ui/src/components/DashboardGlobalHealth.js
@@ -17,7 +17,8 @@ import {
 import { useIntl } from 'react-intl';
 import { useStartingTimeStamp } from '../containers/StartTimeProvider';
 import LoaderComponent from '@scality/core-ui/dist/components/loader/Loader.component';
-import CircleStatus, { StatusIcon } from './CircleStatus';
+import CircleStatus from './CircleStatus';
+import StatusIcon from './StatusIcon';
 import GlobalHealthBarComponent from '@scality/core-ui/dist/components/globalhealthbar/GlobalHealthBar.component';
 import { getClusterAlertSegmentQuery } from '../services/platformlibrary/metrics';
 import { useMetricsTimeSpan } from '@scality/core-ui/dist/next';

--- a/ui/src/components/DashboardPlane.test.js
+++ b/ui/src/components/DashboardPlane.test.js
@@ -67,7 +67,7 @@ describe("the dashboard network's plane panel", () => {
     // Have to any type jest.fn function to avoid Flow warning for mockImplementation()
     (useHighestSeverityAlerts: any).mockImplementation(() => noAlerts);
     render(<DashboardPlaneHealth />);
-    expect(screen.getAllByLabelText(`status ${STATUS_HEALTH}`)).toHaveLength(
+    expect(screen.getAllByLabelText(`Check-circle status ${STATUS_HEALTH}`)).toHaveLength(
       NB_ITEMS,
     );
   });
@@ -80,7 +80,7 @@ describe("the dashboard network's plane panel", () => {
     render(<DashboardPlaneHealth />);
 
     // Verify
-    expect(screen.getAllByLabelText(`status ${STATUS_WARNING}`)).toHaveLength(
+    expect(screen.getAllByLabelText(`Exclamation-circle status ${STATUS_WARNING}`)).toHaveLength(
       NB_ITEMS,
     );
     expect(screen.getAllByTestId('alert-link')).toHaveLength(NB_ITEMS);
@@ -94,7 +94,7 @@ describe("the dashboard network's plane panel", () => {
     render(<DashboardPlaneHealth />);
 
     // Verify
-    expect(screen.getAllByLabelText(`status ${STATUS_CRITICAL}`)).toHaveLength(
+    expect(screen.getAllByLabelText(`Times-circle status ${STATUS_CRITICAL}`)).toHaveLength(
       NB_ITEMS,
     );
     expect(screen.getAllByTestId('alert-link')).toHaveLength(NB_ITEMS);

--- a/ui/src/components/DashboardServices.test.js
+++ b/ui/src/components/DashboardServices.test.js
@@ -76,7 +76,7 @@ describe('the dashboard inventory panel', () => {
     render(<DashboardServices />);
 
     // Verify
-    expect(screen.getAllByLabelText(`status ${STATUS_HEALTH}`)).toHaveLength(8);
+    expect(screen.getAllByLabelText(`Check-circle status ${STATUS_HEALTH}`)).toHaveLength(8);
   });
 
   test('displays the services panel and display all 8 warning statuses when warning alerts are present as well as link to the alerts page', async () => {
@@ -87,7 +87,7 @@ describe('the dashboard inventory panel', () => {
     render(<DashboardServices />);
 
     // Verify
-    expect(screen.getAllByLabelText(`status ${STATUS_WARNING}`)).toHaveLength(
+    expect(screen.getAllByLabelText(`Exclamation-circle status ${STATUS_WARNING}`)).toHaveLength(
       8,
     );
     expect(screen.getAllByTestId('alert-link')).toHaveLength(8);
@@ -101,7 +101,7 @@ describe('the dashboard inventory panel', () => {
     render(<DashboardServices />);
 
     // Verify
-    expect(screen.getAllByLabelText(`status ${STATUS_CRITICAL}`)).toHaveLength(
+    expect(screen.getAllByLabelText(`Times-circle status ${STATUS_CRITICAL}`)).toHaveLength(
       8,
     );
     expect(screen.getAllByTestId('alert-link')).toHaveLength(8);

--- a/ui/src/components/NodePartitionTable.test.js
+++ b/ui/src/components/NodePartitionTable.test.js
@@ -356,7 +356,7 @@ describe('the system partition table', () => {
     await waitForLoadingToFinish();
 
     // Verify
-    expect(screen.getByLabelText('status warning')).toBeInTheDocument();
+    expect(screen.getByLabelText('Exclamation-circle status warning')).toBeInTheDocument();
     expect(screen.getByLabelText('97%')).toBeInTheDocument();
     expect(screen.getByText('/mnt/testpart')).toBeInTheDocument();
     // since we use the same query, so the number of global size is the same as usage

--- a/ui/src/components/StatusIcon.js
+++ b/ui/src/components/StatusIcon.js
@@ -11,7 +11,6 @@ import {
 const StatusIcon = styled.i`
   color: ${(props) => {
     const theme = props.theme;
-    console.log(theme);
     let color;
 
     switch (props.status) {

--- a/ui/src/components/StatusIcon.js
+++ b/ui/src/components/StatusIcon.js
@@ -1,0 +1,40 @@
+import styled from 'styled-components';
+
+import {
+  STATUS_WARNING,
+  STATUS_CRITICAL,
+  STATUS_SUCCESS,
+  STATUS_NONE,
+  STATUS_HEALTH,
+} from '../constants.js';
+
+const StatusIcon = styled.i`
+  color: ${(props) => {
+    const theme = props.theme;
+    console.log(theme);
+    let color;
+
+    switch (props.status) {
+      case STATUS_SUCCESS:
+        color = theme.statusHealthy;
+        break;
+      case STATUS_WARNING:
+        color = theme.statusWarning;
+        break;
+      case STATUS_CRITICAL:
+        color = theme.statusCritical;
+        break;
+      case STATUS_NONE:
+        color = theme.textTertiary;
+        break;
+      case STATUS_HEALTH:
+        color = theme.statusHealthy;
+        break;
+      default:
+        color = theme.textTertiary;
+    }
+    return color;
+  }};
+`;
+
+export default StatusIcon;


### PR DESCRIPTION
This PR fixes rendering issue for CircleStatus by avoiding non-necessary re-renders

**Component**:

`CircleStatus`, `StatusIcon`

**Context**: 

When `Icons` from Core-UI are implemented into `CircleStatus` component, they may re-render periodically even when an update was not required (e.g.: Status not changing).

**Summary**:

By adding a prop update verification into `CircleStatus`, component will now only re-render when status is changing, in order to avoid non-necessary re-renders.

Also, `StatusIcon` component is now in a dedicated file since it is now no longer used by `CircleStatus`.

**Acceptance criteria**: 

Health icons in Core-UI ([See related PR](https://github.com/scality/core-ui/pull/378)) should be merged and available first, in order to have access to the icons used by `CircleStatus`.

---

See: ARTESCA-2152
