### PR TITLE
charts,salt,build: Bump fluent-bit chart to 0.20.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,10 +115,10 @@
   (PR[#3762](https://github.com/scality/metalk8s/pull/3762))
 
 - Migrate from grafana fluent-bit deprecated chart to fluent-bit fluent chart
-  version [0.19.19](https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.19.19)
+  version [0.20.3](https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.20.3)
   The fluent-bit-plugin-loki image has been changed accordingly to fluent-bit
-  version [1.8.12](https://github.com/fluent/fluent-bit/releases/tag/v1.8.12)
-  (PR[#3709](https://github.com/scality/metalk8s/pull/3709))
+  version [1.9.5](https://github.com/fluent/fluent-bit/releases/tag/v1.9.5)
+  (PR[#3761](https://github.com/scality/metalk8s/pull/3761))
 
 - Bump MetalLB chart version to
   [3.0.6](https://artifacthub.io/packages/helm/bitnami/metallb/3.0.6)

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -263,8 +263,8 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     ),
     Image(
         name="fluent-bit",
-        version="1.8.12",
-        digest="sha256:35de7f8e4cf845c060d3feb09e19254177993537dfb7b8a06a8ba5748e6b8551",
+        version="1.9.6",
+        digest="sha256:dff47966c7c5f91fdfe44e94938db092902e0670302c853bd463d8e277756751",
     ),
 )
 

--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -1,9 +1,9 @@
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update fluent-bit image to 1.8.12."
+      description: "Update fluent-bit image to 1.9.6."
 apiVersion: v1
-appVersion: 1.8.12
+appVersion: 1.9.6
 description: Fast and lightweight log processor and forwarder or Linux, OSX and BSD
   family operating systems.
 home: https://fluentbit.io/
@@ -13,7 +13,7 @@ keywords:
 - fluent-bit
 - fluentd
 maintainers:
-- email: eduardo@treasure-data.com
+- email: eduardo@calyptia.com
   name: edsiper
 - email: naseem@transit.app
   name: naseemkullah
@@ -24,4 +24,4 @@ maintainers:
 name: fluent-bit
 sources:
 - https://github.com/fluent/fluent-bit/
-version: 0.19.19
+version: 0.20.4

--- a/charts/fluent-bit/templates/clusterrole.yaml
+++ b/charts/fluent-bit/templates/clusterrole.yaml
@@ -29,4 +29,14 @@ rules:
     verbs:
       - use
   {{- end }}
+  {{- if and .Values.openShift.enabled .Values.openShift.securityContextConstraints.create }}
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - {{ include "fluent-bit.fullname" . }}
+    verbs:
+      - use
+  {{- end }}
 {{- end -}}

--- a/charts/fluent-bit/templates/scc.yaml
+++ b/charts/fluent-bit/templates/scc.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.openShift.enabled .Values.openShift.securityContextConstraints.create }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: {{ include "fluent-bit.fullname" . }}
+{{- if .Values.openShift.securityContextConstraints.annotations }}
+  annotations:
+    {{- toYaml .Values.openShift.securityContextConstraints.annotations | nindent 4 }}
+{{- end }}
+allowPrivilegedContainer: true
+allowPrivilegeEscalation: true
+allowHostDirVolumePlugin: true
+defaultAllowPrivilegeEscalation: false
+# forbid host namespaces
+allowHostNetwork: false
+allowHostIPC: false
+allowHostPorts: false
+allowHostPID: false
+allowedCapabilities: []
+forbiddenSysctls:
+- "*"
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - configMap
+  - emptyDir
+  - hostPath
+  - persistentVolumeClaim
+  - secret
+{{- end }}

--- a/charts/fluent-bit/templates/service.yaml
+++ b/charts/fluent-bit/templates/service.yaml
@@ -13,6 +13,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if and (eq .Values.service.type "ClusterIP") (.Values.service.clusterIP) }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -7,7 +7,7 @@ kind: DaemonSet
 replicaCount: 1
 
 image:
-  repository: fluent/fluent-bit
+  repository: cr.fluentbit.io/fluent/fluent-bit
   # Overrides the image tag whose default is {{ .Chart.AppVersion }}
   tag: ""
   pullPolicy: Always
@@ -34,6 +34,14 @@ rbac:
 podSecurityPolicy:
   create: false
   annotations: {}
+
+openShift:
+  # Sets Openshift support
+  enabled: false
+  # Creates SCC for Fluent-bit when Openshift support is enabled
+  securityContextConstraints:
+    create: true
+    annotations: {}
 
 podSecurityContext: {}
 #   fsGroup: 2000
@@ -71,6 +79,7 @@ service:
   port: 2020
   labels: {}
   # nodePort: 30020
+  # clusterIP: 172.16.10.1
   annotations: {}
 #   prometheus.io/path: "/api/v1/metrics/prometheus"
 #   prometheus.io/port: "2020"

--- a/salt/metalk8s/addons/logging/fluent-bit/deployed/chart.sls
+++ b/salt/metalk8s/addons/logging/fluent-bit/deployed/chart.sls
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: fluent-bit
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.8.12
-    helm.sh/chart: fluent-bit-0.19.19
+    app.kubernetes.io/version: 1.9.6
+    helm.sh/chart: fluent-bit-0.20.4
     heritage: metalk8s
   name: fluent-bit
   namespace: metalk8s-logging
@@ -28,8 +28,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: fluent-bit
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.8.12
-    helm.sh/chart: fluent-bit-0.19.19
+    app.kubernetes.io/version: 1.9.6
+    helm.sh/chart: fluent-bit-0.20.4
     heritage: metalk8s
   name: fluent-bit
   namespace: metalk8s-logging
@@ -52,8 +52,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: fluent-bit
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.8.12
-    helm.sh/chart: fluent-bit-0.19.19
+    app.kubernetes.io/version: 1.9.6
+    helm.sh/chart: fluent-bit-0.20.4
     heritage: metalk8s
   name: fluent-bit
   namespace: metalk8s-logging
@@ -74,8 +74,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: fluent-bit
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.8.12
-    helm.sh/chart: fluent-bit-0.19.19
+    app.kubernetes.io/version: 1.9.6
+    helm.sh/chart: fluent-bit-0.20.4
     heritage: metalk8s
   name: fluent-bit
   namespace: metalk8s-logging
@@ -98,8 +98,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: fluent-bit
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.8.12
-    helm.sh/chart: fluent-bit-0.19.19
+    app.kubernetes.io/version: 1.9.6
+    helm.sh/chart: fluent-bit-0.20.4
     heritage: metalk8s
   name: fluent-bit
   namespace: metalk8s-logging
@@ -121,7 +121,7 @@ spec:
         app.kubernetes.io/name: fluent-bit
     spec:
       containers:
-      - image: {% endraw -%}{{ build_image_name("fluent-bit", False) }}{%- raw %}:1.8.12
+      - image: {% endraw -%}{{ build_image_name("fluent-bit", False) }}{%- raw %}:1.9.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -193,8 +193,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: fluent-bit
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.8.12
-    helm.sh/chart: fluent-bit-0.19.19
+    app.kubernetes.io/version: 1.9.6
+    helm.sh/chart: fluent-bit-0.20.4
     heritage: metalk8s
     metalk8s.scality.com/monitor: ''
   name: fluent-bit


### PR DESCRIPTION
We also bump the fluent-bit container image to v1.9.5