### PR TITLE
salt: Add some default topology labels on nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Add `metalk8s-operator` to manage Workload Plane Ingress virtual IPs
   (PR[#3864](https://github.com/scality/metalk8s/pull/3864))
 
+- Add default `topology.kubernetes.io/region` and `topology.kubernetes.io/zone`
+  topology labels on nodes
+  (PR[#3897](https://github.com/scality/metalk8s/pull/3897))
+
 - Add support for a `metalk8s.scality.com/force-lvcreate` annotation on `Volume`
   objects of type `LVMLogicalVolume` to force the creation of their LV (use with
   caution) (PR[#3877](https://github.com/scality/metalk8s/pull/3877))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@
 - Add `metalk8s-operator` to manage Workload Plane Ingress virtual IPs
   (PR[#3864](https://github.com/scality/metalk8s/pull/3864))
 
-- Add default `topology.kubernetes.io/region` and `topology.kubernetes.io/zone`
-  topology labels on nodes
-  (PR[#3889](https://github.com/scality/metalk8s/pull/3889))
-
 - Add support for a `metalk8s.scality.com/force-lvcreate` annotation on `Volume`
   objects of type `LVMLogicalVolume` to force the creation of their LV (use with
   caution) (PR[#3877](https://github.com/scality/metalk8s/pull/3877))

--- a/docs/installation/expansion.rst
+++ b/docs/installation/expansion.rst
@@ -135,8 +135,6 @@ following the template below:
        metalk8s.scality.com/ssh-user: 'root'
      labels:
        metalk8s.scality.com/version: '|version|'
-       topology.kubernetes.io/region: 'default'
-       topology.kubernetes.io/zone: 'default'
        <role labels>
    spec:
      taints: <taints>

--- a/examples/new-node.yaml
+++ b/examples/new-node.yaml
@@ -15,8 +15,6 @@ metadata:
     metalk8s.scality.com/version: '2.0'
     node-role.kubernetes.io/master: ''
     node-role.kubernetes.io/etcd: ''
-    topology.kubernetes.io/region: 'default'
-    topology.kubernetes.io/zone: 'default'
 spec:
   taints:
   - effect: NoSchedule

--- a/examples/new-node_vagrant.yaml
+++ b/examples/new-node_vagrant.yaml
@@ -15,8 +15,6 @@ metadata:
     metalk8s.scality.com/version: '2.0'
     node-role.kubernetes.io/master: ''
     node-role.kubernetes.io/etcd: ''
-    topology.kubernetes.io/region: 'default'
-    topology.kubernetes.io/zone: 'default'
 spec:
   taints:
   - effect: NoSchedule

--- a/salt/metalk8s/defaults.yaml
+++ b/salt/metalk8s/defaults.yaml
@@ -12,6 +12,11 @@ metalk8s:
 kubernetes:
   cluster: kubernetes
 
+  nodes:
+    default_labels:
+      topology.kubernetes.io/region: default
+      topology.kubernetes.io/zone: default
+
 kubeadm_preflight:
   mandatory:
     packages:

--- a/salt/metalk8s/kubernetes/mark-control-plane/deployed.sls
+++ b/salt/metalk8s/kubernetes/mark-control-plane/deployed.sls
@@ -1,4 +1,5 @@
 {%- from "metalk8s/map.jinja" import kubelet with context %}
+{%- from "metalk8s/map.jinja" import kubernetes with context %}
 
 {%- set node_name = pillar.bootstrap_id %}
 {%- set cri_socket = kubelet.service.options['container-runtime-endpoint'] %}
@@ -18,5 +19,14 @@ Mark node {{ node_name }} as bootstrap:
     - defaults:
         node_name: {{ node_name }}
         cri_socket: {{ cri_socket }}
+    - require:
+      - test: Ensure node {{ node_name }} exists
+
+Ensure node {{ node_name }} default labels exist:
+  metalk8s_kubernetes.labels_exist:
+    - name: {{ node_name }}
+    - apiVersion: v1
+    - kind: Node
+    - labels: {{ kubernetes.nodes.default_labels | tojson }}
     - require:
       - test: Ensure node {{ node_name }} exists

--- a/salt/metalk8s/kubernetes/mark-control-plane/files/bootstrap_node_update.yaml.j2.in
+++ b/salt/metalk8s/kubernetes/mark-control-plane/files/bootstrap_node_update.yaml.j2.in
@@ -31,8 +31,6 @@
   {%- endfor %}
 {%- endif %}
 
-{%- set topology_labels = ["topology.kubernetes.io/region", "topology.kubernetes.io/zone"] %}
-
 kind: Node
 apiVersion: v1
 metadata:
@@ -43,11 +41,6 @@ metadata:
     node-role.kubernetes.io/etcd: ""
     node-role.kubernetes.io/bootstrap: ""
     node-role.kubernetes.io/infra: ""
-    {%- for label in topology_labels %}
-      {%- if label not in node_obj["metadata"].get("labels", {}) %}
-    {{ label }}: default
-      {%- endif %}
-    {%- endfor %}
   annotations:
     kubeadm.alpha.kubernetes.io/cri-socket: {{ cri_socket }}
 {%- if update_taints %}

--- a/salt/metalk8s/orchestrate/deploy_node.sls
+++ b/salt/metalk8s/orchestrate/deploy_node.sls
@@ -1,4 +1,5 @@
 {%- from "metalk8s/map.jinja" import defaults with context %}
+{%- from "metalk8s/map.jinja" import kubernetes with context %}
 {%- from "metalk8s/map.jinja" import networks with context %}
 {%- from "metalk8s/map.jinja" import repo with context %}
 
@@ -119,6 +120,13 @@ Refresh the mine:
   salt.function:
     - name: mine.update
     - tgt: '*'
+
+Ensure node default labels exist:
+  metalk8s_kubernetes.labels_exist:
+    - name: {{ node_name }}
+    - apiVersion: v1
+    - kind: Node
+    - labels: {{ kubernetes.nodes.default_labels | tojson }}
 
 Cordon the node:
   metalk8s_cordon.node_cordoned:

--- a/tests/install/steps/files/control-plane-node.yaml.tpl
+++ b/tests/install/steps/files/control-plane-node.yaml.tpl
@@ -7,8 +7,6 @@ metadata:
     node-role.kubernetes.io/master: ''
     node-role.kubernetes.io/etcd: ''
     node-role.kubernetes.io/infra: ''
-    topology.kubernetes.io/region: 'default'
-    topology.kubernetes.io/zone: 'default'
   annotations:
     metalk8s.scality.com/ssh-user: centos
     metalk8s.scality.com/ssh-port: "22"

--- a/ui/src/ducks/app/nodes.js
+++ b/ui/src/ducks/app/nodes.js
@@ -356,8 +356,6 @@ export function* createNode({ payload }) {
       name: payload.name,
       labels: {
         'metalk8s.scality.com/version': clusterVersion,
-        'topology.kubernetes.io/region': 'default',
-        'topology.kubernetes.io/zone': 'default',
       },
       annotations: {
         'metalk8s.scality.com/ssh-user': payload.ssh_user,


### PR DESCRIPTION
NOTE: We revert changes from #3889 as we will handle the default label setting
directly in salt so that it's transparent for the user, they do not need
to explicitly set those labels from the node object