### PR TITLE
charts,salt: Bump Dex to 2.35.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@
   images to `rockylinux:8.7.20230215`
   (PR[#4011](https://github.com/scality/metalk8s/pull/4011))
 
+- Bump dex chart version to
+  [0.13.0](https://github.com/dexidp/helm-charts/releases/tag/dex-0.13.0)
+  Dex itself has been bumped accordingly to
+  [v2.35.3](https://github.com/dexidp/dex/releases/tag/v2.35.3)
+  (PR[#4012](https://github.com/scality/metalk8s/pull/4012))
+
 ### Bug fixes
 
 - Fix a bug in Workload Plane Ingress Virtual IPs that make the DaemonSet Pod

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -123,8 +123,8 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     ),
     Image(
         name="dex",
-        version="v2.34.0",
-        digest="sha256:72b9cd039152ed5e8c5c745ac62a131b943bec9f9fe0b995e8821a4e35c8522e",
+        version="v2.35.3",
+        digest="sha256:13964b29d63efcd1490d1a500c4332c642655fe4ca613683fa4dde9a205dd0f7",
     ),
     Image(
         name="etcd",

--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,12 +1,12 @@
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: "`networkPolicy` value to enable network policy and define optional custom Egress rules"
+      description: "Common labels to all resources created by the chart"
   artifacthub.io/images: |
     - name: dex
-      image: ghcr.io/dexidp/dex:v2.34.0
+      image: ghcr.io/dexidp/dex:v2.35.3
 apiVersion: v2
-appVersion: 2.34.0
+appVersion: 2.35.3
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable
   connectors.
 home: https://dexidp.io/
@@ -26,4 +26,4 @@ sources:
 - https://github.com/dexidp/dex
 - https://github.com/dexidp/helm-charts/tree/master/charts/dex
 type: application
-version: 0.11.1
+version: 0.13.0

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -1,6 +1,6 @@
 # dex
 
-![version: 0.11.1](https://img.shields.io/badge/version-0.11.1-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.34.0](https://img.shields.io/badge/app%20version-2.34.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
+![version: 0.13.0](https://img.shields.io/badge/version-0.13.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.35.3](https://img.shields.io/badge/app%20version-2.35.3-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
 
 OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
 
@@ -111,6 +111,7 @@ ingress:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | replicaCount | int | `1` | Number of replicas (pods) to launch. |
+| commonLabels | object | `{}` | Labels to apply to all resources and selectors. |
 | image.repository | string | `"ghcr.io/dexidp/dex"` | Name of the image repository to pull the container image from. |
 | image.pullPolicy | string | `"IfNotPresent"` | [Image pull policy](https://kubernetes.io/docs/concepts/containers/images/#updating-images) for updating already existing images on a node. |
 | image.tag | string | `""` | Image tag override for the default value (chart appVersion). |

--- a/charts/dex/templates/_helpers.tpl
+++ b/charts/dex/templates/_helpers.tpl
@@ -40,6 +40,9 @@ helm.sh/chart: {{ include "dex.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -5,6 +5,10 @@
 # -- Number of replicas (pods) to launch.
 replicaCount: 1
 
+# -- Labels to apply to all resources and selectors.
+commonLabels: {}
+# team_name: dev
+
 image:
   # -- Name of the image repository to pull the container image from.
   repository: ghcr.io/dexidp/dex

--- a/salt/metalk8s/addons/dex/deployed/chart.sls
+++ b/salt/metalk8s/addons/dex/deployed/chart.sls
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.34.0
-    helm.sh/chart: dex-0.11.1
+    app.kubernetes.io/version: 2.35.3
+    helm.sh/chart: dex-0.13.0
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -28,8 +28,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.34.0
-    helm.sh/chart: dex-0.11.1
+    app.kubernetes.io/version: 2.35.3
+    helm.sh/chart: dex-0.13.0
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -50,8 +50,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.34.0
-    helm.sh/chart: dex-0.11.1
+    app.kubernetes.io/version: 2.35.3
+    helm.sh/chart: dex-0.13.0
     heritage: metalk8s
   name: dex-cluster
   namespace: metalk8s-auth
@@ -72,8 +72,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.34.0
-    helm.sh/chart: dex-0.11.1
+    app.kubernetes.io/version: 2.35.3
+    helm.sh/chart: dex-0.13.0
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -93,8 +93,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.34.0
-    helm.sh/chart: dex-0.11.1
+    app.kubernetes.io/version: 2.35.3
+    helm.sh/chart: dex-0.13.0
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -115,8 +115,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.34.0
-    helm.sh/chart: dex-0.11.1
+    app.kubernetes.io/version: 2.35.3
+    helm.sh/chart: dex-0.13.0
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -151,8 +151,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.34.0
-    helm.sh/chart: dex-0.11.1
+    app.kubernetes.io/version: 2.35.3
+    helm.sh/chart: dex-0.13.0
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -192,7 +192,7 @@ spec:
         env:
         - name: KUBERNETES_POD_NAMESPACE
           value: metalk8s-auth
-        image: {% endraw -%}{{ build_image_name("dex", False) }}{%- raw %}:v2.34.0
+        image: {% endraw -%}{{ build_image_name("dex", False) }}{%- raw %}:v2.35.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -262,8 +262,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.34.0
-    helm.sh/chart: dex-0.11.1
+    app.kubernetes.io/version: 2.35.3
+    helm.sh/chart: dex-0.13.0
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth


### PR DESCRIPTION
Bump the ghcr.io/dexidp/dex image to v2.35.3

Bump the chart to 0.13.0 using:

```
rm -rf charts/dex
helm repo add dex https://charts.dexidp.io
helm repo update
helm fetch -d charts --untar dex/dex
```

Re-apply the patch for HTTPS support for Ingress (see dexidp/helm-charts#15)

Then render the chart with:

```
./doit.sh codegen:chart_dex
```