### PR TITLE
ui: Fix MODULE_NOT_FOUND error on har-validator package while installing cypress@5.6.0

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -1224,7 +1224,7 @@ stages:
           name: Install Cypress and its dependencies
           workdir: build/ui
           command: |
-            PKGS="cypress cypress-cucumber-preprocessor cypress-wait-until @testing-library/cypress"
+            PKGS="har-validator cypress cypress-cucumber-preprocessor cypress-wait-until @testing-library/cypress"
             for pkg in $PKGS; do
               npm install --no-save --no-package-lock $pkg@$(node -p \
                 -e "require('./package-lock.json').dependencies['$pkg'].version" \

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -1228,7 +1228,7 @@ stages:
             for pkg in $PKGS; do
               npm install --no-save --no-package-lock $pkg@$(node -p \
                 -e "require('./package-lock.json').dependencies['$pkg'].version" \
-              )
+              ) || exit 1
             done
           haltOnFailure: true
       - ShellCommand:

--- a/eve/workers/pod-integration-tests/ui/worker.Dockerfile
+++ b/eve/workers/pod-integration-tests/ui/worker.Dockerfile
@@ -32,7 +32,9 @@ USER eve
 # Pre-install Cypress to save it in cache
 WORKDIR /tmp
 COPY package-lock.json ./
-RUN npm install --no-save --no-package-lock cypress@$(node -p \
+RUN npm install --no-save --no-package-lock har-validator@$(node -p \
+        -e "require('./package-lock.json').dependencies['har-validator'].version" \
+    ) && npm install --no-save --no-package-lock cypress@$(node -p \
         -e "require('./package-lock.json').dependencies.cypress.version" \
     )
 

--- a/ui/cypress/requirements.sh
+++ b/ui/cypress/requirements.sh
@@ -28,6 +28,7 @@ RPM_PACKAGES=(
     xorg-x11-server-Xvfb
 )
 NODE_PACKAGES=(
+    har-validator@5.1.5
     cypress@5.6.0
     cypress-cucumber-preprocessor@4.0.0
     cypress-wait-until@1.7.1

--- a/ui/package.json
+++ b/ui/package.json
@@ -112,6 +112,7 @@
     "fs-extra": "^10.0.0",
     "handlebars": "^4.7.7",
     "handlebars-loader": "^1.7.1",
+    "har-validator": "^5.1.5",
     "html-loader": "^2.1.2",
     "html-webpack-plugin": "^5.3.1",
     "identity-obj-proxy": "^3.0.0",


### PR DESCRIPTION
**Component**:

CI

**Context**: 

Installing cypress@5.6.0 in the CI is failling because har-validator package is not found (due to deprecation).

**Summary**:

Forcing installation of the latest available version of this package would solve the issue for now. In the middle/long term cypress should be updated to rely on non-deprecated packages.
