### PR TITLE
alert-tree: Add missing "group_by" on Node alerts

### DIFF
--- a/tools/lib-alert-tree/metalk8s/nodes.py
+++ b/tools/lib-alert-tree/metalk8s/nodes.py
@@ -21,6 +21,7 @@ SYSTEM_PARTITION_WARNING, SYSTEM_PARTITION_CRITICAL = severity_pair(
         Existing.critical("NodeFilesystemSpaceFillingUp"),
     ],
     duration="1m",
+    group_by=["mountpoint", "instance"],
 )
 
 NODE_WARNING, NODE_CRITICAL = severity_pair(
@@ -50,4 +51,5 @@ NODE_WARNING, NODE_CRITICAL = severity_pair(
         SYSTEM_PARTITION_CRITICAL,
     ],
     duration="1m",
+    group_by=["instance"],
 )

--- a/tools/rule_extractor/alerting_rules.csv
+++ b/tools/rule_extractor/alerting_rules.csv
@@ -1,151 +1,151 @@
-AlertingServiceAtRisk,critical,The alerting service is at risk.
 ClusterAtRisk,critical,The cluster is at risk.
+NodeAtRisk,critical,The node {{ $labels.instance }} is at risk.
+SystemPartitionAtRisk,critical,The system partition {{ $labels.mountpoint }} on node {{ $labels.instance }} is at risk.
+PlatformServicesAtRisk,critical,The Platform services are at risk.
 CoreServicesAtRisk,critical,The Core services are at risk.
 KubernetesControlPlaneAtRisk,critical,The Kubernetes control plane is at risk.
-MonitoringServiceAtRisk,critical,The monitoring service is at risk.
-NodeAtRisk,critical,The node {{ $labels.instance }} is at risk.
 ObservabilityServicesAtRisk,critical,The observability services are at risk.
-PlatformServicesAtRisk,critical,The Platform services are at risk.
-SystemPartitionAtRisk,critical,The system partition {{ $labels.mountpoint }} on node {{ $labels.instance }} is at risk.
+MonitoringServiceAtRisk,critical,The monitoring service is at risk.
+AlertingServiceAtRisk,critical,The alerting service is at risk.
 VolumeAtRisk,critical,The volume {{ $labels.persistentvolumeclaim }} in namespace {{ $labels.namespace }} on node {{ $labels.instance }} is at risk.
-AccessServicesDegraded,warning,The Access services are degraded.
-AlertingServiceDegraded,warning,The alerting service is degraded.
-AuthenticationServiceDegraded,warning,The Authentication service for K8S API is degraded.
-BootstrapServicesDegraded,warning,The MetalK8s Bootstrap services are degraded.
 ClusterDegraded,warning,The cluster is degraded.
-CoreServicesDegraded,warning,The Core services are degraded.
-DashboardingServiceDegraded,warning,The dashboarding service is degraded.
-IngressControllerServicesDegraded,warning,The Ingress Controllers for control plane and workload plane are degraded.
-KubernetesControlPlaneDegraded,warning,The Kubernetes control plane is degraded.
-LoggingServiceDegraded,warning,The logging service is degraded.
-MonitoringServiceDegraded,warning,The monitoring service is degraded.
 NetworkDegraded,warning,The network is degraded.
 NodeDegraded,warning,The node {{ $labels.instance }} is degraded.
-ObservabilityServicesDegraded,warning,The observability services are degraded.
-PlatformServicesDegraded,warning,The Platform services are degraded.
 SystemPartitionDegraded,warning,The system partition {{ $labels.mountpoint }} on node {{ $labels.instance }} is degraded.
+PlatformServicesDegraded,warning,The Platform services are degraded.
+AccessServicesDegraded,warning,The Access services are degraded.
+AuthenticationServiceDegraded,warning,The Authentication service for K8S API is degraded.
+IngressControllerServicesDegraded,warning,The Ingress Controllers for control plane and workload plane are degraded.
+CoreServicesDegraded,warning,The Core services are degraded.
+KubernetesControlPlaneDegraded,warning,The Kubernetes control plane is degraded.
+BootstrapServicesDegraded,warning,The MetalK8s Bootstrap services are degraded.
+ObservabilityServicesDegraded,warning,The observability services are degraded.
+MonitoringServiceDegraded,warning,The monitoring service is degraded.
+AlertingServiceDegraded,warning,The alerting service is degraded.
+LoggingServiceDegraded,warning,The logging service is degraded.
+DashboardingServiceDegraded,warning,The dashboarding service is degraded.
 VolumeDegraded,warning,The volume {{ $labels.persistentvolumeclaim }} in namespace {{ $labels.namespace }} on node {{ $labels.instance }} is degraded.
-AlertmanagerClusterCrashlooping,critical,Half or more of the Alertmanager instances within the same cluster are crashlooping.
-AlertmanagerClusterDown,critical,Half or more of the Alertmanager instances within the same cluster are down.
+AlertmanagerFailedReload,critical,Reloading an Alertmanager configuration has failed.
+AlertmanagerMembersInconsistent,critical,A member of an Alertmanager cluster has not found all other cluster members.
+AlertmanagerFailedToSendAlerts,warning,An Alertmanager instance failed to send notifications.
 AlertmanagerClusterFailedToSendAlerts,critical,All Alertmanager instances in a cluster failed to send notifications to a critical integration.
 AlertmanagerClusterFailedToSendAlerts,warning,All Alertmanager instances in a cluster failed to send notifications to a non-critical integration.
 AlertmanagerConfigInconsistent,critical,Alertmanager instances within the same cluster have different configurations.
-AlertmanagerFailedReload,critical,Reloading an Alertmanager configuration has failed.
-AlertmanagerFailedToSendAlerts,warning,An Alertmanager instance failed to send notifications.
-AlertmanagerMembersInconsistent,critical,A member of an Alertmanager cluster has not found all other cluster members.
-etcdGRPCRequestsSlow,critical,"etcd cluster ""{{ $labels.job }}"": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}."
-etcdHTTPRequestsSlow,warning,etcd instance {{ $labels.instance }} HTTP requests to {{ $labels.method }} are slow.
-etcdHighCommitDurations,warning,"etcd cluster ""{{ $labels.job }}"": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}."
-etcdHighFsyncDurations,warning,"etcd cluster ""{{ $labels.job }}"": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}."
-etcdHighNumberOfFailedGRPCRequests,critical,"etcd cluster ""{{ $labels.job }}"": {{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}."
-etcdHighNumberOfFailedGRPCRequests,warning,"etcd cluster ""{{ $labels.job }}"": {{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}."
-etcdHighNumberOfFailedHTTPRequests,critical,{{ $value }}% of requests for {{ $labels.method }} failed on etcd instance {{ $labels.instance }}.
-etcdHighNumberOfFailedHTTPRequests,warning,{{ $value }}% of requests for {{ $labels.method }} failed on etcd instance {{ $labels.instance }}
-etcdHighNumberOfFailedProposals,warning,"etcd cluster ""{{ $labels.job }}"": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}."
-etcdHighNumberOfLeaderChanges,warning,"etcd cluster ""{{ $labels.job }}"": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour."
+AlertmanagerClusterDown,critical,Half or more of the Alertmanager instances within the same cluster are down.
+AlertmanagerClusterCrashlooping,critical,Half or more of the Alertmanager instances within the same cluster are crashlooping.
 etcdInsufficientMembers,critical,"etcd cluster ""{{ $labels.job }}"": insufficient members ({{ $value }})."
-etcdMemberCommunicationSlow,warning,"etcd cluster ""{{ $labels.job }}"": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}."
 etcdNoLeader,critical,"etcd cluster ""{{ $labels.job }}"": member {{ $labels.instance }} has no leader."
+etcdHighNumberOfLeaderChanges,warning,"etcd cluster ""{{ $labels.job }}"": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour."
+etcdHighNumberOfFailedGRPCRequests,warning,"etcd cluster ""{{ $labels.job }}"": {{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}."
+etcdHighNumberOfFailedGRPCRequests,critical,"etcd cluster ""{{ $labels.job }}"": {{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}."
+etcdGRPCRequestsSlow,critical,"etcd cluster ""{{ $labels.job }}"": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}."
+etcdMemberCommunicationSlow,warning,"etcd cluster ""{{ $labels.job }}"": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}."
+etcdHighNumberOfFailedProposals,warning,"etcd cluster ""{{ $labels.job }}"": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}."
+etcdHighFsyncDurations,warning,"etcd cluster ""{{ $labels.job }}"": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}."
+etcdHighCommitDurations,warning,"etcd cluster ""{{ $labels.job }}"": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}."
+etcdHighNumberOfFailedHTTPRequests,warning,{{ $value }}% of requests for {{ $labels.method }} failed on etcd instance {{ $labels.instance }}
+etcdHighNumberOfFailedHTTPRequests,critical,{{ $value }}% of requests for {{ $labels.method }} failed on etcd instance {{ $labels.instance }}.
+etcdHTTPRequestsSlow,warning,etcd instance {{ $labels.instance }} HTTP requests to {{ $labels.method }} are slow.
 TargetDown,warning,One or more targets are unreachable.
 Watchdog,none,An alert that should always be firing to certify that Alertmanager is working properly.
-KubeAPIErrorBudgetBurn,warning,The API server is burning too much error budget.
+KubeAPIErrorBudgetBurn,critical,The API server is burning too much error budget.
 KubeAPIErrorBudgetBurn,critical,The API server is burning too much error budget.
 KubeAPIErrorBudgetBurn,warning,The API server is burning too much error budget.
-KubeAPIErrorBudgetBurn,critical,The API server is burning too much error budget.
+KubeAPIErrorBudgetBurn,warning,The API server is burning too much error budget.
 KubeStateMetricsListErrors,critical,kube-state-metrics is experiencing errors in list operations.
+KubeStateMetricsWatchErrors,critical,kube-state-metrics is experiencing errors in watch operations.
 KubeStateMetricsShardingMismatch,critical,kube-state-metrics sharding is misconfigured.
 KubeStateMetricsShardsMissing,critical,kube-state-metrics shards are missing.
-KubeStateMetricsWatchErrors,critical,kube-state-metrics is experiencing errors in watch operations.
-KubeContainerWaiting,warning,Pod container waiting longer than 1 hour
-KubeDaemonSetMisScheduled,warning,DaemonSet pods are misscheduled.
-KubeDaemonSetNotScheduled,warning,DaemonSet pods are not scheduled.
-KubeDaemonSetRolloutStuck,warning,DaemonSet rollout is stuck.
-KubeDeploymentGenerationMismatch,warning,Deployment generation mismatch due to possible roll-back
-KubeDeploymentReplicasMismatch,warning,Deployment has not matched the expected number of replicas.
-KubeHpaMaxedOut,warning,HPA is running at max replicas
-KubeHpaReplicasMismatch,warning,HPA has not matched descired number of replicas.
-KubeJobCompletion,warning,Job did not complete in time
-KubeJobFailed,warning,Job failed to complete.
 KubePodCrashLooping,warning,Pod is crash looping.
 KubePodNotReady,warning,Pod has been in a non-ready state for more than 15 minutes.
-KubeStatefulSetGenerationMismatch,warning,StatefulSet generation mismatch due to possible roll-back
+KubeDeploymentGenerationMismatch,warning,Deployment generation mismatch due to possible roll-back
+KubeDeploymentReplicasMismatch,warning,Deployment has not matched the expected number of replicas.
 KubeStatefulSetReplicasMismatch,warning,Deployment has not matched the expected number of replicas.
+KubeStatefulSetGenerationMismatch,warning,StatefulSet generation mismatch due to possible roll-back
 KubeStatefulSetUpdateNotRolledOut,warning,StatefulSet update has not been rolled out.
-CPUThrottlingHigh,info,Processes experience elevated CPU throttling.
+KubeDaemonSetRolloutStuck,warning,DaemonSet rollout is stuck.
+KubeContainerWaiting,warning,Pod container waiting longer than 1 hour
+KubeDaemonSetNotScheduled,warning,DaemonSet pods are not scheduled.
+KubeDaemonSetMisScheduled,warning,DaemonSet pods are misscheduled.
+KubeJobCompletion,warning,Job did not complete in time
+KubeJobFailed,warning,Job failed to complete.
+KubeHpaReplicasMismatch,warning,HPA has not matched descired number of replicas.
+KubeHpaMaxedOut,warning,HPA is running at max replicas
 KubeCPUOvercommit,warning,Cluster has overcommitted CPU resource requests.
-KubeCPUQuotaOvercommit,warning,Cluster has overcommitted CPU resource requests.
 KubeMemoryOvercommit,warning,Cluster has overcommitted memory resource requests.
+KubeCPUQuotaOvercommit,warning,Cluster has overcommitted CPU resource requests.
 KubeMemoryQuotaOvercommit,warning,Cluster has overcommitted memory resource requests.
 KubeQuotaAlmostFull,info,Namespace quota is going to be full.
-KubeQuotaExceeded,warning,Namespace quota has exceeded the limits.
 KubeQuotaFullyUsed,info,Namespace quota is fully used.
-KubePersistentVolumeErrors,critical,PersistentVolume is having issues with provisioning.
+KubeQuotaExceeded,warning,Namespace quota has exceeded the limits.
+CPUThrottlingHigh,info,Processes experience elevated CPU throttling.
 KubePersistentVolumeFillingUp,critical,PersistentVolume is filling up.
 KubePersistentVolumeFillingUp,warning,PersistentVolume is filling up.
-AggregatedAPIDown,warning,An aggregated API is down.
+KubePersistentVolumeErrors,critical,PersistentVolume is having issues with provisioning.
+KubeVersionMismatch,warning,Different semantic versions of Kubernetes components running.
+KubeClientErrors,warning,Kubernetes API server client is experiencing errors.
+KubeClientCertificateExpiration,warning,Client certificate is about to expire.
+KubeClientCertificateExpiration,critical,Client certificate is about to expire.
 AggregatedAPIErrors,warning,An aggregated API has reported errors.
+AggregatedAPIDown,warning,An aggregated API is down.
 KubeAPIDown,critical,Target disappeared from Prometheus target discovery.
 KubeAPITerminatedRequests,warning,The apiserver has terminated {{ $value | humanizePercentage }} of its incoming requests.
-KubeClientCertificateExpiration,critical,Client certificate is about to expire.
-KubeClientCertificateExpiration,warning,Client certificate is about to expire.
-KubeClientErrors,warning,Kubernetes API server client is experiencing errors.
-KubeVersionMismatch,warning,Different semantic versions of Kubernetes components running.
 KubeControllerManagerDown,critical,Target disappeared from Prometheus target discovery.
 KubeNodeNotReady,warning,Node is not ready.
-KubeNodeReadinessFlapping,warning,Node readiness status is flapping.
 KubeNodeUnreachable,warning,Node is unreachable.
-KubeletClientCertificateExpiration,critical,Kubelet client certificate is about to expire.
-KubeletClientCertificateExpiration,warning,Kubelet client certificate is about to expire.
-KubeletClientCertificateRenewalErrors,warning,Kubelet has failed to renew its client certificate.
-KubeletDown,critical,Target disappeared from Prometheus target discovery.
+KubeletTooManyPods,warning,Kubelet is running at capacity.
+KubeNodeReadinessFlapping,warning,Node readiness status is flapping.
 KubeletPlegDurationHigh,warning,Kubelet Pod Lifecycle Event Generator is taking too long to relist.
 KubeletPodStartUpLatencyHigh,warning,Kubelet Pod startup latency is too high.
-KubeletServerCertificateExpiration,critical,Kubelet server certificate is about to expire.
+KubeletClientCertificateExpiration,warning,Kubelet client certificate is about to expire.
+KubeletClientCertificateExpiration,critical,Kubelet client certificate is about to expire.
 KubeletServerCertificateExpiration,warning,Kubelet server certificate is about to expire.
+KubeletServerCertificateExpiration,critical,Kubelet server certificate is about to expire.
+KubeletClientCertificateRenewalErrors,warning,Kubelet has failed to renew its client certificate.
 KubeletServerCertificateRenewalErrors,warning,Kubelet has failed to renew its server certificate.
-KubeletTooManyPods,warning,Kubelet is running at capacity.
+KubeletDown,critical,Target disappeared from Prometheus target discovery.
 KubeSchedulerDown,critical,Target disappeared from Prometheus target discovery.
-NodeClockNotSynchronising,warning,Clock on {{ $labels.instance }} is not synchronising. Ensure NTP is configured on this host.
-NodeClockSkewDetected,warning,Clock on {{ $labels.instance }} is out of sync by more than 300s. Ensure NTP is configured correctly on this host.
-NodeFileDescriptorLimit,critical,Kernel is predicted to exhaust file descriptors limit soon.
-NodeFileDescriptorLimit,warning,Kernel is predicted to exhaust file descriptors limit soon.
-NodeFilesystemAlmostOutOfFiles,critical,Filesystem has less than 8% inodes left.
-NodeFilesystemAlmostOutOfFiles,warning,Filesystem has less than 15% inodes left.
-NodeFilesystemAlmostOutOfSpace,critical,Filesystem has less than 12% space left.
-NodeFilesystemAlmostOutOfSpace,warning,Filesystem has less than 20% space left.
-NodeFilesystemFilesFillingUp,critical,Filesystem is predicted to run out of inodes within the next 4 hours.
-NodeFilesystemFilesFillingUp,warning,Filesystem is predicted to run out of inodes within the next 24 hours.
-NodeFilesystemSpaceFillingUp,critical,Filesystem is predicted to run out of space within the next 4 hours.
 NodeFilesystemSpaceFillingUp,warning,Filesystem is predicted to run out of space within the next 24 hours.
-NodeHighNumberConntrackEntriesUsed,warning,Number of conntrack are getting close to the limit
+NodeFilesystemSpaceFillingUp,critical,Filesystem is predicted to run out of space within the next 4 hours.
+NodeFilesystemAlmostOutOfSpace,warning,Filesystem has less than 20% space left.
+NodeFilesystemAlmostOutOfSpace,critical,Filesystem has less than 12% space left.
+NodeFilesystemFilesFillingUp,warning,Filesystem is predicted to run out of inodes within the next 24 hours.
+NodeFilesystemFilesFillingUp,critical,Filesystem is predicted to run out of inodes within the next 4 hours.
+NodeFilesystemAlmostOutOfFiles,warning,Filesystem has less than 15% inodes left.
+NodeFilesystemAlmostOutOfFiles,critical,Filesystem has less than 8% inodes left.
 NodeNetworkReceiveErrs,warning,Network interface is reporting many receive errors.
 NodeNetworkTransmitErrs,warning,Network interface is reporting many transmit errors.
+NodeHighNumberConntrackEntriesUsed,warning,Number of conntrack are getting close to the limit
+NodeClockSkewDetected,warning,Clock on {{ $labels.instance }} is out of sync by more than 300s. Ensure NTP is configured correctly on this host.
+NodeClockNotSynchronising,warning,Clock on {{ $labels.instance }} is not synchronising. Ensure NTP is configured on this host.
+NodeTextFileCollectorScrapeError,warning,Node Exporter text file collector failed to scrape.
 NodeRAIDDegraded,critical,RAID Array is degraded
 NodeRAIDDiskFailure,warning,Failed device in RAID array
-NodeTextFileCollectorScrapeError,warning,Node Exporter text file collector failed to scrape.
+NodeFileDescriptorLimit,warning,Kernel is predicted to exhaust file descriptors limit soon.
+NodeFileDescriptorLimit,critical,Kernel is predicted to exhaust file descriptors limit soon.
 NodeNetworkInterfaceFlapping,warning,Network interface is often changin it's status
 PrometheusBadConfig,critical,Failed Prometheus configuration reload.
-PrometheusDuplicateTimestamps,warning,Prometheus is dropping samples with duplicate timestamps.
-PrometheusErrorSendingAlertsToAnyAlertmanager,critical,Prometheus encounters more than 3% errors sending alerts to any Alertmanager.
-PrometheusErrorSendingAlertsToSomeAlertmanagers,warning,Prometheus has encountered more than 1% errors sending alerts to a specific Alertmanager.
-PrometheusLabelLimitHit,warning,Prometheus has dropped targets because some scrape configs have exceeded the labels limit.
-PrometheusMissingRuleEvaluations,warning,Prometheus is missing rule evaluations due to slow rule group evaluation.
-PrometheusNotConnectedToAlertmanagers,warning,Prometheus is not connected to any Alertmanagers.
-PrometheusNotIngestingSamples,warning,Prometheus is not ingesting samples.
 PrometheusNotificationQueueRunningFull,warning,Prometheus alert notification queue predicted to run full in less than 30m.
+PrometheusErrorSendingAlertsToSomeAlertmanagers,warning,Prometheus has encountered more than 1% errors sending alerts to a specific Alertmanager.
+PrometheusNotConnectedToAlertmanagers,warning,Prometheus is not connected to any Alertmanagers.
+PrometheusTSDBReloadsFailing,warning,Prometheus has issues reloading blocks from disk.
+PrometheusTSDBCompactionsFailing,warning,Prometheus has issues compacting blocks.
+PrometheusNotIngestingSamples,warning,Prometheus is not ingesting samples.
+PrometheusDuplicateTimestamps,warning,Prometheus is dropping samples with duplicate timestamps.
 PrometheusOutOfOrderTimestamps,warning,Prometheus drops samples with out-of-order timestamps.
 PrometheusRemoteStorageFailures,critical,Prometheus fails to send samples to remote storage.
 PrometheusRemoteWriteBehind,critical,Prometheus remote write is behind.
 PrometheusRemoteWriteDesiredShards,warning,Prometheus remote write desired shards calculation wants to run more than configured max shards.
 PrometheusRuleFailures,critical,Prometheus is failing rule evaluations.
-PrometheusTSDBCompactionsFailing,warning,Prometheus has issues compacting blocks.
-PrometheusTSDBReloadsFailing,warning,Prometheus has issues reloading blocks from disk.
+PrometheusMissingRuleEvaluations,warning,Prometheus is missing rule evaluations due to slow rule group evaluation.
 PrometheusTargetLimitHit,warning,Prometheus has dropped targets because some scrape configs have exceeded the targets limit.
+PrometheusLabelLimitHit,warning,Prometheus has dropped targets because some scrape configs have exceeded the labels limit.
 PrometheusTargetSyncFailure,critical,Prometheus has failed to sync targets.
+PrometheusErrorSendingAlertsToAnyAlertmanager,critical,Prometheus encounters more than 3% errors sending alerts to any Alertmanager.
 PrometheusOperatorListErrors,warning,Errors while performing list operations in controller.
+PrometheusOperatorWatchErrors,warning,Errors while performing watch operations in controller.
+PrometheusOperatorSyncFailed,warning,Last controller reconciliation failed
+PrometheusOperatorReconcileErrors,warning,Errors while reconciling controller.
 PrometheusOperatorNodeLookupErrors,warning,Errors while reconciling Prometheus.
 PrometheusOperatorNotReady,warning,Prometheus operator not ready
-PrometheusOperatorReconcileErrors,warning,Errors while reconciling controller.
 PrometheusOperatorRejectedResources,warning,Resources rejected by Prometheus operator
-PrometheusOperatorSyncFailed,warning,Last controller reconciliation failed
-PrometheusOperatorWatchErrors,warning,Errors while performing watch operations in controller.

--- a/tools/rule_extractor/alerting_rules.json
+++ b/tools/rule_extractor/alerting_rules.json
@@ -1,14 +1,26 @@
 [
     {
-        "message": "The alerting service is at risk.",
-        "name": "AlertingServiceAtRisk",
-        "query": "sum(ALERTS{alertname=\"AlertmanagerConfigInconsistent\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"AlertmanagerMembersInconsistent\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"AlertmanagerFailedReload\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
-        "severity": "critical"
-    },
-    {
         "message": "The cluster is at risk.",
         "name": "ClusterAtRisk",
         "query": "sum(ALERTS{alertname=\"NodeAtRisk\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"PlatformServicesAtRisk\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"VolumeAtRisk\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
+        "severity": "critical"
+    },
+    {
+        "message": "The node {{ $labels.instance }} is at risk.",
+        "name": "NodeAtRisk",
+        "query": "sum by(instance) (ALERTS{alertname=\"KubeletClientCertificateExpiration\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"NodeRAIDDegraded\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"SystemPartitionAtRisk\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
+        "severity": "critical"
+    },
+    {
+        "message": "The system partition {{ $labels.mountpoint }} on node {{ $labels.instance }} is at risk.",
+        "name": "SystemPartitionAtRisk",
+        "query": "sum by(mountpoint, instance) (ALERTS{alertname=\"NodeFilesystemAlmostOutOfSpace\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"NodeFilesystemAlmostOutOfFiles\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"NodeFilesystemFilesFillingUp\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"NodeFilesystemSpaceFillingUp\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
+        "severity": "critical"
+    },
+    {
+        "message": "The Platform services are at risk.",
+        "name": "PlatformServicesAtRisk",
+        "query": "sum(ALERTS{alertname=\"CoreServicesAtRisk\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"ObservabilityServicesAtRisk\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
         "severity": "critical"
     },
     {
@@ -24,33 +36,21 @@
         "severity": "critical"
     },
     {
-        "message": "The monitoring service is at risk.",
-        "name": "MonitoringServiceAtRisk",
-        "query": "sum(ALERTS{alertname=\"PrometheusRuleFailures\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"PrometheusRemoteWriteBehind\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"PrometheusRemoteStorageFailures\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"PrometheusErrorSendingAlertsToAnyAlertmanager\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"PrometheusBadConfig\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
-        "severity": "critical"
-    },
-    {
-        "message": "The node {{ $labels.instance }} is at risk.",
-        "name": "NodeAtRisk",
-        "query": "sum(ALERTS{alertname=\"KubeletClientCertificateExpiration\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"NodeRAIDDegraded\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"SystemPartitionAtRisk\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
-        "severity": "critical"
-    },
-    {
         "message": "The observability services are at risk.",
         "name": "ObservabilityServicesAtRisk",
         "query": "sum(ALERTS{alertname=\"MonitoringServiceAtRisk\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"AlertingServiceAtRisk\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
         "severity": "critical"
     },
     {
-        "message": "The Platform services are at risk.",
-        "name": "PlatformServicesAtRisk",
-        "query": "sum(ALERTS{alertname=\"CoreServicesAtRisk\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"ObservabilityServicesAtRisk\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
+        "message": "The monitoring service is at risk.",
+        "name": "MonitoringServiceAtRisk",
+        "query": "sum(ALERTS{alertname=\"PrometheusRuleFailures\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"PrometheusRemoteWriteBehind\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"PrometheusRemoteStorageFailures\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"PrometheusErrorSendingAlertsToAnyAlertmanager\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"PrometheusBadConfig\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
         "severity": "critical"
     },
     {
-        "message": "The system partition {{ $labels.mountpoint }} on node {{ $labels.instance }} is at risk.",
-        "name": "SystemPartitionAtRisk",
-        "query": "sum(ALERTS{alertname=\"NodeFilesystemAlmostOutOfSpace\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"NodeFilesystemAlmostOutOfFiles\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"NodeFilesystemFilesFillingUp\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"NodeFilesystemSpaceFillingUp\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
+        "message": "The alerting service is at risk.",
+        "name": "AlertingServiceAtRisk",
+        "query": "sum(ALERTS{alertname=\"AlertmanagerConfigInconsistent\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"AlertmanagerMembersInconsistent\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"AlertmanagerFailedReload\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
         "severity": "critical"
     },
     {
@@ -60,69 +60,9 @@
         "severity": "critical"
     },
     {
-        "message": "The Access services are degraded.",
-        "name": "AccessServicesDegraded",
-        "query": "sum(ALERTS{alertname=\"AuthenticationServiceDegraded\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"IngressControllerServicesDegraded\",alertstate=\"firing\",severity=\"warning\"}) >= 1",
-        "severity": "warning"
-    },
-    {
-        "message": "The alerting service is degraded.",
-        "name": "AlertingServiceDegraded",
-        "query": "sum(ALERTS{alertname=\"AlertmanagerFailedReload\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeStatefulSetReplicasMismatch\",alertstate=\"firing\",namespace=~\"metalk8s-monitoring\",severity=\"warning\",statefulset=~\"alertmanager-prometheus-operator-alertmanager\"} or ALERTS{alertname=\"KubeStatefulSetGenerationMismatch\",alertstate=\"firing\",namespace=~\"metalk8s-monitoring\",severity=\"warning\",statefulset=~\"alertmanager-prometheus-operator-alertmanager\"} or ALERTS{alertname=\"KubeStatefulSetUpdateNotRolledOut\",alertstate=\"firing\",namespace=~\"metalk8s-monitoring\",severity=\"warning\",statefulset=~\"alertmanager-prometheus-operator-alertmanager\"}) >= 1",
-        "severity": "warning"
-    },
-    {
-        "message": "The Authentication service for K8S API is degraded.",
-        "name": "AuthenticationServiceDegraded",
-        "query": "sum(ALERTS{alertname=\"KubeDeploymentReplicasMismatch\",alertstate=\"firing\",deployment=~\"dex\",namespace=~\"metalk8s-auth\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentGenerationMismatch\",alertstate=\"firing\",deployment=~\"dex\",namespace=~\"metalk8s-auth\",severity=\"warning\"}) >= 1",
-        "severity": "warning"
-    },
-    {
-        "message": "The MetalK8s Bootstrap services are degraded.",
-        "name": "BootstrapServicesDegraded",
-        "query": "sum(ALERTS{alertname=\"KubePodNotReady\",alertstate=\"firing\",namespace=~\"kube-system\",pod=~\"repositories-.*\",severity=\"warning\"} or ALERTS{alertname=\"KubePodNotReady\",alertstate=\"firing\",namespace=~\"kube-system\",pod=~\"salt-master-.*\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentReplicasMismatch\",alertstate=\"firing\",deployment=~\"storage-operator\",namespace=~\"kube-system\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentGenerationMismatch\",alertstate=\"firing\",deployment=~\"storage-operator\",namespace=~\"kube-system\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentReplicasMismatch\",alertstate=\"firing\",deployment=~\"metalk8s-ui\",namespace=~\"metalk8s-ui\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentGenerationMismatch\",alertstate=\"firing\",deployment=~\"metalk8s-ui\",namespace=~\"metalk8s-ui\",severity=\"warning\"}) >= 1",
-        "severity": "warning"
-    },
-    {
         "message": "The cluster is degraded.",
         "name": "ClusterDegraded",
         "query": "sum(ALERTS{alertname=\"NetworkDegraded\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeDegraded\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PlatformServicesDegraded\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"VolumeDegraded\",alertstate=\"firing\",severity=\"warning\"}) >= 1",
-        "severity": "warning"
-    },
-    {
-        "message": "The Core services are degraded.",
-        "name": "CoreServicesDegraded",
-        "query": "sum(ALERTS{alertname=\"KubernetesControlPlaneDegraded\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"BootstrapServicesDegraded\",alertstate=\"firing\",severity=\"warning\"}) >= 1",
-        "severity": "warning"
-    },
-    {
-        "message": "The dashboarding service is degraded.",
-        "name": "DashboardingServiceDegraded",
-        "query": "sum(ALERTS{alertname=\"KubeDeploymentReplicasMismatch\",alertstate=\"firing\",deployment=~\"prometheus-operator-grafana\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentGenerationMismatch\",alertstate=\"firing\",deployment=~\"prometheus-operator-grafana\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"}) >= 1",
-        "severity": "warning"
-    },
-    {
-        "message": "The Ingress Controllers for control plane and workload plane are degraded.",
-        "name": "IngressControllerServicesDegraded",
-        "query": "sum(ALERTS{alertname=\"KubeDeploymentReplicasMismatch\",alertstate=\"firing\",deployment=~\"ingress-nginx-defaultbackend\",namespace=~\"metalk8s-ingress\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentGenerationMismatch\",alertstate=\"firing\",deployment=~\"ingress-nginx-defaultbackend\",namespace=~\"metalk8s-ingress\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetNotScheduled\",alertstate=\"firing\",daemonset=~\"ingress-nginx-controller\",namespace=~\"metalk8s-ingress\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetMisScheduled\",alertstate=\"firing\",daemonset=~\"ingress-nginx-controller\",namespace=~\"metalk8s-ingress\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetRolloutStuck\",alertstate=\"firing\",daemonset=~\"ingress-nginx-controller\",namespace=~\"metalk8s-ingress\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetNotScheduled\",alertstate=\"firing\",daemonset=~\"ingress-nginx-control-plane-controller\",namespace=~\"metalk8s-ingress\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetMisScheduled\",alertstate=\"firing\",daemonset=~\"ingress-nginx-control-plane-controller\",namespace=~\"metalk8s-ingress\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetRolloutStuck\",alertstate=\"firing\",daemonset=~\"ingress-nginx-control-plane-controller\",namespace=~\"metalk8s-ingress\",severity=\"warning\"}) >= 1",
-        "severity": "warning"
-    },
-    {
-        "message": "The Kubernetes control plane is degraded.",
-        "name": "KubernetesControlPlaneDegraded",
-        "query": "sum(ALERTS{alertname=\"KubeAPIErrorBudgetBurn\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"etcdHighNumberOfFailedGRPCRequests\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"etcdHTTPRequestsSlow\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"etcdHighCommitDurations\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"etcdHighFsyncDurations\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"etcdHighNumberOfFailedHTTPRequests\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"etcdHighNumberOfFailedProposals\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"etcdHighNumberOfLeaderChanges\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"etcdMemberCommunicationSlow\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeCPUOvercommit\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeCPUQuotaOvercommit\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeMemoryOvercommit\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeMemoryQuotaOvercommit\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeClientCertificateExpiration\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeClientErrors\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeVersionMismatch\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentReplicasMismatch\",alertstate=\"firing\",deployment=~\"coredns\",namespace=~\"kube-system\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentGenerationMismatch\",alertstate=\"firing\",deployment=~\"coredns\",namespace=~\"kube-system\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentReplicasMismatch\",alertstate=\"firing\",deployment=~\"prometheus-adapter\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentGenerationMismatch\",alertstate=\"firing\",deployment=~\"prometheus-adapter\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentReplicasMismatch\",alertstate=\"firing\",deployment=~\"prometheus-operator-kube-state-metrics\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentGenerationMismatch\",alertstate=\"firing\",deployment=~\"prometheus-operator-kube-state-metrics\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"}) >= 1",
-        "severity": "warning"
-    },
-    {
-        "message": "The logging service is degraded.",
-        "name": "LoggingServiceDegraded",
-        "query": "sum(ALERTS{alertname=\"KubeStatefulSetReplicasMismatch\",alertstate=\"firing\",namespace=~\"metalk8s-logging\",severity=\"warning\",statefulset=~\"loki\"} or ALERTS{alertname=\"KubeStatefulSetGenerationMismatch\",alertstate=\"firing\",namespace=~\"metalk8s-logging\",severity=\"warning\",statefulset=~\"loki\"} or ALERTS{alertname=\"KubeStatefulSetUpdateNotRolledOut\",alertstate=\"firing\",namespace=~\"metalk8s-logging\",severity=\"warning\",statefulset=~\"loki\"} or ALERTS{alertname=\"KubeDaemonSetNotScheduled\",alertstate=\"firing\",daemonset=~\"fluentbit\",namespace=~\"metalk8s-logging\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetMisScheduled\",alertstate=\"firing\",daemonset=~\"fluentbit\",namespace=~\"metalk8s-logging\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetRolloutStuck\",alertstate=\"firing\",daemonset=~\"fluentbit\",namespace=~\"metalk8s-logging\",severity=\"warning\"}) >= 1",
-        "severity": "warning"
-    },
-    {
-        "message": "The monitoring service is degraded.",
-        "name": "MonitoringServiceDegraded",
-        "query": "sum(ALERTS{alertname=\"PrometheusTargetLimitHit\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusTSDBReloadsFailing\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusTSDBCompactionsFailing\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusRemoteWriteDesiredShards\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusOutOfOrderTimestamps\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusNotificationQueueRunningFull\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusNotIngestingSamples\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusNotConnectedToAlertmanagers\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusMissingRuleEvaluations\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusErrorSendingAlertsToSomeAlertmanagers\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusDuplicateTimestamps\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusOperatorWatchErrors\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusOperatorSyncFailed\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusOperatorRejectedResources\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusOperatorReconcileErrors\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusOperatorNotReady\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusOperatorNodeLookupErrors\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusOperatorListErrors\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeStatefulSetReplicasMismatch\",alertstate=\"firing\",namespace=~\"metalk8s-monitoring\",severity=\"warning\",statefulset=~\"prometheus-prometheus-operator-prometheus\"} or ALERTS{alertname=\"KubeStatefulSetGenerationMismatch\",alertstate=\"firing\",namespace=~\"metalk8s-monitoring\",severity=\"warning\",statefulset=~\"prometheus-prometheus-operator-prometheus\"} or ALERTS{alertname=\"KubeStatefulSetUpdateNotRolledOut\",alertstate=\"firing\",namespace=~\"metalk8s-monitoring\",severity=\"warning\",statefulset=~\"prometheus-prometheus-operator-prometheus\"} or ALERTS{alertname=\"KubeDeploymentReplicasMismatch\",alertstate=\"firing\",deployment=~\"prometheus-operator-operator\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentGenerationMismatch\",alertstate=\"firing\",deployment=~\"prometheus-operator-operator\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetNotScheduled\",alertstate=\"firing\",daemonset=~\"prometheus-operator-prometheus-node-exporter\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetMisScheduled\",alertstate=\"firing\",daemonset=~\"prometheus-operator-prometheus-node-exporter\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetRolloutStuck\",alertstate=\"firing\",daemonset=~\"prometheus-operator-prometheus-node-exporter\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"}) >= 1",
         "severity": "warning"
     },
     {
@@ -134,13 +74,13 @@
     {
         "message": "The node {{ $labels.instance }} is degraded.",
         "name": "NodeDegraded",
-        "query": "sum(ALERTS{alertname=\"KubeNodeNotReady\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeNodeReadinessFlapping\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeNodeUnreachable\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletClientCertificateExpiration\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletClientCertificateRenewalErrors\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletPlegDurationHigh\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletPodStartUpLatencyHigh\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletServerCertificateExpiration\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletServerCertificateRenewalErrors\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletTooManyPods\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeClockNotSynchronising\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeClockSkewDetected\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeRAIDDiskFailure\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeTextFileCollectorScrapeError\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"SystemPartitionDegraded\",alertstate=\"firing\",severity=\"warning\"}) >= 1",
+        "query": "sum by(instance) (ALERTS{alertname=\"KubeNodeNotReady\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeNodeReadinessFlapping\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeNodeUnreachable\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletClientCertificateExpiration\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletClientCertificateRenewalErrors\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletPlegDurationHigh\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletPodStartUpLatencyHigh\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletServerCertificateExpiration\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletServerCertificateRenewalErrors\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletTooManyPods\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeClockNotSynchronising\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeClockSkewDetected\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeRAIDDiskFailure\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeTextFileCollectorScrapeError\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"SystemPartitionDegraded\",alertstate=\"firing\",severity=\"warning\"}) >= 1",
         "severity": "warning"
     },
     {
-        "message": "The observability services are degraded.",
-        "name": "ObservabilityServicesDegraded",
-        "query": "sum(ALERTS{alertname=\"MonitoringServiceDegraded\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"AlertingServiceDegraded\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"LoggingServiceDegraded\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"DashboardingServiceDegraded\",alertstate=\"firing\",severity=\"warning\"}) >= 1",
+        "message": "The system partition {{ $labels.mountpoint }} on node {{ $labels.instance }} is degraded.",
+        "name": "SystemPartitionDegraded",
+        "query": "sum by(mountpoint, instance) (ALERTS{alertname=\"NodeFilesystemAlmostOutOfSpace\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeFilesystemAlmostOutOfFiles\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeFilesystemFilesFillingUp\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeFilesystemSpaceFillingUp\",alertstate=\"firing\",severity=\"warning\"}) >= 1",
         "severity": "warning"
     },
     {
@@ -150,9 +90,69 @@
         "severity": "warning"
     },
     {
-        "message": "The system partition {{ $labels.mountpoint }} on node {{ $labels.instance }} is degraded.",
-        "name": "SystemPartitionDegraded",
-        "query": "sum(ALERTS{alertname=\"NodeFilesystemAlmostOutOfSpace\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeFilesystemAlmostOutOfFiles\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeFilesystemFilesFillingUp\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeFilesystemSpaceFillingUp\",alertstate=\"firing\",severity=\"warning\"}) >= 1",
+        "message": "The Access services are degraded.",
+        "name": "AccessServicesDegraded",
+        "query": "sum(ALERTS{alertname=\"AuthenticationServiceDegraded\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"IngressControllerServicesDegraded\",alertstate=\"firing\",severity=\"warning\"}) >= 1",
+        "severity": "warning"
+    },
+    {
+        "message": "The Authentication service for K8S API is degraded.",
+        "name": "AuthenticationServiceDegraded",
+        "query": "sum(ALERTS{alertname=\"KubeDeploymentReplicasMismatch\",alertstate=\"firing\",deployment=~\"dex\",namespace=~\"metalk8s-auth\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentGenerationMismatch\",alertstate=\"firing\",deployment=~\"dex\",namespace=~\"metalk8s-auth\",severity=\"warning\"}) >= 1",
+        "severity": "warning"
+    },
+    {
+        "message": "The Ingress Controllers for control plane and workload plane are degraded.",
+        "name": "IngressControllerServicesDegraded",
+        "query": "sum(ALERTS{alertname=\"KubeDeploymentReplicasMismatch\",alertstate=\"firing\",deployment=~\"ingress-nginx-defaultbackend\",namespace=~\"metalk8s-ingress\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentGenerationMismatch\",alertstate=\"firing\",deployment=~\"ingress-nginx-defaultbackend\",namespace=~\"metalk8s-ingress\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetNotScheduled\",alertstate=\"firing\",daemonset=~\"ingress-nginx-controller\",namespace=~\"metalk8s-ingress\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetMisScheduled\",alertstate=\"firing\",daemonset=~\"ingress-nginx-controller\",namespace=~\"metalk8s-ingress\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetRolloutStuck\",alertstate=\"firing\",daemonset=~\"ingress-nginx-controller\",namespace=~\"metalk8s-ingress\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetNotScheduled\",alertstate=\"firing\",daemonset=~\"ingress-nginx-control-plane-controller\",namespace=~\"metalk8s-ingress\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetMisScheduled\",alertstate=\"firing\",daemonset=~\"ingress-nginx-control-plane-controller\",namespace=~\"metalk8s-ingress\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetRolloutStuck\",alertstate=\"firing\",daemonset=~\"ingress-nginx-control-plane-controller\",namespace=~\"metalk8s-ingress\",severity=\"warning\"}) >= 1",
+        "severity": "warning"
+    },
+    {
+        "message": "The Core services are degraded.",
+        "name": "CoreServicesDegraded",
+        "query": "sum(ALERTS{alertname=\"KubernetesControlPlaneDegraded\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"BootstrapServicesDegraded\",alertstate=\"firing\",severity=\"warning\"}) >= 1",
+        "severity": "warning"
+    },
+    {
+        "message": "The Kubernetes control plane is degraded.",
+        "name": "KubernetesControlPlaneDegraded",
+        "query": "sum(ALERTS{alertname=\"KubeAPIErrorBudgetBurn\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"etcdHighNumberOfFailedGRPCRequests\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"etcdHTTPRequestsSlow\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"etcdHighCommitDurations\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"etcdHighFsyncDurations\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"etcdHighNumberOfFailedHTTPRequests\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"etcdHighNumberOfFailedProposals\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"etcdHighNumberOfLeaderChanges\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"etcdMemberCommunicationSlow\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeCPUOvercommit\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeCPUQuotaOvercommit\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeMemoryOvercommit\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeMemoryQuotaOvercommit\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeClientCertificateExpiration\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeClientErrors\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeVersionMismatch\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentReplicasMismatch\",alertstate=\"firing\",deployment=~\"coredns\",namespace=~\"kube-system\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentGenerationMismatch\",alertstate=\"firing\",deployment=~\"coredns\",namespace=~\"kube-system\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentReplicasMismatch\",alertstate=\"firing\",deployment=~\"prometheus-adapter\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentGenerationMismatch\",alertstate=\"firing\",deployment=~\"prometheus-adapter\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentReplicasMismatch\",alertstate=\"firing\",deployment=~\"prometheus-operator-kube-state-metrics\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentGenerationMismatch\",alertstate=\"firing\",deployment=~\"prometheus-operator-kube-state-metrics\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"}) >= 1",
+        "severity": "warning"
+    },
+    {
+        "message": "The MetalK8s Bootstrap services are degraded.",
+        "name": "BootstrapServicesDegraded",
+        "query": "sum(ALERTS{alertname=\"KubePodNotReady\",alertstate=\"firing\",namespace=~\"kube-system\",pod=~\"repositories-.*\",severity=\"warning\"} or ALERTS{alertname=\"KubePodNotReady\",alertstate=\"firing\",namespace=~\"kube-system\",pod=~\"salt-master-.*\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentReplicasMismatch\",alertstate=\"firing\",deployment=~\"storage-operator\",namespace=~\"kube-system\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentGenerationMismatch\",alertstate=\"firing\",deployment=~\"storage-operator\",namespace=~\"kube-system\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentReplicasMismatch\",alertstate=\"firing\",deployment=~\"metalk8s-ui\",namespace=~\"metalk8s-ui\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentGenerationMismatch\",alertstate=\"firing\",deployment=~\"metalk8s-ui\",namespace=~\"metalk8s-ui\",severity=\"warning\"}) >= 1",
+        "severity": "warning"
+    },
+    {
+        "message": "The observability services are degraded.",
+        "name": "ObservabilityServicesDegraded",
+        "query": "sum(ALERTS{alertname=\"MonitoringServiceDegraded\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"AlertingServiceDegraded\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"LoggingServiceDegraded\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"DashboardingServiceDegraded\",alertstate=\"firing\",severity=\"warning\"}) >= 1",
+        "severity": "warning"
+    },
+    {
+        "message": "The monitoring service is degraded.",
+        "name": "MonitoringServiceDegraded",
+        "query": "sum(ALERTS{alertname=\"PrometheusTargetLimitHit\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusTSDBReloadsFailing\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusTSDBCompactionsFailing\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusRemoteWriteDesiredShards\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusOutOfOrderTimestamps\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusNotificationQueueRunningFull\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusNotIngestingSamples\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusNotConnectedToAlertmanagers\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusMissingRuleEvaluations\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusErrorSendingAlertsToSomeAlertmanagers\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusDuplicateTimestamps\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusOperatorWatchErrors\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusOperatorSyncFailed\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusOperatorRejectedResources\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusOperatorReconcileErrors\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusOperatorNotReady\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusOperatorNodeLookupErrors\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusOperatorListErrors\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeStatefulSetReplicasMismatch\",alertstate=\"firing\",namespace=~\"metalk8s-monitoring\",severity=\"warning\",statefulset=~\"prometheus-prometheus-operator-prometheus\"} or ALERTS{alertname=\"KubeStatefulSetGenerationMismatch\",alertstate=\"firing\",namespace=~\"metalk8s-monitoring\",severity=\"warning\",statefulset=~\"prometheus-prometheus-operator-prometheus\"} or ALERTS{alertname=\"KubeStatefulSetUpdateNotRolledOut\",alertstate=\"firing\",namespace=~\"metalk8s-monitoring\",severity=\"warning\",statefulset=~\"prometheus-prometheus-operator-prometheus\"} or ALERTS{alertname=\"KubeDeploymentReplicasMismatch\",alertstate=\"firing\",deployment=~\"prometheus-operator-operator\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentGenerationMismatch\",alertstate=\"firing\",deployment=~\"prometheus-operator-operator\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetNotScheduled\",alertstate=\"firing\",daemonset=~\"prometheus-operator-prometheus-node-exporter\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetMisScheduled\",alertstate=\"firing\",daemonset=~\"prometheus-operator-prometheus-node-exporter\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetRolloutStuck\",alertstate=\"firing\",daemonset=~\"prometheus-operator-prometheus-node-exporter\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"}) >= 1",
+        "severity": "warning"
+    },
+    {
+        "message": "The alerting service is degraded.",
+        "name": "AlertingServiceDegraded",
+        "query": "sum(ALERTS{alertname=\"AlertmanagerFailedReload\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeStatefulSetReplicasMismatch\",alertstate=\"firing\",namespace=~\"metalk8s-monitoring\",severity=\"warning\",statefulset=~\"alertmanager-prometheus-operator-alertmanager\"} or ALERTS{alertname=\"KubeStatefulSetGenerationMismatch\",alertstate=\"firing\",namespace=~\"metalk8s-monitoring\",severity=\"warning\",statefulset=~\"alertmanager-prometheus-operator-alertmanager\"} or ALERTS{alertname=\"KubeStatefulSetUpdateNotRolledOut\",alertstate=\"firing\",namespace=~\"metalk8s-monitoring\",severity=\"warning\",statefulset=~\"alertmanager-prometheus-operator-alertmanager\"}) >= 1",
+        "severity": "warning"
+    },
+    {
+        "message": "The logging service is degraded.",
+        "name": "LoggingServiceDegraded",
+        "query": "sum(ALERTS{alertname=\"KubeStatefulSetReplicasMismatch\",alertstate=\"firing\",namespace=~\"metalk8s-logging\",severity=\"warning\",statefulset=~\"loki\"} or ALERTS{alertname=\"KubeStatefulSetGenerationMismatch\",alertstate=\"firing\",namespace=~\"metalk8s-logging\",severity=\"warning\",statefulset=~\"loki\"} or ALERTS{alertname=\"KubeStatefulSetUpdateNotRolledOut\",alertstate=\"firing\",namespace=~\"metalk8s-logging\",severity=\"warning\",statefulset=~\"loki\"} or ALERTS{alertname=\"KubeDaemonSetNotScheduled\",alertstate=\"firing\",daemonset=~\"fluentbit\",namespace=~\"metalk8s-logging\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetMisScheduled\",alertstate=\"firing\",daemonset=~\"fluentbit\",namespace=~\"metalk8s-logging\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetRolloutStuck\",alertstate=\"firing\",daemonset=~\"fluentbit\",namespace=~\"metalk8s-logging\",severity=\"warning\"}) >= 1",
+        "severity": "warning"
+    },
+    {
+        "message": "The dashboarding service is degraded.",
+        "name": "DashboardingServiceDegraded",
+        "query": "sum(ALERTS{alertname=\"KubeDeploymentReplicasMismatch\",alertstate=\"firing\",deployment=~\"prometheus-operator-grafana\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentGenerationMismatch\",alertstate=\"firing\",deployment=~\"prometheus-operator-grafana\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"}) >= 1",
         "severity": "warning"
     },
     {
@@ -162,16 +162,22 @@
         "severity": "warning"
     },
     {
-        "message": "Half or more of the Alertmanager instances within the same cluster are crashlooping.",
-        "name": "AlertmanagerClusterCrashlooping",
-        "query": "(count by(namespace, service) (changes(process_start_time_seconds{job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"}[10m]) > 4) / count by(namespace, service) (up{job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"})) >= 0.5",
+        "message": "Reloading an Alertmanager configuration has failed.",
+        "name": "AlertmanagerFailedReload",
+        "query": "max_over_time(alertmanager_config_last_reload_successful{job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"}[5m]) == 0",
         "severity": "critical"
     },
     {
-        "message": "Half or more of the Alertmanager instances within the same cluster are down.",
-        "name": "AlertmanagerClusterDown",
-        "query": "(count by(namespace, service) (avg_over_time(up{job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"}[5m]) < 0.5) / count by(namespace, service) (up{job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"})) >= 0.5",
+        "message": "A member of an Alertmanager cluster has not found all other cluster members.",
+        "name": "AlertmanagerMembersInconsistent",
+        "query": "max_over_time(alertmanager_cluster_members{job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"}[5m]) < on(namespace, service) group_left() count by(namespace, service) (max_over_time(alertmanager_cluster_members{job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"}[5m]))",
         "severity": "critical"
+    },
+    {
+        "message": "An Alertmanager instance failed to send notifications.",
+        "name": "AlertmanagerFailedToSendAlerts",
+        "query": "(rate(alertmanager_notifications_failed_total{job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"}[5m]) / rate(alertmanager_notifications_total{job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"}[5m])) > 0.01",
+        "severity": "warning"
     },
     {
         "message": "All Alertmanager instances in a cluster failed to send notifications to a critical integration.",
@@ -192,45 +198,39 @@
         "severity": "critical"
     },
     {
-        "message": "Reloading an Alertmanager configuration has failed.",
-        "name": "AlertmanagerFailedReload",
-        "query": "max_over_time(alertmanager_config_last_reload_successful{job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"}[5m]) == 0",
+        "message": "Half or more of the Alertmanager instances within the same cluster are down.",
+        "name": "AlertmanagerClusterDown",
+        "query": "(count by(namespace, service) (avg_over_time(up{job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"}[5m]) < 0.5) / count by(namespace, service) (up{job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"})) >= 0.5",
         "severity": "critical"
     },
     {
-        "message": "An Alertmanager instance failed to send notifications.",
-        "name": "AlertmanagerFailedToSendAlerts",
-        "query": "(rate(alertmanager_notifications_failed_total{job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"}[5m]) / rate(alertmanager_notifications_total{job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"}[5m])) > 0.01",
-        "severity": "warning"
-    },
-    {
-        "message": "A member of an Alertmanager cluster has not found all other cluster members.",
-        "name": "AlertmanagerMembersInconsistent",
-        "query": "max_over_time(alertmanager_cluster_members{job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"}[5m]) < on(namespace, service) group_left() count by(namespace, service) (max_over_time(alertmanager_cluster_members{job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"}[5m]))",
+        "message": "Half or more of the Alertmanager instances within the same cluster are crashlooping.",
+        "name": "AlertmanagerClusterCrashlooping",
+        "query": "(count by(namespace, service) (changes(process_start_time_seconds{job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"}[10m]) > 4) / count by(namespace, service) (up{job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"})) >= 0.5",
         "severity": "critical"
     },
     {
-        "message": "etcd cluster \"{{ $labels.job }}\": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.",
-        "name": "etcdGRPCRequestsSlow",
-        "query": "histogram_quantile(0.99, sum by(job, instance, grpc_service, grpc_method, le) (rate(grpc_server_handling_seconds_bucket{grpc_type=\"unary\",job=~\".*etcd.*\"}[5m]))) > 0.15",
+        "message": "etcd cluster \"{{ $labels.job }}\": insufficient members ({{ $value }}).",
+        "name": "etcdInsufficientMembers",
+        "query": "sum by(job) (up{job=~\".*etcd.*\"} == bool 1) < ((count by(job) (up{job=~\".*etcd.*\"}) + 1) / 2)",
         "severity": "critical"
     },
     {
-        "message": "etcd instance {{ $labels.instance }} HTTP requests to {{ $labels.method }} are slow.",
-        "name": "etcdHTTPRequestsSlow",
-        "query": "histogram_quantile(0.99, rate(etcd_http_successful_duration_seconds_bucket[5m])) > 0.15",
+        "message": "etcd cluster \"{{ $labels.job }}\": member {{ $labels.instance }} has no leader.",
+        "name": "etcdNoLeader",
+        "query": "etcd_server_has_leader{job=~\".*etcd.*\"} == 0",
+        "severity": "critical"
+    },
+    {
+        "message": "etcd cluster \"{{ $labels.job }}\": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.",
+        "name": "etcdHighNumberOfLeaderChanges",
+        "query": "rate(etcd_server_leader_changes_seen_total{job=~\".*etcd.*\"}[15m]) > 3",
         "severity": "warning"
     },
     {
-        "message": "etcd cluster \"{{ $labels.job }}\": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.",
-        "name": "etcdHighCommitDurations",
-        "query": "histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job=~\".*etcd.*\"}[5m])) > 0.25",
-        "severity": "warning"
-    },
-    {
-        "message": "etcd cluster \"{{ $labels.job }}\": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.",
-        "name": "etcdHighFsyncDurations",
-        "query": "histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job=~\".*etcd.*\"}[5m])) > 0.5",
+        "message": "etcd cluster \"{{ $labels.job }}\": {{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}.",
+        "name": "etcdHighNumberOfFailedGRPCRequests",
+        "query": "100 * sum by(job, instance, grpc_service, grpc_method) (rate(grpc_server_handled_total{grpc_code!=\"OK\",job=~\".*etcd.*\"}[5m])) / sum by(job, instance, grpc_service, grpc_method) (rate(grpc_server_handled_total{job=~\".*etcd.*\"}[5m])) > 1",
         "severity": "warning"
     },
     {
@@ -240,39 +240,9 @@
         "severity": "critical"
     },
     {
-        "message": "etcd cluster \"{{ $labels.job }}\": {{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}.",
-        "name": "etcdHighNumberOfFailedGRPCRequests",
-        "query": "100 * sum by(job, instance, grpc_service, grpc_method) (rate(grpc_server_handled_total{grpc_code!=\"OK\",job=~\".*etcd.*\"}[5m])) / sum by(job, instance, grpc_service, grpc_method) (rate(grpc_server_handled_total{job=~\".*etcd.*\"}[5m])) > 1",
-        "severity": "warning"
-    },
-    {
-        "message": "{{ $value }}% of requests for {{ $labels.method }} failed on etcd instance {{ $labels.instance }}.",
-        "name": "etcdHighNumberOfFailedHTTPRequests",
-        "query": "sum by(method) (rate(etcd_http_failed_total{code!=\"404\",job=~\".*etcd.*\"}[5m])) / sum by(method) (rate(etcd_http_received_total{job=~\".*etcd.*\"}[5m])) > 0.05",
-        "severity": "critical"
-    },
-    {
-        "message": "{{ $value }}% of requests for {{ $labels.method }} failed on etcd instance {{ $labels.instance }}",
-        "name": "etcdHighNumberOfFailedHTTPRequests",
-        "query": "sum by(method) (rate(etcd_http_failed_total{code!=\"404\",job=~\".*etcd.*\"}[5m])) / sum by(method) (rate(etcd_http_received_total{job=~\".*etcd.*\"}[5m])) > 0.01",
-        "severity": "warning"
-    },
-    {
-        "message": "etcd cluster \"{{ $labels.job }}\": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.",
-        "name": "etcdHighNumberOfFailedProposals",
-        "query": "rate(etcd_server_proposals_failed_total{job=~\".*etcd.*\"}[15m]) > 5",
-        "severity": "warning"
-    },
-    {
-        "message": "etcd cluster \"{{ $labels.job }}\": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.",
-        "name": "etcdHighNumberOfLeaderChanges",
-        "query": "rate(etcd_server_leader_changes_seen_total{job=~\".*etcd.*\"}[15m]) > 3",
-        "severity": "warning"
-    },
-    {
-        "message": "etcd cluster \"{{ $labels.job }}\": insufficient members ({{ $value }}).",
-        "name": "etcdInsufficientMembers",
-        "query": "sum by(job) (up{job=~\".*etcd.*\"} == bool 1) < ((count by(job) (up{job=~\".*etcd.*\"}) + 1) / 2)",
+        "message": "etcd cluster \"{{ $labels.job }}\": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.",
+        "name": "etcdGRPCRequestsSlow",
+        "query": "histogram_quantile(0.99, sum by(job, instance, grpc_service, grpc_method, le) (rate(grpc_server_handling_seconds_bucket{grpc_type=\"unary\",job=~\".*etcd.*\"}[5m]))) > 0.15",
         "severity": "critical"
     },
     {
@@ -282,10 +252,40 @@
         "severity": "warning"
     },
     {
-        "message": "etcd cluster \"{{ $labels.job }}\": member {{ $labels.instance }} has no leader.",
-        "name": "etcdNoLeader",
-        "query": "etcd_server_has_leader{job=~\".*etcd.*\"} == 0",
+        "message": "etcd cluster \"{{ $labels.job }}\": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.",
+        "name": "etcdHighNumberOfFailedProposals",
+        "query": "rate(etcd_server_proposals_failed_total{job=~\".*etcd.*\"}[15m]) > 5",
+        "severity": "warning"
+    },
+    {
+        "message": "etcd cluster \"{{ $labels.job }}\": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.",
+        "name": "etcdHighFsyncDurations",
+        "query": "histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job=~\".*etcd.*\"}[5m])) > 0.5",
+        "severity": "warning"
+    },
+    {
+        "message": "etcd cluster \"{{ $labels.job }}\": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.",
+        "name": "etcdHighCommitDurations",
+        "query": "histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job=~\".*etcd.*\"}[5m])) > 0.25",
+        "severity": "warning"
+    },
+    {
+        "message": "{{ $value }}% of requests for {{ $labels.method }} failed on etcd instance {{ $labels.instance }}",
+        "name": "etcdHighNumberOfFailedHTTPRequests",
+        "query": "sum by(method) (rate(etcd_http_failed_total{code!=\"404\",job=~\".*etcd.*\"}[5m])) / sum by(method) (rate(etcd_http_received_total{job=~\".*etcd.*\"}[5m])) > 0.01",
+        "severity": "warning"
+    },
+    {
+        "message": "{{ $value }}% of requests for {{ $labels.method }} failed on etcd instance {{ $labels.instance }}.",
+        "name": "etcdHighNumberOfFailedHTTPRequests",
+        "query": "sum by(method) (rate(etcd_http_failed_total{code!=\"404\",job=~\".*etcd.*\"}[5m])) / sum by(method) (rate(etcd_http_received_total{job=~\".*etcd.*\"}[5m])) > 0.05",
         "severity": "critical"
+    },
+    {
+        "message": "etcd instance {{ $labels.instance }} HTTP requests to {{ $labels.method }} are slow.",
+        "name": "etcdHTTPRequestsSlow",
+        "query": "histogram_quantile(0.99, rate(etcd_http_successful_duration_seconds_bucket[5m])) > 0.15",
+        "severity": "warning"
     },
     {
         "message": "One or more targets are unreachable.",
@@ -302,20 +302,8 @@
     {
         "message": "The API server is burning too much error budget.",
         "name": "KubeAPIErrorBudgetBurn",
-        "query": "sum(apiserver_request:burnrate1d) > (3 * 0.01) and sum(apiserver_request:burnrate2h) > (3 * 0.01)",
-        "severity": "warning"
-    },
-    {
-        "message": "The API server is burning too much error budget.",
-        "name": "KubeAPIErrorBudgetBurn",
         "query": "sum(apiserver_request:burnrate1h) > (14.4 * 0.01) and sum(apiserver_request:burnrate5m) > (14.4 * 0.01)",
         "severity": "critical"
-    },
-    {
-        "message": "The API server is burning too much error budget.",
-        "name": "KubeAPIErrorBudgetBurn",
-        "query": "sum(apiserver_request:burnrate3d) > (1 * 0.01) and sum(apiserver_request:burnrate6h) > (1 * 0.01)",
-        "severity": "warning"
     },
     {
         "message": "The API server is burning too much error budget.",
@@ -324,9 +312,27 @@
         "severity": "critical"
     },
     {
+        "message": "The API server is burning too much error budget.",
+        "name": "KubeAPIErrorBudgetBurn",
+        "query": "sum(apiserver_request:burnrate1d) > (3 * 0.01) and sum(apiserver_request:burnrate2h) > (3 * 0.01)",
+        "severity": "warning"
+    },
+    {
+        "message": "The API server is burning too much error budget.",
+        "name": "KubeAPIErrorBudgetBurn",
+        "query": "sum(apiserver_request:burnrate3d) > (1 * 0.01) and sum(apiserver_request:burnrate6h) > (1 * 0.01)",
+        "severity": "warning"
+    },
+    {
         "message": "kube-state-metrics is experiencing errors in list operations.",
         "name": "KubeStateMetricsListErrors",
         "query": "(sum(rate(kube_state_metrics_list_total{job=\"kube-state-metrics\",result=\"error\"}[5m])) / sum(rate(kube_state_metrics_list_total{job=\"kube-state-metrics\"}[5m]))) > 0.01",
+        "severity": "critical"
+    },
+    {
+        "message": "kube-state-metrics is experiencing errors in watch operations.",
+        "name": "KubeStateMetricsWatchErrors",
+        "query": "(sum(rate(kube_state_metrics_watch_total{job=\"kube-state-metrics\",result=\"error\"}[5m])) / sum(rate(kube_state_metrics_watch_total{job=\"kube-state-metrics\"}[5m]))) > 0.01",
         "severity": "critical"
     },
     {
@@ -342,33 +348,15 @@
         "severity": "critical"
     },
     {
-        "message": "kube-state-metrics is experiencing errors in watch operations.",
-        "name": "KubeStateMetricsWatchErrors",
-        "query": "(sum(rate(kube_state_metrics_watch_total{job=\"kube-state-metrics\",result=\"error\"}[5m])) / sum(rate(kube_state_metrics_watch_total{job=\"kube-state-metrics\"}[5m]))) > 0.01",
-        "severity": "critical"
-    },
-    {
-        "message": "Pod container waiting longer than 1 hour",
-        "name": "KubeContainerWaiting",
-        "query": "sum by(namespace, pod, container) (kube_pod_container_status_waiting_reason{job=\"kube-state-metrics\",namespace=~\".*\"}) > 0",
+        "message": "Pod is crash looping.",
+        "name": "KubePodCrashLooping",
+        "query": "increase(kube_pod_container_status_restarts_total{job=\"kube-state-metrics\",namespace=~\".*\"}[10m]) > 0 and kube_pod_container_status_waiting{job=\"kube-state-metrics\",namespace=~\".*\"} == 1",
         "severity": "warning"
     },
     {
-        "message": "DaemonSet pods are misscheduled.",
-        "name": "KubeDaemonSetMisScheduled",
-        "query": "kube_daemonset_status_number_misscheduled{job=\"kube-state-metrics\",namespace=~\".*\"} > 0",
-        "severity": "warning"
-    },
-    {
-        "message": "DaemonSet pods are not scheduled.",
-        "name": "KubeDaemonSetNotScheduled",
-        "query": "kube_daemonset_status_desired_number_scheduled{job=\"kube-state-metrics\",namespace=~\".*\"} - kube_daemonset_status_current_number_scheduled{job=\"kube-state-metrics\",namespace=~\".*\"} > 0",
-        "severity": "warning"
-    },
-    {
-        "message": "DaemonSet rollout is stuck.",
-        "name": "KubeDaemonSetRolloutStuck",
-        "query": "((kube_daemonset_status_current_number_scheduled{job=\"kube-state-metrics\",namespace=~\".*\"} != kube_daemonset_status_desired_number_scheduled{job=\"kube-state-metrics\",namespace=~\".*\"}) or (kube_daemonset_status_number_misscheduled{job=\"kube-state-metrics\",namespace=~\".*\"} != 0) or (kube_daemonset_updated_number_scheduled{job=\"kube-state-metrics\",namespace=~\".*\"} != kube_daemonset_status_desired_number_scheduled{job=\"kube-state-metrics\",namespace=~\".*\"}) or (kube_daemonset_status_number_available{job=\"kube-state-metrics\",namespace=~\".*\"} != kube_daemonset_status_desired_number_scheduled{job=\"kube-state-metrics\",namespace=~\".*\"})) and (changes(kube_daemonset_updated_number_scheduled{job=\"kube-state-metrics\",namespace=~\".*\"}[5m]) == 0)",
+        "message": "Pod has been in a non-ready state for more than 15 minutes.",
+        "name": "KubePodNotReady",
+        "query": "sum by(namespace, pod) (max by(namespace, pod) (kube_pod_status_phase{job=\"kube-state-metrics\",namespace=~\".*\",phase=~\"Pending|Unknown\"}) * on(namespace, pod) group_left(owner_kind) topk by(namespace, pod) (1, max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!=\"Job\"}))) > 0",
         "severity": "warning"
     },
     {
@@ -384,15 +372,45 @@
         "severity": "warning"
     },
     {
-        "message": "HPA is running at max replicas",
-        "name": "KubeHpaMaxedOut",
-        "query": "kube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\",namespace=~\".*\"} == kube_horizontalpodautoscaler_spec_max_replicas{job=\"kube-state-metrics\",namespace=~\".*\"}",
+        "message": "Deployment has not matched the expected number of replicas.",
+        "name": "KubeStatefulSetReplicasMismatch",
+        "query": "(kube_statefulset_status_replicas_ready{job=\"kube-state-metrics\",namespace=~\".*\"} != kube_statefulset_status_replicas{job=\"kube-state-metrics\",namespace=~\".*\"}) and (changes(kube_statefulset_status_replicas_updated{job=\"kube-state-metrics\",namespace=~\".*\"}[10m]) == 0)",
         "severity": "warning"
     },
     {
-        "message": "HPA has not matched descired number of replicas.",
-        "name": "KubeHpaReplicasMismatch",
-        "query": "(kube_horizontalpodautoscaler_status_desired_replicas{job=\"kube-state-metrics\",namespace=~\".*\"} != kube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\",namespace=~\".*\"}) and (kube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\",namespace=~\".*\"} > kube_horizontalpodautoscaler_spec_min_replicas{job=\"kube-state-metrics\",namespace=~\".*\"}) and (kube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\",namespace=~\".*\"} < kube_horizontalpodautoscaler_spec_max_replicas{job=\"kube-state-metrics\",namespace=~\".*\"}) and changes(kube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\",namespace=~\".*\"}[15m]) == 0",
+        "message": "StatefulSet generation mismatch due to possible roll-back",
+        "name": "KubeStatefulSetGenerationMismatch",
+        "query": "kube_statefulset_status_observed_generation{job=\"kube-state-metrics\",namespace=~\".*\"} != kube_statefulset_metadata_generation{job=\"kube-state-metrics\",namespace=~\".*\"}",
+        "severity": "warning"
+    },
+    {
+        "message": "StatefulSet update has not been rolled out.",
+        "name": "KubeStatefulSetUpdateNotRolledOut",
+        "query": "(max without(revision) (kube_statefulset_status_current_revision{job=\"kube-state-metrics\",namespace=~\".*\"} unless kube_statefulset_status_update_revision{job=\"kube-state-metrics\",namespace=~\".*\"}) * (kube_statefulset_replicas{job=\"kube-state-metrics\",namespace=~\".*\"} != kube_statefulset_status_replicas_updated{job=\"kube-state-metrics\",namespace=~\".*\"})) and (changes(kube_statefulset_status_replicas_updated{job=\"kube-state-metrics\",namespace=~\".*\"}[5m]) == 0)",
+        "severity": "warning"
+    },
+    {
+        "message": "DaemonSet rollout is stuck.",
+        "name": "KubeDaemonSetRolloutStuck",
+        "query": "((kube_daemonset_status_current_number_scheduled{job=\"kube-state-metrics\",namespace=~\".*\"} != kube_daemonset_status_desired_number_scheduled{job=\"kube-state-metrics\",namespace=~\".*\"}) or (kube_daemonset_status_number_misscheduled{job=\"kube-state-metrics\",namespace=~\".*\"} != 0) or (kube_daemonset_updated_number_scheduled{job=\"kube-state-metrics\",namespace=~\".*\"} != kube_daemonset_status_desired_number_scheduled{job=\"kube-state-metrics\",namespace=~\".*\"}) or (kube_daemonset_status_number_available{job=\"kube-state-metrics\",namespace=~\".*\"} != kube_daemonset_status_desired_number_scheduled{job=\"kube-state-metrics\",namespace=~\".*\"})) and (changes(kube_daemonset_updated_number_scheduled{job=\"kube-state-metrics\",namespace=~\".*\"}[5m]) == 0)",
+        "severity": "warning"
+    },
+    {
+        "message": "Pod container waiting longer than 1 hour",
+        "name": "KubeContainerWaiting",
+        "query": "sum by(namespace, pod, container) (kube_pod_container_status_waiting_reason{job=\"kube-state-metrics\",namespace=~\".*\"}) > 0",
+        "severity": "warning"
+    },
+    {
+        "message": "DaemonSet pods are not scheduled.",
+        "name": "KubeDaemonSetNotScheduled",
+        "query": "kube_daemonset_status_desired_number_scheduled{job=\"kube-state-metrics\",namespace=~\".*\"} - kube_daemonset_status_current_number_scheduled{job=\"kube-state-metrics\",namespace=~\".*\"} > 0",
+        "severity": "warning"
+    },
+    {
+        "message": "DaemonSet pods are misscheduled.",
+        "name": "KubeDaemonSetMisScheduled",
+        "query": "kube_daemonset_status_number_misscheduled{job=\"kube-state-metrics\",namespace=~\".*\"} > 0",
         "severity": "warning"
     },
     {
@@ -408,40 +426,16 @@
         "severity": "warning"
     },
     {
-        "message": "Pod is crash looping.",
-        "name": "KubePodCrashLooping",
-        "query": "increase(kube_pod_container_status_restarts_total{job=\"kube-state-metrics\",namespace=~\".*\"}[10m]) > 0 and kube_pod_container_status_waiting{job=\"kube-state-metrics\",namespace=~\".*\"} == 1",
+        "message": "HPA has not matched descired number of replicas.",
+        "name": "KubeHpaReplicasMismatch",
+        "query": "(kube_horizontalpodautoscaler_status_desired_replicas{job=\"kube-state-metrics\",namespace=~\".*\"} != kube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\",namespace=~\".*\"}) and (kube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\",namespace=~\".*\"} > kube_horizontalpodautoscaler_spec_min_replicas{job=\"kube-state-metrics\",namespace=~\".*\"}) and (kube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\",namespace=~\".*\"} < kube_horizontalpodautoscaler_spec_max_replicas{job=\"kube-state-metrics\",namespace=~\".*\"}) and changes(kube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\",namespace=~\".*\"}[15m]) == 0",
         "severity": "warning"
     },
     {
-        "message": "Pod has been in a non-ready state for more than 15 minutes.",
-        "name": "KubePodNotReady",
-        "query": "sum by(namespace, pod) (max by(namespace, pod) (kube_pod_status_phase{job=\"kube-state-metrics\",namespace=~\".*\",phase=~\"Pending|Unknown\"}) * on(namespace, pod) group_left(owner_kind) topk by(namespace, pod) (1, max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!=\"Job\"}))) > 0",
+        "message": "HPA is running at max replicas",
+        "name": "KubeHpaMaxedOut",
+        "query": "kube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\",namespace=~\".*\"} == kube_horizontalpodautoscaler_spec_max_replicas{job=\"kube-state-metrics\",namespace=~\".*\"}",
         "severity": "warning"
-    },
-    {
-        "message": "StatefulSet generation mismatch due to possible roll-back",
-        "name": "KubeStatefulSetGenerationMismatch",
-        "query": "kube_statefulset_status_observed_generation{job=\"kube-state-metrics\",namespace=~\".*\"} != kube_statefulset_metadata_generation{job=\"kube-state-metrics\",namespace=~\".*\"}",
-        "severity": "warning"
-    },
-    {
-        "message": "Deployment has not matched the expected number of replicas.",
-        "name": "KubeStatefulSetReplicasMismatch",
-        "query": "(kube_statefulset_status_replicas_ready{job=\"kube-state-metrics\",namespace=~\".*\"} != kube_statefulset_status_replicas{job=\"kube-state-metrics\",namespace=~\".*\"}) and (changes(kube_statefulset_status_replicas_updated{job=\"kube-state-metrics\",namespace=~\".*\"}[10m]) == 0)",
-        "severity": "warning"
-    },
-    {
-        "message": "StatefulSet update has not been rolled out.",
-        "name": "KubeStatefulSetUpdateNotRolledOut",
-        "query": "(max without(revision) (kube_statefulset_status_current_revision{job=\"kube-state-metrics\",namespace=~\".*\"} unless kube_statefulset_status_update_revision{job=\"kube-state-metrics\",namespace=~\".*\"}) * (kube_statefulset_replicas{job=\"kube-state-metrics\",namespace=~\".*\"} != kube_statefulset_status_replicas_updated{job=\"kube-state-metrics\",namespace=~\".*\"})) and (changes(kube_statefulset_status_replicas_updated{job=\"kube-state-metrics\",namespace=~\".*\"}[5m]) == 0)",
-        "severity": "warning"
-    },
-    {
-        "message": "Processes experience elevated CPU throttling.",
-        "name": "CPUThrottlingHigh",
-        "query": "sum by(container, pod, namespace) (increase(container_cpu_cfs_throttled_periods_total{container!=\"\"}[5m])) / sum by(container, pod, namespace) (increase(container_cpu_cfs_periods_total[5m])) > (25 / 100)",
-        "severity": "info"
     },
     {
         "message": "Cluster has overcommitted CPU resource requests.",
@@ -450,15 +444,15 @@
         "severity": "warning"
     },
     {
-        "message": "Cluster has overcommitted CPU resource requests.",
-        "name": "KubeCPUQuotaOvercommit",
-        "query": "sum(kube_resourcequota{job=\"kube-state-metrics\",resource=\"cpu\",type=\"hard\"}) / sum(kube_node_status_allocatable{resource=\"cpu\"}) > 1.5",
-        "severity": "warning"
-    },
-    {
         "message": "Cluster has overcommitted memory resource requests.",
         "name": "KubeMemoryOvercommit",
         "query": "sum(namespace_memory:kube_pod_container_resource_requests:sum) / sum(kube_node_status_allocatable{resource=\"memory\"}) > ((count(kube_node_status_allocatable{resource=\"memory\"}) > 1) - 1) / count(kube_node_status_allocatable{resource=\"memory\"})",
+        "severity": "warning"
+    },
+    {
+        "message": "Cluster has overcommitted CPU resource requests.",
+        "name": "KubeCPUQuotaOvercommit",
+        "query": "sum(kube_resourcequota{job=\"kube-state-metrics\",resource=\"cpu\",type=\"hard\"}) / sum(kube_node_status_allocatable{resource=\"cpu\"}) > 1.5",
         "severity": "warning"
     },
     {
@@ -474,22 +468,22 @@
         "severity": "info"
     },
     {
-        "message": "Namespace quota has exceeded the limits.",
-        "name": "KubeQuotaExceeded",
-        "query": "kube_resourcequota{job=\"kube-state-metrics\",type=\"used\"} / ignoring(instance, job, type) (kube_resourcequota{job=\"kube-state-metrics\",type=\"hard\"} > 0) > 1",
-        "severity": "warning"
-    },
-    {
         "message": "Namespace quota is fully used.",
         "name": "KubeQuotaFullyUsed",
         "query": "kube_resourcequota{job=\"kube-state-metrics\",type=\"used\"} / ignoring(instance, job, type) (kube_resourcequota{job=\"kube-state-metrics\",type=\"hard\"} > 0) == 1",
         "severity": "info"
     },
     {
-        "message": "PersistentVolume is having issues with provisioning.",
-        "name": "KubePersistentVolumeErrors",
-        "query": "kube_persistentvolume_status_phase{job=\"kube-state-metrics\",phase=~\"Failed|Pending\"} > 0",
-        "severity": "critical"
+        "message": "Namespace quota has exceeded the limits.",
+        "name": "KubeQuotaExceeded",
+        "query": "kube_resourcequota{job=\"kube-state-metrics\",type=\"used\"} / ignoring(instance, job, type) (kube_resourcequota{job=\"kube-state-metrics\",type=\"hard\"} > 0) > 1",
+        "severity": "warning"
+    },
+    {
+        "message": "Processes experience elevated CPU throttling.",
+        "name": "CPUThrottlingHigh",
+        "query": "sum by(container, pod, namespace) (increase(container_cpu_cfs_throttled_periods_total{container!=\"\"}[5m])) / sum by(container, pod, namespace) (increase(container_cpu_cfs_periods_total[5m])) > (25 / 100)",
+        "severity": "info"
     },
     {
         "message": "PersistentVolume is filling up.",
@@ -504,15 +498,45 @@
         "severity": "warning"
     },
     {
-        "message": "An aggregated API is down.",
-        "name": "AggregatedAPIDown",
-        "query": "(1 - max by(name, namespace) (avg_over_time(aggregator_unavailable_apiservice[10m]))) * 100 < 85",
+        "message": "PersistentVolume is having issues with provisioning.",
+        "name": "KubePersistentVolumeErrors",
+        "query": "kube_persistentvolume_status_phase{job=\"kube-state-metrics\",phase=~\"Failed|Pending\"} > 0",
+        "severity": "critical"
+    },
+    {
+        "message": "Different semantic versions of Kubernetes components running.",
+        "name": "KubeVersionMismatch",
+        "query": "count(count by(git_version) (label_replace(kubernetes_build_info{job!~\"kube-dns|coredns\"}, \"git_version\", \"$1\", \"git_version\", \"(v[0-9]*.[0-9]*).*\"))) > 1",
         "severity": "warning"
+    },
+    {
+        "message": "Kubernetes API server client is experiencing errors.",
+        "name": "KubeClientErrors",
+        "query": "(sum by(instance, job) (rate(rest_client_requests_total{code=~\"5..\"}[5m])) / sum by(instance, job) (rate(rest_client_requests_total[5m]))) > 0.01",
+        "severity": "warning"
+    },
+    {
+        "message": "Client certificate is about to expire.",
+        "name": "KubeClientCertificateExpiration",
+        "query": "apiserver_client_certificate_expiration_seconds_count{job=\"apiserver\"} > 0 and on(job) histogram_quantile(0.01, sum by(job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job=\"apiserver\"}[5m]))) < 604800",
+        "severity": "warning"
+    },
+    {
+        "message": "Client certificate is about to expire.",
+        "name": "KubeClientCertificateExpiration",
+        "query": "apiserver_client_certificate_expiration_seconds_count{job=\"apiserver\"} > 0 and on(job) histogram_quantile(0.01, sum by(job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job=\"apiserver\"}[5m]))) < 86400",
+        "severity": "critical"
     },
     {
         "message": "An aggregated API has reported errors.",
         "name": "AggregatedAPIErrors",
         "query": "sum by(name, namespace) (increase(aggregator_unavailable_apiservice_total[10m])) > 4",
+        "severity": "warning"
+    },
+    {
+        "message": "An aggregated API is down.",
+        "name": "AggregatedAPIDown",
+        "query": "(1 - max by(name, namespace) (avg_over_time(aggregator_unavailable_apiservice[10m]))) * 100 < 85",
         "severity": "warning"
     },
     {
@@ -528,30 +552,6 @@
         "severity": "warning"
     },
     {
-        "message": "Client certificate is about to expire.",
-        "name": "KubeClientCertificateExpiration",
-        "query": "apiserver_client_certificate_expiration_seconds_count{job=\"apiserver\"} > 0 and on(job) histogram_quantile(0.01, sum by(job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job=\"apiserver\"}[5m]))) < 86400",
-        "severity": "critical"
-    },
-    {
-        "message": "Client certificate is about to expire.",
-        "name": "KubeClientCertificateExpiration",
-        "query": "apiserver_client_certificate_expiration_seconds_count{job=\"apiserver\"} > 0 and on(job) histogram_quantile(0.01, sum by(job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job=\"apiserver\"}[5m]))) < 604800",
-        "severity": "warning"
-    },
-    {
-        "message": "Kubernetes API server client is experiencing errors.",
-        "name": "KubeClientErrors",
-        "query": "(sum by(instance, job) (rate(rest_client_requests_total{code=~\"5..\"}[5m])) / sum by(instance, job) (rate(rest_client_requests_total[5m]))) > 0.01",
-        "severity": "warning"
-    },
-    {
-        "message": "Different semantic versions of Kubernetes components running.",
-        "name": "KubeVersionMismatch",
-        "query": "count(count by(git_version) (label_replace(kubernetes_build_info{job!~\"kube-dns|coredns\"}, \"git_version\", \"$1\", \"git_version\", \"(v[0-9]*.[0-9]*).*\"))) > 1",
-        "severity": "warning"
-    },
-    {
         "message": "Target disappeared from Prometheus target discovery.",
         "name": "KubeControllerManagerDown",
         "query": "absent(up{job=\"kube-controller-manager\"} == 1)",
@@ -564,40 +564,22 @@
         "severity": "warning"
     },
     {
-        "message": "Node readiness status is flapping.",
-        "name": "KubeNodeReadinessFlapping",
-        "query": "sum by(node) (changes(kube_node_status_condition{condition=\"Ready\",status=\"true\"}[15m])) > 2",
-        "severity": "warning"
-    },
-    {
         "message": "Node is unreachable.",
         "name": "KubeNodeUnreachable",
         "query": "(kube_node_spec_taint{effect=\"NoSchedule\",job=\"kube-state-metrics\",key=\"node.kubernetes.io/unreachable\"} unless ignoring(key, value) kube_node_spec_taint{job=\"kube-state-metrics\",key=~\"ToBeDeletedByClusterAutoscaler|cloud.google.com/impending-node-termination|aws-node-termination-handler/spot-itn\"}) == 1",
         "severity": "warning"
     },
     {
-        "message": "Kubelet client certificate is about to expire.",
-        "name": "KubeletClientCertificateExpiration",
-        "query": "kubelet_certificate_manager_client_ttl_seconds < 86400",
-        "severity": "critical"
-    },
-    {
-        "message": "Kubelet client certificate is about to expire.",
-        "name": "KubeletClientCertificateExpiration",
-        "query": "kubelet_certificate_manager_client_ttl_seconds < 604800",
+        "message": "Kubelet is running at capacity.",
+        "name": "KubeletTooManyPods",
+        "query": "count by(node) ((kube_pod_status_phase{job=\"kube-state-metrics\",phase=\"Running\"} == 1) * on(instance, pod, namespace, cluster) group_left(node) topk by(instance, pod, namespace, cluster) (1, kube_pod_info{job=\"kube-state-metrics\"})) / max by(node) (kube_node_status_capacity{job=\"kube-state-metrics\",resource=\"pods\"} != 1) > 0.95",
         "severity": "warning"
     },
     {
-        "message": "Kubelet has failed to renew its client certificate.",
-        "name": "KubeletClientCertificateRenewalErrors",
-        "query": "increase(kubelet_certificate_manager_client_expiration_renew_errors[5m]) > 0",
+        "message": "Node readiness status is flapping.",
+        "name": "KubeNodeReadinessFlapping",
+        "query": "sum by(node) (changes(kube_node_status_condition{condition=\"Ready\",status=\"true\"}[15m])) > 2",
         "severity": "warning"
-    },
-    {
-        "message": "Target disappeared from Prometheus target discovery.",
-        "name": "KubeletDown",
-        "query": "absent(up{job=\"kubelet\",metrics_path=\"/metrics\"} == 1)",
-        "severity": "critical"
     },
     {
         "message": "Kubelet Pod Lifecycle Event Generator is taking too long to relist.",
@@ -612,9 +594,15 @@
         "severity": "warning"
     },
     {
-        "message": "Kubelet server certificate is about to expire.",
-        "name": "KubeletServerCertificateExpiration",
-        "query": "kubelet_certificate_manager_server_ttl_seconds < 86400",
+        "message": "Kubelet client certificate is about to expire.",
+        "name": "KubeletClientCertificateExpiration",
+        "query": "kubelet_certificate_manager_client_ttl_seconds < 604800",
+        "severity": "warning"
+    },
+    {
+        "message": "Kubelet client certificate is about to expire.",
+        "name": "KubeletClientCertificateExpiration",
+        "query": "kubelet_certificate_manager_client_ttl_seconds < 86400",
         "severity": "critical"
     },
     {
@@ -624,87 +612,33 @@
         "severity": "warning"
     },
     {
+        "message": "Kubelet server certificate is about to expire.",
+        "name": "KubeletServerCertificateExpiration",
+        "query": "kubelet_certificate_manager_server_ttl_seconds < 86400",
+        "severity": "critical"
+    },
+    {
+        "message": "Kubelet has failed to renew its client certificate.",
+        "name": "KubeletClientCertificateRenewalErrors",
+        "query": "increase(kubelet_certificate_manager_client_expiration_renew_errors[5m]) > 0",
+        "severity": "warning"
+    },
+    {
         "message": "Kubelet has failed to renew its server certificate.",
         "name": "KubeletServerCertificateRenewalErrors",
         "query": "increase(kubelet_server_expiration_renew_errors[5m]) > 0",
         "severity": "warning"
     },
     {
-        "message": "Kubelet is running at capacity.",
-        "name": "KubeletTooManyPods",
-        "query": "count by(node) ((kube_pod_status_phase{job=\"kube-state-metrics\",phase=\"Running\"} == 1) * on(instance, pod, namespace, cluster) group_left(node) topk by(instance, pod, namespace, cluster) (1, kube_pod_info{job=\"kube-state-metrics\"})) / max by(node) (kube_node_status_capacity{job=\"kube-state-metrics\",resource=\"pods\"} != 1) > 0.95",
-        "severity": "warning"
+        "message": "Target disappeared from Prometheus target discovery.",
+        "name": "KubeletDown",
+        "query": "absent(up{job=\"kubelet\",metrics_path=\"/metrics\"} == 1)",
+        "severity": "critical"
     },
     {
         "message": "Target disappeared from Prometheus target discovery.",
         "name": "KubeSchedulerDown",
         "query": "absent(up{job=\"kube-scheduler\"} == 1)",
-        "severity": "critical"
-    },
-    {
-        "message": "Clock on {{ $labels.instance }} is not synchronising. Ensure NTP is configured on this host.",
-        "name": "NodeClockNotSynchronising",
-        "query": "min_over_time(node_timex_sync_status[5m]) == 0 and node_timex_maxerror_seconds >= 16",
-        "severity": "warning"
-    },
-    {
-        "message": "Clock on {{ $labels.instance }} is out of sync by more than 300s. Ensure NTP is configured correctly on this host.",
-        "name": "NodeClockSkewDetected",
-        "query": "(node_timex_offset_seconds > 0.05 and deriv(node_timex_offset_seconds[5m]) >= 0) or (node_timex_offset_seconds < -0.05 and deriv(node_timex_offset_seconds[5m]) <= 0)",
-        "severity": "warning"
-    },
-    {
-        "message": "Kernel is predicted to exhaust file descriptors limit soon.",
-        "name": "NodeFileDescriptorLimit",
-        "query": "(node_filefd_allocated{job=\"node-exporter\"} * 100 / node_filefd_maximum{job=\"node-exporter\"} > 90)",
-        "severity": "critical"
-    },
-    {
-        "message": "Kernel is predicted to exhaust file descriptors limit soon.",
-        "name": "NodeFileDescriptorLimit",
-        "query": "(node_filefd_allocated{job=\"node-exporter\"} * 100 / node_filefd_maximum{job=\"node-exporter\"} > 70)",
-        "severity": "warning"
-    },
-    {
-        "message": "Filesystem has less than 8% inodes left.",
-        "name": "NodeFilesystemAlmostOutOfFiles",
-        "query": "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100 < 8 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
-        "severity": "critical"
-    },
-    {
-        "message": "Filesystem has less than 15% inodes left.",
-        "name": "NodeFilesystemAlmostOutOfFiles",
-        "query": "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100 < 15 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
-        "severity": "warning"
-    },
-    {
-        "message": "Filesystem has less than 12% space left.",
-        "name": "NodeFilesystemAlmostOutOfSpace",
-        "query": "(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_size_bytes{fstype!=\"\",job=\"node-exporter\"} * 100 < 12 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
-        "severity": "critical"
-    },
-    {
-        "message": "Filesystem has less than 20% space left.",
-        "name": "NodeFilesystemAlmostOutOfSpace",
-        "query": "(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_size_bytes{fstype!=\"\",job=\"node-exporter\"} * 100 < 20 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
-        "severity": "warning"
-    },
-    {
-        "message": "Filesystem is predicted to run out of inodes within the next 4 hours.",
-        "name": "NodeFilesystemFilesFillingUp",
-        "query": "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100 < 20 and predict_linear(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"}[6h], 4 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
-        "severity": "critical"
-    },
-    {
-        "message": "Filesystem is predicted to run out of inodes within the next 24 hours.",
-        "name": "NodeFilesystemFilesFillingUp",
-        "query": "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100 < 40 and predict_linear(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"}[6h], 24 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
-        "severity": "warning"
-    },
-    {
-        "message": "Filesystem is predicted to run out of space within the next 4 hours.",
-        "name": "NodeFilesystemSpaceFillingUp",
-        "query": "(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_size_bytes{fstype!=\"\",job=\"node-exporter\"} * 100 < 20 and predict_linear(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\"}[6h], 4 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
         "severity": "critical"
     },
     {
@@ -714,10 +648,46 @@
         "severity": "warning"
     },
     {
-        "message": "Number of conntrack are getting close to the limit",
-        "name": "NodeHighNumberConntrackEntriesUsed",
-        "query": "(node_nf_conntrack_entries / node_nf_conntrack_entries_limit) > 0.75",
+        "message": "Filesystem is predicted to run out of space within the next 4 hours.",
+        "name": "NodeFilesystemSpaceFillingUp",
+        "query": "(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_size_bytes{fstype!=\"\",job=\"node-exporter\"} * 100 < 20 and predict_linear(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\"}[6h], 4 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
+        "severity": "critical"
+    },
+    {
+        "message": "Filesystem has less than 20% space left.",
+        "name": "NodeFilesystemAlmostOutOfSpace",
+        "query": "(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_size_bytes{fstype!=\"\",job=\"node-exporter\"} * 100 < 20 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
         "severity": "warning"
+    },
+    {
+        "message": "Filesystem has less than 12% space left.",
+        "name": "NodeFilesystemAlmostOutOfSpace",
+        "query": "(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_size_bytes{fstype!=\"\",job=\"node-exporter\"} * 100 < 12 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
+        "severity": "critical"
+    },
+    {
+        "message": "Filesystem is predicted to run out of inodes within the next 24 hours.",
+        "name": "NodeFilesystemFilesFillingUp",
+        "query": "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100 < 40 and predict_linear(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"}[6h], 24 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
+        "severity": "warning"
+    },
+    {
+        "message": "Filesystem is predicted to run out of inodes within the next 4 hours.",
+        "name": "NodeFilesystemFilesFillingUp",
+        "query": "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100 < 20 and predict_linear(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"}[6h], 4 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
+        "severity": "critical"
+    },
+    {
+        "message": "Filesystem has less than 15% inodes left.",
+        "name": "NodeFilesystemAlmostOutOfFiles",
+        "query": "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100 < 15 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
+        "severity": "warning"
+    },
+    {
+        "message": "Filesystem has less than 8% inodes left.",
+        "name": "NodeFilesystemAlmostOutOfFiles",
+        "query": "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100 < 8 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
+        "severity": "critical"
     },
     {
         "message": "Network interface is reporting many receive errors.",
@@ -729,6 +699,30 @@
         "message": "Network interface is reporting many transmit errors.",
         "name": "NodeNetworkTransmitErrs",
         "query": "increase(node_network_transmit_errs_total[2m]) / rate(node_network_transmit_packets_total[2m]) > 0.01",
+        "severity": "warning"
+    },
+    {
+        "message": "Number of conntrack are getting close to the limit",
+        "name": "NodeHighNumberConntrackEntriesUsed",
+        "query": "(node_nf_conntrack_entries / node_nf_conntrack_entries_limit) > 0.75",
+        "severity": "warning"
+    },
+    {
+        "message": "Clock on {{ $labels.instance }} is out of sync by more than 300s. Ensure NTP is configured correctly on this host.",
+        "name": "NodeClockSkewDetected",
+        "query": "(node_timex_offset_seconds > 0.05 and deriv(node_timex_offset_seconds[5m]) >= 0) or (node_timex_offset_seconds < -0.05 and deriv(node_timex_offset_seconds[5m]) <= 0)",
+        "severity": "warning"
+    },
+    {
+        "message": "Clock on {{ $labels.instance }} is not synchronising. Ensure NTP is configured on this host.",
+        "name": "NodeClockNotSynchronising",
+        "query": "min_over_time(node_timex_sync_status[5m]) == 0 and node_timex_maxerror_seconds >= 16",
+        "severity": "warning"
+    },
+    {
+        "message": "Node Exporter text file collector failed to scrape.",
+        "name": "NodeTextFileCollectorScrapeError",
+        "query": "node_textfile_scrape_error{job=\"node-exporter\"} == 1",
         "severity": "warning"
     },
     {
@@ -744,10 +738,16 @@
         "severity": "warning"
     },
     {
-        "message": "Node Exporter text file collector failed to scrape.",
-        "name": "NodeTextFileCollectorScrapeError",
-        "query": "node_textfile_scrape_error{job=\"node-exporter\"} == 1",
+        "message": "Kernel is predicted to exhaust file descriptors limit soon.",
+        "name": "NodeFileDescriptorLimit",
+        "query": "(node_filefd_allocated{job=\"node-exporter\"} * 100 / node_filefd_maximum{job=\"node-exporter\"} > 70)",
         "severity": "warning"
+    },
+    {
+        "message": "Kernel is predicted to exhaust file descriptors limit soon.",
+        "name": "NodeFileDescriptorLimit",
+        "query": "(node_filefd_allocated{job=\"node-exporter\"} * 100 / node_filefd_maximum{job=\"node-exporter\"} > 90)",
+        "severity": "critical"
     },
     {
         "message": "Network interface is often changin it's status",
@@ -762,33 +762,15 @@
         "severity": "critical"
     },
     {
-        "message": "Prometheus is dropping samples with duplicate timestamps.",
-        "name": "PrometheusDuplicateTimestamps",
-        "query": "rate(prometheus_target_scrapes_sample_duplicate_timestamp_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) > 0",
+        "message": "Prometheus alert notification queue predicted to run full in less than 30m.",
+        "name": "PrometheusNotificationQueueRunningFull",
+        "query": "(predict_linear(prometheus_notifications_queue_length{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m], 60 * 30) > min_over_time(prometheus_notifications_queue_capacity{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]))",
         "severity": "warning"
-    },
-    {
-        "message": "Prometheus encounters more than 3% errors sending alerts to any Alertmanager.",
-        "name": "PrometheusErrorSendingAlertsToAnyAlertmanager",
-        "query": "min without(alertmanager) (rate(prometheus_notifications_errors_total{alertmanager!~\"\",job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) / rate(prometheus_notifications_sent_total{alertmanager!~\"\",job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m])) * 100 > 3",
-        "severity": "critical"
     },
     {
         "message": "Prometheus has encountered more than 1% errors sending alerts to a specific Alertmanager.",
         "name": "PrometheusErrorSendingAlertsToSomeAlertmanagers",
         "query": "(rate(prometheus_notifications_errors_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) / rate(prometheus_notifications_sent_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m])) * 100 > 1",
-        "severity": "warning"
-    },
-    {
-        "message": "Prometheus has dropped targets because some scrape configs have exceeded the labels limit.",
-        "name": "PrometheusLabelLimitHit",
-        "query": "increase(prometheus_target_scrape_pool_exceeded_label_limits_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) > 0",
-        "severity": "warning"
-    },
-    {
-        "message": "Prometheus is missing rule evaluations due to slow rule group evaluation.",
-        "name": "PrometheusMissingRuleEvaluations",
-        "query": "increase(prometheus_rule_group_iterations_missed_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) > 0",
         "severity": "warning"
     },
     {
@@ -798,15 +780,27 @@
         "severity": "warning"
     },
     {
+        "message": "Prometheus has issues reloading blocks from disk.",
+        "name": "PrometheusTSDBReloadsFailing",
+        "query": "increase(prometheus_tsdb_reloads_failures_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[3h]) > 0",
+        "severity": "warning"
+    },
+    {
+        "message": "Prometheus has issues compacting blocks.",
+        "name": "PrometheusTSDBCompactionsFailing",
+        "query": "increase(prometheus_tsdb_compactions_failed_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[3h]) > 0",
+        "severity": "warning"
+    },
+    {
         "message": "Prometheus is not ingesting samples.",
         "name": "PrometheusNotIngestingSamples",
         "query": "(rate(prometheus_tsdb_head_samples_appended_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) <= 0 and (sum without(scrape_job) (prometheus_target_metadata_cache_entries{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}) > 0 or sum without(rule_group) (prometheus_rule_group_rules{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}) > 0))",
         "severity": "warning"
     },
     {
-        "message": "Prometheus alert notification queue predicted to run full in less than 30m.",
-        "name": "PrometheusNotificationQueueRunningFull",
-        "query": "(predict_linear(prometheus_notifications_queue_length{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m], 60 * 30) > min_over_time(prometheus_notifications_queue_capacity{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]))",
+        "message": "Prometheus is dropping samples with duplicate timestamps.",
+        "name": "PrometheusDuplicateTimestamps",
+        "query": "rate(prometheus_target_scrapes_sample_duplicate_timestamp_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) > 0",
         "severity": "warning"
     },
     {
@@ -840,15 +834,9 @@
         "severity": "critical"
     },
     {
-        "message": "Prometheus has issues compacting blocks.",
-        "name": "PrometheusTSDBCompactionsFailing",
-        "query": "increase(prometheus_tsdb_compactions_failed_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[3h]) > 0",
-        "severity": "warning"
-    },
-    {
-        "message": "Prometheus has issues reloading blocks from disk.",
-        "name": "PrometheusTSDBReloadsFailing",
-        "query": "increase(prometheus_tsdb_reloads_failures_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[3h]) > 0",
+        "message": "Prometheus is missing rule evaluations due to slow rule group evaluation.",
+        "name": "PrometheusMissingRuleEvaluations",
+        "query": "increase(prometheus_rule_group_iterations_missed_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) > 0",
         "severity": "warning"
     },
     {
@@ -858,15 +846,45 @@
         "severity": "warning"
     },
     {
+        "message": "Prometheus has dropped targets because some scrape configs have exceeded the labels limit.",
+        "name": "PrometheusLabelLimitHit",
+        "query": "increase(prometheus_target_scrape_pool_exceeded_label_limits_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) > 0",
+        "severity": "warning"
+    },
+    {
         "message": "Prometheus has failed to sync targets.",
         "name": "PrometheusTargetSyncFailure",
         "query": "increase(prometheus_target_sync_failed_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[30m]) > 0",
         "severity": "critical"
     },
     {
+        "message": "Prometheus encounters more than 3% errors sending alerts to any Alertmanager.",
+        "name": "PrometheusErrorSendingAlertsToAnyAlertmanager",
+        "query": "min without(alertmanager) (rate(prometheus_notifications_errors_total{alertmanager!~\"\",job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) / rate(prometheus_notifications_sent_total{alertmanager!~\"\",job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m])) * 100 > 3",
+        "severity": "critical"
+    },
+    {
         "message": "Errors while performing list operations in controller.",
         "name": "PrometheusOperatorListErrors",
         "query": "(sum by(controller, namespace) (rate(prometheus_operator_list_operations_failed_total{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"}[10m])) / sum by(controller, namespace) (rate(prometheus_operator_list_operations_total{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"}[10m]))) > 0.4",
+        "severity": "warning"
+    },
+    {
+        "message": "Errors while performing watch operations in controller.",
+        "name": "PrometheusOperatorWatchErrors",
+        "query": "(sum by(controller, namespace) (rate(prometheus_operator_watch_operations_failed_total{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"}[10m])) / sum by(controller, namespace) (rate(prometheus_operator_watch_operations_total{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"}[10m]))) > 0.4",
+        "severity": "warning"
+    },
+    {
+        "message": "Last controller reconciliation failed",
+        "name": "PrometheusOperatorSyncFailed",
+        "query": "min_over_time(prometheus_operator_syncs{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\",status=\"failed\"}[5m]) > 0",
+        "severity": "warning"
+    },
+    {
+        "message": "Errors while reconciling controller.",
+        "name": "PrometheusOperatorReconcileErrors",
+        "query": "(sum by(controller, namespace) (rate(prometheus_operator_reconcile_errors_total{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"}[5m]))) / (sum by(controller, namespace) (rate(prometheus_operator_reconcile_operations_total{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"}[5m]))) > 0.1",
         "severity": "warning"
     },
     {
@@ -882,27 +900,9 @@
         "severity": "warning"
     },
     {
-        "message": "Errors while reconciling controller.",
-        "name": "PrometheusOperatorReconcileErrors",
-        "query": "(sum by(controller, namespace) (rate(prometheus_operator_reconcile_errors_total{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"}[5m]))) / (sum by(controller, namespace) (rate(prometheus_operator_reconcile_operations_total{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"}[5m]))) > 0.1",
-        "severity": "warning"
-    },
-    {
         "message": "Resources rejected by Prometheus operator",
         "name": "PrometheusOperatorRejectedResources",
         "query": "min_over_time(prometheus_operator_managed_resources{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\",state=\"rejected\"}[5m]) > 0",
-        "severity": "warning"
-    },
-    {
-        "message": "Last controller reconciliation failed",
-        "name": "PrometheusOperatorSyncFailed",
-        "query": "min_over_time(prometheus_operator_syncs{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\",status=\"failed\"}[5m]) > 0",
-        "severity": "warning"
-    },
-    {
-        "message": "Errors while performing watch operations in controller.",
-        "name": "PrometheusOperatorWatchErrors",
-        "query": "(sum by(controller, namespace) (rate(prometheus_operator_watch_operations_failed_total{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"}[10m])) / sum by(controller, namespace) (rate(prometheus_operator_watch_operations_total{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"}[10m]))) > 0.4",
         "severity": "warning"
     }
 ]


### PR DESCRIPTION
We forgot these when migrating from the previous definitions, which
leads to empty labels and incorrect grouping (only one alert can fire,
even if multiple nodes / partitions are affected).