### PR TITLE
charts,salt,tests: Do no longer use `loadBalancerIP` field for svc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Bump etcd version to [3.5.3](https://github.com/etcd-io/etcd/releases/tag/v3.5.3)
   (PR[#3832](https://github.com/scality/metalk8s/pull/3832))
 
+- No longer use deprecated field `loadBalancerIP` for LoadBalancer service
+  (PR[#3834](https://github.com/scality/metalk8s/pull/3834))
+
 ## Release 123.0.2 (in development)
 
 ## Release 123.0.1

--- a/charts/ingress-nginx-control-plane-deployment.yaml
+++ b/charts/ingress-nginx-control-plane-deployment.yaml
@@ -47,7 +47,9 @@ controller:
     node-role.kubernetes.io/master: ''
 
   service:
-    loadBalancerIP: '__var__(salt.metalk8s_network.get_control_plane_ingress_ip())'
+    annotations:
+      metallb.universe.tf/loadBalancerIPs: '__var__(salt.metalk8s_network.get_control_plane_ingress_ip())'
+
     externalTrafficPolicy: Local
 
     enableHttp: false

--- a/salt/metalk8s/addons/nginx-ingress-control-plane/deployed/chart-deployment.sls
+++ b/salt/metalk8s/addons/nginx-ingress-control-plane/deployed/chart-deployment.sls
@@ -284,7 +284,8 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations: null
+  annotations:
+    metallb.universe.tf/loadBalancerIPs: {% endraw -%}{{ salt.metalk8s_network.get_control_plane_ingress_ip() }}{%- raw %}
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx-control-plane
@@ -301,7 +302,6 @@ spec:
   ipFamilies:
   - IPv4
   ipFamilyPolicy: SingleStack
-  loadBalancerIP: {% endraw -%}{{ salt.metalk8s_network.get_control_plane_ingress_ip() }}{%- raw %}
   ports:
   - appProtocol: https
     name: https

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,7 +88,10 @@ def control_plane_ingress_ip(k8s_client):
         name="ingress-nginx-control-plane-controller",
         namespace="metalk8s-ingress",
     )
-    return ingress_svc.spec.loadBalancerIP or ingress_svc.spec.externalIPs[0]
+    if ingress_svc.status.loadBalancer.ingress:
+        return ingress_svc.status.loadBalancer.ingress[0].ip
+    else:
+        return ingress_svc.spec.externalIPs[0]
 
 
 @pytest.fixture


### PR DESCRIPTION
Since Kubernetes 1.24 setting the `loadBalancerIP` on a Service is
deprecated