### PR TITLE
salt,docs,tests: Add ability to change exposed NodePort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
   Ingress could be exposed on a different IP
   (PR[#3755](https://github.com/scality/metalk8s/pull/3755))
 
+- Add ability to change the nodeport CIDRs, so that NodePort
+  services could be exposed on a different IP
+  (PR[#3807](https://github.com/scality/metalk8s/pull/3807))
+
 - Add the [`iftop`](http://www.ex-parrot.com/pdw/iftop/) tool to the
   `metalk8s-utils` container
   (PR[#3773](https://github.com/scality/metalk8s/pull/3773))

--- a/docs/installation/bootstrap.rst
+++ b/docs/installation/bootstrap.rst
@@ -66,6 +66,9 @@ Configuration
         portmap:
           cidr:
             - <CIDR-notation>
+        nodeport:
+          cidr:
+            - <CIDR-notation>
       proxies:
         http: <http://proxy-ip:proxy-port>
         https: <https://proxy-ip:proxy-port>
@@ -187,6 +190,12 @@ notation for it's various subfields.
         that if you change this ``portmap`` the Workload Plane Ingress will
         be exposed on IPs matching the ``portmap`` range of IP on every
         member of the cluster
+
+      The ``nodeport`` field is not mandatory, though can be changed in order
+      to expose the ``nodePort`` services on different IPs, with ``cidr`` you
+      can define a list of range of IP addresses that will be used at the host
+      level for each member of the cluster to expose the ``nodePort`` services
+      (default to node Workload Plane IP)
 
 The ``proxies`` field can be omitted if there is no proxy to configure.
 The 2 entries ``http`` and ``https`` are used to configure the containerd

--- a/salt/_modules/metalk8s_network.py
+++ b/salt/_modules/metalk8s_network.py
@@ -285,6 +285,22 @@ def get_portmap_ips(as_cidr=False):
     return sorted(result)
 
 
+def get_nodeport_cidrs():
+    result = set()
+    nodeport_cidrs = __salt__["pillar.get"]("networks:nodeport:cidr")
+
+    if nodeport_cidrs:
+        if not isinstance(nodeport_cidrs, list):
+            nodeport_cidrs = [nodeport_cidrs]
+        result = set(nodeport_cidrs)
+    else:
+        result = set(__salt__["pillar.get"]("networks:workload_plane:cidr"))
+
+    result.add("127.0.0.1/32")
+
+    return sorted(result)
+
+
 def get_control_plane_ingress_external_ips():
     """Get all Control Plane Ingress external IPs
 

--- a/salt/_pillar/metalk8s.py
+++ b/salt/_pillar/metalk8s.py
@@ -129,6 +129,7 @@ def _load_networks(config_data):
         "pod": networks_data.get("pods", DEFAULT_POD_NETWORK),
         "service": networks_data.get("services", DEFAULT_SERVICE_NETWORK),
         "portmap": networks_data.get("portmap"),
+        "nodeport": networks_data.get("nodeport"),
     }
 
 

--- a/salt/metalk8s/kubernetes/kube-proxy/deployed.sls
+++ b/salt/metalk8s/kubernetes/kube-proxy/deployed.sls
@@ -82,7 +82,7 @@ Deploy kube-proxy (ConfigMap):
             kind: KubeProxyConfiguration
             metricsBindAddress: @HOST_IP@:10249
             mode: ""
-            nodePortAddresses: {{ networks.workload_plane.cidr | tojson }}
+            nodePortAddresses: {{ salt.metalk8s_network.get_nodeport_cidrs() | tojson }}
             oomScoreAdj: null
             portRange: ""
             showHiddenMetricsForVersion: ""
@@ -130,6 +130,10 @@ Deploy kube-proxy (DaemonSet):
             metadata:
               annotations:
                 scheduler.alpha.kubernetes.io/critical-pod: ""
+                # NOTE: Add annotation for config checksum, so that Pod get restarted on
+                # ConfigMap change
+                checksum/config: __slot__:salt:metalk8s_kubernetes.get_object_digest(kind="ConfigMap",
+                  apiVersion="v1", namespace="kube-system", name="kube-proxy", path="data")
               creationTimestamp: null
               labels:
                 k8s-app: kube-proxy

--- a/salt/tests/unit/formulas/fixtures/salt.py
+++ b/salt/tests/unit/formulas/fixtures/salt.py
@@ -457,6 +457,9 @@ register_basic("metalk8s_network.get_control_plane_ingress_endpoint")(
 register_basic("metalk8s_network.get_portmap_ips")(
     MagicMock(return_value=["192.168.1.100", "127.0.0.1"])
 )
+register_basic("metalk8s_network.get_nodeport_cidrs")(
+    MagicMock(return_value=["192.168.2.0/24", "127.0.0.1/32"])
+)
 register_basic("metalk8s_network.get_control_plane_ingress_external_ips")(
     MagicMock(
         return_value=[

--- a/salt/tests/unit/modules/files/test_metalk8s_network.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_network.yaml
@@ -239,6 +239,29 @@ get_portmap_ips:
       - 10.20.10.10
       - 127.0.0.1
 
+get_nodeport_cidrs:
+  # 1. Nominal (no CIDRs, using workload plane CIDR)
+  - wp_cidrs:
+      - 10.10.10.0/16
+    result:
+      - 10.10.10.0/16
+      - 127.0.0.1/32
+
+  # 2. Define CIDR in config
+  - nodeport_cidrs: 10.20.0.0/16
+    result:
+      - 10.20.0.0/16
+      - 127.0.0.1/32
+
+  # 4. Multiple CIDRs
+  - nodeport_cidrs:
+      - 10.20.0.0/16
+      - 10.30.0.0/16
+    result:
+      - 10.20.0.0/16
+      - 10.30.0.0/16
+      - 127.0.0.1/32
+
 get_control_plane_ingress_external_ips:
   # 1. Nominal single node (using bootstrap IP)
   - cp_ingress_ip_ret: 1.1.1.1

--- a/salt/tests/unit/modules/test_metalk8s_network.py
+++ b/salt/tests/unit/modules/test_metalk8s_network.py
@@ -395,6 +395,26 @@ class Metalk8sNetworkTestCase(TestCase, mixins.LoaderModuleMockMixin):
         ):
             self.assertEqual(result, metalk8s_network.get_portmap_ips(**kwargs))
 
+    @utils.parameterized_from_cases(YAML_TESTS_CASES["get_nodeport_cidrs"])
+    def test_get_nodeport_cidrs(self, result, nodeport_cidrs=None, wp_cidrs=None):
+        """
+        Tests the return of `get_nodeport_cidrs` function
+        """
+
+        def _pillar_get(key):
+            if "nodeport" in key:
+                return nodeport_cidrs
+            if "workload_plane" in key:
+                return wp_cidrs
+            raise Exception("Should not happen !!")
+
+        salt_dict = {
+            "pillar.get": MagicMock(side_effect=_pillar_get),
+        }
+
+        with patch.dict(metalk8s_network.__salt__, salt_dict):
+            self.assertEqual(result, metalk8s_network.get_nodeport_cidrs())
+
     @utils.parameterized_from_cases(
         YAML_TESTS_CASES["get_control_plane_ingress_external_ips"]
     )

--- a/tests/post/features/network.feature
+++ b/tests/post/features/network.feature
@@ -5,3 +5,23 @@ Feature: Network
         And we run on an untainted single node
         Then ports check succeed
         And we have only expected processes listening
+
+    Scenario: Access using NodePort on workload-plane IP
+        Given the Kubernetes API is available
+        When we create a 'test-svc-1' NodePort service that expose a simple pod
+        Then a request on the 'test-svc-1' NodePort on a workload-plane IP returns 200
+
+    Scenario: Access using NodePort on control-plane IP
+        Given the Kubernetes API is available
+        And the node control-plane IP is not equal to its workload-plane IP
+        When we create a 'test-svc-2' NodePort service that expose a simple pod
+        Then a request on the 'test-svc-2' NodePort on a control-plane IP should not return
+
+    Scenario: Expose NodePort on Control Plane
+        Given the Kubernetes API is available
+        And the node control-plane IP is not equal to its workload-plane IP
+        When we create a 'test-svc-3' NodePort service that expose a simple pod
+        And we set nodeport CIDRs to control-plane CIDR
+        And we wait for the rollout of 'daemonset/kube-proxy' in namespace 'kube-system' to complete
+        Then a request on the 'test-svc-3' NodePort on a control-plane IP returns 200
+        And a request on the 'test-svc-3' NodePort on a workload-plane IP should not return

--- a/tests/post/steps/conftest.py
+++ b/tests/post/steps/conftest.py
@@ -123,6 +123,17 @@ def check_multi_node(k8s_client):
         pytest.skip("We skip single node cluster for this test")
 
 
+@given("the node control-plane IP is not equal to its workload-plane IP")
+def node_control_plane_ip_is_not_equal_to_its_workload_plane_ip(host):
+    data = utils.get_grain(host, "metalk8s")
+
+    assert "control_plane_ip" in data
+    assert "workload_plane_ip" in data
+
+    if data["control_plane_ip"] == data["workload_plane_ip"]:
+        pytest.skip("Node control-plane IP is equal to node workload-plane IP")
+
+
 # }}}
 
 # Then {{{


### PR DESCRIPTION
In order to be able to expose the NodePort services on another IP
than the Workload Plane IP of each node, we allow setting the nodeport
CIDRs from the bootstrap configuration file