### PR TITLE
buildchain: Do no longer pin doit version

### DIFF
--- a/buildchain/requirements.in
+++ b/buildchain/requirements.in
@@ -1,4 +1,4 @@
 -c platform-requirements.txt
-git+git://github.com/pydoit/doit.git@baa3713bb0f3230e1bcbfe956a1dd01fd27ebed9#egg=doit
+doit ~= 0.34.0
 docker ~= 4.1.0
 PyYAML ~= 5.3.1

--- a/buildchain/requirements.txt
+++ b/buildchain/requirements.txt
@@ -4,17 +4,17 @@
 #
 #    tox -e pip-compile
 #
-certifi==2020.12.5        # via requests
-chardet==4.0.0            # via requests
-cloudpickle==1.6.0        # via doit
-docker==4.1.0             # via -r /home/alexandre/work/scm/metalk8s/worktrees/improvement/3217-buildchain-verbosity/buildchain/requirements.in
-git+git://github.com/pydoit/doit.git@baa3713bb0f3230e1bcbfe956a1dd01fd27ebed9#egg=doit  # via -r /home/alexandre/work/scm/metalk8s/worktrees/improvement/3217-buildchain-verbosity/buildchain/requirements.in
-idna==2.10                # via requests
-pyyaml==5.3.1             # via -r /home/alexandre/work/scm/metalk8s/worktrees/improvement/3217-buildchain-verbosity/buildchain/requirements.in
-requests==2.25.1          # via docker
-six==1.15.0               # via docker, websocket-client
-urllib3==1.26.4           # via requests
-websocket-client==0.58.0  # via docker
+certifi==2021.10.8        # via requests
+charset-normalizer==2.0.10  # via requests
+cloudpickle==2.0.0        # via doit
+docker==4.1.0             # via -r /home/teddy/metalk8s/buildchain/requirements.in
+doit==0.34.0              # via -r /home/teddy/metalk8s/buildchain/requirements.in
+idna==3.3                 # via requests
+pyyaml==5.3.1             # via -r /home/teddy/metalk8s/buildchain/requirements.in
+requests==2.27.1          # via docker
+six==1.16.0               # via docker
+urllib3==1.26.8           # via requests
+websocket-client==1.2.3   # via docker
 # Note: these come from 'buildchain/platform-requirements.txt'
 macfsevents==0.8.1; sys_platform=="darwin"  # via doit
 pyinotify==0.9.6; sys_platform=="linux"     # via doit


### PR DESCRIPTION
Clone of doit repos using unauthenticated git protocol is no longer supported

```console
Collecting doit from git+git://github.com/pydoit/doit.git@baa3713bb0f3230e1bcbfe956a1dd01fd27ebed9#egg=doit (from -r buildchain/requirements.txt (line 11))
  Cloning git://github.com/pydoit/doit.git (to baa3713bb0f3230e1bcbfe956a1dd01fd27ebed9) to /tmp/pip-build-pnsfy3zq/doit
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
```

Since doit 0.34.0 get released we do no longer need a specific doit
commit.

Sees: 3997aedc1dbd19ca2380ed9b0a95d4d3de78077b