### PR TITLE
build: Do no longer check the nginx image digest

### DIFF
--- a/buildchain/buildchain/docker_command.py
+++ b/buildchain/buildchain/docker_command.py
@@ -278,7 +278,9 @@ def docker_tag(repository: str, full_name: str, version: str) -> None:
         ValueError: default_error_handler,
     }
 )
-def docker_pull(repository: str, name: str, version: str, digest: str) -> None:
+def docker_pull(
+    repository: str, name: str, version: str, digest: Optional[str] = None
+) -> None:
     """Pull a Docker image using Docker API.
 
     Arguments:
@@ -292,7 +294,7 @@ def docker_pull(repository: str, name: str, version: str, digest: str) -> None:
         "{}/{}".format(repository, name),
         tag=version,
     )
-    if pulled.id != digest:
+    if digest and pulled.id != digest:
         raise ValueError(
             "Image {name}:{version} pulled from {repository} "
             "doesn't match expected digest: "

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -157,7 +157,9 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     Image(
         name="nginx",
         version=NGINX_IMAGE_VERSION,
-        digest="sha256:51696c87e77e4ff7a53af9be837f35d4eacdb47b4ca83ba5fd5e4b5101d98502",
+        # Do not check the digest for this image, since this one is re-published
+        # several times with the same tag
+        digest=None,
     ),
     Image(
         name="nginx-ingress-controller",


### PR DESCRIPTION
The nginx image digest is quite often republished with the same tag (but
a different digest), to avoid breaking the build when it happens, let's
just not check the digest for this specific image