### PR TITLE
charts,salt,build: Bump NGINX Ingress chart to v4.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Bump Grafana image version to 8.3.4-ubuntu
   (PR[#3684](https://github.com/scality/metalk8s/pull/3684))
 
+- Bump ingress-nginx chart version to 4.0.9
+  nginx-ingress-controller image has been bumped accordingly to v1.0.5
+  (PR[#3691](https://github.com/scality/metalk8s/pull/3691))
+
 ### Bug fixes
 
 - Disable fluent-bit service monitor as currently the fluent-bit

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -161,8 +161,8 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     ),
     Image(
         name="nginx-ingress-controller",
-        version="v1.0.0",
-        digest="sha256:0851b34f69f69352bf168e6ccf30e1e20714a264ab1ecd1933e4d8c0fc3215c6",
+        version="v1.0.5",
+        digest="sha256:55a1fcda5b7657c372515fe402c3e39ad93aa59f6e4378e82acd99912fe6028d",
     ),
     Image(
         name="nginx-ingress-defaultbackend-amd64",

--- a/charts/ingress-nginx-control-plane-daemonset.yaml
+++ b/charts/ingress-nginx-control-plane-daemonset.yaml
@@ -11,6 +11,8 @@ controller:
     name: nginx-control-plane
     controllerValue: "k8s.io/ingress-nginx-control-plane"
 
+  ingressClass: nginx-control-plane
+
   admissionWebhooks:
     enabled: false
 

--- a/charts/ingress-nginx-control-plane-deployment.yaml
+++ b/charts/ingress-nginx-control-plane-deployment.yaml
@@ -11,6 +11,8 @@ controller:
     name: nginx-control-plane
     controllerValue: "k8s.io/ingress-nginx-control-plane"
 
+  ingressClass: nginx-control-plane
+
   admissionWebhooks:
     enabled: false
 

--- a/charts/ingress-nginx/CHANGELOG.md
+++ b/charts/ingress-nginx/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 4.0.9
+
+- [6992] https://github.com/kubernetes/ingress-nginx/pull/6992 Add ability to specify labels for all resources
+
+### 4.0.7
+
+- [7923] https://github.com/kubernetes/ingress-nginx/pull/7923 Release v1.0.5 of ingress-nginx
+- [7806] https://github.com/kubernetes/ingress-nginx/pull/7806 Choice option for internal/external loadbalancer type service
+
+### 4.0.6
+
+- [7804] https://github.com/kubernetes/ingress-nginx/pull/7804 Release v1.0.4 of ingress-nginx
+- [7651] https://github.com/kubernetes/ingress-nginx/pull/7651 Support ipFamilyPolicy and ipFamilies fields in Helm Chart
+- [7798] https://github.com/kubernetes/ingress-nginx/pull/7798 Exoscale: use HTTP Healthcheck mode
+- [7793] https://github.com/kubernetes/ingress-nginx/pull/7793 Update kube-webhook-certgen to v1.1.1
+
+### 4.0.5
+
+- [7740] https://github.com/kubernetes/ingress-nginx/pull/7740 Release v1.0.3 of ingress-nginx
+
+### 4.0.3
+
+- [7707] https://github.com/kubernetes/ingress-nginx/pull/7707 Release v1.0.2 of ingress-nginx
+
+### 4.0.2 
+
+- [7681] https://github.com/kubernetes/ingress-nginx/pull/7681 Release v1.0.1 of ingress-nginx
+
+### 4.0.1 
+
+- [7535] https://github.com/kubernetes/ingress-nginx/pull/7535 Release v1.0.0 ingress-nginx
+
 ### 3.34.0
 
 - [7256] https://github.com/kubernetes/ingress-nginx/pull/7256 Add namespace field in the namespace scoped resource templates

--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -1,11 +1,10 @@
 annotations:
   artifacthub.io/changes: |
-    - Support for Ingress object v1 and drop support for v1beta1
-    - Update to go 1.17
-    - Fix some bugs
+    - choice option for internal/external loadbalancer type service
+    - use controller v1.0.5
   artifacthub.io/prerelease: "false"
 apiVersion: v2
-appVersion: 1.0.0
+appVersion: 1.0.5
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer
 home: https://github.com/kubernetes/ingress-nginx
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
@@ -19,4 +18,4 @@ name: ingress-nginx
 sources:
 - https://github.com/kubernetes/ingress-nginx
 type: application
-version: 4.0.1
+version: 4.0.9

--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -2,13 +2,14 @@
 
 [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer
 
-To use, add the `kubernetes.io/ingress.class: nginx` annotation to your Ingress resources.
+To use, add `ingressClassName: nginx` spec field or the `kubernetes.io/ingress.class: nginx` annotation to your Ingress resources.
 
 This chart bootstraps an ingress-nginx deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
 
-- Kubernetes v1.16+
+- Chart version 3.x.x: Kubernetes v1.16+
+- Chart version 4.x.x and above: Kubernetes v1.19+
 
 ## Get Repo Info
 
@@ -84,7 +85,8 @@ else it would make it impossible to evacuate a node. See [gh issue #7127](https:
 
 The Nginx ingress controller can export Prometheus metrics, by setting `controller.metrics.enabled` to `true`.
 
-You can add Prometheus annotations to the metrics service using `controller.metrics.service.annotations`. Alternatively, if you use the Prometheus Operator, you can enable ServiceMonitor creation using `controller.metrics.serviceMonitor.enabled`.
+You can add Prometheus annotations to the metrics service using `controller.metrics.service.annotations`.
+Alternatively, if you use the Prometheus Operator, you can enable ServiceMonitor creation using `controller.metrics.serviceMonitor.enabled`. And set `controller.metrics.serviceMonitor.additionalLabels.release="prometheus"`. "release=prometheus" should match the label configured in the prometheus servicemonitor ( see `kubectl get servicemonitor prometheus-kube-prom-prometheus -oyaml -n prometheus`)
 
 ### ingress-nginx nginx\_status page/stats server
 
@@ -176,8 +178,8 @@ controller:
         networking.gke.io/load-balancer-type: "Internal"
         # For earlier versions
         # cloud.google.com/load-balancer-type: "Internal"
-        
-        # Any other annotation can be declared here. 
+
+        # Any other annotation can be declared here.
 ```
 
 Example for Azure:

--- a/charts/ingress-nginx/ci/daemonset-customconfig-values.yaml
+++ b/charts/ingress-nginx/ci/daemonset-customconfig-values.yaml
@@ -4,6 +4,7 @@ controller:
     tag: 1.0.0-dev
     digest: null
   kind: DaemonSet
+  allowSnippetAnnotations: false
   admissionWebhooks:
     enabled: false
   service:

--- a/charts/ingress-nginx/ci/deployment-customconfig-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-customconfig-values.yaml
@@ -5,6 +5,7 @@ controller:
     digest: null
   config:
     use-proxy-protocol: "true"
+  allowSnippetAnnotations: false
   admissionWebhooks:
     enabled: false
   service:

--- a/charts/ingress-nginx/templates/NOTES.txt
+++ b/charts/ingress-nginx/templates/NOTES.txt
@@ -29,27 +29,35 @@ Get the application URL by running these commands:
 
 An example Ingress that makes use of the controller:
 
+{{- $isV1 := semverCompare ">=1" .Chart.AppVersion}}
   apiVersion: networking.k8s.io/v1
   kind: Ingress
   metadata:
-    annotations:
-      kubernetes.io/ingress.class: {{ .Values.controller.ingressClass }}
     name: example
     namespace: foo
+    {{- if eq $isV1 false }}
+    annotations:
+      kubernetes.io/ingress.class: {{ .Values.controller.ingressClass }}
+    {{- end }}
   spec:
+    {{- if $isV1 }}
+    ingressClassName: {{ .Values.controller.ingressClassResource.name }}
+    {{- end }}
     rules:
       - host: www.example.com
         http:
           paths:
             - backend:
-                serviceName: exampleService
-                servicePort: 80
+                service:
+                  name: exampleService
+                  port:
+                    number: 80
               path: /
     # This section is only required if TLS is to be enabled for the Ingress
     tls:
-        - hosts:
-            - www.example.com
-          secretName: example-tls
+      - hosts:
+        - www.example.com
+        secretName: example-tls
 
 If TLS is enabled for the Ingress, a Secret containing the certificate and key must also be provided:
 

--- a/charts/ingress-nginx/templates/_helpers.tpl
+++ b/charts/ingress-nginx/templates/_helpers.tpl
@@ -30,6 +30,24 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
+
+{{/*
+Container SecurityContext.
+*/}}
+{{- define "controller.containerSecurityContext" -}}
+{{- if .Values.controller.containerSecurityContext -}}
+{{- toYaml .Values.controller.containerSecurityContext -}}
+{{- else -}}
+capabilities:
+  drop:
+  - ALL
+  add:
+  - NET_BIND_SERVICE
+runAsUser: {{ .Values.controller.image.runAsUser }}
+allowPrivilegeEscalation: {{ .Values.controller.image.allowPrivilegeEscalation }}
+{{- end }}
+{{- end -}}
+
 {{/*
 Create a default fully qualified controller name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).

--- a/charts/ingress-nginx/templates/_params.tpl
+++ b/charts/ingress-nginx/templates/_params.tpl
@@ -1,0 +1,59 @@
+{{- define "ingress-nginx.params" -}}
+- /nginx-ingress-controller
+{{- if .Values.defaultBackend.enabled }}
+- --default-backend-service=$(POD_NAMESPACE)/{{ include "ingress-nginx.defaultBackend.fullname" . }}
+{{- end }}
+{{- if and .Values.controller.publishService.enabled .Values.controller.service.enabled }}
+{{- if .Values.controller.service.external.enabled }}
+- --publish-service={{ template "ingress-nginx.controller.publishServicePath" . }}
+{{- else if .Values.controller.service.internal.enabled }}
+- --publish-service={{ template "ingress-nginx.controller.publishServicePath" . }}-internal
+{{- end }}
+{{- end }}
+- --election-id={{ .Values.controller.electionID }}
+- --controller-class={{ .Values.controller.ingressClassResource.controllerValue }}
+- --configmap={{ default "$(POD_NAMESPACE)" .Values.controller.configMapNamespace }}/{{ include "ingress-nginx.controller.fullname" . }}
+{{- if .Values.tcp }}
+- --tcp-services-configmap={{ default "$(POD_NAMESPACE)" .Values.controller.tcp.configMapNamespace }}/{{ include "ingress-nginx.fullname" . }}-tcp
+{{- end }}
+{{- if .Values.udp }}
+- --udp-services-configmap={{ default "$(POD_NAMESPACE)" .Values.controller.udp.configMapNamespace }}/{{ include "ingress-nginx.fullname" . }}-udp
+{{- end }}
+{{- if .Values.controller.scope.enabled }}
+- --watch-namespace={{ default "$(POD_NAMESPACE)" .Values.controller.scope.namespace }}
+{{- end }}
+{{- if and (not .Values.controller.scope.enabled) .Values.controller.scope.namespaceSelector }}
+- --watch-namespace-selector={{ default "" .Values.controller.scope.namespaceSelector }}
+{{- end }}
+{{- if and .Values.controller.reportNodeInternalIp .Values.controller.hostNetwork }}
+- --report-node-internal-ip-address={{ .Values.controller.reportNodeInternalIp }}
+{{- end }}
+{{- if .Values.controller.admissionWebhooks.enabled }}
+- --validating-webhook=:{{ .Values.controller.admissionWebhooks.port }}
+- --validating-webhook-certificate={{ .Values.controller.admissionWebhooks.certificate }}
+- --validating-webhook-key={{ .Values.controller.admissionWebhooks.key }}
+{{- end }}
+{{- if .Values.controller.maxmindLicenseKey }}
+- --maxmind-license-key={{ .Values.controller.maxmindLicenseKey }}
+{{- end }}
+{{- if .Values.controller.healthCheckHost }}
+- --healthz-host={{ .Values.controller.healthCheckHost }}
+{{- end }}
+{{- if not (eq .Values.controller.healthCheckPath "/healthz") }}
+- --health-check-path={{ .Values.controller.healthCheckPath }}
+{{- end }}
+{{- if .Values.controller.ingressClassByName }}
+- --ingress-class-by-name=true
+{{- end }}
+{{- if .Values.controller.watchIngressWithoutClass }}
+- --watch-ingress-without-class=true
+{{- end }}
+{{- range $key, $value := .Values.controller.extraArgs }}
+{{- /* Accept keys without values or with false as value */}}
+{{- if eq ($value | quote | len) 2 }}
+- --{{ $key }}
+{{- else }}
+- --{{ $key }}={{ $value }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/clusterrole.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/clusterrole.yaml
@@ -9,6 +9,9 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook
+    {{- with .Values.controller.admissionWebhooks.patch.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 rules:
   - apiGroups:
       - admissionregistration.k8s.io

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
@@ -9,6 +9,9 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook
+    {{- with .Values.controller.admissionWebhooks.patch.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -10,6 +10,9 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook
+    {{- with .Values.controller.admissionWebhooks.patch.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
 {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" }}
   # Alpha feature since k8s 1.12
@@ -24,6 +27,9 @@ spec:
       labels:
         {{- include "ingress-nginx.labels" . | nindent 8 }}
         app.kubernetes.io/component: admission-webhook
+        {{- with .Values.controller.admissionWebhooks.patch.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
     {{- if .Values.controller.admissionWebhooks.patch.priorityClassName }}
       priorityClassName: {{ .Values.controller.admissionWebhooks.patch.priorityClassName }}

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -10,6 +10,9 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook
+    {{- with .Values.controller.admissionWebhooks.patch.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
 {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" }}
   # Alpha feature since k8s 1.12
@@ -24,6 +27,9 @@ spec:
       labels:
         {{- include "ingress-nginx.labels" . | nindent 8 }}
         app.kubernetes.io/component: admission-webhook
+        {{- with .Values.controller.admissionWebhooks.patch.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
     {{- if .Values.controller.admissionWebhooks.patch.priorityClassName }}
       priorityClassName: {{ .Values.controller.admissionWebhooks.patch.priorityClassName }}

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/psp.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/psp.yaml
@@ -9,6 +9,9 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook
+    {{- with .Values.controller.admissionWebhooks.patch.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   allowPrivilegeEscalation: false
   fsGroup:

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/role.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/role.yaml
@@ -10,6 +10,9 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook
+    {{- with .Values.controller.admissionWebhooks.patch.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 rules:
   - apiGroups:
       - ""

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/rolebinding.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/rolebinding.yaml
@@ -10,6 +10,9 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook
+    {{- with .Values.controller.admissionWebhooks.patch.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/serviceaccount.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/serviceaccount.yaml
@@ -10,4 +10,7 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook
+    {{- with .Values.controller.admissionWebhooks.patch.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/charts/ingress-nginx/templates/admission-webhooks/validating-webhook.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/validating-webhook.yaml
@@ -10,6 +10,9 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook
+    {{- with .Values.controller.admissionWebhooks.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ include "ingress-nginx.fullname" . }}-admission
 webhooks:
   - name: validate.nginx.ingress.kubernetes.io

--- a/charts/ingress-nginx/templates/clusterrole.yaml
+++ b/charts/ingress-nginx/templates/clusterrole.yaml
@@ -10,6 +10,9 @@ kind: ClusterRole
 metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
+    {{- with .Values.controller.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ include "ingress-nginx.fullname" . }}
 rules:
   - apiGroups:
@@ -20,6 +23,9 @@ rules:
       - nodes
       - pods
       - secrets
+{{- if not .Values.controller.scope.enabled }}
+      - namespaces
+{{- end}}
     verbs:
       - list
       - watch

--- a/charts/ingress-nginx/templates/clusterrolebinding.yaml
+++ b/charts/ingress-nginx/templates/clusterrolebinding.yaml
@@ -4,6 +4,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
+    {{- with .Values.controller.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ include "ingress-nginx.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/ingress-nginx/templates/controller-configmap-addheaders.yaml
+++ b/charts/ingress-nginx/templates/controller-configmap-addheaders.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
+    {{- with .Values.controller.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ include "ingress-nginx.fullname" . }}-custom-add-headers
   namespace: {{ .Release.Namespace }}
 data: {{ toYaml .Values.controller.addHeaders | nindent 2 }}

--- a/charts/ingress-nginx/templates/controller-configmap-proxyheaders.yaml
+++ b/charts/ingress-nginx/templates/controller-configmap-proxyheaders.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
+    {{- with .Values.controller.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ include "ingress-nginx.fullname" . }}-custom-proxy-headers
   namespace: {{ .Release.Namespace }}
 data:

--- a/charts/ingress-nginx/templates/controller-configmap-tcp.yaml
+++ b/charts/ingress-nginx/templates/controller-configmap-tcp.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
+    {{- with .Values.controller.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- if .Values.controller.tcp.annotations }}
   annotations: {{ toYaml .Values.controller.tcp.annotations | nindent 4 }}
 {{- end }}

--- a/charts/ingress-nginx/templates/controller-configmap-udp.yaml
+++ b/charts/ingress-nginx/templates/controller-configmap-udp.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
+    {{- with .Values.controller.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- if .Values.controller.udp.annotations }}
   annotations: {{ toYaml .Values.controller.udp.annotations | nindent 4 }}
 {{- end }}

--- a/charts/ingress-nginx/templates/controller-configmap.yaml
+++ b/charts/ingress-nginx/templates/controller-configmap.yaml
@@ -4,12 +4,16 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
+    {{- with .Values.controller.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- if .Values.controller.configAnnotations }}
   annotations: {{ toYaml .Values.controller.configAnnotations | nindent 4 }}
 {{- end }}
   name: {{ include "ingress-nginx.controller.fullname" . }}
   namespace: {{ .Release.Namespace }}
 data:
+  allow-snippet-annotations: "{{ .Values.controller.allowSnippetAnnotations }}"
 {{- if .Values.controller.addHeaders }}
   add-headers: {{ .Release.Namespace }}/{{ include "ingress-nginx.fullname" . }}-custom-add-headers
 {{- end }}
@@ -20,6 +24,6 @@ data:
   ssl-dh-param: {{ printf "%s/%s" .Release.Namespace (include "ingress-nginx.controller.fullname" .) }}
 {{- end }}
 {{- range $key, $value := .Values.controller.config }}
-    {{ $key | nindent 2 }}: {{ $value | quote }}
+    {{- $key | nindent 2 }}: {{ $value | quote }}
 {{- end }}
 

--- a/charts/ingress-nginx/templates/controller-daemonset.yaml
+++ b/charts/ingress-nginx/templates/controller-daemonset.yaml
@@ -35,6 +35,9 @@ spec:
       labels:
         {{- include "ingress-nginx.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: controller
+        {{- with .Values.controller.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- if .Values.controller.podLabels }}
         {{- toYaml .Values.controller.podLabels | nindent 8 }}
       {{- end }}
@@ -75,53 +78,7 @@ spec:
           lifecycle: {{ toYaml .Values.controller.lifecycle | nindent 12 }}
         {{- end }}
           args:
-            - /nginx-ingress-controller
-          {{- if .Values.defaultBackend.enabled }}
-            - --default-backend-service=$(POD_NAMESPACE)/{{ include "ingress-nginx.defaultBackend.fullname" . }}
-          {{- end }}
-          {{- if .Values.controller.publishService.enabled }}
-            - --publish-service={{ template "ingress-nginx.controller.publishServicePath" . }}
-          {{- end }}
-            - --election-id={{ .Values.controller.electionID }}
-            - --controller-class={{ .Values.controller.ingressClassResource.controllerValue }}
-            - --configmap={{ default "$(POD_NAMESPACE)" .Values.controller.configMapNamespace }}/{{ include "ingress-nginx.controller.fullname" . }}
-          {{- if .Values.tcp }}
-            - --tcp-services-configmap={{ default "$(POD_NAMESPACE)" .Values.controller.tcp.configMapNamespace }}/{{ include "ingress-nginx.fullname" . }}-tcp
-          {{- end }}
-          {{- if .Values.udp }}
-            - --udp-services-configmap={{ default "$(POD_NAMESPACE)" .Values.controller.udp.configMapNamespace }}/{{ include "ingress-nginx.fullname" . }}-udp
-          {{- end }}
-          {{- if .Values.controller.scope.enabled }}
-            - --watch-namespace={{ default "$(POD_NAMESPACE)" .Values.controller.scope.namespace }}
-          {{- end }}
-          {{- if and .Values.controller.reportNodeInternalIp .Values.controller.hostNetwork }}
-            - --report-node-internal-ip-address={{ .Values.controller.reportNodeInternalIp }}
-          {{- end }}
-          {{- if .Values.controller.admissionWebhooks.enabled }}
-            - --validating-webhook=:{{ .Values.controller.admissionWebhooks.port }}
-            - --validating-webhook-certificate={{ .Values.controller.admissionWebhooks.certificate }}
-            - --validating-webhook-key={{ .Values.controller.admissionWebhooks.key }}
-          {{- end }}
-          {{- if .Values.controller.maxmindMirror }}
-            - --maxmind-mirror={{ .Values.controller.maxmindMirror }}
-          {{- end}}
-          {{- if .Values.controller.maxmindLicenseKey }}
-            - --maxmind-license-key={{ .Values.controller.maxmindLicenseKey }}
-          {{- end }}
-          {{- if not (eq .Values.controller.healthCheckPath "/healthz") }}
-            - --health-check-path={{ .Values.controller.healthCheckPath }}
-          {{- end }}
-          {{- if .Values.controller.watchIngressWithoutClass }}
-            - --watch-ingress-without-class=true
-          {{- end }}
-          {{- range $key, $value := .Values.controller.extraArgs }}
-            {{- /* Accept keys without values or with false as value */}}
-            {{- if eq ($value | quote | len) 2 }}
-            - --{{ $key }}
-            {{- else }}
-            - --{{ $key }}={{ $value }}
-            {{- end }}
-          {{- end }}
+            {{- include "ingress-nginx.params" . | nindent 12 }}
           securityContext:
             capabilities:
                 drop:

--- a/charts/ingress-nginx/templates/controller-deployment.yaml
+++ b/charts/ingress-nginx/templates/controller-deployment.yaml
@@ -39,6 +39,9 @@ spec:
       labels:
         {{- include "ingress-nginx.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: controller
+        {{- with .Values.controller.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- if .Values.controller.podLabels }}
         {{- toYaml .Values.controller.podLabels | nindent 8 }}
       {{- end }}
@@ -54,7 +57,7 @@ spec:
       imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
     {{- end }}
     {{- if .Values.controller.priorityClassName }}
-      priorityClassName: {{ .Values.controller.priorityClassName }}
+      priorityClassName: {{ .Values.controller.priorityClassName | quote }}
     {{- end }}
     {{- if or .Values.controller.podSecurityContext .Values.controller.sysctls }}
       securityContext:
@@ -79,58 +82,8 @@ spec:
           lifecycle: {{ toYaml .Values.controller.lifecycle | nindent 12 }}
         {{- end }}
           args:
-            - /nginx-ingress-controller
-          {{- if .Values.defaultBackend.enabled }}
-            - --default-backend-service=$(POD_NAMESPACE)/{{ include "ingress-nginx.defaultBackend.fullname" . }}
-          {{- end }}
-          {{- if .Values.controller.publishService.enabled }}
-            - --publish-service={{ template "ingress-nginx.controller.publishServicePath" . }}
-          {{- end }}
-            - --election-id={{ .Values.controller.electionID }}
-            - --controller-class={{ .Values.controller.ingressClassResource.controllerValue }}
-            - --configmap={{ default "$(POD_NAMESPACE)" .Values.controller.configMapNamespace }}/{{ include "ingress-nginx.controller.fullname" . }}
-          {{- if .Values.tcp }}
-            - --tcp-services-configmap={{ default "$(POD_NAMESPACE)" .Values.controller.tcp.configMapNamespace }}/{{ include "ingress-nginx.fullname" . }}-tcp
-          {{- end }}
-          {{- if .Values.udp }}
-            - --udp-services-configmap={{ default "$(POD_NAMESPACE)" .Values.controller.udp.configMapNamespace }}/{{ include "ingress-nginx.fullname" . }}-udp
-          {{- end }}
-          {{- if .Values.controller.scope.enabled }}
-            - --watch-namespace={{ default "$(POD_NAMESPACE)" .Values.controller.scope.namespace }}
-          {{- end }}
-          {{- if and .Values.controller.reportNodeInternalIp .Values.controller.hostNetwork }}
-            - --report-node-internal-ip-address={{ .Values.controller.reportNodeInternalIp }}
-          {{- end }}
-          {{- if .Values.controller.admissionWebhooks.enabled }}
-            - --validating-webhook=:{{ .Values.controller.admissionWebhooks.port }}
-            - --validating-webhook-certificate={{ .Values.controller.admissionWebhooks.certificate }}
-            - --validating-webhook-key={{ .Values.controller.admissionWebhooks.key }}
-          {{- end }}
-          {{- if .Values.controller.maxmindLicenseKey }}
-            - --maxmind-license-key={{ .Values.controller.maxmindLicenseKey }}
-          {{- end }}
-          {{- if not (eq .Values.controller.healthCheckPath "/healthz") }}
-            - --health-check-path={{ .Values.controller.healthCheckPath }}
-          {{- end }}
-          {{- if .Values.controller.watchIngressWithoutClass }}
-            - --watch-ingress-without-class=true
-          {{- end }}
-          {{- range $key, $value := .Values.controller.extraArgs }}
-            {{- /* Accept keys without values or with false as value */}}
-            {{- if eq ($value | quote | len) 2 }}
-            - --{{ $key }}
-            {{- else }}
-            - --{{ $key }}={{ $value }}
-            {{- end }}
-          {{- end }}
-          securityContext:
-            capabilities:
-                drop:
-                - ALL
-                add:
-                - NET_BIND_SERVICE
-            runAsUser: {{ .Values.controller.image.runAsUser }}
-            allowPrivilegeEscalation: {{ .Values.controller.image.allowPrivilegeEscalation }}
+            {{- include "ingress-nginx.params" . | nindent 12 }}
+          securityContext: {{ include "controller.containerSecurityContext" . | nindent 12 }}
           env:
             - name: POD_NAME
               valueFrom:

--- a/charts/ingress-nginx/templates/controller-hpa.yaml
+++ b/charts/ingress-nginx/templates/controller-hpa.yaml
@@ -11,6 +11,9 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
+    {{- with .Values.controller.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ include "ingress-nginx.controller.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:

--- a/charts/ingress-nginx/templates/controller-keda.yaml
+++ b/charts/ingress-nginx/templates/controller-keda.yaml
@@ -7,6 +7,9 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
+    {{- with .Values.controller.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ include "ingress-nginx.controller.fullname" . }}
   {{- if .Values.controller.keda.scaledObject.annotations }}
   annotations: {{ toYaml .Values.controller.keda.scaledObject.annotations | nindent 4 }}

--- a/charts/ingress-nginx/templates/controller-poddisruptionbudget.yaml
+++ b/charts/ingress-nginx/templates/controller-poddisruptionbudget.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
+    {{- with .Values.controller.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ include "ingress-nginx.controller.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:

--- a/charts/ingress-nginx/templates/controller-psp.yaml
+++ b/charts/ingress-nginx/templates/controller-psp.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
+    {{- with .Values.controller.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   allowedCapabilities:
     - NET_BIND_SERVICE

--- a/charts/ingress-nginx/templates/controller-role.yaml
+++ b/charts/ingress-nginx/templates/controller-role.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
+    {{- with .Values.controller.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ include "ingress-nginx.fullname" . }}
   namespace: {{ .Release.Namespace }}
 rules:

--- a/charts/ingress-nginx/templates/controller-rolebinding.yaml
+++ b/charts/ingress-nginx/templates/controller-rolebinding.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
+    {{- with .Values.controller.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ include "ingress-nginx.fullname" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:

--- a/charts/ingress-nginx/templates/controller-service-internal.yaml
+++ b/charts/ingress-nginx/templates/controller-service-internal.yaml
@@ -51,6 +51,28 @@ spec:
       nodePort: {{ .Values.controller.service.nodePorts.https }}
     {{- end }}
   {{- end }}
+  {{- range $key, $value := .Values.tcp }}
+    - name: {{ $key }}-tcp
+      port: {{ $key }}
+      protocol: TCP
+      targetPort: {{ $key }}-tcp
+    {{- if $.Values.controller.service.nodePorts.tcp }}
+    {{- if index $.Values.controller.service.nodePorts.tcp $key }}
+      nodePort: {{ index $.Values.controller.service.nodePorts.tcp $key }}
+    {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- range $key, $value := .Values.udp }}
+    - name: {{ $key }}-udp
+      port: {{ $key }}
+      protocol: UDP
+      targetPort: {{ $key }}-udp
+    {{- if $.Values.controller.service.nodePorts.udp }}
+    {{- if index $.Values.controller.service.nodePorts.udp $key }}
+      nodePort: {{ index $.Values.controller.service.nodePorts.udp $key }}
+    {{- end }}
+    {{- end }}
+  {{- end }}
   selector:
     {{- include "ingress-nginx.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: controller

--- a/charts/ingress-nginx/templates/controller-service-metrics.yaml
+++ b/charts/ingress-nginx/templates/controller-service-metrics.yaml
@@ -33,6 +33,7 @@ spec:
   ports:
     - name: metrics
       port: {{ .Values.controller.metrics.service.servicePort }}
+      protocol: TCP
       targetPort: metrics
     {{- $setNodePorts := (or (eq .Values.controller.metrics.service.type "NodePort") (eq .Values.controller.metrics.service.type "LoadBalancer")) }}
     {{- if (and $setNodePorts (not (empty .Values.controller.metrics.service.nodePort))) }}

--- a/charts/ingress-nginx/templates/controller-service-webhook.yaml
+++ b/charts/ingress-nginx/templates/controller-service-webhook.yaml
@@ -8,6 +8,9 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
+    {{- with .Values.controller.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ include "ingress-nginx.controller.fullname" . }}-admission
   namespace: {{ .Release.Namespace }}
 spec:

--- a/charts/ingress-nginx/templates/controller-service.yaml
+++ b/charts/ingress-nginx/templates/controller-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.service.enabled -}}
+{{- if and .Values.controller.service.enabled .Values.controller.service.external.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -36,6 +36,16 @@ spec:
 {{- end }}
 {{- if .Values.controller.service.healthCheckNodePort }}
   healthCheckNodePort: {{ .Values.controller.service.healthCheckNodePort }}
+{{- end }}
+{{- if semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version -}}
+{{- if .Values.controller.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.controller.service.ipFamilyPolicy }}
+{{- end }}
+{{- end }}
+{{- if semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version -}}
+{{- if .Values.controller.service.ipFamilies }}
+  ipFamilies: {{ toYaml .Values.controller.service.ipFamilies | nindent 4 }}
+{{- end }}
 {{- end }}
   ports:
   {{- $setNodePorts := (or (eq .Values.controller.service.type "NodePort") (eq .Values.controller.service.type "LoadBalancer")) }}

--- a/charts/ingress-nginx/templates/controller-serviceaccount.yaml
+++ b/charts/ingress-nginx/templates/controller-serviceaccount.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
+    {{- with .Values.controller.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ template "ingress-nginx.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}

--- a/charts/ingress-nginx/templates/controller-servicemonitor.yaml
+++ b/charts/ingress-nginx/templates/controller-servicemonitor.yaml
@@ -27,10 +27,6 @@ spec:
 {{- end }}
 {{- if .Values.controller.metrics.serviceMonitor.namespaceSelector }}
   namespaceSelector: {{ toYaml .Values.controller.metrics.serviceMonitor.namespaceSelector | nindent 4 }}
-{{ else }}
-  namespaceSelector:
-    matchNames:
-      - {{ .Release.Namespace }}
 {{- end }}
 {{- if .Values.controller.metrics.serviceMonitor.targetLabels }}
   targetLabels:

--- a/charts/ingress-nginx/templates/default-backend-deployment.yaml
+++ b/charts/ingress-nginx/templates/default-backend-deployment.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: default-backend
+    {{- with .Values.defaultBackend.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ include "ingress-nginx.defaultBackend.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
@@ -24,6 +27,9 @@ spec:
       labels:
         {{- include "ingress-nginx.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: default-backend
+        {{- with .Values.defaultBackend.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- if .Values.defaultBackend.podLabels }}
         {{- toYaml .Values.defaultBackend.podLabels | nindent 8 }}
       {{- end }}

--- a/charts/ingress-nginx/templates/default-backend-hpa.yaml
+++ b/charts/ingress-nginx/templates/default-backend-hpa.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: default-backend
+    {{- with .Values.defaultBackend.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ template "ingress-nginx.defaultBackend.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:

--- a/charts/ingress-nginx/templates/default-backend-poddisruptionbudget.yaml
+++ b/charts/ingress-nginx/templates/default-backend-poddisruptionbudget.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: default-backend
+    {{- with .Values.defaultBackend.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ include "ingress-nginx.defaultBackend.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:

--- a/charts/ingress-nginx/templates/default-backend-psp.yaml
+++ b/charts/ingress-nginx/templates/default-backend-psp.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: default-backend
+    {{- with .Values.defaultBackend.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   allowPrivilegeEscalation: false
   fsGroup:

--- a/charts/ingress-nginx/templates/default-backend-role.yaml
+++ b/charts/ingress-nginx/templates/default-backend-role.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: default-backend
+    {{- with .Values.defaultBackend.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ include "ingress-nginx.fullname" . }}-backend
   namespace: {{ .Release.Namespace }}
 rules:

--- a/charts/ingress-nginx/templates/default-backend-rolebinding.yaml
+++ b/charts/ingress-nginx/templates/default-backend-rolebinding.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: default-backend
+    {{- with .Values.defaultBackend.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ include "ingress-nginx.fullname" . }}-backend
   namespace: {{ .Release.Namespace }}
 roleRef:

--- a/charts/ingress-nginx/templates/default-backend-service.yaml
+++ b/charts/ingress-nginx/templates/default-backend-service.yaml
@@ -8,6 +8,9 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: default-backend
+    {{- with .Values.defaultBackend.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ include "ingress-nginx.defaultBackend.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:

--- a/charts/ingress-nginx/templates/default-backend-serviceaccount.yaml
+++ b/charts/ingress-nginx/templates/default-backend-serviceaccount.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: default-backend
+    {{- with .Values.defaultBackend.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ template "ingress-nginx.defaultBackend.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 automountServiceAccountToken: {{ .Values.defaultBackend.serviceAccount.automountServiceAccountToken }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -15,8 +15,8 @@ controller:
     # for backwards compatibility consider setting the full image url via the repository value below
     # use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
     # repository:
-    tag: "v1.0.0"
-    digest: sha256:0851b34f69f69352bf168e6ccf30e1e20714a264ab1ecd1933e4d8c0fc3215c6
+    tag: "v1.0.5"
+    digest: sha256:55a1fcda5b7657c372515fe402c3e39ad93aa59f6e4378e82acd99912fe6028d
     pullPolicy: IfNotPresent
     # www-data -> uid 101
     runAsUser: 101
@@ -65,6 +65,15 @@ controller:
   # Overrides value for --watch-ingress-without-class flag of the controller binary
   # Defaults to false
   watchIngressWithoutClass: false
+
+  # Process IngressClass per name (additionally as per spec.controller)
+  ingressClassByName: false
+
+  # This configuration defines if Ingress Controller should allow users to set
+  # their own *-snippet annotations, otherwise this is forbidden / dropped
+  # when users add those annotations.
+  # Global snippets in ConfigMap are still respected
+  allowSnippetAnnotations: true
 
   # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
   # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920
@@ -128,6 +137,9 @@ controller:
   scope:
     enabled: false
     namespace: ""   # defaults to $(POD_NAMESPACE)
+    # When scope.enabled == false, instead of watching all namespaces, we watching namespaces whose labels
+    #   only match with namespaceSelector. Format like foo=bar. Defaults to empty, means watching all namespaces.
+    namespaceSelector: ""
 
   ## Allows customization of the configmap / nginx-configmap namespace
   ##
@@ -175,7 +187,7 @@ controller:
   annotations: {}
   #  keel.sh/pollSchedule: "@every 60m"
 
-  ## Labels to be added to the controller Deployment or DaemonSet
+  ## Labels to be added to the controller Deployment or DaemonSet and other resources that do not have option to specify labels
   ##
   labels: {}
   #  keel.sh/policy: patch
@@ -311,6 +323,11 @@ controller:
   # the healthz-port parameter are forwarded internally to this path.
   healthCheckPath: "/healthz"
 
+  # Address to bind the health check endpoint.
+  # It is better to set this option to the internal node address
+  # if the ingress nginx controller is running in the hostNetwork: true mode.
+  healthCheckHost: ""
+
   ## Annotations to be added to controller pods
   ##
   podAnnotations: {}
@@ -430,19 +447,30 @@ controller:
     enableHttp: true
     enableHttps: true
 
-    ## Set external traffic policy to: "Local" to preserve source IP on
-    ## providers supporting it
+    ## Set external traffic policy to: "Local" to preserve source IP on providers supporting it.
     ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
     # externalTrafficPolicy: ""
 
-    # Must be either "None" or "ClientIP" if set. Kubernetes will default to "None".
-    # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+    ## Must be either "None" or "ClientIP" if set. Kubernetes will default to "None".
+    ## Ref: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
     # sessionAffinity: ""
 
-    # specifies the health check node port (numeric port number) for the service. If healthCheckNodePort isn’t specified,
-    # the service controller allocates a port from your cluster’s NodePort range.
-    # Ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+    ## Specifies the health check node port (numeric port number) for the service. If healthCheckNodePort isn’t specified,
+    ## the service controller allocates a port from your cluster’s NodePort range.
+    ## Ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
     # healthCheckNodePort: 0
+
+    ## Represents the dual-stack-ness requested or required by this Service. Possible values are
+    ## SingleStack, PreferDualStack or RequireDualStack.
+    ## The ipFamilies and clusterIPs fields depend on the value of this field.
+    ## Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/
+    ipFamilyPolicy: "SingleStack"
+
+    ## List of IP families (e.g. IPv4, IPv6) assigned to the service. This field is usually assigned automatically
+    ## based on cluster configuration and the ipFamilyPolicy field.
+    ## Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/
+    ipFamilies:
+      - IPv4
 
     ports:
       http: 80
@@ -465,6 +493,9 @@ controller:
       https: ""
       tcp: {}
       udp: {}
+
+    external:
+      enabled: true
 
     ## Enables an additional internal load balancer (besides the external one).
     ## Annotations are mandatory for the load balancer to come up. Varies with the cloud service.
@@ -532,6 +563,8 @@ controller:
     key: "/usr/local/certificates/key"
     namespaceSelector: {}
     objectSelector: {}
+    ## Labels to be added to admission webhooks
+    labels: {}
 
     # Use an existing PSP instead of creating one
     existingPsp: ""
@@ -565,8 +598,8 @@ controller:
         # for backwards compatibility consider setting the full image url via the repository value below
         # use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
         # repository:
-        tag: v1.0
-        digest: sha256:f3b6b39a6062328c095337b4cadcefd1612348fdd5190b1dcbcb9b9e90bd8068
+        tag: v1.1.1
+        digest: sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660
         pullPolicy: IfNotPresent
       ## Provide a priority class name to the webhook patching job
       ##
@@ -575,6 +608,8 @@ controller:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations: []
+      ## Labels to be added to patch job resources
+      labels: {}
       runAsUser: 2000
 
   metrics:
@@ -743,6 +778,12 @@ defaultBackend:
   ##
   podSecurityContext: {}
 
+  ## Security Context policies for controller main container.
+  ## See https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/ for
+  ## notes on enabling and using sysctls
+  ##
+  containerSecurityContext: {}
+
   # labels to add to the pod container metadata
   podLabels: {}
   #  key: value
@@ -803,6 +844,8 @@ defaultBackend:
     type: ClusterIP
 
   priorityClassName: ""
+  ## Labels to be added to the default backend resources
+  labels: {}
 
 ## Enable RBAC as per https://github.com/kubernetes/ingress-nginx/blob/main/docs/deploy/rbac.md and https://github.com/kubernetes/ingress-nginx/issues/266
 rbac:

--- a/salt/metalk8s/addons/nginx-ingress-control-plane/deployed/chart-daemonset.sls
+++ b/salt/metalk8s/addons/nginx-ingress-control-plane/deployed/chart-daemonset.sls
@@ -16,14 +16,15 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
 ---
 apiVersion: v1
-data: null
+data:
+  allow-snippet-annotations: 'true'
 kind: ConfigMap
 metadata:
   labels:
@@ -32,8 +33,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx-control-plane-controller
   namespace: metalk8s-ingress
@@ -46,8 +47,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -60,6 +61,7 @@ rules:
   - nodes
   - pods
   - secrets
+  - namespaces
   verbs:
   - list
   - watch
@@ -115,8 +117,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -138,8 +140,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -223,8 +225,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -246,8 +248,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx-control-plane-controller-metrics
   namespace: metalk8s-ingress
@@ -255,6 +257,7 @@ spec:
   ports:
   - name: metrics
     port: 10254
+    protocol: TCP
     targetPort: metrics
   selector:
     app.kubernetes.io/component: controller
@@ -272,8 +275,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx-control-plane-controller
   namespace: metalk8s-ingress
@@ -281,6 +284,9 @@ spec:
   externalIPs:
   - '{%- endraw -%}{{ salt.metalk8s_network.get_control_plane_ingress_ip() }}{%- raw
     -%}'
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
   ports:
   - appProtocol: https
     name: https
@@ -302,8 +308,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx-control-plane-controller
   namespace: metalk8s-ingress
@@ -343,7 +349,7 @@ spec:
         - name: LD_PRELOAD
           value: /usr/local/lib/libmimalloc.so
         image: '{%- endraw -%}{{ build_image_name("nginx-ingress-controller", False)
-          }}{%- raw -%}:v1.0.0'
+          }}{%- raw -%}:v1.0.5'
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -421,8 +427,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: nginx-control-plane
   namespace: metalk8s-ingress
@@ -438,8 +444,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
     metalk8s.scality.com/monitor: ''
   name: ingress-nginx-control-plane-controller
@@ -448,9 +454,6 @@ spec:
   endpoints:
   - interval: 30s
     port: metrics
-  namespaceSelector:
-    matchNames:
-    - metalk8s-ingress
   selector:
     matchLabels:
       app.kubernetes.io/component: controller

--- a/salt/metalk8s/addons/nginx-ingress-control-plane/deployed/chart-deployment.sls
+++ b/salt/metalk8s/addons/nginx-ingress-control-plane/deployed/chart-deployment.sls
@@ -16,8 +16,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -32,14 +32,15 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx-control-plane-backend
   namespace: metalk8s-ingress
 ---
 apiVersion: v1
-data: null
+data:
+  allow-snippet-annotations: 'true'
 kind: ConfigMap
 metadata:
   labels:
@@ -48,8 +49,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx-control-plane-controller
   namespace: metalk8s-ingress
@@ -62,8 +63,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -76,6 +77,7 @@ rules:
   - nodes
   - pods
   - secrets
+  - namespaces
   verbs:
   - list
   - watch
@@ -131,8 +133,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -154,8 +156,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -239,8 +241,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -262,8 +264,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx-control-plane-controller-metrics
   namespace: metalk8s-ingress
@@ -271,6 +273,7 @@ spec:
   ports:
   - name: metrics
     port: 10254
+    protocol: TCP
     targetPort: metrics
   selector:
     app.kubernetes.io/component: controller
@@ -288,13 +291,16 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx-control-plane-controller
   namespace: metalk8s-ingress
 spec:
   externalTrafficPolicy: Local
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
   loadBalancerIP: {% endraw -%}{{ salt.metalk8s_network.get_control_plane_ingress_ip() }}{%- raw %}
   ports:
   - appProtocol: https
@@ -317,8 +323,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx-control-plane-defaultbackend
   namespace: metalk8s-ingress
@@ -344,8 +350,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx-control-plane-controller
   namespace: metalk8s-ingress
@@ -394,7 +400,7 @@ spec:
               fieldPath: metadata.namespace
         - name: LD_PRELOAD
           value: /usr/local/lib/libmimalloc.so
-        image: {% endraw -%}{{ build_image_name("nginx-ingress-controller", False) }}{%- raw %}:v1.0.0
+        image: {% endraw -%}{{ build_image_name("nginx-ingress-controller", False) }}{%- raw %}:v1.0.5
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -470,8 +476,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx-control-plane-defaultbackend
   namespace: metalk8s-ingress
@@ -551,8 +557,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: nginx-control-plane
   namespace: metalk8s-ingress
@@ -568,8 +574,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
     metalk8s.scality.com/monitor: ''
   name: ingress-nginx-control-plane-controller
@@ -578,9 +584,6 @@ spec:
   endpoints:
   - interval: 30s
     port: metrics
-  namespaceSelector:
-    matchNames:
-    - metalk8s-ingress
   selector:
     matchLabels:
       app.kubernetes.io/component: controller

--- a/salt/metalk8s/addons/nginx-ingress/deployed/chart.sls
+++ b/salt/metalk8s/addons/nginx-ingress/deployed/chart.sls
@@ -16,8 +16,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx
   namespace: metalk8s-ingress
@@ -32,14 +32,15 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx-backend
   namespace: metalk8s-ingress
 ---
 apiVersion: v1
-data: null
+data:
+  allow-snippet-annotations: 'true'
 kind: ConfigMap
 metadata:
   labels:
@@ -48,8 +49,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx-controller
   namespace: metalk8s-ingress
@@ -62,8 +63,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx
   namespace: metalk8s-ingress
@@ -76,6 +77,7 @@ rules:
   - nodes
   - pods
   - secrets
+  - namespaces
   verbs:
   - list
   - watch
@@ -131,8 +133,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx
   namespace: metalk8s-ingress
@@ -154,8 +156,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx
   namespace: metalk8s-ingress
@@ -239,8 +241,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx
   namespace: metalk8s-ingress
@@ -262,8 +264,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx-controller-metrics
   namespace: metalk8s-ingress
@@ -271,6 +273,7 @@ spec:
   ports:
   - name: metrics
     port: 10254
+    protocol: TCP
     targetPort: metrics
   selector:
     app.kubernetes.io/component: controller
@@ -288,12 +291,15 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx-controller
   namespace: metalk8s-ingress
 spec:
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
   ports:
   - appProtocol: http
     name: http
@@ -320,8 +326,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx-defaultbackend
   namespace: metalk8s-ingress
@@ -347,8 +353,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx-controller
   namespace: metalk8s-ingress
@@ -389,7 +395,7 @@ spec:
         - name: LD_PRELOAD
           value: /usr/local/lib/libmimalloc.so
         image: '{%- endraw -%}{{ build_image_name("nginx-ingress-controller", False)
-          }}{%- raw -%}:v1.0.0'
+          }}{%- raw -%}:v1.0.5'
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -463,8 +469,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: ingress-nginx-defaultbackend
   namespace: metalk8s-ingress
@@ -544,8 +550,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
   name: nginx
   namespace: metalk8s-ingress
@@ -561,8 +567,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.0.0
-    helm.sh/chart: ingress-nginx-4.0.1
+    app.kubernetes.io/version: 1.0.5
+    helm.sh/chart: ingress-nginx-4.0.9
     heritage: metalk8s
     metalk8s.scality.com/monitor: ''
   name: ingress-nginx-controller
@@ -571,9 +577,6 @@ spec:
   endpoints:
   - interval: 30s
     port: metrics
-  namespaceSelector:
-    matchNames:
-    - metalk8s-ingress
   selector:
     matchLabels:
       app.kubernetes.io/component: controller


### PR DESCRIPTION
Bump the NGINX Ingress chart to v4.0.9 and also bump the ingress
controller image to v1.0.5