### PR TITLE
Metalk8s UI: Add useFakeTimers() in beforeEach

### DIFF
--- a/ui/src/components/NodePartitionTable.test.js
+++ b/ui/src/components/NodePartitionTable.test.js
@@ -107,12 +107,13 @@ describe('the system partition table', () => {
   beforeAll(() => {
     server.listen();
   });
+  beforeEach(() => {
+    // use fake timers to let react query retry immediately after promise failure
+    jest.useFakeTimers();
+  });
 
   test('displays the table', async () => {
     // Setup
-
-    // use fake timers to let react query retry immediately after promise failure
-    jest.useFakeTimers();
     initializeProm(`http://${FAKE_CONTROL_PLANE_IP}:8443/api/prometheus`);
     initializeAM(`http://${FAKE_CONTROL_PLANE_IP}:8443/api/alertmanager`);
     initializeLoki(`http://${FAKE_CONTROL_PLANE_IP}:8443/api/loki`);
@@ -137,9 +138,9 @@ describe('the system partition table', () => {
 
   test('handles server error', async () => {
     // S
-    jest.useFakeTimers();
     initializeProm(`http://${FAKE_CONTROL_PLANE_IP}:8443/api/prometheus`);
     initializeAM(`http://${FAKE_CONTROL_PLANE_IP}:8443/api/alertmanager`);
+    initializeLoki(`http://${FAKE_CONTROL_PLANE_IP}:8443/api/loki`);
 
     // override the default route with error status
     server.use(


### PR DESCRIPTION
**Component**:  UI

**Context**: 

**Summary**:
Add useFakeTimers() in beforeEach to fix the flakiness in the CI unit test.


**Acceptance criteria**: 
CI unit test pass.

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
