### PR TITLE
charts,salt: Disable service monitor for fluent-bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 - Bump Grafana image version to 8.3.4-ubuntu
   (PR[#3684](https://github.com/scality/metalk8s/pull/3684))
 
+### Bug fixes
+
+- Disable fluent-bit service monitor as currently the fluent-bit
+  HTTP server that serve metrics does not work
+  (PR[#3689](https://github.com/scality/metalk8s/pull/3689))
+
 ## Release 2.11.0
 ### Additions
 

--- a/charts/fluent-bit.yaml
+++ b/charts/fluent-bit.yaml
@@ -120,7 +120,10 @@ volumeMounts:
   readOnly: true
 
 serviceMonitor:
-  enabled: true
+  # Disabled for the moment as http_server does not work with current
+  # fluent-bit version + kubernetes version
+  # See: https://github.com/fluent/fluent-bit/issues/4063
+  enabled: false
   interval: ""
   additionalLabels:
     metalk8s.scality.com/monitor: ''

--- a/salt/metalk8s/addons/logging/fluent-bit/deployed/chart.sls
+++ b/salt/metalk8s/addons/logging/fluent-bit/deployed/chart.sls
@@ -147,30 +147,6 @@ subjects:
 - kind: ServiceAccount
   name: fluent-bit
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: fluent-bit
-    app.kubernetes.io/managed-by: salt
-    app.kubernetes.io/name: fluent-bit
-    app.kubernetes.io/part-of: metalk8s
-    chart: fluent-bit-2.2.0
-    heritage: metalk8s
-    release: fluent-bit
-  name: fluent-bit-headless
-  namespace: metalk8s-logging
-spec:
-  clusterIP: None
-  ports:
-  - name: http-metrics
-    port: 2020
-    protocol: TCP
-    targetPort: http-metrics
-  selector:
-    app: fluent-bit
-    release: fluent-bit
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -257,30 +233,5 @@ spec:
         name: runlog
   updateStrategy:
     type: RollingUpdate
----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  labels:
-    app: fluent-bit
-    app.kubernetes.io/managed-by: salt
-    app.kubernetes.io/name: fluent-bit
-    app.kubernetes.io/part-of: metalk8s
-    chart: fluent-bit-2.2.0
-    heritage: metalk8s
-    metalk8s.scality.com/monitor: ''
-  name: fluent-bit
-  namespace: metalk8s-logging
-spec:
-  endpoints:
-  - path: /api/v1/metrics/prometheus
-    port: http-metrics
-  namespaceSelector:
-    matchNames:
-    - metalk8s-logging
-  selector:
-    matchLabels:
-      app: fluent-bit
-      release: fluent-bit
 
 {% endraw %}


### PR DESCRIPTION
HTTP_server of fluent-bit is disabled because of a bug with fluent-bit
version and Kubernetes version, since this HTTP_server is used to serve
metrics we also disable the service monitor to not have "false" alert
because of it