### PR TITLE
charts,salt: Rework node-exporter filesystem filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 ## Release 2.10.9 (in development)
+## Bug fixes
+
+- Filter out some filesystem (NSFS, iso9660) from node exporter since
+  metrics for those filesystem does not bring any value
+  (PR[#3661](https:github.com/scality/metalk8s/pull/3661))
 
 ## Release 2.10.8
 ## Enhancements

--- a/charts/kube-prometheus-stack.yaml
+++ b/charts/kube-prometheus-stack.yaml
@@ -220,8 +220,8 @@ prometheus-node-exporter:
     repository: '__image__(node-exporter)'
   extraArgs:
     - --collector.diskstats.ignored-devices=^(ram|fd)\\d+$
-    - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
-    - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
+    - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+|var/lib/containerd/.+)($|/)
+    - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$
 
 
 kubeEtcd:

--- a/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
@@ -57366,8 +57366,8 @@ spec:
         - --path.rootfs=/host/root
         - --web.listen-address=$(HOST_IP):9100
         - --collector.diskstats.ignored-devices=^(ram|fd)\\d+$
-        - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
-        - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
+        - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+|var/lib/containerd/.+)($|/)
+        - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$
         env:
         - name: HOST_IP
           value: 0.0.0.0


### PR DESCRIPTION
Update the prometheus node exporter filtering so that it matches upstream
one (filtering out NSFS, ISO9660, kubelet directory, ...)

We also filter out the `/var/lib/containerd` directory since we run on
containerd

Re-render the salt state using:
```
./charts/render.py prometheus-operator \
  charts/kube-prometheus-stack.yaml charts/kube-prometheus-stack/ \
  --namespace metalk8s-monitoring \
  --service-config grafana metalk8s-grafana-config \
                   metalk8s/addons/prometheus-operator/config/grafana.yaml \
                   metalk8s-monitoring \
  --service-config prometheus metalk8s-prometheus-config \
                   metalk8s/addons/prometheus-operator/config/prometheus.yaml \
                   metalk8s-monitoring \
  --service-config alertmanager metalk8s-alertmanager-config \
                   metalk8s/addons/prometheus-operator/config/alertmanager.yaml \
                   metalk8s-monitoring \
  --service-config dex metalk8s-dex-config \
                   metalk8s/addons/dex/config/dex.yaml.j2 metalk8s-auth \
  --drop-prometheus-rules charts/drop-prometheus-rules.yaml \
> salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
```