### PR TITLE
charts,salt,build,tests: Bump Dex chart to v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,11 @@
   `salt-master` container
   (PR[#3773](https://github.com/scality/metalk8s/pull/3773))
 
+- Bump Dex chart version to [0.8.2](https://artifacthub.io/packages/helm/dex/dex/0.8.2),
+  Dex image has been bumped accordingly to
+  [v2.31.1](https://github.com/dexidp/dex/releases/tag/v2.31.1)
+  (PR[#3765](https://github.com/scality/metalk8s/pull/3765))
+
 ## Release 2.11.8 (in development)
 
 ## Release 2.11.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,7 @@
 
 - Bump Dex chart version to [0.8.2](https://artifacthub.io/packages/helm/dex/dex/0.8.2),
   Dex image has been bumped accordingly to
-  [v2.31.1](https://github.com/dexidp/dex/releases/tag/v2.31.1)
+  [v2.31.2](https://github.com/dexidp/dex/releases/tag/v2.31.2)
   (PR[#3765](https://github.com/scality/metalk8s/pull/3765))
 
 ## Release 2.11.8 (in development)

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -283,6 +283,8 @@ SALT_FILES: Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path("salt/metalk8s/addons/dex/deployed/secret.sls"),
     Path("salt/metalk8s/addons/dex/deployed/service-configuration.sls"),
     Path("salt/metalk8s/addons/dex/deployed/tls-secret.sls"),
+    Path("salt/metalk8s/addons/dex/deployed/post-upgrade.sls"),
+    Path("salt/metalk8s/addons/dex/deployed/post-downgrade.sls"),
     Path("salt/metalk8s/addons/dex/deployed/clusterrolebinding.sls"),
     targets.SerializedData(
         task_name="theme-configmap.sls",

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -113,8 +113,8 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     ),
     Image(
         name="dex",
-        version="v2.31.1",
-        digest="sha256:6d75c7b5214699941b0dd2fd3d39a4b1288868001ed324e5bb1b90978f411bfa",
+        version="v2.31.2",
+        digest="sha256:a4422334fc2fa528f0b9ca59fe1dff1f41ec66e5086facc85b32fc8d3da72a79",
     ),
     Image(
         name="etcd",

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -113,8 +113,8 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     ),
     Image(
         name="dex",
-        version="v2.30.0",
-        digest="sha256:63fc6ee14bcf1868ebfba90885aec76597e0f27bc8e89d1fd238b1f2ee3dea6e",
+        version="v2.31.1",
+        digest="sha256:6d75c7b5214699941b0dd2fd3d39a4b1288868001ed324e5bb1b90978f411bfa",
     ),
     Image(
         name="etcd",

--- a/charts/dex.yaml
+++ b/charts/dex.yaml
@@ -1,5 +1,8 @@
 image:
   repository: '__image__(dex)'
+  # NOTE: we explicitly select a tag because the latest chart doesn't include
+  # this version yet, which we still want for some security fixes
+  tag: "v2.31.2"
 
 nodeSelector:
   node-role.kubernetes.io/infra: ''

--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,12 +1,12 @@
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "`clusterIP` value to control the IP when using ClusterIP service type"
+    - kind: changed
+      description: "Restore `ClusterRoleBinding` when using cluster scoped permissions"
   artifacthub.io/images: |
     - name: dex
-      image: ghcr.io/dexidp/dex:v2.30.0
+      image: ghcr.io/dexidp/dex:v2.31.1
 apiVersion: v2
-appVersion: 2.30.0
+appVersion: 2.31.1
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable
   connectors.
 home: https://dexidp.io/
@@ -26,4 +26,4 @@ sources:
 - https://github.com/dexidp/dex
 - https://github.com/dexidp/helm-charts/tree/master/charts/dex
 type: application
-version: 0.6.3
+version: 0.8.2

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -1,6 +1,6 @@
 # dex
 
-![version: 0.6.3](https://img.shields.io/badge/version-0.6.3-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.30.0](https://img.shields.io/badge/app%20version-2.30.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
+![version: 0.8.2](https://img.shields.io/badge/version-0.8.2-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.31.1](https://img.shields.io/badge/app%20version-2.31.1-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
 
 OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
 
@@ -127,10 +127,12 @@ ingress:
 | volumeMounts | list | `[]` | Additional [volume mounts](https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1) for details. |
 | envFrom | list | `[]` | Additional environment variables mounted from [secrets](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables) or [config maps](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables) for details. |
 | env | object | `{}` | Additional environment variables passed directly to containers. See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables) for details. |
+| envVars | list | `[]` | Similar to env but with support for all possible configurations. See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables) for details. |
 | serviceAccount.create | bool | `true` | Enable service account creation. |
 | serviceAccount.annotations | object | `{}` | Annotations to be added to the service account. |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |
 | rbac.create | bool | `true` | Specifies whether RBAC resources should be created. If disabled, the operator is responsible for creating the necessary resources based on the templates. |
+| rbac.createClusterScoped | bool | `true` | Specifies which RBAC resources should be created. If disabled, the operator is responsible for creating the necessary resources (ClusterRole and RoleBinding or CRD's) |
 | podAnnotations | object | `{}` | Annotations to be added to pods. |
 | podDisruptionBudget.enabled | bool | `false` | Enable a [pod distruption budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) to help dealing with [disruptions](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/). It is **highly recommended** for webhooks as disruptions can prevent launching new pods. |
 | podDisruptionBudget.minAvailable | int/percentage | `nil` | Number or percentage of pods that must remain available. |
@@ -152,11 +154,18 @@ ingress:
 | ingress.annotations | object | `{}` | Annotations to be added to the ingress. |
 | ingress.hosts | list | See [values.yaml](values.yaml). | Ingress host configuration. |
 | ingress.tls | list | See [values.yaml](values.yaml). | Ingress TLS configuration. |
+| serviceMonitor.enabled | bool | `false` | Enable Prometheus ServiceMonitor. See the [documentation](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/design.md#servicemonitor) and the [API reference](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor) for details. |
+| serviceMonitor.namespace | string | Release namespace. | Namespace where the ServiceMonitor resource should be deployed. |
+| serviceMonitor.interval | duration | `nil` | Prometheus scrape interval. |
+| serviceMonitor.scrapeTimeout | duration | `nil` | Prometheus scrape timeout. |
+| serviceMonitor.labels | object | `{}` | Labels to be added to the ServiceMonitor. |
 | resources | object | No requests or limits. | Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) for details. |
 | autoscaling | object | Disabled by default. | Autoscaling configuration (see [values.yaml](values.yaml) for details). |
 | nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) configuration. |
 | tolerations | list | `[]` | [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for node taints. See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) for details. |
 | affinity | object | `{}` | [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) configuration. See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) for details. |
+| topologySpreadConstraints | list | `[]` | [TopologySpreadConstraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) configuration. See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) for details. |
+| strategy | object | `{}` | Deployment [strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) configuration. |
 
 ## Migrating from stable/dex (or banzaicloud-stable/dex) chart
 

--- a/charts/dex/templates/deployment.yaml
+++ b/charts/dex/templates/deployment.yaml
@@ -8,13 +8,13 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
-  selector:
-    matchLabels:
-      {{- include "dex.selectorLabels" . | nindent 6 }}
   {{- with .Values.strategy }}
   strategy:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  selector:
+    matchLabels:
+      {{- include "dex.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -38,7 +38,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- with .Values.hostAliases }}
-      hostAliases: 
+      hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
@@ -68,6 +68,9 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+          {{- with .Values.envVars }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}
@@ -119,6 +122,10 @@ spec:
       {{- end }}
       {{- with .Values.affinity }}
       affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}

--- a/charts/dex/templates/ingress.yaml
+++ b/charts/dex/templates/ingress.yaml
@@ -1,9 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "dex.fullname" . -}}
 {{- $svcPort := .Values.service.ports.http.port -}}
-{{- if .Values.https.enabled -}}
-  {{- $svcPort = .Values.service.ports.https.port -}}
-{{- end }}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}

--- a/charts/dex/templates/ingress.yaml
+++ b/charts/dex/templates/ingress.yaml
@@ -1,6 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "dex.fullname" . -}}
 {{- $svcPort := .Values.service.ports.http.port -}}
+{{- if .Values.https.enabled -}}
+  {{- $svcPort = .Values.service.ports.https.port -}}
+{{- end }}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}

--- a/charts/dex/templates/rbac.yaml
+++ b/charts/dex/templates/rbac.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: {{ include "dex.fullname" . }}
   labels:
@@ -9,15 +9,38 @@ rules:
   - apiGroups: ["dex.coreos.com"]
     resources: ["*"]
     verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "dex.fullname" . }}
+  labels:
+    {{- include "dex.labels" . | nindent 4 }}
+roleRef:
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+  name: {{ include "dex.fullname" . }}  
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "dex.serviceAccountName" . }}
+{{- if .Values.rbac.createClusterScoped }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "dex.fullname" . }}
+  labels:
+    {{- include "dex.labels" . | nindent 4 }}
+rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
-    verbs: ["create"]
-
+    verbs: ["list", "create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "dex.fullname" . }}
+  name: {{ include "dex.fullname" . }}-cluster
   labels:
     {{- include "dex.labels" . | nindent 4 }}
 roleRef:
@@ -28,4 +51,5 @@ subjects:
 - kind: ServiceAccount
   namespace: {{ .Release.Namespace }}
   name: {{ include "dex.serviceAccountName" . }}
+{{- end }}
 {{- end }}

--- a/charts/dex/templates/servicemonitor.yaml
+++ b/charts/dex/templates/servicemonitor.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "dex.fullname" . }}
+  {{- with .Values.serviceMonitor.namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  labels:
+    {{- include "dex.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+      {{ toYaml . | indent 4}}
+    {{- end }}
+spec:
+  endpoints:
+    - port: telemetry
+      {{- with .Values.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+  jobLabel: {{ include "dex.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "dex.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -67,6 +67,22 @@ envFrom: []
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables) for details.
 env: {}
 
+# -- Similar to env but with support for all possible configurations.
+# See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables) for details.
+envVars: []
+# - name: SOME_ENV_VAR
+#   value: value
+# - name: SOME_ENV_VAR2
+#   valueFrom:
+#     secretKeyRef:
+#       name: secret-name
+#       key: secret-key
+# - name: SOME_ENV_VAR3
+#   valueFrom:
+#     configMapKeyRef:
+#       name: config-map-name
+#       key: config-map-key
+
 serviceAccount:
   # -- Enable service account creation.
   create: true
@@ -82,6 +98,10 @@ rbac:
   # -- Specifies whether RBAC resources should be created.
   # If disabled, the operator is responsible for creating the necessary resources based on the templates.
   create: true
+
+  # -- Specifies which RBAC resources should be created.
+  # If disabled, the operator is responsible for creating the necessary resources (ClusterRole and RoleBinding or CRD's)
+  createClusterScoped: true
 
 # -- Annotations to be added to pods.
 podAnnotations: {}
@@ -174,6 +194,24 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+serviceMonitor:
+  # -- Enable Prometheus ServiceMonitor.
+  # See the [documentation](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/design.md#servicemonitor) and the [API reference](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor) for details.
+  enabled: false
+
+  # -- Namespace where the ServiceMonitor resource should be deployed.
+  # @default -- Release namespace.
+  namespace: ""
+
+  # -- (duration) Prometheus scrape interval.
+  interval:
+
+  # -- (duration) Prometheus scrape timeout.
+  scrapeTimeout:
+
+  # -- Labels to be added to the ServiceMonitor.
+  labels: {}
+
 # -- Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) for details.
 # @default -- No requests or limits.
@@ -208,3 +246,13 @@ tolerations: []
 # -- [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) configuration.
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) for details.
 affinity: {}
+
+# -- [TopologySpreadConstraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) configuration.
+# See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) for details.
+topologySpreadConstraints: []
+
+# -- Deployment [strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) configuration.
+strategy: {}
+  # rollingUpdate:
+  #   maxUnavailable: 1
+  # type: RollingUpdate

--- a/salt/metalk8s/addons/dex/deployed/chart.sls
+++ b/salt/metalk8s/addons/dex/deployed/chart.sls
@@ -277,7 +277,7 @@ spec:
           service:
             name: dex
             port:
-              number: 5556
+              number: 5554
         path: /oidc
         pathType: Prefix
 

--- a/salt/metalk8s/addons/dex/deployed/chart.sls
+++ b/salt/metalk8s/addons/dex/deployed/chart.sls
@@ -1,7 +1,7 @@
 #!jinja | metalk8s_kubernetes
 
 {%- from "metalk8s/repo/macro.sls" import build_image_name with context %}
-{% set dex_defaults = salt.slsutil.renderer('salt://metalk8s/addons/dex/config/dex.yaml.j2', saltenv=saltenv) %}
+{%- set dex_defaults = salt.slsutil.renderer('salt://metalk8s/addons/dex/config/dex.yaml.j2', saltenv=saltenv) %}
 {%- set dex = salt.metalk8s_service_configuration.get_service_conf('metalk8s-auth', 'metalk8s-dex-config', dex_defaults) %}
 
 {% raw %}
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.30.0
-    helm.sh/chart: dex-0.6.3
+    app.kubernetes.io/version: 2.31.1
+    helm.sh/chart: dex-0.8.2
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -28,23 +28,18 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.30.0
-    helm.sh/chart: dex-0.6.3
+    app.kubernetes.io/version: 2.31.1
+    helm.sh/chart: dex-0.8.2
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
 rules:
 - apiGroups:
-  - dex.coreos.com
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
   verbs:
+  - list
   - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -55,14 +50,57 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.30.0
-    helm.sh/chart: dex-0.6.3
+    app.kubernetes.io/version: 2.31.1
+    helm.sh/chart: dex-0.8.2
+    heritage: metalk8s
+  name: dex-cluster
+  namespace: metalk8s-auth
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dex
+subjects:
+- kind: ServiceAccount
+  name: dex
+  namespace: metalk8s-auth
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/instance: dex
+    app.kubernetes.io/managed-by: salt
+    app.kubernetes.io/name: dex
+    app.kubernetes.io/part-of: metalk8s
+    app.kubernetes.io/version: 2.31.1
+    helm.sh/chart: dex-0.8.2
+    heritage: metalk8s
+  name: dex
+  namespace: metalk8s-auth
+rules:
+- apiGroups:
+  - dex.coreos.com
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: dex
+    app.kubernetes.io/managed-by: salt
+    app.kubernetes.io/name: dex
+    app.kubernetes.io/part-of: metalk8s
+    app.kubernetes.io/version: 2.31.1
+    helm.sh/chart: dex-0.8.2
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: dex
 subjects:
 - kind: ServiceAccount
@@ -77,8 +115,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.30.0
-    helm.sh/chart: dex-0.6.3
+    app.kubernetes.io/version: 2.31.1
+    helm.sh/chart: dex-0.8.2
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -113,8 +151,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.30.0
-    helm.sh/chart: dex-0.6.3
+    app.kubernetes.io/version: 2.31.1
+    helm.sh/chart: dex-0.8.2
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -154,7 +192,7 @@ spec:
         env:
         - name: KUBERNETES_POD_NAMESPACE
           value: metalk8s-auth
-        image: {% endraw -%}{{ build_image_name("dex", False) }}{%- raw %}:v2.30.0
+        image: {% endraw -%}{{ build_image_name("dex", False) }}{%- raw %}:v2.31.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -224,8 +262,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.30.0
-    helm.sh/chart: dex-0.6.3
+    app.kubernetes.io/version: 2.31.1
+    helm.sh/chart: dex-0.8.2
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -239,7 +277,7 @@ spec:
           service:
             name: dex
             port:
-              number: 5554
+              number: 5556
         path: /oidc
         pathType: Prefix
 

--- a/salt/metalk8s/addons/dex/deployed/chart.sls
+++ b/salt/metalk8s/addons/dex/deployed/chart.sls
@@ -192,7 +192,7 @@ spec:
         env:
         - name: KUBERNETES_POD_NAMESPACE
           value: metalk8s-auth
-        image: {% endraw -%}{{ build_image_name("dex", False) }}{%- raw %}:v2.31.1
+        image: {% endraw -%}{{ build_image_name("dex", False) }}{%- raw %}:v2.31.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/salt/metalk8s/addons/dex/deployed/post-downgrade.sls
+++ b/salt/metalk8s/addons/dex/deployed/post-downgrade.sls
@@ -1,0 +1,30 @@
+{%- set dest_version = pillar.metalk8s.cluster_version %}
+
+{#- Some objects has been removed/renamed with the new dex chart,
+    so let's cleanup new ones
+    NOTE: This logic can be removed in `development/124.0` #}
+
+{%- if salt.pkg.version_cmp(dest_version, '123.0.0') == -1 %}
+
+Cleanup new dex-cluster ClusterRoleBinding:
+    metalk8s_kubernetes.object_absent:
+        - apiVersion: rbac.authorization.k8s.io/v1
+        - kind: ClusterRoleBinding
+        - name: dex-cluster
+        - namespace: metalk8s-auth
+
+Cleanup new dex Role:
+    metalk8s_kubernetes.object_absent:
+        - apiVersion: rbac.authorization.k8s.io/v1
+        - kind: Role
+        - name: dex
+        - namespace: metalk8s-auth
+
+Cleanup new dex RoleBinding:
+    metalk8s_kubernetes.object_absent:
+        - apiVersion: rbac.authorization.k8s.io/v1
+        - kind: RoleBinding
+        - name: dex
+        - namespace: metalk8s-auth
+
+{%- endif %}

--- a/salt/metalk8s/addons/dex/deployed/post-upgrade.sls
+++ b/salt/metalk8s/addons/dex/deployed/post-upgrade.sls
@@ -1,0 +1,10 @@
+{#- Some objects has been removed/renamed with the new dex chart,
+    so let's cleanup old ones
+    NOTE: This logic can be removed in `development/124.0` #}
+
+Delete old dex ClusterRoleBinding:
+    metalk8s_kubernetes.object_absent:
+        - apiVersion: rbac.authorization.k8s.io/v1
+        - kind: ClusterRoleBinding
+        - name: dex
+        - namespace: metalk8s-auth

--- a/salt/metalk8s/orchestrate/downgrade/post.sls
+++ b/salt/metalk8s/orchestrate/downgrade/post.sls
@@ -3,3 +3,4 @@
 include:
   - metalk8s.addons.prometheus-operator.post-downgrade
   - metalk8s.addons.logging.fluent-bit.deployed.post-downgrade
+  - metalk8s.addons.dex.deployed.post-downgrade

--- a/salt/metalk8s/orchestrate/upgrade/post.sls
+++ b/salt/metalk8s/orchestrate/upgrade/post.sls
@@ -4,3 +4,4 @@ include:
   - metalk8s.addons.prometheus-operator.post-upgrade
   - metalk8s.addons.ui.post-upgrade
   - metalk8s.addons.logging.fluent-bit.deployed.post-upgrade
+  - metalk8s.addons.dex.deployed.post-upgrade


### PR DESCRIPTION
```
rm -rf charts/dex
helm repo add dex https://charts.dexidp.io
helm repo update
helm fetch -d charts --untar dex/dex
```

Render chart to salt state using
```
./charts/render.py dex charts/dex.yaml charts/dex \
  --namespace metalk8s-auth \
  --service-config dex metalk8s-dex-config \
  metalk8s/addons/dex/config/dex.yaml.j2 metalk8s-auth \
  > salt/metalk8s/addons/dex/deployed/chart.sls
```

**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

**Summary**:

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
