### PR TITLE
MetalK8s UI: Fix the bug of the CP/WP avg metrics

### DIFF
--- a/ui/src/services/platformlibrary/metrics.js
+++ b/ui/src/services/platformlibrary/metrics.js
@@ -248,7 +248,7 @@ export const getControlPlaneBandWidthAvgInQuery = (
   }
 
   const nodeCPBandwithInAvgPrometheusQuery = encodeURIComponent(
-    `${nodesCPBandwidthInPrometheusQuery.join('+')} / ${
+    `(${nodesCPBandwidthInPrometheusQuery.join('+')}) / ${
       nodesCPBandwidthInPrometheusQuery.length
     }`,
   );
@@ -290,7 +290,7 @@ export const getControlPlaneBandWidthAvgOutQuery = (
   }
 
   const nodeCPBandwithAvgOutPrometheusQuery = encodeURIComponent(
-    `${nodesCPBandwidthOutPrometheusQuery.join('+')} / ${
+    `(${nodesCPBandwidthOutPrometheusQuery.join('+')}) / ${
       nodesCPBandwidthOutPrometheusQuery.length
     }`,
   );
@@ -377,7 +377,7 @@ export const getWorkloadPlaneBandWidthAvgInQuery = (
   }
 
   const nodeWPBandwithInAvgPrometheusQuery = encodeURIComponent(
-    `${nodesWPBandwidthInPrometheusQuery.join('+')} / ${
+    `(${nodesWPBandwidthInPrometheusQuery.join('+')}) / ${
       nodesWPBandwidthInPrometheusQuery.length
     }`,
   );
@@ -419,7 +419,7 @@ export const getWorkloadPlaneBandWidthAvgOutQuery = (
   }
 
   const nodeWPBandwithAvgOutPrometheusQuery = encodeURIComponent(
-    `${nodesWPBandwidthOutPrometheusQuery.join('+')} / ${
+    `(${nodesWPBandwidthOutPrometheusQuery.join('+')}) / ${
       nodesWPBandwidthOutPrometheusQuery.length
     }`,
   );


### PR DESCRIPTION
**Component**: UI

**Context**: 
The avg of Control plane bandwidth and Workload bandwidth is not correctly computed on the UI side.
which cause the AVG is always bigger than any of the single node

**Summary**:


**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
