### PR TITLE
Ease Federated App deployment on Workload Plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ### Enhancements
 
+- Add support in CSC to manage a new configuration for Shell UI on the WorkloadPlane
+  (PR[#4124](https://github.com/scality/metalk8s/pull/4124))
+
 - Bump Kubernetes version to
   [1.26.5](https://github.com/kubernetes/kubernetes/releases/tag/v1.26.5)
   (PR[#4074](https://github.com/scality/metalk8s/pull/4074))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Add support in CSC to manage a new configuration for Shell UI on the WorkloadPlane
   (PR[#4124](https://github.com/scality/metalk8s/pull/4124))
 
+- Define workloadplane ingress default backend to be Shell UI
+  (PR[#4124](https://github.com/scality/metalk8s/pull/4124))
+
 - Bump Kubernetes version to
   [1.26.5](https://github.com/kubernetes/kubernetes/releases/tag/v1.26.5)
   (PR[#4074](https://github.com/scality/metalk8s/pull/4074))

--- a/buildchain/buildchain/image.py
+++ b/buildchain/buildchain/image.py
@@ -179,7 +179,6 @@ IMGS_PER_REPOSITORY: Dict[str, List[str]] = {
         "fluent-bit",
     ],
     constants.GOOGLE_REPOSITORY: [
-        "nginx-ingress-defaultbackend-amd64",
         "pause",
     ],
     constants.GRAFANA_REPOSITORY: [
@@ -224,7 +223,6 @@ REMOTE_NAMES: Dict[str, str] = {
     "calico-node": "node",
     "calico-kube-controllers": "kube-controllers",
     "nginx-ingress-controller": "controller",
-    "nginx-ingress-defaultbackend-amd64": "defaultbackend-amd64",
 }
 
 SAVE_AS: Dict[str, List[targets.ImageSaveFormat]] = {

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -375,6 +375,7 @@ SALT_FILES: Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path("salt/metalk8s/addons/ui/deployed/init.sls"),
     Path("salt/metalk8s/addons/ui/config/metalk8s-shell-ui-config.yaml.j2"),
     Path("salt/metalk8s/addons/ui/config/metalk8s-ui-config.yaml.j2"),
+    Path("salt/metalk8s/addons/ui/config/workloadplane-shell-ui-config.yaml.j2"),
     targets.TemplateFile(
         task_name="salt/metalk8s/addons/ui/config/deployed-ui-apps.yaml.j2",
         source=constants.ROOT.joinpath(

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -180,11 +180,6 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
         digest="sha256:e5c4824e7375fcf2a393e1c03c293b69759af37a9ca6abdb91b13d78a93da8bd",
     ),
     Image(
-        name="nginx-ingress-defaultbackend-amd64",
-        version="1.5",
-        digest="sha256:4dc5e07c8ca4e23bddb3153737d7b8c556e5fb2f29c4558b7cd6e6df99c512c7",
-    ),
-    Image(
         name="node-exporter",
         version="v1.6.0",
         digest="sha256:d2e48098c364e61ee62d9016eed863b66331d87cf67146f2068b70ed9d9b4f98",

--- a/charts/ingress-nginx-control-plane.yaml
+++ b/charts/ingress-nginx-control-plane.yaml
@@ -3,8 +3,6 @@ controller:
     digest: null
     repository: '{%- endraw -%}{{ build_image_name(\"nginx-ingress-controller\", False) }}{%- raw -%}'
 
-  defaultBackendService: 'metalk8s-ingress/nginx-ingress-default-backend'
-
   electionID: ingress-control-plane-controller-leader
 
   ingressClassResource:

--- a/charts/ingress-nginx.yaml
+++ b/charts/ingress-nginx.yaml
@@ -28,6 +28,7 @@ controller:
     type: ClusterIP
 
   extraArgs:
+    default-backend-service: metalk8s-ui/metalk8s-ui
     default-ssl-certificate: "metalk8s-ingress/ingress-workload-plane-default-certificate"
     metrics-per-host: false
 
@@ -39,18 +40,4 @@ controller:
         metalk8s.scality.com/monitor: ''
 
 defaultBackend:
-  enabled: true
-
-  image:
-    repository: '{%- endraw -%}{{ build_image_name(\"nginx-ingress-defaultbackend-amd64\", False) }}{%- raw -%}'
-
-  tolerations:
-    - key: "node-role.kubernetes.io/bootstrap"
-      operator: "Exists"
-      effect: "NoSchedule"
-    - key: "node-role.kubernetes.io/infra"
-      operator: "Exists"
-      effect: "NoSchedule"
-
-  nodeSelector:
-    node-role.kubernetes.io/infra: ''
+  enabled: false

--- a/docs/operation/cluster_and_service_configuration.rst
+++ b/docs/operation/cluster_and_service_configuration.rst
@@ -132,6 +132,17 @@ The default Shell UI configuration values are specified below:
 
 See :ref:`csc-shell-ui-config-customization` to override these defaults.
 
+Shell UI Workload Plane Default Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Shell UI has a different configuration for the workload plane.
+
+The default Shell UI workload plane configuration values are specified below:
+
+.. literalinclude:: ../../salt/metalk8s/addons/ui/config/workloadplane-shell-ui-config.yaml.j2
+   :lines: 3-
+
+
 Service Configurations Customization
 ------------------------------------
 
@@ -987,6 +998,72 @@ To change the UI navigation menu entries, follow these steps:
                           --kubeconfig /etc/kubernetes/admin.conf \\
                           salt-master-bootstrap -- salt-run state.sls \\
                           metalk8s.addons.ui.deployed saltenv=metalk8s-|version|
+
+
+MetalK8s Shell UI Workloadplane Configuration Customization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default configuration for MetalK8s Shell UI workloadplane can be overridden by
+editing its Cluster and Service ConfigMap ``workloadplane-shell-ui-config`` in
+namespace ``metalk8s-ui`` under the key ``data.config\.yaml``.
+
+Changing UI Menu Entries
+""""""""""""""""""""""""
+
+To change the UI navigation menu entries on the workloadplane, follow these
+steps:
+
+#. Edit the ConfigMap:
+
+.. code-block:: shell
+
+    root@bootstrap $ kubectl --kubeconfig /etc/kubernetes/admin.conf \
+                    edit configmap -n metalk8s-ui \
+                    workloadplane-shell-ui-config
+
+#. Edit the ``navbar`` field. As an example, we add an entry to
+   the ``main`` section (there is also a ``subLogin`` section):
+
+.. code-block:: yaml
+
+    apiVersion: v1
+    kind: ConfigMap
+    data:
+      config.yaml: |-
+        apiVersion: addons.metalk8s.scality.com/v1alpha1
+        kind: WorkloadplaneShellUIConfig
+        spec:
+          deployedApps:
+            - kind: ModuleFederatedAppKind,
+              name: appname,
+              version: x.y.z,
+              url: https://app.url,
+              appHistoryBasePath: ""
+          config:
+            # [...]
+            navbar:
+              # [...]
+              main:
+                # [...]
+                kind: ModuleFederatedAppKind
+                view: ViewToFederate
+                # Alternatively for a non federated app
+                isExternal: true
+                label:
+                  en: Documentation
+                  fr: Documentation
+                url: https://13.48.197.10:8443/docs/
+
+#. Apply your changes by running:
+
+.. parsed-literal::
+
+      root\@bootstrap $ kubectl exec -n kube-system -c salt-master \\
+                          --kubeconfig /etc/kubernetes/admin.conf \\
+                          salt-master-bootstrap -- salt-run state.sls \\
+                          metalk8s.addons.ui.deployed saltenv=metalk8s-|version|
+
+
 
 Replicas Count Customization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/salt/metalk8s/addons/nginx-ingress/deployed/init.sls
+++ b/salt/metalk8s/addons/nginx-ingress/deployed/init.sls
@@ -28,3 +28,12 @@ Delete old deployment for the default backend:
     - namespace: metalk8s-ingress
     - require:
       - sls: metalk8s.addons.nginx-ingress.deployed.chart
+
+Delete old serviceaccount for the default backend:
+  metalk8s_kubernetes.object_absent:
+    - apiVersion: v1
+    - kind: ServiceAccount
+    - name: ingress-nginx-backend
+    - namespace: metalk8s-ingress
+    - require:
+      - sls: metalk8s.addons.nginx-ingress.deployed.chart

--- a/salt/metalk8s/addons/nginx-ingress/deployed/init.sls
+++ b/salt/metalk8s/addons/nginx-ingress/deployed/init.sls
@@ -22,7 +22,7 @@ Delete old service for the default backend:
 
 Delete old deployment for the default backend:
   metalk8s_kubernetes.object_absent:
-    - apiVersion: v1
+    - apiVersion: apps/v1
     - kind: Deployment
     - name: ingress-nginx-defaultbackend
     - namespace: metalk8s-ingress

--- a/salt/metalk8s/addons/nginx-ingress/deployed/init.sls
+++ b/salt/metalk8s/addons/nginx-ingress/deployed/init.sls
@@ -6,3 +6,25 @@ include:
   - .dashboards
   - .service-configuration
   - .config-map
+
+{#- In MetalK8s 126.0 we remove the default backend for the workloadplane,
+    let's remove old objects #}
+{#- This logic can be removed in `development/127.0` #}
+
+Delete old service for the default backend:
+  metalk8s_kubernetes.object_absent:
+    - apiVersion: v1
+    - kind: Service
+    - name: ingress-nginx-defaultbackend
+    - namespace: metalk8s-ingress
+    - require:
+      - sls: metalk8s.addons.nginx-ingress.deployed.chart
+
+Delete old deployment for the default backend:
+  metalk8s_kubernetes.object_absent:
+    - apiVersion: v1
+    - kind: Deployment
+    - name: ingress-nginx-defaultbackend
+    - namespace: metalk8s-ingress
+    - require:
+      - sls: metalk8s.addons.nginx-ingress.deployed.chart

--- a/salt/metalk8s/addons/ui/config/workloadplane-shell-ui-config.yaml.j2
+++ b/salt/metalk8s/addons/ui/config/workloadplane-shell-ui-config.yaml.j2
@@ -1,0 +1,21 @@
+#!jinja|yaml
+
+# Defaults for configuration of Shell-UI Workload Plane
+apiVersion: addons.metalk8s.scality.com/v1alpha1
+kind: WorkloadPlaneShellUIConfig
+spec:
+  deployedApps: []
+  config: 
+    discoveryUrl: /shell/deployed-ui-apps.json
+    logo:
+      light: /brand/assets/logo-light.svg
+      dark: /brand/assets/logo-dark.svg
+      darkRebrand: /brand/assets/logo-darkRebrand.svg
+    favicon: /brand/favicon-metalk8s.svg
+    canChangeLanguage: false
+    canChangeTheme: false
+    productName: MetalK8s
+    themes:
+      darkRebrand: 
+        logoPath: /brand/assets/logo-darkRebrand.svg
+ 

--- a/salt/metalk8s/addons/ui/deployed/files/metalk8s-ui-deployment.yaml.j2
+++ b/salt/metalk8s/addons/ui/deployed/files/metalk8s-ui-deployment.yaml.j2
@@ -67,6 +67,9 @@ spec:
           - name: deployed-ui-apps-volume
             mountPath: /etc/metalk8s/ui/deployed-ui-apps
             readOnly: true
+          - name: workloadplane-shell-ui-config-volume
+            mountPath: /usr/share/nginx/html/wp
+            readOnly: true
       volumes:
         - name: metalk8s-ui-volume
           configMap:
@@ -77,3 +80,6 @@ spec:
         - name: deployed-ui-apps-volume
           configMap:
             name: deployed-ui-apps-generated
+        - name: workloadplane-shell-ui-config-volume
+          configMap:
+            name: workloadplane-shell-ui-config-generated

--- a/salt/metalk8s/addons/ui/deployed/ui-configuration.sls
+++ b/salt/metalk8s/addons/ui/deployed/ui-configuration.sls
@@ -25,6 +25,38 @@ include:
   )
 %}
 
+{%- set workloadplane_shell_ui_config = salt.metalk8s_kubernetes.get_object(
+        kind='ConfigMap',
+        apiVersion='v1',
+        namespace='metalk8s-ui',
+        name='workloadplane-shell-ui-config',
+  )
+%}
+
+{%- if workloadplane_shell_ui_config is none %}
+
+Create workloadplane-shell-ui-config ConfigMap:
+  metalk8s_kubernetes.object_present:
+    - manifest:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: workloadplane-shell-ui-config
+          namespace: metalk8s-ui
+        data:
+          config.yaml: |-
+            apiVersion: addons.metalk8s.scality.com/v1alpha1
+            kind: WorkloadPlaneShellUIConfig
+            spec: {}
+
+
+{%- else %}
+
+workloadplane-shell-ui-config ConfigMap already exist:
+  test.succeed_without_changes: []
+
+{%- endif %}
+
 {%- if deployed_ui_apps is none %}
 
 Create deployed-ui-apps ConfigMap:

--- a/salt/metalk8s/addons/ui/deployed/ui.sls.in
+++ b/salt/metalk8s/addons/ui/deployed/ui.sls.in
@@ -31,6 +31,16 @@ include:
     )
 %}
 
+{%- set workloadplane_shell_ui_defaults = salt.slsutil.renderer(
+        'salt://metalk8s/addons/ui/config/workloadplane-shell-ui-config.yaml.j2', saltenv=saltenv
+    )
+%}
+
+{%- set workloadplane_shell_ui_config = salt.metalk8s_service_configuration.get_service_conf(
+        'metalk8s-ui', 'workloadplane-shell-ui-config', workloadplane_shell_ui_defaults
+    )
+%}
+
 {%- set stripped_base_path = metalk8s_ui_config.spec.basePath.strip('/') %}
 {%- set normalized_base_path = '/' ~ stripped_base_path %}
 
@@ -136,6 +146,20 @@ Create shell-ui ConfigMap:
         data:
           config.json: |-
             {{ metalk8s_shell_ui_config.spec | tojson }}
+
+Create workloadplane-shell-ui-config-generated ConfigMap:
+  metalk8s_kubernetes.object_present:
+    - manifest:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: workloadplane-shell-ui-config-generated
+          namespace: metalk8s-ui
+        data:
+          config.json: |-
+            {{ workloadplane_shell_ui_config.spec.config | tojson }}
+          deployed-ui-apps.json: |-
+            {{ workloadplane_shell_ui_config.spec.deployedApps | tojson }}
 
 Create deployed-ui-apps ConfigMap:
   metalk8s_kubernetes.object_present:

--- a/tests/post/features/ingress.feature
+++ b/tests/post/features/ingress.feature
@@ -20,6 +20,7 @@ Feature: Ingress
         When we create a 'metalk8s-test-1' Ingress on path '/_metalk8s-test-1' on 'repositories' service on 'http' in 'kube-system' namespace
         And we perform an HTTPS request on path '/_metalk8s-test-1' on port 443 on a workload-plane IP
         Then the server returns 200 'OK'
+        And the server should not respond with shell-ui index
 
     Scenario: Create new Ingress object (nginx class)
         Given the Kubernetes API is available
@@ -27,6 +28,7 @@ Feature: Ingress
         When we create a 'metalk8s-test-2' Ingress with class 'nginx' on path '/_metalk8s-test-2' on 'repositories' service on 'http' in 'kube-system' namespace
         And we perform an HTTPS request on path '/_metalk8s-test-2' on port 443 on a workload-plane IP
         Then the server returns 200 'OK'
+        And the server should not respond with shell-ui index
 
     Scenario: Create new Ingress object (invalid class)
         Given the Kubernetes API is available
@@ -63,6 +65,7 @@ Feature: Ingress
         And we wait for the rollout of 'daemonset/ingress-nginx-controller' in namespace 'metalk8s-ingress' to complete
         Then the '{wp_ingress_vips}' IPs are spread on nodes
         And an HTTP request on port 80 on '{wp_ingress_vips}' IPs returns 200 'OK'
+        And the server should not respond with shell-ui index
 
     Scenario: Workload Plane Ingress VIPs reconfiguration
         Given the Kubernetes API is available
@@ -76,6 +79,7 @@ Feature: Ingress
         And we wait for the rollout of 'daemonset/ingress-nginx-controller' in namespace 'metalk8s-ingress' to complete
         Then the '{wp_ingress_second_pool}' IPs are spread on nodes
         And an HTTP request on port 80 on '{wp_ingress_second_pool}' IPs returns 200 'OK'
+        And the server should not respond with shell-ui index
         And the '{wp_ingress_first_pool}' IPs are no longer available on nodes
         And an HTTP request on port 80 on '{wp_ingress_first_pool}' IPs should not return
 
@@ -91,8 +95,10 @@ Feature: Ingress
         And we wait for the rollout of 'daemonset/ingress-nginx-controller' in namespace 'metalk8s-ingress' to complete
         Then the '{wp_ingress_first_pool}' IPs are spread on nodes
         And an HTTP request on port 80 on '{wp_ingress_first_pool}' IPs returns 200 'OK'
+        And the server should not respond with shell-ui index
         And the '{wp_ingress_second_pool}' IPs are spread on nodes
         And an HTTP request on port 80 on '{wp_ingress_second_pool}' IPs returns 200 'OK'
+        And the server should not respond with shell-ui index
 
     Scenario: Failover of Workload Plane Ingress VIPs
         Given the Kubernetes API is available
@@ -104,6 +110,7 @@ Feature: Ingress
         And we stop the node 'node-1' Workload Plane Ingress
         Then the '{wp_ingress_vips}' IPs should no longer sit on the node 'node-1'
         And an HTTP request on port 80 on '{wp_ingress_vips}' IPs returns 200 'OK'
+        And the server should not respond with shell-ui index
 
     @authentication
     Scenario: Failover of Control Plane Ingress VIP

--- a/tests/post/features/ingress.feature
+++ b/tests/post/features/ingress.feature
@@ -4,13 +4,15 @@ Feature: Ingress
         Given the Kubernetes API is available
         And pods with label 'app.kubernetes.io/name=ingress-nginx' are 'Ready'
         When we perform an HTTP request on port 80 on a workload-plane IP
-        Then the server returns 404 'Not Found'
+        Then the server returns 200 'OK'
+        And the server should respond with shell-ui index
 
     Scenario: Access HTTPS services
         Given the Kubernetes API is available
         And pods with label 'app.kubernetes.io/name=ingress-nginx' are 'Ready'
         When we perform an HTTPS request on port 443 on a workload-plane IP
-        Then the server returns 404 'Not Found'
+        Then the server returns 200 'OK'
+        And the server should respond with shell-ui index
 
     Scenario: Create new Ingress object (without class)
         Given the Kubernetes API is available
@@ -31,7 +33,8 @@ Feature: Ingress
         And pods with label 'app.kubernetes.io/name=ingress-nginx' are 'Ready'
         When we create a 'metalk8s-test-3' Ingress with class 'invalid-class' on path '/_metalk8s-test-3' on 'repositories' service on 'http' in 'kube-system' namespace
         And we perform an HTTPS request on path '/_metalk8s-test-3' on port 443 on a workload-plane IP
-        Then the server returns 404 'Not Found'
+        Then the server returns 200 'OK'
+        And the server should respond with shell-ui index
 
     Scenario: Access HTTP services on control-plane IP
         Given the Kubernetes API is available
@@ -59,7 +62,7 @@ Feature: Ingress
         And we trigger a rollout restart of 'daemonset/ingress-nginx-controller' in namespace 'metalk8s-ingress'
         And we wait for the rollout of 'daemonset/ingress-nginx-controller' in namespace 'metalk8s-ingress' to complete
         Then the '{wp_ingress_vips}' IPs are spread on nodes
-        And an HTTP request on port 80 on '{wp_ingress_vips}' IPs returns 404 'Not Found'
+        And an HTTP request on port 80 on '{wp_ingress_vips}' IPs returns 200 'OK'
 
     Scenario: Workload Plane Ingress VIPs reconfiguration
         Given the Kubernetes API is available
@@ -72,7 +75,7 @@ Feature: Ingress
         And we trigger a rollout restart of 'daemonset/ingress-nginx-controller' in namespace 'metalk8s-ingress'
         And we wait for the rollout of 'daemonset/ingress-nginx-controller' in namespace 'metalk8s-ingress' to complete
         Then the '{wp_ingress_second_pool}' IPs are spread on nodes
-        And an HTTP request on port 80 on '{wp_ingress_second_pool}' IPs returns 404 'Not Found'
+        And an HTTP request on port 80 on '{wp_ingress_second_pool}' IPs returns 200 'OK'
         And the '{wp_ingress_first_pool}' IPs are no longer available on nodes
         And an HTTP request on port 80 on '{wp_ingress_first_pool}' IPs should not return
 
@@ -87,9 +90,9 @@ Feature: Ingress
         And we trigger a rollout restart of 'daemonset/ingress-nginx-controller' in namespace 'metalk8s-ingress'
         And we wait for the rollout of 'daemonset/ingress-nginx-controller' in namespace 'metalk8s-ingress' to complete
         Then the '{wp_ingress_first_pool}' IPs are spread on nodes
-        And an HTTP request on port 80 on '{wp_ingress_first_pool}' IPs returns 404 'Not Found'
+        And an HTTP request on port 80 on '{wp_ingress_first_pool}' IPs returns 200 'OK'
         And the '{wp_ingress_second_pool}' IPs are spread on nodes
-        And an HTTP request on port 80 on '{wp_ingress_second_pool}' IPs returns 404 'Not Found'
+        And an HTTP request on port 80 on '{wp_ingress_second_pool}' IPs returns 200 'OK'
 
     Scenario: Failover of Workload Plane Ingress VIPs
         Given the Kubernetes API is available
@@ -100,7 +103,7 @@ Feature: Ingress
         When we wait for the rollout of 'daemonset/ingress-nginx-controller' in namespace 'metalk8s-ingress' to complete
         And we stop the node 'node-1' Workload Plane Ingress
         Then the '{wp_ingress_vips}' IPs should no longer sit on the node 'node-1'
-        And an HTTP request on port 80 on '{wp_ingress_vips}' IPs returns 404 'Not Found'
+        And an HTTP request on port 80 on '{wp_ingress_vips}' IPs returns 200 'OK'
 
     @authentication
     Scenario: Failover of Control Plane Ingress VIP

--- a/tests/post/features/ingress.feature
+++ b/tests/post/features/ingress.feature
@@ -53,7 +53,8 @@ Feature: Ingress
         And we trigger a rollout restart of 'daemonset/ingress-nginx-controller' in namespace 'metalk8s-ingress'
         And we wait for the rollout of 'daemonset/ingress-nginx-controller' in namespace 'metalk8s-ingress' to complete
         Then an HTTP request on port 80 on a workload-plane IP should not return
-        And an HTTP request on port 80 on a control-plane IP returns 404 'Not Found'
+        And an HTTP request on port 80 on a control-plane IP returns 200 'OK'
+        And the server should respond with shell-ui index
 
     Scenario: Expose Workload Plane Ingress on some VIPs
         Given the Kubernetes API is available

--- a/tests/post/features/ingress.feature
+++ b/tests/post/features/ingress.feature
@@ -66,7 +66,7 @@ Feature: Ingress
         And we wait for the rollout of 'daemonset/ingress-nginx-controller' in namespace 'metalk8s-ingress' to complete
         Then the '{wp_ingress_vips}' IPs are spread on nodes
         And an HTTP request on port 80 on '{wp_ingress_vips}' IPs returns 200 'OK'
-        And the server should not respond with shell-ui index
+        And the server should respond with shell-ui index
 
     Scenario: Workload Plane Ingress VIPs reconfiguration
         Given the Kubernetes API is available
@@ -80,7 +80,7 @@ Feature: Ingress
         And we wait for the rollout of 'daemonset/ingress-nginx-controller' in namespace 'metalk8s-ingress' to complete
         Then the '{wp_ingress_second_pool}' IPs are spread on nodes
         And an HTTP request on port 80 on '{wp_ingress_second_pool}' IPs returns 200 'OK'
-        And the server should not respond with shell-ui index
+        And the server should respond with shell-ui index
         And the '{wp_ingress_first_pool}' IPs are no longer available on nodes
         And an HTTP request on port 80 on '{wp_ingress_first_pool}' IPs should not return
 
@@ -96,10 +96,10 @@ Feature: Ingress
         And we wait for the rollout of 'daemonset/ingress-nginx-controller' in namespace 'metalk8s-ingress' to complete
         Then the '{wp_ingress_first_pool}' IPs are spread on nodes
         And an HTTP request on port 80 on '{wp_ingress_first_pool}' IPs returns 200 'OK'
-        And the server should not respond with shell-ui index
+        And the server should respond with shell-ui index
         And the '{wp_ingress_second_pool}' IPs are spread on nodes
         And an HTTP request on port 80 on '{wp_ingress_second_pool}' IPs returns 200 'OK'
-        And the server should not respond with shell-ui index
+        And the server should respond with shell-ui index
 
     Scenario: Failover of Workload Plane Ingress VIPs
         Given the Kubernetes API is available
@@ -111,7 +111,7 @@ Feature: Ingress
         And we stop the node 'node-1' Workload Plane Ingress
         Then the '{wp_ingress_vips}' IPs should no longer sit on the node 'node-1'
         And an HTTP request on port 80 on '{wp_ingress_vips}' IPs returns 200 'OK'
-        And the server should not respond with shell-ui index
+        And the server should respond with shell-ui index
 
     @authentication
     Scenario: Failover of Control Plane Ingress VIP

--- a/tests/post/features/sanity.feature
+++ b/tests/post/features/sanity.feature
@@ -36,7 +36,6 @@ Feature: Cluster Sanity Checks
         | kube-system         | coredns                                |
         | kube-system         | metalk8s-operator-controller-manager   |
         | kube-system         | storage-operator-controller-manager    |
-        | metalk8s-ingress    | ingress-nginx-defaultbackend           |
         | metalk8s-monitoring | prometheus-adapter                     |
         | metalk8s-monitoring | prometheus-operator-grafana            |
         | metalk8s-monitoring | prometheus-operator-kube-state-metrics |

--- a/tests/post/steps/test_ingress.py
+++ b/tests/post/steps/test_ingress.py
@@ -569,17 +569,13 @@ def server_returns(host, context, status_code, reason):
     assert response.status_code == int(status_code)
     assert response.reason == reason
 
-@then(
-    parsers.re(r"the server should respond with shell-ui index"),
-)
+@then("the server should respond with shell-ui index")
 def shell_ui_returns(host, context):
     response = context.get("response")
     assert response is not None
     assert "window.shellUIRemoteEntryUrl = \"/shell/remoteEntry.js" in response.text
 
-@then(
-    parsers.re(r"the server should not respond with shell-ui index"),
-)
+@then("the server should not respond with shell-ui index")
 def shell_ui_not_returns(host, context):
     response = context.get("response")
     assert response is not None

--- a/tests/post/steps/test_ingress.py
+++ b/tests/post/steps/test_ingress.py
@@ -571,7 +571,6 @@ def server_returns(host, context, status_code, reason):
 
 @then(
     parsers.re(r"the server should respond with shell-ui index"),
-    converters=dict(status_code=int),
 )
 def shell_ui_returns(host, context):
     response = context.get("response")
@@ -580,7 +579,6 @@ def shell_ui_returns(host, context):
 
 @then(
     parsers.re(r"the server should not respond with shell-ui index"),
-    converters=dict(status_code=int),
 )
 def shell_ui_not_returns(host, context):
     response = context.get("response")

--- a/tests/post/steps/test_ingress.py
+++ b/tests/post/steps/test_ingress.py
@@ -569,17 +569,19 @@ def server_returns(host, context, status_code, reason):
     assert response.status_code == int(status_code)
     assert response.reason == reason
 
+
 @then("the server should respond with shell-ui index")
 def shell_ui_returns(host, context):
     response = context.get("response")
     assert response is not None
-    assert "window.shellUIRemoteEntryUrl = \"/shell/remoteEntry.js" in response.text
+    assert "window.shellUIRemoteEntryUrl = "/shell/remoteEntry.js" in response.text
+
 
 @then("the server should not respond with shell-ui index")
 def shell_ui_not_returns(host, context):
     response = context.get("response")
     assert response is not None
-    assert "window.shellUIRemoteEntryUrl = \"/shell/remoteEntry.js" not in response.text
+    assert "window.shellUIRemoteEntryUrl = "/shell/remoteEntry.js" not in response.text
 
 
 @then("the server should not respond")

--- a/tests/post/steps/test_ingress.py
+++ b/tests/post/steps/test_ingress.py
@@ -574,14 +574,14 @@ def server_returns(host, context, status_code, reason):
 def shell_ui_returns(host, context):
     response = context.get("response")
     assert response is not None
-    assert "window.shellUIRemoteEntryUrl = "/shell/remoteEntry.js" in response.text
+    assert 'window.shellUIRemoteEntryUrl = "/shell/remoteEntry.js' in response.text
 
 
 @then("the server should not respond with shell-ui index")
 def shell_ui_not_returns(host, context):
     response = context.get("response")
     assert response is not None
-    assert "window.shellUIRemoteEntryUrl = "/shell/remoteEntry.js" not in response.text
+    assert 'window.shellUIRemoteEntryUrl = "/shell/remoteEntry.js' not in response.text
 
 
 @then("the server should not respond")

--- a/tests/post/steps/test_ingress.py
+++ b/tests/post/steps/test_ingress.py
@@ -641,6 +641,7 @@ def server_request_returns_multiple_ips(
         )
         try:
             response = requests.get(endpoint, verify=False)
+            context["response"] = response
         except Exception as exc:
             raise AssertionError(f"Unable to reach ingress on '{endpoint}': {exc}")
 

--- a/tests/post/steps/test_ingress.py
+++ b/tests/post/steps/test_ingress.py
@@ -569,6 +569,15 @@ def server_returns(host, context, status_code, reason):
     assert response.status_code == int(status_code)
     assert response.reason == reason
 
+@then(
+    parsers.re(r"the server should respond with shell-ui index"),
+    converters=dict(status_code=int),
+)
+def shell_ui_returns(host, context):
+    response = context.get("response")
+    assert response is not None
+    assert "window.shellUIRemoteEntryUrl = \"/shell/remoteEntry.js" in response.text
+
 
 @then("the server should not respond")
 def server_does_not_respond(host, context):

--- a/tests/post/steps/test_ingress.py
+++ b/tests/post/steps/test_ingress.py
@@ -578,6 +578,15 @@ def shell_ui_returns(host, context):
     assert response is not None
     assert "window.shellUIRemoteEntryUrl = \"/shell/remoteEntry.js" in response.text
 
+@then(
+    parsers.re(r"the server should not respond with shell-ui index"),
+    converters=dict(status_code=int),
+)
+def shell_ui_not_returns(host, context):
+    response = context.get("response")
+    assert response is not None
+    assert "window.shellUIRemoteEntryUrl = \"/shell/remoteEntry.js" not in response.text
+
 
 @then("the server should not respond")
 def server_does_not_respond(host, context):


### PR DESCRIPTION
**Component**:

salt, csc

**Context**: 

In order to deploy federated app in an easier way on the workloadplane, we introduce here a new workloadplane configuation for Shell UI and a new default backend for the WP ingress.

