### PR TITLE
ui: Make sure that K8S client is reinitialised when the access token is renewed

### DIFF
--- a/ui/src/containers/PrivateRoute.js
+++ b/ui/src/containers/PrivateRoute.js
@@ -23,7 +23,7 @@ const InternalPrivateRoute = ({
   useMemo(() => {
     dispatch(updateAPIConfigAction(userData));
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [!userData]);
+  }, [userData?.token]);
 
   if (isAuthError) {
     return (


### PR DESCRIPTION
**Component**:

ui

**Context**: 

K8S client may not be using the latest available token and hence the UI may display authorisation errors when K8S client is using an expired token to retrieve informations.

**Summary**:

In this PR I make sure that anytime the token change we reinit K8S client with the newly negotiated one.