### PR TITLE
images: Pin python protobuf version and change salt repo URL

### DIFF
--- a/images/metalk8s-utils/configure-repos.sh
+++ b/images/metalk8s-utils/configure-repos.sh
@@ -19,8 +19,8 @@ EOF
 cat > /etc/yum.repos.d/saltstack.repo << EOF
 [saltstack]
 name=SaltStack repo for RHEL/CentOS \$releasever
-baseurl=https://repo.saltstack.com/py3/redhat/\$releasever/\$basearch/archive/$SALT_VERSION
+baseurl=https://repo.saltproject.io/py3/redhat/\$releasever/\$basearch/archive/$SALT_VERSION
 enabled=1
 gpgcheck=1
-gpgkey=https://repo.saltstack.com/py3/redhat/\$releasever/\$basearch/archive/$SALT_VERSION/SALTSTACK-GPG-KEY.pub
+gpgkey=https://repo.saltproject.io/py3/redhat/\$releasever/\$basearch/archive/$SALT_VERSION/SALTSTACK-GPG-KEY.pub
 EOF

--- a/images/salt-master/Dockerfile
+++ b/images/salt-master/Dockerfile
@@ -18,7 +18,7 @@ gpgkey=https://repo.saltstack.com/py3/redhat/\$releasever/\$basearch/archive/%s/
  && yum install -y epel-release \
  && yum install -y python3-pip \
  && pip3 install pip==20.1 \
- && pip3 install "etcd3 != 0.11.0" \
+ && pip3 install "protobuf ~= 3.19.4" "etcd3 != 0.11.0" \
  && yum install -y git \
  && pip3 install "git+https://github.com/kubernetes-client/python.git@cef5e9bd10a6d5ca4d9c83da46ccfe2114cdaaf8#egg=kubernetes" \
  && yum remove -y git \

--- a/images/salt-master/Dockerfile
+++ b/images/salt-master/Dockerfile
@@ -9,11 +9,11 @@ ENV LC_ALL=en_US.UTF-8
 # Install saltstack
 RUN printf "[saltstack-repo]\n\
 name=SaltStack repo for RHEL/CentOS \$releasever\n\
-baseurl=https://repo.saltstack.com/py3/redhat/\$releasever/\$basearch/archive/%s\n\
+baseurl=https://repo.saltproject.io/py3/redhat/\$releasever/\$basearch/archive/%s\n\
 enabled=1\n\
 gpgcheck=1\n\
-gpgkey=https://repo.saltstack.com/py3/redhat/\$releasever/\$basearch/archive/%s/SALTSTACK-GPG-KEY.pub\n" ${SALT_VERSION} ${SALT_VERSION} >/etc/yum.repos.d/saltstack.repo \
- && rpm --import https://repo.saltstack.com/py3/redhat/7/x86_64/archive/${SALT_VERSION}/SALTSTACK-GPG-KEY.pub \
+gpgkey=https://repo.saltproject.io/py3/redhat/\$releasever/\$basearch/archive/%s/SALTSTACK-GPG-KEY.pub\n" ${SALT_VERSION} ${SALT_VERSION} >/etc/yum.repos.d/saltstack.repo \
+ && rpm --import https://repo.saltproject.io/py3/redhat/7/x86_64/archive/${SALT_VERSION}/SALTSTACK-GPG-KEY.pub \
  && yum clean expire-cache \
  && yum install -y epel-release \
  && yum install -y python3-pip \


### PR DESCRIPTION
Fix the build of salt-master and metalk8s-utils images

- `etcd3` python lib require `protobuf>=3.6.1` python lib and the latest `protobuf` version is not compatible with python3.6
```console
# pip3 install etcd3
Collecting etcd3
  Using cached etcd3-0.12.0.tar.gz (63 kB)
Collecting grpcio>=1.27.1
  Downloading grpcio-1.46.3-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (4.4 MB)
     |████████████████████████████████| 4.4 MB 14.0 MB/s 
Collecting protobuf>=3.6.1
  Downloading protobuf-4.21.0-py2.py3-none-any.whl (164 kB)
     |████████████████████████████████| 164 kB 65.9 MB/s 
ERROR: Package 'protobuf' requires a different Python: 3.6.8 not in '>=3.7'
```
- Salt master repo URL moved and yum does not handle redirect
```console
failure: repodata/repomd.xml from saltstack-repo: [Errno 256] No more mirrors to try.
https://repo.saltstack.com/py3/redhat/7/x86_64/archive/3002.8/repodata/repomd.xml: [Errno 14] HTTPS Error 301 - Moved Permanently
```

