### PR TITLE
scripts,salt: Do not reconfigure repository in local mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Fix MetalK8s sosreport plugin so that it properly retrieve namespaces
   (PR[#3740](https://github.com/scality/metalk8s/pull/3740))
 
+- Fix an issue that, if the upgrade fail at some point, you may be
+  left with no solutions Images available from the internal registry
+  (PR[#3741](https://github.com/scality/metalk8s/pull/3741))
+
 ## Release 2.11.4
 ### Bug fixes
 

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -627,7 +627,6 @@ SALT_FILES: Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path("salt/metalk8s/repo/macro.sls"),
     Path("salt/metalk8s/repo/redhat.sls"),
     Path("salt/metalk8s/roles/bootstrap/absent.sls"),
-    Path("salt/metalk8s/roles/bootstrap/components.sls"),
     Path("salt/metalk8s/roles/bootstrap/init.sls"),
     Path("salt/metalk8s/roles/bootstrap/local.sls"),
     Path("salt/metalk8s/roles/ca/absent.sls"),

--- a/salt/metalk8s/orchestrate/bootstrap/pre-upgrade.sls
+++ b/salt/metalk8s/orchestrate/bootstrap/pre-upgrade.sls
@@ -12,6 +12,7 @@ Prepare for Salt Master upgrade:
       - metalk8s.salt.master.certs
       - metalk8s.salt.master.kubeconfig
       - metalk8s.kubernetes.apiserver-proxy
+      - metalk8s.repo.installed
     - tgt: {{ salt['metalk8s.minions_by_role']('bootstrap') | first }}
     - saltenv: {{ saltenv }}
     - sync_mods: all

--- a/salt/metalk8s/roles/bootstrap/components.sls
+++ b/salt/metalk8s/roles/bootstrap/components.sls
@@ -1,4 +1,0 @@
-include:
-  - metalk8s.repo.installed
-  - metalk8s.salt.master.certs.salt-api
-  - metalk8s.salt.master.installed

--- a/salt/metalk8s/roles/bootstrap/local.sls
+++ b/salt/metalk8s/roles/bootstrap/local.sls
@@ -2,5 +2,7 @@ include:
   - metalk8s.archives.mounted
   - metalk8s.kubernetes.kubelet.standalone
   - metalk8s.internal.preflight
-  - .components
+  - metalk8s.repo.installed
+  - metalk8s.salt.master.certs.salt-api
+  - metalk8s.salt.master.installed
   - metalk8s.kubectl

--- a/scripts/upgrade.sh.in
+++ b/scripts/upgrade.sh.in
@@ -75,22 +75,17 @@ trap cleanup EXIT
 . "$BASE_DIR"/common.sh
 
 upgrade_bootstrap () {
-    local saltmaster_endpoint repo_endpoint
     "$SALT_CALL" saltutil.sync_all saltenv="$SALTENV"
-    saltmaster_endpoint="$($SALT_CALL pillar.get \
-        metalk8s:endpoints:salt-master --out txt | cut -d' ' -f2- )"
-    repo_endpoint="$($SALT_CALL pillar.get \
-        metalk8s:endpoints:repositories --out txt | cut -d' ' -f2- )"
 
     SALT_MASTER_CALL=(crictl exec -i "$(get_salt_container)")
     "${SALT_MASTER_CALL[@]}" salt-run state.orchestrate \
         metalk8s.orchestrate.bootstrap.pre-upgrade \
         saltenv="$SALTENV"
 
+    # Upgrade salt-master in local mode since salt-master will
+    # restart
     "${SALT_CALL}" --local --retcode-passthrough state.sls sync_mods="all" \
-        metalk8s.roles.bootstrap.components saltenv="$SALTENV" \
-        pillar="{'metalk8s': {'endpoints': {'salt-master': $saltmaster_endpoint, \
-        'repositories': $repo_endpoint}}}"
+        metalk8s.salt.master.installed saltenv="$SALTENV"
 }
 
 launch_pre_upgrade () {


### PR DESCRIPTION
Since the salt state to configure the repository relies on some variable from
pillar available in salt-master to manage the solution images, if we run
the repository state in local mode the solution image will no longer be
available in the registry

To avoid that kind of issue during the upgrade we only run the salt
master state in local mode