### PR TITLE
shell: Wrap federated routes with a router

### DIFF
--- a/shell-ui/src/FederatedApp.jsx
+++ b/shell-ui/src/FederatedApp.jsx
@@ -142,21 +142,26 @@ function InternalRouter(): Node {
       exact: view.exact,
       strict: view.strict,
       sensitive: view.sensitive,
-      component: () => (
-        <FederatedRoute
-          url={
-            app.url +
-            retrieveConfiguration({
-              configType: 'build',
-              name: app.name,
-            }).spec.remoteEntryPath
-          }
-          module={view.module}
-          scope={view.scope}
-          app={app}
-          groups={groups}
-        />
-      ),
+      component: () => {
+        const federatedAppHistory = useMemo(() => createBrowserHistory({basename: app.appHistoryBasePath }), []);
+
+        return (
+        <Router history={federatedAppHistory}>
+          <FederatedRoute
+            url={
+              app.url +
+              retrieveConfiguration({
+                configType: 'build',
+                name: app.name,
+              }).spec.remoteEntryPath
+            }
+            module={view.module}
+            scope={view.scope}
+            app={app}
+            groups={groups}
+          />
+        </Router>
+      )},
     }));
 
   return (


### PR DESCRIPTION
**Component**:

shell

**Context**: 

Before this modification if a federated app embed more than one route under the same path the navigation from shell-ui was broken as the federated app history didn't receive updates from navigation performed in the shell
