### PR TITLE
salt,build: Properly require tar package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 ## Release 124.0.2 (in development)
 
+### Bug fixes
+
+- Ensure that tar is installed before using it
+  (PR[#3919](https://github.com/scality/metalk8s/pull/3919))
+
 ## Release 124.0.1
 
 ### Bug fixes 

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -385,6 +385,7 @@ PACKAGES: Dict[str, Any] = {
         PackageVersion(name="python36-pyOpenSSL"),
         PackageVersion(name="salt-minion", version=SALT_VERSION),
         PackageVersion(name="socat"),
+        PackageVersion(name="tar"),
         PackageVersion(name="util-linux"),
         PackageVersion(name="yum-utils"),
         PackageVersion(name="xfsprogs"),

--- a/salt/metalk8s/defaults.yaml
+++ b/salt/metalk8s/defaults.yaml
@@ -20,6 +20,7 @@ kubernetes:
 kubeadm_preflight:
   mandatory:
     packages:
+      - tar
       - util-linux            # provides nsenter, mount
       - iproute               # provides ip
       - iptables              # provides iptables


### PR DESCRIPTION
Since tar package is required by MetalK8s backup script, this package should be installed automatically
