### PR TITLE
salt: fix backup replication job name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 - Bump Kubernetes version to 1.21.6
   (PR[#3583](https://github.com/scality/metalk8s/pull/3583))
 
+## Bug fixes
+
+- Fix the backup replication Job name which was including the node name,
+  so that he could exceed the limit of 63 characters.
+  (PR[#3584](https://github.com/scality/metalk8s/pull/3584))
+
+- Fluent-bit instances stayed stuck when a Loki instance was down, blocking
+  the whole logging pipeline. It is now fixed as we configure fluent-bit to
+  talk with Loki's service and use memberlist to keep the Loki instances
+  replicated.
+  (PR[#3557](https://github.com/scality/metalk8s/pull/3557))
+
 ## Release 2.10.4
 ## Bug fixes
 

--- a/salt/metalk8s/addons/dex/deployed/service-configuration.sls
+++ b/salt/metalk8s/addons/dex/deployed/service-configuration.sls
@@ -33,56 +33,7 @@ Create Dex ServiceConfiguration (metalk8s-auth/metalk8s-dex-config):
 
 {%- else %}
 
-  {%- set config_data = dex_service_config.data['config.yaml'] | load_yaml %}
-
-  {%- if config_data.apiVersion == 'addons.metalk8s.scality.com' %}
-
-Convert old Dex ServiceConfiguration to new format:
-  metalk8s_kubernetes.object_present:
-    - manifest:
-        apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          name: metalk8s-dex-config
-          namespace: metalk8s-auth
-        data:
-          config.yaml: |-
-            apiVersion: addons.metalk8s.scality.com/v1alpha2
-            kind: DexConfig
-            spec:
-            {%- if 'deployment' in config_data.spec %}
-              deployment:
-                {{ config_data.spec.deployment | yaml(False) | indent(16) }}
-            {%- endif %}
-
-              config:
-            {%- if 'localuserstore' in config_data.spec %}
-                enablePasswordDB: {{ config_data.spec.localuserstore.enabled }}
-                staticPasswords:
-                {{ config_data.spec.localuserstore.userlist | yaml(False)
-                                                            | indent(16) }}
-            {%- endif %}
-
-            {%- if 'connectors' in config_data.spec %}
-                connectors:
-                {{ config_data.spec.connectors | yaml(False) | indent(16) }}
-            {%- endif %}
-
-          {# We backup the previous config, in case of issues #}
-          previous-config.yaml: |-
-            {{ config_data | yaml(False) | indent(12) }}
-
-  {%- elif config_data.apiVersion == 'addons.metalk8s.scality.com/v1alpha2' %}
-
-Dex ServiceConfiguration already exists in expected format:
+Dex ServiceConfiguration already exists:
   test.succeed_without_changes: []
-
-  {%- else %}
-
-Dex ServiceConfiguration has unexpected format:
-  test.fail_without_changes:
-    - comment: Found unexpected apiVersion "{{ config_data.apiVersion }}"
-
-  {%- endif %}
 
 {%- endif %}

--- a/salt/metalk8s/addons/logging/loki/deployed/service-configuration.sls
+++ b/salt/metalk8s/addons/logging/loki/deployed/service-configuration.sls
@@ -27,7 +27,7 @@ Create metalk8s-loki-config ConfigMap:
 
 {%- else %}
 
-metalk8s-loki-config ConfigMap already exist:
+metalk8s-loki-config ConfigMap already exists:
   test.succeed_without_changes: []
 
 {%- endif %}

--- a/salt/metalk8s/addons/prometheus-operator/deployed/service-configuration.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/service-configuration.sls
@@ -66,7 +66,7 @@ Create prometheus-config ConfigMap:
 
 {%- else %}
 
-metalk8s-prometheus-config ConfigMap already exist:
+metalk8s-prometheus-config ConfigMap already exists:
   test.succeed_without_changes: []
 
 {%- endif %}
@@ -89,7 +89,7 @@ Create alertmanager-config ConfigMap:
 
 {%- else %}
 
-metalk8s-alertmanager-config ConfigMap already exist:
+metalk8s-alertmanager-config ConfigMap already exists:
   test.succeed_without_changes: []
 
 {%- endif %}

--- a/salt/metalk8s/addons/prometheus-operator/post-upgrade.sls
+++ b/salt/metalk8s/addons/prometheus-operator/post-upgrade.sls
@@ -2,9 +2,3 @@
 
 include:
   - .post-cleanup
-
-Delete old metalk8s-prometheus StorageClass:
-  metalk8s_kubernetes.object_absent:
-    - apiVersion: storage.k8s.io/v1
-    - kind: StorageClass
-    - name: metalk8s-prometheus

--- a/salt/metalk8s/orchestrate/backup/files/job.yaml.j2
+++ b/salt/metalk8s/orchestrate/backup/files/job.yaml.j2
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: backup-replication-{{ node }}
+  name: {{ name }}
   namespace: kube-system
   labels:
     app.kubernetes.io/name: backup-replication
@@ -10,7 +10,7 @@ metadata:
 spec:
   backoffLimit: 4
   parallelism: 1
-  ttlSecondsAfterFinished: 120
+  ttlSecondsAfterFinished: 86400
   template:
     metadata:
       labels:

--- a/salt/metalk8s/orchestrate/backup/replication.sls
+++ b/salt/metalk8s/orchestrate/backup/replication.sls
@@ -10,6 +10,7 @@ Schedule backup replication Job on {{ node }}:
     - name: salt://{{ slspath }}/files/job.yaml.j2
     - template: jinja
     - defaults:
+        name: backup-replication-{{ salt.random.get_str(length=15) | lower }}
         node: {{ node }}
         image: {{ image }}
 

--- a/salt/tests/unit/formulas/config.yaml
+++ b/salt/tests/unit/formulas/config.yaml
@@ -298,6 +298,7 @@ metalk8s:
           _cases:
             "Create job manifest for a node":
               extra_context:
+                name: replication-backup-012345689abcde
                 node: master-1
                 image: registry/some-image-name:tag
 


### PR DESCRIPTION
**Component**: salt, backup

**Context**:
We were using the nodeName in the Job name but the nodeName can be very long, meaning the Job name could exceed the limit of 63 characters, thus making it impossible to run.

**Summary**:
We now generate a random ID of 15 chars.
It also allows to keep the previous backup Job a little longer (1 day), to be able to retrieve logs from the previous replication run without any risk of conflict if a new one had to be scheduled.
