### PR TITLE
Fix responsible on large screens

### DIFF
--- a/shell-ui/package-lock.json
+++ b/shell-ui/package-lock.json
@@ -1958,8 +1958,8 @@
       "dev": true
     },
     "@scality/core-ui": {
-      "version": "github:scality/core-ui#89448b23065f0d6e8a2cc764b918211e063ea355",
-      "from": "github:scality/core-ui#v0.22.3"
+      "version": "github:scality/core-ui#3c4253f328ad41c68ce9062059cf7042180efea4",
+      "from": "github:scality/core-ui#v0.22.6"
     },
     "@scality/module-federation": {
       "version": "github:scality/module-federation#a4f1cf882646c8d859b9081dc8b66e5647962456",

--- a/shell-ui/package-lock.json
+++ b/shell-ui/package-lock.json
@@ -1958,8 +1958,8 @@
       "dev": true
     },
     "@scality/core-ui": {
-      "version": "github:scality/core-ui#88c828152e2973189a068b27ad237b5a6feee85c",
-      "from": "github:scality/core-ui#v0.22.1"
+      "version": "github:scality/core-ui#89448b23065f0d6e8a2cc764b918211e063ea355",
+      "from": "github:scality/core-ui#v0.22.3"
     },
     "@scality/module-federation": {
       "version": "github:scality/module-federation#a4f1cf882646c8d859b9081dc8b66e5647962456",

--- a/shell-ui/package.json
+++ b/shell-ui/package.json
@@ -47,7 +47,7 @@
     "webpack-dev-server": "^3.11.2"
   },
   "dependencies": {
-    "@scality/core-ui": "github:scality/core-ui.git#v0.22.1",
+    "@scality/core-ui": "github:scality/core-ui.git#v0.22.3",
     "@scality/module-federation": "github:scality/module-federation.git#1.0.0",
     "oidc-client": "^1.11.3",
     "oidc-react": "^1.1.5",

--- a/shell-ui/package.json
+++ b/shell-ui/package.json
@@ -47,7 +47,7 @@
     "webpack-dev-server": "^3.11.2"
   },
   "dependencies": {
-    "@scality/core-ui": "github:scality/core-ui.git#v0.22.3",
+    "@scality/core-ui": "github:scality/core-ui.git#v0.22.6",
     "@scality/module-federation": "github:scality/module-federation.git#1.0.0",
     "oidc-client": "^1.11.3",
     "oidc-react": "^1.1.5",

--- a/shell-ui/src/navbar/NavBar.js
+++ b/shell-ui/src/navbar/NavBar.js
@@ -32,7 +32,7 @@ import { useLocation } from 'react-router-dom';
 import { matchPath, RouteProps } from 'react-router';
 
 const Logo = styled.img`
-  height: 30px;
+  height: 2.143rem;
 `;
 
 export const LoadingNavbar = ({ logo }: { logo: string }): Node => (

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -4708,8 +4708,8 @@
       }
     },
     "@scality/core-ui": {
-      "version": "github:scality/core-ui#88c828152e2973189a068b27ad237b5a6feee85c",
-      "from": "github:scality/core-ui#v0.22.1"
+      "version": "github:scality/core-ui#89448b23065f0d6e8a2cc764b918211e063ea355",
+      "from": "github:scality/core-ui#v0.22.3"
     },
     "@scality/module-federation": {
       "version": "github:scality/module-federation#a4f1cf882646c8d859b9081dc8b66e5647962456",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -4708,8 +4708,8 @@
       }
     },
     "@scality/core-ui": {
-      "version": "github:scality/core-ui#89448b23065f0d6e8a2cc764b918211e063ea355",
-      "from": "github:scality/core-ui#v0.22.3"
+      "version": "github:scality/core-ui#3c4253f328ad41c68ce9062059cf7042180efea4",
+      "from": "github:scality/core-ui#v0.22.6"
     },
     "@scality/module-federation": {
       "version": "github:scality/module-federation#a4f1cf882646c8d859b9081dc8b66e5647962456",

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.3",
     "@fortawesome/react-fontawesome": "^0.1.14",
     "@kubernetes/client-node": "github:scality/kubernetes-client-javascript.git#browser-0.10.2-63-g579d066",
-    "@scality/core-ui": "github:scality/core-ui.git#v0.22.1",
+    "@scality/core-ui": "github:scality/core-ui.git#v0.22.3",
     "@scality/module-federation": "github:scality/module-federation.git#1.0.0",
     "axios": "^0.21.1",
     "formik": "2.2.5",

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.3",
     "@fortawesome/react-fontawesome": "^0.1.14",
     "@kubernetes/client-node": "github:scality/kubernetes-client-javascript.git#browser-0.10.2-63-g579d066",
-    "@scality/core-ui": "github:scality/core-ui.git#v0.22.3",
+    "@scality/core-ui": "github:scality/core-ui.git#v0.22.6",
     "@scality/module-federation": "github:scality/module-federation.git#1.0.0",
     "axios": "^0.21.1",
     "formik": "2.2.5",

--- a/ui/src/components/NodeListTable.js
+++ b/ui/src/components/NodeListTable.js
@@ -17,6 +17,7 @@ import { EmptyTable } from '@scality/core-ui';
 import { Button } from '@scality/core-ui/dist/next';
 import { useIntl } from 'react-intl';
 import { compareHealth, useTableSortURLSync } from '../services/utils';
+import { SortCaretWrapper } from './style/CommonLayoutStyle';
 import {
   API_STATUS_READY,
   API_STATUS_NOT_READY,
@@ -148,11 +149,6 @@ const StatusText = styled.div`
   color: ${(props) => {
     return props.textColor;
   }};
-`;
-
-export const SortCaretWrapper = styled.span`
-  padding-left: ${padding.smaller};
-  position: absolute;
 `;
 
 export const SortIncentive = styled.span`
@@ -421,7 +417,7 @@ const NodeListTable = (props) => {
       {
         Header: 'Health',
         accessor: 'health',
-        cellStyle: { textAlign: 'center', width: '70px' },
+        cellStyle: { textAlign: 'center', width: '5rem' },
         Cell: (cellProps) => {
           const { health } = cellProps.value;
           return <CircleStatus status={health} />;

--- a/ui/src/components/NodePageOverviewTab.js
+++ b/ui/src/components/NodePageOverviewTab.js
@@ -12,7 +12,15 @@ import { Steppers, Loader } from '@scality/core-ui';
 import { Button } from '@scality/core-ui/dist/next';
 import isEmpty from 'lodash.isempty';
 import { deployNodeAction } from '../ducks/app/nodes';
-import { NodeTab } from './style/CommonLayoutStyle';
+import {
+  NodeTab,
+  OverviewInformationLabel,
+  OverviewInformationSpan,
+  OverviewInformationValue,
+  OverviewResourceName,
+  ActiveAlertTitle,
+  ActiveAlertWrapper,
+} from './style/CommonLayoutStyle';
 import CircleStatus from './CircleStatus';
 import { API_STATUS_UNKNOWN } from '../constants';
 import { useIntl } from 'react-intl';
@@ -23,33 +31,11 @@ const TabContentContainer = styled.div`
   height: calc(100vh - 40px - 2.8rem);
 `;
 
-const InformationSpan = styled.div`
-  padding: 0 0 ${padding.large} ${padding.large};
-`;
-
-const InformationLabel = styled.span`
-  display: inline-block;
-  min-width: 150px;
-  font-weight: ${fontWeight.bold};
-  font-size: ${fontSize.base};
-  color: ${(props) => props.theme.textSecondary};
-`;
-
-const InformationValue = styled.span`
-  color: ${(props) => props.theme.textPrimary};
-  font-size: ${fontSize.base};
-`;
-
 const NodeNameContainer = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
   padding: ${padding.large} 0 ${padding.larger} ${padding.large};
-`;
-
-const NodeName = styled.span`
-  font-size: ${fontSize.larger};
-  padding-left: ${padding.smaller};
 `;
 
 const StatusText = styled.span`
@@ -62,20 +48,6 @@ const Detail = styled.div`
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-`;
-
-const ActiveAlertTitle = styled.div`
-  color: ${(props) => props.theme.textPrimary};
-  font-size: ${fontSize.base};
-  font-weight: ${fontWeight.bold};
-  padding: 0 0 ${padding.base} 0;
-`;
-
-const ActiveAlertWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  padding: 0 ${padding.larger} 0 ${padding.base};
-  width: 200px;
 `;
 
 const DeployButton = styled(Button)`
@@ -193,7 +165,7 @@ const NodePageOverviewTab = (props) => {
         <NodeNameContainer>
           <div>
             <CircleStatus status={currentNode?.health?.health}></CircleStatus>
-            <NodeName>{nodeName}</NodeName>
+            <OverviewResourceName>{nodeName}</OverviewResourceName>
           </div>
           {currentNodeReturnByK8S?.status === API_STATUS_UNKNOWN && !currentNodeReturnByK8S.internalIP ? (
             !currentNodeReturnByK8S?.deploying ? (
@@ -217,25 +189,25 @@ const NodePageOverviewTab = (props) => {
 
         <Detail>
           <div>
-            <InformationSpan>
-              <InformationLabel>Control Plane IP</InformationLabel>
-              <InformationValue>
+            <OverviewInformationSpan>
+              <OverviewInformationLabel>Control Plane IP</OverviewInformationLabel>
+              <OverviewInformationValue>
                 {currentNode?.name?.controlPlaneIP}
-              </InformationValue>
-            </InformationSpan>
-            <InformationSpan>
-              <InformationLabel>Workload Plane IP</InformationLabel>
-              <InformationValue>
+              </OverviewInformationValue>
+            </OverviewInformationSpan>
+            <OverviewInformationSpan>
+              <OverviewInformationLabel>Workload Plane IP</OverviewInformationLabel>
+              <OverviewInformationValue>
                 {currentNode?.name?.workloadPlaneIP}
-              </InformationValue>
-            </InformationSpan>
-            <InformationSpan>
-              <InformationLabel>Roles</InformationLabel>
-              <InformationValue>{currentNode?.roles}</InformationValue>
-            </InformationSpan>
-            <InformationSpan>
-              <InformationLabel>Status</InformationLabel>
-              <InformationValue>
+              </OverviewInformationValue>
+            </OverviewInformationSpan>
+            <OverviewInformationSpan>
+              <OverviewInformationLabel>Roles</OverviewInformationLabel>
+              <OverviewInformationValue>{currentNode?.roles}</OverviewInformationValue>
+            </OverviewInformationSpan>
+            <OverviewInformationSpan>
+              <OverviewInformationLabel>Status</OverviewInformationLabel>
+              <OverviewInformationValue>
                 {currentNode?.status?.computedStatus?.map((cond) => {
                   return (
                     <StatusText
@@ -246,14 +218,14 @@ const NodePageOverviewTab = (props) => {
                     </StatusText>
                   );
                 })}
-              </InformationValue>
-            </InformationSpan>
-            <InformationSpan>
-              <InformationLabel>
+              </OverviewInformationValue>
+            </OverviewInformationSpan>
+            <OverviewInformationSpan>
+              <OverviewInformationLabel>
                 {intl.formatMessage({ id: 'creationTime' })}
-              </InformationLabel>
+              </OverviewInformationLabel>
               {creationTimestamp ? (
-                <InformationValue>
+                <OverviewInformationValue>
                   <FormattedDate
                     value={creationTimestamp}
                     year="numeric"
@@ -266,31 +238,31 @@ const NodePageOverviewTab = (props) => {
                     second="2-digit"
                     value={creationTimestamp}
                   />
-                </InformationValue>
+                </OverviewInformationValue>
               ) : (
                 ''
               )}
-            </InformationSpan>
-            <InformationSpan>
-              <InformationLabel>K8s Version</InformationLabel>
-              <InformationValue>
+            </OverviewInformationSpan>
+            <OverviewInformationSpan>
+              <OverviewInformationLabel>K8s Version</OverviewInformationLabel>
+              <OverviewInformationValue>
                 {currentNodeReturnByK8S?.kubeletVersion}
-              </InformationValue>
-            </InformationSpan>
-            <InformationSpan>
-              <InformationLabel>Volumes</InformationLabel>
-              <InformationValue>
+              </OverviewInformationValue>
+            </OverviewInformationSpan>
+            <OverviewInformationSpan>
+              <OverviewInformationLabel>Volumes</OverviewInformationLabel>
+              <OverviewInformationValue>
                 {volumesAttachedCurrentNode?.length ??
                   intl.formatMessage({ id: 'unknown' })}
-              </InformationValue>
-            </InformationSpan>
-            <InformationSpan>
-              <InformationLabel>Pods</InformationLabel>
-              <InformationValue>
+              </OverviewInformationValue>
+            </OverviewInformationSpan>
+            <OverviewInformationSpan>
+              <OverviewInformationLabel>Pods</OverviewInformationLabel>
+              <OverviewInformationValue>
                 {podsScheduledOnCurrentNode?.length ??
                   intl.formatMessage({ id: 'unknown' })}
-              </InformationValue>
-            </InformationSpan>
+              </OverviewInformationValue>
+            </OverviewInformationSpan>
           </div>
           <ActiveAlertWrapper>
             <ActiveAlertTitle>

--- a/ui/src/components/NodePagePodsTab.js
+++ b/ui/src/components/NodePagePodsTab.js
@@ -4,7 +4,7 @@ import { useTable } from 'react-table';
 import styled from 'styled-components';
 import { Tooltip } from '@scality/core-ui';
 
-import { fontSize, padding } from '@scality/core-ui/dist/style/theme';
+import { fontSize, padding, spacing } from '@scality/core-ui/dist/style/theme';
 import { NodeTab } from './style/CommonLayoutStyle';
 import { TooltipContent } from './TableRow';
 
@@ -160,7 +160,7 @@ const NodePagePodsTab = (props) => {
       {
         Header: 'Status',
         accessor: 'status',
-        cellStyle: { width: '100px' },
+        cellStyle: { width: '7.143rem' },
         Cell: (cellProps) => {
           const { status, numContainer, numContainerRunning } = cellProps.value;
           return status === STATUS_RUNNING ? (
@@ -179,7 +179,7 @@ const NodePagePodsTab = (props) => {
       {
         Header: 'Age',
         accessor: 'age',
-        cellStyle: { width: '60px' },
+        cellStyle: { width: '4.286rem' },
       },
       {
         Header: 'Namespace',
@@ -188,7 +188,7 @@ const NodePagePodsTab = (props) => {
       {
         Header: 'Logs',
         accessor: 'log',
-        cellStyle: { textAlign: 'center', width: '40px' },
+        cellStyle: { textAlign: 'center', width: spacing.sp40 },
         Cell: ({ value }) => {
           return (
             <Tooltip

--- a/ui/src/components/NodePageVolumesTable.js
+++ b/ui/src/components/NodePageVolumesTable.js
@@ -332,7 +332,8 @@ const VolumeListTable = (props) => {
         accessor: 'health',
         cellStyle: {
           textAlign: 'center',
-          flexBasis: '105px',
+          width: '5rem',
+          paddingRight: '0.714rem',
         },
         Cell: (cellProps) => {
           return (
@@ -347,7 +348,7 @@ const VolumeListTable = (props) => {
         cellStyle: {
           textAlign: 'left',
           flex: 1,
-          minWidth: '95px',
+          minWidth: '6.429rem',
           color: theme.selectedActive,
         },
         Cell: ({ value, row }) => {
@@ -372,7 +373,7 @@ const VolumeListTable = (props) => {
         accessor: 'usage',
         cellStyle: {
           textAlign: 'center',
-          width: '120px',
+          width: '8.571rem',
         },
         Cell: ({ value }) => {
           return (
@@ -391,8 +392,8 @@ const VolumeListTable = (props) => {
         accessor: 'storageCapacity',
         cellStyle: {
           textAlign: 'right',
-          width: '65px',
-          paddingRight: '5px',
+          width: '6rem',
+          paddingRight: '0.357rem',
         },
         sortType: 'size',
         Cell: ({ value }) => formatSizeForDisplay(value),
@@ -402,7 +403,7 @@ const VolumeListTable = (props) => {
         accessor: 'status',
         cellStyle: {
           textAlign: 'center',
-          width: '65px',
+          width: '6rem',
         },
         Cell: (cellProps) => {
           const volume = volumeListData?.find(
@@ -463,8 +464,8 @@ const VolumeListTable = (props) => {
         accessor: 'latency',
         cellStyle: {
           textAlign: 'right',
-          width: '75px',
-          paddingRight: '6px',
+          width: '5.357rem',
+          paddingRight: '1rem',
         },
         Cell: (cellProps) => {
           return cellProps.value !== undefined ? cellProps.value + ' µs' : null;

--- a/ui/src/components/VolumeListTable.js
+++ b/ui/src/components/VolumeListTable.js
@@ -369,7 +369,8 @@ const VolumeListTable = (props) => {
         accessor: 'health',
         cellStyle: {
           textAlign: 'center',
-          width: '75px',
+          width: '4.286rem',
+          paddingRight: '1rem',
         },
         Cell: (cellProps) => {
           return (
@@ -384,7 +385,7 @@ const VolumeListTable = (props) => {
         cellStyle: {
           textAlign: 'left',
           flex: 1,
-          minWidth: '95px',
+          minWidth: '4rem',
         },
       },
       {
@@ -392,7 +393,8 @@ const VolumeListTable = (props) => {
         accessor: 'usage',
         cellStyle: {
           textAlign: 'center',
-          width: isNodeColumn ? '70px' : '150px',
+          width: isNodeColumn ? '5rem' : '10.714rem',
+          paddingRight: '0.714rem',
         },
         Cell: ({ value }) => {
           return (
@@ -411,8 +413,8 @@ const VolumeListTable = (props) => {
         accessor: 'storageCapacity',
         cellStyle: {
           textAlign: 'right',
-          width: isNodeColumn ? '70px' : '110px',
-          paddingRight: '5px',
+          width: isNodeColumn ? '5.714rem' : '7.857rem',
+          paddingRight: '1rem',
         },
         sortType: 'size',
         Cell: ({ value }) => formatSizeForDisplay(value),
@@ -422,7 +424,8 @@ const VolumeListTable = (props) => {
         accessor: 'status',
         cellStyle: {
           textAlign: 'center',
-          width: isNodeColumn ? '60px' : '120px',
+          width: isNodeColumn ? '3.929rem' : '7.857rem',
+          paddingRight: '0.714rem',
         },
         Cell: (cellProps) => {
           const volume = volumeListData?.find(
@@ -483,8 +486,8 @@ const VolumeListTable = (props) => {
         accessor: 'latency',
         cellStyle: {
           textAlign: 'right',
-          width: isNodeColumn ? '70px' : '110px',
-          paddingRight: '6px',
+          width: isNodeColumn ? '4.643rem' : '7.857rem',
+          paddingRight: '1rem',
         },
         Cell: (cellProps) => {
           return cellProps.value !== undefined ? cellProps.value + ' µs' : null;
@@ -499,8 +502,8 @@ const VolumeListTable = (props) => {
     cellStyle: {
       textAlign: 'left',
       flex: 1,
-      paddingLeft: '12px',
-      minWidth: '50px',
+      paddingLeft: '0.857rem',
+      minWidth: '3.214rem',
     },
   };
   if (isNodeColumn) {

--- a/ui/src/components/VolumeOverviewTab.js
+++ b/ui/src/components/VolumeOverviewTab.js
@@ -22,7 +22,16 @@ import {
 import { Modal, ProgressBar, Loader } from '@scality/core-ui';
 import { Button } from '@scality/core-ui/dist/next';
 import { useIntl } from 'react-intl';
-import { VolumeTab } from './style/CommonLayoutStyle';
+import {
+  VolumeTab,
+  OverviewInformationLabel,
+  OverviewInformationSpan,
+  OverviewInformationValue,
+  OverviewClickableInformationValue,
+  OverviewResourceName,
+  ActiveAlertTitle,
+  ActiveAlertWrapper,
+} from './style/CommonLayoutStyle';
 import { formatSizeForDisplay } from '../services/utils';
 
 const VolumeDetailCardContainer = styled.div`
@@ -36,37 +45,6 @@ const VolumeTitleSection = styled.div`
   padding: ${padding.large} ${padding.base} ${padding.larger} ${padding.large};
   display: flex;
   justify-content: space-between;
-`;
-
-const VolumeName = styled.span`
-  font-size: ${fontSize.larger};
-  padding-left: ${padding.smaller};
-`;
-
-const InformationSpan = styled.div`
-  padding-bottom: ${padding.large};
-  padding-left: ${padding.large};
-  display: flex;
-`;
-
-const InformationLabel = styled.span`
-  display: inline-block;
-  min-width: 150px;
-  font-weight: ${fontWeight.bold};
-  font-size: ${fontSize.base};
-  color: ${(props) => props.theme.textSecondary};
-`;
-
-const InformationValue = styled.span`
-  color: ${(props) => props.theme.textPrimary};
-  font-size: ${fontSize.base};
-`;
-
-const ClickableInformationValue = styled.span`
-  color: ${(props) => props.theme.selectedActive};
-  font-size: ${fontSize.base};
-  font-weight: ${fontWeight.semibold};
-  cursor: pointer;
 `;
 
 const VolumeGraph = styled.div`
@@ -117,12 +95,6 @@ const LabelName = styled.span`
 const LabelValue = styled.span`
   font-size: ${fontSize.small};
   color: ${(props) => props.theme.textPrimary};
-`;
-
-const AlertsCounterContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  width: 200px;
 `;
 
 const VolumeDetailCard = (props) => {
@@ -211,7 +183,7 @@ const VolumeDetailCard = (props) => {
       <VolumeTitleSection data-cy="volume_detail_card_name">
         <div>
           <CircleStatus className="fas fa-circle" status={health} />
-          <VolumeName>{name}</VolumeName>
+          <OverviewResourceName>{name}</OverviewResourceName>
         </div>
         <Button
           variant="danger"
@@ -227,42 +199,42 @@ const VolumeDetailCard = (props) => {
       </VolumeTitleSection>
       <VolumeDetailCardContainer>
         <div>
-          <InformationSpan>
-            <InformationLabel>
+          <OverviewInformationSpan>
+            <OverviewInformationLabel>
               {intl.formatMessage({ id: 'node' })}
-            </InformationLabel>
-            <ClickableInformationValue onClick={onClickNodeName}>
+            </OverviewInformationLabel>
+            <OverviewClickableInformationValue onClick={onClickNodeName}>
               {nodeName}
-            </ClickableInformationValue>
-          </InformationSpan>
-          <InformationSpan>
-            <InformationLabel>
+            </OverviewClickableInformationValue>
+          </OverviewInformationSpan>
+          <OverviewInformationSpan>
+            <OverviewInformationLabel>
               {intl.formatMessage({ id: 'size' })}
-            </InformationLabel>
-            <InformationValue data-cy="volume_size_value">
+            </OverviewInformationLabel>
+            <OverviewInformationValue data-cy="volume_size_value">
               {storageCapacity || intl.formatMessage({id: 'unknown'})}
-            </InformationValue>
-          </InformationSpan>
-          <InformationSpan>
-            <InformationLabel>
+            </OverviewInformationValue>
+          </OverviewInformationSpan>
+          <OverviewInformationSpan>
+            <OverviewInformationLabel>
               {intl.formatMessage({ id: 'status' })}
-            </InformationLabel>
-            <InformationValue data-cy="volume_status_value">
+            </OverviewInformationLabel>
+            <OverviewInformationValue data-cy="volume_status_value">
               {status}
-            </InformationValue>
-          </InformationSpan>
-          <InformationSpan>
-            <InformationLabel>
+            </OverviewInformationValue>
+          </OverviewInformationSpan>
+          <OverviewInformationSpan>
+            <OverviewInformationLabel>
               {intl.formatMessage({ id: 'storageClass' })}
-            </InformationLabel>
-            <InformationValue>{storageClassName}</InformationValue>
-          </InformationSpan>
-          <InformationSpan>
-            <InformationLabel>
+            </OverviewInformationLabel>
+            <OverviewInformationValue>{storageClassName}</OverviewInformationValue>
+          </OverviewInformationSpan>
+          <OverviewInformationSpan>
+            <OverviewInformationLabel>
               {intl.formatMessage({ id: 'creationTime' })}
-            </InformationLabel>
+            </OverviewInformationLabel>
             {creationTimestamp ? (
-              <InformationValue>
+              <OverviewInformationValue>
                 <FormattedDate
                   value={creationTimestamp}
                   year="numeric"
@@ -275,49 +247,49 @@ const VolumeDetailCard = (props) => {
                   second="2-digit"
                   value={creationTimestamp}
                 />
-              </InformationValue>
+              </OverviewInformationValue>
             ) : (
               ''
             )}
-          </InformationSpan>
-          <InformationSpan>
-            <InformationLabel>
+          </OverviewInformationSpan>
+          <OverviewInformationSpan>
+            <OverviewInformationLabel>
               {intl.formatMessage({ id: 'volume_type' })}
-            </InformationLabel>
-            <InformationValue>{volumeType}</InformationValue>
-          </InformationSpan>
-          <InformationSpan>
-            <InformationLabel>
+            </OverviewInformationLabel>
+            <OverviewInformationValue>{volumeType}</OverviewInformationValue>
+          </OverviewInformationSpan>
+          <OverviewInformationSpan>
+            <OverviewInformationLabel>
               {intl.formatMessage({ id: 'used_by' })}
-            </InformationLabel>
-            <InformationValue>{usedPodName}</InformationValue>
-          </InformationSpan>
-          <InformationSpan>
+            </OverviewInformationLabel>
+            <OverviewInformationValue>{usedPodName}</OverviewInformationValue>
+          </OverviewInformationSpan>
+          <OverviewInformationSpan>
             {volumeType !== LVM_LOGICAL_VOLUME ? (
               <>
-                <InformationLabel data-cy="backend_disk_label">
+                <OverviewInformationLabel data-cy="backend_disk_label">
                   {intl.formatMessage({ id: 'backend_disk' })}
-                </InformationLabel>
-                <InformationValue data-cy="backend_disk_value">
+                </OverviewInformationLabel>
+                <OverviewInformationValue data-cy="backend_disk_value">
                   {devicePath}
-                </InformationValue>
+                </OverviewInformationValue>
               </>
             ) : (
               <>
-                <InformationLabel data-cy="vg_name_label">
+                <OverviewInformationLabel data-cy="vg_name_label">
                   VG Name
-                </InformationLabel>
-                <InformationValue data-cy="vg_name_value">
+                </OverviewInformationLabel>
+                <OverviewInformationValue data-cy="vg_name_value">
                   {vgName}
-                </InformationValue>
+                </OverviewInformationValue>
               </>
             )}
-          </InformationSpan>
-          <InformationSpan>
-            <InformationLabel>
+          </OverviewInformationSpan>
+          <OverviewInformationSpan>
+            <OverviewInformationLabel>
               {intl.formatMessage({ id: 'labels' })}
-            </InformationLabel>
-            <InformationValue>
+            </OverviewInformationLabel>
+            <OverviewInformationValue>
               {labels?.map((label) => {
                 return (
                   <div key={label.name}>
@@ -330,16 +302,16 @@ const VolumeDetailCard = (props) => {
                   </div>
                 );
               })}
-            </InformationValue>
-          </InformationSpan>
+            </OverviewInformationValue>
+          </OverviewInformationSpan>
         </div>
 
         <VolumeGraph>
           {alertlist && (
-            <AlertsCounterContainer>
-              <VolumeSectionTitle>
+            <ActiveAlertWrapper>
+              <ActiveAlertTitle>
                 {intl.formatMessage({ id: 'active_alerts' })}
-              </VolumeSectionTitle>
+              </ActiveAlertTitle>
               <ActiveAlertsCounter
                 criticalCounter={
                   alertlist?.filter(
@@ -352,7 +324,7 @@ const VolumeDetailCard = (props) => {
                   ).length
                 }
               />
-            </AlertsCounterContainer>
+            </ActiveAlertWrapper>
           )}
           {condition === VOLUME_CONDITION_LINK && (
             <VolumeUsage>

--- a/ui/src/components/style/CommonLayoutStyle.js
+++ b/ui/src/components/style/CommonLayoutStyle.js
@@ -177,6 +177,8 @@ export const OverviewInformationSpan = styled.div`
 export const OverviewInformationValue = styled.span`
   color: ${(props) => props.theme.textPrimary};
   font-size: ${fontSize.base};
+  word-wrap: break-word;
+  max-width: 20rem;
 `;
 
 export const OverviewClickableInformationValue = styled.span`
@@ -201,6 +203,6 @@ export const ActiveAlertTitle = styled.div`
 export const ActiveAlertWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  padding: 0 ${padding.larger} 0 ${padding.base};
+  padding: 0 ${padding.base} 0 0;
   width: 200px;
 `;

--- a/ui/src/components/style/CommonLayoutStyle.js
+++ b/ui/src/components/style/CommonLayoutStyle.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { padding, fontWeight } from '@scality/core-ui/dist/style/theme';
+import { padding, fontWeight, fontSize, spacing } from '@scality/core-ui/dist/style/theme';
 
 export const PageContainer = styled.div`
   display: flex;
@@ -77,7 +77,7 @@ export const NodeTab = styled.div`
 `;
 
 export const SortCaretWrapper = styled.span`
-  padding-left: 1px;
+  padding-left: ${spacing.sp4};
   position: absolute;
 `;
 
@@ -158,4 +158,49 @@ export const PageSubtitle = styled.h3`
   margin: ${padding.small} 0;
   display: flex;
   align-items: center;
+`;
+
+export const OverviewInformationLabel = styled.span`
+  display: inline-block;
+  min-width: 10.714rem;
+  font-weight: ${fontWeight.bold};
+  font-size: ${fontSize.base};
+  color: ${(props) => props.theme.textSecondary};
+`;
+
+export const OverviewInformationSpan = styled.div`
+  padding-bottom: ${padding.large};
+  padding-left: ${padding.large};
+  display: flex;
+`;
+
+export const OverviewInformationValue = styled.span`
+  color: ${(props) => props.theme.textPrimary};
+  font-size: ${fontSize.base};
+`;
+
+export const OverviewClickableInformationValue = styled.span`
+  color: ${(props) => props.theme.selectedActive};
+  font-size: ${fontSize.base};
+  font-weight: ${fontWeight.semibold};
+  cursor: pointer;
+`;
+
+export const OverviewResourceName = styled.span`
+  font-size: ${fontSize.larger};
+  padding-left: ${padding.smaller};
+`;
+
+export const ActiveAlertTitle = styled.div`
+  color: ${(props) => props.theme.textPrimary};
+  font-size: ${fontSize.base};
+  font-weight: ${fontWeight.bold};
+  padding: 0 0 ${padding.base} 0;
+`;
+
+export const ActiveAlertWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 0 ${padding.larger} 0 ${padding.base};
+  width: 200px;
 `;


### PR DESCRIPTION
css: replace px by rem for Node/Volume/NodePageVolumes Table & NodePagePods/VolumeOverview Tab

**Component**:

NodeListTable, NodePagePodsTab, NodePageVolumesTable, VolumeListTable, VolumeOverviewTab

**Context**: 

On large screens, some components will have odd sizing, causing responsive issues.

**Summary**:

This PR replaces px values by rem values in order to add responsiveness to those components.

**Acceptance criteria**: 

This PR will fix some responsive issues and is related to [this PR](https://github.com/scality/core-ui/pull/383) on Core-UI, that will fix responsive for Core-UI components used by Metalk8s. PR on Core-UI needs to be merged first.

---

See: ARTESCA-2092 & ARTESCA-919