### PR TITLE
charts,salt: Set UID for grafana datasources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,9 @@
   metalk8s-sosreport package compatible with sos version 4.0+
   (PR[#3664](https://github.com/scality/metalk8s/pull/3664))
 
+- Explicitly set the Grafana datasource UID to `metalk8s-<datasource_name>`
+  (PR[#3668](https://github.com/scality/metalk8s/pull/3668))
+
 ## Bug fixes
 
 - [#3601](https://github.com/scality/metalk8s/issues/3601) - Marks

--- a/charts/kube-prometheus-stack.yaml
+++ b/charts/kube-prometheus-stack.yaml
@@ -165,8 +165,20 @@ grafana:
         foldersFromFilesStructure: true
 
     datasources:
+      # NOTE: We do not deploy default datasource as we want to set UID
+      # and it's not possible using this template
+      defaultDatasourceEnabled: false
+
+  additionalDataSources:
+    - name: Prometheus
+      uid: metalk8s-prometheus
+      type: prometheus
+      access: proxy
+      isDefault: true
       # Service deployed by Thanos
       url: http://thanos-query-http:10902/
+      jsonData:
+        timeInterval: 30s
 
   nodeSelector:
     node-role.kubernetes.io/infra: ''

--- a/salt/metalk8s/addons/logging/loki/deployed/datasource.sls
+++ b/salt/metalk8s/addons/logging/loki/deployed/datasource.sls
@@ -19,6 +19,7 @@ Deploy ConfigMap for Loki datasource:
             apiVersion: 1
             datasources:
             - name: Loki
+              uid: metalk8s-loki
               type: loki
               access: proxy
               url: http://loki.metalk8s-logging.svc.cluster.local:3100/

--- a/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
@@ -25089,13 +25089,14 @@ data:
   datasource.yaml: |-
     apiVersion: 1
     datasources:
-    - name: Prometheus
-      type: prometheus
-      url: http://thanos-query-http:10902/
-      access: proxy
+    - access: proxy
       isDefault: true
       jsonData:
         timeInterval: 30s
+      name: Prometheus
+      type: prometheus
+      uid: metalk8s-prometheus
+      url: http://thanos-query-http:10902/
 kind: ConfigMap
 metadata:
   labels:


### PR DESCRIPTION
Since in newer grafana version we need to use the datasource UID to
reference it, we explicitly set the datasource UID from ConfigMap so
that it's easier to reference