### PR TITLE
packages/sosreport: Add `kubectl top` output in MetalK8s plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Release 127.0.1 (in development)
 
+### Enhancements
+
+- Add `kubectl top` output as part of `metalk8s`
+  sosreport plugin
+  (PR[#4312](https://github.com/scality/metalk8s/pull/4312))
+
 ### Bug fixes
 
 - In order to reduce slow DNS impact, let's disable


### PR DESCRIPTION
Example report 
``` console
$ find . -name '*top.txt'
./sos_commands/metalk8s/flat/pod_ns_metalk8s-monitoring_top.txt
./sos_commands/metalk8s/flat/pod_ns_metalk8s-vips_top.txt
./sos_commands/metalk8s/flat/pod_ns_metalk8s-ingress_top.txt
./sos_commands/metalk8s/flat/pod_ns_metalk8s-logging_top.txt
./sos_commands/metalk8s/flat/pod_ns_metalk8s-ui_top.txt
./sos_commands/metalk8s/flat/pod_ns_kube-system_top.txt
./sos_commands/metalk8s/flat/node_top.txt
./sos_commands/metalk8s/by-namespaces/kube-system/pod/top.txt
./sos_commands/metalk8s/by-namespaces/metalk8s-ingress/pod/top.txt
./sos_commands/metalk8s/by-namespaces/metalk8s-logging/pod/top.txt
./sos_commands/metalk8s/by-namespaces/metalk8s-monitoring/pod/top.txt
./sos_commands/metalk8s/by-namespaces/metalk8s-ui/pod/top.txt
./sos_commands/metalk8s/by-namespaces/metalk8s-vips/pod/top.txt
./sos_commands/metalk8s/by-namespaces/_no_namespace/node/top.txt
./sos_commands/metalk8s/by-resources/pod/kube-system/top.txt
./sos_commands/metalk8s/by-resources/pod/metalk8s-ingress/top.txt
./sos_commands/metalk8s/by-resources/pod/metalk8s-logging/top.txt
./sos_commands/metalk8s/by-resources/pod/metalk8s-monitoring/top.txt
./sos_commands/metalk8s/by-resources/pod/metalk8s-ui/top.txt
./sos_commands/metalk8s/by-resources/pod/metalk8s-vips/top.txt
./sos_commands/metalk8s/by-resources/node/top.txt

```
