### PR TITLE
packages: Make our sosreport package compatible with new sos version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,10 @@
   and enable Grafana folder generation from dashboard file structure (PR
   [#3620](https://github.com/scality/metalk8s/pull/3620))
 
+- [#3387](https://github.com/scality/metalk8s/issues/3387) - Make
+  metalk8s-sosreport package compatible with sos version 4.0+
+  (PR[#3664](https://github.com/scality/metalk8s/pull/3664))
+
 ## Bug fixes
 
 - [#3601](https://github.com/scality/metalk8s/issues/3601) - Marks

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -22,7 +22,6 @@ CALICO_VERSION: str = "3.20.0"
 K8S_VERSION: str = "1.22.5"
 SALT_VERSION: str = "3002.7"
 CONTAINERD_VERSION: str = "1.5.8"
-SOS_VERSION: str = "< 4.0"
 
 CALICO_RELEASE: str = "1"
 CONTAINERD_RELEASE: str = "1"
@@ -362,8 +361,6 @@ PACKAGES: Dict[str, Any] = {
         PackageVersion(name="runc"),
         PackageVersion(name="salt-minion", version=SALT_VERSION),
         PackageVersion(name="socat"),
-        # TODO download built package dependencies
-        PackageVersion(name="sos", version=SOS_VERSION),
         PackageVersion(name="util-linux"),
         PackageVersion(name="yum-utils"),
         PackageVersion(name="xfsprogs"),
@@ -381,6 +378,7 @@ PACKAGES: Dict[str, Any] = {
                 release="{0}.el7".format(CONTAINERD_RELEASE),
             ),
             PackageVersion(name="container-selinux"),  # TODO #1710
+            PackageVersion(name="sos", version="< 4.0"),
             PackageVersion(
                 name="metalk8s-sosreport",
                 version=SHORT_VERSION,
@@ -401,6 +399,7 @@ PACKAGES: Dict[str, Any] = {
             ),
             PackageVersion(name="container-selinux"),
             PackageVersion(name="iptables-ebtables", override="ebtables"),
+            PackageVersion(name="sos", version=">= 4.0"),
             PackageVersion(
                 name="metalk8s-sosreport",
                 version=SHORT_VERSION,

--- a/packages/common/metalk8s-sosreport/containerd.py
+++ b/packages/common/metalk8s-sosreport/containerd.py
@@ -1,6 +1,10 @@
 #! /bin/env python3
 
-from sos.plugins import Plugin, RedHatPlugin
+# sos plugin layout changed in sos 4.0
+try:
+    from sos.report.plugins import Plugin, RedHatPlugin
+except ImportError:
+    from sos.plugins import Plugin, RedHatPlugin
 
 
 class containerd(Plugin, RedHatPlugin):

--- a/packages/common/metalk8s-sosreport/metalk8s.py
+++ b/packages/common/metalk8s-sosreport/metalk8s.py
@@ -3,7 +3,12 @@
 from os import path
 
 import requests
-from sos.plugins import Plugin, RedHatPlugin
+
+# sos plugin layout changed in sos 4.0
+try:
+    from sos.report.plugins import Plugin, RedHatPlugin
+except ImportError:
+    from sos.plugins import Plugin, RedHatPlugin
 
 
 class metalk8s(Plugin, RedHatPlugin):

--- a/packages/redhat/common/metalk8s-sosreport.spec
+++ b/packages/redhat/common/metalk8s-sosreport.spec
@@ -5,11 +5,13 @@ Summary: 	Metalk8s SOS report custom plugins
 
 BuildRequires: /usr/bin/pathfix.py
 
-# Does not work with 4.0.0 and later
-Requires: sos >= 3.1, sos < 4.0
+# sos layout changed in version 4.0, in order to make things simpler
+# let's consider we have sos >= 4.0 for RHEL 8+ and sos < 4.0 for RHEL 7
 %if 0%{rhel} >= 8
+Requires: sos >= 4.0
 Requires: python3 >= 3.6
 %else
+Requires: sos >= 3.1, sos < 4.0
 Requires: python >= 2.6, python < 2.8
 # NameError on FileNotFoundError in sos 3.5 python2.7
 Conflicts: sos = 3.5
@@ -27,14 +29,16 @@ Source1:        ../../common/metalk8s-sosreport/containerd.py
 
 %if 0%{rhel} >= 8
 %define python_lib %{python3_sitelib}
+%define report_plugins %{python_lib}/sos/report/plugins
 %else
 %define python_lib %{python_sitelib}
+%define report_plugins %{python_lib}/sos/plugins
 %endif
 
 %install
-install -m 755 -d %{buildroot}/%{python_lib}/sos/plugins
-install -p -m 755 %{_topdir}/SOURCES/metalk8s.py %{buildroot}/%{python_lib}/sos/plugins/metalk8s.py
-install -p -m 755 %{_topdir}/SOURCES/containerd.py %{buildroot}/%{python_lib}/sos/plugins/containerd.py
+install -m 755 -d %{buildroot}/%{report_plugins}
+install -p -m 755 %{_topdir}/SOURCES/metalk8s.py %{buildroot}/%{report_plugins}/metalk8s.py
+install -p -m 755 %{_topdir}/SOURCES/containerd.py %{buildroot}/%{report_plugins}/containerd.py
 %if 0%{rhel} >= 8
 pathfix.py -pni "%{__python3} %{py3_shbang_opts}" %{buildroot}%{python_lib}
 %else
@@ -43,18 +47,18 @@ pathfix.py -pni "%{__python} %{py_shbang_opts}" %{buildroot}%{python_lib}
 
 %files
 %defattr(-,root,root)
-%{python_lib}/sos/plugins/containerd.py
-%{python_lib}/sos/plugins/metalk8s.py
+%{report_plugins}/containerd.py
+%{report_plugins}/metalk8s.py
 %if 0%{rhel} >= 8
-%{python_lib}/sos/plugins/__pycache__/containerd.cpython-%{python3_version_nodots}.pyc
-%{python_lib}/sos/plugins/__pycache__/containerd.cpython-%{python3_version_nodots}.opt-?.pyc
-%{python_lib}/sos/plugins/__pycache__/metalk8s.cpython-%{python3_version_nodots}.pyc
-%{python_lib}/sos/plugins/__pycache__/metalk8s.cpython-%{python3_version_nodots}.opt-?.pyc
+%{report_plugins}/__pycache__/containerd.cpython-%{python3_version_nodots}.pyc
+%{report_plugins}/__pycache__/containerd.cpython-%{python3_version_nodots}.opt-?.pyc
+%{report_plugins}/__pycache__/metalk8s.cpython-%{python3_version_nodots}.pyc
+%{report_plugins}/__pycache__/metalk8s.cpython-%{python3_version_nodots}.opt-?.pyc
 %else
-%{python_lib}/sos/plugins/metalk8s.pyc
-%{python_lib}/sos/plugins/containerd.pyc
-%{python_lib}/sos/plugins/metalk8s.pyo
-%{python_lib}/sos/plugins/containerd.pyo
+%{report_plugins}/metalk8s.pyc
+%{report_plugins}/containerd.pyc
+%{report_plugins}/metalk8s.pyo
+%{report_plugins}/containerd.pyo
 %endif
 
 %changelog


### PR DESCRIPTION
Since sos layout changed in 4.0 and CentOS 7 does not have this sos
version available by default, so we need some logic in the packages
in order to be compatible with sos > 4.0 and sos < 4.0.

We enforce sos < 4.0 for CentOS/RHEL 7 and sos >= 4.0 for RHEL8

Fixes: #3387