### PR TITLE
Refactor UI Node Metric Charts by using custom chart hooks

### DIFF
--- a/ui/src/components/MetricChart.js
+++ b/ui/src/components/MetricChart.js
@@ -1,12 +1,9 @@
-import React, { useRef, useEffect, useState } from 'react';
-import { useQuery, type UseQueryOptions } from 'react-query';
-import {
-  LineTemporalChart,
-  useMetricsTimeSpan,
-} from '@scality/core-ui/dist/next';
-import { useStartingTimeStamp } from '../containers/StartTimeProvider';
+import { useCallback } from 'react';
+import { type UseQueryOptions } from 'react-query';
+import { LineTemporalChart } from '@scality/core-ui/dist/next';
 import { convertPrometheusResultToSerieWithAverage } from '../services/graphUtils';
 import { HEIGHT_DEFAULT_CHART } from '../constants';
+import { useChartSeries } from '../hooks';
 
 const MetricChart = ({
   title,
@@ -27,87 +24,44 @@ const MetricChart = ({
   getMetricAvgQuery: UseQueryOptions,
   unitRange?: { threshold: number, label: string }[],
 }) => {
-  const { startingTimeISO, currentTimeISO } = useStartingTimeStamp();
-  const { frequency } = useMetricsTimeSpan();
-
-  const startTimeRef = useRef(startingTimeISO);
-  const chartStartTimeRef = useRef(startingTimeISO); //IMPORTANT: the ref of the previous start time
-  const [series, setSeries] = useState([]);
-
-  startTimeRef.current = startingTimeISO;
-
-  const metricQuery = useQuery(
-    getMetricQuery(instanceIP, {
-      startingTimeISO,
-      currentTimeISO,
-      frequency,
-    }),
-  );
-
-  const metricAvgQuery = useQuery(
-    getMetricAvgQuery(
-      {
-        startingTimeISO,
-        currentTimeISO,
-        frequency,
+  const { isLoading, series, startingTimeStamp } = useChartSeries({
+    getQueries: useCallback(
+      (timeSpanProps) => {
+        if (showAvg) {
+          return [
+            getMetricQuery(instanceIP, timeSpanProps),
+            getMetricAvgQuery(timeSpanProps, showAvg),
+          ];
+        } else {
+          return [getMetricQuery(instanceIP, timeSpanProps)];
+        }
       },
-      showAvg,
+      [instanceIP, showAvg],
     ),
-  );
-
-  const nodeIPAddress = { internalIP: instanceIP, name: nodeName };
-
-  const isMetricDataLoading = metricQuery.isLoading;
-  const isMetricAvgDataLoading = metricAvgQuery.isLoading;
-
-  useEffect(() => {
-    if (!isMetricDataLoading && !showAvg && metricQuery.data) {
-      // single node metrics
-      chartStartTimeRef.current = startTimeRef.current;
-      setSeries(
-        convertPrometheusResultToSerieWithAverage(
-          metricQuery.data,
-          nodeIPAddress.name,
-        ),
-      );
-    } else if (
-      !isMetricAvgDataLoading &&
-      !isMetricDataLoading &&
-      showAvg &&
-      metricQuery.data &&
-      metricAvgQuery.data
-    ) {
-      // show cluster average
-      chartStartTimeRef.current = startTimeRef.current;
-      setSeries(
-        convertPrometheusResultToSerieWithAverage(
-          metricQuery.data,
-          nodeIPAddress.name,
-          metricAvgQuery.data,
-        ),
-      );
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    isMetricDataLoading,
-    isMetricAvgDataLoading,
-    showAvg,
-    JSON.stringify(metricQuery.data),
-    JSON.stringify(metricAvgQuery.data),
-  ]);
+    transformPrometheusDataToSeries: useCallback(
+      ([result, resultAvg]) => {
+        if (showAvg) {
+          return convertPrometheusResultToSerieWithAverage(
+            result,
+            nodeName,
+            resultAvg,
+          );
+        } else {
+          return convertPrometheusResultToSerieWithAverage(result, nodeName);
+        }
+      },
+      [nodeName, showAvg],
+    ),
+  });
 
   return (
     <LineTemporalChart
       series={series}
       height={HEIGHT_DEFAULT_CHART}
       title={title}
-      startingTimeStamp={Date.parse(chartStartTimeRef.current) / 1000}
+      startingTimeStamp={startingTimeStamp}
       yAxisType={yAxisType}
-      isLoading={
-        showAvg
-          ? isMetricAvgDataLoading && isMetricDataLoading
-          : isMetricDataLoading
-      }
+      isLoading={isLoading}
       unitRange={unitRange}
     />
   );

--- a/ui/src/containers/NodePageMetricsTab.js
+++ b/ui/src/containers/NodePageMetricsTab.js
@@ -10,6 +10,7 @@ import { useIntl } from 'react-intl';
 import { SyncedCursorCharts } from '@scality/core-ui/dist/next';
 import { UNIT_RANGE_BS } from '@scality/core-ui/dist/components/linetemporalchart/LineTemporalChart.component';
 import { updateNodeStatsFetchArgumentAction } from '../ducks/app/monitoring';
+import type { NodesState } from '../ducks/app/nodes';
 import {
   NodeTab,
   MetricsActionContainer,
@@ -104,7 +105,7 @@ const NodePageMetricsTab = ({
   instanceIP: string,
   controlPlaneInterface: string,
   workloadPlaneInterface: string,
-  nodesIPsInfo: [],
+  nodesIPsInfo: $PropertyType<NodesState, 'IPsInfo'>,
 }) => {
   const dispatch = useDispatch();
   const history = useHistory();

--- a/ui/src/services/platformlibrary/metrics.js
+++ b/ui/src/services/platformlibrary/metrics.js
@@ -460,7 +460,7 @@ export const getControlPlaneBandWidthAvgInQuery = (
     },
     refetchOnMount: false,
     refetchOnWindowFocus: false,
-    enabled: showAvg,
+    enabled: !!(showAvg && Object.keys(nodesIPsInfo).length),
   };
 };
 
@@ -502,7 +502,7 @@ export const getControlPlaneBandWidthAvgOutQuery = (
     },
     refetchOnMount: false,
     refetchOnWindowFocus: false,
-    enabled: showAvg,
+    enabled: !!(showAvg && Object.keys(nodesIPsInfo).length),
   };
 };
 
@@ -589,7 +589,7 @@ export const getWorkloadPlaneBandWidthAvgInQuery = (
     },
     refetchOnMount: false,
     refetchOnWindowFocus: false,
-    enabled: showAvg,
+    enabled: !!(showAvg && Object.keys(nodesIPsInfo).length),
   };
 };
 
@@ -631,7 +631,7 @@ export const getWorkloadPlaneBandWidthAvgOutQuery = (
     },
     refetchOnMount: false,
     refetchOnWindowFocus: false,
-    enabled: showAvg,
+    enabled: !!(showAvg && Object.keys(nodesIPsInfo).length),
   };
 };
 


### PR DESCRIPTION
**Component**: UI

**Context**: 
All the charts in the UI use the custom chart hook to retrieve the series, but the charts on Node Metrics Tab, which was a technical debt. 

**Summary**:
The aim of this PR is to refactor the component `<MetricChart/>` and `<MetricSymmetricalChart/>` to use the `useChartSeries`and `useSymetricalChartSeries` to retrieve all the props for LinetemporalChart.

**Acceptance criteria**: 
The Node Metrics Charts should behave the same as before. 
