### PR TITLE
Handle 401 unauthorized error in the UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@
   highly-available when we have multiple Prometheus instances
   (PR[#3573](https://github.com/scality/metalk8s/pull/3573))
 
+- Handle 401 unauthorized error in MetalK8s UI
+  (PR[#3640](https://github.com/scality/metalk8s/pull/3640))
 ## Bug fixes
 
 - [#3601](https://github.com/scality/metalk8s/issues/3601) - Marks

--- a/shell-ui/package-lock.json
+++ b/shell-ui/package-lock.json
@@ -1958,8 +1958,8 @@
       "dev": true
     },
     "@scality/core-ui": {
-      "version": "github:scality/core-ui#877d6440521a3a3fcd00fb88d0ce7039bf9b221f",
-      "from": "github:scality/core-ui#v0.24.2"
+      "version": "github:scality/core-ui#9f1d3de45649ee0c420b1a804b77d15cb2d9c363",
+      "from": "github:scality/core-ui#v0.25.0"
     },
     "@scality/module-federation": {
       "version": "github:scality/module-federation#a4f1cf882646c8d859b9081dc8b66e5647962456",

--- a/shell-ui/package.json
+++ b/shell-ui/package.json
@@ -47,7 +47,7 @@
     "webpack-dev-server": "^3.11.2"
   },
   "dependencies": {
-    "@scality/core-ui": "github:scality/core-ui.git#v0.24.2",
+    "@scality/core-ui": "github:scality/core-ui.git#v0.25.0",
     "@scality/module-federation": "github:scality/module-federation.git#1.0.0",
     "oidc-client": "^1.11.3",
     "oidc-react": "^1.1.5",

--- a/shell-ui/src/FederatedApp.jsx
+++ b/shell-ui/src/FederatedApp.jsx
@@ -37,11 +37,7 @@ import {
   useConfigRetriever,
   useDiscoveredViews,
 } from './initFederation/ConfigurationProviders';
-import {
-  Route,
-  Switch,
-  Router,
-} from 'react-router-dom';
+import { Route, Switch, Router } from 'react-router-dom';
 import {
   ShellConfigProvider,
   useShellConfig,
@@ -203,13 +199,17 @@ function WithInitFederationProviders({ children }: { children: Node }) {
 export default function App(): Node {
   return (
     <ScrollbarWrapper>
-      <QueryClientProvider client={queryClient} contextSharing={true}>
-        <ShellConfigProvider shellConfigUrl={'/shell/config.json'}>
-          <WithInitFederationProviders>
-            <InternalApp />
-          </WithInitFederationProviders>
-        </ShellConfigProvider>
-      </QueryClientProvider>
+      <div
+        style={{ height: '100vh', display: 'flex', flexDirection: 'column' }}
+      >
+        <QueryClientProvider client={queryClient} contextSharing={true}>
+          <ShellConfigProvider shellConfigUrl={'/shell/config.json'}>
+            <WithInitFederationProviders>
+              <InternalApp />
+            </WithInitFederationProviders>
+          </ShellConfigProvider>
+        </QueryClientProvider>
+      </div>
     </ScrollbarWrapper>
   );
 }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -4708,8 +4708,8 @@
       }
     },
     "@scality/core-ui": {
-      "version": "github:scality/core-ui#877d6440521a3a3fcd00fb88d0ce7039bf9b221f",
-      "from": "github:scality/core-ui#v0.24.2"
+      "version": "github:scality/core-ui#9f1d3de45649ee0c420b1a804b77d15cb2d9c363",
+      "from": "github:scality/core-ui#v0.25.0"
     },
     "@scality/module-federation": {
       "version": "github:scality/module-federation#a4f1cf882646c8d859b9081dc8b66e5647962456",

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.3",
     "@fortawesome/react-fontawesome": "^0.1.14",
     "@kubernetes/client-node": "github:scality/kubernetes-client-javascript.git#browser-0.10.2-63-g579d066",
-    "@scality/core-ui": "github:scality/core-ui.git#v0.24.2",
+    "@scality/core-ui": "github:scality/core-ui.git#v0.25.0",
     "@scality/module-federation": "github:scality/module-federation.git#1.0.0",
     "axios": "^0.21.1",
     "formik": "2.2.5",

--- a/ui/src/FederableApp.js
+++ b/ui/src/FederableApp.js
@@ -18,13 +18,21 @@ import { useTypedSelector } from './hooks';
 import { setHistory as setReduxHistory } from './ducks/history';
 import { setApiConfigAction } from './ducks/config';
 import { initToggleSideBarAction } from './ducks/app/layout';
+import { authErrorAction } from './ducks/app/authError';
+import { AuthError } from './services/errorhandler';
 
 const composeEnhancers =
   typeof window === 'object' && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
     ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({})
     : compose;
 
-const sagaMiddleware = createSagaMiddleware();
+const sagaMiddleware = createSagaMiddleware({
+  onError: (error) => {
+    if (error instanceof AuthError) {
+      store.dispatch(authErrorAction());
+    }
+  },
+});
 const enhancer = composeEnhancers(applyMiddleware(sagaMiddleware));
 export const store = createStore(reducer, enhancer);
 

--- a/ui/src/containers/PrivateRoute.js
+++ b/ui/src/containers/PrivateRoute.js
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import { Route } from 'react-router-dom';
-import { ErrorPage500, ErrorPageAuth } from '@scality/core-ui';
+import { useHistory } from 'react-router';
+import { ErrorPage500, ErrorPageAuth, ErrorPage401 } from '@scality/core-ui';
 import { useTypedSelector } from '../hooks';
 import { ComponentWithFederatedImports } from '@scality/module-federation';
 import { useDispatch } from 'react-redux';
@@ -13,16 +14,28 @@ const InternalPrivateRoute = ({
   ...rest
 }) => {
   const { language, api } = useTypedSelector((state) => state.config);
+  const { isAuthError } = useTypedSelector((state) => state.app.authError);
   const url_support = api?.url_support;
   const { userData } = moduleExports['./auth/AuthProvider'].useAuth();
   const dispatch = useDispatch();
+  const history = useHistory();
 
   useMemo(() => {
     dispatch(updateAPIConfigAction(userData));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [!userData]);
 
-  if (userData.token && userData.username) {
+  if (isAuthError) {
+    return (
+      <ErrorPage401
+        supportLink={url_support}
+        locale={language}
+        onReturnHomeClick={() => {
+          history.push('/');
+        }}
+      />
+    );
+  } else if (userData.token && userData.username) {
     return <Route {...rest} component={component} />;
   } else {
     return (

--- a/ui/src/ducks/app/authError.js
+++ b/ui/src/ducks/app/authError.js
@@ -1,0 +1,29 @@
+//@flow
+export type AuthErrorState = {
+  isAuthError: boolean,
+};
+
+type AuthErrorAction = {
+  type: 'AUTH_ERROR',
+};
+
+const defaultState: AuthErrorState = {
+  isAuthError: false,
+};
+
+export default function reducer(
+  state: AuthErrorState = defaultState,
+  action: AuthErrorAction,
+) {
+  switch (action.type) {
+    case 'AUTH_ERROR': {
+      return { ...state, isAuthError: true };
+    }
+    default:
+      return { ...state };
+  }
+}
+
+export function authErrorAction() {
+  return { type: 'AUTH_ERROR' };
+}

--- a/ui/src/ducks/reducer.js
+++ b/ui/src/ducks/reducer.js
@@ -9,6 +9,8 @@ import pods from './app/pods';
 import type { PodsState } from './app/pods';
 import volumes from './app/volumes';
 import type { VolumesState } from './app/volumes';
+import authError from './app/authError';
+import type { AuthErrorState } from './app/authError';
 import login from './login';
 import type { LoginState } from './login';
 import layout from './app/layout';
@@ -31,6 +33,7 @@ const rootReducer = combineReducers({
     salt,
     monitoring,
     volumes,
+    authError,
   }),
   oidc: oidcReducer,
   history: historyReducer,
@@ -49,6 +52,7 @@ export type RootState = {
     layout: LayoutState,
     salt: SaltState,
     monitoring: MonitoringState,
+    authError: AuthErrorState,
   },
 };
 

--- a/ui/src/services/errorhandler.js
+++ b/ui/src/services/errorhandler.js
@@ -1,0 +1,13 @@
+export class AuthError extends Error {}
+
+export function handleUnAuthorizedError({ error }) {
+  if (
+    error?.response?.statusCode === 401 ||
+    error?.response?.statusCode === 403 ||
+    error?.response?.status === 401 ||
+    error?.response?.status === 403
+  ) {
+    throw new AuthError();
+  }
+  return { error };
+}

--- a/ui/src/services/k8s/core.js
+++ b/ui/src/services/k8s/core.js
@@ -1,10 +1,11 @@
+import { handleUnAuthorizedError } from '../errorhandler';
 import { coreV1, appsV1 } from './api';
 
 export async function getNodes() {
   try {
     return await coreV1.listNode();
   } catch (error) {
-    return { error };
+    return handleUnAuthorizedError({ error });
   }
 }
 
@@ -12,7 +13,7 @@ export async function getPods() {
   try {
     return await coreV1.listPodForAllNamespaces();
   } catch (error) {
-    return { error };
+    return handleUnAuthorizedError({ error });
   }
 }
 
@@ -25,7 +26,7 @@ export async function getKubeSystemNamespace() {
       'metadata.name=kube-system',
     );
   } catch (error) {
-    return { error };
+    return handleUnAuthorizedError({ error });
   }
 }
 
@@ -33,7 +34,7 @@ export async function createNode(payload) {
   try {
     return await coreV1.createNode(payload);
   } catch (error) {
-    return { error };
+    return handleUnAuthorizedError({ error });
   }
 }
 
@@ -57,7 +58,7 @@ export async function listNamespaces({
       options,
     );
   } catch (error) {
-    return { error };
+    return handleUnAuthorizedError({ error });
   }
 }
 
@@ -72,7 +73,7 @@ export async function queryPodInNamespace(namespace, podLabel) {
       `app=${podLabel}`,
     );
   } catch (error) {
-    return { error };
+    return handleUnAuthorizedError({ error });
   }
 }
 
@@ -86,7 +87,7 @@ export async function createNamespacedConfigMap(name, namespace, restProps) {
   try {
     return await coreV1.createNamespacedConfigMap(namespace, body);
   } catch (error) {
-    return { error };
+    return handleUnAuthorizedError({ error });
   }
 }
 
@@ -115,7 +116,7 @@ export async function patchNamespacedConfigMap(
       { headers: { 'Content-Type': cTypeHeader } },
     );
   } catch (error) {
-    return { error };
+    return handleUnAuthorizedError({ error });
   }
 }
 
@@ -123,7 +124,7 @@ export async function getNamespacedDeployment(name, namespace) {
   try {
     return await appsV1.readNamespacedDeployment(name, namespace);
   } catch (error) {
-    return { error };
+    return handleUnAuthorizedError({ error });
   }
 }
 
@@ -131,7 +132,7 @@ export async function readNode(name) {
   try {
     return await coreV1.readNode(name);
   } catch (error) {
-    return { error };
+    return handleUnAuthorizedError({ error });
   }
 }
 
@@ -139,6 +140,6 @@ export async function readNamespacedConfigMap(nameConfigMap, namespace) {
   try {
     return await coreV1.readNamespacedConfigMap(nameConfigMap, namespace);
   } catch (error) {
-    return { error };
+    return handleUnAuthorizedError({ error });
   }
 }

--- a/ui/src/services/k8s/volumes.js
+++ b/ui/src/services/k8s/volumes.js
@@ -1,4 +1,5 @@
 //@flow
+import { handleUnAuthorizedError } from '../errorhandler';
 import { coreV1, storage } from './api';
 
 export async function getPersistentVolumes() {
@@ -8,7 +9,7 @@ export async function getPersistentVolumes() {
   try {
     return await coreV1.listPersistentVolume();
   } catch (error) {
-    return { error };
+    return handleUnAuthorizedError({ error });
   }
 }
 
@@ -19,7 +20,7 @@ export async function getStorageClass() {
   try {
     return await storage.listStorageClass();
   } catch (error) {
-    return { error };
+    return handleUnAuthorizedError({ error });
   }
 }
 
@@ -30,6 +31,6 @@ export async function getPersistentVolumeClaims() {
   try {
     return await coreV1.listPersistentVolumeClaimForAllNamespaces();
   } catch (error) {
-    return { error };
+    return handleUnAuthorizedError({ error });
   }
 }


### PR DESCRIPTION
**Component**: UI

**Context**: 
The aim of this PR is to handle correctly the 401 unauthorize error on the UI side.

**Summary**:
Add Error Reducer in order to dispatch authErrorAction.
We throw out AuthError when we get unauthorized status from Salt API and K8s API, and catch it at the top of reducer.
In the PrivateRoute, we display the `<ErrorPage401/>` if isAuthError is true in the redux-store. 


**Acceptance criteria**: 
EN:
![image](https://user-images.githubusercontent.com/18453133/146037117-5a7a6f2e-2187-41c2-83df-d244e8365b67.png)
FR:
![image](https://user-images.githubusercontent.com/18453133/146161057-4177f73b-0a88-4cf1-b443-6332dacad233.png)

Core-ui v0.25.0 includes this 401 unauthorized error page. 
