### PR TITLE
Fix responsible on large screens

### DIFF
--- a/ui/src/components/NodeListTable.js
+++ b/ui/src/components/NodeListTable.js
@@ -421,7 +421,7 @@ const NodeListTable = (props) => {
       {
         Header: 'Health',
         accessor: 'health',
-        cellStyle: { textAlign: 'center', width: '70px' },
+        cellStyle: { textAlign: 'center', width: '4.5rem' },
         Cell: (cellProps) => {
           const { health } = cellProps.value;
           return <CircleStatus status={health} />;

--- a/ui/src/components/NodePagePodsTab.js
+++ b/ui/src/components/NodePagePodsTab.js
@@ -160,7 +160,7 @@ const NodePagePodsTab = (props) => {
       {
         Header: 'Status',
         accessor: 'status',
-        cellStyle: { width: '100px' },
+        cellStyle: { width: '7rem' },
         Cell: (cellProps) => {
           const { status, numContainer, numContainerRunning } = cellProps.value;
           return status === STATUS_RUNNING ? (
@@ -179,7 +179,7 @@ const NodePagePodsTab = (props) => {
       {
         Header: 'Age',
         accessor: 'age',
-        cellStyle: { width: '60px' },
+        cellStyle: { width: '4.5rem' },
       },
       {
         Header: 'Namespace',
@@ -188,7 +188,7 @@ const NodePagePodsTab = (props) => {
       {
         Header: 'Logs',
         accessor: 'log',
-        cellStyle: { textAlign: 'center', width: '40px' },
+        cellStyle: { textAlign: 'center', width: '2.5rem' },
         Cell: ({ value }) => {
           return (
             <Tooltip

--- a/ui/src/components/NodePageVolumesTable.js
+++ b/ui/src/components/NodePageVolumesTable.js
@@ -372,7 +372,7 @@ const VolumeListTable = (props) => {
         accessor: 'usage',
         cellStyle: {
           textAlign: 'center',
-          width: '120px',
+          width: '6rem',
         },
         Cell: ({ value }) => {
           return (
@@ -391,8 +391,8 @@ const VolumeListTable = (props) => {
         accessor: 'storageCapacity',
         cellStyle: {
           textAlign: 'right',
-          width: '65px',
-          paddingRight: '5px',
+          width: '5rem',
+          paddingRight: '0.75rem',
         },
         sortType: 'size',
         Cell: ({ value }) => formatSizeForDisplay(value),
@@ -402,7 +402,7 @@ const VolumeListTable = (props) => {
         accessor: 'status',
         cellStyle: {
           textAlign: 'center',
-          width: '65px',
+          width: '4rem',
         },
         Cell: (cellProps) => {
           const volume = volumeListData?.find(
@@ -463,8 +463,8 @@ const VolumeListTable = (props) => {
         accessor: 'latency',
         cellStyle: {
           textAlign: 'right',
-          width: '75px',
-          paddingRight: '6px',
+          width: '4.5rem',
+          paddingRight: '0.75rem',
         },
         Cell: (cellProps) => {
           return cellProps.value !== undefined ? cellProps.value + ' µs' : null;

--- a/ui/src/components/VolumeListTable.js
+++ b/ui/src/components/VolumeListTable.js
@@ -369,7 +369,7 @@ const VolumeListTable = (props) => {
         accessor: 'health',
         cellStyle: {
           textAlign: 'center',
-          width: '75px',
+          width: '4.5rem',
         },
         Cell: (cellProps) => {
           return (
@@ -392,7 +392,7 @@ const VolumeListTable = (props) => {
         accessor: 'usage',
         cellStyle: {
           textAlign: 'center',
-          width: isNodeColumn ? '70px' : '150px',
+          width: isNodeColumn ? '4rem' : '150px',
         },
         Cell: ({ value }) => {
           return (
@@ -411,8 +411,8 @@ const VolumeListTable = (props) => {
         accessor: 'storageCapacity',
         cellStyle: {
           textAlign: 'right',
-          width: isNodeColumn ? '70px' : '110px',
-          paddingRight: '5px',
+          width: isNodeColumn ? '5.5rem' : '110px',
+          paddingRight: '0.75rem',
         },
         sortType: 'size',
         Cell: ({ value }) => formatSizeForDisplay(value),
@@ -422,7 +422,7 @@ const VolumeListTable = (props) => {
         accessor: 'status',
         cellStyle: {
           textAlign: 'center',
-          width: isNodeColumn ? '60px' : '120px',
+          width: isNodeColumn ? '4rem' : '120px',
         },
         Cell: (cellProps) => {
           const volume = volumeListData?.find(
@@ -483,8 +483,8 @@ const VolumeListTable = (props) => {
         accessor: 'latency',
         cellStyle: {
           textAlign: 'right',
-          width: isNodeColumn ? '70px' : '110px',
-          paddingRight: '6px',
+          width: isNodeColumn ? '4.5rem' : '110px',
+          paddingRight: '0.75rem',
         },
         Cell: (cellProps) => {
           return cellProps.value !== undefined ? cellProps.value + ' µs' : null;

--- a/ui/src/components/VolumeOverviewTab.js
+++ b/ui/src/components/VolumeOverviewTab.js
@@ -51,7 +51,7 @@ const InformationSpan = styled.div`
 
 const InformationLabel = styled.span`
   display: inline-block;
-  min-width: 150px;
+  min-width: 7rem;
   font-weight: ${fontWeight.bold};
   font-size: ${fontSize.base};
   color: ${(props) => props.theme.textSecondary};


### PR DESCRIPTION
css: replace px by rem for Node/Volume/NodePageVolumes Table & NodePagePods/VolumeOverview Tab

**Component**:

NodeListTable, NodePagePodsTab, NodePageVolumesTable, VolumeListTable, VolumeOverviewTab

**Context**: 

On large screens, some components will have odd sizing, causing responsive issues.

**Summary**:

This PR replaces px values by rem values in order to add responsiveness to those components.

**Acceptance criteria**: 

This PR will fix some responsive issues and is related to [this PR](https://github.com/scality/core-ui/pull/380) on Core-UI, that will fix responsive for Core-UI components used by Metalk8s.

---

See: ARTESCA-2092