### PR TITLE
salt: Remove the Control Plane Ingress controller PDB in pre-upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
   Grafana datasources
   (PR[#3717](https://github.com/scality/metalk8s/pull/3717))
 
+- Fix a bug during the upgrade that block the eviction of the Control Plane Ingress
+  controller Pod
+  (PR[#3724](https://github.com/scality/metalk8s/pull/3724))
+
 ## Release 2.11.2
 ### Bug fixes
 

--- a/images/metalk8s-utils/configure-repos.sh
+++ b/images/metalk8s-utils/configure-repos.sh
@@ -11,7 +11,7 @@ name=Kubernetes
 baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el$CENTOS_VERSION-x86_64
 enabled=1
 gpgcheck=1
-repo_gpgcheck=1
+repo_gpgcheck=0
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
        https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOF

--- a/packages/redhat/common/yum_repositories/kubernetes.repo
+++ b/packages/redhat/common/yum_repositories/kubernetes.repo
@@ -3,6 +3,6 @@ name=Kubernetes
 baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
 enabled=1
 gpgcheck=1
-repo_gpgcheck=1
+repo_gpgcheck=0
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
        https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg

--- a/salt/metalk8s/orchestrate/upgrade/pre.sls
+++ b/salt/metalk8s/orchestrate/upgrade/pre.sls
@@ -2,6 +2,21 @@
 # NOTE: This state should be called by salt-master using the saltenv of
 # the destination version (salt-master should have been upgraded)
 
+# In 2.10.x we deploy an invalid PodDisruptionBudget with minAvailable set to 0
+# this PDB may break the upgrade as the Ingress Controller does not work properly
+# during this upgrade
+# NOTE: It only happen when the Control Plane Ingress is deployed as a Deployment
+# Since it's a really specific case we just delete this PDB so that we are able to
+# upgrade in this case
+# NOTE: We do no longer deploy this PDB in 2.11+
+# NOTE: It should be removed in `development/123.0`
+Ensure the Control Plane Ingress PodDisruptionBudget does not exists:
+  metalk8s_kubernetes.object_absent:
+    - apiVersion: policy/v1
+    - kind: PodDisruptionBudget
+    - name: ingress-nginx-control-plane-controller
+    - namespace: metalk8s-ingress
+
 {%- set cp_nodes = salt.metalk8s.minions_by_role('master') %}
 {%- if cp_nodes|length == 1 %}
 


### PR DESCRIPTION
The control plane Ingress might be not working during the upgrade
but since it's only for a specific upgrade path and transient since it's
fixed after the upgrade we only remove the PodDisruptionBugdget so that
the upgrade complete

---

NOTE: The workaround has been removed in 123.0 integration branch