### PR TITLE
operator: Add liveness probe to keepalived

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,9 @@
   [1.19](https://golang.org/doc/devel/release.html#go1.19.minor)
   (PR[#4110](https://github.com/scality/metalk8s/pull/4110))
 
+- Add liveness probe to `keepalived` pod 
+  (PR[#4118](https://github.com/scality/metalk8s/pull/4118))
+
 ## Release 125.0.6 (In development)
 
 

--- a/images/metalk8s-keepalived/Dockerfile
+++ b/images/metalk8s-keepalived/Dockerfile
@@ -39,6 +39,7 @@ COPY --chown=keepalived:keepalived keepalived.conf.j2 /etc/keepalived/
 COPY --chown=keepalived:keepalived check-get.sh /etc/keepalived/
 
 COPY --chown=keepalived:keepalived generate-config.py /
+COPY --chown=keepalived:keepalived liveness-probe.sh /
 COPY --chown=keepalived:keepalived entrypoint.sh /
 
 COPY --chown=keepalived:keepalived --from=build-step /keepalived /usr/sbin/

--- a/images/metalk8s-keepalived/README.md
+++ b/images/metalk8s-keepalived/README.md
@@ -7,7 +7,7 @@ This image is composed of several scripts.
 
 ## Entrypoint script
 
-This script is the entrypoint for the container, it generate the
+This script is the entrypoint for the container, it generates the
 configuration and start keepalived process.
 
 ## Generate config script
@@ -39,7 +39,7 @@ addresses:
 The check script is used by keepalived to check that the local node, where
 the keepalived process is running, is ready to get some load.
 
-It check that the local Ingress Controller is available
+It checks that the local Ingress Controller is available.
 
 ## Dockerfile
 

--- a/images/metalk8s-keepalived/liveness-probe.sh
+++ b/images/metalk8s-keepalived/liveness-probe.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -xue -o pipefail
+
+# Simple check to ensure that the config does not need to be updated
+/generate-config.py --input /etc/keepalived/keepalived-input.yaml --template /etc/keepalived/keepalived.conf.j2 | diff -qw /etc/keepalived/keepalived.conf -

--- a/operator/pkg/controller/virtualippool/controller.go
+++ b/operator/pkg/controller/virtualippool/controller.go
@@ -468,6 +468,20 @@ func (r *VirtualIPPoolReconciler) mutateDaemonSet(obj *appsv1.DaemonSet) error {
 			},
 		},
 	}
+	if container.LivenessProbe == nil {
+		container.LivenessProbe = &corev1.Probe{}
+	}
+	container.LivenessProbe.ProbeHandler = corev1.ProbeHandler{
+		Exec: &corev1.ExecAction{
+			Command: []string{
+				"/liveness-probe.sh",
+			},
+		},
+	}
+	container.LivenessProbe.InitialDelaySeconds = 10
+	container.LivenessProbe.PeriodSeconds = 30
+	container.LivenessProbe.TimeoutSeconds = 10
+	container.LivenessProbe.FailureThreshold = 1
 
 	return nil
 }


### PR DESCRIPTION
**Component**: operator

**Context**: Keepalived maps its configuration upon interface names. When VIPs are managed by keepalived and an interface which has VIP changes name or goes down, keepalived does not sync.  Therefore, the configuration is not correct and must be regenerated. The config is set up at pod startup. 

**Summary**: Adding a liveness probe in Kubernetes to restart the keepalived pod 

