### PR TITLE
salt,dex: Allow to disable Dex deployment and configure another IDP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # CHANGELOG
 ## Release 123.0.0 (in development)
 
+### Additions
+
+- Add ability to deploy MetalK8s without Dex and possibility to configure
+  your own IDP for kube-apiserver, Grafana and MetalK8s UI
+  (PR[#3688](https://github.com/scality/metalk8s/pull/3688))
+
 ### Enhancements
 
 - Bump Kubernetes version to

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -346,7 +346,7 @@ SALT_FILES: Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path("salt/metalk8s/addons/prometheus-operator/post-downgrade.sls"),
     Path("salt/metalk8s/addons/prometheus-operator/post-upgrade.sls"),
     Path("salt/metalk8s/addons/prometheus-operator/config/alertmanager.yaml"),
-    Path("salt/metalk8s/addons/prometheus-operator/config/grafana.yaml"),
+    Path("salt/metalk8s/addons/prometheus-operator/config/grafana.yaml.j2"),
     Path("salt/metalk8s/addons/prometheus-operator/config/prometheus.yaml"),
     Path(
         "salt/metalk8s/addons/prometheus-operator/deployed/",
@@ -359,6 +359,7 @@ SALT_FILES: Tuple[Union[Path, targets.AtomicTarget], ...] = (
         "salt/metalk8s/addons/prometheus-operator/deployed/files/",
         "node-exporter-full.json",
     ),
+    Path("salt/metalk8s/addons/prometheus-operator/deployed/grafana-ini-configmap.sls"),
     Path("salt/metalk8s/addons/prometheus-operator/deployed/init.sls"),
     Path("salt/metalk8s/addons/prometheus-operator/deployed/namespace.sls"),
     Path("salt/metalk8s/addons/prometheus-operator/deployed/prometheus-rules.sls"),

--- a/charts/kube-prometheus-stack.yaml
+++ b/charts/kube-prometheus-stack.yaml
@@ -214,25 +214,8 @@ grafana:
     hosts:
       - 'null'
 
-  grafana.ini:
-    server:
-      root_url: '__escape__({{ "{{ salt.metalk8s_network.get_control_plane_ingress_endpoint() }}" }}/grafana)'
-    analytics:
-      reporting_enabled: false
-      check_for_updates: false
-    auth:
-      oauth_auto_login: true
-    auth.generic_oauth:
-      enabled: true
-      tls_skip_verify_insecure: true
-      scopes: "openid profile email groups"
-      client_id: "grafana-ui"
-      client_secret: "4lqK98NcsWG5qBRHJUqYM1"
-      auth_url: '__escape__({{ "{{ salt.metalk8s_network.get_control_plane_ingress_endpoint() }}" }}/oidc/auth)'
-      token_url:  '__escape__({{ "{{ salt.metalk8s_network.get_control_plane_ingress_endpoint() }}" }}/oidc/token)'
-      api_url: '__escape__({{ "{{ salt.metalk8s_network.get_control_plane_ingress_endpoint() }}" }}/oidc/userinfo)'
-      role_attribute_path: >-
-        contains(`{% endraw %}{{ "{{ dex.spec.config.staticPasswords | map(attribute='email') | list | tojson }}" }}{% raw %}`, email) && 'Admin'
+  # NOTE: This config is managed directly in a salt state
+  grafana.ini: {}
 
   testFramework:
     enabled: false

--- a/charts/render.py
+++ b/charts/render.py
@@ -480,7 +480,7 @@ def main():
     config = []
     for name, configmap, path, service_namespace in args.service_configs or []:
         import_csc_yaml.append(
-            "{{% set {0}_defaults = "
+            "{{%- set {0}_defaults = "
             "salt.slsutil.renderer('salt://{1}', saltenv=saltenv) %}}".format(
                 name,
                 path,

--- a/docs/installation/bootstrap.rst
+++ b/docs/installation/bootstrap.rst
@@ -73,6 +73,9 @@ Configuration
         minion: <hostname-of-the-bootstrap-node>
       archives:
         - <path-to-metalk8s-iso>
+      addons:
+        dex:
+          enabled: True
       kubernetes:
         apiServer:
           featureGates:
@@ -187,6 +190,14 @@ For example;
 The ``archives`` field is a list of absolute paths to MetalK8s ISO files. When
 the bootstrap script is executed, those ISOs are automatically mounted and the
 system is configured to re-mount them automatically after a reboot.
+
+The ``addons`` field can be omitted if you do not have any specific addons
+to configure.
+
+  If you need to disable deployment of ``dex`` as default OIDC used by
+  MetalK8s you can disable it by setting ``addons.dex.enabled`` to ``false``.
+  If ``dex`` is disabled you will not be able to use the MetalK8s UI and
+  Grafana.
 
 The ``kubernetes`` field can be omitted if you do not have any specific
 Kubernetes `Feature Gates`_ to enable or disable and if you are ok with

--- a/docs/installation/bootstrap.rst
+++ b/docs/installation/bootstrap.rst
@@ -78,6 +78,7 @@ Configuration
           enabled: True
       kubernetes:
         apiServer:
+          oidc: {}
           featureGates:
             <feature_gate_name>: True
         controllerManager:
@@ -207,6 +208,20 @@ defaults kubernetes configuration.
   configure the corresponding entries in the
   ``kubernetes.apiServer.featureGates`` mapping.
 
+  If ``dex`` is enabled, it will be used as ``oidc`` for ``kube-apiserver``
+  but you can use a `specific OpenID for kube-apiserver`_, to do so:
+
+    .. code-block:: yaml
+
+      kubernetes:
+        apiServer:
+          oidc:
+            issuerURL: <OIDC issuer URL>
+            clientID: <Client ID>
+            CAFile: <Certificate Authority certificate file>
+            usernameClaim: <Username Claim>
+            groupsClaim: <Groups Claim>
+
   If you want to override the default ``coreDNS`` podAntiAffinity or number of
   replicas, by default MetalK8s deploy 2 replicas and use soft podAntiAffinity
   on hostname so that if it's possible ``coreDNS`` pods will be spread on
@@ -230,6 +245,7 @@ defaults kubernetes configuration.
   disabled (default to ``500``)
 
 .. _Feature Gates: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
+.. _specific OpenID for kube-apiserver: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens
 
 .. _Bootstrap SSH Provisioning:
 

--- a/docs/operation/cluster_and_service_configuration.rst
+++ b/docs/operation/cluster_and_service_configuration.rst
@@ -51,9 +51,9 @@ Prometheus, with nice graphs.
 
 The default configuration values for Grafana are specified below:
 
-.. literalinclude:: ../../salt/metalk8s/addons/prometheus-operator/config/grafana.yaml
+.. literalinclude:: ../../salt/metalk8s/addons/prometheus-operator/config/grafana.yaml.j2
    :language: yaml
-   :lines: 3-
+   :lines: 8-31,33-43
 
 .. _csc-prometheus-default-configuration:
 

--- a/docs/operation/cluster_and_service_configuration.rst
+++ b/docs/operation/cluster_and_service_configuration.rst
@@ -97,7 +97,7 @@ The default configuration values for MetalK8s UI are specified below:
 
 .. literalinclude:: ../../salt/metalk8s/addons/ui/config/metalk8s-ui-config.yaml.j2
    :language: yaml
-   :lines: 3-
+   :lines: 3-6,8-14,16-
 
 See :ref:`csc-ui-customization` to override these defaults.
 

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -348,6 +348,7 @@ models:
         ARCHIVE: metalk8s.iso
         COREDNS_AFFINITY: "{}"
         CP_INGRESS_AFFINITY: "{}"
+        DEX_ENABLED: "true"
       command: |
         ssh -F ssh_config bootstrap "
         sudo bash << EOF
@@ -371,6 +372,9 @@ models:
         archives:
           - \"\$(readlink -f \"${ARCHIVE}\")\"
         debug: ${DEBUG}
+        addons:
+          dex:
+            enabled: ${DEX_ENABLED}
         kubernetes:
           coreDNS:
             affinity: ${COREDNS_AFFINITY}
@@ -896,6 +900,7 @@ stages:
             - lifecycle-major-version
             - bootstrap-restore
             - single-node-install-rocky-8
+            - single-node-no-idp
           haltOnFailure: true
       - TriggerStages:
           name: Trigger publish stage
@@ -2777,6 +2782,74 @@ stages:
           <<: *wait_debug
           env:
             STEP_NAME: single-node-solutions
+      - ShellCommand: *terraform_destroy
+
+  single-node-no-idp:
+    _metalk8s_internal_info:
+      junit_info: &_no-idp_single-node_junit_info
+        TEST_SUITE: install
+        CLASS_NAME: "single node.%(prop:os:-centos-7)s"
+        TEST_NAME: no idp
+    simultaneous_builds: 20
+    worker: *openstack_worker
+    steps:
+      - Git: *git_pull
+      - ShellCommand:
+          <<: *add_final_status_artifact_failed
+          env:
+            <<: *_env_final_status_artifact_failed
+            <<: *_no-idp_single-node_junit_info
+            STEP_NAME: single-node-no-idp
+      - ShellCommand: *yum_clean_all
+      - ShellCommand: *ssh_ip_setup
+      - ShellCommand: *git_pull_terraform
+      - ShellCommand: *retrieve_iso
+      - ShellCommand: *retrieve_iso_checksum
+      - ShellCommand: *check_iso_checksum
+      - ShellCommand: *terraform_install
+      - ShellCommand: *terraform_install_check
+      - ShellCommand: *terraform_init
+      - ShellCommand: *terraform_validate
+      - ShellCommand: *terraform_apply
+      - ShellCommand: *set_bootstrap_minion_id_ssh
+      - ShellCommand:
+          <<: *bootstrap_config_ssh
+          env:
+            <<: *_env_bootstrap_config_ssh
+            DEX_ENABLED: "false"
+      - ShellCommand: *copy_iso_bootstrap_ssh
+      - ShellCommand: *create_mountpoint_ssh
+      - ShellCommand: *mount_iso_ssh
+      - ShellCommand: *run_bootstrap_ssh
+      - ShellCommand: *provision_volumes_ssh
+      - ShellCommand:
+          <<: *untaint_bootstrap_ssh
+          doStepIf: true
+      - ShellCommand: *wait_pods_stable_ssh
+      - ShellCommand: *git_pull_ssh
+      - ShellCommand:
+          <<: *bastion_fast_tests
+          env:
+            <<: *_env_bastion_tests
+            PYTEST_FILTERS: "post and ci and not multinode and not slow and not registry_ha and not authentication"
+      - ShellCommand: *generate_report_over_ssh
+      - ShellCommand:
+          <<: *collect_report_over_ssh
+          env:
+            <<: *_env_collect_report_over_ssh
+            STEP_NAME: single-node-no-idp
+      - Upload: *upload_report_artifacts
+      - ShellCommand:
+          <<: *add_final_status_artifact_success
+          env:
+            <<: *_env_final_status_artifact_success
+            <<: *_no-idp_single-node_junit_info
+            STEP_NAME: single-node-no-idp
+      - Upload: *upload_final_status_artifact
+      - ShellCommand:
+          <<: *wait_debug
+          env:
+            STEP_NAME: single-node-no-idp
       - ShellCommand: *terraform_destroy
 
   generate-snapshot:

--- a/salt/_modules/metalk8s_service_configuration.py
+++ b/salt/_modules/metalk8s_service_configuration.py
@@ -59,9 +59,7 @@ def get_service_conf(
         ) from exc
 
     if manifest is None:
-        raise CommandExecutionError(
-            "Expected ConfigMap object but got {}".format(manifest)
-        )
+        return default_csc
 
     try:
         conf_section = manifest.get("data", {}).get("config.yaml", {})

--- a/salt/_pillar/metalk8s.py
+++ b/salt/_pillar/metalk8s.py
@@ -190,6 +190,14 @@ def _load_kubernetes(config_data):
     return kubernetes_data
 
 
+def _load_addons(config_data):
+    addons_data = config_data.get("addons", {})
+
+    addons_data.setdefault("dex", {}).setdefault("enabled", True)
+
+    return addons_data
+
+
 def ext_pillar(minion_id, pillar, bootstrap_config):  # pylint: disable=unused-argument
     config = _load_config(bootstrap_config)
     if config.get("_errors"):
@@ -215,6 +223,7 @@ def ext_pillar(minion_id, pillar, bootstrap_config):  # pylint: disable=unused-a
             "metalk8s": metal_data,
             "proxies": config.get("proxies", {}),
             "kubernetes": _load_kubernetes(config),
+            "addons": _load_addons(config),
         }
 
         if not isinstance(metal_data["archives"], list):

--- a/salt/metalk8s/addons/dex/certs/server.sls
+++ b/salt/metalk8s/addons/dex/certs/server.sls
@@ -1,3 +1,5 @@
+{%- if pillar.addons.dex.enabled %}
+
 {%- from "metalk8s/map.jinja" import certificates with context %}
 {%- from "metalk8s/map.jinja" import coredns with context %}
 {%- from "metalk8s/map.jinja" import dex with context %}
@@ -56,3 +58,10 @@ Generate Dex server certificate:
     - dir_mode: '0755'
     - require:
       - x509: Create Dex server private key
+
+{%- else %}
+
+Dex is disabled, no certificates to generate:
+  test.nop
+
+{%- endif %}

--- a/salt/metalk8s/addons/dex/deployed/init.sls
+++ b/salt/metalk8s/addons/dex/deployed/init.sls
@@ -9,6 +9,8 @@
 # * chart                  -> charts used to deploy Dex
 # * clusterrolebinding     -> binds dex static user to cluster admin
 
+{%- if pillar.addons.dex.enabled %}
+
 include:
 - .namespace
 - .tls-secret
@@ -18,3 +20,10 @@ include:
 - .secret
 - .chart
 - .clusterrolebinding
+
+{%- else %}
+
+Dex is disabled, nothing to deploy:
+  test.nop
+
+{%- endif %}

--- a/salt/metalk8s/addons/prometheus-operator/config/grafana.yaml
+++ b/salt/metalk8s/addons/prometheus-operator/config/grafana.yaml
@@ -1,9 +1,0 @@
-#!yaml
-
-# Configuration of the Grafana service
-apiVersion: addons.metalk8s.scality.com
-kind: GrafanaConfig
-spec:
-  # Configure the Grafana Deployment
-  deployment:
-    replicas: 1

--- a/salt/metalk8s/addons/prometheus-operator/config/grafana.yaml.j2
+++ b/salt/metalk8s/addons/prometheus-operator/config/grafana.yaml.j2
@@ -1,0 +1,44 @@
+#!jinja|yaml
+
+{%- if pillar.addons.dex.enabled %}
+  {%- set dex_defaults = salt.slsutil.renderer('salt://metalk8s/addons/dex/config/dex.yaml.j2', saltenv=saltenv) %}
+  {%- set dex = salt.metalk8s_service_configuration.get_service_conf('metalk8s-auth', 'metalk8s-dex-config', dex_defaults) %}
+{%- endif %}
+{%- set control_plane_ingress_endpoint = salt.metalk8s_network.get_control_plane_ingress_endpoint() %}
+
+# Configuration of the Grafana service
+apiVersion: addons.metalk8s.scality.com
+kind: GrafanaConfig
+spec:
+  # Configure the Grafana Deployment
+  deployment:
+    replicas: 1
+  config:
+    grafana.ini:
+      analytics:
+        check_for_updates: false
+        reporting_enabled: false
+      paths:
+        data: /var/lib/grafana/
+        logs: /var/log/grafana
+        plugins: /var/lib/grafana/plugins
+        provisioning: /etc/grafana/provisioning
+      log:
+        mode: console
+      server:
+        root_url: "{{ control_plane_ingress_endpoint }}/grafana"
+      auth:
+        disable_login_form: true
+{%- if pillar.addons.dex.enabled %}
+        oauth_auto_login: true
+      auth.generic_oauth:
+        api_url: "{{ control_plane_ingress_endpoint }}/oidc/userinfo"
+        auth_url: "{{ control_plane_ingress_endpoint }}/oidc/auth"
+        client_id: grafana-ui
+        client_secret: 4lqK98NcsWG5qBRHJUqYM1
+        enabled: true
+        role_attribute_path: contains(`{{ dex.spec.config.staticPasswords | map(attribute='email') | list | tojson }}`, email) && 'Admin'
+        scopes: openid profile email groups
+        tls_skip_verify_insecure: true
+        token_url: "{{ control_plane_ingress_endpoint }}/oidc/token"
+{%- endif %}

--- a/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
@@ -1,14 +1,12 @@
 #!jinja | metalk8s_kubernetes
 
 {%- from "metalk8s/repo/macro.sls" import build_image_name with context %}
-{% set grafana_defaults = salt.slsutil.renderer('salt://metalk8s/addons/prometheus-operator/config/grafana.yaml', saltenv=saltenv) %}
-{% set prometheus_defaults = salt.slsutil.renderer('salt://metalk8s/addons/prometheus-operator/config/prometheus.yaml', saltenv=saltenv) %}
-{% set alertmanager_defaults = salt.slsutil.renderer('salt://metalk8s/addons/prometheus-operator/config/alertmanager.yaml', saltenv=saltenv) %}
-{% set dex_defaults = salt.slsutil.renderer('salt://metalk8s/addons/dex/config/dex.yaml.j2', saltenv=saltenv) %}
+{%- set grafana_defaults = salt.slsutil.renderer('salt://metalk8s/addons/prometheus-operator/config/grafana.yaml.j2', saltenv=saltenv) %}
+{%- set prometheus_defaults = salt.slsutil.renderer('salt://metalk8s/addons/prometheus-operator/config/prometheus.yaml', saltenv=saltenv) %}
+{%- set alertmanager_defaults = salt.slsutil.renderer('salt://metalk8s/addons/prometheus-operator/config/alertmanager.yaml', saltenv=saltenv) %}
 {%- set grafana = salt.metalk8s_service_configuration.get_service_conf('metalk8s-monitoring', 'metalk8s-grafana-config', grafana_defaults) %}
 {%- set prometheus = salt.metalk8s_service_configuration.get_service_conf('metalk8s-monitoring', 'metalk8s-prometheus-config', prometheus_defaults) %}
 {%- set alertmanager = salt.metalk8s_service_configuration.get_service_conf('metalk8s-monitoring', 'metalk8s-alertmanager-config', alertmanager_defaults) %}
-{%- set dex = salt.metalk8s_service_configuration.get_service_conf('metalk8s-auth', 'metalk8s-dex-config', dex_defaults) %}
 
 {% raw %}
 
@@ -25897,48 +25895,6 @@ metadata:
     helm.sh/chart: grafana-6.21.2
     heritage: metalk8s
   name: prometheus-operator-grafana-config-dashboards
-  namespace: metalk8s-monitoring
----
-apiVersion: v1
-data:
-  grafana.ini: |-
-    [analytics]
-    check_for_updates = false
-    reporting_enabled = false
-    [auth]
-    oauth_auto_login = true
-    [auth.generic_oauth]
-    api_url = "{% endraw -%}{{ salt.metalk8s_network.get_control_plane_ingress_endpoint() }}/oidc/userinfo{%- raw %}"
-    auth_url = "{% endraw -%}{{ salt.metalk8s_network.get_control_plane_ingress_endpoint() }}/oidc/auth{%- raw %}"
-    client_id = grafana-ui
-    client_secret = 4lqK98NcsWG5qBRHJUqYM1
-    enabled = true
-    role_attribute_path = contains(`{% endraw %}{{ dex.spec.config.staticPasswords | map(attribute='email') | list | tojson }}{% raw %}`, email) && 'Admin'
-    scopes = openid profile email groups
-    tls_skip_verify_insecure = true
-    token_url = "{% endraw -%}{{ salt.metalk8s_network.get_control_plane_ingress_endpoint() }}/oidc/token{%- raw %}"
-    [grafana_net]
-    url = https://grafana.net
-    [log]
-    mode = console
-    [paths]
-    data = /var/lib/grafana/
-    logs = /var/log/grafana
-    plugins = /var/lib/grafana/plugins
-    provisioning = /etc/grafana/provisioning
-    [server]
-    root_url = "{% endraw -%}{{ salt.metalk8s_network.get_control_plane_ingress_endpoint() }}/grafana{%- raw %}"
-kind: ConfigMap
-metadata:
-  labels:
-    app.kubernetes.io/instance: prometheus-operator
-    app.kubernetes.io/managed-by: salt
-    app.kubernetes.io/name: grafana
-    app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 8.3.4-ubuntu
-    helm.sh/chart: grafana-6.21.2
-    heritage: metalk8s
-  name: prometheus-operator-grafana
   namespace: metalk8s-monitoring
 ---
 apiVersion: v1

--- a/salt/metalk8s/addons/prometheus-operator/deployed/grafana-ini-configmap.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/grafana-ini-configmap.sls
@@ -1,0 +1,30 @@
+{%- set grafana_defaults = salt.slsutil.renderer(
+    'salt://metalk8s/addons/prometheus-operator/config/grafana.yaml.j2',
+    saltenv=saltenv,
+) %}
+
+{%- set grafana = salt.metalk8s_service_configuration.get_service_conf(
+    'metalk8s-monitoring', 'metalk8s-grafana-config', grafana_defaults
+) %}
+
+Create Grafana INI Configuration ConfigMap:
+  metalk8s_kubernetes.object_present:
+    - manifest:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          labels:
+            app.kubernetes.io/instance: prometheus-operator
+            app.kubernetes.io/managed-by: salt
+            app.kubernetes.io/name: grafana
+            app.kubernetes.io/part-of: metalk8s
+          name: prometheus-operator-grafana
+          namespace: metalk8s-monitoring
+        data:
+          grafana.ini: |-
+{%- for key, value in grafana.spec.config["grafana.ini"].items() %}
+            [{{ key }}]
+  {%- for element, element_value in value.items() %}
+            {{ element }} = {{ element_value }}
+  {%- endfor %}
+{%- endfor %}

--- a/salt/metalk8s/addons/prometheus-operator/deployed/init.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/init.sls
@@ -3,6 +3,7 @@ include:
   - .namespace
   - .cleanup
   - .alertmanager-configuration-secret
+  - .grafana-ini-configmap
   - .dashboards
   - .service-configuration
   - .chart

--- a/salt/metalk8s/addons/ui/config/metalk8s-shell-ui-config.yaml.j2
+++ b/salt/metalk8s/addons/ui/config/metalk8s-shell-ui-config.yaml.j2
@@ -1,7 +1,9 @@
 #!jinja|yaml
 
-{%- set dex_defaults = salt.slsutil.renderer('salt://metalk8s/addons/dex/config/dex.yaml.j2', saltenv=saltenv) %}
-{%- set dex = salt.metalk8s_service_configuration.get_service_conf('metalk8s-auth', 'metalk8s-dex-config', dex_defaults) %}
+{%- if pillar.addons.dex.enabled %}
+  {%- set dex_defaults = salt.slsutil.renderer('salt://metalk8s/addons/dex/config/dex.yaml.j2', saltenv=saltenv) %}
+  {%- set dex = salt.metalk8s_service_configuration.get_service_conf('metalk8s-auth', 'metalk8s-dex-config', dex_defaults) %}
+{%- endif %}
 {%- set metalk8s_ui_defaults = salt.slsutil.renderer(
         'salt://metalk8s/addons/ui/config/metalk8s-ui-config.yaml.j2', saltenv=saltenv
     )
@@ -12,11 +14,11 @@
     )
 %}
 
-
 # Defaults for shell UI configuration
 apiVersion: addons.metalk8s.scality.com/v1alpha2
 kind: ShellUIConfig
 spec:
+{%- if pillar.addons.dex.enabled %}
   oidc:
     providerUrl: "/oidc"
     redirectUrl: "{{ salt.metalk8s_network.get_control_plane_ingress_endpoint() }}/{{ metalk8s_ui_config.spec.basePath.lstrip('/') }}"
@@ -24,9 +26,10 @@ spec:
     responseType: "id_token"
     scopes: "openid profile email groups offline_access audience:server:client_id:oidc-auth-client"
   userGroupsMapping:
-{%- for user in dex.spec.config.staticPasswords | map(attribute='email') %}
+  {%- for user in dex.spec.config.staticPasswords | map(attribute='email') %}
     "{{ user }}": [metalk8s:admin]
-{%- endfor %}
+  {%- endfor %}
+{%- endif %}
   discoveryUrl: "/shell/deployed-ui-apps.json"
   logo:
     light: /brand/assets/logo-light.svg

--- a/salt/metalk8s/addons/ui/config/metalk8s-ui-config.yaml.j2
+++ b/salt/metalk8s/addons/ui/config/metalk8s-ui-config.yaml.j2
@@ -4,6 +4,7 @@
 apiVersion: addons.metalk8s.scality.com/v1alpha2
 kind: UIConfig
 spec:
+{%- if pillar.addons.dex.enabled %}
   auth:
     kind: "OIDC"
     providerUrl: "/oidc"
@@ -11,5 +12,6 @@ spec:
     clientId: "metalk8s-ui"
     responseType: "id_token"
     scopes: "openid profile email groups offline_access audience:server:client_id:oidc-auth-client"
+{%- endif %}
   title: Metalk8s Platform
   basePath: /

--- a/salt/metalk8s/addons/ui/deployed/ui.sls.in
+++ b/salt/metalk8s/addons/ui/deployed/ui.sls.in
@@ -89,7 +89,9 @@ Create metalk8s-ui ConfigMap:
                   "ui_base_path": "{{ normalized_base_path }}",
                   "url_support": "https://github.com/scality/metalk8s/discussions/new"
                 },
+                {%- if metalk8s_ui_config.spec.get("auth") %}
                 "auth": {{ metalk8s_ui_config.spec.auth | tojson }}
+                {%- endif %}
               }
             }
           config.json: |
@@ -108,6 +110,7 @@ Create metalk8s-ui ConfigMap:
               "alerts_lib_version": "@@ShellUIVersion",
               "url_support": "https://github.com/scality/metalk8s/discussions/new"
             }
+
 Create shell-ui ConfigMap:
   metalk8s_kubernetes.object_present:
     - manifest:

--- a/salt/metalk8s/kubernetes/apiserver/installed.sls
+++ b/salt/metalk8s/kubernetes/apiserver/installed.sls
@@ -96,13 +96,15 @@ Create kube-apiserver Pod manifest:
           - --bind-address={{ host }}
           - --encryption-provider-config={{ encryption_k8s_path }}
           - --cors-allowed-origins=.*
+          {%- if pillar.addons.dex.enabled %}
           - --oidc-issuer-url={{ salt.metalk8s_network.get_control_plane_ingress_endpoint() }}/oidc
           - --oidc-client-id=oidc-auth-client
           - --oidc-ca-file=/etc/metalk8s/pki/nginx-ingress/ca.crt
           - --oidc-username-claim=email
-          - '"--oidc-username-prefix=oidc:"'
           - --oidc-groups-claim=groups
+          - '"--oidc-username-prefix=oidc:"'
           - '"--oidc-groups-prefix=oidc:"'
+          {%- endif %}
           - --v={{ 2 if metalk8s.debug else 0 }}
           {% if feature_gates %}
           - --feature-gates={{ feature_gates | join(",") }}

--- a/salt/metalk8s/roles/ca/init.sls
+++ b/salt/metalk8s/roles/ca/init.sls
@@ -2,5 +2,7 @@ include:
   - metalk8s.kubernetes.ca
   - metalk8s.kubernetes.sa
   - metalk8s.addons.nginx-ingress.ca
+{%- if pillar.addons.dex.enabled %}
   - metalk8s.addons.dex.ca
+{%- endif %}
   - metalk8s.backup.certs.ca

--- a/salt/metalk8s/service-configuration/deployed/init.sls
+++ b/salt/metalk8s/service-configuration/deployed/init.sls
@@ -7,6 +7,8 @@
 # default configurations to startup
 include:
   - metalk8s.addons.prometheus-operator.deployed.service-configuration
+{%- if pillar.addons.dex.enabled %}
   - metalk8s.addons.dex.deployed.service-configuration
+{%- endif %}
   - metalk8s.addons.logging.loki.deployed.service-configuration
   - metalk8s.addons.ui.deployed.ui-configuration

--- a/salt/tests/unit/formulas/config.yaml
+++ b/salt/tests/unit/formulas/config.yaml
@@ -185,6 +185,22 @@ metalk8s:
                   HTTPS_PROXY: https://my-proxy.local
 
   kubernetes:
+    apiserver:
+      files:
+        installed.sls:
+          _cases:
+            "With an external OIDC":
+              pillar_overrides:
+                kubernetes:
+                  apiServer:
+                    oidc:
+                      issuerURL: "https://issuer-url/oidc"
+                      clientID: "oidc-client"
+                      CAFile: "/path/to/some/ca.crt"
+                      usernameClaim: "email"
+                      groupsClaim: "groups"
+            "With default OIDC (Dex)": {}
+
     apiserver-proxy:
       files:
         apiserver-proxy.yaml.j2:

--- a/salt/tests/unit/formulas/data/base_pillar.yaml
+++ b/salt/tests/unit/formulas/data/base_pillar.yaml
@@ -184,3 +184,6 @@ kubernetes:
       podAntiAffinity:
         soft:
           - topologyKey: kubernetes.io/hostname
+addons:
+  dex:
+    enabled: True

--- a/salt/tests/unit/modules/files/test_metalk8s_service_configuration.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_service_configuration.yaml
@@ -64,6 +64,24 @@ get_service_config:
           containers:
             - name: my_new_container
 
+  #. Success: retrieved ConfigMap manifest is empty
+  - configmap_name: 'my_configmap'
+    configmap_obj: null
+    default_csc:
+      apiVersion: my_apiVersion1
+      kind: my_kind1
+      spec:
+        deployment:
+          replicas: my_replicas
+          containers: my_containers
+    result:
+      apiVersion: my_apiVersion1
+      kind: my_kind1
+      spec:
+        deployment:
+          replicas: my_replicas
+          containers: my_containers
+
   #. Error: missing configmap_name
   - configmap_name: null
     result: "Expected a ConfigMap name but got None"
@@ -79,12 +97,6 @@ get_service_config:
   - configmap_name: 'my_configmap'
     object_get: False
     result: "Failed to read ConfigMap object my_configmap"
-    raises: True
-
-  #. Error: retrieved ConfigMap manifest is empty
-  - configmap_name: 'my_configmap'
-    configmap_obj: null
-    result: "Expected ConfigMap object but got None"
     raises: True
 
   #. Error: yaml error raised when reading config.yaml

--- a/tests/post/features/ingress.feature
+++ b/tests/post/features/ingress.feature
@@ -40,6 +40,7 @@ Feature: Ingress
         When we perform an HTTP request on port 80 on a control-plane IP
         Then the server should not respond
 
+    @authentication
     Scenario: Failover of Control Plane Ingress VIP using MetalLB
         Given the Kubernetes API is available
         And we are on a multi node cluster
@@ -48,6 +49,7 @@ Feature: Ingress
         Then the node hosting the Control Plane Ingress VIP changed
         And we are able to login to Dex as 'admin@metalk8s.invalid' using password 'password'
 
+    @authentication
     Scenario: Change Control Plane Ingress IP to node-1 IP
         Given the Kubernetes API is available
         And we are on a multi node cluster
@@ -59,6 +61,7 @@ Feature: Ingress
         Then the control plane ingress IP is equal to node 'node-1' IP
         And we are able to login to Dex as 'admin@metalk8s.invalid' using password 'password'
 
+    @authentication
     Scenario: Enable MetalLB
         Given the Kubernetes API is available
         And a VIP for Control Plane Ingress is available

--- a/tests/post/features/sanity.feature
+++ b/tests/post/features/sanity.feature
@@ -35,7 +35,6 @@ Feature: Cluster Sanity Checks
         | kube-system         | calico-kube-controllers                |
         | kube-system         | coredns                                |
         | kube-system         | storage-operator                       |
-        | metalk8s-auth       | dex                                    |
         | metalk8s-ingress    | ingress-nginx-defaultbackend           |
         | metalk8s-monitoring | prometheus-adapter                     |
         | metalk8s-monitoring | prometheus-operator-grafana            |
@@ -54,6 +53,11 @@ Feature: Cluster Sanity Checks
         | metalk8s-ingress    | ingress-nginx-controller                     |
         | metalk8s-monitoring | prometheus-operator-prometheus-node-exporter |
         | metalk8s-logging    | fluent-bit                                   |
+
+    # We do a special case for Dex since Dex may not be deployed in every environment
+    @authentication
+    Scenario: Dex has available replicas
+        Then the Deployment 'dex' in the 'metalk8s-auth' namespace has all desired replicas available
 
     # We do a special case for Control Plane Ingress Controller and MetalLB
     # since those ones are not deployed in every environment

--- a/tests/post/features/service_configuration.feature
+++ b/tests/post/features/service_configuration.feature
@@ -1,5 +1,6 @@
 @post @local @ci @csc
 Feature: Cluster and Services Configurations
+    @authentication
     Scenario: Propagation of Service Configurations to underlying Services
         Given the Kubernetes API is available
         And pods with label 'app.kubernetes.io/name=dex' are 'Ready'
@@ -10,6 +11,7 @@ Feature: Cluster and Services Configurations
         And we wait for the rollout of 'deploy/dex' in namespace 'metalk8s-auth' to complete
         Then we have '3' at 'status.availableReplicas' for 'dex' Deployment in namespace 'metalk8s-auth'
 
+    @authentication
     Scenario: Update Admin static user password
         Given the Kubernetes API is available
         And we have a 'metalk8s-dex-config' CSC in namespace 'metalk8s-auth'
@@ -30,6 +32,7 @@ Feature: Cluster and Services Configurations
         And we apply the 'metalk8s.addons.prometheus-operator.deployed' state
         Then we have an alert rule 'NodeFilesystemSpaceFillingUp' in group 'node-exporter' with severity 'warning' and 'annotations.summary' equal to 'Filesystem is predicted to run out of space within the next 48 hours.'
 
+    @authentication
     Scenario: Dex pods spreading
         Given the Kubernetes API is available
         And we are on a multi node cluster

--- a/tests/post/steps/test_sanity.py
+++ b/tests/post/steps/test_sanity.py
@@ -63,6 +63,14 @@ def test_statefulset_running(host):
 
 @scenario(
     "../features/sanity.feature",
+    "Dex has available replicas",
+)
+def test_dex_deploy(host):
+    pass
+
+
+@scenario(
+    "../features/sanity.feature",
     "Control Plane Ingress Controller when MetalLB is disabled",
 )
 def test_cp_ingress_controller_no_metallb(host):


### PR DESCRIPTION
**Component**: salt, dex

**Context**:
We want to be able to not deploy Dex and rather rely on an external IDP.

**Summary**:

To disable Dex deployment at installation,
you must add the following to the boostrap config:

```
addons:
  dex:
    enabled: false
```

**Acceptance criteria**: 
We can use another IDP than Dex (e.g. Keycloak) and everything work fine.