### PR TITLE
packages,buildchain: Update the link to download containerd go code

### DIFF
--- a/buildchain/buildchain/packaging.py
+++ b/buildchain/buildchain/packaging.py
@@ -485,7 +485,7 @@ def _rpm_package_containerd(releasever: str) -> targets.RPMPackage:
             Path("0001-Revert-commit-for-Windows-metrics.patch"),
             Path("containerd.service"),
             Path("containerd.toml"),
-            Path("containerd-{}.tar.gz".format(versions.CONTAINERD_VERSION)),
+            Path("v{}.tar.gz".format(versions.CONTAINERD_VERSION)),
         ]
         + extra_sources,
     )

--- a/packages/redhat/common/containerd.spec
+++ b/packages/redhat/common/containerd.spec
@@ -10,7 +10,7 @@ Version:        1.4.3
 ExclusiveArch: %{?go_arches:%{go_arches}}%{!?go_arches:%{ix86} x86_64 %{arm} aarch64 ppc64le s390x %{mips}}
 %global debug_package %{nil}
 %global gourl https://%{goipath}
-%global gosource %{gourl}/archive/v%{version}/%{name}-%{version}.tar.gz
+%global gosource %{gourl}/archive/refs/tags/v%{version}.tar.gz
 %define gobuildroot %{expand:
 GO_BUILD_PATH=$PWD/_build
 install -m 0755 -vd $(dirname $GO_BUILD_PATH/src/%{goipath})


### PR DESCRIPTION
Since the URL used to download go source code for containerd changed, we
need to update it
