### PR TITLE
tests: Use a specific cache file for every k8s_client

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,12 +104,14 @@ def control_plane_ingress_ep(k8s_client, control_plane_ingress_ip):
 
 
 @pytest.fixture
-def k8s_client(request, kubeconfig):
+def k8s_client(kubeconfig, tmp_path):
     """Return a DynamicClient to use for interaction with all K8s APIs."""
     k8s_apiclient = kubernetes.config.new_client_from_config(
         config_file=kubeconfig, persist_config=False
     )
-    return kubernetes.dynamic.DynamicClient(k8s_apiclient)
+    return kubernetes.dynamic.DynamicClient(
+        k8s_apiclient, cache_file=str(tmp_path / "k8s-client-cache")
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
Since the k8s_client cached information may change between runs, for
For example when we run a test before the upgrade and after, we need to reload
the cache