### PR TITLE
salt: Do not fail if CP Ingress IP not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,10 @@
   so that kubelet does not remove it
   (PR[#3624](https://github.com/scality/metalk8s/pull/3624))
 
+- Do not fail if the Control Plane Ingress section exists in the
+  Bootstrap configuration file, but Ingress IP is not set.
+  (PR[#3675](https://github.com/scality/metalk8s/pull/3675))
+
 ## Release 2.10.9 (in development)
 ## Bug fixes
 

--- a/salt/_modules/metalk8s_network.py
+++ b/salt/_modules/metalk8s_network.py
@@ -229,7 +229,7 @@ def routes():
 
 
 def get_control_plane_ingress_ip():
-    if "ingress" in __pillar__["networks"]["control_plane"]:
+    if __pillar__["networks"]["control_plane"].get("ingress", {}).get("ip"):
         return __pillar__["networks"]["control_plane"]["ingress"]["ip"]
 
     # Use Bootstrap Control Plane IP as Ingress Control plane IP


### PR DESCRIPTION
Do not fail if the Control Plane Ingress section exists in the
Bootstrap configuration file, but Ingress IP is not set.