### PR TITLE
ci: Bump terraform snapshot repo tag from 0.3.0 to 0.3.2

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -18,7 +18,7 @@ models:
       name: Git pull terraform snapshot
       command: >
         git clone --depth 1 "git@github.com:scality/terraform-snapshot.git"
-        --branch "0.3.0"
+        --branch "0.3.2"
       haltOnFailure: true
   - ShellCommand: &git_pull_ssh
       name: Git pull on bastion


### PR DESCRIPTION
This new version includes a bump of both RHEL 7 version from 7.6 to 7.9 and RHEL 8 version from 8.2 to 8.5.