### PR TITLE
salt: Add the `grains_cache` option to Salt minions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   salt FQDNs grains that are not used today
   (PR[#4287](https://github.com/scality/metalk8s/pull/4287))
 
+- Add an option on the Salt minion `grains_cache: true`. It allows
+  MetalK8s to be deployed and upgraded with a non responding DNS. 
+  (PR[#4311](https://github.com/scality/metalk8s/pull/4311))
+
 ## Release 127.0.0
 
 ### Additions

--- a/salt/metalk8s/node/grains.sls
+++ b/salt/metalk8s/node/grains.sls
@@ -16,6 +16,8 @@ Set control_plane_ip grain:
   grains.present:
     - name: metalk8s:control_plane_ip
     - value: {{ control_plane_ip }}
+    - onchanges_in:
+      - module: Force sync of grains
 
 {%- else %}
 
@@ -35,10 +37,21 @@ Set workload_plane_ip grain:
   grains.present:
     - name: metalk8s:workload_plane_ip
     - value: {{ workload_plane_ip }}
+    - onchanges_in:
+      - module: Force sync of grains
 
 {%- else %}
 
 No workload-plane network interface present on the host:
   test.fail_without_changes
+
+{%- endif %}
+
+{%- if control_plane_ip or workload_plane_ip %}
+
+{#- Since we enable grains cache, the cache is not refreshed automatically #}
+Force sync of grains:
+  module.run:
+    - saltutil.sync_grains: []
 
 {%- endif %}

--- a/salt/metalk8s/salt/minion/files/minion-99-metalk8s.conf.j2
+++ b/salt/metalk8s/salt/minion/files/minion-99-metalk8s.conf.j2
@@ -4,6 +4,8 @@ id: {{ minion_id }}
 retry_dns_count: 5
 enable_fqdns_grains: false
 
+grains_cache: true
+
 # use new module.run format
 use_superseded:
   - module.run

--- a/salt/metalk8s/salt/minion/local.sls
+++ b/salt/metalk8s/salt/minion/local.sls
@@ -29,3 +29,4 @@ Configure salt minion for local mode:
           - metalk8s: /etc/metalk8s/bootstrap.yaml
         retry_dns_count: 3
         enable_fqdns_grains: false
+        grains_cache: true


### PR DESCRIPTION
Force the sync of the custom set grains. Relates to https://github.com/saltstack/salt/issues/54331