### PR TITLE
Improvement/artesca 10189 change nodes name

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -12,7 +12,7 @@
         "@hookform/resolvers": "^3.1.0",
         "@js-temporal/polyfill": "^0.4.4",
         "@kubernetes/client-node": "github:scality/kubernetes-client-javascript.git#browser-0.10.4-64-ge7c6721",
-        "@scality/core-ui": "0.121.0",
+        "@scality/core-ui": "^0.121.0",
         "@scality/module-federation": "github:scality/module-federation.git#1.2.0",
         "axios": "^0.21.1",
         "canvas": "^2.9.3",
@@ -5157,6 +5157,23 @@
         "vega-embed": "6.0.0",
         "vega-lite": "5.0.0",
         "vega-tooltip": "0.27.0"
+      }
+    },
+    "node_modules/@scality/core-ui/node_modules/@floating-ui/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.1"
+      }
+    },
+    "node_modules/@scality/core-ui/node_modules/@floating-ui/dom": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+      "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
+      "dependencies": {
+        "@floating-ui/core": "^1.0.0",
+        "@floating-ui/utils": "^0.2.0"
       }
     },
     "node_modules/@scality/module-federation": {
@@ -28041,11 +28058,13 @@
     },
     "node_modules/vega-event-selector": {
       "version": "2.0.6",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-2.0.6.tgz",
+      "integrity": "sha512-UwCu50Sqd8kNZ1X/XgiAY+QAyQUmGFAwyDu7y0T5fs6/TPQnDo/Bo346NgSgINBEhEKOAMY1Nd/rPOk4UEm/ew=="
     },
     "node_modules/vega-expression": {
       "version": "4.0.1",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-4.0.1.tgz",
+      "integrity": "sha512-ZrDj0hP8NmrCpdLFf7Rd/xMUHGoSYsAOTaYp7uXZ2dkEH5x0uPy5laECMc8TiQvL8W+8IrN2HAWCMRthTSRe2Q==",
       "dependencies": {
         "vega-util": "^1.16.0"
       }
@@ -33709,6 +33728,25 @@
         "vega-embed": "6.0.0",
         "vega-lite": "5.0.0",
         "vega-tooltip": "0.27.0"
+      },
+      "dependencies": {
+        "@floating-ui/core": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+          "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+          "requires": {
+            "@floating-ui/utils": "^0.2.1"
+          }
+        },
+        "@floating-ui/dom": {
+          "version": "1.6.3",
+          "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+          "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
+          "requires": {
+            "@floating-ui/core": "^1.0.0",
+            "@floating-ui/utils": "^0.2.0"
+          }
+        }
       }
     },
     "@scality/module-federation": {
@@ -50151,10 +50189,14 @@
       }
     },
     "vega-event-selector": {
-      "version": "2.0.6"
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-2.0.6.tgz",
+      "integrity": "sha512-UwCu50Sqd8kNZ1X/XgiAY+QAyQUmGFAwyDu7y0T5fs6/TPQnDo/Bo346NgSgINBEhEKOAMY1Nd/rPOk4UEm/ew=="
     },
     "vega-expression": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-4.0.1.tgz",
+      "integrity": "sha512-ZrDj0hP8NmrCpdLFf7Rd/xMUHGoSYsAOTaYp7uXZ2dkEH5x0uPy5laECMc8TiQvL8W+8IrN2HAWCMRthTSRe2Q==",
       "requires": {
         "vega-util": "^1.16.0"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,7 +7,7 @@
     "@hookform/resolvers": "^3.1.0",
     "@js-temporal/polyfill": "^0.4.4",
     "@kubernetes/client-node": "github:scality/kubernetes-client-javascript.git#browser-0.10.4-64-ge7c6721",
-    "@scality/core-ui": "0.121.0",
+    "@scality/core-ui": "^0.121.0",
     "@scality/module-federation": "github:scality/module-federation.git#1.2.0",
     "axios": "^0.21.1",
     "canvas": "^2.9.3",

--- a/ui/src/FederableApp.tsx
+++ b/ui/src/FederableApp.tsx
@@ -14,7 +14,7 @@ import {
   ComponentWithFederatedImports,
   useCurrentApp,
 } from '@scality/module-federation';
-import { Loader } from '@scality/core-ui';
+import { Loader, ToastProvider } from '@scality/core-ui';
 import { ErrorPage500 } from '@scality/core-ui';
 import App from './containers/App';
 import reducer from './ducks/reducer';
@@ -172,9 +172,11 @@ export default function FederableApp() {
   return (
     <Provider store={store}>
       <AppConfigProvider>
-        <RouterWithBaseName>
-          <App />
-        </RouterWithBaseName>
+        <ToastProvider>
+          <RouterWithBaseName>
+            <App />
+          </RouterWithBaseName>
+        </ToastProvider>
       </AppConfigProvider>
     </Provider>
   );

--- a/ui/src/components/CircleStatus.tsx
+++ b/ui/src/components/CircleStatus.tsx
@@ -9,7 +9,7 @@ import {
 } from '../constants';
 import { IconName } from '@scality/core-ui/dist/components/icon/Icon.component';
 
-const getStyle = (status) => {
+export const getStyle = (status) => {
   switch (status) {
     case STATUS_SUCCESS:
     case STATUS_HEALTH:

--- a/ui/src/components/DashboardInventory.tsx
+++ b/ui/src/components/DashboardInventory.tsx
@@ -63,7 +63,6 @@ const DashboardInventory = () => {
     alertsLibrary.getVolumesAlertSelectors(),
   );
   const volumesStatus = highestAlertToStatus(volumesAlerts);
-  // @ts-expect-error - FIXME when you are working on it
   const token = useTypedSelector((state) => state.oidc?.user?.token);
   const config = useTypedSelector((state) => state.config.api?.url);
   const { data: volumesCount } = useQuery(

--- a/ui/src/components/NodeListTable.tsx
+++ b/ui/src/components/NodeListTable.tsx
@@ -36,7 +36,7 @@ const NodeListTable = ({ nodeTableData }) => {
         },
       },
       {
-        Header: 'Name',
+        Header: 'Description',
         accessor: 'name',
         cellStyle: {
           flex: 1,
@@ -46,7 +46,7 @@ const NodeListTable = ({ nodeTableData }) => {
           return (
             <>
               <Text data-cy="node_table_name_cell" variant="Basic" isEmphazed>
-                {name}
+                {value.displayName || name}
               </Text>
               <Stack>
                 {controlPlaneIP ? (

--- a/ui/src/components/NodePageOverviewTab.spec.tsx
+++ b/ui/src/components/NodePageOverviewTab.spec.tsx
@@ -1,0 +1,116 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { mockOffsetSize } from '../tests/mocks/util';
+import NodePageOverviewTab from './NodePageOverviewTab';
+import { render } from './__TEST__/util';
+
+const SUT = jest.fn();
+
+const mockProps = {
+  nodeName: 'mock-node',
+  nodeTableData: [
+    {
+      id: 'mock-id',
+      name: {
+        name: 'mock-node',
+        displayName: 'mock-display-name',
+        controlPlaneIP: '',
+        workloadPlaneIP: '',
+      },
+      status: {
+        status: 'ready',
+        conditions: [],
+        statusTextColor: '#0AADA6',
+        computedStatus: ['ready'],
+      },
+      roles: 'bootstrap',
+      health: {
+        health: 'healthy',
+        totalAlertsCounter: 0,
+        criticalAlertsCounter: 0,
+        warningAlertsCounter: 0,
+      },
+    },
+  ],
+  nodes: [],
+  pods: [],
+  volumes: [],
+};
+
+const server = setupServer(
+  rest.patch(
+    `http://localhost/api/kubernetes/api/v1/nodes/${mockProps.nodeName}`,
+    (req, res, ctx) => {
+      SUT(req.body);
+      return res(ctx.status(200), ctx.json({}));
+    },
+  ),
+);
+
+describe('NodePageOverviewTab', () => {
+  beforeAll(() => {
+    server.listen({
+      onUnhandledRequest: 'warn',
+    });
+    mockOffsetSize(200, 100);
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('should display node page overview', () => {
+    render(<NodePageOverviewTab {...mockProps} />);
+
+    expect(screen.getByText('mock-id')).toBeInTheDocument();
+    expect(screen.getByText('mock-node')).toBeInTheDocument();
+    expect(screen.getByText('mock-display-name')).toBeInTheDocument();
+  });
+
+  it('should modify display name', async () => {
+    const props = {
+      nodeName: 'mock-node',
+      nodeTableData: [
+        {
+          id: 'mock-id',
+          name: {
+            name: 'mock-node',
+            controlPlaneIP: '',
+            workloadPlaneIP: '',
+          },
+          status: {
+            status: 'ready',
+            conditions: [],
+            statusTextColor: '#0AADA6',
+            computedStatus: ['ready'],
+          },
+          roles: 'bootstrap',
+          health: {
+            health: 'healthy',
+            totalAlertsCounter: 0,
+            criticalAlertsCounter: 0,
+            warningAlertsCounter: 0,
+          },
+        },
+      ],
+      nodes: [],
+      pods: [],
+      volumeS: [],
+    };
+
+    const NEW_DISPLAY_NAME = 'new-display-name';
+
+    render(<NodePageOverviewTab {...props} />);
+
+    await userEvent.tab();
+    await userEvent.keyboard('{enter}');
+    await userEvent.type(document.activeElement, NEW_DISPLAY_NAME);
+    await userEvent.keyboard('{enter}');
+
+    expect(SUT).toHaveBeenCalledWith({
+      metadata: { labels: { 'metalk8s.scality.com/name': NEW_DISPLAY_NAME } },
+    });
+  });
+});

--- a/ui/src/components/NodePageOverviewTab.tsx
+++ b/ui/src/components/NodePageOverviewTab.tsx
@@ -1,32 +1,31 @@
-import React, { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { FormattedDate, FormattedTime } from 'react-intl';
-import styled from 'styled-components';
+import { InlineInput, Loader, Stack, Steppers } from '@scality/core-ui';
+import { Button } from '@scality/core-ui/dist/next';
 import {
-  padding,
   fontSize,
   fontWeight,
+  padding,
 } from '@scality/core-ui/dist/style/theme';
-import ActiveAlertsCounter from './ActiveAlertsCounter';
-import { Steppers, Loader } from '@scality/core-ui';
-import { Button } from '@scality/core-ui/dist/next';
 import isEmpty from 'lodash.isempty';
+import { useEffect } from 'react';
+import { FormattedDate, FormattedTime, useIntl } from 'react-intl';
+import { useDispatch, useSelector } from 'react-redux';
+import styled from 'styled-components';
+import { API_STATUS_UNKNOWN } from '../constants';
 import {
   deployNodeAction,
   fetchClusterVersionAction,
 } from '../ducks/app/nodes';
+import { useUpdateNodeDisplayName } from '../hooks/nodes';
+import ActiveAlertsCounter from './ActiveAlertsCounter';
 import {
+  ActiveAlertTitle,
+  ActiveAlertWrapper,
   NodeTab,
   OverviewInformationLabel,
   OverviewInformationSpan,
   OverviewInformationValue,
-  OverviewResourceName,
-  ActiveAlertTitle,
-  ActiveAlertWrapper,
+  OverviewInformationWrapper,
 } from './style/CommonLayoutStyle';
-import CircleStatus from './CircleStatus';
-import { API_STATUS_UNKNOWN } from '../constants';
-import { useIntl } from 'react-intl';
 const TabContentContainer = styled.div`
   overflow-y: auto;
   // 100vh subtract the height of navbar and tab header
@@ -92,6 +91,7 @@ const NodePageOverviewTab = (props) => {
       (job) => job.type === 'deploy-node' && job.node === nodeName,
     ),
   );
+
   let activeJob = jobs.find((job) => !job.completed);
 
   if (activeJob === undefined) {
@@ -169,14 +169,14 @@ const NodePageOverviewTab = (props) => {
   const podsScheduledOnCurrentNode = pods?.filter(
     (pod) => pod.nodeName === nodeName,
   );
+
+  const mutation = useUpdateNodeDisplayName(nodeName);
+
   return (
     <NodeTab>
       <TabContentContainer>
         <NodeNameContainer>
-          <div>
-            <CircleStatus status={currentNode?.health?.health}></CircleStatus>
-            <OverviewResourceName>{nodeName}</OverviewResourceName>
-          </div>
+          <p></p>
           {currentNodeReturnByK8S?.status === API_STATUS_UNKNOWN &&
           !currentNodeReturnByK8S.internalIP ? (
             !currentNodeReturnByK8S?.deploying ? (
@@ -209,44 +209,81 @@ const NodePageOverviewTab = (props) => {
         <Detail>
           <div>
             <OverviewInformationSpan>
+              <OverviewInformationLabel>Node ID</OverviewInformationLabel>
+              <OverviewInformationWrapper>
+                <OverviewInformationValue>
+                  {currentNode?.id}
+                </OverviewInformationValue>
+              </OverviewInformationWrapper>
+            </OverviewInformationSpan>
+            <Stack
+              direction="horizontal"
+              style={{ paddingLeft: 20, paddingBottom: 20 }}
+            >
+              <OverviewInformationLabel>Display Name</OverviewInformationLabel>
+              <InlineInput
+                key={currentNode?.name?.displayName}
+                id="node-name-input"
+                autoFocus
+                changeMutation={mutation}
+                defaultValue={currentNode?.name?.displayName}
+              />
+            </Stack>
+            <OverviewInformationSpan>
+              <OverviewInformationLabel>Name</OverviewInformationLabel>
+              <OverviewInformationWrapper>
+                <OverviewInformationValue>
+                  {currentNode?.name?.name}
+                </OverviewInformationValue>
+              </OverviewInformationWrapper>
+            </OverviewInformationSpan>
+            <OverviewInformationSpan>
               <OverviewInformationLabel>
                 Control Plane IP
               </OverviewInformationLabel>
-              <OverviewInformationValue>
-                {currentNode?.name?.controlPlaneIP}
-              </OverviewInformationValue>
+              <OverviewInformationWrapper>
+                <OverviewInformationValue>
+                  {currentNode?.name?.controlPlaneIP}
+                </OverviewInformationValue>
+              </OverviewInformationWrapper>
             </OverviewInformationSpan>
             <OverviewInformationSpan>
               <OverviewInformationLabel>
                 Workload Plane IP
               </OverviewInformationLabel>
-              <OverviewInformationValue>
-                {currentNode?.name?.workloadPlaneIP}
-              </OverviewInformationValue>
+              <OverviewInformationWrapper>
+                <OverviewInformationValue>
+                  {currentNode?.name?.workloadPlaneIP}
+                </OverviewInformationValue>
+              </OverviewInformationWrapper>
             </OverviewInformationSpan>
             <OverviewInformationSpan>
               <OverviewInformationLabel>Roles</OverviewInformationLabel>
-              <OverviewInformationValue>
-                {currentNode?.roles}
-              </OverviewInformationValue>
+              <OverviewInformationWrapper>
+                <OverviewInformationValue>
+                  {currentNode?.roles}
+                </OverviewInformationValue>
+              </OverviewInformationWrapper>
             </OverviewInformationSpan>
             <OverviewInformationSpan>
               <OverviewInformationLabel>Status</OverviewInformationLabel>
-              <OverviewInformationValue>
-                {currentNode?.status?.computedStatus?.map((cond) => {
-                  return (
-                    <StatusText
-                      key={cond}
-                      // @ts-expect-error - FIXME when you are working on it
-                      textColor={currentNode?.status?.statusColor}
-                    >
-                      {intl.formatMessage({
-                        id: `${cond}`,
-                      })}
-                    </StatusText>
-                  );
-                })}
-              </OverviewInformationValue>
+              <OverviewInformationWrapper>
+                <OverviewInformationValue>
+                  {currentNode?.status?.computedStatus?.map((cond) => {
+                    return (
+                      <StatusText
+                        key={cond}
+                        // @ts-expect-error - FIXME when you are working on it
+                        textColor={currentNode?.status?.statusColor}
+                      >
+                        {intl.formatMessage({
+                          id: `${cond}`,
+                        })}
+                      </StatusText>
+                    );
+                  })}
+                </OverviewInformationValue>
+              </OverviewInformationWrapper>
             </OverviewInformationSpan>
             <OverviewInformationSpan>
               <OverviewInformationLabel>
@@ -255,47 +292,55 @@ const NodePageOverviewTab = (props) => {
                 })}
               </OverviewInformationLabel>
               {creationTimestamp ? (
-                <OverviewInformationValue>
-                  <FormattedDate
-                    value={creationTimestamp}
-                    year="numeric"
-                    month="short"
-                    day="2-digit"
-                  />{' '}
-                  <FormattedTime
-                    hour="2-digit"
-                    minute="2-digit"
-                    second="2-digit"
-                    value={creationTimestamp}
-                  />
-                </OverviewInformationValue>
+                <OverviewInformationWrapper>
+                  <OverviewInformationValue>
+                    <FormattedDate
+                      value={creationTimestamp}
+                      year="numeric"
+                      month="short"
+                      day="2-digit"
+                    />{' '}
+                    <FormattedTime
+                      hour="2-digit"
+                      minute="2-digit"
+                      second="2-digit"
+                      value={creationTimestamp}
+                    />
+                  </OverviewInformationValue>
+                </OverviewInformationWrapper>
               ) : (
                 ''
               )}
             </OverviewInformationSpan>
             <OverviewInformationSpan>
               <OverviewInformationLabel>K8s Version</OverviewInformationLabel>
-              <OverviewInformationValue>
-                {currentNodeReturnByK8S?.kubeletVersion}
-              </OverviewInformationValue>
+              <OverviewInformationWrapper>
+                <OverviewInformationValue>
+                  {currentNodeReturnByK8S?.kubeletVersion}
+                </OverviewInformationValue>
+              </OverviewInformationWrapper>
             </OverviewInformationSpan>
             <OverviewInformationSpan>
               <OverviewInformationLabel>Volumes</OverviewInformationLabel>
-              <OverviewInformationValue>
-                {volumesAttachedCurrentNode?.length ??
-                  intl.formatMessage({
-                    id: 'unknown',
-                  })}
-              </OverviewInformationValue>
+              <OverviewInformationWrapper>
+                <OverviewInformationValue>
+                  {volumesAttachedCurrentNode?.length ??
+                    intl.formatMessage({
+                      id: 'unknown',
+                    })}
+                </OverviewInformationValue>
+              </OverviewInformationWrapper>
             </OverviewInformationSpan>
             <OverviewInformationSpan>
               <OverviewInformationLabel>Pods</OverviewInformationLabel>
-              <OverviewInformationValue>
-                {podsScheduledOnCurrentNode?.length ??
-                  intl.formatMessage({
-                    id: 'unknown',
-                  })}
-              </OverviewInformationValue>
+              <OverviewInformationWrapper>
+                <OverviewInformationValue>
+                  {podsScheduledOnCurrentNode?.length ??
+                    intl.formatMessage({
+                      id: 'unknown',
+                    })}
+                </OverviewInformationValue>
+              </OverviewInformationWrapper>
             </OverviewInformationSpan>
           </div>
           <ActiveAlertWrapper>

--- a/ui/src/components/__TEST__/util.tsx
+++ b/ui/src/components/__TEST__/util.tsx
@@ -18,6 +18,7 @@ import translations_en from '../../translations/en.json';
 import StartTimeProvider from '../../containers/StartTimeProvider';
 import { ConfigContext } from '../../FederableApp';
 import { coreUIAvailableThemes } from '@scality/core-ui/dist/style/theme';
+import { ToastProvider } from '@scality/core-ui';
 
 const composeEnhancers =
   // @ts-expect-error - FIXME when you are working on it
@@ -91,21 +92,23 @@ export const AllTheProviders = (
       return (
         <Router history={history}>
           <IntlProvider locale="en" messages={translations_en}>
-            <Provider store={buildStore()}>
-              <QueryClientProvider client={queryClient}>
-                <MetricsTimeSpanProvider>
-                  <StartTimeProvider>
-                    <AlertProvider>
-                      <ThemeProvider theme={theme}>
-                        <ConfigContext.Provider value={metalk8sConfig}>
-                          {children}
-                        </ConfigContext.Provider>
-                      </ThemeProvider>
-                    </AlertProvider>
-                  </StartTimeProvider>
-                </MetricsTimeSpanProvider>
-              </QueryClientProvider>
-            </Provider>
+            <ToastProvider>
+              <Provider store={buildStore()}>
+                <QueryClientProvider client={queryClient}>
+                  <MetricsTimeSpanProvider>
+                    <StartTimeProvider>
+                      <AlertProvider>
+                        <ThemeProvider theme={theme}>
+                          <ConfigContext.Provider value={metalk8sConfig}>
+                            {children}
+                          </ConfigContext.Provider>
+                        </ThemeProvider>
+                      </AlertProvider>
+                    </StartTimeProvider>
+                  </MetricsTimeSpanProvider>
+                </QueryClientProvider>
+              </Provider>
+            </ToastProvider>
           </IntlProvider>
         </Router>
       );
@@ -118,21 +121,23 @@ export const AllTheProviders = (
       >
         <Router history={history}>
           <IntlProvider locale="en" messages={translations_en}>
-            <Provider store={buildStore()}>
-              <QueryClientProvider client={queryClient}>
-                <MetricsTimeSpanProvider>
-                  <StartTimeProvider>
-                    <AlertProvider>
-                      <ThemeProvider theme={theme}>
-                        <ConfigContext.Provider value={metalk8sConfig}>
-                          {children}
-                        </ConfigContext.Provider>
-                      </ThemeProvider>
-                    </AlertProvider>
-                  </StartTimeProvider>
-                </MetricsTimeSpanProvider>
-              </QueryClientProvider>
-            </Provider>
+            <ToastProvider>
+              <Provider store={buildStore()}>
+                <QueryClientProvider client={queryClient}>
+                  <MetricsTimeSpanProvider>
+                    <StartTimeProvider>
+                      <AlertProvider>
+                        <ThemeProvider theme={theme}>
+                          <ConfigContext.Provider value={metalk8sConfig}>
+                            {children}
+                          </ConfigContext.Provider>
+                        </ThemeProvider>
+                      </AlertProvider>
+                    </StartTimeProvider>
+                  </MetricsTimeSpanProvider>
+                </QueryClientProvider>
+              </Provider>
+            </ToastProvider>
           </IntlProvider>
         </Router>
       </StyleSheetManager>

--- a/ui/src/components/style/CommonLayoutStyle.ts
+++ b/ui/src/components/style/CommonLayoutStyle.ts
@@ -135,6 +135,9 @@ export const OverviewInformationSpan = styled.div`
   padding-left: ${padding.large};
   display: flex;
 `;
+export const OverviewInformationWrapper = styled.div`
+  padding-left: 0.313rem;
+`;
 export const OverviewInformationValue = styled.span`
   color: ${(props) => props.theme.textPrimary};
   font-size: ${fontSize.base};

--- a/ui/src/containers/NodePageContent.tsx
+++ b/ui/src/containers/NodePageContent.tsx
@@ -1,20 +1,17 @@
 /* eslint no-unused-vars: 0 */
-import React, { useEffect, useState, Fragment } from 'react';
+import { AppContainer, EmptyState, TwoPanelLayout } from '@scality/core-ui';
+import { useEffect, useState } from 'react';
 import {
-  Route,
-  useRouteMatch,
-  Switch,
   Redirect,
+  Route,
+  Switch,
   useHistory,
+  useRouteMatch,
 } from 'react-router-dom';
 import NodeListTable from '../components/NodeListTable';
-import NodePageRSP from './NodePageRSP';
-import {
-  LeftSideInstanceList,
-  RightSidePanel,
-} from '../components/style/CommonLayoutStyle';
+import { LeftSideInstanceList } from '../components/style/CommonLayoutStyle';
 import { usePrevious } from '../services/utils';
-import { AppContainer, EmptyState, TwoPanelLayout } from '@scality/core-ui';
+import NodePageRSP from './NodePageRSP';
 
 // <NodePageContent> get the current selected node and pass it to <NodeListTable> and <NodePageRSP>
 const NodePageContent = (props) => {

--- a/ui/src/containers/NodePageRSP.tsx
+++ b/ui/src/containers/NodePageRSP.tsx
@@ -4,7 +4,14 @@ import { useSelector, useDispatch } from 'react-redux';
 import { useRouteMatch } from 'react-router';
 import { Tabs } from '@scality/core-ui/dist/next';
 import { NoResult } from '@scality/core-ui/dist/components/tablev2/Tablestyle';
-import { TextBadge } from '@scality/core-ui';
+import {
+  AppContainer,
+  Icon,
+  Stack,
+  TextBadge,
+  Text,
+  ConstrainedText,
+} from '@scality/core-ui';
 import { fetchPodsAction } from '../ducks/app/pods';
 import { getPodsListData } from '../services/PodUtils';
 import { useURLQuery, useRefreshEffect } from '../services/utils';
@@ -32,6 +39,7 @@ import { NODE_ALERTS_GROUP, PORT_NODE_EXPORTER } from '../constants';
 import { useAlerts } from './AlertProvider';
 import { useIntl } from 'react-intl';
 import { queryTimeSpansCodes } from '@scality/core-ui/dist/components/constants';
+import { getStyle } from '../components/CircleStatus';
 const THREE_MINUTES = 3 * 60 * 1000;
 
 // <NodePageRSP> fetches the data for all the tabs given the current selected Node
@@ -135,8 +143,27 @@ const NodePageRSP = (props) => {
   const criticalAlerts = alertsNode.filter(
     (alert) => alert.severity === 'critical',
   );
+
+  const { color } = getStyle(currentNode?.health?.health);
+
   return name && currentNode ? (
     <RightSidePanel>
+      <AppContainer.OverallSummary background="backgroundLevel3">
+        <Stack gap="r16">
+          <div style={{ flex: 'none' }}>
+            <Icon name="Node-backend" size="2x" color={color} withWrapper />
+          </div>
+
+          <div style={{ overflow: 'hidden', width: '40rem' }}>
+            <Text color="textPrimary" variant="Large">
+              <ConstrainedText
+                text={currentNode.name.displayName || name}
+                lineClamp={2}
+              />
+            </Text>
+          </div>
+        </Stack>
+      </AppContainer.OverallSummary>
       <Tabs>
         <Tabs.Tab
           path={`${url}/overview`}

--- a/ui/src/ducks/app/nodes.ts
+++ b/ui/src/ducks/app/nodes.ts
@@ -170,6 +170,8 @@ export type NodesState = {
   currentNodeObject: any;
   // TODO: define the type of this
   list: {
+    id: string;
+    displayName?: string;
     name: string;
     metalk8s_version: string;
     status: 'ready' | 'not_ready' | 'unknown';
@@ -354,6 +356,8 @@ export function* fetchNodes() {
           );
           const nodeRoles = nodeRolesLabels?.map((nRL) => nRL.split('/')[1]);
           return {
+            id: node.metadata.uid,
+            displayName: node.metadata.labels['metalk8s.scality.com/name'],
             name: node.metadata.name,
             metalk8s_version:
               node.metadata.labels['metalk8s.scality.com/version'],

--- a/ui/src/ducks/oidc.ts
+++ b/ui/src/ducks/oidc.ts
@@ -5,7 +5,7 @@ const defaultState = {
   user: null,
 };
 export type UserState = {
-  user: User | null | undefined;
+  user: (User | null | undefined) & { token: string };
 };
 type SetUserAction = {
   type: 'SET_USER';

--- a/ui/src/hooks/nodes.ts
+++ b/ui/src/hooks/nodes.ts
@@ -1,24 +1,23 @@
 import { useEffect } from 'react';
 import { useMutation, useQuery } from 'react-query';
 import { useDispatch, useSelector } from 'react-redux';
-import { nodeKey } from '../services/k8s/core.key';
+import { useConfig } from '../FederableApp';
 import {
-  API_STATUS_READY,
   API_STATUS_NOT_READY,
+  API_STATUS_READY,
   API_STATUS_UNKNOWN,
   REFRESH_TIMEOUT,
 } from '../constants';
-import { allJobsSelector } from '../ducks/app/salt';
 import {
-  ROLE_PREFIX,
   FETCH_NODES_IPS_INTERFACES,
-  updateNodesAction,
-  fetchNodes,
+  ROLE_PREFIX,
   fetchNodesAction,
+  updateNodesAction,
 } from '../ducks/app/nodes';
-import { useK8sApiConfig } from '../services/k8s/api';
-import { useConfig } from '../FederableApp';
+import { allJobsSelector } from '../ducks/app/salt';
 import { useTypedSelector } from '../hooks';
+import { useK8sApiConfig } from '../services/k8s/api';
+import { nodeKey } from '../services/k8s/core.key';
 const FIVE_SECOND_IN_MS = 5000;
 export function useAllNodesQueryOption(deployingNodes) {
   const { coreV1 } = useK8sApiConfig();

--- a/ui/src/services/NodeUtils.ts
+++ b/ui/src/services/NodeUtils.ts
@@ -124,10 +124,12 @@ export const getNodeListData = (alerts: Array<Alert>, theme: CoreUITheme) =>
 
           return {
             // According to the design, the IPs of Control Plane and Workload Plane are in the same Cell with Name
+            id: node.id,
             name: {
               name: node.name,
               controlPlaneIP: IPsInfo?.controlPlane?.ip,
               workloadPlaneIP: IPsInfo?.workloadPlane?.ip,
+              displayName: node?.displayName,
             },
             status: {
               status: node.status,


### PR DESCRIPTION
This pull request primarily focuses on updating the UI package dependencies, refactoring the UI components, and improving the test coverage. The most significant changes include updating the `@scality/core-ui` package, adding new dependencies in `ui/package-lock.json`, refactoring the `NodePageOverviewTab.tsx` and `NodePageRSP.tsx` components, and updating the test utilities.

Dependency updates:

* `ui/package.json` and `ui/package-lock.json`: Updated the `@scality/core-ui` package from a fixed version to a version range. This change allows the use of the most recent patch and minor updates of this package without changing the `package.json` file. [[1]](diffhunk://#diff-86dd4842508e2d279ac0a1b9a660d6494b53ee7ccf321d641c0421cb15202fa6L15-R15) [[2]](diffhunk://#diff-193b27d62e4fbda3d563009fed5ec6761a05f73558d94b39fab63ae948c679eaL10-R10)
* [`ui/package-lock.json`](diffhunk://#diff-86dd4842508e2d279ac0a1b9a660d6494b53ee7ccf321d641c0421cb15202fa6R5162-R5178): Added new dependencies related to `@scality/core-ui` and `vega-event-selector`. These additions are likely a result of the updated `@scality/core-ui` package. [[1]](diffhunk://#diff-86dd4842508e2d279ac0a1b9a660d6494b53ee7ccf321d641c0421cb15202fa6R5162-R5178) [[2]](diffhunk://#diff-86dd4842508e2d279ac0a1b9a660d6494b53ee7ccf321d641c0421cb15202fa6L28044-R28067) [[3]](diffhunk://#diff-86dd4842508e2d279ac0a1b9a660d6494b53ee7ccf321d641c0421cb15202fa6R33731-R33749) [[4]](diffhunk://#diff-86dd4842508e2d279ac0a1b9a660d6494b53ee7ccf321d641c0421cb15202fa6L50154-R50199)

UI refactoring:

* [`ui/src/components/NodePageOverviewTab.tsx`](diffhunk://#diff-51e095eb32ce2548e755eb8b1002f4532c0202f97a5705219babc2add74297c1L1-L29): Refactored the component to include the node ID and display name in the overview information. Also, introduced an inline input for modifying the display name. [[1]](diffhunk://#diff-51e095eb32ce2548e755eb8b1002f4532c0202f97a5705219babc2add74297c1L1-L29) [[2]](diffhunk://#diff-51e095eb32ce2548e755eb8b1002f4532c0202f97a5705219babc2add74297c1R93) [[3]](diffhunk://#diff-51e095eb32ce2548e755eb8b1002f4532c0202f97a5705219babc2add74297c1R171-R178) [[4]](diffhunk://#diff-51e095eb32ce2548e755eb8b1002f4532c0202f97a5705219babc2add74297c1R210-R231)
* [`ui/src/components/NodePageRSP.tsx`](diffhunk://#diff-53bce1c8789ff7b908e2fa8583cf3ac26ffa731acbb2123bbf1d46d5261e8265L7-R14): Refactored the component to include a new `AppContainer.OverallSummary` section with an icon and the node name. [[1]](diffhunk://#diff-53bce1c8789ff7b908e2fa8583cf3ac26ffa731acbb2123bbf1d46d5261e8265L7-R14) [[2]](diffhunk://#diff-53bce1c8789ff7b908e2fa8583cf3ac26ffa731acbb2123bbf1d46d5261e8265R42) [[3]](diffhunk://#diff-53bce1c8789ff7b908e2fa8583cf3ac26ffa731acbb2123bbf1d46d5261e8265R146-R163)

Test improvements:

* [`ui/src/components/__TEST__/util.tsx`](diffhunk://#diff-fd57ed0037f17f138d374efa1894149316aa0db2aeb9eca72415d1401f9c8d02R21): Updated the test utilities to include a `ToastProvider` in the test providers. This change allows the testing of components that use toast notifications. [[1]](diffhunk://#diff-fd57ed0037f17f138d374efa1894149316aa0db2aeb9eca72415d1401f9c8d02R21) [[2]](diffhunk://#diff-fd57ed0037f17f138d374efa1894149316aa0db2aeb9eca72415d1401f9c8d02R95) [[3]](diffhunk://#diff-fd57ed0037f17f138d374efa1894149316aa0db2aeb9eca72415d1401f9c8d02R111) [[4]](diffhunk://#diff-fd57ed0037f17f138d374efa1894149316aa0db2aeb9eca72415d1401f9c8d02R124) [[5]](diffhunk://#diff-fd57ed0037f17f138d374efa1894149316aa0db2aeb9eca72415d1401f9c8d02R140)
* [`ui/src/components/NodePageOverviewTab.spec.tsx`](diffhunk://#diff-430d32ba9d0f1bdd32bda2400885df04bef9af31811d363b0da87438fd03c6b9R1-R116): Added a new test suite for the `NodePageOverviewTab` component. This suite includes tests for displaying the node page overview and modifying the display name.

Minor changes:

* [`ui/src/components/CircleStatus.tsx`](diffhunk://#diff-8a4695a19d08ae8b68e8bcbbe4933989687835f5990854e6d0aa4a543284085eL12-R12): Exported the `getStyle` function, which is likely used in other components or tests.
* `ui/src/components/DashboardInventory.tsx` and `ui/src/components/NodeListTable.tsx`: Made minor changes in these components, possibly as part of a larger refactoring or to fix TypeScript errors. [[1]](diffhunk://#diff-5832d868f1e622246182b02be57b480c29969febb5014addc44f87a803d35c4bL66) [[2]](diffhunk://#diff-d71a22fdd961d05590caedc651378e732db30be7186b2f9d5a5adc8c34eeaa83L39-R39)
* [`ui/src/FederableApp.tsx`](diffhunk://#diff-dc7bcecf4e16cee368d127f4587789bb5a68eb72576600f1a0724f73729e9d64L17-R17): Imported the `ToastProvider` from `@scality/core-ui` and used it to wrap the main app component. This change enables the use of toast notifications throughout the app. [[1]](diffhunk://#diff-dc7bcecf4e16cee368d127f4587789bb5a68eb72576600f1a0724f73729e9d64L17-R17) [[2]](diffhunk://#diff-dc7bcecf4e16cee368d127f4587789bb5a68eb72576600f1a0724f73729e9d64R175-R179)
* [`ui/src/containers/NodePageContent.tsx`](diffhunk://#diff-aeb5fdba1240165e5a79e6d90457c32a82210ed02a870ddbe8a89a317bdb8106L2-R14): Made minor changes in the import order.

![Capture d’écran 2024-03-04 à 16 40 14](https://github.com/scality/metalk8s/assets/135591453/f40e9efc-e10c-4d2e-b263-f917ab4ad1cd)
![Capture d’écran 2024-03-04 à 16 40 31](https://github.com/scality/metalk8s/assets/135591453/07cf0ff9-846f-4e1c-8a7d-27b84138d73a)
