### PR TITLE
shell-ui: Show the Notification Center only for platform admin

### DIFF
--- a/shell-ui/src/auth/AuthProvider.tsx
+++ b/shell-ui/src/auth/AuthProvider.tsx
@@ -132,14 +132,16 @@ function OAuth2AuthProvider({ children }: { children: React.ReactNode }) {
   return <OIDCAuthProvider {...oidcConfig}>{children}</OIDCAuthProvider>;
 }
 
+export type UserData = {
+  token: string;
+  username: string;
+  groups: string[];
+  email: string;
+  id: string;
+};
+
 export function useAuth(): {
-  userData?: {
-    token: string;
-    username: string;
-    groups: string[];
-    email: string;
-    id: string;
-  };
+  userData?: UserData;
 } {
   const auth = useOauth2Auth(); // todo add support for OAuth2Proxy
 

--- a/shell-ui/src/navbar/NavBar.tsx
+++ b/shell-ui/src/navbar/NavBar.tsx
@@ -12,7 +12,7 @@ import { useTheme } from 'styled-components';
 import { useLanguage } from './lang';
 import { useThemeName } from './theme';
 import { useIntl } from 'react-intl';
-import { useAuth, useLogOut } from '../auth/AuthProvider';
+import { UserData, useAuth, useLogOut } from '../auth/AuthProvider';
 import {
   ViewDefinition,
   BuildtimeWebFinger,
@@ -291,6 +291,16 @@ export const Navbar = ({
       ),
   }));
 
+  const PLATFORM_ADMIN_ROLE = 'PlatformAdmin';
+  const isPlatformAdmin = (userData?: UserData): boolean => {
+    if (userData) {
+      if (userData.groups.includes(PLATFORM_ADMIN_ROLE)) {
+        return true;
+      }
+    }
+    return false;
+  };
+
   const notificationTab = {
     type: 'custom',
     icon: <></>,
@@ -299,7 +309,6 @@ export const Navbar = ({
 
   const rightTabs = [
     ...secondaryTabs,
-    notificationTab,
     {
       type: 'dropdown',
       text: userData?.username || '',
@@ -347,6 +356,9 @@ export const Navbar = ({
     },
   ];
 
+  if (isPlatformAdmin(userData)) {
+    rightTabs.splice(secondaryTabs.length - 1, 0, notificationTab);
+  }
   if (canChangeLanguage) {
     rightTabs.unshift({
       type: 'dropdown',

--- a/shell-ui/src/setupTests.ts
+++ b/shell-ui/src/setupTests.ts
@@ -37,16 +37,16 @@ export function mockOidcReact() {
   return {
     ...original,
     //Pass down all the exported objects
-    useAuth: () => ({
+    useAuth: jest.fn().mockImplementation(() => ({
       userData: {
         profile: {
-          groups: ['group1'],
+          groups: ['PlatformAdmin'],
           email: 'test@test.invalid',
           name: 'user',
           sub: 'userID',
         },
       },
-    }),
+    })),
   };
 }
 


### PR DESCRIPTION
**Component**: Shell UI

**Context**:  Show the Notification Center only for platform admin

**Summary**: We just need to hide the Notification Center Component from Navbar. But the logic has been implemented in Version, Alert and License. there is no need to change.

**Acceptance criteria**: 
