### PR TITLE
build: Replace CentOS 7 base images with Rocky Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,10 @@
   `metalk8s-utils` container
   (PR[#3773](https://github.com/scality/metalk8s/pull/3773))
 
+- Change base image from `centos:7.6.1810` to `rockylinux:8.5.20220308` for the
+  `salt-master` container
+  (PR[#3773](https://github.com/scality/metalk8s/pull/3773))
+
 ## Release 2.11.8 (in development)
 
 ## Release 2.11.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,18 @@
   Ingress could be exposed on a different IP
   (PR[#3755](https://github.com/scality/metalk8s/pull/3755))
 
+- Add the [`iftop`](http://www.ex-parrot.com/pdw/iftop/) tool to the
+  `metalk8s-utils` container
+  (PR[#3773](https://github.com/scality/metalk8s/pull/3773))
+
 ### Removals
 
 - The `Statefulsets` Grafana dashboard has been removed
   (PR[#3763](https://github.com/scality/metalk8s/pull/3763))
+
+- Remove the [`jnettop`](https://sourceforge.net/projects/jnettop/) tool from
+  the `metalk8s-utils` container
+  (PR[#3773](https://github.com/scality/metalk8s/pull/3773))
 
 ### Enhancements
 
@@ -87,6 +95,10 @@
 
 - Bump nginx image to [1.21.6-alpine](https://github.com/nginx/nginx/releases/tag/release-1.21.6)
   (PR[#3710](https://github.com/scality/metalk8s/pull/3710))
+
+- Change base image from `centos:7.9.2009` to `rockylinux:8.5.20220308` for the
+  `metalk8s-utils` container
+  (PR[#3773](https://github.com/scality/metalk8s/pull/3773))
 
 ## Release 2.11.8 (in development)
 

--- a/buildchain/buildchain/image.py
+++ b/buildchain/buildchain/image.py
@@ -240,7 +240,11 @@ TO_BUILD: Tuple[targets.LocalImage, ...] = (
     ),
     _local_image(
         name="salt-master",
-        build_args={"SALT_VERSION": versions.SALT_VERSION},
+        build_args={
+            "BASE_IMAGE": versions.ROCKY_BASE_IMAGE,
+            "BASE_IMAGE_SHA256": versions.ROCKY_BASE_IMAGE_SHA256,
+            "SALT_VERSION": versions.SALT_VERSION,
+        },
     ),
     _local_image(
         name="metalk8s-ui",

--- a/buildchain/buildchain/image.py
+++ b/buildchain/buildchain/image.py
@@ -262,8 +262,8 @@ TO_BUILD: Tuple[targets.LocalImage, ...] = (
     _local_image(
         name="metalk8s-utils",
         build_args={
-            "BASE_IMAGE": versions.CENTOS_BASE_IMAGE,
-            "BASE_IMAGE_SHA256": versions.CENTOS_BASE_IMAGE_SHA256,
+            "BASE_IMAGE": versions.ROCKY_BASE_IMAGE,
+            "BASE_IMAGE_SHA256": versions.ROCKY_BASE_IMAGE_SHA256,
             "BUILD_DATE": datetime.datetime.now(datetime.timezone.utc)
             .astimezone()
             .isoformat(),
@@ -271,6 +271,7 @@ TO_BUILD: Tuple[targets.LocalImage, ...] = (
             "METALK8S_VERSION": versions.VERSION,
             "SALT_VERSION": versions.SALT_VERSION,
             "KUBERNETES_VERSION": versions.K8S_VERSION,
+            "ETCD_VERSION": f"v{versions.ETCD_VERSION}",
         },
     ),
     _local_image(

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -64,12 +64,6 @@ SHELL_UI_VERSION: str = json.loads(shell_ui_package_contents)["version"]
 # }}}
 # Container images {{{
 
-CENTOS_BASE_IMAGE: str = "docker.io/centos"
-CENTOS_BASE_IMAGE_SHA256: str = (
-    # centos:7.9.2009
-    "e4ca2ed0202e76be184e75fb26d14bf974193579039d5573fb2348664deef76e"
-)
-
 ROCKY_BASE_IMAGE: str = "docker.io/rockylinux"
 ROCKY_BASE_IMAGE_SHA256: str = (
     # rockylinux:8.5.20220308

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -70,6 +70,14 @@ CENTOS_BASE_IMAGE_SHA256: str = (
     "e4ca2ed0202e76be184e75fb26d14bf974193579039d5573fb2348664deef76e"
 )
 
+ROCKY_BASE_IMAGE: str = "docker.io/rockylinux"
+ROCKY_BASE_IMAGE_SHA256: str = (
+    # rockylinux:8.5.20220308
+    "c7d13ea4d57355aaad6b6ebcdcca50f5be65fc821f54161430f5c25641d68c5c"
+)
+
+ETCD_VERSION: str = "3.5.1"
+ETCD_IMAGE_VERSION: str = f"{ETCD_VERSION}-0"
 NGINX_IMAGE_VERSION: str = "1.21.6-alpine"
 NODEJS_IMAGE_VERSION: str = "14.16.0"
 
@@ -116,7 +124,7 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     ),
     Image(
         name="etcd",
-        version="3.5.1-0",
+        version=ETCD_IMAGE_VERSION,
         digest="sha256:64b9ea357325d5db9f8a723dcf503b5a449177b17ac87d69481e126bb724c263",
     ),
     Image(

--- a/images/metalk8s-utils/Dockerfile
+++ b/images/metalk8s-utils/Dockerfile
@@ -53,7 +53,9 @@ LABEL maintainer="squad-metalk8s@scality.com" \
       com.scality.metalk8s.version="$METALK8S_VERSION"
 
 # Final layers, installing tooling
-RUN dnf install -y epel-release && \
+RUN dnf clean expire-cache && \
+    dnf update -y && \
+    dnf install -y epel-release && \
     dnf install -y \
         bash-completion \
         bind-utils \

--- a/images/metalk8s-utils/Dockerfile
+++ b/images/metalk8s-utils/Dockerfile
@@ -1,6 +1,6 @@
 # SHA256 digest of the base image
 ARG BASE_IMAGE_SHA256
-ARG BASE_IMAGE=docker.io/centos
+ARG BASE_IMAGE=docker.io/rockylinux
 
 FROM $BASE_IMAGE@sha256:$BASE_IMAGE_SHA256
 
@@ -8,6 +8,8 @@ FROM $BASE_IMAGE@sha256:$BASE_IMAGE_SHA256
 ARG KUBERNETES_VERSION
 # Salt version
 ARG SALT_VERSION
+# Etcd version
+ARG ETCD_VERSION
 
 COPY configure-repos.sh /
 RUN /configure-repos.sh $SALT_VERSION && rm /configure-repos.sh
@@ -22,7 +24,7 @@ ARG VERSION
 ARG METALK8S_VERSION
 
 # These contain BUILD_DATE so should come 'late' for layer caching
-LABEL maintainer="moonshot-platform@scality.com" \
+LABEL maintainer="squad-metalk8s@scality.com" \
       # http://label-schema.org/rc1/
       org.label-schema.build-date="$BUILD_DATE" \
       org.label-schema.name="metalk8s-utils" \
@@ -35,7 +37,7 @@ LABEL maintainer="moonshot-platform@scality.com" \
       org.label-schema.schema-version="1.0" \
       # https://github.com/opencontainers/image-spec/blob/master/annotations.md
       org.opencontainers.image.created="$BUILD_DATE" \
-      org.opencontainers.image.authors="moonshot-platform@scality.com" \
+      org.opencontainers.image.authors="squad-metalk8s@scality.com" \
       org.opencontainers.image.url="https://github.com/scality/metalk8s/" \
       org.opencontainers.image.source="https://github.com/scality/metalk8s.git" \
       org.opencontainers.image.version="$VERSION" \
@@ -51,10 +53,9 @@ LABEL maintainer="moonshot-platform@scality.com" \
       com.scality.metalk8s.version="$METALK8S_VERSION"
 
 # Final layers, installing tooling
-RUN yum install -y epel-release && \
-    yum install -y --setopt=skip_missing_names_on_install=False \
+RUN dnf install -y epel-release && \
+    dnf install -y \
         bash-completion \
-        bash-completion-extras \
         bind-utils \
         bzip2 \
         conntrack-tools \
@@ -62,13 +63,13 @@ RUN yum install -y epel-release && \
         curl \
         e2fsprogs \
         ebtables \
-        etcd \
         ethtool \
         gdb \
         git \
         htop \
         httpd-tools \
         httpie \
+        iftop \
         iotop \
         iperf \
         iperf3 \
@@ -76,7 +77,6 @@ RUN yum install -y epel-release && \
         ipset \
         iptables \
         ipvsadm \
-        jnettop \
         jq \
         "kubectl-${KUBERNETES_VERSION}" \
         less \
@@ -109,6 +109,16 @@ RUN yum install -y epel-release && \
         wireshark \
         xfsprogs \
         && \
-    yum clean all
+    dnf clean all
+
+# etcd is not packaged in RHEL/Rocky/CentOS 8 Extras repository, so we download/install
+# it manually
+RUN mkdir /tmp/etcd-download && \
+    curl -L https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz \
+        -o /tmp/etcd-${ETCD_VERSION}-linux-amd64.tar.gz && \
+    tar xzvf /tmp/etcd-${ETCD_VERSION}-linux-amd64.tar.gz -C /tmp/etcd-download --strip-components=1 && \
+    rm -f /tmp/etcd-${ETCD_VERSION}-linux-amd64.tar.gz && \
+    mv /tmp/etcd-download/etcdctl /usr/bin && \
+    rm -rf /tmp/etcd-download
 
 RUN kubectl completion bash > /etc/bash_completion.d/kubectl

--- a/images/metalk8s-utils/Dockerfile
+++ b/images/metalk8s-utils/Dockerfile
@@ -10,7 +10,7 @@ ARG KUBERNETES_VERSION
 ARG SALT_VERSION
 
 COPY configure-repos.sh /
-RUN /configure-repos.sh 7 $SALT_VERSION && rm /configure-repos.sh
+RUN /configure-repos.sh $SALT_VERSION && rm /configure-repos.sh
 
 # Timestamp of the build, formatted as RFC3339
 ARG BUILD_DATE

--- a/images/metalk8s-utils/configure-repos.sh
+++ b/images/metalk8s-utils/configure-repos.sh
@@ -2,13 +2,12 @@
 
 set -xue -o pipefail
 
-CENTOS_VERSION=$1
-SALT_VERSION=$2
+SALT_VERSION=$1
 
 cat > /etc/yum.repos.d/kubernetes.repo << EOF
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el$CENTOS_VERSION-x86_64
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
 enabled=1
 gpgcheck=1
 repo_gpgcheck=0

--- a/images/salt-master/Dockerfile
+++ b/images/salt-master/Dockerfile
@@ -16,6 +16,7 @@ gpgcheck=1\n\
 gpgkey=https://repo.saltproject.io/py3/redhat/\$releasever/\$basearch/archive/%s/SALTSTACK-GPG-KEY.pub\n" ${SALT_VERSION} ${SALT_VERSION} >/etc/yum.repos.d/saltstack.repo \
  && rpm --import https://repo.saltproject.io/py3/redhat/8/x86_64/archive/${SALT_VERSION}/SALTSTACK-GPG-KEY.pub \
  && dnf clean expire-cache \
+ && dnf update -y \
  && dnf install -y glibc-all-langpacks langpacks-en \
  && dnf install -y epel-release \
  && dnf install -y python3-pip \

--- a/images/salt-master/Dockerfile
+++ b/images/salt-master/Dockerfile
@@ -1,32 +1,34 @@
-FROM centos:7.6.1810
+# SHA256 digest of the base image
+ARG BASE_IMAGE_SHA256
+ARG BASE_IMAGE=docker.io/rockylinux
 
-MAINTAINER moonshot-platform <moonshot-platform@scality.com>
+FROM ${BASE_IMAGE}@sha256:${BASE_IMAGE_SHA256}
 
 # Versions to use
 ARG SALT_VERSION
-ENV LC_ALL=en_US.UTF-8
 
-# Install saltstack
+# Install Saltstack and other dependencies
 RUN printf "[saltstack-repo]\n\
 name=SaltStack repo for RHEL/CentOS \$releasever\n\
 baseurl=https://repo.saltproject.io/py3/redhat/\$releasever/\$basearch/archive/%s\n\
 enabled=1\n\
 gpgcheck=1\n\
 gpgkey=https://repo.saltproject.io/py3/redhat/\$releasever/\$basearch/archive/%s/SALTSTACK-GPG-KEY.pub\n" ${SALT_VERSION} ${SALT_VERSION} >/etc/yum.repos.d/saltstack.repo \
- && rpm --import https://repo.saltproject.io/py3/redhat/7/x86_64/archive/${SALT_VERSION}/SALTSTACK-GPG-KEY.pub \
- && yum clean expire-cache \
- && yum install -y epel-release \
- && yum install -y python3-pip \
- && pip3 install pip==20.1 \
+ && rpm --import https://repo.saltproject.io/py3/redhat/8/x86_64/archive/${SALT_VERSION}/SALTSTACK-GPG-KEY.pub \
+ && dnf clean expire-cache \
+ && dnf install -y glibc-all-langpacks langpacks-en \
+ && dnf install -y epel-release \
+ && dnf install -y python3-pip \
+ && pip3 install "pip == 20.1" \
  && pip3 install "protobuf ~= 3.19.4" "etcd3 != 0.11.0" \
- && yum install -y git \
+ && dnf install -y git \
  && pip3 install "git+https://github.com/kubernetes-client/python.git@cef5e9bd10a6d5ca4d9c83da46ccfe2114cdaaf8#egg=kubernetes" \
- && yum remove -y git \
- && pip3 uninstall -y \
-     requests \
-     urllib3 \
- && yum install -y salt-master salt-api salt-ssh openssh-clients \
- && yum clean all
+ && dnf remove -y git \
+ && dnf install -y salt-master salt-api salt-ssh openssh-clients \
+ && dnf clean all
+
+# Set up locale
+ENV LC_ALL=en_US.UTF-8
 
 # Disable host key checking due to a bug in salt-ssh
 # Sees: https://github.com/saltstack/salt/issues/59691

--- a/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
+++ b/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
@@ -13,6 +13,13 @@ peer:
 # Enable grains caching on salt-master
 grains_cache: True
 
+# We now run salt-master on Rocky Linux, but it is not yet fully supported by
+# SaltStack 3002, so we emulate it runs on CentOS, as before. This should be
+# removed with SaltStack 3004.
+grains:
+  os_family: RedHat
+  os: CentOS
+
 # We use information from the `metalk8s_node` ext_pillar to match in
 # `pillar/top.sls`, hence we need to load them first.
 ext_pillar_first: true


### PR DESCRIPTION
**Component**: build

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: There are some CVEs (notably [CVE-2018-25032](https://nvd.nist.gov/vuln/detail/CVE-2018-25032)) for which a fix is only available in Red Hat 8 repositories, so we want to take a safer bet by running on a more recent base OS

**Summary**: The base image for `metalk8s-utils` and `salt-master` is changed from `centos:7` to `rockylinux:8.5`.

**Acceptance criteria**: Everything keeps working as before.