### PR TITLE
build: Add codegen for addons charts rendering

### DIFF
--- a/.pylint-dict
+++ b/.pylint-dict
@@ -22,6 +22,7 @@ containerd
 dataset
 de
 debuild
+Dex
 docstring
 dockerfile
 doit

--- a/.pylint-dict
+++ b/.pylint-dict
@@ -13,6 +13,7 @@ cli
 cni
 cmd
 cmp
+codegen
 config
 cp
 checksum

--- a/.pylint-dict
+++ b/.pylint-dict
@@ -75,6 +75,7 @@ sdk
 skopeo
 sls
 srv
+Thanos
 timestamp
 tmp
 tmpfs

--- a/.pylint-dict
+++ b/.pylint-dict
@@ -36,6 +36,7 @@ getattr
 getitem
 globals
 gofmt
+Kube
 html
 init
 io

--- a/buildchain/buildchain/codegen.py
+++ b/buildchain/buildchain/codegen.py
@@ -14,6 +14,21 @@ from buildchain import types
 from buildchain import utils
 
 
+def get_task_information() -> types.TaskDict:
+    """Retrieve all the task information from codegen"""
+    result: types.TaskDict = {
+        "actions": [],
+        "task_dep": [],
+        "file_dep": [],
+    }
+    for task_fun in CODEGEN:
+        task = task_fun()
+        for key, value in result.items():
+            value.extend(task.get(key, []))
+
+    return result
+
+
 def task_codegen() -> Iterator[types.TaskDict]:
     """Run the code generation tools."""
     for create_codegen_task in CODEGEN:

--- a/buildchain/buildchain/codegen.py
+++ b/buildchain/buildchain/codegen.py
@@ -69,10 +69,38 @@ def codegen_storage_operator() -> types.TaskDict:
     }
 
 
+def codegen_chart_dex() -> types.TaskDict:
+    """Generate the SLS file for Dex using the chart render script."""
+    target_sls = constants.ROOT / "salt/metalk8s/addons/dex/deployed/chart.sls"
+    chart_dir = constants.CHART_ROOT / "dex"
+    value_file = constants.CHART_ROOT / "dex.yaml"
+    cmd = (
+        f"{constants.CHART_RENDER_CMD} dex {value_file} {chart_dir} "
+        "--namespace metalk8s-auth "
+        "--service-config dex metalk8s-dex-config "
+        "metalk8s/addons/dex/config/dex.yaml.j2 metalk8s-auth "
+        f"--output {target_sls}"
+    )
+
+    file_dep = list(utils.git_ls(chart_dir))
+    file_dep.append(value_file)
+    file_dep.append(constants.CHART_RENDER_SCRIPT)
+
+    return {
+        "name": "chart_dex",
+        "title": utils.title_with_subtask_name("CODEGEN"),
+        "doc": codegen_chart_dex.__doc__,
+        "actions": [doit.action.CmdAction(cmd)],
+        "file_dep": file_dep,
+        "task_dep": ["check_for:tox", "check_for:helm"],
+    }
+
+
 # List of available code generation tasks.
 CODEGEN: Tuple[Callable[[], types.TaskDict], ...] = (
     codegen_storage_operator,
     codegen_metalk8s_operator,
+    codegen_chart_dex,
 )
 
 

--- a/buildchain/buildchain/codegen.py
+++ b/buildchain/buildchain/codegen.py
@@ -291,6 +291,33 @@ def codegen_chart_metallb() -> types.TaskDict:
     }
 
 
+def codegen_chart_prometheus_adapter() -> types.TaskDict:
+    """Generate the SLS file for Prometheus Adapter using the chart render script."""
+    target_sls = (
+        constants.ROOT / "salt/metalk8s/addons/prometheus-adapter/deployed/chart.sls"
+    )
+    chart_dir = constants.CHART_ROOT / "prometheus-adapter"
+    value_file = constants.CHART_ROOT / "prometheus-adapter.yaml"
+    cmd = (
+        f"{constants.CHART_RENDER_CMD} prometheus-adapter {value_file} {chart_dir} "
+        "--namespace metalk8s-monitoring "
+        f"--output {target_sls}"
+    )
+
+    file_dep = list(utils.git_ls(chart_dir))
+    file_dep.append(value_file)
+    file_dep.append(constants.CHART_RENDER_SCRIPT)
+
+    return {
+        "name": "chart_prometheus-adapter",
+        "title": utils.title_with_subtask_name("CODEGEN"),
+        "doc": codegen_chart_prometheus_adapter.__doc__,
+        "actions": [doit.action.CmdAction(cmd)],
+        "file_dep": file_dep,
+        "task_dep": ["check_for:tox", "check_for:helm"],
+    }
+
+
 # List of available code generation tasks.
 CODEGEN: Tuple[Callable[[], types.TaskDict], ...] = (
     codegen_storage_operator,
@@ -301,6 +328,7 @@ CODEGEN: Tuple[Callable[[], types.TaskDict], ...] = (
     codegen_chart_kube_prometheus_stack,
     codegen_chart_loki,
     codegen_chart_metallb,
+    codegen_chart_prometheus_adapter,
 )
 
 

--- a/buildchain/buildchain/config.py
+++ b/buildchain/buildchain/config.py
@@ -58,6 +58,7 @@ class ExtCommand(enum.Enum):
     GIT = os.getenv("GIT_BIN", "git")
     GOFMT = os.getenv("GOFMT_BIN", "gofmt")
     HARDLINK = os.getenv("HARDLINK_BIN", "hardlink")
+    HELM = os.getenv("HELM_BIN", "helm")
     IMPLANTISOMD5 = os.getenv("IMPLANTISOMD5_BIN", "implantisomd5")
     MAKE = os.getenv("MAKE_BIN", "make")
     MKISOFS = os.getenv("MKISOFS_BIN", "mkisofs")

--- a/buildchain/buildchain/constants.py
+++ b/buildchain/buildchain/constants.py
@@ -9,7 +9,7 @@ import subprocess
 from typing import List, Optional, FrozenSet
 
 from buildchain import ROOT  # Re-export ROOT through this module.
-from buildchain import config
+from buildchain import config, versions
 
 
 # Max length of a "command".
@@ -71,6 +71,10 @@ REDHAT_ENTRYPOINT: Path = ROOT / "packages/redhat/common/entrypoint.sh"
 UI_PUBLIC: Path = ROOT / "ui/public"
 UI_BRANDING: Path = UI_PUBLIC / "brand"
 UI_ASSETS: Path = UI_BRANDING / "assets"
+
+# Path to the chart files
+CHART_ROOT: Path = ROOT / "charts"
+CHART_RENDER_SCRIPT: Path = CHART_ROOT / "render.py"
 
 # }}}
 # Vagrant parameters {{{
@@ -139,6 +143,8 @@ METALK8S_OPERATOR_SDK_GENERATE_CMDS: List[List[str]] = [
     [config.ExtCommand.MAKE.value, "manifests"],
     [config.ExtCommand.MAKE.value, "metalk8s"],
 ]
+
+CHART_RENDER_CMD: str = f"tox -e chart-render -- --kube-version {versions.K8S_VERSION}"
 
 # For mypy, see `--no-implicit-reexport` documentation.
 __all__ = ["ROOT"]

--- a/buildchain/buildchain/utils.py
+++ b/buildchain/buildchain/utils.py
@@ -8,7 +8,7 @@ import inspect
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any, Callable, Iterator, List, Optional
+from typing import Any, Callable, Iterator, List, Optional, Union
 
 from docker.types import Mount  # type: ignore
 
@@ -114,7 +114,7 @@ def bind_ro_mount(source: Path, target: Path) -> Mount:
     return bind_mount(source=source, target=target, read_only=True)
 
 
-def git_ls(directory: Optional[str] = None) -> Iterator[Path]:
+def git_ls(directory: Optional[Union[str, Path]] = None) -> Iterator[Path]:
     """Return the list of files tracked by Git under `root` (recursively).
 
     Arguments:
@@ -123,7 +123,13 @@ def git_ls(directory: Optional[str] = None) -> Iterator[Path]:
     Returns:
         A list of files tracked by Git.
     """
-    root = constants.ROOT if directory is None else constants.ROOT / directory
+    if directory is None:
+        root = constants.ROOT
+    elif isinstance(directory, Path):
+        root = directory
+    else:
+        root = constants.ROOT / directory
+
     assert root.is_dir()
     return map(
         Path,

--- a/buildchain/static-container-registry/test.sh
+++ b/buildchain/static-container-registry/test.sh
@@ -21,7 +21,7 @@ TEST_SKOPEO=${TEST_SKOPEO:-1}
 
 if [ "$TEST_DOCKER" -eq 1 ]; then
 test_docker() {
-        for image in ${AVAILABLE_IMAGES[*]}; do
+        for image in "${AVAILABLE_IMAGES[@]}"; do
                 assert "$DOCKER pull '$REGISTRY/$image'"
         done
 }
@@ -29,7 +29,7 @@ fi
 
 if [ "$TEST_CONTAINERD" -eq 1 ]; then
 test_containerd() {
-        for image in ${AVAILABLE_IMAGES[*]}; do
+        for image in "${AVAILABLE_IMAGES[@]}"; do
                 assert "sudo ${CRICTL} --image-endpoint unix:///run/containerd/containerd.sock pull '$REGISTRY/$image'"
         done
 }
@@ -37,7 +37,7 @@ fi
 
 if [ "$TEST_CRIO" -eq 1 ]; then
 test_crio() {
-        for image in ${AVAILABLE_IMAGES[*]}; do
+        for image in "${AVAILABLE_IMAGES[@]}"; do
                 assert "sudo ${CRICTL} --image-endpoint unix:///run/crio/crio.sock pull '$REGISTRY/$image'"
         done
 }
@@ -45,7 +45,7 @@ fi
 
 if [ "$TEST_SKOPEO" -eq 1 ]; then
 test_skopeo() {
-        for image in ${AVAILABLE_IMAGES[*]}; do
+        for image in "${AVAILABLE_IMAGES[@]}"; do
                 assert "$SKOPEO --debug inspect --tls-verify=false 'docker://$REGISTRY/$image'"
         done
 }
@@ -83,7 +83,7 @@ setup() {
         while [ $i -gt 0 ]; do
                 local ok
                 ok=$($CURL --silent "http://$REGISTRY/v2/" 2>/dev/null)
-                if [ "x$ok" = 'xok' ]; then
+                if [ "$ok" = 'ok' ]; then
                         i=0
                 else
                         sleep 0.1

--- a/charts/render.py
+++ b/charts/render.py
@@ -333,6 +333,9 @@ def main():
         "-n", "--namespace", default="default", help="Namespace to deploy this chart in"
     )
     parser.add_argument("values", help="Our custom chart values")
+    parser.add_argument(
+        "-o", "--output", default="", help="Output file for SLS, default to stdout"
+    )
 
     class ActionServiceConfigArgs(argparse.Action):
         def __call__(self, parser, args, values, option_string=None):
@@ -493,12 +496,10 @@ def main():
             )
         )
 
-    sys.stdout.write(
-        START_BLOCK.format(
-            csc_defaults="\n".join(import_csc_yaml), configlines="\n".join(config)
-        ).lstrip()
-    )
-    sys.stdout.write("\n")
+    out = START_BLOCK.format(
+        csc_defaults="\n".join(import_csc_yaml), configlines="\n".join(config)
+    ).lstrip()
+    out += "\n"
 
     manifests = []
     for doc in yaml.safe_load_all(template):
@@ -515,9 +516,15 @@ def main():
     )
     stream.seek(0)
 
-    sys.stdout.write(replace_magic_strings(stream.read()))
+    out += replace_magic_strings(stream.read())
 
-    sys.stdout.write(END_BLOCK)
+    out += END_BLOCK
+
+    if args.output:
+        with open(args.output, "w") as fd:
+            fd.write(out)
+    else:
+        sys.stdout.write(out)
 
 
 if __name__ == "__main__":

--- a/eve/get_product_version.sh
+++ b/eve/get_product_version.sh
@@ -2,6 +2,6 @@
 
 script_full_path=$(readlink -f "$0")
 file_dir=$(dirname "$script_full_path")/..
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 source "$file_dir/VERSION" && \
     echo "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}"

--- a/eve/wait_pods_stable.sh
+++ b/eve/wait_pods_stable.sh
@@ -57,7 +57,7 @@ check_pods_stabilization() {
 check_kubeconfig() {
     if [ ! -r "$KUBECONFIG" ]; then
         if [ -f "$KUBECONFIG" ]; then
-            echo "Unable to read $KUBECONFIG, check you have sufficient"
+            echo "Unable to read $KUBECONFIG, check you have sufficient" \
                  "rights or try to launch this script using sudo." 2>&1
         else
             echo "No such file: $KUBECONFIG" 2>&1

--- a/eve/workers/pod-linter/Dockerfile
+++ b/eve/workers/pod-linter/Dockerfile
@@ -1,9 +1,10 @@
 # CI lint container - Fedora for recent ShellCheck version
-FROM fedora:32
+FROM fedora:36
 
 ARG BUILDBOT_VERSION=2.0.1
 ARG GO_VERSION=1.17.5
 ARG OPERATOR_SDK_VERSION=v0.17.0
+ARG HELM_VERSION=3.9.4
 
 ENV LANG=en_US.utf8
 
@@ -29,6 +30,12 @@ RUN dnf install -y git \
   && chown -R eve:eve /home/eve \
   && pip3 install tox \
   && pip3 install buildbot-worker==${BUILDBOT_VERSION}
+
+# Install helm
+RUN curl -ORL https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz \
+  && tar xzvf helm-v${HELM_VERSION}-linux-amd64.tar.gz \
+  && mv linux-amd64/helm /usr/bin/helm \
+  && rm -rf helm-v${HELM_VERSION}-linux-amd64.tar.gz linux-amd64
 
 # Add eve to sudoers.
 RUN echo "eve ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/eve

--- a/scripts/backup.sh.in
+++ b/scripts/backup.sh.in
@@ -68,7 +68,7 @@ cleanup() {
 trap cleanup EXIT
 
 BASE_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 . "$BASE_DIR"/common.sh
 
 _save_cp() {

--- a/scripts/bootstrap.sh.in
+++ b/scripts/bootstrap.sh.in
@@ -63,7 +63,7 @@ declare -a PACKAGES=(
     genisoimage
 )
 
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 . "$BASE_DIR"/common.sh
 
 orchestrate_bootstrap() {

--- a/scripts/common.sh.in
+++ b/scripts/common.sh.in
@@ -238,7 +238,7 @@ pre_minion_checks() {
         die "OS $OS not supported"
     fi
 
-    test "x$(whoami)" = "xroot" || die "Script must run as root"
+    test "$(whoami)" = "root" || die "Script must run as root"
     test -n "$SYSTEMCTL" || die "systemctl not found"
     test -x "$SYSTEMCTL" || die "systemctl at '$SYSTEMCTL' is not executable"
 }
@@ -337,7 +337,7 @@ retry() {
     until stdout=$("$@"); do
         exit_code=$?
         (( ++try ))
-        if [ $try -gt "$retries" ]; then
+        if [ "$try" -gt "$retries" ]; then
             echo "Failed to run '$*' after $retries retries." >&2
             return $exit_code
         fi

--- a/scripts/downgrade.sh.in
+++ b/scripts/downgrade.sh.in
@@ -83,7 +83,7 @@ cleanup() {
 
 trap cleanup EXIT
 
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 . "$BASE_DIR"/common.sh
 
 precheck_downgrade () {

--- a/scripts/iso-manager.sh
+++ b/scripts/iso-manager.sh
@@ -72,7 +72,7 @@ trap cleanup EXIT
 
 BASE_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 . "$BASE_DIR"/common.sh
 
 # helper function to set the current saltenv

--- a/scripts/restore.sh.in
+++ b/scripts/restore.sh.in
@@ -77,7 +77,7 @@ declare -a PACKAGES=(
     genisoimage
 )
 
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 . "$BASE_DIR"/common.sh
 
 _save_cp() {

--- a/scripts/solutions.sh
+++ b/scripts/solutions.sh
@@ -206,7 +206,7 @@ cleanup() {
 trap cleanup EXIT
 
 BASE_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 . "$BASE_DIR"/common.sh
 
 check_command_mandatory_options() {
@@ -321,8 +321,7 @@ check_namespace() {
     fi
 
     if ! namespace_is_in_environment "$NAMESPACE" "$NAME" &> /dev/null; then
-        echo 1>&2 "Namespace '$NAMESPACE' is not linked to the"
-            "Environment '$NAME'"
+        echo 1>&2 "Namespace '$NAMESPACE' is not linked to the Environment '$NAME'"
         return 1
     fi
 }

--- a/scripts/upgrade.sh.in
+++ b/scripts/upgrade.sh.in
@@ -71,7 +71,7 @@ cleanup() {
 
 trap cleanup EXIT
 
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 . "$BASE_DIR"/common.sh
 
 upgrade_bootstrap () {

--- a/tests/test-certificates-beacon.sh
+++ b/tests/test-certificates-beacon.sh
@@ -23,7 +23,7 @@ WAIT_RENEWAL=${WAIT_RENEWAL:-120}
 
 # shellcheck disable=SC1090
 . "$ARCHIVE_PRODUCT_INFO"
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 . "$ARCHIVE_MOUNTPOINT/common.sh"
 
 override_pillar_conf() {

--- a/tox.ini
+++ b/tox.ini
@@ -127,6 +127,14 @@ commands =
     bash -c "shellcheck $(git ls-files | grep -P '\.sh$')"
     bash -c "shellcheck $(git ls-files | grep -P '\.sh\.in$')"
 
+[testenv:chart-render]
+description =
+    Run the chart render script
+deps =
+    pyyaml
+commands =
+    {toxinidir}/charts/render.py {posargs}
+
 [testenv:tests]
 description =
     Run tests suite remotely (uses local Vagrant configuration by default).


### PR DESCRIPTION
Allow to use doit to generate the charts SLS, and also validate the generated SLS content in the CI

```console
$ ./doit.sh list --all codegen
codegen                               Run the code generation tools.
codegen:chart_dex                     Generate the SLS file for Dex using the chart render script.
codegen:chart_fluent-bit              Generate the SLS file for fluent-bit using the chart render script.
codegen:chart_ingress-nginx           Generate the SLS file for NGINX Ingress using the chart render script.
codegen:chart_kube-prometheus-stack   Generate the SLS file for Kube Prometheus Stack using the chart render script.
codegen:chart_loki                    Generate the SLS file for Loki using the chart render script.
codegen:chart_metallb                 Generate the SLS file for MetalLB using the chart render script.
codegen:chart_prometheus-adapter      Generate the SLS file for Prometheus Adapter using the chart render script.
codegen:chart_thanos                  Generate the SLS file for Thanos using the chart render script.
codegen:metalk8s_operator             Generate Go code for the MetalK8s Operator using the Operator SDK Makefile.
codegen:storage_operator              Generate Go code for the Storage Operator using the Operator SDK Makefile.
```

---

NOTE: This is not the best approach the `charts/render.py` script should be migrated in the buildchain (or we should totally change the way to manage "addons" but ... you know :smile: ), but at least it's better than having the command in commit message :) 