### PR TITLE
shell-ui: Filter out the non active alerts

### DIFF
--- a/shell-ui/src/alerts/alertHooks.test.tsx
+++ b/shell-ui/src/alerts/alertHooks.test.tsx
@@ -1,60 +1,82 @@
-import React, { createContext, useContext } from 'react';
-import packageJson from '../../package.json';
-const { version } = packageJson;
+import React from 'react';
 import { setupServer } from 'msw/node';
 import { rest } from 'msw';
 import { renderHook } from '@testing-library/react-hooks';
-import { QueryClient, QueryClientProvider, useQuery } from 'react-query';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import AlertProvider from './AlertProvider';
 import { useHighestSeverityAlerts } from './alertHooks';
 import { afterAll, beforeAll, jest } from '@jest/globals';
 const testService = 'http://10.0.0.1/api/alertmanager';
+
+const VOLUME_DEGRADED_ALERT = {
+  annotations: {
+    description:
+      'Filesystem on /dev/vdc at 192.168.1.29:9100 has only 3.13% available space left.',
+    runbook_url:
+      'https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodefilesystemalmostoutofspace',
+    summary: 'Filesystem has less than 5% space left.',
+  },
+  endsAt: new Date(new Date().getTime() + 1000 * 60 * 60 * 24).toISOString(),
+  fingerprint: '37b2591ac3cdb320',
+  startsAt: '2021-01-25T09:12:05.358Z',
+  updatedAt: '2021-01-29T07:36:11.363Z',
+  generatorURL:
+    'http://prometheus-operator-prometheus.metalk8s-monitoring:9090/graph?g0.expr=%28node_filesystem_avail_bytes%7Bfstype%21%3D%22%22%2Cjob%3D%22node-exporter%22%7D+%2F+node_filesystem_size_bytes%7Bfstype%21%3D%22%22%2Cjob%3D%22node-exporter%22%7D+%2A+100+%3C+5+and+node_filesystem_readonly%7Bfstype%21%3D%22%22%2Cjob%3D%22node-exporter%22%7D+%3D%3D+0%29&g0.tab=1',
+  labels: {
+    alertname: 'VolumeDegraded',
+    severity: 'warning',
+  },
+  status: {
+    state: 'active',
+  },
+};
+const VOLUME_AT_RISK_ALERT = {
+  annotations: {
+    description:
+      'Filesystem on /dev/vdc at 192.168.1.29:9100 has only 3.13% available space left.',
+    runbook_url:
+      'https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodefilesystemalmostoutofspace',
+    summary: 'Filesystem has less than 5% space left.',
+  },
+  endsAt: new Date(new Date().getTime() + 1000 * 60 * 60 * 24).toISOString(),
+  fingerprint: '37b2591ac3cdb320',
+  startsAt: '2021-01-25T09:12:05.358Z',
+  updatedAt: '2021-01-29T07:36:11.363Z',
+  generatorURL:
+    'http://prometheus-operator-prometheus.metalk8s-monitoring:9090/graph?g0.expr=%28node_filesystem_avail_bytes%7Bfstype%21%3D%22%22%2Cjob%3D%22node-exporter%22%7D+%2F+node_filesystem_size_bytes%7Bfstype%21%3D%22%22%2Cjob%3D%22node-exporter%22%7D+%2A+100+%3C+5+and+node_filesystem_readonly%7Bfstype%21%3D%22%22%2Cjob%3D%22node-exporter%22%7D+%3D%3D+0%29&g0.tab=1',
+  labels: {
+    alertname: 'VolumeAtRisk',
+    severity: 'critical',
+  },
+  status: {
+    state: 'active',
+  },
+};
+const VOLUME_AT_RISK_ALERT_NON_ACTIVE = {
+  annotations: {
+    description:
+      'Filesystem on /dev/vdc at 192.168.1.29:9100 has only 3.13% available space left.',
+    runbook_url:
+      'https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodefilesystemalmostoutofspace',
+    summary: 'Filesystem has less than 5% space left.',
+  },
+  endsAt: new Date(new Date().getTime() + 1000 * 60 * 60 * 24).toISOString(),
+  fingerprint: '37b2591ac3cdb320',
+  startsAt: '2021-01-25T09:12:05.358Z',
+  updatedAt: '2021-01-29T07:36:11.363Z',
+  generatorURL:
+    'http://prometheus-operator-prometheus.metalk8s-monitoring:9090/graph?g0.expr=%28node_filesystem_avail_bytes%7Bfstype%21%3D%22%22%2Cjob%3D%22node-exporter%22%7D+%2F+node_filesystem_size_bytes%7Bfstype%21%3D%22%22%2Cjob%3D%22node-exporter%22%7D+%2A+100+%3C+5+and+node_filesystem_readonly%7Bfstype%21%3D%22%22%2Cjob%3D%22node-exporter%22%7D+%3D%3D+0%29&g0.tab=1',
+  labels: {
+    alertname: 'VolumeAtRisk',
+    severity: 'critical',
+  },
+  status: {
+    state: 'suppressed',
+  },
+};
 const server = setupServer(
   rest.get(`${testService}/api/v2/alerts`, (req, res, ctx) => {
-    const alerts = [
-      {
-        annotations: {
-          description:
-            'Filesystem on /dev/vdc at 192.168.1.29:9100 has only 3.13% available space left.',
-          runbook_url:
-            'https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodefilesystemalmostoutofspace',
-          summary: 'Filesystem has less than 5% space left.',
-        },
-        endsAt: new Date(
-          new Date().getTime() + 1000 * 60 * 60 * 24,
-        ).toISOString(),
-        fingerprint: '37b2591ac3cdb320',
-        startsAt: '2021-01-25T09:12:05.358Z',
-        updatedAt: '2021-01-29T07:36:11.363Z',
-        generatorURL:
-          'http://prometheus-operator-prometheus.metalk8s-monitoring:9090/graph?g0.expr=%28node_filesystem_avail_bytes%7Bfstype%21%3D%22%22%2Cjob%3D%22node-exporter%22%7D+%2F+node_filesystem_size_bytes%7Bfstype%21%3D%22%22%2Cjob%3D%22node-exporter%22%7D+%2A+100+%3C+5+and+node_filesystem_readonly%7Bfstype%21%3D%22%22%2Cjob%3D%22node-exporter%22%7D+%3D%3D+0%29&g0.tab=1',
-        labels: {
-          alertname: 'VolumeDegraded',
-          severity: 'warning',
-        },
-      },
-      {
-        annotations: {
-          description:
-            'Filesystem on /dev/vdc at 192.168.1.29:9100 has only 3.13% available space left.',
-          runbook_url:
-            'https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodefilesystemalmostoutofspace',
-          summary: 'Filesystem has less than 5% space left.',
-        },
-        endsAt: new Date(
-          new Date().getTime() + 1000 * 60 * 60 * 24,
-        ).toISOString(),
-        fingerprint: '37b2591ac3cdb320',
-        startsAt: '2021-01-25T09:12:05.358Z',
-        updatedAt: '2021-01-29T07:36:11.363Z',
-        generatorURL:
-          'http://prometheus-operator-prometheus.metalk8s-monitoring:9090/graph?g0.expr=%28node_filesystem_avail_bytes%7Bfstype%21%3D%22%22%2Cjob%3D%22node-exporter%22%7D+%2F+node_filesystem_size_bytes%7Bfstype%21%3D%22%22%2Cjob%3D%22node-exporter%22%7D+%2A+100+%3C+5+and+node_filesystem_readonly%7Bfstype%21%3D%22%22%2Cjob%3D%22node-exporter%22%7D+%3D%3D+0%29&g0.tab=1',
-        labels: {
-          alertname: 'VolumeAtRisk',
-          severity: 'critical',
-        },
-      },
-    ];
+    const alerts = [VOLUME_DEGRADED_ALERT, VOLUME_AT_RISK_ALERT];
     return res(ctx.json(alerts));
   }),
 );
@@ -66,7 +88,9 @@ describe('useHighestSeverityAlerts hook', () => {
     }),
   );
   afterEach(() => server.resetHandlers());
-
+  afterAll(() => {
+    server.close();
+  });
   const wrapper = ({ children }) => (
     <QueryClientProvider client={new QueryClient()}>
       <AlertProvider alertManagerUrl={testService}>{children}</AlertProvider>
@@ -104,7 +128,27 @@ describe('useHighestSeverityAlerts hook', () => {
     // V
     expect(result.current).toEqual([]);
   });
-  afterAll(() => {
-    server.close();
+  it('should get VolumeDegraded alert when VolumeDegraded is active and VolumeAtRisk is inactive', async () => {
+    //S
+    server.use(
+      rest.get(`${testService}/api/v2/alerts`, (req, res, ctx) => {
+        const alerts = [VOLUME_DEGRADED_ALERT, VOLUME_AT_RISK_ALERT_NON_ACTIVE];
+        return res(ctx.json(alerts));
+      }),
+    );
+    const { result, waitForNextUpdate } = renderHook(
+      () =>
+        useHighestSeverityAlerts({
+          alertname: ['VolumeAtRisk', 'VolumeDegraded'],
+        }),
+      {
+        wrapper,
+      },
+    );
+    // E
+    await waitForNextUpdate();
+    // V
+    expect(result.current[0].labels.alertname).toEqual('VolumeDegraded');
+    expect(result.current.length).toEqual(1);
   });
 });

--- a/shell-ui/src/alerts/services/alertUtils.ts
+++ b/shell-ui/src/alerts/services/alertUtils.ts
@@ -19,6 +19,7 @@ export type Alert = {
   severity: string;
   labels: AlertLabels;
   originalAlert: PrometheusAlert;
+  status: string;
   summary?: string;
   documentationUrl?: string;
 };
@@ -106,6 +107,7 @@ export const formatActiveAlerts = (alerts: Array<PrometheusAlert>): Alert[] => {
       },
       childrenJsonPath: alert.annotations && alert.annotations.childrenJsonPath,
       originalAlert: alert,
+      status: alert.status.state,
     };
   });
 };
@@ -160,7 +162,7 @@ export const filterAlerts = (
   }
 
   return alerts.filter((alert) => {
-    return isAlertSelected(alert.labels, filters);
+    return isAlertSelected(alert.labels, filters) && alert.status === 'active';
   });
 };
 // check if the given time is between the start and end


### PR DESCRIPTION
**Component**: Shell UI

**Context**: 
Following the act of silencing an alert, the alert's status would transition to suppressed. Nonetheless, our aim is to fetch solely the active alerts. Therefore, we must sort out and exclude the alerts that are not currently active.

**Summary**:

**Acceptance criteria**: 
On the Alert Page, only the active alerts should be visible.

