### PR TITLE
ARTESCA-11664: display name when empty

### DIFF
--- a/ui/src/components/NodePageOverviewTab.spec.tsx
+++ b/ui/src/components/NodePageOverviewTab.spec.tsx
@@ -110,7 +110,50 @@ describe('NodePageOverviewTab', () => {
     await userEvent.keyboard('{enter}');
 
     expect(SUT).toHaveBeenCalledWith({
-      metadata: { labels: { 'metalk8s.scality.com/name': NEW_DISPLAY_NAME } },
+      metadata: {
+        labels: {
+          'metalk8s.scality.com/name': `${props.nodeName}${NEW_DISPLAY_NAME}`,
+        },
+      },
     });
+  });
+
+  it('should display name even if displayName is not empty', async () => {
+    const testProps = {
+      nodeName: 'mock-node',
+      nodeTableData: [
+        {
+          id: 'mock-id',
+          name: {
+            name: 'mock-node',
+            displayName: '',
+            controlPlaneIP: '',
+            workloadPlaneIP: '',
+          },
+          status: {
+            status: 'ready',
+            conditions: [],
+            statusTextColor: '#0AADA6',
+            computedStatus: ['ready'],
+          },
+          roles: 'bootstrap',
+          health: {
+            health: 'healthy',
+            totalAlertsCounter: 0,
+            criticalAlertsCounter: 0,
+            warningAlertsCounter: 0,
+          },
+        },
+      ],
+      nodes: [],
+      pods: [],
+      volumes: [],
+    };
+
+    render(<NodePageOverviewTab {...testProps} />);
+
+    const inputs = await screen.findAllByText(testProps.nodeName);
+
+    expect(inputs.length).toBe(2);
   });
 });

--- a/ui/src/components/NodePageOverviewTab.tsx
+++ b/ui/src/components/NodePageOverviewTab.tsx
@@ -226,7 +226,9 @@ const NodePageOverviewTab = (props) => {
                 id="node-name-input"
                 autoFocus
                 changeMutation={mutation}
-                defaultValue={currentNode?.name?.displayName}
+                defaultValue={
+                  currentNode?.name?.displayName || currentNode?.name?.name
+                }
               />
             </Stack>
             <OverviewInformationSpan>


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

**Summary**:

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
