### PR TITLE
Bugfix: retrieve cluster version in node list component so that it is available when deploying 

### DIFF
--- a/ui/src/components/NodePageOverviewTab.js
+++ b/ui/src/components/NodePageOverviewTab.js
@@ -178,7 +178,7 @@ const NodePageOverviewTab = (props) => {
                 label={intl.formatMessage({ id: 'deploy' })}
                 variant="secondary"
                 onClick={() => {
-                  dispatch(deployNodeAction({ nodeName }));
+                  dispatch(deployNodeAction({ name: nodeName }));
                 }}
               />
             ) : (

--- a/ui/src/components/NodePageOverviewTab.js
+++ b/ui/src/components/NodePageOverviewTab.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { FormattedDate, FormattedTime } from 'react-intl';
 import styled from 'styled-components';
@@ -11,7 +11,7 @@ import ActiveAlertsCounter from './ActiveAlertsCounter';
 import { Steppers, Loader } from '@scality/core-ui';
 import { Button } from '@scality/core-ui/dist/next';
 import isEmpty from 'lodash.isempty';
-import { deployNodeAction } from '../ducks/app/nodes';
+import { deployNodeAction, fetchClusterVersionAction } from '../ducks/app/nodes';
 import {
   NodeTab,
   OverviewInformationLabel,
@@ -89,6 +89,11 @@ const NodePageOverviewTab = (props) => {
   const { nodeTableData, nodes, volumes, pods, nodeName } = props;
   const intl = useIntl();
   const dispatch = useDispatch();
+
+  //Node deployment rely on the cluster version hence we need to ensure to have fetch it here 
+  useEffect(() => {
+    dispatch(fetchClusterVersionAction());
+  }, [dispatch]);
 
   const jobs = useSelector((state) =>
     state.app.salt.jobs.filter(

--- a/ui/src/containers/NodeList.js
+++ b/ui/src/containers/NodeList.js
@@ -1,6 +1,6 @@
 //@flow
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useHistory } from 'react-router';
 import styled from 'styled-components';
@@ -9,6 +9,7 @@ import { Button } from '@scality/core-ui/dist/next';
 import { padding } from '@scality/core-ui/dist/style/theme';
 import {
   deployNodeAction,
+  fetchClusterVersionAction,
   refreshNodesAction,
   stopRefreshNodesAction,
 } from '../ducks/app/nodes';
@@ -61,6 +62,11 @@ const NodeList = () => {
   const deployNode = (payload) => dispatch(deployNodeAction(payload));
   const intl = useIntl();
   useRefreshEffect(refreshNodesAction, stopRefreshNodesAction);
+
+  //Node deployment rely on the cluster version hence we need to ensure to have fetch it here 
+  useEffect(() => {
+    dispatch(fetchClusterVersionAction());
+  }, [dispatch]);
 
   const [sortBy, setSortBy] = useState('name');
   const [sortDirection, setSortDirection] = useState('ASC');


### PR DESCRIPTION
**Component**:

UI

**Context**: 

Deploying a node from the UI was not operating normally.

**Summary**:

Redux state was not initiated with cluster version and the node name was not sent when deploying the node.
