### PR TITLE
Bump Kubernetes to 1.24.3 and etcd to 3.5.3-0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # CHANGELOG
 ## Release 124.0.0 (in development)
 
+### Enhancements
+
+- Bump Kubernetes version to
+  [1.24.3](https://github.com/kubernetes/kubernetes/releases/tag/v1.24.3)
+  (PR[#3832](https://github.com/scality/metalk8s/pull/3832))
+
 ## Release 123.0.2 (in development)
 
 ## Release 123.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   [1.24.3](https://github.com/kubernetes/kubernetes/releases/tag/v1.24.3)
   (PR[#3832](https://github.com/scality/metalk8s/pull/3832))
 
+- Bump etcd version to [3.5.3](https://github.com/etcd-io/etcd/releases/tag/v3.5.3)
+  (PR[#3832](https://github.com/scality/metalk8s/pull/3832))
+
 ## Release 123.0.2 (in development)
 
 ## Release 123.0.1

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -70,7 +70,7 @@ ROCKY_BASE_IMAGE_SHA256: str = (
     "c7d13ea4d57355aaad6b6ebcdcca50f5be65fc821f54161430f5c25641d68c5c"
 )
 
-ETCD_VERSION: str = "3.5.1"
+ETCD_VERSION: str = "3.5.3"
 ETCD_IMAGE_VERSION: str = f"{ETCD_VERSION}-0"
 NGINX_IMAGE_VERSION: str = "1.21.6-alpine"
 NODEJS_IMAGE_VERSION: str = "14.16.0"
@@ -124,7 +124,7 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     Image(
         name="etcd",
         version=ETCD_IMAGE_VERSION,
-        digest="sha256:64b9ea357325d5db9f8a723dcf503b5a449177b17ac87d69481e126bb724c263",
+        digest="sha256:13f53ed1d91e2e11aac476ee9a0269fdda6cc4874eba903efd40daf50c55eee5",
     ),
     Image(
         name="grafana",

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -19,7 +19,7 @@ Image = namedtuple("Image", ("name", "version", "digest"))
 # Project-wide versions {{{
 
 CALICO_VERSION: str = "3.23.1"
-K8S_VERSION: str = "1.23.8"
+K8S_VERSION: str = "1.24.3"
 SALT_VERSION: str = "3002.9"
 CONTAINERD_VERSION: str = "1.6.4"
 
@@ -139,22 +139,22 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     Image(
         name="kube-apiserver",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:41b72e33afeba7e925f002b6bd3ac33a6bc364a03514bfd7416793b3a4fbadaa",
+        digest="sha256:a04609b85962da7e6531d32b75f652b4fb9f5fe0b0ee0aa160856faad8ec5d96",
     ),
     Image(
         name="kube-controller-manager",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:9c890c050cbf6991750dbd21473760eaef5175d90e944bb92be5c02cb5297e16",
+        digest="sha256:f504eead8b8674ebc9067370ef51abbdc531b4a81813bfe464abccb8c76b6a53",
     ),
     Image(
         name="kube-proxy",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:71e8db32908c9db3ecbf48cf22af3b366c8a07b66f86b2cb553874402f8f068c",
+        digest="sha256:c1b135231b5b1a6799346cd701da4b59e5b7ef8e694ec7b04fb23b8dbe144137",
     ),
     Image(
         name="kube-scheduler",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:cf1842e377fa32a72dab549e203dbb51c20189f9321d2d2b5e7f96214f60ab05",
+        digest="sha256:e199523298224cd9f2a9a43c7c2c37fa57aff87648ed1e1de9984eba6f6005f0",
     ),
     Image(
         name="kube-state-metrics",

--- a/salt/metalk8s/kubernetes/etcd/installed.sls
+++ b/salt/metalk8s/kubernetes/etcd/installed.sls
@@ -80,9 +80,6 @@ Create local etcd Pod manifest:
           - --trusted-ca-file=/etc/kubernetes/pki/etcd/ca.crt
         # }
           - --initial-cluster-state={{ state }}
-          # See https://github.com/etcd-io/etcd/issues/13766
-          # https://groups.google.com/a/kubernetes.io/g/dev/c/B7gJs88XtQc/m/rSgNOzV2BwAJ?utm_medium=email&utm_source=footer
-          - --experimental-initial-corrupt-check=true
         volumes:
           - path: /var/lib/etcd
             name: etcd-data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -163,20 +163,6 @@ def admin_sa(k8s_client):
                 raise AssertionError("ServiceAccount not yet created")
             raise
 
-        assert sa_obj.secrets
-        assert sa_obj.secrets[0].name
-
-        try:
-            secret_obj = k8s_client.resources.get(api_version="v1", kind="Secret").get(
-                sa_obj.secrets[0].name, sa_namespace
-            )
-        except kubernetes.client.rest.ApiException as err:
-            if err.status == 404:
-                raise AssertionError("Secret not yet created")
-            raise
-
-        assert secret_obj.data.get("token")
-
     # Wait for ClusterRoleBinding to exists
     utils.retry(_check_crb_exists, times=20, wait=3)
 


### PR DESCRIPTION
We also update the test as with this new Kubernetes 1.24, ServiceAccount
secret is not created by default and we need to explicitly get a token
from APIServer

NOTE: This new etcd version contains the fix
for https://github.com/etcd-io/etcd/issues/13766 so we no longer need
the `--experimental-initial-corrupt-check=true` flag