### PR TITLE
charts,salt: Update PodMonitor selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@
   HTTP server that serve metrics does not work
   (PR[#3689](https://github.com/scality/metalk8s/pull/3689))
 
+### Breaking changes
+
+- [#2199](https://github.com/scality/metalk8s/issues/2199) - Prometheus label
+  selector for `PodMonitor` has changed from `release: prometheus-operator` to
+  `metalk8s.scality.com/monitor: ''`
+  (PR[#3692](https://github.com/scality/metalk8s/pull/3692))
+
 ## Release 2.11.0
 ### Additions
 

--- a/charts/kube-prometheus-stack.yaml
+++ b/charts/kube-prometheus-stack.yaml
@@ -113,6 +113,10 @@ prometheus:
     nodeSelector:
       node-role.kubernetes.io/infra: ''
 
+    podMonitorSelector:
+      matchLabels:
+        metalk8s.scality.com/monitor: ''
+
     serviceMonitorSelector:
       matchLabels:
         metalk8s.scality.com/monitor: ''

--- a/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
@@ -62331,7 +62331,7 @@ spec:
   podMonitorNamespaceSelector: {}
   podMonitorSelector:
     matchLabels:
-      release: prometheus-operator
+      metalk8s.scality.com/monitor: ''
   portName: http-web
   probeNamespaceSelector: {}
   probeSelector:


### PR DESCRIPTION
Oversight from #3356, with this PodMonitor objects are selected using
the same label.

Re-render prometheus-operator salt state using:
```
./charts/render.py prometheus-operator \
  charts/kube-prometheus-stack.yaml \
  charts/kube-prometheus-stack/ \
  --namespace metalk8s-monitoring \
  --service-config grafana \
  metalk8s-grafana-config \
  metalk8s/addons/prometheus-operator/config/grafana.yaml \
  metalk8s-monitoring \
  --service-config prometheus \
  metalk8s-prometheus-config \
  metalk8s/addons/prometheus-operator/config/prometheus.yaml \
  metalk8s-monitoring \
  --service-config alertmanager \
  metalk8s-alertmanager-config \
  metalk8s/addons/prometheus-operator/config/alertmanager.yaml \
  metalk8s-monitoring \
  --service-config dex \
  metalk8s-dex-config \
  metalk8s/addons/dex/config/dex.yaml.j2 metalk8s-auth \
  --drop-prometheus-rules charts/drop-prometheus-rules.yaml \
  --patch 'PrometheusRule,metalk8s-monitoring,prometheus-operator-kubernetes-system-kubelet,spec:groups:0:rules:1:for,"5m"' \
  > salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
```

---

See #3356
See #2199