### PR TITLE
salt,docs,tests: Allow to change portmap IPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   your own IDP for kube-apiserver, Grafana and MetalK8s UI
   (PR[#3688](https://github.com/scality/metalk8s/pull/3688))
 
+- Add ability to change the portmap CIDRs, so that Workload Plane
+  Ingress could be exposed on a different IP
+  (PR[#3755](https://github.com/scality/metalk8s/pull/3755))
+
 ### Enhancements
 
 - Bump Kubernetes version to

--- a/docs/installation/bootstrap.rst
+++ b/docs/installation/bootstrap.rst
@@ -63,6 +63,9 @@ Configuration
           mtu: <network-MTU>
         pods: <CIDR-notation>
         services: <CIDR-notation>
+        portmap:
+          cidr:
+            - <CIDR-notation>
       proxies:
         http: <http://proxy-ip:proxy-port>
         https: <https://proxy-ip:proxy-port>
@@ -171,6 +174,19 @@ notation for it's various subfields.
             networks:
               pods: 10.233.0.0/16
               services: 10.96.0.0/12
+
+      The ``portmap`` field is not mandatory, though can be changed in order
+      to expose the ``hostPort`` on different IPs, with ``cidr`` you can
+      define a list of range of IP addresses that will be used at the host
+      level for each member of the cluster to expose the ``portmap`` (default
+      to node Workload Plane IP)
+
+      .. note::
+
+        The Workload Plane Ingress rely on those ``hostPort``, which means
+        that if you change this ``portmap`` the Workload Plane Ingress will
+        be exposed on IPs matching the ``portmap`` range of IP on every
+        member of the cluster
 
 The ``proxies`` field can be omitted if there is no proxy to configure.
 The 2 entries ``http`` and ``https`` are used to configure the containerd

--- a/salt/_modules/metalk8s_network.py
+++ b/salt/_modules/metalk8s_network.py
@@ -257,3 +257,22 @@ def get_control_plane_ingress_endpoint():
     return "https://{}:8443".format(
         __salt__["metalk8s_network.get_control_plane_ingress_ip"]()
     )
+
+
+def get_portmap_ips(as_cidr=False):
+    portmap_ips = set()
+    portmap_cidrs = __salt__["pillar.get"]("networks:portmap:cidr")
+
+    if portmap_cidrs:
+        if not isinstance(portmap_cidrs, list):
+            portmap_cidrs = [portmap_cidrs]
+        for cidr in portmap_cidrs:
+            portmap_ips.update(__salt__["network.ip_addrs"](cidr=cidr))
+    else:
+        portmap_ips = {__grains__["metalk8s"]["workload_plane_ip"]}
+
+    portmap_ips.add("127.0.0.1")
+
+    if as_cidr:
+        return [f"{ip}/32" for ip in sorted(portmap_ips)]
+    return sorted(portmap_ips)

--- a/salt/_pillar/metalk8s.py
+++ b/salt/_pillar/metalk8s.py
@@ -128,6 +128,7 @@ def _load_networks(config_data):
         "workload_plane": networks_data["workloadPlane"],
         "pod": networks_data.get("pods", DEFAULT_POD_NETWORK),
         "service": networks_data.get("services", DEFAULT_SERVICE_NETWORK),
+        "portmap": networks_data.get("portmap"),
     }
 
 

--- a/salt/metalk8s/addons/nginx-ingress/certs/server.sls
+++ b/salt/metalk8s/addons/nginx-ingress/certs/server.sls
@@ -26,13 +26,12 @@ Create Workload-Plane Ingress server private key:
 {%- set certSANs = [
     grains.fqdn,
     'localhost',
-    '127.0.0.1',
     'nginx-ingress-workload-plane',
     'nginx-ingress-workload-plane.metalk8s-ingress',
     'nginx-ingress-workload-plane.metalk8s-ingress.svc',
     'nginx-ingress-workload-plane.metalk8s-ingress.svc.' ~ coredns.cluster_domain,
-    grains.metalk8s.workload_plane_ip,
 ] %}
+{%- do certSANs.extend(salt.metalk8s_network.get_portmap_ips()) %}
 
 Generate Workload-Plane Ingress server certificate:
   x509.certificate_managed:

--- a/salt/metalk8s/kubernetes/cni/calico/configured.sls
+++ b/salt/metalk8s/kubernetes/cni/calico/configured.sls
@@ -63,7 +63,9 @@ Create CNI calico configuration file:
             snat: true
             capabilities:
               portMappings: true
-            conditionsV4: ["-d", "{{ grains.metalk8s.workload_plane_ip }}/32,127.0.0.1/32"]
+            conditionsV4:
+              - "-d"
+              - "{{ salt.metalk8s_network.get_portmap_ips(as_cidr=True) | join(',') }}"
           # Note: Calico upstream enables the `bandwidth` CNI plugin by default.
           # However, this plugin (executable) is not available in the CNI RPM
           # package we currently install. Hence, not enabling this functionality

--- a/salt/tests/unit/formulas/fixtures/salt.py
+++ b/salt/tests/unit/formulas/fixtures/salt.py
@@ -424,6 +424,9 @@ register_basic("metalk8s_network.get_control_plane_ingress_ip")(
 register_basic("metalk8s_network.get_control_plane_ingress_endpoint")(
     MagicMock(return_value="https://192.168.1.240:8443")
 )
+register_basic("metalk8s_network.get_portmap_ips")(
+    MagicMock(return_value=["192.168.1.100", "127.0.0.1"])
+)
 
 
 @register_basic("metalk8s_network.get_ip_from_cidrs")

--- a/salt/tests/unit/modules/files/test_metalk8s_network.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_network.yaml
@@ -135,3 +135,99 @@ get_control_plane_ingress_endpoint:
   - cp_ingress_ip_ret: "Error because of banana"
     raises: true
     result: "Error because of banana"
+
+get_portmap_ips:
+  # 1. Nominal (no CIDRs, using workload plane IP)
+  - result:
+      - 10.10.10.10
+      - 127.0.0.1
+  - as_cidr: True
+    result:
+      - 10.10.10.10/32
+      - 127.0.0.1/32
+
+  # 2. Define CIDR in config
+  - cidrs: 10.20.0.0/16
+    ip_addrs:
+      10.20.0.0/16:
+        - 10.20.0.20
+    result:
+      - 10.20.0.20
+      - 127.0.0.1
+
+  # 3. Multiple IPs in a single CIDR
+  - cidrs:
+      - 10.20.0.0/16
+    ip_addrs:
+      10.20.0.0/16:
+        - 10.20.0.20
+        - 10.20.0.21
+    result:
+      - 10.20.0.20
+      - 10.20.0.21
+      - 127.0.0.1
+
+  # 4. Multiple CIDRs (only an IP in one CIDR)
+  - cidrs:
+      - 10.20.0.0/16
+      - 10.30.0.0/16
+    ip_addrs:
+      10.20.0.0/16:
+        - 10.20.0.10
+      10.30.0.0/16: []
+    result:
+      - 10.20.0.10
+      - 127.0.0.1
+
+  # 5. Multiple CIDRs (one IP per CIDR)
+  - cidrs:
+      - 10.20.0.0/16
+      - 10.30.0.0/16
+    ip_addrs:
+      10.20.0.0/16:
+        - 10.20.0.10
+      10.30.0.0/16:
+        - 10.30.0.10
+    result:
+      - 10.20.0.10
+      - 10.30.0.10
+      - 127.0.0.1
+
+  # 6. Multiple IPs in multiple CIDRs
+  - cidrs:
+      - 10.20.0.0/16
+      - 10.30.0.0/16
+      - 10.40.0.0/16
+      - 10.50.0.0/16
+    ip_addrs:
+      10.20.0.0/16:
+        - 10.20.0.10
+        - 10.20.0.21
+      10.30.0.0/16: []
+      10.40.0.0/16:
+        - 10.40.0.10
+      10.50.0.0/16:
+        - 10.50.0.10
+        - 10.50.0.21
+    result:
+      - 10.20.0.10
+      - 10.20.0.21
+      - 10.40.0.10
+      - 10.50.0.10
+      - 10.50.0.21
+      - 127.0.0.1
+
+  # 7. CIDRs overlap
+  - cidrs:
+      - 10.20.10.0/24
+      - 10.20.0.0/16
+    ip_addrs:
+      10.20.10.0/24:
+        - 10.20.10.10
+      10.20.0.0/16:
+        - 10.20.0.10
+        - 10.20.10.10
+    result:
+      - 10.20.0.10
+      - 10.20.10.10
+      - 127.0.0.1

--- a/salt/tests/unit/modules/test_metalk8s_network.py
+++ b/salt/tests/unit/modules/test_metalk8s_network.py
@@ -363,3 +363,25 @@ class Metalk8sNetworkTestCase(TestCase, mixins.LoaderModuleMockMixin):
                 self.assertEqual(
                     metalk8s_network.get_control_plane_ingress_endpoint(), result
                 )
+
+    @utils.parameterized_from_cases(YAML_TESTS_CASES["get_portmap_ips"])
+    def test_get_portmap_ips(self, result, cidrs=None, ip_addrs=None, **kwargs):
+        """
+        Tests the return of `get_portmap_ips` function
+        """
+        grains = {"metalk8s": {"workload_plane_ip": "10.10.10.10"}}
+
+        def _get_ip_addrs(cidr):
+            if isinstance(ip_addrs, dict):
+                return ip_addrs.get(cidr)
+            return ip_addrs
+
+        salt_dict = {
+            "pillar.get": MagicMock(return_value=cidrs),
+            "network.ip_addrs": MagicMock(side_effect=_get_ip_addrs),
+        }
+
+        with patch.dict(metalk8s_network.__salt__, salt_dict), patch.dict(
+            metalk8s_network.__grains__, grains
+        ):
+            self.assertEqual(result, metalk8s_network.get_portmap_ips(**kwargs))

--- a/tests/post/features/ingress.feature
+++ b/tests/post/features/ingress.feature
@@ -40,6 +40,15 @@ Feature: Ingress
         When we perform an HTTP request on port 80 on a control-plane IP
         Then the server should not respond
 
+    Scenario: Expose Workload Plane Ingress on Control Plane
+        Given the Kubernetes API is available
+        And the node control-plane IP is not equal to its workload-plane IP
+        When we set portmap CIDRs to control-plane CIDR
+        And we trigger a rollout restart of 'daemonset/ingress-nginx-controller' in namespace 'metalk8s-ingress'
+        And we wait for the rollout of 'daemonset/ingress-nginx-controller' in namespace 'metalk8s-ingress' to complete
+        Then an HTTP request on port 80 on a workload-plane IP should not return
+        And an HTTP request on port 80 on a control-plane IP returns 404 'Not Found'
+
     @authentication
     Scenario: Failover of Control Plane Ingress VIP using MetalLB
         Given the Kubernetes API is available


### PR DESCRIPTION
In order to be able to expose the Workload Plane Ingress on another IP
than the Workload Plane IP of each node, we allow setting the portmap
CIDRs from the bootstrap configuration file