### PR TITLE
MetalK8s UI: Fix the node metrics don't get updated when switching to a node which is not available

### DIFF
--- a/ui/src/components/MetricSymmetricalChart.js
+++ b/ui/src/components/MetricSymmetricalChart.js
@@ -109,7 +109,9 @@ const MetricSymmetricalChart = ({
     metricBelowAvgQuery.isLoading;
 
   useEffect(() => {
-    if (
+    if (!planeInterface) {
+      setSeries([]);
+    } else if (
       !isMetricsDataLoading &&
       !showAvg &&
       //solve the graph doesn't get updated

--- a/ui/src/components/NodePagePodsTab.js
+++ b/ui/src/components/NodePagePodsTab.js
@@ -52,7 +52,7 @@ const Body = styled.tbody`
   /* To display scroll bar on the table */
   display: block;
   /* 100vh - navbar - tabs button height - tabs content padding - table header */
-  height: calc(100vh - 178px);
+  height: calc(100vh - 12.71rem);
   overflow: auto;
   overflow-y: auto;
 `;

--- a/ui/src/components/NodePageVolumesTable.js
+++ b/ui/src/components/NodePageVolumesTable.js
@@ -82,7 +82,7 @@ const VolumeListContainer = styled.div`
 const Body = styled.div`
   display: block;
   // 100vh - 48px(Navbar) - 77px(Table Search) - 32px(Table Header) - 15px(Margin bottom)
-  height: calc(100vh - 200px);
+  height: calc(100vh - 14.28rem);
 `;
 
 const CreateVolumeButton = styled(Button)`

--- a/ui/src/components/VolumeListTable.js
+++ b/ui/src/components/VolumeListTable.js
@@ -93,7 +93,7 @@ const VolumeListContainer = styled.div`
 const Body = styled.div`
   display: block;
   // 100vh - 48px(Navbar) - 77px(Table Search) - 32px(Table Header) - 15px(Margin bottom)
-  height: calc(100vh - 172px);
+  height: calc(100vh - 12rem);
 `;
 
 const CreateVolumeButton = styled(Button)`

--- a/ui/src/components/style/CommonLayoutStyle.js
+++ b/ui/src/components/style/CommonLayoutStyle.js
@@ -21,6 +21,7 @@ export const LeftSideInstanceList = styled.div`
   width: 49%;
   margin-bottom: 20px;
   min-width: 450px;
+  background-color: ${(props) => props.theme.backgroundLevel2};
 `;
 
 export const RightSidePanel = styled.div`


### PR DESCRIPTION
**Component**: ui

**Context**: Fix the bugs

**Summary**:
Scroll issue in Node page - volume/ pod tabs

When one node is down, the node metrics keep the data of the previous node




**Acceptance criteria**: 
![image](https://user-images.githubusercontent.com/18453133/140967396-61a72e83-6df6-4ad6-9563-8a58da3d123a.png)


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
