### PR TITLE
images,build: Build our Keepalived image based on alpine

### DIFF
--- a/buildchain/buildchain/image.py
+++ b/buildchain/buildchain/image.py
@@ -241,6 +241,20 @@ TO_BUILD: Tuple[targets.LocalImage, ...] = (
         name="metalk8s-alert-logger",
     ),
     _local_image(
+        name="metalk8s-keepalived",
+        build_args={
+            "BASE_IMAGE": versions.ALPINE_BASE_IMAGE,
+            "BASE_IMAGE_SHA256": versions.ALPINE_BASE_IMAGE_SHA256,
+            "BUILD_DATE": datetime.datetime.now(datetime.timezone.utc)
+            .astimezone()
+            .isoformat(),
+            "VCS_REF": constants.GIT_REF or "<unknown>",
+            "VERSION": versions.VERSION,
+            "METALK8S_VERSION": versions.VERSION,
+            "KEEPALIVED_VERSION": versions.KEEPALIVED_VERSION,
+        },
+    ),
+    _local_image(
         name="salt-master",
         build_args={
             "BASE_IMAGE": versions.ROCKY_BASE_IMAGE,

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -64,6 +64,12 @@ SHELL_UI_VERSION: str = json.loads(shell_ui_package_contents)["version"]
 # }}}
 # Container images {{{
 
+ALPINE_BASE_IMAGE: str = "docker.io/alpine"
+ALPINE_BASE_IMAGE_SHA256: str = (
+    # alpine:3.16.1
+    "7580ece7963bfa863801466c0a488f11c86f85d9988051a9f9c68cb27f6b7872"
+)
+
 ROCKY_BASE_IMAGE: str = "docker.io/rockylinux"
 ROCKY_BASE_IMAGE_SHA256: str = (
     # rockylinux:8.5.20220308
@@ -74,6 +80,7 @@ ETCD_VERSION: str = "3.5.3"
 ETCD_IMAGE_VERSION: str = f"{ETCD_VERSION}-0"
 NGINX_IMAGE_VERSION: str = "1.21.6-alpine"
 NODEJS_IMAGE_VERSION: str = "14.16.0"
+KEEPALIVED_VERSION: str = "2.2.7"
 
 # Current build IDs, to be augmented whenever we rebuild the corresponding
 # image, e.g. because the `Dockerfile` is changed, or one of the dependencies
@@ -226,6 +233,11 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     # Local images
     Image(
         name="metalk8s-alert-logger",
+        version=VERSION,
+        digest=None,
+    ),
+    Image(
+        name="metalk8s-keepalived",
         version=VERSION,
         digest=None,
     ),

--- a/images/metalk8s-keepalived/Dockerfile
+++ b/images/metalk8s-keepalived/Dockerfile
@@ -1,0 +1,86 @@
+# SHA256 digest of the base image
+ARG BASE_IMAGE_SHA256
+ARG BASE_IMAGE=docker.io/alpine
+
+# NOTE: We need to build keepalived ourself to enable JSON, so that we can
+# use the JSON signal to get the current keepalived status in JSON format
+# The keepalived binary from the package is not build with JSON enabled
+FROM ${BASE_IMAGE}@sha256:${BASE_IMAGE_SHA256} AS build-step
+
+# Keepalived version to use
+ARG KEEPALIVED_VERSION
+
+WORKDIR /home/keepalived
+
+RUN apk add --no-cache make gcc curl autoconf automake musl-dev libnl3-dev libnftnl-dev openssl-dev \
+  && curl --fail -Lo keepalived.tar.gz https://github.com/acassen/keepalived/archive/refs/tags/v${KEEPALIVED_VERSION}.tar.gz \
+  && tar xvf keepalived.tar.gz && cd "keepalived-${KEEPALIVED_VERSION}" \
+  && ./autogen.sh \
+  && ./configure --enable-vrrp -enable-sha1 --enable-json \
+  && make && cp bin/keepalived /keepalived
+
+
+FROM ${BASE_IMAGE}@sha256:${BASE_IMAGE_SHA256}
+
+# Timestamp of the build, formatted as RFC3339
+ARG BUILD_DATE
+# Git revision o the tree at build time
+ARG VCS_REF
+# Version of the image
+ARG VERSION
+# Version of the project, e.g. `git describe --always --long --dirty --broken`
+ARG METALK8S_VERSION
+
+RUN addgroup -S keepalived \
+  && adduser -D -S -G keepalived keepalived \
+  && chown -R keepalived:keepalived /run \
+  && mkdir -p /etc/keepalived \
+  && chown -R keepalived:keepalived /etc/keepalived
+
+COPY --chown=keepalived:keepalived keepalived.conf.j2 /etc/keepalived/
+COPY --chown=keepalived:keepalived check-ingress.sh /etc/keepalived/
+
+COPY --chown=keepalived:keepalived generate-config.py /
+COPY --chown=keepalived:keepalived entrypoint.sh /
+
+COPY --chown=keepalived:keepalived --from=build-step /keepalived /usr/sbin/
+
+RUN apk add --no-cache libcap \
+  && setcap     cap_net_admin,cap_net_bind_service,cap_net_raw,cap_setuid,cap_setgid=+ep /usr/sbin/keepalived \
+  && setcap -v  cap_net_admin,cap_net_bind_service,cap_net_raw,cap_setuid,cap_setgid=+ep /usr/sbin/keepalived \
+  && apk del libcap
+
+RUN apk add --no-cache libnl3 libnftnl bash curl py3-jinja2 py3-yaml
+
+USER keepalived
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/etc/keepalived/keepalived-input.yaml"]
+
+# These contain BUILD_DATE so should come 'late' for layer caching
+LABEL maintainer="squad-metalk8s@scality.com" \
+      # http://label-schema.org/rc1/
+      org.label-schema.build-date="$BUILD_DATE" \
+      org.label-schema.name="metalk8s-keepalived" \
+      org.label-schema.description="MetalK8s Keepalived container" \
+      org.label-schema.url="https://github.com/scality/metalk8s/" \
+      org.label-schema.vcs-url="https://github.com/scality/metalk8s.git" \
+      org.label-schema.vcs-ref="$VCS_REF" \
+      org.label-schema.vendor="Scality" \
+      org.label-schema.version="$VERSION" \
+      org.label-schema.schema-version="1.0" \
+      # https://github.com/opencontainers/image-spec/blob/master/annotations.md
+      org.opencontainers.image.created="$BUILD_DATE" \
+      org.opencontainers.image.authors="squad-metalk8s@scality.com" \
+      org.opencontainers.image.url="https://github.com/scality/metalk8s/" \
+      org.opencontainers.image.source="https://github.com/scality/metalk8s.git" \
+      org.opencontainers.image.version="$VERSION" \
+      org.opencontainers.image.revision="$VCS_REF" \
+      org.opencontainers.image.vendor="Scality" \
+      org.opencontainers.image.title="metalk8s-keepalived" \
+      org.opencontainers.image.description="MetalK8s Keepalived container" \
+      # https://docs.openshift.org/latest/creating_images/metadata.html
+      io.openshift.tags="metalk8s,keepalived" \
+      io.k8s.description="MetalK8s Keepalived container" \
+      # Various
+      com.scality.metalk8s.version="$METALK8S_VERSION"

--- a/images/metalk8s-keepalived/README.md
+++ b/images/metalk8s-keepalived/README.md
@@ -1,0 +1,49 @@
+# Keepalived container image
+
+This a custom container image used in MetalK8s to manage
+Virtual IPs spread on the nodes to expose the Workload Plane Ingress.
+
+This image is composed of several scripts.
+
+## Entrypoint script
+
+This script is the entrypoint for the container, it generate the
+configuration and start keepalived process.
+
+## Generate config script
+
+This script is used at container startup to generate the keepalived
+configuration from a more high level configuration.
+
+The input data should look like the following example:
+
+```yaml
+apiVersion: metalk8s.scality.com/v1alpha1
+kind: KeepalivedConfiguration
+addresses:
+  - ip: 192.168.1.200   # Virtual IP address
+    node: node-1        # Master node name for this IP
+    vr_id: 10           # Virtual router ID
+  - ip: 192.168.1.201
+    node: node-2
+    vr_id: 15
+  - ip: 192.168.1.202
+    node: node-3
+    vr_id: 45
+  - ip: 192.168.1.203
+    vr_id: 12
+```
+
+## Check script
+
+The check script is used by keepalived to check that the local node, where
+the keepalived process is running, is ready to get some load.
+
+It check that the local Ingress Controller is available
+
+## Dockerfile
+
+We need to build keepalived ourself to enable JSON, so that we can
+use the JSON signal to get the current keepalived status in JSON format.
+
+The keepalived binary from the package is not build with JSON enabled.

--- a/images/metalk8s-keepalived/check-ingress.sh
+++ b/images/metalk8s-keepalived/check-ingress.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -xue -o pipefail
+
+TIMEOUT=2
+
+curl --insecure --silent --max-time "$TIMEOUT" \
+    --output /dev/null --show-error --fail \
+    "https://127.0.0.1:443/healthz"

--- a/images/metalk8s-keepalived/entrypoint.sh
+++ b/images/metalk8s-keepalived/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -xue -o pipefail
+
+/generate-config.py --input "$1" --template "/etc/keepalived/keepalived.conf.j2" --output "/etc/keepalived/keepalived.conf"
+
+exec keepalived \
+    --log-console --log-detail \
+    --dont-fork --dont-respawn \
+    --address-monitoring \
+    --dump-conf --use-file "/etc/keepalived/keepalived.conf"

--- a/images/metalk8s-keepalived/generate-config.py
+++ b/images/metalk8s-keepalived/generate-config.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import re
+import subprocess
+import yaml
+
+import jinja2
+
+
+EXPECTED_KIND = "KeepalivedConfiguration"
+SUPPORTED_API_VERSION = ["metalk8s.scality.com/v1alpha1"]
+
+
+def get_interface_from_ip(ip):
+    # NOTE: We do not have any easy way (without an external lib)
+    # to retrieve the interface easily in Python
+    # So let's rely on `ip route get`
+    output = subprocess.check_output(f"ip route get {ip}", shell=True, text=True)
+
+    match = re.search(r"^.+ dev (?P<iface>.+) src .+$", output, re.MULTILINE)
+    return match.group("iface")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-i", "--input", help="Data input file", required=True)
+    parser.add_argument("-t", "--template", help=" Data template file", required=True)
+    parser.add_argument(
+        "-o", "--output", help="Output file (default stdout)", default="/dev/stdout"
+    )
+    args = parser.parse_args()
+
+    with open(args.input, mode="r") as in_fd:
+        input_data = yaml.safe_load(in_fd)
+
+    if input_data["kind"] != EXPECTED_KIND:
+        raise ValueError(
+            f"Invalid kind '{input_data['kind']}' expected {EXPECTED_KIND}"
+        )
+    if input_data["apiVersion"] not in SUPPORTED_API_VERSION:
+        raise ValueError(
+            f"ApiVersion '{input_data['apiVersion']}' not supported, "
+            f"expected one of {', '.join(SUPPORTED_API_VERSION)}"
+        )
+
+    environment = jinja2.Environment(loader=jinja2.FileSystemLoader("./"))
+    temp = environment.get_template(args.template)
+    temp.globals["get_interface_from_ip"] = get_interface_from_ip
+
+    with open(args.output, mode="w", encoding="utf-8") as out_fd:
+        out_fd.write(temp.render(input=input_data, env=os.environ))
+
+
+if __name__ == "__main__":
+    main()

--- a/images/metalk8s-keepalived/keepalived.conf.j2
+++ b/images/metalk8s-keepalived/keepalived.conf.j2
@@ -1,0 +1,29 @@
+global_defs {
+    enable_script_security
+    script_user keepalived keepalived
+}
+
+vrrp_script check_ingress {
+    script "/etc/keepalived/check-ingress.sh"
+    interval 5
+    weight 60
+}
+
+{%- for addr in input["addresses"] %}
+
+{%- set is_master = addr.get("node") == env["NODE_NAME"] %}
+
+vrrp_instance VI_{{ loop.index }} {
+    state {{ 'MASTER' if is_master else 'BACKUP' }}
+    interface {{ get_interface_from_ip(addr["ip"]) }}
+    priority {{ '150' if is_master else '100' }}
+    virtual_router_id {{ addr["vr_id"] }}
+    virtual_ipaddress {
+        {{ addr["ip"] }}
+    }
+    track_script {
+        check_ingress
+    }
+}
+
+{%- endfor %}


### PR DESCRIPTION
Build our own keepalived container image based on alpine that will be
used later to manage Workload Plane Ingress VIPs.

---
<details><summary>Manual tests I ran</summary>

- Creating a test DaemonSet and High Level Config Map
```yaml
# deploy.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: test-cm
data:
  keepalived-input.yaml: |
    apiVersion: metalk8s.scality.com/v1alpha1
    kind: KeepalivedConfiguration
    addresses:
      - ip: 192.168.1.200
        node: metalk8s-cty13-bootstrap.novalocal
        vr_id: 10
      - ip: 192.168.1.201
        node: metalk8s-cty13-node-1.novalocal
        vr_id: 15
      - ip: 192.168.1.202
        node: metalk8s-cty13-node-2.novalocal
        vr_id: 45
      - ip: 192.168.1.203
        vr_id: 12
---
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: test-vip
spec:
  selector:
    matchLabels:
      app.kubernetes.io/instance: keepalived
      app.kubernetes.io/name: keepalived
  template:
    metadata:
      labels:
        app.kubernetes.io/instance: keepalived
        app.kubernetes.io/name: keepalived
      annotations:
        checksum/config: abcd123
    spec:
      containers:
        - name: keepalived
          image: metalk8s-registry-from-config.invalid/metalk8s-124.0.0-dev/metalk8s-keepalived:124.0.0-dev
          env:
            - name: NODE_NAME
              valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: spec.nodeName
          volumeMounts:
            - mountPath: /etc/keepalived/keepalived-input.yaml
              subPath: keepalived-input.yaml
              name: hl-config
          securityContext:
            capabilities:
              drop:
                - ALL
              add:
                - NET_ADMIN
                - NET_BIND_SERVICE
                - NET_RAW
                - SETUID
                - SETGID
                - NET_BROADCAST
      hostNetwork: true
      volumes:
        - configMap:
            name: test-cm
          name: hl-config
```

- Resulting keepalived config on bootstrap node
```
global_defs {
    enable_script_security
    script_user keepalived keepalived
}

vrrp_script check_ingress {
    script "/etc/keepalived/check-ingress.sh"
    interval 5
    weight 60
}

vrrp_instance VI_1 {
    state MASTER
    interface eth1 
    priority 150
    virtual_router_id 10
    virtual_ipaddress {
        192.168.1.200
    }
    track_script {
        check_ingress
    }
}

vrrp_instance VI_2 {
    state BACKUP
    interface eth1 
    priority 100
    virtual_router_id 15
    virtual_ipaddress {
        192.168.1.201
    }
    track_script {
        check_ingress
    }
}

vrrp_instance VI_3 {
    state BACKUP
    interface eth1 
    priority 100
    virtual_router_id 45
    virtual_ipaddress {
        192.168.1.202
    }
    track_script {
        check_ingress
    }
}

vrrp_instance VI_4 {
    state BACKUP
    interface eth1 
    priority 100
    virtual_router_id 12
    virtual_ipaddress {
        192.168.1.203
    }
    track_script {
        check_ingress
    }
}
```

- IPs are properly spread on nodes
- Failover when a node goes down => works well
- Failover when Ingress pod goes down => works well
- Failover when keepalived pod goes down => works well
- JSON signal works well
```json
# kill -$(keepalived --signum=JSON) $(cat /run/keepalived.pid)
# cat /tmp/keepalived.json | python3 -m json.tool
[
    {
        "data": {
            "iname": "VI_1",
            "dont_track_primary": 0,
            "skip_check_adv_addr": 0,
            "strict_mode": 0,
            "vmac_ifname": "",
            "ifp_ifname": "eth1",
            "master_priority": 0,
            "last_transition": 1660318834.037695,
            "garp_delay": 5,
            "garp_refresh": 0,
            "garp_rep": 5,
            "garp_refresh_rep": 1,
            "garp_lower_prio_delay": 5,
            "garp_lower_prio_rep": 5,
            "lower_prio_no_advert": 0,
            "higher_prio_send_advert": 0,
            "vrid": 10,
            "base_priority": 150,
            "effective_priority": 210,
            "vipset": true,
            "promote_secondaries": false,
            "adver_int": 1,
            "master_adver_int": 1,
            "accept": 1,
            "nopreempt": false,
            "preempt_delay": 0,
            "state": 2,
            "wantstate": 2,
            "version": 2,
            "smtp_alert": false,
            "notify_deleted": false,
            "vips": [
                "192.168.1.200 dev eth1 scope global set"
            ],
            "track_script": [
                "'/etc/keepalived/check-ingress.sh'"
            ],
            "auth_type": 0
        },
        "stats": {
            "advert_rcvd": 3,
            "advert_sent": 132,
            "become_master": 1,
            "release_master": 0,
            "packet_len_err": 0,
            "advert_interval_err": 0,
            "ip_ttl_err": 0,
            "invalid_type_rcvd": 0,
            "addr_list_err": 0,
            "invalid_authtype": 0,
            "authtype_mismatch": 0,
            "auth_failure": 0,
            "pri_zero_rcvd": 0,
            "pri_zero_sent": 0
        }
    },
    {
        "data": {
            "iname": "VI_2",
            "dont_track_primary": 0,
            "skip_check_adv_addr": 0,
            "strict_mode": 0,
            "vmac_ifname": "",
            "ifp_ifname": "eth1",
            "master_priority": 210,
            "last_transition": 1660318860.428099,
            "garp_delay": 5,
            "garp_refresh": 0,
            "garp_rep": 5,
            "garp_refresh_rep": 1,
            "garp_lower_prio_delay": 5,
            "garp_lower_prio_rep": 5,
            "lower_prio_no_advert": 0,
            "higher_prio_send_advert": 0,
            "vrid": 15,
            "base_priority": 100,
            "effective_priority": 160,
            "vipset": false,
            "promote_secondaries": false,
            "adver_int": 1,
            "master_adver_int": 1,
            "accept": 1,
            "nopreempt": false,
            "preempt_delay": 0,
            "state": 1,
            "wantstate": 1,
            "version": 2,
            "smtp_alert": false,
            "notify_deleted": false,
            "vips": [
                "192.168.1.201 dev eth1 scope global"
            ],
            "track_script": [
                "'/etc/keepalived/check-ingress.sh'"
            ],
            "auth_type": 0
        },
        "stats": {
            "advert_rcvd": 127,
            "advert_sent": 12,
            "become_master": 1,
            "release_master": 1,
            "packet_len_err": 0,
            "advert_interval_err": 0,
            "ip_ttl_err": 0,
            "invalid_type_rcvd": 0,
            "addr_list_err": 0,
            "invalid_authtype": 0,
            "authtype_mismatch": 0,
            "auth_failure": 0,
            "pri_zero_rcvd": 2,
            "pri_zero_sent": 0
        }
    },
    {
        "data": {
            "iname": "VI_3",
            "dont_track_primary": 0,
            "skip_check_adv_addr": 0,
            "strict_mode": 0,
            "vmac_ifname": "",
            "ifp_ifname": "eth1",
            "master_priority": 210,
            "last_transition": 1660318858.376188,
            "garp_delay": 5,
            "garp_refresh": 0,
            "garp_rep": 5,
            "garp_refresh_rep": 1,
            "garp_lower_prio_delay": 5,
            "garp_lower_prio_rep": 5,
            "lower_prio_no_advert": 0,
            "higher_prio_send_advert": 0,
            "vrid": 45,
            "base_priority": 100,
            "effective_priority": 160,
            "vipset": false,
            "promote_secondaries": false,
            "adver_int": 1,
            "master_adver_int": 1,
            "accept": 1,
            "nopreempt": false,
            "preempt_delay": 0,
            "state": 1,
            "wantstate": 1,
            "version": 2,
            "smtp_alert": false,
            "notify_deleted": false,
            "vips": [
                "192.168.1.202 dev eth1 scope global"
            ],
            "track_script": [
                "'/etc/keepalived/check-ingress.sh'"
            ],
            "auth_type": 0
        },
        "stats": {
            "advert_rcvd": 127,
            "advert_sent": 10,
            "become_master": 1,
            "release_master": 1,
            "packet_len_err": 0,
            "advert_interval_err": 0,
            "ip_ttl_err": 0,
            "invalid_type_rcvd": 0,
            "addr_list_err": 0,
            "invalid_authtype": 0,
            "authtype_mismatch": 0,
            "auth_failure": 0,
            "pri_zero_rcvd": 1,
            "pri_zero_sent": 0
        }
    },
    {
        "data": {
            "iname": "VI_4",
            "dont_track_primary": 0,
            "skip_check_adv_addr": 0,
            "strict_mode": 0,
            "vmac_ifname": "",
            "ifp_ifname": "eth1",
            "master_priority": 160,
            "last_transition": 1660318849.132555,
            "garp_delay": 5,
            "garp_refresh": 0,
            "garp_rep": 5,
            "garp_refresh_rep": 1,
            "garp_lower_prio_delay": 5,
            "garp_lower_prio_rep": 5,
            "lower_prio_no_advert": 0,
            "higher_prio_send_advert": 0,
            "vrid": 12,
            "base_priority": 100,
            "effective_priority": 160,
            "vipset": true,
            "promote_secondaries": false,
            "adver_int": 1,
            "master_adver_int": 1,
            "accept": 1,
            "nopreempt": false,
            "preempt_delay": 0,
            "state": 2,
            "wantstate": 2,
            "version": 2,
            "smtp_alert": false,
            "notify_deleted": false,
            "vips": [
                "192.168.1.203 dev eth1 scope global set"
            ],
            "track_script": [
                "'/etc/keepalived/check-ingress.sh'"
            ],
            "auth_type": 0
        },
        "stats": {
            "advert_rcvd": 19,
            "advert_sent": 117,
            "become_master": 1,
            "release_master": 0,
            "packet_len_err": 0,
            "advert_interval_err": 0,
            "ip_ttl_err": 0,
            "invalid_type_rcvd": 0,
            "addr_list_err": 0,
            "invalid_authtype": 0,
            "authtype_mismatch": 0,
            "auth_failure": 0,
            "pri_zero_rcvd": 1,
            "pri_zero_sent": 0
        }
    }
]
```
</details>