### PR TITLE
salt: Enable `initial-corrupt-check` for etcd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   left with no solutions Images available from the internal registry
   (PR[#3741](https://github.com/scality/metalk8s/pull/3741))
 
+- Enable `initial-corrupt-check` for etcd in order to try
+  to avoid data inconsistency issue in etcd
+  (PR[#3742](https://github.com/scality/metalk8s/pull/3742))
+
 ## Release 2.11.4
 ### Bug fixes
 

--- a/salt/metalk8s/kubernetes/etcd/installed.sls
+++ b/salt/metalk8s/kubernetes/etcd/installed.sls
@@ -80,6 +80,9 @@ Create local etcd Pod manifest:
           - --trusted-ca-file=/etc/kubernetes/pki/etcd/ca.crt
         # }
           - --initial-cluster-state={{ state }}
+          # See https://github.com/etcd-io/etcd/issues/13766
+          # https://groups.google.com/a/kubernetes.io/g/dev/c/B7gJs88XtQc/m/rSgNOzV2BwAJ?utm_medium=email&utm_source=footer
+          - --experimental-initial-corrupt-check=true
         volumes:
           - path: /var/lib/etcd
             name: etcd-data


### PR DESCRIPTION
Sees: https://github.com/kubernetes/kubeadm/issues/2676
Sees: https://github.com/etcd-io/etcd/issues/13766
Sees: https://groups.google.com/a/kubernetes.io/g/dev/c/B7gJs88XtQc/m/rSgNOzV2BwAJ?utm_medium=email&utm_source=footer