### PR TITLE
.readthedocs.yaml: Add readthedocs config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,18 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+  apt_packages:
+    - plantuml
+
+python:
+  install:
+    - requirements: docs/requirements.txt
+
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: true


### PR DESCRIPTION
Starting from September 25, 2023, the readthedocs configuration file becomes mandatory, so let's create one