### PR TITLE
.github: Pin openstacksdk version for generate snapshot

### DIFF
--- a/.github/actions/generate-snapshots/action.yaml
+++ b/.github/actions/generate-snapshots/action.yaml
@@ -24,10 +24,11 @@ runs:
   steps:
     - name: Install dependencies for Openstack
       if: contains('ovh', inputs.cloud)
-      run: ./terraform-snapshot/requirements.sh
+      run: |
+        sudo yum install -y python36-pip jq
+        pip3 install --user --upgrade pip
+        pip3 install --user python-openstackclient~=5.8.0 openstacksdk~=1.4.0
       shell: bash
-      env:
-        CLOUD: openstack
     - name: Generate '${{ inputs.snapshot-name }}' snapshots
       # NOTE: we're adding ~/.local/bin since that's where pip will install the openstack
       # client executable

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,6 +30,13 @@ jobs:
       artifact-name: ${{ steps.upload.outputs.name }}
       artifact-link: ${{ steps.upload.outputs.link }}
     steps:
+      - name: Cleanup some unused ressources
+        # Because of the large number of images we embed in the ISO
+        # the disk space available start to be a problem.
+        # Let's remove some unused ressources to free some space.
+        run: |-
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
       - name: Checkout
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Latest openstacksdk version is no longer compatible with python3.6 but still marked as compatible
To avoid any issue in the future, let's pin the version for this lib and openstackclient