### PR TITLE
Allow to setup Loki `resources` from CSC

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 21.7b0
+    rev: 22.3.0
     hooks:
       - id: black
         name: Formatting Python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 ## Release 2.11.5 (in development)
+### Enhancements
 
+- Make Loki pod resources configurable
+  (PR[#3737](https://github.com/scality/metalk8s/pull/3737))
 ## Release 2.11.4
 ### Bug fixes
 

--- a/charts/loki.yaml
+++ b/charts/loki.yaml
@@ -157,7 +157,7 @@ readinessProbe:
 
 replicas: '__var__(loki.spec.deployment.replicas)'
 
-resources: {}
+resources: '__var__(loki.spec.deployment.resources)'
 # limits:
 #   cpu: 200m
 #   memory: 256Mi

--- a/docs/operation/cluster_and_service_configuration.rst
+++ b/docs/operation/cluster_and_service_configuration.rst
@@ -690,6 +690,36 @@ configuration, see the official `Loki documentation`_.
 
 .. _Loki documentation: https://grafana.com/docs/loki/latest/configuration/
 
+Add Loki memory limit
+"""""""""""""""""""""
+
+Loki consumes some memory to store chunks before they get written to disks.
+Its memory consumption really depends on the usage, which is why we do not
+set any limit by default.
+
+However, if Loki is unable to write to the disk for any reason, it will
+continue keeping logs in memory, leading to large memory consumption until
+the issue is resolved. To prevent Loki from taking too much from the host,
+potentially leading to starvation, you can define a resource limit on the
+Pod.
+
+For example, to set the limit to 4 GiB, the ConfigMap must be
+edited as follows:
+
+.. code-block:: yaml
+
+    apiVersion: v1
+    kind: ConfigMap
+    data:
+      config.yaml: |-
+        apiVersion: addons.metalk8s.scality.com
+        kind: LokiConfig
+        spec:
+          deployment:
+            resources:
+              limits:
+                memory: "4Gi"
+
 Changing the logs retention period
 """"""""""""""""""""""""""""""""""
 

--- a/salt/_modules/metalk8s_volumes.py
+++ b/salt/_modules/metalk8s_volumes.py
@@ -606,16 +606,16 @@ def _quantity_to_bytes(quantity):
     """
     UNIT_FACTOR = {
         None: 1,
-        "Ki": 2 ** 10,
-        "Mi": 2 ** 20,
-        "Gi": 2 ** 30,
-        "Ti": 2 ** 40,
-        "Pi": 2 ** 50,
-        "k": 10 ** 3,
-        "M": 10 ** 6,
-        "G": 10 ** 9,
-        "T": 10 ** 12,
-        "P": 10 ** 15,
+        "Ki": 2**10,
+        "Mi": 2**20,
+        "Gi": 2**30,
+        "Ti": 2**40,
+        "Pi": 2**50,
+        "k": 10**3,
+        "M": 10**6,
+        "G": 10**9,
+        "T": 10**12,
+        "P": 10**15,
     }
     size_regex = r"^(?P<size>[1-9][0-9]*)(?P<unit>[kKMGTP]i?)?$"
     match = re.match(size_regex, quantity)

--- a/salt/metalk8s/addons/logging/loki/config/loki.yaml
+++ b/salt/metalk8s/addons/logging/loki/config/loki.yaml
@@ -6,6 +6,9 @@ kind: LokiConfig
 spec:
   deployment:
     replicas: 1
+    resources:
+      requests:
+        memory: "256Mi"
   config:
     auth_enabled: false
     chunk_store_config:

--- a/salt/metalk8s/addons/logging/loki/deployed/chart.sls
+++ b/salt/metalk8s/addons/logging/loki/deployed/chart.sls
@@ -227,7 +227,7 @@ spec:
             path: /ready
             port: http-metrics
           initialDelaySeconds: 45
-        resources: {}
+        resources: {% endraw -%}{{ loki.spec.deployment.resources }}{%- raw %}
         securityContext:
           readOnlyRootFilesystem: true
         volumeMounts:

--- a/tests/post/steps/test_volume.py
+++ b/tests/post/steps/test_volume.py
@@ -495,16 +495,16 @@ def _quantity_to_bytes(quantity):
     """
     UNIT_FACTOR = {
         None: 1,
-        "Ki": 2 ** 10,
-        "Mi": 2 ** 20,
-        "Gi": 2 ** 30,
-        "Ti": 2 ** 40,
-        "Pi": 2 ** 50,
-        "k": 10 ** 3,
-        "M": 10 ** 6,
-        "G": 10 ** 9,
-        "T": 10 ** 12,
-        "P": 10 ** 15,
+        "Ki": 2**10,
+        "Mi": 2**20,
+        "Gi": 2**30,
+        "Ti": 2**40,
+        "Pi": 2**50,
+        "k": 10**3,
+        "M": 10**6,
+        "G": 10**9,
+        "T": 10**12,
+        "P": 10**15,
     }
     size_regex = r"^(?P<size>[1-9][0-9]*)(?P<unit>[kKMGTP]i?)?$"
     match = re.match(size_regex, quantity)


### PR DESCRIPTION
Since Loki has no way to limit the "in-memory" total chunk size in some
cases we may want to put a hard limit on the memory for the Loki pod in
order to avoid Loki to consume all the memory and make the server crash