### PR TITLE
charts,salt: Make node-exporter only listening on node IP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
   controller Pod
   (PR[#3724](https://github.com/scality/metalk8s/pull/3724))
 
+- [#2166](https://github.com/scality/metalk8s/issues/2166) - Make
+  Prometheus node exporter listening only on the Control Plane IP
+  (PR[#3725](https://github.com/scality/metalk8s/pull/3725))
+
 ## Release 2.11.2
 ### Bug fixes
 

--- a/charts/kube-prometheus-stack.yaml
+++ b/charts/kube-prometheus-stack.yaml
@@ -251,6 +251,8 @@ kube-state-metrics:
 
 
 prometheus-node-exporter:
+  service:
+    listenOnAllInterfaces: false
   image:
     repository: '__image__(node-exporter)'
   extraArgs:

--- a/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
@@ -61802,7 +61802,10 @@ spec:
         - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$
         env:
         - name: HOST_IP
-          value: 0.0.0.0
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.hostIP
         image: {% endraw -%}{{ build_image_name("node-exporter", False) }}{%- raw %}:v1.2.2
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/salt/metalk8s/defaults.yaml
+++ b/salt/metalk8s/defaults.yaml
@@ -122,7 +122,7 @@ networks:
       127.0.0.1:9099:
         expected: calico-node
         description: Calico node
-      0.0.0.0:9100:
+      control_plane_ip:9100:
         expected: node_exporter
         description: Node exporter
       127.0.0.1:10248:


### PR DESCRIPTION
NOTE: Node IP is set to Control Plane IP

Fixes: #2166 
