### PR TITLE
Do not hardcode `cluster.local`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,9 @@
 - Explicitly set the Grafana datasource UID to `metalk8s-<datasource_name>`
   (PR[#3668](https://github.com/scality/metalk8s/pull/3668))
 
+- Do not use `cluster.local` suffix in Loki datasources
+  (PR[#3679](https://github.com/scality/metalk8s/pull/3679))
+
 ## Bug fixes
 
 - [#3601](https://github.com/scality/metalk8s/issues/3601) - Marks

--- a/salt/metalk8s/addons/dex/certs/server.sls
+++ b/salt/metalk8s/addons/dex/certs/server.sls
@@ -1,4 +1,5 @@
 {%- from "metalk8s/map.jinja" import certificates with context %}
+{%- from "metalk8s/map.jinja" import coredns with context %}
 {%- from "metalk8s/map.jinja" import dex with context %}
 
 {%- set oidc_service_ip = salt.metalk8s_network.get_oidc_service_ip() %}
@@ -29,7 +30,7 @@ Create Dex server private key:
     'dex',
     'dex.metalk8s-auth',
     'dex.metalk8s-auth.svc',
-    'dex.metalk8s-auth.svc.cluster.local',
+    'dex.metalk8s-auth.svc.' ~ coredns.cluster_domain,
     oidc_service_ip,
     grains.metalk8s.control_plane_ip,
 ] %}

--- a/salt/metalk8s/addons/logging/loki/deployed/datasource.sls
+++ b/salt/metalk8s/addons/logging/loki/deployed/datasource.sls
@@ -22,5 +22,5 @@ Deploy ConfigMap for Loki datasource:
               uid: metalk8s-loki
               type: loki
               access: proxy
-              url: http://loki.metalk8s-logging.svc.cluster.local:3100/
+              url: http://loki.metalk8s-logging.svc:3100/
               version: 1

--- a/salt/metalk8s/addons/nginx-ingress-control-plane/certs/server.sls
+++ b/salt/metalk8s/addons/nginx-ingress-control-plane/certs/server.sls
@@ -1,4 +1,5 @@
 {%- from "metalk8s/map.jinja" import certificates with context %}
+{%- from "metalk8s/map.jinja" import coredns with context %}
 {%- from "metalk8s/map.jinja" import nginx_ingress with context %}
 
 {%- set private_key_path = "/etc/metalk8s/pki/nginx-ingress/control-plane-server.key" %}
@@ -28,7 +29,7 @@ Create Control-Plane Ingress server private key:
     'nginx-ingress-control-plane',
     'nginx-ingress-control-plane.metalk8s-ingress',
     'nginx-ingress-control-plane.metalk8s-ingress.svc',
-    'nginx-ingress-control-plane.metalk8s-ingress.svc.cluster.local',
+    'nginx-ingress-control-plane.metalk8s-ingress.svc.' ~ coredns.cluster_domain,
     salt.metalk8s_network.get_control_plane_ingress_ip(),
 ] %}
 

--- a/salt/metalk8s/addons/nginx-ingress/certs/server.sls
+++ b/salt/metalk8s/addons/nginx-ingress/certs/server.sls
@@ -1,4 +1,5 @@
 {%- from "metalk8s/map.jinja" import certificates with context %}
+{%- from "metalk8s/map.jinja" import coredns with context %}
 {%- from "metalk8s/map.jinja" import nginx_ingress with context %}
 
 {%- set private_key_path = "/etc/metalk8s/pki/nginx-ingress/workload-plane-server.key" %}
@@ -29,7 +30,7 @@ Create Workload-Plane Ingress server private key:
     'nginx-ingress-workload-plane',
     'nginx-ingress-workload-plane.metalk8s-ingress',
     'nginx-ingress-workload-plane.metalk8s-ingress.svc',
-    'nginx-ingress-workload-plane.metalk8s-ingress.svc.cluster.local',
+    'nginx-ingress-workload-plane.metalk8s-ingress.svc.' ~ coredns.cluster_domain,
     grains.metalk8s.workload_plane_ip,
 ] %}
 

--- a/salt/metalk8s/addons/ui/deployed/dependencies.sls
+++ b/salt/metalk8s/addons/ui/deployed/dependencies.sls
@@ -1,4 +1,6 @@
-#! metalk8s_kubernetes
+#!jinja | metalk8s_kubernetes
+
+{%- from "metalk8s/map.jinja" import coredns with context %}
 
 kind: Service
 apiVersion: v1
@@ -13,7 +15,7 @@ metadata:
     heritage: metalk8s
 spec:
   type: ExternalName
-  externalName: kubernetes.default.svc.cluster.local
+  externalName: kubernetes.default.svc.{{ coredns.cluster_domain }}
   ports:
     - name: https
       port: 443
@@ -31,7 +33,7 @@ metadata:
     heritage: metalk8s
 spec:
   type: ExternalName
-  externalName: salt-master.kube-system.svc.cluster.local
+  externalName: salt-master.kube-system.svc.{{ coredns.cluster_domain }}
   ports:
     - name: https
       port: 4507
@@ -49,7 +51,7 @@ metadata:
     heritage: metalk8s
 spec:
   type: ExternalName
-  externalName: thanos-query-http.metalk8s-monitoring.svc.cluster.local
+  externalName: thanos-query-http.metalk8s-monitoring.svc.{{ coredns.cluster_domain }}
   ports:
     - name: http
       port: 10902
@@ -67,7 +69,7 @@ metadata:
     heritage: metalk8s
 spec:
   type: ExternalName
-  externalName: prometheus-operator-alertmanager.metalk8s-monitoring.svc.cluster.local
+  externalName: prometheus-operator-alertmanager.metalk8s-monitoring.svc.{{ coredns.cluster_domain }}
   ports:
     - name: http
       port: 9093
@@ -85,7 +87,7 @@ metadata:
     heritage: metalk8s
 spec:
   type: ExternalName
-  externalName: loki.metalk8s-logging.svc.cluster.local
+  externalName: loki.metalk8s-logging.svc.{{ coredns.cluster_domain }}
   ports:
     - name: http
       port: 3100

--- a/salt/metalk8s/backup/certs/server.sls
+++ b/salt/metalk8s/backup/certs/server.sls
@@ -1,4 +1,4 @@
-{%- from "metalk8s/map.jinja" import backup_server, certificates with context %}
+{%- from "metalk8s/map.jinja" import backup_server, coredns, certificates with context %}
 
 {%- set private_key_path = "/etc/metalk8s/pki/backup-server/server.key" %}
 
@@ -24,7 +24,7 @@ Create backup server private key:
     'backup',
     'backup.kube-system',
     'backup.kube-system.svc',
-    'backup.kube-system.svc.cluster.local',
+    'backup.kube-system.svc.' ~ coredns.cluster_domain,
 ] %}
 
 Generate backup server certificate:

--- a/salt/metalk8s/kubernetes/apiserver/certs/server.sls
+++ b/salt/metalk8s/kubernetes/apiserver/certs/server.sls
@@ -1,4 +1,5 @@
 {%- from "metalk8s/map.jinja" import certificates with context %}
+{%- from "metalk8s/map.jinja" import coredns with context %}
 {%- from "metalk8s/map.jinja" import kube_api with context %}
 
 {%- set kubernetes_service_ip = salt.metalk8s_network.get_kubernetes_service_ip() %}
@@ -27,7 +28,7 @@ Create kube-apiserver private key:
     'kubernetes',
     'kubernetes.default',
     'kubernetes.default.svc',
-    'kubernetes.default.svc.cluster.local',
+    'kubernetes.default.svc.' ~ coredns.cluster_domain,
     kubernetes_service_ip,
     grains['metalk8s']['control_plane_ip'],
     '127.0.0.1',

--- a/salt/metalk8s/kubernetes/apiserver/installed.sls
+++ b/salt/metalk8s/kubernetes/apiserver/installed.sls
@@ -1,5 +1,6 @@
 {%- from "metalk8s/repo/macro.sls" import build_image_name with context %}
 {%- from "metalk8s/map.jinja" import certificates with context %}
+{%- from "metalk8s/map.jinja" import coredns with context %}
 {%- from "metalk8s/map.jinja" import metalk8s with context %}
 {%- from "metalk8s/map.jinja" import networks with context %}
 
@@ -85,7 +86,7 @@ Create kube-apiserver Pod manifest:
           - --requestheader-group-headers=X-Remote-Group
           - --requestheader-username-headers=X-Remote-User
           - --secure-port=6443
-          - --service-account-issuer=https://kubernetes.default.svc.cluster.local
+          - --service-account-issuer=https://kubernetes.default.svc.{{ coredns.cluster_domain }}
           - --service-account-key-file=/etc/kubernetes/pki/sa.pub
           - --service-account-signing-key-file=/etc/kubernetes/pki/sa.key
           - --service-cluster-ip-range={{ networks.service }}

--- a/salt/metalk8s/kubernetes/kubelet/standalone.sls
+++ b/salt/metalk8s/kubernetes/kubelet/standalone.sls
@@ -1,3 +1,4 @@
+{%- from "metalk8s/map.jinja" import coredns with context %}
 {%- from "metalk8s/map.jinja" import kubelet with context %}
 {%- from "metalk8s/map.jinja" import metalk8s with context %}
 {%- from "metalk8s/repo/macro.sls" import build_image_name with context %}
@@ -61,7 +62,7 @@ Create kubelet config file:
         cgroupDriver: systemd
         clusterDNS:
           - {{ cluster_dns_ip }}
-        clusterDomain: cluster.local
+        clusterDomain: {{ coredns.cluster_domain }}
         cpuManagerReconcilePeriod: 0s
         evictionPressureTransitionPeriod: 0s
         fileCheckFrequency: 0s

--- a/salt/metalk8s/salt/master/certs/salt-api.sls
+++ b/salt/metalk8s/salt/master/certs/salt-api.sls
@@ -1,4 +1,5 @@
 {%- from "metalk8s/map.jinja" import certificates with context %}
+{%- from "metalk8s/map.jinja" import coredns with context %}
 {%- from "metalk8s/map.jinja" import kube_api with context %}
 
 {%- set private_key_path = "/etc/salt/pki/api/salt-api.key" %}
@@ -26,7 +27,7 @@ Create Salt API private key:
     'salt-master',
     'salt-master.kube-system',
     'salt-master.kube-system.svc',
-    'salt-master.kube-system.svc.cluster.local',
+    'salt-master.kube-system.svc.' ~ coredns.cluster_domain,
     grains['metalk8s']['control_plane_ip'],
 ]
 %}


### PR DESCRIPTION
- Remove `cluster.local` suffix from Loki datasources (as it's not needed)
- Do not hardcode `cluster.local` instead use the default variable define at one place

```console
$ git grep -F "cluster.local" ':(exclude)charts/' ':(exclude)docs/developer'
salt/metalk8s/defaults.yaml:  cluster_domain: cluster.local
```