### PR TITLE
Fix upgrade from MetalK8s 2.10.x to 2.11

### DIFF
--- a/salt/metalk8s/addons/prometheus-operator/deployed/init.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/init.sls
@@ -8,3 +8,31 @@ include:
   - .chart
   - .prometheus-rules
   - .thanos-chart
+
+{#- Due to a change of kube-state-metrics deployment labelSelector in 2.11.0, which is immutable field
+    Manually delete the kube-state-metrics deployment object if it's an old one
+    NOTE: This logic can be removed in `development/123.0` #}
+{%- set ksm_deploy = salt.metalk8s_kubernetes.get_object(
+    kind="Deployment",
+    apiVersion="apps/v1",
+    name="prometheus-operator-kube-state-metrics",
+    namespace="metalk8s-monitoring"
+) %}
+{%- if ksm_deploy and salt.pkg.version_cmp(
+        ksm_deploy["metadata"]["labels"]["metalk8s.scality.com/version"],
+        "2.11.0"
+    ) == -1 %}
+
+Delete the old kube-state-metrics deployment:
+  metalk8s_kubernetes.object_absent:
+    - apiVersion: apps/v1
+    - kind: Deployment
+    - name: prometheus-operator-kube-state-metrics
+    - namespace: metalk8s-monitoring
+    - wait:
+        attempts: 30
+        sleep: 10
+    - require_in:
+      - sls: metalk8s.addons.prometheus-operator.deployed.chart
+
+{%- endif %}


### PR DESCRIPTION
Since the LabelSelector for the kube-state-metrics deployment changed in
8be15bd810d434bc61f762023b4afe5625695c64, we cannot replace the
kube-state-metrics deployment object if the old one exists, that's why
we ensure old kube-state-metrics deployment get removed before deploying
the new one