### PR TITLE
salt,tests: Allow forcing the creation of an LV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@
   topology labels on nodes
   (PR[#3889](https://github.com/scality/metalk8s/pull/3889))
 
+- Add support for a `metalk8s.scality.com/force-lvcreate` annotation on `Volume`
+  objects of type `LVMLogicalVolume` to force the creation of their LV (use with
+  caution) (PR[#3877](https://github.com/scality/metalk8s/pull/3877))
+
+  _Note: this is only needed for RHEL 8 or Rocky Linux 8, LVM versions provided
+  on CentOS 7 and RHEL 7 ignore previous signatures on LV creation._
+
 ### Removals
 
 - The deprecated long name `--archive` for the "add" option to the `iso-manager.sh`

--- a/docs/_infos/volumes.yaml
+++ b/docs/_infos/volumes.yaml
@@ -55,3 +55,11 @@ volume_types:
         lvmLogicalVolume:
           vgName: <vg_name>
           size: 10Gi
+    notes: |
+      .. tip::
+
+         You can add the ``metalk8s.scality.com/force-lvcreate`` annotation
+         (value does not matter) to LVMLogicalVolume objects to force the LV
+         creation. This will wipe any existing FS signature on the created LV,
+         so use with caution.
+         If the LV already exists however, it will just attempt to use it as is.

--- a/docs/operation/volume_management/volume_creation_deletion_cli.rst
+++ b/docs/operation/volume_management/volume_creation_deletion_cli.rst
@@ -38,6 +38,8 @@ Creating a Volume
        {% for key, info in volume_info["fields"].items() %}
        - **{{ key }}**: {{ info }}.
        {% endfor %}
+
+       {{ volume_info.get("notes", "") }}
        {% endfor %}
 
 #. Create the Volume.

--- a/salt/_modules/metalk8s_volumes.py
+++ b/salt/_modules/metalk8s_volumes.py
@@ -484,9 +484,17 @@ class LVMLogicalVolume(RawBlockDevice):
         return bool(lv_info and lv_info.get(self.path))
 
     def create(self):
+        force_annotation = (
+            self.get("metadata")
+            .get("annotations", {})
+            .get("metalk8s.scality.com/force-lvcreate")
+        )
         try:
             ret = __salt__["lvm.lvcreate"](
-                lvname=self.lv_name, vgname=self.vg_name, size="{}b".format(self.size)
+                lvname=self.lv_name,
+                vgname=self.vg_name,
+                size="{}b".format(self.size),
+                force=force_annotation is not None,
             )
         except Exception as exc:
             raise CommandExecutionError(

--- a/salt/tests/unit/modules/files/test_metalk8s_volumes.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_volumes.yaml
@@ -137,7 +137,7 @@ _volumes_details: &volumes_details
         lastUpdateTime: '2020-07-11T13:55:26Z'
         status: 'True'
         type: Ready
-  my-lvm-lv-volume:
+  my-lvm-lv-volume: &_lv_volume
     apiVersion: storage.metalk8s.scality.com/v1alpha1
     kind: Volume
     metadata:
@@ -542,18 +542,37 @@ create:
         of: informations
       "Output from lvcreate": All good
     pillar_volumes: *volumes_details
+    lvcreate_forced: false
 
   # unable to create the LVM LV (raise when calling `lvcreate`)
   - name: my-lvm-lv-volume
     pillar_volumes: *volumes_details
     lvcreate: null
     raise_msg: "cannot create LVM LogicalVolume my-lvm-lv-volume in VG my_vg"
+    lvcreate_forced: false
 
   # unable to create the LVM LV (usual "vg does not exist")
   - name: my-lvm-lv-volume
     pillar_volumes: *volumes_details
     lvcreate: 'Volume group "my_vg" not found Penguin'
     raise_msg: 'cannot create LVM LogicalVolume my-lvm-lv-volume in VG my_vg: Volume group "my_vg" not found Penguin'
+    lvcreate_forced: false
+
+  # annotation to force the call to lvcreate
+  - name: example
+    pillar_volumes:
+      example:
+        <<: *_lv_volume
+        metadata:
+          name: example
+          uid: 6474cda7-0dbe-40fc-9842-3cb0404a725a
+          annotations:
+            metalk8s.scality.com/force-lvcreate: ""
+    lvcreate:
+      /dev/my_vg/example:
+        all: good
+      Output from lvcreate: All good
+    lvcreate_forced: true
 
   ## LVM LogicalVolume block volume
   # create a simple LVM LV volume
@@ -564,18 +583,21 @@ create:
         of: informations
       "Output from lvcreate": All good
     pillar_volumes: *volumes_details
+    lvcreate_forced: false
 
   # unable to create the LVM LV (raise when calling `lvcreate`)
   - name: my-lvm-lv-block-volume
     pillar_volumes: *volumes_details
     lvcreate: null
     raise_msg: "cannot create LVM LogicalVolume my-lvm-lv-block-volume in VG my_vg"
+    lvcreate_forced: false
 
   # unable to create the LVM LV (usual "vg does not exist")
   - name: my-lvm-lv-block-volume
     pillar_volumes: *volumes_details
     lvcreate: 'Volume group "my_vg" not found Penguin'
     raise_msg: 'cannot create LVM LogicalVolume my-lvm-lv-block-volume in VG my_vg: Volume group "my_vg" not found Penguin'
+    lvcreate_forced: false
 
   ## Invalid volumes
   # specified volume is not in the pillar

--- a/salt/tests/unit/modules/test_metalk8s_volumes.py
+++ b/salt/tests/unit/modules/test_metalk8s_volumes.py
@@ -84,7 +84,13 @@ class Metalk8sVolumesTestCase(TestCase, mixins.LoaderModuleMockMixin):
 
     @utils.parameterized_from_cases(YAML_TESTS_CASES["create"])
     def test_create(
-        self, name, raise_msg=None, pillar_volumes=None, ftruncate=True, lvcreate=None
+        self,
+        name,
+        raise_msg=None,
+        pillar_volumes=None,
+        ftruncate=True,
+        lvcreate=None,
+        lvcreate_forced=None,
     ):
         """
         Tests the return of `create` function
@@ -122,6 +128,12 @@ class Metalk8sVolumesTestCase(TestCase, mixins.LoaderModuleMockMixin):
             else:
                 # This function does not return anything
                 metalk8s_volumes.create(name)
+
+        if lvcreate_forced is not None:
+            lvcreate_mock.assert_called_once()
+            call_kwargs = lvcreate_mock.call_args[1]
+            self.assertIn("force", call_kwargs)
+            self.assertEqual(call_kwargs["force"], lvcreate_forced)
 
     @utils.parameterized_from_cases(YAML_TESTS_CASES["is_prepared"])
     def test_is_prepared(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -323,6 +323,17 @@ def given_count_running_pods(request, k8s_client, pods_count, label, namespace, 
     return count_running_pods(request, k8s_client, pods_count, label, namespace, node)
 
 
+@given(parsers.parse("the grain '{grain}' is not {value}"))
+def skip_on_grain(host, grain, value):
+    with host.sudo():
+        ret = host.check_output(f"salt-call --out json --local grains.get {grain}")
+
+    result = json.loads(ret)["local"]
+    value = json.loads(value)
+    if result == value:
+        pytest.skip(f"Grain '{grain}' is equal to '{value}'")
+
+
 # }}}
 # When {{{
 


### PR DESCRIPTION
In case a formatted LV was removed without wiping its FS signature, creation from storage-operator will fail. We add support for an annotation (metalk8s.scality.com/force-lvcreate) to force the creation of the LV, at the risk of also wiping the previous FS contents.