### PR TITLE
Revert "build: Bump Kubernetes version to 1.23.1"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 ### Enhancements
 
 - Bump Kubernetes version to
-  [1.23.1](https://github.com/kubernetes/kubernetes/releases/tag/v1.23.1)
-  (PR[#3655](https://github.com/scality/metalk8s/pull/3655))
+  [1.23.0](https://github.com/kubernetes/kubernetes/releases/tag/v1.23.0)
+  (PR[#3634](https://github.com/scality/metalk8s/pull/3634))
 
 - Bump etcd version to [3.5.1](https://github.com/etcd-io/etcd/releases/tag/v3.5.1)
   (PR[#3634](https://github.com/scality/metalk8s/pull/3634))

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -19,7 +19,7 @@ Image = namedtuple("Image", ("name", "version", "digest"))
 # Project-wide versions {{{
 
 CALICO_VERSION: str = "3.20.0"
-K8S_VERSION: str = "1.23.1"
+K8S_VERSION: str = "1.23.0"
 SALT_VERSION: str = "3002.7"
 CONTAINERD_VERSION: str = "1.5.8"
 
@@ -132,22 +132,22 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     Image(
         name="kube-apiserver",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:f54681a71cce62cbc1b13ebb3dbf1d880f849112789811f98b6aebd2caa2f255",
+        digest="sha256:d10db42c2353539ce15006854edfb6707ba6025f282d59d962729ed3b6039004",
     ),
     Image(
         name="kube-controller-manager",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:a7ed87380108a2d811f0d392a3fe87546c85bc366e0d1e024dfa74eb14468604",
+        digest="sha256:0bfbb13e5e9cec329523b6f654687af8ce058adbc90b42e5af7a929ac22e2a53",
     ),
     Image(
         name="kube-proxy",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:e40f3a28721588affcf187f3f246d1e078157dabe274003eaa2957a83f7170c8",
+        digest="sha256:2e8292d30042bb75f745d2a90d0fc4fbc3a3b1bdbe5b9d3bf50dd866c62b2ba7",
     ),
     Image(
         name="kube-scheduler",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:8be4eb1593cf9ff2d91b44596633b7815a3753696031a1eb4273d1b39427fa8c",
+        digest="sha256:af8166ce28baa7cb902a2c0d16da865d5d7c892fe1b41187fd4be78ec6291c23",
     ),
     Image(
         name="kube-state-metrics",


### PR DESCRIPTION
This reverts commit fed26f6d1ed3b4809582200356695c54665c1d6a.

It seems today Kubernetes 1.23.1 and 1.23.2 does not work well with our
tests, we do not know the root cause for the moment, in the meantime
just use 1.23.0