### PR TITLE
ui: fix the alert not displaying correctly when the name is too long

### DIFF
--- a/ui/src/containers/AlertPage.js
+++ b/ui/src/containers/AlertPage.js
@@ -16,11 +16,7 @@ import { useAlerts } from './AlertProvider';
 import StatusIcon from '../components/StatusIcon';
 import CircleStatus from '../components/CircleStatus';
 import { TextBadge } from '../components/style/CommonLayoutStyle';
-import {
-  STATUS_WARNING,
-  STATUS_CRITICAL,
-  STATUS_HEALTH,
-} from '../constants';
+import { STATUS_WARNING, STATUS_CRITICAL, STATUS_HEALTH } from '../constants';
 import {
   compareHealth,
   useURLQuery,
@@ -89,18 +85,13 @@ const AlertStatusIcon = styled.div`
   height: 3rem;
   text-align: center;
 
-  &>span {
+  & > span {
     margin: 0;
   }
 `;
 
-const getAlertStatus = (critical, warning) => (
-  critical > 0
-  ? STATUS_CRITICAL
-  : warning > 0
-  ? STATUS_WARNING
-  : STATUS_HEALTH
-);
+const getAlertStatus = (critical, warning) =>
+  critical > 0 ? STATUS_CRITICAL : warning > 0 ? STATUS_WARNING : STATUS_HEALTH;
 
 function AlertPageHeader({
   activeAlerts,
@@ -118,10 +109,7 @@ function AlertPageHeader({
       <Title>
         <AlertStatusIcon>
           <StatusWrapper status={alertStatus}>
-            <StatusIcon
-              status={alertStatus}
-              className="fa fa-bell"
-            />
+            <StatusIcon status={alertStatus} className="fa fa-bell" />
           </StatusWrapper>
         </AlertStatusIcon>
         <>{intl.formatMessage({ id: 'alerts' })}</>
@@ -332,10 +320,12 @@ function ActiveAlertTab({ columns, data }) {
   );
 
   // Synchronizes the params query with the Table sort state
-  const sorted = headerGroups[0].headers.find((item) => item.isSorted === true)
-    ?.id;
-  const desc = headerGroups[0].headers.find((item) => item.isSorted === true)
-    ?.isSortedDesc;
+  const sorted = headerGroups[0].headers.find(
+    (item) => item.isSorted === true,
+  )?.id;
+  const desc = headerGroups[0].headers.find(
+    (item) => item.isSorted === true,
+  )?.isSortedDesc;
   useTableSortURLSync(sorted, desc, data, DEFAULT_SORTING_KEY);
 
   return (
@@ -453,7 +443,11 @@ export default function AlertPage() {
       {
         Header: 'Name',
         accessor: 'labels.alertname',
-        cellStyle: { width: '300px' },
+        cellStyle: {
+          width: '300px',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+        },
         sortType: 'name',
       },
       {


### PR DESCRIPTION
**Component**:

alert page

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 
Very long name are not correctly displayed in the alert table

Before
![image-2021-10-28-09-05-30-680](https://user-images.githubusercontent.com/9944133/146359079-a8bb3c4d-8f9c-4d8a-b0e3-590f95f00e18.png)

After
![Capture d’écran du 2021-12-16 11-56-39](https://user-images.githubusercontent.com/9944133/146360045-9a7cae58-4e54-4c54-b54d-a83f439a2795.png)


**Summary**:
add ellipsis

