### PR TITLE
operator: Ensure `default` namespace exists in tests

### DIFF
--- a/operator/pkg/controller/utils/object_test.go
+++ b/operator/pkg/controller/utils/object_test.go
@@ -46,6 +46,11 @@ var _ = Describe("ObjectHandler", func() {
 		c, err = client.New(cfg, client.Options{})
 		Expect(err).ToNot(HaveOccurred())
 
+		ctx = context.Background()
+
+		// Ensure the "default" namespace exists
+		c.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}})
+
 		log = logf.Log.WithName("utils-test-logger")
 		recorder = record.NewFakeRecorder(10)
 		componentName = "testcomponentname"
@@ -56,7 +61,6 @@ var _ = Describe("ObjectHandler", func() {
 			c, scheme.Scheme, recorder, log,
 			componentName, appName,
 		)
-		ctx = context.Background()
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
envtest seems to have some flakies about the "default" namespace that from time to time does not exist, to avoid any flaky during the test let's always try to create this "default" namespace before each test