### PR TITLE
ui: Update core-ui version in package-lock

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -5754,8 +5754,8 @@
       }
     },
     "node_modules/@scality/core-ui": {
-      "version": "0.63.0",
-      "resolved": "git+ssh://git@github.com/scality/core-ui.git#9da821f3a26dd7d37d225d3d90430d6e3636eeb4",
+      "version": "0.72.0",
+      "resolved": "git+ssh://git@github.com/scality/core-ui.git#804bc69ddf28f8ffac5cd351b409506ed0d8e09e",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@floating-ui/dom": "^0.1.10"
@@ -29718,7 +29718,7 @@
       }
     },
     "@scality/core-ui": {
-      "version": "git+ssh://git@github.com/scality/core-ui.git#9da821f3a26dd7d37d225d3d90430d6e3636eeb4",
+      "version": "git+ssh://git@github.com/scality/core-ui.git#804bc69ddf28f8ffac5cd351b409506ed0d8e09e",
       "from": "@scality/core-ui@github:scality/core-ui#v0.72.0",
       "requires": {
         "@floating-ui/dom": "^0.1.10"


### PR DESCRIPTION
**Component**:  UI

**Context**: 
When we bump core-ui version in MetalK8s UI and Shell-ui, it's necessary to check if `"node_modules/@scality/core-ui":` in `package-lock.json` get updated.

**Summary**:

**Acceptance criteria**: 
