### PR TITLE
Add StatusWrapper on health Icons

### DIFF
--- a/shell-ui/package-lock.json
+++ b/shell-ui/package-lock.json
@@ -1958,8 +1958,8 @@
       "dev": true
     },
     "@scality/core-ui": {
-      "version": "github:scality/core-ui#88c828152e2973189a068b27ad237b5a6feee85c",
-      "from": "github:scality/core-ui#v0.22.1"
+      "version": "github:scality/core-ui#3c4253f328ad41c68ce9062059cf7042180efea4",
+      "from": "github:scality/core-ui#v0.22.6"
     },
     "@scality/module-federation": {
       "version": "github:scality/module-federation#a4f1cf882646c8d859b9081dc8b66e5647962456",

--- a/shell-ui/package.json
+++ b/shell-ui/package.json
@@ -47,7 +47,7 @@
     "webpack-dev-server": "^3.11.2"
   },
   "dependencies": {
-    "@scality/core-ui": "github:scality/core-ui.git#v0.22.1",
+    "@scality/core-ui": "github:scality/core-ui.git#v0.22.6",
     "@scality/module-federation": "github:scality/module-federation.git#1.0.0",
     "oidc-client": "^1.11.3",
     "oidc-react": "^1.1.5",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -4708,8 +4708,8 @@
       }
     },
     "@scality/core-ui": {
-      "version": "github:scality/core-ui#88c828152e2973189a068b27ad237b5a6feee85c",
-      "from": "github:scality/core-ui#v0.22.1"
+      "version": "github:scality/core-ui#3c4253f328ad41c68ce9062059cf7042180efea4",
+      "from": "github:scality/core-ui#v0.22.6"
     },
     "@scality/module-federation": {
       "version": "github:scality/module-federation#a4f1cf882646c8d859b9081dc8b66e5647962456",

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.3",
     "@fortawesome/react-fontawesome": "^0.1.14",
     "@kubernetes/client-node": "github:scality/kubernetes-client-javascript.git#browser-0.10.2-63-g579d066",
-    "@scality/core-ui": "github:scality/core-ui.git#v0.22.1",
+    "@scality/core-ui": "github:scality/core-ui.git#v0.22.6",
     "@scality/module-federation": "github:scality/module-federation.git#1.0.0",
     "axios": "^0.21.1",
     "formik": "2.2.5",

--- a/ui/src/components/CircleStatus.js
+++ b/ui/src/components/CircleStatus.js
@@ -38,14 +38,16 @@ const getStyle = (status) => {
   }
 }
 
-const CircleStatus = React.memo((props) => {
+const CircleStatus = (props) => {
   const { status, size } = props;
   const { name, color } = getStyle(status);
 
   if (size === undefined || size === CIRCLE_BASE_SIZE || size === CIRCLE_DOUBLE_SIZE)
     return (
-      <Icon name={name} color={color} size={size === CIRCLE_DOUBLE_SIZE ? "2x" : "1x"} ariaLabel={`status ${status}`}/>
+      <i>
+        <Icon name={name} color={color} size={size === CIRCLE_DOUBLE_SIZE ? "2x" : "1x"} ariaLabel={`status ${status}`}/>
+      </i>
     );
-});
+};
 
 export default CircleStatus;

--- a/ui/src/components/DashboardGlobalHealth.js
+++ b/ui/src/components/DashboardGlobalHealth.js
@@ -9,6 +9,7 @@ import {
   SmallerText,
 } from '@scality/core-ui/dist/components/text/Text.component';
 import TooltipComponent from '@scality/core-ui/dist/components/tooltip/Tooltip.component';
+import { StatusWrapper } from '@scality/core-ui';
 import {
   highestAlertToStatus,
   useAlertLibrary,
@@ -57,6 +58,10 @@ const HealthBarContainer = styled.div`
   margin: 0 auto;
 `;
 
+const PlatformStatusIcon = styled.div`
+  font-size: 2rem;
+`;
+
 const DashboardGlobalHealth = () => {
   const intl = useIntl();
   const theme = useTheme();
@@ -76,10 +81,14 @@ const DashboardGlobalHealth = () => {
     <GlobalHealthContainer>
       <div className="datacenter">
         <SpacedBox ml={12} mr={12}>
-          <StatusIcon
-            status={platformStatus}
-            className="fa fa-warehouse fa-2x"
-          ></StatusIcon>
+          <PlatformStatusIcon>
+            <StatusWrapper status={platformStatus}>
+              <StatusIcon
+                status={platformStatus}
+                className="fa fa-warehouse"
+              />
+            </StatusWrapper>
+          </PlatformStatusIcon>
         </SpacedBox>
 
         <LargerText>{intl.formatMessage({ id: 'platform' })}</LargerText>

--- a/ui/src/components/DashboardInventory.js
+++ b/ui/src/components/DashboardInventory.js
@@ -2,9 +2,10 @@
 
 import React from 'react';
 import { useQuery } from 'react-query';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import Card from '@scality/core-ui/dist/components/card/Card.component';
 import Loader from '@scality/core-ui/dist/components/loader/Loader.component';
+import { StatusWrapper, Icon } from '@scality/core-ui';
 import {
   spacing,
   fontSize,
@@ -42,30 +43,23 @@ const CardsWrapper = styled.div`
 
 const InventoryIcon = styled.i`
   font-size: ${fontSize.larger};
-  margin-right: ${spacing.sp4};
-  ${(props) => {
-    switch (props.status) {
-      case STATUS_WARNING:
-        return css`
-          color: ${props.theme.statusWarning};
-        `;
-      case STATUS_CRITICAL:
-        return css`
-          color: ${props.theme.statusCritical};
-        `;
-
-      default:
-        return css`
-          color: ${props.theme.statusHealthy};
-        `;
-    }
-  }}
 `;
 
 const InventoryValue = styled.span`
   font-size: ${fontSize.larger};
   font-weight: ${fontWeight.bold};
 `;
+
+const getStatusColor = (status) => {
+  switch (status) {
+    case STATUS_WARNING:
+      return "statusWarning";
+    case STATUS_CRITICAL:
+      return "statusCritical";
+    default:
+      return "statusHealthy";
+  }
+}
 
 const DashboardInventory = () => {
   const intl = useIntl();
@@ -110,11 +104,15 @@ const DashboardInventory = () => {
             </Card.Header>
             <Card.BodyContainer>
               <Card.Body>
-                <InventoryIcon
-                  className="fas fa-server"
-                  status={nodesStatus}
-                  aria-label={nodesStatus}
-                />
+                <InventoryIcon>
+                  <StatusWrapper status={nodesStatus}>
+                    <Icon
+                      name={"Node-backend"}
+                      color={getStatusColor(nodesStatus)}
+                      ariaLabel={nodesStatus}
+                    />
+                  </StatusWrapper>
+                </InventoryIcon>
                 <InventoryValue aria-label={`${nodesCount} nodes`}>
                   {nodesCount}
                 </InventoryValue>
@@ -139,11 +137,15 @@ const DashboardInventory = () => {
             </Card.Header>
             <Card.BodyContainer>
               <Card.Body>
-                <InventoryIcon
-                  className="fas fa-hdd"
-                  status={volumesStatus}
-                  aria-label={volumesStatus}
-                />
+                <InventoryIcon>
+                  <StatusWrapper status={volumesStatus}>
+                    <Icon
+                      name={"Volume-backend"}
+                      color={getStatusColor(volumesStatus)}
+                      ariaLabel={volumesStatus}
+                    />
+                  </StatusWrapper>
+                </InventoryIcon>
                 <InventoryValue aria-label={`${volumesCount} volumes`}>
                   {volumesCount}
                 </InventoryValue>

--- a/ui/src/components/DashboardInventory.test.js
+++ b/ui/src/components/DashboardInventory.test.js
@@ -9,6 +9,11 @@ import {
   getNodesCountQuery,
   getVolumesCountQuery,
 } from '../services/platformlibrary/k8s.js';
+import {
+  STATUS_WARNING,
+  STATUS_CRITICAL,
+  STATUS_HEALTH,
+} from '../constants.js';
 
 const alertsCritical = [
   {
@@ -83,7 +88,8 @@ describe('the dashboard inventory panel', () => {
     await waitForLoadingToFinish();
 
     // Verify
-    expect(screen.getAllByLabelText('critical').length).toEqual(2);
+    expect(screen.getAllByLabelText(`Node-backend ${STATUS_CRITICAL}`).length).toEqual(1);
+    expect(screen.getAllByLabelText(`Volume-backend ${STATUS_CRITICAL}`).length).toEqual(1);
   });
 
   test('displays properly the status WARNING for nodes and volumes', async () => {
@@ -97,7 +103,8 @@ describe('the dashboard inventory panel', () => {
     await waitForLoadingToFinish();
 
     // Verify
-    expect(screen.getAllByLabelText('warning').length).toEqual(2);
+    expect(screen.getAllByLabelText(`Node-backend ${STATUS_WARNING}`).length).toEqual(1);
+    expect(screen.getAllByLabelText(`Volume-backend ${STATUS_WARNING}`).length).toEqual(1);
   });
 
   test('displays properly the status HEALTHY for nodes and volumes', async () => {
@@ -111,7 +118,8 @@ describe('the dashboard inventory panel', () => {
     await waitForLoadingToFinish();
 
     // Verify
-    expect(screen.getAllByLabelText('healthy').length).toEqual(2);
+    expect(screen.getAllByLabelText(`Node-backend ${STATUS_HEALTH}`).length).toEqual(1);
+    expect(screen.getAllByLabelText(`Volume-backend ${STATUS_HEALTH}`).length).toEqual(1);
   });
 
   test('displays the loader if the query does not return a result', async () => {

--- a/ui/src/containers/AlertPage.js
+++ b/ui/src/containers/AlertPage.js
@@ -1,6 +1,6 @@
 //@flow
 import React, { useMemo } from 'react';
-import styled, { useTheme } from 'styled-components';
+import styled from 'styled-components';
 import { useHistory } from 'react-router';
 import { useLocation } from 'react-router-dom';
 import {
@@ -10,11 +10,17 @@ import {
   useFilters,
   useGlobalFilter,
 } from 'react-table';
-import { EmptyTable, SearchInput } from '@scality/core-ui';
+import { EmptyTable, SearchInput, StatusWrapper } from '@scality/core-ui';
 import { padding, fontSize } from '@scality/core-ui/dist/style/theme';
 import { useAlerts } from './AlertProvider';
+import StatusIcon from '../components/StatusIcon';
 import CircleStatus from '../components/CircleStatus';
 import { TextBadge } from '../components/style/CommonLayoutStyle';
+import {
+  STATUS_WARNING,
+  STATUS_CRITICAL,
+  STATUS_HEALTH,
+} from '../constants';
 import {
   compareHealth,
   useURLQuery,
@@ -73,34 +79,28 @@ const SeperationLine = styled.div`
   position: absolute;
 `;
 
-function AlertLogo({
-  color,
-}: {
-  color: 'statusHealthy' | 'statusWarning' | 'statusCritical',
-}) {
-  const theme = useTheme();
-  return (
-    <svg
-      width="66"
-      height="66"
-      viewBox="0 0 66 66"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <circle
-        cx="33"
-        cy="33"
-        r="32"
-        fill={theme.backgroundLevel1}
-        stroke={theme.infoPrimary}
-      />
-      <path
-        d="M33 50C35.1875 50 36.9375 48.25 36.9375 46H29C29 48.25 30.75 50 33 50ZM46.4375 40.6875C45.25 39.375 42.9375 37.4375 42.9375 31C42.9375 26.1875 39.5625 22.3125 34.9375 21.3125V20C34.9375 18.9375 34.0625 18 33 18C31.875 18 31 18.9375 31 20V21.3125C26.375 22.3125 23 26.1875 23 31C23 37.4375 20.6875 39.375 19.5 40.6875C19.125 41.0625 18.9375 41.5625 19 42C19 43.0625 19.75 44 21 44H44.9375C46.1875 44 46.9375 43.0625 47 42C47 41.5625 46.8125 41.0625 46.4375 40.6875Z"
-        fill={theme[color]}
-      />
-    </svg>
-  );
-}
+const AlertStatusIcon = styled.div`
+  font-size: 2rem;
+  border: 1px solid ${(props) => props.theme.infoPrimary};
+  border-radius: 50%;
+  background: ${(props) => props.theme.backgroundLevel1};
+  padding: 0.7rem 0.5rem 0.3rem;
+  width: 3rem;
+  height: 3rem;
+  text-align: center;
+
+  &>span {
+    margin: 0;
+  }
+`;
+
+const getAlertStatus = (critical, warning) => (
+  critical > 0
+  ? STATUS_CRITICAL
+  : warning > 0
+  ? STATUS_WARNING
+  : STATUS_HEALTH
+);
 
 function AlertPageHeader({
   activeAlerts,
@@ -112,18 +112,18 @@ function AlertPageHeader({
   warning: number,
 }) {
   const intl = useIntl();
+  const alertStatus = getAlertStatus(critical, warning);
   return (
     <AlertPageHeaderContainer>
       <Title>
-        <AlertLogo
-          color={
-            critical > 0
-              ? 'statusCritical'
-              : warning > 0
-              ? 'statusWarning'
-              : 'statusHealthy'
-          }
-        />
+        <AlertStatusIcon>
+          <StatusWrapper status={alertStatus}>
+            <StatusIcon
+              status={alertStatus}
+              className="fa fa-bell"
+            />
+          </StatusWrapper>
+        </AlertStatusIcon>
         <>{intl.formatMessage({ id: 'alerts' })}</>
         <SeperationLine />
       </Title>


### PR DESCRIPTION
**Component**:

DashboardGlobalHealth , DashboardInventory , AlertPageHeader, CircleStatus

**Context**: 

Health Icons only relies on color code to show health status, which is not enough for users who may has difficulties to see.

**Summary**:

This PR adds `StatusWrapper` around health icons, to add a badge on their top-right corner, in order to make status easier to understand.
This PR will also fix an alignment issue for health icons on Volumes tables (In Volumes page and Node Volumes tab).

**Acceptance criteria**: 

This PR relies on [this PR](https://github.com/scality/core-ui/pull/384) on Core-UI, which will add `StatusWrapper`.
PR on Core-UI needs to be merged first.

---

See: ARTESCA-2404