### PR TITLE
salt: Use `generateName` to create Job for backup replication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
   replicated.
   (PR[#3557](https://github.com/scality/metalk8s/pull/3557))
 
+- Properly handle `generateName` in our Salt Kubernetes module
+  (PR[#3590](https://github.com/scality/metalk8s/pull/3590))
+
 ## Release 2.10.4
 ## Bug fixes
 

--- a/salt/metalk8s/orchestrate/backup/files/job.yaml.j2
+++ b/salt/metalk8s/orchestrate/backup/files/job.yaml.j2
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ name }}
+  generateName: backup-replication-
   namespace: kube-system
   labels:
     app.kubernetes.io/name: backup-replication

--- a/salt/metalk8s/orchestrate/backup/replication.sls
+++ b/salt/metalk8s/orchestrate/backup/replication.sls
@@ -10,7 +10,6 @@ Schedule backup replication Job on {{ node }}:
     - name: salt://{{ slspath }}/files/job.yaml.j2
     - template: jinja
     - defaults:
-        name: backup-replication-{{ salt.random.get_str(length=15) | lower }}
         node: {{ node }}
         image: {{ image }}
 

--- a/salt/tests/unit/formulas/config.yaml
+++ b/salt/tests/unit/formulas/config.yaml
@@ -298,7 +298,6 @@ metalk8s:
           _cases:
             "Create job manifest for a node":
               extra_context:
-                name: replication-backup-012345689abcde
                 node: master-1
                 image: registry/some-image-name:tag
 


### PR DESCRIPTION
- Fix a bug in salt Kubernetes state module to handle properly `generateName`
- Use `generateName` for Job name for backup replication
