### PR TITLE
salt: Remove metalk8s.volumes from highstate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   in [124.0.0](https://github.com/scality/metalk8s/releases/124.0.0)
   changelog)
   (PR[#3909](https://github.com/scality/metalk8s/pull/3909))
+- Do not attempt to provision Volumes in highstate (this avoids breaking when
+  device paths have changed between reboots)
+  (PR[#3913](https://github.com/scality/metalk8s/pull/3913))
 
 ## Release 124.0.0
 

--- a/salt/metalk8s/roles/node/init.sls
+++ b/salt/metalk8s/roles/node/init.sls
@@ -4,4 +4,3 @@ include:
   - metalk8s.kubernetes.apiserver-proxy
   - metalk8s.internal.preflight
   - metalk8s.beacon.certificates
-  - metalk8s.volumes


### PR DESCRIPTION
This was added to ensure loop devices backed by sparse files had an updated logic after upgrading (with systemd units).

The side-effect is that upgrading a system where device paths have changed (e.g. because of a reboot and different load order) can break, since running `metalk8s_volumes.is_prepared` on such devices will return False, and raise when we try to format them.

Since this is not needed anymore (the units will already exist), and can be added back in the future if required, it is safe to remove for now.