### PR TITLE
Manage `podAntiAffinity` and number of replicas for Control Plane Ingress Controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,10 @@
   hostname, so that if it's possible each `CoreDNS` pods will sit on different infra node
   (PR[#3579](https://github.com/scality/metalk8s/pull/3579))
 
-- Allow to manage soft and hard `podAntiAffinity` for Control Plane Ingress Controller
-  from Bootstrap configuration file, with a default soft anti-affinity on hostname,
-  so that if it's possible each Control Plane Ingress Controller pods will sit on
-  a different master node
+- Allow to manage number of replicas and, soft and hard `podAntiAffinity`
+  for Control Plane Ingress Controller from Bootstrap configuration file, with
+  a default soft anti-affinity on hostname, so that if it's possible each
+  Control Plane Ingress Controller pods will sit on a different master node
   (PR[#3617](https://github.com/scality/metalk8s/pull/3617))
 
 - Allow to manage soft and hard `podAntiAffinity` for `Dex` from Cluster

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
   hostname, so that if it's possible each `CoreDNS` pods will sit on different infra node
   (PR[#3579](https://github.com/scality/metalk8s/pull/3579))
 
+- Allow to manage soft and hard `podAntiAffinity` for Control Plane Ingress Controller
+  from Bootstrap configuration file, with a default soft anti-affinity on hostname,
+  so that if it's possible each Control Plane Ingress Controller pods will sit on
+  a different master node
+  (PR[#3617](https://github.com/scality/metalk8s/pull/3617))
+
 - Allow to manage soft and hard `podAntiAffinity` for `Dex` from Cluster
   and Services Configurations, with a default soft anti-affinity on hostname,
   so that if it's possible each `Dex` pods will sit on a different infra node

--- a/charts/ingress-nginx-control-plane-deployment.yaml
+++ b/charts/ingress-nginx-control-plane-deployment.yaml
@@ -22,6 +22,13 @@ controller:
 
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+
+  affinity: '__var_quoted__(salt.metalk8s_service_configuration.get_pod_affinity(
+    pillar.networks.control_plane.ingress.controller.affinity,
+    {"app.kubernetes.io/component": "controller", "app.kubernetes.io/instance": "ingress-nginx-control-plane", "app.kubernetes.io/name": "ingress-nginx"},
+    "metalk8s-ingress"))'
 
   tolerations:
     - key: "node-role.kubernetes.io/bootstrap"

--- a/charts/ingress-nginx-control-plane-deployment.yaml
+++ b/charts/ingress-nginx-control-plane-deployment.yaml
@@ -16,7 +16,7 @@ controller:
 
   kind: Deployment
 
-  replicaCount: 2
+  replicaCount: '__var__(pillar.networks.control_plane.ingress.controller.replicas)'
 
   minAvailable: 0
 

--- a/docs/installation/bootstrap.rst
+++ b/docs/installation/bootstrap.rst
@@ -50,6 +50,7 @@ Configuration
           ingress:
             ip: <IP-for-ingress>
             controller:
+              replicas: 2
               affinity:
                 podAntiAffinity:
                   hard: []
@@ -108,14 +109,15 @@ notation for it's various subfields.
       control plane component).
 
       If you want to override the default ``controlPlane`` ``ingress``
-      controller podAntiAffinity, by default MetalK8s use soft podAntiAffinity
-      on hostname so that if it's possible those controllers pods will be
-      spread on different ``master`` nodes.
+      controller podAntiAffinity or number of replicas, by default MetalK8s
+      deploy 2 replicas and use soft podAntiAffinity on hostname so that if
+      it's possible those controllers pods will be spread on different
+      ``master`` nodes.
 
       .. note::
 
-        Affinity for control plane ingress controller will be
-        ignored if ``MetalLB`` is disabled, as this control plane
+        Affinity and number of replicas for control plane ingress controller
+        will be ignored if ``MetalLB`` is disabled, as this control plane
         ingress controller will be deployed as a DaemonSet, which means that
         a pod will run on every ``master`` nodes by default.
 

--- a/docs/installation/bootstrap.rst
+++ b/docs/installation/bootstrap.rst
@@ -49,6 +49,12 @@ Configuration
           cidr: <CIDR-notation>
           ingress:
             ip: <IP-for-ingress>
+            controller:
+              affinity:
+                podAntiAffinity:
+                  hard: []
+                  soft:
+                    - topologyKey: kubernetes.io/hostname
           metalLB:
             enabled: <boolean>
         workloadPlane:
@@ -100,6 +106,18 @@ notation for it's various subfields.
       Ingress IP is the control plane IP of the Bootstrap node (which means
       that if you lose the Bootstrap node, you no longer have access to any
       control plane component).
+
+      If you want to override the default ``controlPlane`` ``ingress``
+      controller podAntiAffinity, by default MetalK8s use soft podAntiAffinity
+      on hostname so that if it's possible those controllers pods will be
+      spread on different ``master`` nodes.
+
+      .. note::
+
+        Affinity for control plane ingress controller will be
+        ignored if ``MetalLB`` is disabled, as this control plane
+        ingress controller will be deployed as a DaemonSet, which means that
+        a pod will run on every ``master`` nodes by default.
 
       This ``ip`` for ``ingress`` can be managed by MetalK8s directly if
       it's possible in your environment, to do so we use

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -347,6 +347,7 @@ models:
         DEBUG: "%(prop:metalk8s_debug:-false)s"
         ARCHIVE: metalk8s.iso
         COREDNS_AFFINITY: "{}"
+        CP_INGRESS_AFFINITY: "{}"
       command: |
         ssh -F ssh_config bootstrap "
         sudo bash << EOF
@@ -360,6 +361,8 @@ models:
             metalLB:
               enabled: true
             ingress:
+              controller:
+                affinity: ${CP_INGRESS_AFFINITY}
               ip: 192.168.1.254
           workloadPlane:
             cidr: 192.168.2.0/24
@@ -2359,8 +2362,9 @@ stages:
           env:
             <<: *_env_bootstrap_config_ssh
             ARCHIVE: /archives/metalk8s.iso
-            COREDNS_AFFINITY: >-
+            COREDNS_AFFINITY: &hard_hostname_podantiaffinity >-
               {"podAntiAffinity": {"hard": [{"topologyKey": "kubernetes.io/hostname"}]}}
+            CP_INGRESS_AFFINITY: *hard_hostname_podantiaffinity
       - ShellCommand:
           <<: *copy_iso_bootstrap_ssh
           env:
@@ -2495,8 +2499,8 @@ stages:
           <<: *bootstrap_config_ssh
           env:
             <<: *_env_bootstrap_config_ssh
-            COREDNS_AFFINITY: >-
-              {"podAntiAffinity": {"hard": [{"topologyKey": "kubernetes.io/hostname"}]}}
+            COREDNS_AFFINITY: *hard_hostname_podantiaffinity
+            CP_INGRESS_AFFINITY: *hard_hostname_podantiaffinity
       - ShellCommand: *copy_iso_bootstrap_ssh
       - ShellCommand: *create_mountpoint_ssh
       - ShellCommand: *mount_iso_ssh

--- a/salt/_pillar/metalk8s.py
+++ b/salt/_pillar/metalk8s.py
@@ -173,6 +173,19 @@ def _load_iso_path(config_data):
     return res
 
 
+def _load_kubernetes(config_data):
+    """Load Kubernetes information from BootstrapConfiguration"""
+    kubernetes_data = config_data.get("kubernetes", {})
+
+    # CoreDNS affinity default to soft podAntiAffinity on hostname
+    kubernetes_data.setdefault("coreDNS", {}).setdefault("affinity", {}).setdefault(
+        "podAntiAffinity", {}
+    ).setdefault("soft", [{"topologyKey": "kubernetes.io/hostname"}])
+    kubernetes_data["coreDNS"].setdefault("replicas", 2)
+
+    return kubernetes_data
+
+
 def ext_pillar(minion_id, pillar, bootstrap_config):  # pylint: disable=unused-argument
     config = _load_config(bootstrap_config)
     if config.get("_errors"):
@@ -197,7 +210,7 @@ def ext_pillar(minion_id, pillar, bootstrap_config):  # pylint: disable=unused-a
             "networks": _load_networks(config),
             "metalk8s": metal_data,
             "proxies": config.get("proxies", {}),
-            "kubernetes": config.get("kubernetes", {}),
+            "kubernetes": _load_kubernetes(config),
         }
 
         if not isinstance(metal_data["archives"], list):

--- a/salt/_pillar/metalk8s.py
+++ b/salt/_pillar/metalk8s.py
@@ -115,6 +115,7 @@ def _load_networks(config_data):
         ).setdefault("affinity", {}).setdefault("podAntiAffinity", {}).setdefault(
             "soft", [{"topologyKey": "kubernetes.io/hostname"}]
         )
+        networks_data["controlPlane"]["ingress"]["controller"].setdefault("replicas", 2)
 
     if errors:
         return __utils__["pillar_utils.errors_to_dict"](errors)

--- a/salt/_pillar/metalk8s.py
+++ b/salt/_pillar/metalk8s.py
@@ -107,6 +107,15 @@ def _load_networks(config_data):
                 "https://github.com/scality/metalk8s/issues/3502"
             )
 
+        # Control Plane Ingress affinity default to soft podAntiAffinity on hostname
+        # NOTE: This affinity is only use when MetalLB is enabled, as if MetalLB is disabled
+        # Control Plane Ingress is deployed as DaemonSet
+        networks_data["controlPlane"].setdefault("ingress", {}).setdefault(
+            "controller", {}
+        ).setdefault("affinity", {}).setdefault("podAntiAffinity", {}).setdefault(
+            "soft", [{"topologyKey": "kubernetes.io/hostname"}]
+        )
+
     if errors:
         return __utils__["pillar_utils.errors_to_dict"](errors)
 

--- a/salt/metalk8s/addons/nginx-ingress-control-plane/deployed/chart-deployment.sls
+++ b/salt/metalk8s/addons/nginx-ingress-control-plane/deployed/chart-deployment.sls
@@ -381,6 +381,8 @@ spec:
       app.kubernetes.io/instance: ingress-nginx-control-plane
       app.kubernetes.io/name: ingress-nginx
   strategy:
+    rollingUpdate:
+      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:
@@ -389,6 +391,10 @@ spec:
         app.kubernetes.io/instance: ingress-nginx-control-plane
         app.kubernetes.io/name: ingress-nginx
     spec:
+      affinity: {% endraw -%}{{ salt.metalk8s_service_configuration.get_pod_affinity(
+        pillar.networks.control_plane.ingress.controller.affinity, {"app.kubernetes.io/component":
+        "controller", "app.kubernetes.io/instance": "ingress-nginx-control-plane",
+        "app.kubernetes.io/name": "ingress-nginx"}, "metalk8s-ingress") }}{%- raw %}
       containers:
       - args:
         - /nginx-ingress-controller

--- a/salt/metalk8s/addons/nginx-ingress-control-plane/deployed/chart-deployment.sls
+++ b/salt/metalk8s/addons/nginx-ingress-control-plane/deployed/chart-deployment.sls
@@ -6,28 +6,6 @@
 
 {% raw %}
 
-apiVersion: policy/v1beta1
-kind: PodDisruptionBudget
-metadata:
-  labels:
-    app.kubernetes.io/component: controller
-    app.kubernetes.io/instance: ingress-nginx-control-plane
-    app.kubernetes.io/managed-by: salt
-    app.kubernetes.io/name: ingress-nginx
-    app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
-    heritage: metalk8s
-  name: ingress-nginx-control-plane-controller
-  namespace: metalk8s-ingress
-spec:
-  minAvailable: 0
-  selector:
-    matchLabels:
-      app.kubernetes.io/component: controller
-      app.kubernetes.io/instance: ingress-nginx-control-plane
-      app.kubernetes.io/name: ingress-nginx
----
 apiVersion: v1
 automountServiceAccountToken: true
 kind: ServiceAccount
@@ -373,7 +351,7 @@ metadata:
   namespace: metalk8s-ingress
 spec:
   minReadySeconds: 0
-  replicas: 2
+  replicas: {% endraw -%}{{ pillar.networks.control_plane.ingress.controller.replicas }}{%- raw %}
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/salt/metalk8s/kubernetes/coredns/deployed.sls
+++ b/salt/metalk8s/kubernetes/coredns/deployed.sls
@@ -3,19 +3,11 @@
 
 {%- set cluster_dns_ip = salt.metalk8s_network.get_cluster_dns_ip() %}
 
-{%- set pillar_coredns = pillar.kubernetes.get("coreDNS", {}) %}
-
-{%- set replicas = pillar_coredns.get("replicas") or 2 %}
+{%- set replicas = pillar.kubernetes.coreDNS.replicas %}
 {%- set label_selector = {"k8s-app": "kube-dns"} %}
 
-{%- set pillar_affinities = pillar_coredns.get("affinity", {}) %}
-{#- NOTE: The default podAntiAffinity is a soft anti-affinity on hostname #}
-{%- do pillar_affinities.setdefault("podAntiAffinity", {}).setdefault(
-    "soft", [{"topologyKey": "kubernetes.io/hostname"}]
-) %}
-
 {%- set affinity = salt.metalk8s_service_configuration.get_pod_affinity(
-    pillar_affinities,
+    pillar.kubernetes.coreDNS.affinity,
     label_selector,
     "kube-system"
 ) %}

--- a/salt/tests/unit/formulas/config.yaml
+++ b/salt/tests/unit/formulas/config.yaml
@@ -147,6 +147,7 @@ metalk8s:
                   control_plane:
                     ingress:
                       controller:
+                        replicas: 2
                         affinity:
                           podAntiAffinity:
                             soft:

--- a/salt/tests/unit/formulas/config.yaml
+++ b/salt/tests/unit/formulas/config.yaml
@@ -137,6 +137,20 @@ metalk8s:
                           active: true
                           mountpoint: /srv/scality/example-solution-1.0.0
 
+    nginx-ingress-control-plane:
+      deployed:
+        chart-deployment.sls:
+          _cases:
+            "Nominal (with soft antiAffinity in pillar)":
+              pillar_overrides:
+                networks:
+                  control_plane:
+                    ingress:
+                      controller:
+                        affinity:
+                          podAntiAffinity:
+                            soft:
+                              - topologyKey: kubernetes.io/hostname
 
   backup:
     deployed:

--- a/salt/tests/unit/formulas/data/base_pillar.yaml
+++ b/salt/tests/unit/formulas/data/base_pillar.yaml
@@ -174,4 +174,10 @@ certificates:
         watched: true
       workload-plane-ingress:
         watched: true
-kubernetes: {}
+kubernetes:
+  coreDNS:
+    replicas: 2
+    affinity:
+      podAntiAffinity:
+        soft:
+          - topologyKey: kubernetes.io/hostname

--- a/tests/post/features/ingress.feature
+++ b/tests/post/features/ingress.feature
@@ -50,3 +50,11 @@ Feature: Ingress
         And we wait for the rollout of 'deploy/dex' in namespace 'metalk8s-auth' to complete
         Then the control plane ingress IP is equal to '{new_cp_ingress_vip}'
         And we are able to login to Dex as 'admin@metalk8s.invalid' using password 'password'
+
+    Scenario: Control Plane Ingress Controller pods spreading
+        Given the Kubernetes API is available
+        And we are on a multi node cluster
+        # Control Plane Ingress Controller is a deployment only when MetalLB is enabled
+        And MetalLB is already enabled
+        Then pods with label 'app.kubernetes.io/component=controller,app.kubernetes.io/instance=ingress-nginx-control-plane,app.kubernetes.io/name=ingress-nginx' are 'Ready'
+        And each pods with label 'app.kubernetes.io/component=controller,app.kubernetes.io/instance=ingress-nginx-control-plane,app.kubernetes.io/name=ingress-nginx' are on a different node

--- a/tests/post/steps/test_ingress.py
+++ b/tests/post/steps/test_ingress.py
@@ -43,6 +43,13 @@ def test_change_cp_ingress_mode(host, teardown):
     pass
 
 
+@scenario(
+    "../features/ingress.feature", "Control Plane Ingress Controller pods spreading"
+)
+def test_cp_ingress_controller_pod_spreading(host):
+    pass
+
+
 @pytest.fixture(scope="function")
 def context():
     return {}

--- a/tests/post/steps/test_ingress.py
+++ b/tests/post/steps/test_ingress.py
@@ -39,7 +39,7 @@ def test_change_cp_ingress_ip(host, teardown):
 
 
 @scenario("../features/ingress.feature", "Enable MetalLB")
-def test_change_cp_ingress_vip(host, teardown):
+def test_change_cp_ingress_mode(host, teardown):
     pass
 
 


### PR DESCRIPTION
**Component**:

'cp ingress'

**Context**: 

See: #3574 

**Summary**:

Add an entry in bootstrap configuration for Control Plane Ingress controller in order to set up `affinity`

NOTE: In this PR we only handle soft and hard `podAntiAffinity`