### PR TITLE
.github,tox.ini: Pin virtualenv version to be compatible with py3.6

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -373,9 +373,7 @@ jobs:
           python-version: "3.6"
       - name: Install deps
         run: |
-          export DEBIAN_FRONTEND=noninteractive
-          sudo apt-get update
-          sudo apt-get install --no-install-recommends -y tox
+          pip install tox
       - name: Run all salt unit tests
         run: tox -e unit-tests
 

--- a/docs/entrypoint.sh
+++ b/docs/entrypoint.sh
@@ -13,4 +13,4 @@ if ! grep -q "$TARGET_UID" /etc/passwd; then
 fi
 
 sudo chown -R "$TARGET_UID:$TARGET_GID" /tmp/tox
-sudo -u "$(id -u -n "$TARGET_UID")" -E TOX_CONFIG_FILE=tox.ini tox --workdir /tmp/tox -e docs -- "$@"
+sudo -u "$(id -u -n "$TARGET_UID")" -E TOX_USER_CONFIG_FILE=tox.ini TOX_CONFIG_FILE=tox.ini tox --workdir /tmp/tox -e docs -- "$@" >&2

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 skipsdist = true
 minversion = 3.18.0
-requires = virtualenv >= 20.0
+# New virtualenv version does not support python3.6
+requires = virtualenv < 20.22.0
 isolated_build = true
 
 [testenv]
@@ -107,6 +108,8 @@ description =
     Run pre-commit hook
 deps =
     pre-commit
+    # New virtualenv version does not support python3.6
+    virtualenv < 20.22.0
 commands =
     bash -c "pre-commit run {posargs}"
 
@@ -115,6 +118,8 @@ description =
     Lint all files using pre-commit
 deps =
     pre-commit
+    # New virtualenv version does not support python3.6
+    virtualenv < 20.22.0
 commands =
     bash -c "pre-commit run --all-files {posargs}"
 


### PR DESCRIPTION
Starting from virtualenv 20.22.0 python3.6 is no longer compatible, which means that tox/pre-commit will not be able to create a virtualenv for python3.6 if the installed virtualenv version is newer
