### PR TITLE
build,packages,salt: Update Calico to 3.22.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
   The pause image has been bump to 3.6
   (PR[#3711](https://github.com/scality/metalk8s/pull/3711))
 
+- Bump Calico version to [3.22.0](https://github.com/projectcalico/calico/releases/tag/v3.22.0)
+  (PR[#3712](https://github.com/scality/metalk8s/pull/3712))
+
 - Allow to resolve the registry endpoint from inside containers using CoreDNS
   (PR[#3690](https://github.com/scality/metalk8s/pull/3690))
 

--- a/buildchain/buildchain/packaging.py
+++ b/buildchain/buildchain/packaging.py
@@ -334,9 +334,8 @@ def _rpm_package_calico(releasever: str) -> targets.RPMPackage:
         name="calico-cni-plugin",
         releasever=releasever,
         sources=[
-            Path("calico-amd64"),
-            Path("calico-ipam-amd64"),
             Path("v{}.tar.gz".format(versions.CALICO_VERSION)),
+            Path("release-v{}.tgz".format(versions.CALICO_VERSION)),
         ],
     )
 

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -18,7 +18,7 @@ Image = namedtuple("Image", ("name", "version", "digest"))
 
 # Project-wide versions {{{
 
-CALICO_VERSION: str = "3.20.0"
+CALICO_VERSION: str = "3.22.0"
 K8S_VERSION: str = "1.23.0"
 SALT_VERSION: str = "3002.7"
 CONTAINERD_VERSION: str = "1.6.0"
@@ -97,12 +97,12 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     Image(
         name="calico-node",
         version=_version_prefix(CALICO_VERSION),
-        digest="sha256:7f9aa7e31fbcea7be64b153f8bcfd494de023679ec10d851a05667f0adb42650",
+        digest="sha256:393eb65c51e5acef64adb0648d9f2d087fcf0639f0020f757e80aa61b6fd0f77",
     ),
     Image(
         name="calico-kube-controllers",
         version=_version_prefix(CALICO_VERSION),
-        digest="sha256:a850ce8daa84433a5641900693b0f8bc8e5177a4aa4cac8cf4b6cd8c24fd9886",
+        digest="sha256:cfb3941c051abfa94bfae1bb907344117fe68914cb2962b4c5640b0b84f3a1d7",
     ),
     Image(
         name="coredns",

--- a/eve/workers/pod-builder/pod.yaml
+++ b/eve/workers/pod-builder/pod.yaml
@@ -47,7 +47,7 @@ spec:
           memory: 6Gi
         limits:
           cpu: "3"
-          memory: 6Gi
+          memory: 12Gi
       env:
         - name: DOCKER_TLS_CERTDIR
           value: ''

--- a/packages/redhat/common/calico-cni-plugin.spec
+++ b/packages/redhat/common/calico-cni-plugin.spec
@@ -1,17 +1,17 @@
 %global provider        github
 %global provider_tld    com
 %global project         projectcalico
-%global repo            cni-plugin
+%global repo            calico
 %global provider_prefix %{provider}.%{provider_tld}/%{project}/%{repo}
 
 %ifarch x86_64
 %global built_arch              amd64
-%global calico_sha256           3a8b8e80599597bed8a4c10a43bad6424c2f3d8c00b3bb26f1268a0cae2a60da
-%global calico_ipam_sha256      3a8b8e80599597bed8a4c10a43bad6424c2f3d8c00b3bb26f1268a0cae2a60da
+%global calico_sha256           6bac456294a08a5bba3121e44056e264f11085f78582b1770df740ebe9a5de5c
+%global calico_ipam_sha256      6bac456294a08a5bba3121e44056e264f11085f78582b1770df740ebe9a5de5c
 %endif
 
 Name:           calico-cni-plugin
-Version:        3.20.0
+Version:        3.22.0
 Release:        1%{?dist}
 Summary:        Calico CNI plugin
 
@@ -21,8 +21,7 @@ ExclusiveOS:    Linux
 License:        ASL 2.0
 URL:            https://%{provider_prefix}
 Source0:        https://%{provider_prefix}/archive/v%{version}.tar.gz
-Source1:        https://%{provider_prefix}/releases/download/v%{version}/calico-%{built_arch}
-Source2:        https://%{provider_prefix}/releases/download/v%{version}/calico-ipam-%{built_arch}
+Source1:        https://%{provider_prefix}/releases/download/v%{version}/release-v%{version}.tgz
 
 BuildRequires:  /usr/bin/sha256sum
 Requires:       kubernetes-cni
@@ -31,15 +30,17 @@ Requires:       kubernetes-cni
 %{summary}
 
 %prep
-%setup -q -n %{repo}-%{version}
-echo "%{calico_sha256}  %{SOURCE1}" | /usr/bin/sha256sum --status --strict --check
-echo "%{calico_ipam_sha256}  %{SOURCE2}" | /usr/bin/sha256sum --status --strict --check
+%setup -b 1 -q -n release-v%{version}/bin/cni/%{built_arch}
+echo "%{calico_sha256}  calico" | /usr/bin/sha256sum --status --strict --check
+echo "%{calico_ipam_sha256}  calico-ipam" | /usr/bin/sha256sum --status --strict --check
+
+%setup -q -n %{repo}-%{version}/cni-plugin
 
 %install
 install -m 755 -d %{buildroot}/opt/cni/bin
 
-install -p -m 755 %{SOURCE1} %{buildroot}/opt/cni/bin/calico
-install -p -m 755 %{SOURCE2} %{buildroot}/opt/cni/bin/calico-ipam
+install -p -m 755 %{_builddir}/release-v%{version}/bin/cni/%{built_arch}/calico %{buildroot}/opt/cni/bin/calico
+install -p -m 755 %{_builddir}/release-v%{version}/bin/cni/%{built_arch}/calico-ipam %{buildroot}/opt/cni/bin/calico-ipam
 
 %files
 /opt/cni/bin/calico
@@ -49,6 +50,9 @@ install -p -m 755 %{SOURCE2} %{buildroot}/opt/cni/bin/calico-ipam
 %doc README.md
 
 %changelog
+* Fri Feb 18 2022 Teddy Andrieux <teddy.andrieux@scality.com> - 3.22.0.1-1
+- Version bump
+
 * Wed Sep 8 2021 Teddy Andrieux <teddy.andrieux@scality.com> - 3.20.0.1-1
 - Version bump
 

--- a/salt/metalk8s/kubernetes/cni/calico/deployed.sls
+++ b/salt/metalk8s/kubernetes/cni/calico/deployed.sls
@@ -21,6 +21,7 @@ data:
   typha_service_name: "none"
   # Configure the backend to use.
   calico_backend: "bird"
+
   # Configure the MTU to use for workload interfaces and tunnels.
   # By default, MTU is auto-detected, and explicitly setting this field should not be required.
   # You can override auto-detection by providing a non-zero value.
@@ -257,8 +258,8 @@ spec:
                   in the specific branch of the Node on "bird.cfg".
                 type: boolean
               maxRestartTime:
-                description: Time to allow for software restart.  When specified, this
-                  is configured as the graceful restart timeout.  When not specified,
+                description: Time to allow for software restart.  When specified,
+                  this is configured as the graceful restart timeout.  When not specified,
                   the BIRD default of 120s is used.
                 type: string
               node:
@@ -388,6 +389,271 @@ status:
   storedVersions: []
 
 ---
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  creationTimestamp: null
+  name: caliconodestatuses.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: CalicoNodeStatus
+    listKind: CalicoNodeStatusList
+    plural: caliconodestatuses
+    singular: caliconodestatus
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CalicoNodeStatusSpec contains the specification for a CalicoNodeStatus
+              resource.
+            properties:
+              classes:
+                description: Classes declares the types of information to monitor
+                  for this calico/node, and allows for selective status reporting
+                  about certain subsets of information.
+                items:
+                  type: string
+                type: array
+              node:
+                description: The node name identifies the Calico node instance for
+                  node status.
+                type: string
+              updatePeriodSeconds:
+                description: UpdatePeriodSeconds is the period at which CalicoNodeStatus
+                  should be updated. Set to 0 to disable CalicoNodeStatus refresh.
+                  Maximum update period is one day.
+                format: int32
+                type: integer
+            type: object
+          status:
+            description: CalicoNodeStatusStatus defines the observed state of CalicoNodeStatus.
+              No validation needed for status since it is updated by Calico.
+            properties:
+              agent:
+                description: Agent holds agent status on the node.
+                properties:
+                  birdV4:
+                    description: BIRDV4 represents the latest observed status of bird4.
+                    properties:
+                      lastBootTime:
+                        description: LastBootTime holds the value of lastBootTime
+                          from bird.ctl output.
+                        type: string
+                      lastReconfigurationTime:
+                        description: LastReconfigurationTime holds the value of lastReconfigTime
+                          from bird.ctl output.
+                        type: string
+                      routerID:
+                        description: Router ID used by bird.
+                        type: string
+                      state:
+                        description: The state of the BGP Daemon.
+                        type: string
+                      version:
+                        description: Version of the BGP daemon
+                        type: string
+                    type: object
+                  birdV6:
+                    description: BIRDV6 represents the latest observed status of bird6.
+                    properties:
+                      lastBootTime:
+                        description: LastBootTime holds the value of lastBootTime
+                          from bird.ctl output.
+                        type: string
+                      lastReconfigurationTime:
+                        description: LastReconfigurationTime holds the value of lastReconfigTime
+                          from bird.ctl output.
+                        type: string
+                      routerID:
+                        description: Router ID used by bird.
+                        type: string
+                      state:
+                        description: The state of the BGP Daemon.
+                        type: string
+                      version:
+                        description: Version of the BGP daemon
+                        type: string
+                    type: object
+                type: object
+              bgp:
+                description: BGP holds node BGP status.
+                properties:
+                  numberEstablishedV4:
+                    description: The total number of IPv4 established bgp sessions.
+                    type: integer
+                  numberEstablishedV6:
+                    description: The total number of IPv6 established bgp sessions.
+                    type: integer
+                  numberNotEstablishedV4:
+                    description: The total number of IPv4 non-established bgp sessions.
+                    type: integer
+                  numberNotEstablishedV6:
+                    description: The total number of IPv6 non-established bgp sessions.
+                    type: integer
+                  peersV4:
+                    description: PeersV4 represents IPv4 BGP peers status on the node.
+                    items:
+                      description: CalicoNodePeer contains the status of BGP peers
+                        on the node.
+                      properties:
+                        peerIP:
+                          description: IP address of the peer whose condition we are
+                            reporting.
+                          type: string
+                        since:
+                          description: Since the state or reason last changed.
+                          type: string
+                        state:
+                          description: State is the BGP session state.
+                          type: string
+                        type:
+                          description: Type indicates whether this peer is configured
+                            via the node-to-node mesh, or via en explicit global or
+                            per-node BGPPeer object.
+                          type: string
+                      type: object
+                    type: array
+                  peersV6:
+                    description: PeersV6 represents IPv6 BGP peers status on the node.
+                    items:
+                      description: CalicoNodePeer contains the status of BGP peers
+                        on the node.
+                      properties:
+                        peerIP:
+                          description: IP address of the peer whose condition we are
+                            reporting.
+                          type: string
+                        since:
+                          description: Since the state or reason last changed.
+                          type: string
+                        state:
+                          description: State is the BGP session state.
+                          type: string
+                        type:
+                          description: Type indicates whether this peer is configured
+                            via the node-to-node mesh, or via en explicit global or
+                            per-node BGPPeer object.
+                          type: string
+                      type: object
+                    type: array
+                required:
+                - numberEstablishedV4
+                - numberEstablishedV6
+                - numberNotEstablishedV4
+                - numberNotEstablishedV6
+                type: object
+              lastUpdated:
+                description: LastUpdated is a timestamp representing the server time
+                  when CalicoNodeStatus object last updated. It is represented in
+                  RFC3339 form and is in UTC.
+                format: date-time
+                nullable: true
+                type: string
+              routes:
+                description: Routes reports routes known to the Calico BGP daemon
+                  on the node.
+                properties:
+                  routesV4:
+                    description: RoutesV4 represents IPv4 routes on the node.
+                    items:
+                      description: CalicoNodeRoute contains the status of BGP routes
+                        on the node.
+                      properties:
+                        destination:
+                          description: Destination of the route.
+                          type: string
+                        gateway:
+                          description: Gateway for the destination.
+                          type: string
+                        interface:
+                          description: Interface for the destination
+                          type: string
+                        learnedFrom:
+                          description: LearnedFrom contains information regarding
+                            where this route originated.
+                          properties:
+                            peerIP:
+                              description: If sourceType is NodeMesh or BGPPeer, IP
+                                address of the router that sent us this route.
+                              type: string
+                            sourceType:
+                              description: Type of the source where a route is learned
+                                from.
+                              type: string
+                          type: object
+                        type:
+                          description: Type indicates if the route is being used for
+                            forwarding or not.
+                          type: string
+                      type: object
+                    type: array
+                  routesV6:
+                    description: RoutesV6 represents IPv6 routes on the node.
+                    items:
+                      description: CalicoNodeRoute contains the status of BGP routes
+                        on the node.
+                      properties:
+                        destination:
+                          description: Destination of the route.
+                          type: string
+                        gateway:
+                          description: Gateway for the destination.
+                          type: string
+                        interface:
+                          description: Interface for the destination
+                          type: string
+                        learnedFrom:
+                          description: LearnedFrom contains information regarding
+                            where this route originated.
+                          properties:
+                            peerIP:
+                              description: If sourceType is NodeMesh or BGPPeer, IP
+                                address of the router that sent us this route.
+                              type: string
+                            sourceType:
+                              description: Type of the source where a route is learned
+                                from.
+                              type: string
+                          type: object
+                        type:
+                          description: Type indicates if the route is being used for
+                            forwarding or not.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -497,7 +763,7 @@ spec:
                 type: boolean
               awsSrcDstCheck:
                 description: 'Set source-destination-check on AWS EC2 instances. Accepted
-                  value must be one of "DoNothing", "Enabled" or "Disabled". [Default:
+                  value must be one of "DoNothing", "Enable" or "Disable". [Default:
                   DoNothing]'
                 enum:
                 - DoNothing
@@ -531,6 +797,13 @@ spec:
                 description: 'BPFEnabled, if enabled Felix will use the BPF dataplane.
                   [Default: false]'
                 type: boolean
+              bpfExtToServiceConnmark:
+                description: 'BPFExtToServiceConnmark in BPF mode, control a 32bit
+                  mark that is set on connections from an external client to a local
+                  service. This mark allows us to control how packets of that connection
+                  are routed within the host and how is routing intepreted by RPF
+                  check. [Default: 0]'
+                type: integer
               bpfExternalServiceMode:
                 description: 'BPFExternalServiceMode in BPF mode, controls how connections
                   from outside the cluster to services (node ports and cluster IPs)
@@ -541,14 +814,6 @@ spec:
                   node appears to use the IP of the ingress node; this requires a
                   permissive L2 network.  [Default: Tunnel]'
                 type: string
-              bpfExtToServiceConnmark:
-                description: 'BPFExtToServiceConnmark in BPF mode, controls a
-                  32bit mark that is set on connections from an external client to
-                  a local service. This mark allows us to control how packets of
-                  that connection are routed within the host and how is routing
-                  intepreted by RPF check. [Default: 0]'
-                type: integer
-
               bpfKubeProxyEndpointSlicesEnabled:
                 description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls
                   whether Felix's embedded kube-proxy accepts EndpointSlices or not.
@@ -897,6 +1162,12 @@ spec:
                   to false. This reduces the number of metrics reported, reducing
                   Prometheus load. [Default: true]'
                 type: boolean
+              prometheusWireGuardMetricsEnabled:
+                description: 'PrometheusWireGuardMetricsEnabled disables wireguard
+                  metrics collection, which the Prometheus client does by default,
+                  when set to false. This reduces the number of metrics reported,
+                  reducing Prometheus load. [Default: true]'
+                type: boolean
               removeExternalRoutes:
                 description: Whether or not to remove device routes that have not
                   been programmed by Felix. Disabling this will allow external applications
@@ -977,6 +1248,10 @@ spec:
               wireguardEnabled:
                 description: 'WireguardEnabled controls whether Wireguard is enabled.
                   [Default: false]'
+                type: boolean
+              wireguardHostEncryptionEnabled:
+                description: 'WireguardHostEncryptionEnabled controls whether Wireguard
+                  host-to-host encryption is enabled. [Default: false]'
                 type: boolean
               wireguardInterfaceName:
                 description: 'WireguardInterfaceName specifies the name to use for
@@ -1187,8 +1462,8 @@ spec:
                             within the selected service(s) will be matched, and only
                             to/from each endpoint's port. \n Services cannot be specified
                             on the same rule as Selector, NotSelector, NamespaceSelector,
-                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                            Only valid on egress rules."
+                            Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                            can only be specified with Services on ingress rules."
                           properties:
                             name:
                               description: Name specifies the name of a Kubernetes
@@ -1413,8 +1688,8 @@ spec:
                             within the selected service(s) will be matched, and only
                             to/from each endpoint's port. \n Services cannot be specified
                             on the same rule as Selector, NotSelector, NamespaceSelector,
-                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                            Only valid on egress rules."
+                            Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                            can only be specified with Services on ingress rules."
                           properties:
                             name:
                               description: Name specifies the name of a Kubernetes
@@ -1560,8 +1835,8 @@ spec:
                             within the selected service(s) will be matched, and only
                             to/from each endpoint's port. \n Services cannot be specified
                             on the same rule as Selector, NotSelector, NamespaceSelector,
-                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                            Only valid on egress rules."
+                            Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                            can only be specified with Services on ingress rules."
                           properties:
                             name:
                               description: Name specifies the name of a Kubernetes
@@ -1786,8 +2061,8 @@ spec:
                             within the selected service(s) will be matched, and only
                             to/from each endpoint's port. \n Services cannot be specified
                             on the same rule as Selector, NotSelector, NamespaceSelector,
-                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                            Only valid on egress rules."
+                            Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                            can only be specified with Services on ingress rules."
                           properties:
                             name:
                               description: Name specifies the name of a Kubernetes
@@ -2257,6 +2532,12 @@ spec:
           spec:
             description: IPPoolSpec contains the specification for an IPPool resource.
             properties:
+              allowedUses:
+                description: AllowedUse controls what the IP pool will be used for.  If
+                  not specified or empty, defaults to ["Tunnel", "Workload"] for back-compatibility
+                items:
+                  type: string
+                type: array
               blockSize:
                 description: The block size to use for IP address assignments from
                   this pool. Defaults to 26 for IPv4 and 112 for IPv6.
@@ -2267,6 +2548,10 @@ spec:
               disabled:
                 description: When disabled is true, Calico IPAM will not assign addresses
                   from this pool.
+                type: boolean
+              disableBGPExport:
+                description: "Disable exporting routes from this IP Pool's CIDR over
+                  BGP. [Default: false]"
                 type: boolean
               ipip:
                 description: 'Deprecated: this field is only used for APIv1 backwards
@@ -2312,6 +2597,57 @@ spec:
                 type: string
             required:
             - cidr
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ipreservations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPReservation
+    listKind: IPReservationList
+    plural: ipreservations
+    singular: ipreservation
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPReservationSpec contains the specification for an IPReservation
+              resource.
+            properties:
+              reservedCIDRs:
+                description: ReservedCIDRs is a list of CIDRs and/or IP addresses
+                  that Calico IPAM will exclude from new allocations.
+                items:
+                  type: string
+                type: array
             type: object
         type: object
     served: true
@@ -2727,8 +3063,8 @@ spec:
                             within the selected service(s) will be matched, and only
                             to/from each endpoint's port. \n Services cannot be specified
                             on the same rule as Selector, NotSelector, NamespaceSelector,
-                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                            Only valid on egress rules."
+                            Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                            can only be specified with Services on ingress rules."
                           properties:
                             name:
                               description: Name specifies the name of a Kubernetes
@@ -2953,8 +3289,8 @@ spec:
                             within the selected service(s) will be matched, and only
                             to/from each endpoint's port. \n Services cannot be specified
                             on the same rule as Selector, NotSelector, NamespaceSelector,
-                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                            Only valid on egress rules."
+                            Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                            can only be specified with Services on ingress rules."
                           properties:
                             name:
                               description: Name specifies the name of a Kubernetes
@@ -3100,8 +3436,8 @@ spec:
                             within the selected service(s) will be matched, and only
                             to/from each endpoint's port. \n Services cannot be specified
                             on the same rule as Selector, NotSelector, NamespaceSelector,
-                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                            Only valid on egress rules."
+                            Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                            can only be specified with Services on ingress rules."
                           properties:
                             name:
                               description: Name specifies the name of a Kubernetes
@@ -3326,8 +3662,8 @@ spec:
                             within the selected service(s) will be matched, and only
                             to/from each endpoint's port. \n Services cannot be specified
                             on the same rule as Selector, NotSelector, NamespaceSelector,
-                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
-                            Only valid on egress rules."
+                            Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                            can only be specified with Services on ingress rules."
                           properties:
                             name:
                               description: Name specifies the name of a Kubernetes
@@ -3484,6 +3820,7 @@ rules:
   - apiGroups: ["crd.projectcalico.org"]
     resources:
       - ippools
+      - ipreservations
     verbs:
       - list
   - apiGroups: ["crd.projectcalico.org"]
@@ -3624,6 +3961,7 @@ rules:
       - globalbgpconfigs
       - bgpconfigurations
       - ippools
+      - ipreservations
       - ipamblocks
       - globalnetworkpolicies
       - globalnetworksets
@@ -3632,6 +3970,7 @@ rules:
       - clusterinformations
       - hostendpoints
       - blockaffinities
+      - caliconodestatuses
     verbs:
       - get
       - list
@@ -3644,6 +3983,12 @@ rules:
       - clusterinformations
     verbs:
       - create
+      - update
+  # Calico must update some CRDs.
+  - apiGroups: [ "crd.projectcalico.org" ]
+    resources:
+      - caliconodestatuses
+    verbs:
       - update
   # Calico stores some configuration information on the node.
   - apiGroups: [""]
@@ -3762,7 +4107,7 @@ spec:
         #       install of CNI and upgrade of ipam are handled in the dedicated
         #       salt states
         #- name: upgrade-ipam
-        #  image: docker.io/calico/cni:v3.20.0
+        #  image: docker.io/calico/cni:v3.22.0
         #  command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
         #  envFrom:
         #  - configMapRef:
@@ -3789,7 +4134,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         #- name: install-cni
-        #  image: docker.io/calico/cni:v3.20.0
+        #  image: docker.io/calico/cni:v3.22.0
         #  command: ["/opt/cni/bin/install"]
         #  envFrom:
         #  - configMapRef:
@@ -3831,7 +4176,7 @@ spec:
         # to communicate with Felix over the Policy Sync API.
         # Note: In MetalK8s, we have no support for Dikastes (yet).
         #- name: flexvol-driver
-        #  image: docker.io/calico/pod2daemon-flexvol:v3.20.0
+        #  image: docker.io/calico/pod2daemon-flexvol:v3.22.0
         #  volumeMounts:
         #  - name: flexvol-driver-host
         #    mountPath: /host/driver
@@ -3932,6 +4277,12 @@ spec:
           resources:
             requests:
               cpu: 250m
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/calico-node
+                - -shutdown
           livenessProbe:
             exec:
               command:


### PR DESCRIPTION
NOTE: cni-plugin repository from Calico does no longer exist now the CNI
plugin is part of the main calico repository.
That's why we need to extract only the CNI plugin from this repository
when building the Calico CNI plugin package.