### PR TITLE
build,salt,charts: Bump grafana image to `8.0.7-ubuntu`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
   nginx-ingress-controller image has been bump accordingly to v0.49.3
   (PR[#3649](https://github.com/scality/metalk8s/pull/3649))
 
+- Bump grafana image to 8.0.7-ubuntu
+  (PR[#3656](https://github.com/scality/metalk8s/pull/3656))
+
 ## Release 2.10.7
 ## Enhancements
 

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -122,8 +122,8 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     ),
     Image(
         name="grafana",
-        version="8.0.6-ubuntu",
-        digest="sha256:e37d12f5772727d6f20a427a68dbcc53b6398931db5d3715baf852b96c18946e",
+        version="8.0.7-ubuntu",
+        digest="sha256:ad2eb464edc39689d6182ebaeae1af5ff043cb8d8a04fc12b4d48a2b911c381f",
     ),
     Image(
         name="k8s-sidecar",

--- a/charts/kube-prometheus-stack.yaml
+++ b/charts/kube-prometheus-stack.yaml
@@ -143,7 +143,7 @@ grafana:
 
   image:
     repository: '__image__(grafana)'
-    tag: '8.0.6-ubuntu'
+    tag: '8.0.7-ubuntu'
 
   sidecar:
     image:

--- a/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
@@ -20422,7 +20422,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 8.0.6-ubuntu
+    app.kubernetes.io/version: 8.0.7-ubuntu
     helm.sh/chart: grafana-6.13.0
     heritage: metalk8s
   name: prometheus-operator-grafana
@@ -20680,7 +20680,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 8.0.6-ubuntu
+    app.kubernetes.io/version: 8.0.7-ubuntu
     helm.sh/chart: grafana-6.13.0
     heritage: metalk8s
   name: prometheus-operator-grafana
@@ -20782,7 +20782,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 8.0.6-ubuntu
+    app.kubernetes.io/version: 8.0.7-ubuntu
     helm.sh/chart: grafana-6.13.0
     heritage: metalk8s
   name: prometheus-operator-grafana
@@ -20811,7 +20811,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 8.0.6-ubuntu
+    app.kubernetes.io/version: 8.0.7-ubuntu
     helm.sh/chart: grafana-6.13.0
     heritage: metalk8s
   name: prometheus-operator-grafana-config-dashboards
@@ -20853,7 +20853,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 8.0.6-ubuntu
+    app.kubernetes.io/version: 8.0.7-ubuntu
     helm.sh/chart: grafana-6.13.0
     heritage: metalk8s
   name: prometheus-operator-grafana
@@ -56295,7 +56295,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 8.0.6-ubuntu
+    app.kubernetes.io/version: 8.0.7-ubuntu
     helm.sh/chart: grafana-6.13.0
     heritage: metalk8s
   name: prometheus-operator-grafana-clusterrole
@@ -56755,7 +56755,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 8.0.6-ubuntu
+    app.kubernetes.io/version: 8.0.7-ubuntu
     helm.sh/chart: grafana-6.13.0
     heritage: metalk8s
   name: prometheus-operator-grafana-clusterrolebinding
@@ -56942,7 +56942,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 8.0.6-ubuntu
+    app.kubernetes.io/version: 8.0.7-ubuntu
     helm.sh/chart: grafana-6.13.0
     heritage: metalk8s
   name: prometheus-operator-grafana
@@ -56991,7 +56991,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 8.0.6-ubuntu
+    app.kubernetes.io/version: 8.0.7-ubuntu
     helm.sh/chart: grafana-6.13.0
     heritage: metalk8s
   name: prometheus-operator-grafana
@@ -57038,7 +57038,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 8.0.6-ubuntu
+    app.kubernetes.io/version: 8.0.7-ubuntu
     helm.sh/chart: grafana-6.13.0
     heritage: metalk8s
   name: prometheus-operator-grafana
@@ -57432,7 +57432,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 8.0.6-ubuntu
+    app.kubernetes.io/version: 8.0.7-ubuntu
     helm.sh/chart: grafana-6.13.0
     heritage: metalk8s
   name: prometheus-operator-grafana
@@ -57453,8 +57453,8 @@ spec:
           apiVersion="v1", namespace="metalk8s-monitoring", name="prometheus-operator-grafana",
           path="data:grafana.ini")
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/sc-dashboard-provider-config: 1fb938ae203ab04abaec138541fafa99df99f419c7c1567c8573f1cb0e9a487c
-        checksum/secret: 81a974a3dea4b80cdc27cccd08b7648f4175ec54526ce15faffd35b6535e0967
+        checksum/sc-dashboard-provider-config: 7e05695fa8d2a6cbe9f24a8eed779433e4bcec289d6ed31ff097e0d7d004d072
+        checksum/secret: dc03a9b41d6022564e69c2cbc964b454692cd0857e1418d37a64dc8d0eb68fa1
       labels:
         app.kubernetes.io/instance: prometheus-operator
         app.kubernetes.io/name: grafana
@@ -57495,7 +57495,7 @@ spec:
           value: /var/lib/grafana/plugins
         - name: GF_PATHS_PROVISIONING
           value: /etc/grafana/provisioning
-        image: {% endraw -%}{{ build_image_name("grafana", False) }}{%- raw %}:8.0.6-ubuntu
+        image: {% endraw -%}{{ build_image_name("grafana", False) }}{%- raw %}:8.0.7-ubuntu
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
@@ -57742,7 +57742,7 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 8.0.6-ubuntu
+    app.kubernetes.io/version: 8.0.7-ubuntu
     helm.sh/chart: grafana-6.13.0
     heritage: metalk8s
   name: prometheus-operator-grafana


### PR DESCRIPTION
The chart was rendered with:
```
./charts/render.py prometheus-operator \
  charts/kube-prometheus-stack.yaml charts/kube-prometheus-stack/ \
  --namespace metalk8s-monitoring \
  --service-config grafana metalk8s-grafana-config \
                   metalk8s/addons/prometheus-operator/config/grafana.yaml \
                   metalk8s-monitoring \
  --service-config prometheus metalk8s-prometheus-config \
                   metalk8s/addons/prometheus-operator/config/prometheus.yaml \
                   metalk8s-monitoring \
  --service-config alertmanager metalk8s-alertmanager-config \
                   metalk8s/addons/prometheus-operator/config/alertmanager.yaml \
                   metalk8s-monitoring \
  --service-config dex metalk8s-dex-config \
                   metalk8s/addons/dex/config/dex.yaml.j2 metalk8s-auth \
  --drop-prometheus-rules charts/drop-prometheus-rules.yaml \
> salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
```