### PR TITLE
Make drain timeout configurable and default to 1h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   (PR[#3607](https://github.com/scality/metalk8s/pull/3607))
 
 - Add ability to change the drain timeout from the upgrade and
-  downgrade scripts
+  downgrade scripts and default to 3600 seconds
   (PR[#3633](https://github.com/scality/metalk8s/pull/3633))
 
 ## Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Bump Kubernetes version to 1.21.7
   (PR[#3607](https://github.com/scality/metalk8s/pull/3607))
 
+- Add ability to change the drain timeout from the upgrade and
+  downgrade scripts
+  (PR[#3633](https://github.com/scality/metalk8s/pull/3633))
+
 ## Bug fixes
 
 - [#3341](https://github.com/scality/metalk8s/issues/3341) - Try to refresh

--- a/salt/_modules/metalk8s_drain.py
+++ b/salt/_modules/metalk8s_drain.py
@@ -166,7 +166,8 @@ class Drain(object):
         self._force = force
         self._grace_period = grace_period
         self._ignore_daemonset = ignore_daemonset
-        self._timeout = timeout or (2 ** 64 - 1)
+        # Default timeout is 3600 seconds
+        self._timeout = timeout or 3600
         self._delete_local_data = delete_local_data
         self._best_effort = best_effort
         self._kwargs = kwargs

--- a/salt/metalk8s/orchestrate/deploy_node.sls
+++ b/salt/metalk8s/orchestrate/deploy_node.sls
@@ -132,6 +132,9 @@ Drain the node:
     - ignore_daemonset: True
     - delete_local_data: True
     - force: True
+    {%- if pillar.orchestrate.get("drain_timeout") %}
+    - timeout: {{ pillar.orchestrate.drain_timeout }}
+    {%- endif %}
     - require:
       - metalk8s_cordon: Cordon the node
     - require_in:

--- a/salt/metalk8s/orchestrate/downgrade/init.sls
+++ b/salt/metalk8s/orchestrate/downgrade/init.sls
@@ -64,6 +64,7 @@ Deploy node {{ node }}:
     - pillar:
         orchestrate:
           node_name: {{ node }}
+          drain_timeout: {{ salt.pillar.get("orchestrate:drain_timeout", default=0) }}
           {%- if pillar.metalk8s.nodes|length == 1 %}
           {#- Do not drain if we are in single node cluster #}
           skip_draining: True

--- a/salt/metalk8s/orchestrate/upgrade/init.sls
+++ b/salt/metalk8s/orchestrate/upgrade/init.sls
@@ -87,6 +87,7 @@ Deploy node {{ node }}:
     - pillar:
         orchestrate:
           node_name: {{ node }}
+          drain_timeout: {{ salt.pillar.get("orchestrate:drain_timeout", default=0) }}
           {%- if pillar.metalk8s.nodes|length == 1 %}
           {#- Do not drain if we are in single node cluster #}
           skip_draining: True

--- a/salt/tests/unit/formulas/config.yaml
+++ b/salt/tests/unit/formulas/config.yaml
@@ -324,6 +324,12 @@ metalk8s:
                 orchestrate:
                   node_name: master-1
                   skip_draining: true
+            "Change drain timeout":
+              pillar_overrides:
+                <<: *pillar_orch_target_master_node
+                orchestrate:
+                  node_name: master-1
+                  drain_timeout: 60
             "Skip etcd role":
               pillar_overrides:
                 <<: *pillar_orch_target_master_node

--- a/salt/tests/unit/formulas/fixtures/salt.py
+++ b/salt/tests/unit/formulas/fixtures/salt.py
@@ -318,12 +318,12 @@ def mine_get(
 
 
 @register("pillar.get")
-def pillar_get(salt_mock: SaltMock, key: str) -> Any:
+def pillar_get(salt_mock: SaltMock, key: str, default: Optional[Any] = None) -> Any:
     """Retrieve a value from the mocked pillar."""
     res = salt_mock._pillar.copy()
     for part in key.split(":"):
         res = res.get(part, {})
-    return res
+    return res or default
 
 
 @register("saltutil.runner")

--- a/scripts/downgrade.sh.in
+++ b/scripts/downgrade.sh.in
@@ -6,6 +6,7 @@ set -o pipefail
 FORCE=''
 VERBOSE=${VERBOSE:-0}
 LOGFILE=/var/log/metalk8s/downgrade.log
+DRAIN_TIMEOUT=${DRAIN_TIMEOUT:-0}
 DRY_RUN=0
 SALTENV=${SALTENV:-}
 DESTINATION_VERSION=""
@@ -21,6 +22,7 @@ _usage() {
     echo "   <destination-version>:        Destination version to downgrade to"
     echo "-f/--force                       Force downgrade when downgrade path"
     echo "                                 is not supported"
+    echo "-D/--drain-timeout:              Change the node drain timeout (in seconds)"
     echo "-l/--log-file <logfile_path>:    Path to log file"
     echo "-v/--verbose:                    Run in verbose mode"
     echo "-d/--dry-run:                    Run actions in dry run mode"
@@ -29,6 +31,10 @@ _usage() {
 
 while (( "$#" )); do
   case "$1" in
+    -D|--drain-timeout)
+      DRAIN_TIMEOUT="$2"
+      shift 2
+      ;;
     -d|--dry-run)
       DRY_RUN=1
       shift
@@ -124,7 +130,7 @@ launch_downgrade () {
     "${SALT_MASTER_CALL[@]}" salt-run state.orchestrate \
         metalk8s.orchestrate.downgrade \
         saltenv="$SALTENV" \
-        ${FORCE:+pillar="{'metalk8s': {'downgrade': {'enabled': true}}}"}
+        pillar="{'orchestrate': {'drain_timeout': $DRAIN_TIMEOUT}${FORCE:+", 'metalk8s': {'downgrade': {'enabled': true}}"}}"
 }
 
 downgrade_bootstrap () {

--- a/scripts/upgrade.sh.in
+++ b/scripts/upgrade.sh.in
@@ -5,6 +5,7 @@ set -o pipefail
 
 VERBOSE=${VERBOSE:-0}
 LOGFILE=/var/log/metalk8s/upgrade.log
+DRAIN_TIMEOUT=${DRAIN_TIMEOUT:-0}
 DRY_RUN=0
 DESTINATION_VERSION=${DESTINATION_VERSION:-@@VERSION}
 # SALTENV must be equal to script version and DESTINATION_VERSION
@@ -17,6 +18,7 @@ BASE_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 _usage() {
     echo "upgrade.sh [options]"
     echo "Options:"
+    echo "-D/--drain-timeout:              Change the node drain timeout (in seconds)"
     echo "-l/--log-file <logfile_path>:    Path to log file"
     echo "-v/--verbose:                    Run in verbose mode"
     echo "-d/--dry-run:                    Run actions in dry run mode"
@@ -25,6 +27,10 @@ _usage() {
 
 while (( "$#" )); do
   case "$1" in
+    -D|--drain-timeout)
+      DRAIN_TIMEOUT="$2"
+      shift 2
+      ;;
     -d|--dry-run)
       DRY_RUN=1
       shift
@@ -163,7 +169,8 @@ upgrade_local_engines () {
 upgrade_nodes () {
     SALT_MASTER_CALL=(crictl exec -i "$(get_salt_container)")
     "${SALT_MASTER_CALL[@]}" salt-run state.orchestrate \
-        metalk8s.orchestrate.upgrade saltenv="$SALTENV"
+        metalk8s.orchestrate.upgrade saltenv="$SALTENV" \
+        pillar="{'orchestrate': {'drain_timeout': $DRAIN_TIMEOUT}}"
 }
 
 precheck_upgrade() {


### PR DESCRIPTION
- Set the default drain timeout to 3600 seconds (1 hour)
- Allow changing the drain timeout from CLI of upgrade and downgrade scripts