### PR TITLE
packages: Install golang 1.15 to build containerd

### DIFF
--- a/packages/redhat/7/Dockerfile
+++ b/packages/redhat/7/Dockerfile
@@ -5,8 +5,12 @@ ARG BUILD_IMAGE=docker.io/centos
 FROM ${BUILD_IMAGE}@sha256:${BUILD_IMAGE_SHA256} as build
 
 ARG SALT_VERSION
+ARG GO_VERSION=1.15.15
+
 ADD common/yum_repositories/*.repo /etc/yum.repos.d/
 RUN sed -i s/@SALT_VERSION@/$SALT_VERSION/ /etc/yum.repos.d/saltstack.repo
+
+ENV GOROOT /usr/local/go
 
 RUN yum install -y --setopt=skip_missing_names_on_install=False \
         createrepo \
@@ -16,17 +20,25 @@ RUN yum install -y --setopt=skip_missing_names_on_install=False \
         rpmdevtools \
         rpmlint \
         yum-utils \
+        gcc \
         && \
     yum clean all
 
 # To build containerd
 RUN yum install -y --setopt=skip_missing_names_on_install=False \
-        golang \
         btrfs-progs-devel \
         go-md2man \
         libseccomp-devel \
         systemd \
+        go-srpm-macros \
         && \
     yum clean all
+
+RUN curl -ORL https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz \
+    && tar xzvf go${GO_VERSION}.linux-amd64.tar.gz \
+    && rm go${GO_VERSION}.linux-amd64.tar.gz \
+    && mv go /usr/local \
+    && ln -s $GOROOT/bin/go /usr/local/bin/go \
+    && ln -s $GOROOT/bin/gofmt /usr/local/bin/gofmt
 
 RUN useradd -m build

--- a/packages/redhat/8/Dockerfile
+++ b/packages/redhat/8/Dockerfile
@@ -7,10 +7,13 @@ FROM ${BUILD_IMAGE}@sha256:${BUILD_IMAGE_SHA256} as build
 RUN useradd -m build
 
 ARG SALT_VERSION
+ARG GO_VERSION=1.15.15
+
 ADD common/yum_repositories/*.repo /etc/yum.repos.d/
 RUN sed -i s/@SALT_VERSION@/$SALT_VERSION/ /etc/yum.repos.d/saltstack.repo
 
-ENV GOPATH=/go
+ENV GOPATH /go
+ENV GOROOT /usr/local/go
 
 RUN dnf install -y --setopt=skip_missing_names_on_install=False \
         createrepo \
@@ -21,9 +24,17 @@ RUN dnf install -y --setopt=skip_missing_names_on_install=False \
         rpmlint \
         yum-utils \
         git \
-        golang \
+        gcc \
         libseccomp-devel \
         && \
-    dnf clean all && \
-    go get github.com/cpuguy83/go-md2man && \
-    ln -s $GOPATH/bin/go-md2man /usr/local/bin/go-md2man
+    dnf clean all
+
+# To build containerd
+RUN curl -ORL https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz \
+    && tar xzvf go${GO_VERSION}.linux-amd64.tar.gz \
+    && rm go${GO_VERSION}.linux-amd64.tar.gz \
+    && mv go /usr/local \
+    && ln -s $GOROOT/bin/go /usr/local/bin/go \
+    && ln -s $GOROOT/bin/gofmt /usr/local/bin/gofmt \
+    && go get github.com/cpuguy83/go-md2man \
+    && ln -s $GOPATH/bin/go-md2man /usr/local/bin/go-md2man

--- a/packages/redhat/common/containerd.spec
+++ b/packages/redhat/common/containerd.spec
@@ -45,7 +45,10 @@ Source3:        60-containerd.conf
 # Carve out code requiring github.com/Microsoft/hcsshim
 Patch0:         0001-Revert-commit-for-Windows-metrics.patch
 
-BuildRequires:  golang >= 1.10
+# NOTE: We do not require golang as currently build does not work
+# with golang >= 1.16, and we will not be able to easily install
+# golang **package** prior to 1.16
+# BuildRequires:  golang >= 1.10
 %if 0%{?el7}
 BuildRequires:  btrfs-progs-devel
 BuildRequires:  go-md2man


### PR DESCRIPTION
In order to build containerd properly let's pin the golang version to
1.15.
NOTE: We do not use golang package as golang 1.15 may not be available
NOTE: We download golang tarball on CentOS7 as well even if golang-1.15
package is available on epel-release, so that if a newer version come
in epel-release the build will still be ok