### PR TITLE
Change Alertmanager external URL so that the link included in emails points to Metalk8s UI

### DIFF
--- a/charts/kube-prometheus-stack.yaml
+++ b/charts/kube-prometheus-stack.yaml
@@ -27,6 +27,8 @@ alertmanager:
         operator: 'Exists'
         effect: 'NoSchedule'
 
+    externalUrl: '__slot__:salt:metalk8s_network.get_control_plane_ingress_endpoint()'
+
     podMetadata:
       annotations:
         # Override default checksum as we want to manage it with salt


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

**Summary**:

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
