### PR TITLE
shell-ui: Add FirstTimeLoginProvider and Mark all the notifications to read after clicking on a specific notification

### DIFF
--- a/shell-ui/src/FederatedApp.spec.tsx
+++ b/shell-ui/src/FederatedApp.spec.tsx
@@ -172,27 +172,6 @@ export const configurationHandlers = [
 ];
 const server = setupServer(...configurationHandlers);
 
-function mockOidcReact() {
-  const { jest } = require('@jest/globals');
-
-  const original = jest.requireActual('oidc-react');
-  return {
-    ...original,
-    //Pass down all the exported objects
-    useAuth: () => ({
-      userData: {
-        profile: {
-          groups: ['group1'],
-          email: 'test@test.invalid',
-          name: 'user',
-        },
-      },
-    }),
-  };
-}
-
-jest.mock('oidc-react', () => mockOidcReact());
-
 const mockOIDCProvider = () => {
   // This is a hack to workarround the following issue : MSW return lower cased content-type header,
   // oidc-client is internally using XMLHttpRequest to perform queries and retrieve response header Content-Type using 'XMLHttpRequest.prototype.getResponseHeader'.

--- a/shell-ui/src/FederatedApp.tsx
+++ b/shell-ui/src/FederatedApp.tsx
@@ -31,6 +31,7 @@ import { ShellHistoryProvider } from './initFederation/ShellHistoryProvider';
 import { CoreUiThemeProvider } from '@scality/core-ui/dist/components/coreuithemeprovider/CoreUiThemeProvider';
 import { ThemeProvider } from './navbar/theme';
 import NotificationCenterProvider from './NotificationCenterProvider';
+import { FirstTimeLoginProvider } from './auth/FirstTimeLoginProvider';
 
 export const queryClient = new QueryClient();
 
@@ -164,11 +165,13 @@ function InternalApp() {
   return (
     <Router history={history}>
       <ShellHistoryProvider>
-        <NotificationCenterProvider>
-          <SolutionsNavbar>
-            <InternalRouter />
-          </SolutionsNavbar>
-        </NotificationCenterProvider>
+        <FirstTimeLoginProvider>
+          <NotificationCenterProvider>
+            <SolutionsNavbar>
+              <InternalRouter />
+            </SolutionsNavbar>
+          </NotificationCenterProvider>
+        </FirstTimeLoginProvider>
       </ShellHistoryProvider>
     </Router>
   );

--- a/shell-ui/src/auth/FirstTimeLoginProvider.tsx
+++ b/shell-ui/src/auth/FirstTimeLoginProvider.tsx
@@ -1,0 +1,73 @@
+import React, { createContext, useEffect, useMemo, useState } from 'react';
+import { useAuth } from './AuthProvider';
+import { useLocation } from 'react-router';
+
+const FirstTimeLoginContext = createContext<null | {
+  firstTimeLogin: boolean | null;
+}>(null);
+
+export const useFirstTimeLogin = (): {
+  firstTimeLogin: boolean | null;
+} => {
+  const contextValue = React.useContext(FirstTimeLoginContext);
+
+  if (contextValue === null) {
+    throw new Error(
+      "Can't use useFirstTimeLogin outside FirstTimeLoginProvider",
+    );
+  }
+
+  return contextValue;
+};
+
+export function FirstTimeLoginProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [firstTimeLogin, setFirstTimeLogin] = useState<boolean | null>(null);
+
+  const { userData } = useAuth();
+  const userID = userData?.id;
+  const ALREADY_LOGGED_IN_USER_IDS = 'alreadyLoggedInUserIds';
+
+  // Store the userID in the LocalStorage to maintain a record of all users who have logged in from this machine
+  const ids = useMemo(
+    () => localStorage.getItem(ALREADY_LOGGED_IN_USER_IDS)?.split(',') || [],
+    [],
+  );
+
+  // Because of the way the OIDC library works there is a redirect to the login page, which causes the firstTimeLogin set to false when redirect to the UI.
+  // So we have to check if it is in the process of signing in and if so, don't set the firstTimeLogin to false.
+  const location = useLocation();
+  const searchParams = new URLSearchParams(location.search);
+  const isSigningIn =
+    searchParams.has('code') &&
+    searchParams.has('state') &&
+    searchParams.has('session_state');
+  useEffect(() => {
+    if (isSigningIn) {
+      return;
+    }
+    if (!ids && userID) {
+      setFirstTimeLogin(true);
+      localStorage.setItem(ALREADY_LOGGED_IN_USER_IDS, userID || '');
+    } else if (userID && ids && !ids.includes(userID)) {
+      setFirstTimeLogin(true);
+      ids?.push(userID);
+      localStorage.setItem(ALREADY_LOGGED_IN_USER_IDS, ids.join(','));
+    } else if (userID && ids && ids.includes(userID)) {
+      setFirstTimeLogin(false);
+    }
+  }, [userID]);
+
+  return (
+    <FirstTimeLoginContext.Provider
+      value={{
+        firstTimeLogin,
+      }}
+    >
+      {children}
+    </FirstTimeLoginContext.Provider>
+  );
+}

--- a/shell-ui/src/auth/FirstTimeLoginProvider.tsx
+++ b/shell-ui/src/auth/FirstTimeLoginProvider.tsx
@@ -25,7 +25,9 @@ export function FirstTimeLoginProvider({
 }: {
   children: React.ReactNode;
 }) {
-  const [firstTimeLogin, setFirstTimeLogin] = useState<boolean | null>(null);
+  const [firstTimeLogin, setFirstTimeLogin] = useState<boolean | undefined>(
+    undefined,
+  );
 
   const { userData } = useAuth();
   const userID = userData?.id;

--- a/shell-ui/src/auth/useFirstTimeLogin.spec.tsx
+++ b/shell-ui/src/auth/useFirstTimeLogin.spec.tsx
@@ -1,0 +1,53 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useFirstTimeLogin } from './FirstTimeLoginProvider';
+import { wrapper } from '../navbar/index.spec';
+import { configurationHandlers } from '../FederatedApp.spec';
+import { setupServer } from 'msw/node';
+
+const server = setupServer(...configurationHandlers);
+
+describe('useFirstTimeLogin hook', () => {
+  beforeAll(() =>
+    server.listen({
+      onUnhandledRequest: 'error',
+    }),
+  );
+  afterEach(() => {
+    localStorage.clear();
+  });
+  afterAll(() => server.close());
+
+  it('should throw an error if used outside FirstTimeLoginProvider', () => {
+    //S+E
+    const { result } = renderHook(() => useFirstTimeLogin());
+    //V
+    expect(result.error).toEqual(
+      Error("Can't use useFirstTimeLogin outside FirstTimeLoginProvider"),
+    );
+  });
+
+  it('should return firstTimeLogin as true if the user is logging in for the first time', async () => {
+    //S
+    const { result, waitForNextUpdate } = renderHook(
+      () => useFirstTimeLogin(),
+      { wrapper },
+    );
+    //E
+    await waitForNextUpdate();
+    //V
+    expect(result.current.firstTimeLogin).toEqual(true);
+  });
+
+  it('should return firstTimeLogin as false if the user is NOT logging in for the first time', async () => {
+    //S
+    localStorage.setItem('alreadyLoggedInUserIds', 'userID');
+    //E
+    const { result, waitForNextUpdate } = renderHook(
+      () => useFirstTimeLogin(),
+      { wrapper },
+    );
+    await waitForNextUpdate();
+    //V
+    expect(result.current.firstTimeLogin).toEqual(false);
+  });
+});

--- a/shell-ui/src/auth/useFirstTimeLogin.spec.tsx
+++ b/shell-ui/src/auth/useFirstTimeLogin.spec.tsx
@@ -39,9 +39,12 @@ describe('useFirstTimeLogin hook', () => {
   });
 
   it('should return firstTimeLogin as false if the user is NOT logging in for the first time', async () => {
-    //S
-    localStorage.setItem('alreadyLoggedInUserIds', 'userID');
     //E
+    const { waitForNextUpdate: waitForNextUpdateFirstRender } = renderHook(
+      () => useFirstTimeLogin(),
+      { wrapper },
+    );
+    await waitForNextUpdateFirstRender();
     const { result, waitForNextUpdate } = renderHook(
       () => useFirstTimeLogin(),
       { wrapper },

--- a/shell-ui/src/navbar/NavbarUpdaterComponents.tsx
+++ b/shell-ui/src/navbar/NavbarUpdaterComponents.tsx
@@ -8,6 +8,8 @@ import { ErrorBoundary } from 'react-error-boundary';
 import { useEffect } from 'react';
 import { useNavbar } from './navbarHooks';
 import { useNotificationCenter } from '../NotificationCenterProvider';
+import { useFirstTimeLogin } from '../auth/FirstTimeLoginProvider';
+import { useAuth } from '../auth/AuthProvider';
 
 export const NavbarUpdaterComponents = () => {
   const deployedApps = useDeployedApps();
@@ -62,6 +64,8 @@ export const NavbarUpdaterComponents = () => {
     timerId = setTimeout(timer, 1000);
     return () => clearTimeout(timerId);
   }, [areRemoteEntriesFileParsed, setMicroAppsAreReady]);
+  const { firstTimeLogin } = useFirstTimeLogin();
+  const { userData } = useAuth();
   return (
     <>
       {componentsToFederate.map((component, index) => {
@@ -81,6 +85,8 @@ export const NavbarUpdaterComponents = () => {
                     navbarManagementProps,
                     publishNotification: publish,
                     unPublishNotification: unPublish,
+                    isFirstTimeLogin: firstTimeLogin,
+                    userData,
                   }}
                 />
               </ErrorBoundary>

--- a/shell-ui/src/navbar/NotificationCenter.spec.tsx
+++ b/shell-ui/src/navbar/NotificationCenter.spec.tsx
@@ -234,6 +234,14 @@ describe('NotificationCenter', () => {
     await waitFor(() => {
       expect(screen.getByText('License page')).toBeInTheDocument();
     });
+
+    // Verify that the notification is marked as read
+    userEvent.click(notificationCenterButton);
+    expect(
+      within(lastNotification).queryByRole('img', {
+        name: /unread notification mark/i,
+      }),
+    ).toBeNull();
   });
 
   it('should not display notifications with the same ID', async () => {
@@ -245,5 +253,34 @@ describe('NotificationCenter', () => {
     userEvent.click(notificationCenterSelectors.notificationCenterButton());
     //V
     expect(screen.getAllByRole('option').length).toBe(3);
+  });
+
+  it('should mark all the notifications as read after checking one specific notification', async () => {
+    //S
+    const { result } = await renderNotificationCenter();
+    publishNewNotifications(result);
+    userEvent.click(notificationCenterSelectors.notificationCenterButton());
+    //E
+    userEvent.click(screen.getAllByRole('option')[0]);
+    //V
+    expect(
+      within(screen.getAllByRole('option')[0]).queryByRole('img', {
+        name: /unread notification mark/i,
+      }),
+    ).toBeNull();
+    expect(
+      within(screen.getAllByRole('option')[1]).queryByRole('img', {
+        name: /unread notification mark/i,
+      }),
+    ).toBeNull();
+    expect(
+      within(screen.getAllByRole('option')[2]).queryByRole('img', {
+        name: /unread notification mark/i,
+      }),
+    ).toBeNull();
+    //E
+    userEvent.click(notificationCenterSelectors.notificationCenterButton());
+    //V
+    expect(screen.queryByRole('option')).not.toBeInTheDocument();
   });
 });

--- a/shell-ui/src/navbar/NotificationCenter.tsx
+++ b/shell-ui/src/navbar/NotificationCenter.tsx
@@ -101,6 +101,7 @@ const NotificationCenter = () => {
         return;
       }
       history.push(selectedItem.redirectUrl);
+      readAllNotifications();
     },
   });
   const isAtLeastOneNotificationUnread = notifications.some(

--- a/shell-ui/src/navbar/index.spec.tsx
+++ b/shell-ui/src/navbar/index.spec.tsx
@@ -15,6 +15,7 @@ import { act } from 'react-test-renderer';
 import { LanguageProvider } from './lang';
 import { ThemeProvider } from './theme';
 import NotificationCenterProvider from '../NotificationCenterProvider';
+import { FirstTimeLoginProvider } from '../auth/FirstTimeLoginProvider';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -25,28 +26,7 @@ const queryClient = new QueryClient({
 });
 const server = setupServer(...configurationHandlers);
 
-function mockOidcReact() {
-  const { jest } = require('@jest/globals');
-
-  const original = jest.requireActual('oidc-react');
-  return {
-    ...original,
-    //Pass down all the exported objects
-    useAuth: () => ({
-      userData: {
-        profile: {
-          groups: ['group1'],
-          email: 'test@test.invalid',
-          name: 'user',
-        },
-      },
-    }),
-  };
-}
-
-jest.mock('oidc-react', () => mockOidcReact());
-
-const wrapper = ({ children }) => {
+export const wrapper = ({ children }) => {
   return (
     <ThemeProvider>
       {(theme) => (
@@ -57,9 +37,11 @@ const wrapper = ({ children }) => {
                 <ShellConfigProvider shellConfigUrl={'/shell/config.json'}>
                   <WithInitFederationProviders>
                     <MemoryRouter>
-                      <ShellHistoryProvider>
-                        <SolutionsNavbar>{children}</SolutionsNavbar>
-                      </ShellHistoryProvider>
+                      <FirstTimeLoginProvider>
+                        <ShellHistoryProvider>
+                          <SolutionsNavbar>{children}</SolutionsNavbar>
+                        </ShellHistoryProvider>
+                      </FirstTimeLoginProvider>
                     </MemoryRouter>
                   </WithInitFederationProviders>
                 </ShellConfigProvider>

--- a/shell-ui/src/setupTests.ts
+++ b/shell-ui/src/setupTests.ts
@@ -29,3 +29,25 @@ Object.defineProperty(window, 'DOMRect', {
   value: DOMRect,
   writable: true,
 });
+
+export function mockOidcReact() {
+  const { jest } = require('@jest/globals');
+
+  const original = jest.requireActual('oidc-react');
+  return {
+    ...original,
+    //Pass down all the exported objects
+    useAuth: () => ({
+      userData: {
+        profile: {
+          groups: ['group1'],
+          email: 'test@test.invalid',
+          name: 'user',
+          sub: 'userID',
+        },
+      },
+    }),
+  };
+}
+
+jest.mock('oidc-react', () => mockOidcReact());


### PR DESCRIPTION
**Component**: Shell-ui

**Context**: 
We want to be able to tell if it's the user first time login. 

**Summary**:
Add FirstTimeLoginProvider which provides a hook useFirstTimeLogin returns if it's the first login for the user.

Also fix a small issue in Notification Center:
Mark all the notifications to read after clicking on a specific notification


**Acceptance criteria**: 

