### PR TITLE
shell: Fix selected items are not anymore highlighted in the navbar for federated modules

### DIFF
--- a/shell-ui/src/navbar/NavBar.js
+++ b/shell-ui/src/navbar/NavBar.js
@@ -93,6 +93,7 @@ const Item = ({
 const Link = ({
   children,
   to,
+  ...props
 }: {
   children: Node,
   to:
@@ -101,7 +102,8 @@ const Link = ({
 }) => {
   const { openLink } = useLinkOpener();
   return (
-    <a href={'#'} onClick={() => openLink(to)}>
+    //$FlowFixMe
+    <a href={'#'} onClick={() => openLink(to)} {...props}>
       {children}
     </a>
   );


### PR DESCRIPTION
**Component**:

shell

**Context**: 

Federated entries were not highlighted when being visited in the navbar

**Summary**:

Forwarding Link props to the a tag fix the issue.

**Acceptance criteria**: 

Federated entries are now correctly highlighted