### PR TITLE
salt: use alertmanager API v2 on metalk8s_monitoring salt module

### DIFF
--- a/salt/_modules/metalk8s_monitoring.py
+++ b/salt/_modules/metalk8s_monitoring.py
@@ -88,7 +88,7 @@ def add_silence(
     }
 
     response = _requests_alertmanager_api(
-        "api/v1/silences", "POST", json=body, **kwargs
+        "api/v2/silences", "POST", json=body, **kwargs
     )
 
     return response["silenceId"]
@@ -109,7 +109,7 @@ def delete_silence(silence_id, **kwargs):
             64d84a9e-cc6e-41ce-83ff-e84771ff6872
     """
     return _requests_alertmanager_api(
-        f"api/v1/silence/{silence_id}", "DELETE", **kwargs
+        f"api/v2/silence/{silence_id}", "DELETE", **kwargs
     )
 
 
@@ -128,8 +128,9 @@ def get_silences(state=None, **kwargs):
         salt-call metalk8s_monitoring.get_silences
         salt-call metalk8s_monitoring.get_silences state=active
     """
-    response = _requests_alertmanager_api("api/v1/silences", "GET", **kwargs)
-
+    response = _requests_alertmanager_api("api/v2/silences", "GET", **kwargs)
+    if response is None or response == []:
+        return []
     if state is not None:
         silences = [
             silence for silence in response if silence["status"]["state"] == state
@@ -155,8 +156,9 @@ def get_alerts(state=None, **kwargs):
         salt-call metalk8s_monitoring.get_alerts
         salt-call metalk8s_monitoring.get_alerts state=suppressed
     """
-    response = _requests_alertmanager_api("api/v1/alerts", "GET", **kwargs)
-
+    response = _requests_alertmanager_api("api/v2/alerts", "GET", **kwargs)
+    if response is None or response == []:
+        return []
     if state is not None:
         alerts = [alert for alert in response if alert["status"]["state"] == state]
     else:

--- a/salt/tests/unit/modules/files/test_metalk8s_monitoring.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_monitoring.yaml
@@ -182,6 +182,14 @@ get_silences:
     result:
       - *active_silence
 
+  - _id: get_empty
+    response: []
+    result: []
+
+  - _id: get_none
+    response: null
+    result: []
+
 get_alerts:
   - _id: without-state
     response: &alerts_list
@@ -203,3 +211,11 @@ get_alerts:
     response: *alerts_list
     result:
       - *active_alert
+
+  - _id: get_empty
+    response: []
+    result: []
+
+  - _id: get_none
+    response: null
+    result: []

--- a/salt/tests/unit/modules/test_metalk8s_monitoring.py
+++ b/salt/tests/unit/modules/test_metalk8s_monitoring.py
@@ -161,7 +161,7 @@ class Metalk8sMonitoringTestCase(TestCase, mixins.LoaderModuleMockMixin):
         request_mock.assert_called_once()
         self.assertEqual(
             request_mock.call_args[0],
-            ("api/v1/silence/d287796c-cf59-4d10-8e5b-d5cc3ff51b9c", "DELETE"),
+            ("api/v2/silence/d287796c-cf59-4d10-8e5b-d5cc3ff51b9c", "DELETE"),
         )
 
     @parameterized.expand(


### PR DESCRIPTION
Co-authored-by: Alex Rodriguez

**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

**Summary**:

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
