### PR TITLE
eve: Bump terraforn-snapshot to 0.5.1

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -18,7 +18,7 @@ models:
       name: Git pull terraform snapshot
       command: >
         git clone --depth 1 "git@github.com:scality/terraform-snapshot.git"
-        --branch "0.3.6"
+        --branch "0.5.1"
       haltOnFailure: true
   - ShellCommand: &git_pull_ssh
       name: Git pull on bastion


### PR DESCRIPTION
NOTE: Snapshot generation as is was not working with 0.3.6