### PR TITLE
salt: Set Loki root path to `/var/loki/loki`

### DIFF
--- a/salt/metalk8s/addons/logging/loki/config/loki.yaml
+++ b/salt/metalk8s/addons/logging/loki/config/loki.yaml
@@ -27,7 +27,7 @@ spec:
       chunk_idle_period: 3m
       chunk_retain_period: 1m
       wal:
-        dir: /var/loki/wal
+        dir: /var/loki/loki/wal
       lifecycler:
         ring:
           kvstore:
@@ -50,9 +50,9 @@ spec:
       http_listen_port: 3100
     storage_config:
       boltdb:
-        directory: /var/loki/index
+        directory: /var/loki/loki/index
       filesystem:
-        directory: /var/loki/chunks
+        directory: /var/loki/loki/chunks
     table_manager:
       retention_deletes_enabled: true
       retention_period: 336h

--- a/salt/metalk8s/addons/logging/loki/deployed/init.sls
+++ b/salt/metalk8s/addons/logging/loki/deployed/init.sls
@@ -65,7 +65,7 @@ Create Loki Cleaner Workaround CronJob:
           concurrencyPolicy: Replace
           jobTemplate:
             spec:
-              {{ workaround_job_spec("/var/loki") | indent(14) }}
+              {{ workaround_job_spec("/var/loki/loki") | indent(14) }}
     - require:
       - sls: metalk8s.addons.logging.loki.deployed.workaround-job-dep
       - sls: metalk8s.addons.logging.loki.deployed.chart


### PR DESCRIPTION
Since Loki new helm chart changed the mountpoint for data from `/data` to `/var/loki` for backward compatibility we need to use `/var/loki/loki` as root path for Index, chunks and wal