### PR TITLE
salt: Ensure that MetalK8s package do not get removed as unused dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,20 @@
   it's possible each MetalK8s UI pods will sit on a different infra node
   (PR[#3848](https://github.com/scality/metalk8s/pull/3848))
 
+- Ensure that on RHEL 8 based OS, packages installed by MetalK8s
+  are marked as "installed by user" so that they do not get removed
+  as "unused dependencies"
+  (PR[#3850](https://github.com/scality/metalk8s/pull/3850))
+
 ### Bug fixes
 
 - Enforce `runc` version lock so that we ensure that it do not get
   "wrongly" updated after installation
   (PR[#3849](https://github.com/scality/metalk8s/pull/3849))
+
+- Fix a bug on RHEL 8 based OS, where the `kubelet` package get
+  removed during the post-upgrade step
+  (PR[#3850](https://github.com/scality/metalk8s/pull/3850))
 
 ## Release 123.0.3
 

--- a/salt/_states/metalk8s_package_manager.py
+++ b/salt/_states/metalk8s_package_manager.py
@@ -25,27 +25,52 @@ def installed(name, version=None, fromrepo=None, pkgs_info=None, **kwargs):
     in `pkgs_info`.
     """
     if version is None or kwargs.get("pkgs"):
-        return __states__["pkg.installed"](
+        ret = __states__["pkg.installed"](
             name=name, version=version, fromrepo=fromrepo, **kwargs
         )
+    else:
+        dep_list = __salt__["metalk8s_package_manager.list_pkg_dependents"](
+            name,
+            version,
+            fromrepo=fromrepo,
+            pkgs_info=pkgs_info,
+        )
+        if dep_list is None:
+            return {
+                "name": name,
+                "result": False,
+                "changes": {},
+                "comment": (
+                    'Failed to update package "{}" and its dependents'.format(name)
+                ),
+            }
 
-    dep_list = __salt__["metalk8s_package_manager.list_pkg_dependents"](
-        name,
-        version,
-        fromrepo=fromrepo,
-        pkgs_info=pkgs_info,
-    )
-    if dep_list is None:
-        return {
-            "name": name,
-            "result": False,
-            "changes": {},
-            "comment": (
-                'Failed to update package "{}" and its dependents'.format(name)
-            ),
-        }
+        pkgs = [{k: v} for k, v in dep_list.items()]
+        ret = __states__["pkg.installed"](
+            name=name, pkgs=pkgs, fromrepo=fromrepo, **kwargs
+        )
 
-    pkgs = [{k: v} for k, v in dep_list.items()]
-    return __states__["pkg.installed"](
-        name=name, pkgs=pkgs, fromrepo=fromrepo, **kwargs
-    )
+    if (
+        ret["result"]
+        and not __opts__["test"]
+        and __grains__["os_family"] == "RedHat"
+        and __grains__["osmajorrelease"] == 8
+    ):
+        # With Salt on RHEL based 8 OS, even if we run a `pkg.installed` the package is not
+        # marked as "installed by the user" if the package get installed earlier as
+        # a dependencies
+        # See: https://github.com/saltstack/salt/issues/62441
+        # So, if we are in this specific case and install succeeded, we explicitly mark the
+        # package as "installed by the user" using `dnf mark install`
+        out = __salt__["cmd.run_all"](f'dnf mark install "{name}"')
+
+        if out["retcode"] != 0:
+            ret["result"] = False
+            ret["comment"] += (
+                f"\nUnable to mark {name} as installed by user:"
+                f"\nSTDERR: {out['stderr']}\nSTDOUT: {out['stdout']}"
+            )
+        else:
+            ret["comment"] += f"\nPackage {name} marked as user installed"
+
+    return ret


### PR DESCRIPTION
Ensure that on RHEL 8 based OS, packages installed by MetalK8s
are marked as "installed by user" so that they do not get removed
as "unused dependencies".

This commit also fixes a bug where the `kubelet` package gets removed
in post-upgrade step that removes the `calico-cni-plugin` package.

See: https://github.com/saltstack/salt/issues/62441