### PR TITLE
salt: Ensure salt-minion restart is run as the last step of the state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@
 - Always set `NO_PROXY` for containerd for internal IPs
   (PR[#3852](https://github.com/scality/metalk8s/pull/3852))
 
+- Fix a bug that may break salt-minion upgrade as the salt-minion
+  restart was not run as the last step of salt-minion upgrade state
+  (PR[#3854](https://github.com/scality/metalk8s/pull/3854))
+
 ## Release 123.0.3
 
 ### Enhancements

--- a/salt/metalk8s/salt/minion/installed.sls
+++ b/salt/metalk8s/salt/minion/installed.sls
@@ -33,6 +33,7 @@ Start and enable Salt minion:
   # we do not want this state to restart salt-minion process just
   # start it if not yet started and enable the service
   service.running:
+    - order: last
     - name: salt-minion
     - enable: True
     - require:

--- a/salt/metalk8s/salt/minion/restart.sls
+++ b/salt/metalk8s/salt/minion/restart.sls
@@ -1,4 +1,5 @@
 Restart salt-minion:
   cmd.wait:  # noqa: 213
+    - order: last
     - name: 'salt-call --local service.restart salt-minion > /dev/null'
     - bg: True


### PR DESCRIPTION
Since we trigger a salt-minion restart as part of a salt state execution
we ran it in the background, so we want this restart to be run at the very
end of the salt states.

But salt does not honor `order: last` when the state that has it also
has some `require` on it, that's why we need to put `order: last` on
all states that should run at the very end