### PR TITLE
scripts: Fix solutions script for RHEL 8

### DIFF
--- a/scripts/solutions.sh
+++ b/scripts/solutions.sh
@@ -394,7 +394,7 @@ check_solution_version_exists() {
         "sys.exit(0 if available else 1);"
     )
 
-    python -c "${python_script[*]}" "$version" "$solution_data"
+    "$PYTHON" -c "${python_script[*]}" "$version" "$solution_data"
 }
 
 check_solution_exists() {


### PR DESCRIPTION
**Component**: scripts, solutions

**Summary**: Use python3 on RHEL 8 instead of python2