### PR TITLE
Improvement/module federation initial load perf improvements

### DIFF
--- a/eve/workers/pod-integration-tests/ui/pod.yaml
+++ b/eve/workers/pod-integration-tests/ui/pod.yaml
@@ -33,6 +33,7 @@ spec:
     volumeMounts:
       - name: shell-ui-files
         mountPath: /tmp/shell-ui-files
+  hostIPC: true
   containers:
   - name: worker
     image: {{ images['worker'] }}

--- a/shell-ui/src/navbar/NavBar.js
+++ b/shell-ui/src/navbar/NavBar.js
@@ -3,7 +3,7 @@ import CoreUINavbar from '@scality/core-ui/dist/components/navbar/Navbar.compone
 import Dropdown from '@scality/core-ui/dist/components/dropdown/Dropdown.component';
 import { type Item as CoreUIDropdownItem } from '@scality/core-ui/src/lib/components/dropdown/Dropdown.component';
 import { useEffect, useLayoutEffect, useState, useCallback } from 'react';
-import styled from 'styled-components';
+import styled, { createGlobalStyle } from 'styled-components';
 import type {
   Options,
   SolutionsNavbarProps,
@@ -42,6 +42,12 @@ export const LoadingNavbar = ({ logo }: { logo: string }): Node => (
     tabs={[{ title: 'loading' }]}
   />
 );
+
+const GlobalStyle = createGlobalStyle`
+  body {
+    background-color: ${(props) => props.theme.backgroundLevel1};
+  }
+`;
 
 const NavbarDropDownItem = styled.div`
   display: flex;
@@ -319,6 +325,7 @@ export const Navbar = ({
 
   return (
     <>
+      <GlobalStyle />
       <CoreUINavbar
         logo={<Logo src={logo} alt="logo" />}
         rightActions={rightActions}

--- a/shell-ui/src/navbar/index.js
+++ b/shell-ui/src/navbar/index.js
@@ -2,7 +2,6 @@
 import React, { useLayoutEffect, type Node, useMemo } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
-import reactToWebComponent from 'react-to-webcomponent';
 import { ThemeProvider as StyledComponentsProvider } from 'styled-components';
 import { WebStorageStateStore } from 'oidc-client';
 import { QueryClient, QueryClientProvider, useQuery } from 'react-query';

--- a/shell-ui/webpack.common.js
+++ b/shell-ui/webpack.common.js
@@ -4,7 +4,7 @@ const path = require('path');
 const deps = require('./package.json').dependencies;
 
 module.exports = {
-  entry: './src/App.jsx',
+  entry: './src/index.js',
   output: {
     path: path.resolve(__dirname, 'build'),
     publicPath: '/shell/',
@@ -78,16 +78,10 @@ module.exports = {
       },
       shared: {
         ...Object.fromEntries(
-          Object.entries(deps).map(([key, version]) => [
-            key,
-            {
-              eager: true,
-            },
-          ]),
+          Object.entries(deps).map(([key, version]) => [key, {}]),
         ),
         '@scality/core-ui': {
           singleton: true,
-          eager: true,
         },
         '@scality/module-federation': {
           singleton: true,
@@ -107,6 +101,26 @@ module.exports = {
           singleton: true,
           eager: true,
           requiredVersion: deps['react-dom'],
+        },
+        'react-query': {
+          singleton: true,
+          eager: true,
+        },
+        'react-router': {
+          singleton: true,
+          eager: true,
+        },
+        'react-router-dom': {
+          singleton: true,
+          eager: true,
+        },
+        polished: {
+          singleton: true,
+          eager: true,
+        },
+        'oidc-client': {
+          singleton: true,
+          eager: true,
         },
       },
     }),

--- a/ui/webpack.common.js
+++ b/ui/webpack.common.js
@@ -98,34 +98,24 @@ module.exports = (env) => ({
       },
       shared: {
         ...Object.fromEntries(
-          Object.entries(deps).map(([key, version]) => [
-            key,
-            {
-              eager: true,
-            },
-          ]),
+          Object.entries(deps).map(([key, version]) => [key, {}]),
         ),
         '@scality/core-ui': {
           singleton: true,
-          eager: true,
         },
         '@scality/module-federation': {
           singleton: true,
-          eager: true,
         },
         'styled-components': {
           singleton: true,
-          eager: true,
           requiredVersion: deps['styled-components'],
         },
         react: {
           singleton: true,
-          eager: true,
           requiredVersion: deps.react,
         },
         'react-dom': {
           singleton: true,
-          eager: true,
           requiredVersion: deps['react-dom'],
         },
       },


### PR DESCRIPTION
**Component**:

ui/shell-ui

**Context**: 

Metalk8s UI was beforehand bundling a certain amount of dependencies within it's remoteEntry bundle (due to the eager flag being set on).
This was consequently slowing down UI loading time.

**Summary**:

This PR improve UI performance by a very high factor (on application where Metalk8s UI is deployed aside of 2 other UI project I've noted a drop of initial loading time from 4.3 seconds to 1.3 seconds, with react being in dev mode so In prod I would expect an even better improvement).