### PR TITLE
operator: Do not override kube-system namespace

### DIFF
--- a/operator/config/metalk8s/delete_ns.yaml
+++ b/operator/config/metalk8s/delete_ns.yaml
@@ -1,0 +1,5 @@
+$patch: delete
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: system

--- a/operator/config/metalk8s/kustomization.yaml
+++ b/operator/config/metalk8s/kustomization.yaml
@@ -16,3 +16,6 @@ patches:
 - path: deploy_patch.yaml
   target:
     kind: Deployment
+
+patchesStrategicMerge:
+  - delete_ns.yaml

--- a/operator/deploy/manifests.yaml
+++ b/operator/deploy/manifests.yaml
@@ -1,10 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    control-plane: controller-manager
-  name: kube-system
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:


### PR DESCRIPTION
Since we deploy the operator on the kube-system namespace we do not need
to create this one, especially since it removes the annotations we set on
this namespace