### PR TITLE
salt: Lower the KubeNodeUnreachable `for` period

### DIFF
--- a/charts/render.py
+++ b/charts/render.py
@@ -433,7 +433,7 @@ def main():
 
     def fixup(doc, patches):
         def _doc_matches(doc, conditions):
-            return all(
+            return doc and all(
                 [
                     doc.get("metadata", {}).get("name") == conditions["name"],
                     doc.get("metadata", {}).get("namespace") == conditions["namespace"],
@@ -445,7 +445,7 @@ def main():
             kind = doc.get("kind")
             if drop_prometheus_rules and kind == "PrometheusRule":
                 doc = remove_prometheus_rules(doc, drop_prometheus_rules)
-            if (
+            elif (
                 kind == "ConfigMap"
                 and doc.get("metadata", {}).get("labels", {}).get("grafana_dashboard")
                 == "1"

--- a/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
@@ -59893,7 +59893,7 @@ spec:
       expr: (kube_node_spec_taint{job="kube-state-metrics",key="node.kubernetes.io/unreachable",effect="NoSchedule"}
         unless ignoring(key,value) kube_node_spec_taint{job="kube-state-metrics",key=~"ToBeDeletedByClusterAutoscaler|cloud.google.com/impending-node-termination|aws-node-termination-handler/spot-itn"})
         == 1
-      for: 15m
+      for: 5m
       labels:
         severity: warning
     - alert: KubeletTooManyPods


### PR DESCRIPTION
**Component**: salt, charts, monitoring

**Context**:
The alert for an unreachable node is sent 15 minutes after the node is detected down, which is a bit too long.

**Summary**:
We patch the Prometheus rule manifest to change this to 5m, with the following command:
```
./charts/render.py prometheus-operator \
  charts/kube-prometheus-stack.yaml \
  charts/kube-prometheus-stack/ \
  --namespace metalk8s-monitoring \
  --service-config grafana \
  metalk8s-grafana-config \
  metalk8s/addons/prometheus-operator/config/grafana.yaml \
  metalk8s-monitoring \
  --service-config prometheus \
  metalk8s-prometheus-config \
  metalk8s/addons/prometheus-operator/config/prometheus.yaml \
  metalk8s-monitoring \
  --service-config alertmanager \
  metalk8s-alertmanager-config \
  metalk8s/addons/prometheus-operator/config/alertmanager.yaml \
  metalk8s-monitoring \
  --service-config dex \
  metalk8s-dex-config \
  metalk8s/addons/dex/config/dex.yaml.j2 metalk8s-auth \
  --drop-prometheus-rules charts/drop-prometheus-rules.yaml \
  --patch 'PrometheusRule,metalk8s-monitoring,prometheus-operator-kubernetes-system-kubelet,spec:groups:0:rules:1:for,"5m"' \
  > salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
```
This method of patching the resulting manifest is not really robust (e.g. if at some point the order of rules changes), but as for now it is the cheapest way of doing this.
We should probably look at what's done here: https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack

**Acceptance criteria**: 
