### PR TITLE
eve: Bump shell-ui build timeout

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -2926,6 +2926,7 @@ stages:
           command: docker build . --tag shell-ui:v%(prop:shell_ui_version)s
           workdir: build/shell-ui
           haltOnFailure: true
+          timeout: 2400
       - ShellCommand:
           name: Save shell-ui container image
           command: >


### PR DESCRIPTION
Some steps of the shell-ui build may take quite some time without output,
(when downloading all packages for example) in order to avoid false
timeout failure when building the docker image, let's bump the timeout