### PR TITLE
charts,salt,tests: Make Ingress controller watch Ingress without class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 ## Release 2.11.3 (in development)
+### Bug fixes
+
+- Fix a bug during the upgrade that makes the workload plane Ingress controller
+  ignore the Ingress object that does not have the class explicitly set
+  (PR[#3704](https://github.com/scality/metalk8s/pull/3704))
 
 ## Release 2.11.2
 ### Bug fixes

--- a/charts/ingress-nginx.yaml
+++ b/charts/ingress-nginx.yaml
@@ -9,6 +9,8 @@ controller:
   ingressClassResource:
     default: true
 
+  watchIngressWithoutClass: true
+
   admissionWebhooks:
     enabled: false
 

--- a/salt/metalk8s/addons/nginx-ingress/deployed/chart.sls
+++ b/salt/metalk8s/addons/nginx-ingress/deployed/chart.sls
@@ -380,6 +380,7 @@ spec:
         - --election-id=ingress-controller-leader
         - --controller-class=k8s.io/ingress-nginx
         - --configmap=$(POD_NAMESPACE)/ingress-nginx-controller
+        - --watch-ingress-without-class=true
         - --default-ssl-certificate=metalk8s-ingress/ingress-workload-plane-default-certificate
         - --metrics-per-host=false
         env:

--- a/tests/post/features/ingress.feature
+++ b/tests/post/features/ingress.feature
@@ -12,6 +12,27 @@ Feature: Ingress
         When we perform an HTTPS request on port 443 on a workload-plane IP
         Then the server returns 404 'Not Found'
 
+    Scenario: Create new Ingress object (without class)
+        Given the Kubernetes API is available
+        And pods with label 'app.kubernetes.io/name=ingress-nginx' are 'Ready'
+        When we create a 'metalk8s-test-1' Ingress on path '/_metalk8s-test-1' on 'repositories' service on 'http' in 'kube-system' namespace
+        And we perform an HTTPS request on path '/_metalk8s-test-1' on port 443 on a workload-plane IP
+        Then the server returns 200 'OK'
+
+    Scenario: Create new Ingress object (nginx class)
+        Given the Kubernetes API is available
+        And pods with label 'app.kubernetes.io/name=ingress-nginx' are 'Ready'
+        When we create a 'metalk8s-test-2' Ingress with class 'nginx' on path '/_metalk8s-test-2' on 'repositories' service on 'http' in 'kube-system' namespace
+        And we perform an HTTPS request on path '/_metalk8s-test-2' on port 443 on a workload-plane IP
+        Then the server returns 200 'OK'
+
+    Scenario: Create new Ingress object (invalid class)
+        Given the Kubernetes API is available
+        And pods with label 'app.kubernetes.io/name=ingress-nginx' are 'Ready'
+        When we create a 'metalk8s-test-3' Ingress with class 'invalid-class' on path '/_metalk8s-test-3' on 'repositories' service on 'http' in 'kube-system' namespace
+        And we perform an HTTPS request on path '/_metalk8s-test-3' on port 443 on a workload-plane IP
+        Then the server returns 404 'Not Found'
+
     Scenario: Access HTTP services on control-plane IP
         Given the Kubernetes API is available
         And pods with label 'app.kubernetes.io/name=ingress-nginx' are 'Ready'


### PR DESCRIPTION
The Workload Plane Ingress is the default Ingress controller that should
be used for Ingress object, so let's make this Ingress controller watch
Ingress object with no class.

NOTE: It shouldn't be needed since we define a default IngressClass
object, but during upgrade, the Ingress object created without Class
in MetalK8s 2.10.x are ignored after upgrade with a message that the
Ingress objects do not have any Class.