### PR TITLE
docs: Update entrypoint so that we use the right user to run tox

### DIFF
--- a/docs/entrypoint.sh
+++ b/docs/entrypoint.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 
 BUILD_DIR=${BUILD_DIR:-/usr/src/metalk8s/docs/_build}
+TARGET_UID=${TARGET_UID:-$(id -u)}
+TARGET_GID=${TARGET_GID:-$(id -g)}
 
-change_build_ownership() {
-    chown -R "${TARGET_UID:-}:${TARGET_GID:-}" "$BUILD_DIR"
-}
+# If we are in docker user and group does not exists so create them
+if ! grep -q "$TARGET_UID" /etc/passwd; then
+  if ! grep -q "$TARGET_GID" /etc/group; then
+    groupadd -g "$TARGET_GID" tempgroup
+  fi
+  useradd -u "$TARGET_UID" -g "$TARGET_GID" tempuser
+fi
 
-trap change_build_ownership EXIT
-
-tox --workdir /tmp/tox -e docs -- "$@"
+sudo chown -R "$TARGET_UID:$TARGET_GID" /tmp/tox
+sudo -u "$(id -u -n "$TARGET_UID")" -E tox --workdir /tmp/tox -e docs -- "$@"


### PR DESCRIPTION
In order to build the documentation, we need to use the right user,
otherwise, git throw an error.
That's why in the build entry point we create a new user with the right IDs
if we need to