### PR TITLE
Manage `podAntiAffinity` and number of replicas for CoreDNS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@
   (PR[#3540](https://github.com/scality/metalk8s/pull/3540))
 
 - [#3574](https://github.com/scality/metalk8s/issues/3574) - Allow to manage
-  soft and hard `podAntiAffinity` for `CoreDNS` from Bootstrap configuration
-  file, with a default soft anti-affinity on hostname, so that if it's
-  possible each `CoreDNS` pods will sit on different infra node
+  number of replicas and, soft and hard `podAntiAffinity` for `CoreDNS`
+  from Bootstrap configuration file, with a default soft anti-affinity on
+  hostname, so that if it's possible each `CoreDNS` pods will sit on different infra node
   (PR[#3579](https://github.com/scality/metalk8s/pull/3579))
 
 ### Removals

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
   when observing the cluster state (used in the UI Dashboard page)
   (PR[#3540](https://github.com/scality/metalk8s/pull/3540))
 
+- [#3574](https://github.com/scality/metalk8s/issues/3574) - Allow to manage
+  soft and hard `podAntiAffinity` for `CoreDNS` from Bootstrap configuration
+  file, with a default soft anti-affinity on hostname, so that if it's
+  possible each `CoreDNS` pods will sit on different infra node
+  (PR[#3579](https://github.com/scality/metalk8s/pull/3579))
+
 ### Removals
 
 - Removed the PDF support for documentation, replaced it with the HTML output

--- a/docs/installation/bootstrap.rst
+++ b/docs/installation/bootstrap.rst
@@ -71,6 +71,7 @@ Configuration
           featureGates:
             <feature_gate_name>: True
         coreDNS:
+          replicas: 2
           podAntiAffinity:
             hard: []
             soft:
@@ -171,12 +172,13 @@ defaults kubernetes configuration.
   configure the corresponding entries in the
   ``kubernetes.apiServer.featureGates`` mapping.
 
-  If you want to override the default ``coreDNS`` podAntiAffinity, by default
-  MetalK8s use soft podAntiAffinity on hostname so that if it's possible
-  ``coreDNS`` pods will be spread on different infra nodes.
-  If you have more infra node than ``coreDNS`` replicas (default is 2), you
-  should set hard podAntiAffinity on hostname so that you are sure that
-  ``coreDNS`` pods sit on different node, to do so:
+  If you want to override the default ``coreDNS`` podAntiAffinity or number of
+  replicas, by default MetalK8s deploy 2 replicas and use soft podAntiAffinity
+  on hostname so that if it's possible ``coreDNS`` pods will be spread on
+  different infra nodes.
+  If you have more infra node than ``coreDNS`` replicas, you should set hard
+  podAntiAffinity on hostname so that you are sure that ``coreDNS`` pods sit
+  on different node, to do so:
 
     .. code-block:: yaml
 

--- a/docs/installation/bootstrap.rst
+++ b/docs/installation/bootstrap.rst
@@ -146,7 +146,7 @@ The ``no_proxy`` entry specifies IPs that should be excluded from proxying,
 it must be a list of hosts, IP addresses or IP ranges in CIDR format.
 For example;
 
-   .. code-block:: shell
+   .. code-block:: yaml
 
       no_proxy:
         - localhost

--- a/docs/installation/bootstrap.rst
+++ b/docs/installation/bootstrap.rst
@@ -70,6 +70,11 @@ Configuration
         apiServer:
           featureGates:
             <feature_gate_name>: True
+        coreDNS:
+          podAntiAffinity:
+            hard: []
+            soft:
+              - topologyKey: kubernetes.io/hostname
 
 The ``networks`` field specifies a range of IP addresses written in CIDR
 notation for it's various subfields.
@@ -159,10 +164,27 @@ the bootstrap script is executed, those ISOs are automatically mounted and the
 system is configured to re-mount them automatically after a reboot.
 
 The ``kubernetes`` field can be omitted if you do not have any specific
-Kubernetes `Feature Gates`_ to enable or disable.
-If you need to enable or disable specific features for ``kube-apiserver``
-configure the corresponding entries in the
-``kubernetes.apiServer.featureGates`` mapping.
+Kubernetes `Feature Gates`_ to enable or disable and if you are ok with
+defaults kubernetes configuration.
+
+  If you need to enable or disable specific features for ``kube-apiserver``
+  configure the corresponding entries in the
+  ``kubernetes.apiServer.featureGates`` mapping.
+
+  If you want to override the default ``coreDNS`` podAntiAffinity, by default
+  MetalK8s use soft podAntiAffinity on hostname so that if it's possible
+  ``coreDNS`` pods will be spread on different infra nodes.
+  If you have more infra node than ``coreDNS`` replicas (default is 2), you
+  should set hard podAntiAffinity on hostname so that you are sure that
+  ``coreDNS`` pods sit on different node, to do so:
+
+    .. code-block:: yaml
+
+      kubernetes:
+        coreDNS:
+          podAntiAffinity:
+            hard:
+              - topologyKey: kubernetes.io/hostname
 
 .. _Feature Gates: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
 

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -346,6 +346,7 @@ models:
       env: &_env_bootstrap_config_ssh
         DEBUG: "%(prop:metalk8s_debug:-false)s"
         ARCHIVE: metalk8s.iso
+        COREDNS_ANTI_AFFINITY: "{}"
       command: |
         ssh -F ssh_config bootstrap "
         sudo bash << EOF
@@ -367,6 +368,9 @@ models:
         archives:
           - \"\$(readlink -f \"${ARCHIVE}\")\"
         debug: ${DEBUG}
+        kubernetes:
+          coreDNS:
+            podAntiAffinity: ${COREDNS_ANTI_AFFINITY}
         END
         EOF"
       haltOnFailure: true
@@ -2355,6 +2359,8 @@ stages:
           env:
             <<: *_env_bootstrap_config_ssh
             ARCHIVE: /archives/metalk8s.iso
+            COREDNS_ANTI_AFFINITY: >-
+              {"hard": [{"topologyKey": "kubernetes.io/hostname"}]}
       - ShellCommand:
           <<: *copy_iso_bootstrap_ssh
           env:

--- a/salt/_modules/metalk8s_kubernetes.py
+++ b/salt/_modules/metalk8s_kubernetes.py
@@ -9,6 +9,7 @@ module, while other methods can be found in `metalk8s_kubernetes_utils.py`,
 `metalk8s_drain.py` and `metalk8s_cordon.py`.
 """
 
+from datetime import datetime
 import json
 import logging
 import re
@@ -327,6 +328,32 @@ def object_exists(kind, apiVersion, name, **kwargs):
         salt-call metalk8s_kubernetes.object_exists kind="Node" apiVersion="v1" name="MyNode"
     """
     return get_object(kind=kind, apiVersion=apiVersion, name=name, **kwargs) is not None
+
+
+# Equivalent of "kubectl rollout restart"
+def rollout_restart(*args, **kwargs):
+    """
+    Simple helper to trigger a rollout restart of Deployment, DaemonSet, ...
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt-call metalk8s_kubernetes.rollout_restart kind="Deployment" apiVersion="apps/v1" name="MyDeployment" namespace="default"
+    """
+    patch = {
+        "spec": {
+            "template": {
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/restartedAt": datetime.now().isoformat()
+                    }
+                }
+            }
+        }
+    }
+
+    return update_object(patch=patch, *args, **kwargs)
 
 
 # Listing resources can benefit from a simpler signature

--- a/salt/metalk8s/kubernetes/coredns/deployed.sls
+++ b/salt/metalk8s/kubernetes/coredns/deployed.sls
@@ -3,9 +3,12 @@
 
 {%- set cluster_dns_ip = salt.metalk8s_network.get_cluster_dns_ip() %}
 
+{%- set pillar_coredns = pillar.kubernetes.get("coreDNS", {}) %}
+
+{%- set replicas = pillar_coredns.get("replicas") or 2 %}
 {%- set label_selector = {"k8s-app": "kube-dns"} %}
 
-{%- set pillar_affinities = pillar.kubernetes.get("coreDNS", {}).get("podAntiAffinity", {}) %}
+{%- set pillar_affinities = pillar_coredns.get("podAntiAffinity", {}) %}
 {#- NOTE: The default podAntiAffinity is a soft anti-affinity on hostname #}
 {%- set soft_affinities = pillar_affinities.get("soft") or [{"topologyKey": "kubernetes.io/hostname"}] %}
 {%- set hard_affinities = pillar_affinities.get("hard") or [] %}
@@ -80,6 +83,7 @@ Create coredns deployment:
     - name: salt://{{ slspath }}/files/coredns-deployment.yaml.j2
     - template: jinja
     - defaults:
+        replicas: {{ replicas }}
         label_selector: {{ label_selector | tojson }}
         affinity: {{ affinity | tojson }}
 

--- a/salt/metalk8s/kubernetes/coredns/files/coredns-deployment.yaml.j2
+++ b/salt/metalk8s/kubernetes/coredns/files/coredns-deployment.yaml.j2
@@ -20,12 +20,14 @@ spec:
       maxUnavailable: 1
   selector:
     matchLabels:
-      k8s-app: kube-dns
+      {{ label_selector | yaml(False) | indent(8) }}
   template:
     metadata:
       labels:
-        k8s-app: kube-dns
+        {{ label_selector | yaml(False) | indent(8) }}
     spec:
+      affinity:
+        {{ affinity | yaml(False) | indent(8) }}
       priorityClassName: system-cluster-critical
       tolerations:
         - key: "CriticalAddonsOnly"

--- a/salt/metalk8s/kubernetes/coredns/files/coredns-deployment.yaml.j2
+++ b/salt/metalk8s/kubernetes/coredns/files/coredns-deployment.yaml.j2
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: metalk8s
     app.kubernetes.io/managed-by: salt
 spec:
-  replicas: 2
+  replicas: {{ replicas }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/salt/metalk8s/orchestrate/deploy_node.sls
+++ b/salt/metalk8s/orchestrate/deploy_node.sls
@@ -307,3 +307,18 @@ Kill kube-controller-manager on all master nodes:
         pattern: kube-controller-manager
     - require:
       - salt: Run the highstate
+
+{%- if 'infra' in roles and 'infra' not in skip_roles %}
+
+# Trigger a restart of CoreDNS pods so that "soft anti-affinity" can be applied
+Restart CoreDNS pods:
+  module.run:
+    - metalk8s_kubernetes.rollout_restart:
+      - name: coredns
+      - namespace: kube-system
+      - kind: Deployment
+      - apiVersion: apps/v1
+    - require:
+      - metalk8s_cordon: Uncordon the node
+
+{%- endif %}

--- a/salt/tests/unit/formulas/config.yaml
+++ b/salt/tests/unit/formulas/config.yaml
@@ -227,6 +227,7 @@ metalk8s:
           _cases:
             "From metalk8s.kubernetes.coredns.deployed":
               extra_context:
+                replicas: 2
                 label_selector:
                   k8s-app: kube-dns
                 affinity:

--- a/salt/tests/unit/formulas/config.yaml
+++ b/salt/tests/unit/formulas/config.yaml
@@ -181,6 +181,66 @@ metalk8s:
                 config_digest: abcdefgh12345
                 metalk8s_version: "2.7.1"
 
+    coredns:
+      deployed.sls:
+        _cases:
+          "Simple hostname soft anti-affinity (default)": {}
+          "Multiple soft anti-affinity":
+            pillar_overrides:
+              kubernetes:
+                coreDNS:
+                  podAntiAffinity:
+                    soft:
+                      - topologyKey: kubernetes.io/hostname
+                      - topologyKey: kubernetes.io/zone
+                        weight: 10
+          "Hard anti-affinity on hostname":
+            pillar_overrides:
+              kubernetes:
+                coreDNS:
+                  podAntiAffinity:
+                    hard:
+                      - topologyKey: kubernetes.io/hostname
+          "Multiple hard anti-affinity":
+            pillar_overrides:
+              kubernetes:
+                coreDNS:
+                  podAntiAffinity:
+                    hard:
+                      - topologyKey: kubernetes.io/hostname
+                      - topologyKey: kubernetes.io/zone
+          "Multiple hard and soft anti-affinity":
+            pillar_overrides:
+              kubernetes:
+                coreDNS:
+                  podAntiAffinity:
+                    soft:
+                      - topologyKey: kubernetes.io/hostname
+                      - topologyKey: kubernetes.io/zone
+                        weight: 10
+                    hard:
+                      - topologyKey: kubernetes.io/hostname
+                      - topologyKey: kubernetes.io/zone
+
+      files:
+        coredns-deployment.yaml.j2:
+          _cases:
+            "From metalk8s.kubernetes.coredns.deployed":
+              extra_context:
+                label_selector:
+                  k8s-app: kube-dns
+                affinity:
+                  podAntiAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      - weight: 1
+                        podAffinityTerm:
+                          labelSelector:
+                            matchLabels:
+                              k8s-app: kube-dns
+                          namespaces:
+                            - kube-system
+                          topologyKey: kubernetes.io/hostname
+
     etcd:
       files:
         manifest.yaml.j2:

--- a/salt/tests/unit/modules/test_metalk8s_kubernetes.py
+++ b/salt/tests/unit/modules/test_metalk8s_kubernetes.py
@@ -431,6 +431,16 @@ class Metalk8sKubernetesTestCase(TestCase, mixins.LoaderModuleMockMixin):
             )
             get_object_mock.assert_called_once()
 
+    def test_rollout_restart(self):
+        """
+        Tests the return of `rollout_restart` function
+        """
+        update_obj_mock = MagicMock(return_value="patched !!")
+
+        with patch.object(metalk8s_kubernetes, "update_object", update_obj_mock):
+            self.assertEqual(metalk8s_kubernetes.rollout_restart(), "patched !!")
+            update_obj_mock.assert_called_once()
+
     @utils.parameterized_from_cases(YAML_TESTS_CASES["list_objects"])
     def test_list_objects(
         self,

--- a/tests/post/features/dns_resolution.feature
+++ b/tests/post/features/dns_resolution.feature
@@ -3,3 +3,9 @@ Feature: CoreDNS resolution
     Scenario: check DNS
         Given pods with label 'k8s-app=kube-dns' are 'Ready'
         Then the hostname 'kubernetes.default' should be resolved
+
+    Scenario: DNS pods spreading
+        Given the Kubernetes API is available
+        And we are on a multi node cluster
+        Then pods with label 'k8s-app=kube-dns' are 'Ready'
+        And each pods with label 'k8s-app=kube-dns' are on a different node

--- a/tests/post/steps/conftest.py
+++ b/tests/post/steps/conftest.py
@@ -135,4 +135,18 @@ def then_check_pod_status(request, host, k8s_client, label, expected_status):
     _check_pods_status(k8s_client, expected_status, ssh_config, label=label)
 
 
+@then(parsers.parse("each pods with label '{selector}' are on a different node"))
+def then_check_pod_different_node(ssh_config, host, k8s_client, selector):
+    pods = kube_utils.get_pods(k8s_client, ssh_config, selector)
+    assert pods
+
+    nodes = set()
+
+    for pod in pods:
+        assert (
+            pod.spec.nodeName not in nodes
+        ), f"Node '{pod.spec.nodeName}' has several Pod with label '{selector}'"
+        nodes.add(pod.spec.nodeName)
+
+
 # }}}

--- a/tests/post/steps/test_dns.py
+++ b/tests/post/steps/test_dns.py
@@ -53,6 +53,11 @@ def test_dns(host):
     pass
 
 
+@scenario("../features/dns_resolution.feature", "DNS pods spreading")
+def test_dns_spread(host):
+    pass
+
+
 @then(parsers.parse("the hostname '{hostname}' should be resolved"))
 def resolve_hostname(utils_pod, host, hostname):
     with host.sudo():


### PR DESCRIPTION
**Component**:

'dns'

**Context**: 

See: #3574 

**Summary**:

Add entry in the bootstrap configuration file to manage the number of replicas to deploy for CoreDNS and the `podAntiAffinity`.

So that users can set that anti-affinity according to the platform and failure scenario he want to support

---

Fixes: #3574 