### PR TITLE
salt,charts: Grafana sidecar picks up dashboards in all namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,12 @@
 
 - Handle 401 unauthorized error in MetalK8s UI
   (PR[#3640](https://github.com/scality/metalk8s/pull/3640))
+  
+- [#3618](https://github.com/scality/metalk8s/issues/3618) Detect Grafana
+  dashboard ConfigMaps in any namespace rather than just `metalk8s-monitoring`,
+  and enable Grafana folder generation from dashboard file structure (PR
+  [#3620](https://github.com/scality/metalk8s/pull/3620))
+
 ## Bug fixes
 
 - [#3601](https://github.com/scality/metalk8s/issues/3601) - Marks

--- a/charts/kube-prometheus-stack.yaml
+++ b/charts/kube-prometheus-stack.yaml
@@ -158,6 +158,12 @@ grafana:
     image:
       repository: '__image__(k8s-sidecar)'
 
+    dashboards:
+      searchNamespace: ALL
+      folderAnnotation: metalk8s.scality.com/grafana-folder-name
+      provider:
+        foldersFromFilesStructure: true
+
     datasources:
       # Service deployed by Thanos
       url: http://thanos-query-http:10902/

--- a/docs/developer/architecture/logs.rst
+++ b/docs/developer/architecture/logs.rst
@@ -704,7 +704,14 @@ An example of what we want is `Loki dashboard`_.
 
   The ``grafana_datasource: "1"`` and ``grafana_dashboard: "1"`` labels are
   what is used by the Prometheus Operator to retrieve datasource and dashboard
-  for Grafana, resources must be deployed in `metalk8s-monitoring` namespace.
+  for Grafana.
+
+  Resources may be deployed in any namespace so long as it contains the above
+  labels.
+
+  The `metalk8s.scality.com/grafana-folder-name` annotation on dashboard
+  resources provide control over the folder in which the dashboard is placed in
+  Grafana.
 
 Loki Volume Purge
 ~~~~~~~~~~~~~~~~~

--- a/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
@@ -25022,13 +25022,12 @@ data:
     providers:
     - name: 'sidecarProvider'
       orgId: 1
-      folder: ''
       type: file
       disableDeletion: false
       allowUiUpdates: false
       updateIntervalSeconds: 30
       options:
-        foldersFromFilesStructure: false
+        foldersFromFilesStructure: true
         path: /tmp/dashboards
 kind: ConfigMap
 metadata:
@@ -61885,7 +61884,7 @@ spec:
           apiVersion="v1", namespace="metalk8s-monitoring", name="prometheus-operator-grafana",
           path="data:grafana.ini")
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/sc-dashboard-provider-config: 1f57959a5b236ca002fed3fe494a562bc462eb0db530ba1500664546d01cb395
+        checksum/sc-dashboard-provider-config: 4b86434bc5d3344f34c6418fe3e431b5dbd5ffb26f52b48a8325c63fff74a1f8
         checksum/secret: 05ea72d91e6ac99b8da34f36157887ab504aba30dde8e63b1d06b3527f889a6e
       labels:
         app.kubernetes.io/instance: prometheus-operator
@@ -61902,6 +61901,10 @@ spec:
           value: /tmp/dashboards
         - name: RESOURCE
           value: both
+        - name: NAMESPACE
+          value: ALL
+        - name: FOLDER_ANNOTATION
+          value: metalk8s.scality.com/grafana-folder-name
         image: {% endraw -%}{{ build_image_name("k8s-sidecar", False) }}{%- raw %}:1.14.2
         imagePullPolicy: IfNotPresent
         name: grafana-sc-dashboard

--- a/tests/post/features/monitoring.feature
+++ b/tests/post/features/monitoring.feature
@@ -62,3 +62,12 @@ Feature: Monitoring is up and running
         And the Grafana API is available
         When we put a datasource as ConfigMap named 'test-new-ds' in namespace 'metalk8s-monitoring'
         Then we have a datasource named 'test-new-ds'
+
+    Scenario: Inserting a new ConfigMap provides a new dashboard
+        Given the Grafana API is available
+        And the 'zenko' namespace exists
+        And we have a dashboard ready with a specific UID
+        When we put the dashboard as a ConfigMap in namespace 'zenko' with folder annotation value 'ZENKO-PLEASE'
+        Then we have the dashboard in folder 'ZENKO-PLEASE' in Grafana
+        Then on deletion of the dashboard's ConfigMap from namespace 'zenko'
+        Then the dashboard is no longer in folder 'ZENKO-PLEASE' in Grafana

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -278,3 +278,10 @@ class GrafanaAPI(BaseAPI):
         return self.request(
             "GET", f"api/datasources/name/{name}", auth=("admin", "admin")
         )
+
+    def get_dashboard(self, uid):
+        return self.request(
+            "GET",
+            f"api/dashboards/uid/{uid}",
+            auth=("admin", "admin"),
+        )


### PR DESCRIPTION
**Component**: salt,charts

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: Allowing solutions to expose dashboards that get picked up by metalk8s' Grafana deployment.


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #3618 

