### PR TITLE
ui: Switch to alertmanager V2 API and fix default email template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
   due to another component modifying the wanted object
   (PR[#4317](https://github.com/scality/metalk8s/pull/4317))
 
+### Bug fixes
+
+- Following to Alert Manager Bump the test email feature from the
+  UI wasn't working correctly.
+  (PR[#4322](https://github.com/scality/metalk8s/pull/4322))
+
 ## Release 127.0.1
 
 ### Enhancements
@@ -24,7 +30,7 @@
   (PR[#4287](https://github.com/scality/metalk8s/pull/4287))
 
 - Add an option on the Salt minion `grains_cache: true`. It allows
-  MetalK8s to be deployed and upgraded with a non responding DNS. 
+  MetalK8s to be deployed and upgraded with a non responding DNS.
   (PR[#4311](https://github.com/scality/metalk8s/pull/4311))
 
 ## Release 127.0.0
@@ -196,7 +202,7 @@
 
   - Bump Prometheus container version to
     [2.45.0](https://github.com/prometheus/prometheus/releases/tag/v2.45.0)
-  - Bump Thanos chart version to 
+  - Bump Thanos chart version to
     [0.4.9](https://artifacthub.io/packages/helm/banzaicloud-stable/thanos/0.4.9),
     Thanos container version to
     [0.31.0](https://github.com/thanos-io/thanos/releases/tag/v0.31.0)
@@ -262,7 +268,7 @@
   [1.19](https://golang.org/doc/devel/release.html#go1.19.minor)
   (PR[#4110](https://github.com/scality/metalk8s/pull/4110))
 
-- Add liveness probe to `keepalived` pod 
+- Add liveness probe to `keepalived` pod
   (PR[#4118](https://github.com/scality/metalk8s/pull/4118))
 
 - Add `kubeReserved` and `systemReserved` resources allocation to `KubeletConfiguration`
@@ -327,6 +333,7 @@
   (PR[4067](https://github.com/scality/metalk8s/pull/4067))
 
 ## Release 125.0.2
+
 ### Bug fixes
 
 - Fix time selector in the Platform page
@@ -513,7 +520,6 @@
 
 ## Release 124.1.4
 
-
 ### Bug fixes
 
 - Fix flaky invalid `HTTPSConnectionPool` exception raised when loading
@@ -588,7 +594,7 @@
 
 ## Release 124.0.1
 
-### Bug fixes 
+### Bug fixes
 
 - Actually bump the alpine base image used by `metalk8s-alert-logger`
   image to `alpine:3.16.2` (this one was wrongly marked as upgraded
@@ -839,18 +845,19 @@
 - Bump kube-prometheus-stack charts version to
   [35.3.1](https://github.com/prometheus-community/helm-charts/releases/tag/kube-prometheus-stack-35.3.1)
   The following images have also been bumped accordingly:
-   - alertmanager to [v0.24.0](https://github.com/prometheus/alertmanager/releases/tag/v0.24.0)
-   - k8s-sidecar to [1.15.6](https://github.com/kiwigrid/k8s-sidecar/releases/tag/1.15.6)
-   - grafana to [8.5.0-ubuntu](https://github.com/grafana/grafana/releases/tag/v8.4.7)
-   - kube-state-metrics to [v2.4.1](https://github.com/kubernetes/kube-state-metrics/releases/tag/v2.4.1)
-   - node-exporter to [v1.3.1](https://github.com/prometheus/node_exporter/releases/tag/v1.3.1)
-   - prometheus to [v2.35.0](https://github.com/prometheus/prometheus/releases/tag/v2.35.0)
-   - prometheus-config-reloader to [v0.56.2](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.56.2)
-   - prometheus-operator to [v0.56.2](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.56.2)
-   - thanos to [v0.25.2](https://github.com/thanos-io/thanos/releases/tag/v0.25.2)
-   This new version also come with Grafana metrics and a dashboard to
-   monitor Grafana
-  (PR[#3763](https://github.com/scality/metalk8s/pull/3763))
+
+  - alertmanager to [v0.24.0](https://github.com/prometheus/alertmanager/releases/tag/v0.24.0)
+  - k8s-sidecar to [1.15.6](https://github.com/kiwigrid/k8s-sidecar/releases/tag/1.15.6)
+  - grafana to [8.5.0-ubuntu](https://github.com/grafana/grafana/releases/tag/v8.4.7)
+  - kube-state-metrics to [v2.4.1](https://github.com/kubernetes/kube-state-metrics/releases/tag/v2.4.1)
+  - node-exporter to [v1.3.1](https://github.com/prometheus/node_exporter/releases/tag/v1.3.1)
+  - prometheus to [v2.35.0](https://github.com/prometheus/prometheus/releases/tag/v2.35.0)
+  - prometheus-config-reloader to [v0.56.2](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.56.2)
+  - prometheus-operator to [v0.56.2](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.56.2)
+  - thanos to [v0.25.2](https://github.com/thanos-io/thanos/releases/tag/v0.25.2)
+    This new version also come with Grafana metrics and a dashboard to
+    monitor Grafana
+    (PR[#3763](https://github.com/scality/metalk8s/pull/3763))
 
 - Bump Prometheus Adapter chart version to
   [3.2.2](https://github.com/prometheus-community/helm-charts/releases/tag/prometheus-adapter-3.2.2)
@@ -879,9 +886,10 @@
 - Bump MetalLB chart version to
   [3.0.6](https://artifacthub.io/packages/helm/bitnami/metallb/3.0.6)
   The following images have also been bumped accordingly:
+
   - metallb-controller to [0.12.1-debian-10-r89](https://github.com/bitnami/bitnami-docker-metallb-controller/releases/tag/0.12.1-debian-10-r89)
   - metallb-speaker to [0.12.1-debian-10-r90](https://github.com/bitnami/bitnami-docker-metallb-speaker/releases/tag/0.12.1-debian-10-r90)
-  (PR[#3777](https://github.com/scality/metalk8s/pull/3777))
+    (PR[#3777](https://github.com/scality/metalk8s/pull/3777))
 
 - Bump nginx image to [1.21.6-alpine](https://github.com/nginx/nginx/releases/tag/release-1.21.6)
   (PR[#3710](https://github.com/scality/metalk8s/pull/3710))
@@ -894,7 +902,7 @@
   `salt-master` container
   (PR[#3773](https://github.com/scality/metalk8s/pull/3773))
 
- - Bump Salt version to [3002.9](https://github.com/saltstack/salt/blob/v3002.9/doc/topics/releases/3002.9.rst)
+- Bump Salt version to [3002.9](https://github.com/saltstack/salt/blob/v3002.9/doc/topics/releases/3002.9.rst)
   (PR[#3811](https://github.com/scality/metalk8s/pull/3811))
 
 - Bump Dex chart version to [0.8.2](https://artifacthub.io/packages/helm/dex/dex/0.8.2),
@@ -905,6 +913,7 @@
 ## Release 2.11.9 (in development)
 
 ## Release 2.11.8
+
 ### Bug fixes
 
 - Properly exit on failure during upgrade and downgrade
@@ -912,10 +921,11 @@
 
 ### Enhancements
 
- - Bump Salt version to 3002.9
+- Bump Salt version to 3002.9
   (PR[#3815](https://github.com/scality/metalk8s/pull/3815))
 
 ## Release 2.11.7
+
 ### Enhancements
 
 - Allow to set Control Plane Ingress IP to an external IP (like
@@ -926,12 +936,14 @@
   (PR[#3758](https://github.com/scality/metalk8s/pull/3758))
 
 ## Release 2.11.6
+
 ### Enhancements
 
- - Bump Salt version to 3002.8
+- Bump Salt version to 3002.8
   (PR[#3744](https://github.com/scality/metalk8s/pull/3744))
 
 ## Release 2.11.5
+
 ### Enhancements
 
 - Make Loki pod resources configurable
@@ -951,6 +963,7 @@
   (PR[#3742](https://github.com/scality/metalk8s/pull/3742))
 
 ## Release 2.11.4
+
 ### Bug fixes
 
 - Downgrade Kubernetes version to 1.22.4 in order to avoid a regression
@@ -961,6 +974,7 @@
   (PR[#3732](https://github.com/scality/metalk8s/pull/3732))
 
 ## Release 2.11.3
+
 ### Enhancements
 
 - Bump Kubernetes version to 1.22.8
@@ -988,6 +1002,7 @@
   (PR[#3725](https://github.com/scality/metalk8s/pull/3725))
 
 ## Release 2.11.2
+
 ### Bug fixes
 
 - Downgrade ingress-nginx chart version to 4.0.6
@@ -997,6 +1012,7 @@
   (PR[#3694](https://github.com/scality/metalk8s/pull/3694))
 
 ## Release 2.11.1
+
 ### Enhancements
 
 - Add each Loki instance as datasources in Grafana dashboards
@@ -1026,6 +1042,7 @@
   (PR[#3692](https://github.com/scality/metalk8s/pull/3692))
 
 ## Release 2.11.0
+
 ### Additions
 
 - Deploy a hierarchy of Prometheus alerts to provide different granularities
@@ -1086,14 +1103,15 @@
 
 - Bump kube-prometheus-stack charts version to 23.2.0
   The following images have also been bumped accordingly:
-   - grafana to 8.3.1-ubuntu
-   - k8s-sidecar to 1.14.2
-   - kube-state-metrics to v2.2.4
-   - node-exporter to v1.2.2
-   - prometheus to v2.31.1
-   - prometheus-config-reloader to v0.52.1
-   - prometheus-operator to v0.52.1
-  (PR[#3639](https://github.com/scality/metalk8s/pull/3639))
+
+  - grafana to 8.3.1-ubuntu
+  - k8s-sidecar to 1.14.2
+  - kube-state-metrics to v2.2.4
+  - node-exporter to v1.2.2
+  - prometheus to v2.31.1
+  - prometheus-config-reloader to v0.52.1
+  - prometheus-operator to v0.52.1
+    (PR[#3639](https://github.com/scality/metalk8s/pull/3639))
 
 - [#3487](https://github.com/scality/metalk8s/issues/3487) - Make Salt
   Kubernetes execution module more flexible relying on `DynamicClient`
@@ -1114,7 +1132,6 @@
 
 - Handle 401 unauthorized error in MetalK8s UI
   (PR[#3640](https://github.com/scality/metalk8s/pull/3640))
-  
 - [#3618](https://github.com/scality/metalk8s/issues/3618) Detect Grafana
   dashboard ConfigMaps in any namespace rather than just `metalk8s-monitoring`,
   and enable Grafana folder generation from dashboard file structure (PR
@@ -1142,6 +1159,7 @@
   (PR[#3675](https://github.com/scality/metalk8s/pull/3675))
 
 ## Release 2.10.9 (in development)
+
 ## Bug fixes
 
 - Filter out some filesystem (NSFS, iso9660) from node exporter since
@@ -1149,6 +1167,7 @@
   (PR[#3661](https:github.com/scality/metalk8s/pull/3661))
 
 ## Release 2.10.8
+
 ## Enhancements
 
 - Bump Kubernetes version to 1.21.8
@@ -1168,12 +1187,14 @@
   (PR[#3651](https://github.com/scality/metalk8s/pull/3651))
 
 ## Release 2.10.7
+
 ## Enhancements
 
 - Skip "Pending" pods when draining a node
   (PR[#3641](https://github.com/scality/metalk8s/pull/3641))
 
 ## Release 2.10.6
+
 ## Enhancements
 
 - Bump Kubernetes version to 1.21.7
@@ -1195,6 +1216,7 @@
   (PR[#3629](https://github.com/scality/metalk8s/pull/3629))
 
 ## Release 2.10.5
+
 ## Enhancements
 
 - Bump Kubernetes version to 1.21.6
@@ -1224,6 +1246,7 @@
   (PR[#3590](https://github.com/scality/metalk8s/pull/3590))
 
 ## Release 2.10.4
+
 ## Bug fixes
 
 - [#3564](https://github.com/scality/metalk8s/issues/3564) - Fix a bug that
@@ -1238,6 +1261,7 @@
   (PR [#3557](https://github.com/scality/metalk8s/pull/3557))
 
 ## Release 2.10.3
+
 ### Enhancements
 
 - Bump Kubernetes version to 1.21.5
@@ -1258,11 +1282,14 @@
   is unavailable (PR[#3521](https://github.com/scality/metalk8s/pull/3521))
 
 ## Release 2.10.2
+
 ### Bug fixes
+
 - Fix the link to documentation from the UI navigation bar
   (PR[#3486](https://github.com/scality/metalk8s/pull/3486))
 
 ## Release 2.10.1
+
 ### Enhancements
 
 - Improve performance of Shell UI when switching between navigation entries
@@ -1291,6 +1318,7 @@
   (PR[#3483](https://github.com/scality/metalk8s/pull/3483))
 
 ## Release 2.10.0
+
 ### Enhancements
 
 - Bump Kubernetes version to 1.21.3
@@ -1318,14 +1346,15 @@
 
 - Bump kube-prometheus-stack charts version to 16.9.1
   The following images have also been bumped accordingly:
-   - grafana to 8.0.1
-   - k8s-sidecar to 1.12.2
-   - kube-state-metrics to v2.0.0
-   - node-exporter to v1.1.2
-   - prometheus to v2.27.1
-   - prometheus-config-reloader to v0.48.1
-   - prometheus-operator to v0.48.1
-  (PR[#3422](https://github.com/scality/metalk8s/pull/3422))
+
+  - grafana to 8.0.1
+  - k8s-sidecar to 1.12.2
+  - kube-state-metrics to v2.0.0
+  - node-exporter to v1.1.2
+  - prometheus to v2.27.1
+  - prometheus-config-reloader to v0.48.1
+  - prometheus-operator to v0.48.1
+    (PR[#3422](https://github.com/scality/metalk8s/pull/3422))
 
 - Bump ingress-nginx chart version to 3.34.0
   nginx-ingress-controller image has been bump accordingly to v0.47.0
@@ -1341,7 +1370,7 @@
 - Allow to manually deploy a second registry container
   (PR[#3400](https://github.com/scality/metalk8s/pull/3400))
 
-- [#3244](https://github.com/scality/metalk8s/issues/3244) - Support 
+- [#3244](https://github.com/scality/metalk8s/issues/3244) - Support
   LVMLogicalVolume volume in the UI
   (PR[#3410](https://github.com/scality/metalk8s/pull/3410))
 
@@ -1358,6 +1387,7 @@
   (PR[#3414](https://github.com/scality/metalk8s/pull/3414))
 
 ### Bug fixes
+
 - [#3445](https://github.com/scality/metalk8s/issues/3445) - Avoid
   kube-apiserver timeout during single node cluster upgrade when a
   lot of pod ran on the node
@@ -1372,16 +1402,21 @@
   (PR[#3356](https://github.com/scality/metalk8s/pull/3356))
 
 ## Release 2.9.3 (in development)
+
 ## Enhancements
+
 - Allow hostPort on 127.0.0.1
   (PR[#3396](https://github.com/scality/metalk8s/pull/3396))
 
 ## Release 2.9.2
+
 ### Bug fixes
+
 - Fixed bug in display when adding a new disk with long labels
   (PR[#3328](https://github.com/scality/metalk8s/issues/3328))
 
 ## Enhancements
+
 - Check on minion ID / Kubernetes node name match constraints
   (PR[#3258](https://github.com/scality/metalk8s/issues/3258))
 
@@ -1389,6 +1424,7 @@
   (PR[#3352](https://github.com/scality/metalk8s/pull/3352))
 
 ## Release 2.9.1
+
 ### Enhancements
 
 - Add an optional order property to manage ordering of navbar entries
@@ -1403,6 +1439,7 @@
   (PR[#3399](https://github.com/scality/metalk8s/pull/3330))
 
 ## Release 2.9.0
+
 ### Features Added
 
 - [#3180](https://github.com/scality/metalk8s/issues/3180) - All alerts from
@@ -1416,6 +1453,7 @@
 - Complete rebranding of MetalK8s UI (PR[#3295](https://github.com/scality/metalk8s/pull/3295))
 
 ### Enhancements
+
 - Bump Kubernetes version to 1.20.6
   (PR[#3311](https://github.com/scality/metalk8s/pull/3311))
 
@@ -1425,14 +1463,14 @@
 - Bump Node.js version to 14.16.0 (PR[#3214](https://github.com/scality/metalk8s/pull/3214))
 
 - Introduce a `shell-ui` project that groups various UI components to be reused by
-solutions UIs (PR[#3106](https://github.com/scality/metalk8s/pull/3106))
+  solutions UIs (PR[#3106](https://github.com/scality/metalk8s/pull/3106))
 
 - Move the navbar component to `shell-ui` to enable its reuse by solutions UIs
-(PR[#3110](https://github.com/scality/metalk8s/pull/3110))
+  (PR[#3110](https://github.com/scality/metalk8s/pull/3110))
 
-- Add a static user/groups mapping configuration as part of `shell-ui` configuration to 
-allow solutions UIs displaying features according to some user groups
-(PR[#3154](https://github.com/scality/metalk8s/pull/3154))
+- Add a static user/groups mapping configuration as part of `shell-ui` configuration to
+  allow solutions UIs displaying features according to some user groups
+  (PR[#3154](https://github.com/scality/metalk8s/pull/3154))
 
 - Enrich `sosreport` output (PR[#3222](https://github.com/scality/metalk8s/pull/3222))
 
@@ -1447,6 +1485,7 @@ allow solutions UIs displaying features according to some user groups
   PR[#3299](https://github.com/scality/metalk8s/pull/3299))
 
 ## Release 2.8.1 (in development)
+
 ### Enhancements
 
 ### Bug fixes
@@ -1456,6 +1495,7 @@ allow solutions UIs displaying features according to some user groups
   (PR [#3224](https://github.com/scality/metalk8s/pull/3224))
 
 ## Release 2.8.0
+
 ### Enhancements
 
 - [#3051](https://github.com/scality/metalk8s/issues/3051) - Prefix OIDC claims
@@ -1527,12 +1567,16 @@ allow solutions UIs displaying features according to some user groups
   (PR [#3167](https://github.com/scality/metalk8s/pull/3167))
 
 ## Release 2.7.4 (in development)
+
 ### Enhancements
+
 - Bump Salt version to 3002.6
   (PR [#3248](https://github.com/scality/metalk8s/pull/3248))
 
 ## Release 2.7.3
+
 ### Enhancements
+
 - [#2992](https://github.com/scality/metalk8s/issues/2992) - Check for conflicting
   packages (`docker`, `docker-ce` and `containerd.io`) on target machines before
   installation (bootstrap or expansion)
@@ -1556,32 +1600,36 @@ allow solutions UIs displaying features according to some user groups
   PR [#3076](https://github.com/scality/metalk8s/pull/3076))
 
 ### Bug fixes
+
 - Do not install `containerd.io` instead of `containerd` and `runc` when this
   package is available in one configured repository
   (PR [#3153](https://github.com/scality/metalk8s/pull/3153), backport of
   PR [#3050](https://github.com/scality/metalk8s/pull/3050))
 
 ### Security fixes
-- Due to vulnerabilities (
-[CVE-2021-3197](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-3197),
-[CVE-2021-25281](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-25281),
-[CVE-2021-25282](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-25282),
-[CVE-2021-25283](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-25283),
-[CVE-2021-25284](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-25284),
-[CVE-2021-3148](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-3148),
-[CVE-2020-35662](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2020-35662),
-[CVE-2021-3144](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-3144),
-[CVE-2020-28972](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2020-28972)
-and
-[CVE-2020-28243](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2020-28243))
-affecting all Salt versions inferior to `3002.5`, this release ships with
-all Saltstack updated to `3002.5`.
 
-    Upgrade Salt to version `3002.5`
-    (PR [#3158](https://github.com/scality/metalk8s/pull/3158))
+- Due to vulnerabilities (
+  [CVE-2021-3197](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-3197),
+  [CVE-2021-25281](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-25281),
+  [CVE-2021-25282](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-25282),
+  [CVE-2021-25283](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-25283),
+  [CVE-2021-25284](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-25284),
+  [CVE-2021-3148](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-3148),
+  [CVE-2020-35662](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2020-35662),
+  [CVE-2021-3144](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-3144),
+  [CVE-2020-28972](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2020-28972)
+  and
+  [CVE-2020-28243](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2020-28243))
+  affecting all Salt versions inferior to `3002.5`, this release ships with
+  all Saltstack updated to `3002.5`.
+
+      Upgrade Salt to version `3002.5`
+      (PR [#3158](https://github.com/scality/metalk8s/pull/3158))
 
 ## Release 2.7.2
+
 ### Enhancements
+
 - Bump Kubernetes version to 1.18.16
   (PR [#3132](https://github.com/scality/metalk8s/pull/3132))
 
@@ -1589,12 +1637,15 @@ all Saltstack updated to `3002.5`.
   (PR [#3125](https://github.com/scality/metalk8s/pull/3125))
 
 ### Bug fixes
+
 - Embed `pause` image version 3.2 instead of 3.1 needed for MetalK8s to work
   offline (needed by containerd version superior to 1.4.0)
   (PR [#3120](https://github.com/scality/metalk8s/pull/3120))
 
 ## Release 2.7.1
+
 ### Bug fixes
+
 - Fix a bug where salt-minion process does not get properly restarted
   (PR [#3059](https://github.com/scality/metalk8s/pull/3059))
 - [#3064](https://github.com/scality/metalk8s/issues/3064) - Fix upgrade from
@@ -1603,12 +1654,15 @@ all Saltstack updated to `3002.5`.
   (PR [#3053](https://github.com/scality/metalk8s/pull/3053))
 
 ## Release 2.7.0
+
 ### Features Added
+
 - [#2964](https://github.com/scality/metalk8s/issues/2964) - [UI] Ability to
   create Volumes in batches
   (PR [#2981](https://github.com/scality/metalk8s/pull/2981))
 
 ### Enhancements
+
 - Bump Kubernetes version to 1.18.15
   (PR [#3035](https://github.com/scality/metalk8s/pull/3035))
 
@@ -1631,6 +1685,7 @@ all Saltstack updated to `3002.5`.
 - Replace the prometheus-operator chart by the kube-prometheus-stack one and
   bump the version to 12.2.3.
   All the container images of this stack have also been bumped:
+
   - alertmanager from v0.20.0 to v0.21.0
   - grafana from 6.7.4 to 7.3.5 (PR [#3006](https://github.com/scality/metalk8s/pull/3006))
   - k8s-sidecar from 0.1.20 to 1.1.0
@@ -1639,7 +1694,7 @@ all Saltstack updated to `3002.5`.
   - prometheus from v2.16.0 to v2.22.1
   - prometheus-config-reload from v0.38.1 to v0.43.2
   - prometheus-operator from v0.38.1 to v0.43.2
-  (PR [#2948](https://github.com/scality/metalk8s/pull/2948))
+    (PR [#2948](https://github.com/scality/metalk8s/pull/2948))
 
 - Bump `prometheus-adapter` chart to 2.10.1
   (PR [#3007](https://github.com/scality/metalk8s/pull/3007))
@@ -1699,6 +1754,7 @@ all Saltstack updated to `3002.5`.
 ## Release 2.6.1
 
 ### Features Added
+
 - [#1887](https://github.com/scality/metalk8s/issues/1887) - All Kubernetes
   kubeconfig, client and server certificates are now automatically regenerated
   when close to the expiration date (less than 45 days)
@@ -1708,6 +1764,7 @@ all Saltstack updated to `3002.5`.
   sort in Nodes list (PR [#2926](https://github.com/scality/metalk8s/pull/2926))
 
 ### Enhancements
+
 - Bump Kubernetes version to 1.17.17
   (PR [#3036](https://github.com/scality/metalk8s/pull/3036))
 
@@ -1715,6 +1772,7 @@ all Saltstack updated to `3002.5`.
   (PR [#2926](https://github.com/scality/metalk8s/pull/2926))
 
 ### Bug Fixes
+
 - [#2949](https://github.com/scality/metalk8s/issues/2949) - [UI] Handle
   terminating environments and improve SaltAPI error handling
   (PR [#2954](https://github.com/scality/metalk8s/pull/2954))
@@ -1722,11 +1780,13 @@ all Saltstack updated to `3002.5`.
 ## Release 2.6.0
 
 ### Breaking changes
+
 - [#2581](https://github.com/scality/metalk8s/issues/2851) - Solution UI are
   no longer deployed by MetalK8s, it's now the responsibility of the Solution
   Operators (PR [#2617](https://github.com/scality/metalk8s/pull/2617))
 
 ### Features Added
+
 - Extend the set of packages installed in the `metalk8s-utils` container image
   (Partially resolves issue [#2156](https://github.com/scality/metalk8s/issues/2156),
   PR [#2374](https://github.com/scality/metalk8s/pull/2374))
@@ -1746,22 +1806,24 @@ all Saltstack updated to `3002.5`.
   [#2745](https://github.com/scality/metalk8s/pull/2745))
 
 ### Security fixes
-- Due to vulnerabilities (
-[CVE-2020-16846](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-16846)
-and
-[CVE-2020-25592](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-25592))
-affecting all Salt-API versions inferior to `3000.5`, this release ships with
-all Saltstack updated to `3000.5`.
 
-    Upgrade Salt to version `3000.5`
-    (PR [#2916](https://github.com/scality/metalk8s/pull/2916))
+- Due to vulnerabilities (
+  [CVE-2020-16846](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-16846)
+  and
+  [CVE-2020-25592](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-25592))
+  affecting all Salt-API versions inferior to `3000.5`, this release ships with
+  all Saltstack updated to `3000.5`.
+
+      Upgrade Salt to version `3000.5`
+      (PR [#2916](https://github.com/scality/metalk8s/pull/2916))
 
 ### Enhancements
+
 - [#2674](https://github.com/scality/metalk8s/issues/2674) - Bump K8S version
-to 1.17.14 (PR [#2923](https://github.com/scality/metalk8s/pull/2923))
+  to 1.17.14 (PR [#2923](https://github.com/scality/metalk8s/pull/2923))
 
 - [#2572](https://github.com/scality/metalk8s/issues/2572) - Bump CoreDNS
-version to 1.6.5 (PR [#2582](https://github.com/scality/metalk8s/pull/2582))
+  version to 1.6.5 (PR [#2582](https://github.com/scality/metalk8s/pull/2582))
 
 - Bump Calico version to 3.16.1
   (PR[#2824](https://github.com/scality/metalk8s/pull/2824))
@@ -1769,6 +1831,7 @@ version to 1.6.5 (PR [#2582](https://github.com/scality/metalk8s/pull/2582))
 ## Release 2.5.3 (in development)
 
 ### Enhancements
+
 - [#3218](https://github.com/scality/metalk8s/issues/3218) - Enrich sosreport
   plugins:
   - Add a Prometheus snapshot
@@ -1776,9 +1839,10 @@ version to 1.6.5 (PR [#2582](https://github.com/scality/metalk8s/pull/2582))
   - Add salt-minion journal
   - Add kubectl top nodes & pods
   - Add bootstrap and solutions configuration files
-  (PR [#3222](https://github.com/scality/metalk8s/pull/3222))
+    (PR [#3222](https://github.com/scality/metalk8s/pull/3222))
 
 ### Bug fixes
+
 - [#3247](https://github.com/scality/metalk8s/issues/3247) - Fix a bug where
   Salt minion process may fail to restart during upgrade or downgrade process
   (PR [#3281](https://github.com/scality/metalk8s/pull/3281))
@@ -1786,6 +1850,7 @@ version to 1.6.5 (PR [#2582](https://github.com/scality/metalk8s/pull/2582))
 ## Release 2.5.2
 
 ### Enhancements
+
 - [#2572](https://github.com/scality/metalk8s/issues/2572) - Bump CoreDNS
   version to 1.6.2 (PR [#2575](https://github.com/scality/metalk8s/pull/2575))
 
@@ -1796,6 +1861,7 @@ version to 1.6.5 (PR [#2582](https://github.com/scality/metalk8s/pull/2582))
   block volume (PR [#2651](https://github.com/scality/metalk8s/pull/2651))
 
 ### Bug fixes
+
 - [#2854](https://github.com/scality/metalk8s/issues/2854) - Bump containerd
   version to 1.2.14 to fix
   [CVE-2020-15157](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15157)
@@ -1830,78 +1896,82 @@ version to 1.6.5 (PR [#2582](https://github.com/scality/metalk8s/pull/2582))
   for details about the new format.
 
 ### Enhancements
+
 - [#2590](https://github.com/scality/metalk8s/issues/2590) - Bump Kubernetes
-version to 1.16.10 (PR [#2597](https://github.com/scality/metalk8s/pull/2597))
+  version to 1.16.10 (PR [#2597](https://github.com/scality/metalk8s/pull/2597))
 
 - [#2423](https://github.com/scality/metalk8s/issues/2423) - Bump
-nginx-ingress-controller version to 0.30.0
-(PR [#2446](https://github.com/scality/metalk8s/pull/2446))
+  nginx-ingress-controller version to 0.30.0
+  (PR [#2446](https://github.com/scality/metalk8s/pull/2446))
 
 - [#2429](https://github.com/scality/metalk8s/issues/2429) - Bump Dex
-version to 2.23.0
-(PR [#2437](https://github.com/scality/metalk8s/pull/2437))
+  version to 2.23.0
+  (PR [#2437](https://github.com/scality/metalk8s/pull/2437))
 
 - [#2430](https://github.com/scality/metalk8s/issues/2430) - Bump
-prometheus-operator version to 8.13.0
-(PR [#2557](https://github.com/scality/metalk8s/pull/2557))
+  prometheus-operator version to 8.13.0
+  (PR [#2557](https://github.com/scality/metalk8s/pull/2557))
 
 - [#2431](https://github.com/scality/metalk8s/issues/2431) - Bump
-Prometheus-adapter version to 0.6.0
-(PR [#2441](https://github.com/scality/metalk8s/pull/2441))
+  Prometheus-adapter version to 0.6.0
+  (PR [#2441](https://github.com/scality/metalk8s/pull/2441))
 
 - [#2488](https://github.com/scality/metalk8s/issues/2488) - Update default
-CSC value during upgrade/downgrade
-(PR [#2513](https://github.com/scality/metalk8s/pull/2513))
+  CSC value during upgrade/downgrade
+  (PR [#2513](https://github.com/scality/metalk8s/pull/2513))
 
 - [#2493](https://github.com/scality/metalk8s/issues/2493) - Use async call
-for disk.dump during Volume provisioning
-(PR [#2571](https://github.com/scality/metalk8s/pull/2571))
+  for disk.dump during Volume provisioning
+  (PR [#2571](https://github.com/scality/metalk8s/pull/2571))
 
 - Add support for CustomResourceDefinition apiextensions.k8s.io/v1 in
-`metalk8s_kubernetes` Salt module
-(PR [#2583](https://github.com/scality/metalk8s/pull/2583))
+  `metalk8s_kubernetes` Salt module
+  (PR [#2583](https://github.com/scality/metalk8s/pull/2583))
 
 ### Bug fixes
+
 - [#2434](https://github.com/scality/metalk8s/issues/2434) - Wait for a
-single Salt Master container during Bootstrap
-(PR [#2435](https://github.com/scality/metalk8s/pull/2435))
+  single Salt Master container during Bootstrap
+  (PR [#2435](https://github.com/scality/metalk8s/pull/2435))
 
 - [#2526](https://github.com/scality/metalk8s/issues/2526) - Add 'groups'
-scope when requesting an id_token from Dex in the UI
-(PR [#2529](https://github.com/scality/metalk8s/pull/2529))
+  scope when requesting an id_token from Dex in the UI
+  (PR [#2529](https://github.com/scality/metalk8s/pull/2529))
 
 - [#2443](https://github.com/scality/metalk8s/issues/2443) - Improve error
-handling for Salt jobs in the UI
-(PR [#2475](https://github.com/scality/metalk8s/pull/2475))
+  handling for Salt jobs in the UI
+  (PR [#2475](https://github.com/scality/metalk8s/pull/2475))
 
 - [#2495](https://github.com/scality/metalk8s/issues/2495) - Fix monitoring
-page to display all alerts in the UI
-(PR [#2503](https://github.com/scality/metalk8s/pull/2503))
+  page to display all alerts in the UI
+  (PR [#2503](https://github.com/scality/metalk8s/pull/2503))
 
 - [#2569](https://github.com/scality/metalk8s/issues/2569) - Restart Dex Pod
-automatically upon CSC Dex configuration changes
-(PR [#2573](https://github.com/scality/metalk8s/pull/2573))
+  automatically upon CSC Dex configuration changes
+  (PR [#2573](https://github.com/scality/metalk8s/pull/2573))
 
 - [#2533](https://github.com/scality/metalk8s/issues/2533) - Use dedicated
-kubeconfig for Salt master
-(PR [#2534](https://github.com/scality/meltalk8s/pull/2534))
+  kubeconfig for Salt master
+  (PR [#2534](https://github.com/scality/meltalk8s/pull/2534))
 
 ## Release 2.5.0
 
 ### Breaking changes
+
 - Basic authentication has been deprecated in favour of OpenID Connect (OIDC)
   with Dex being deployed as a local Identity Provider, used by Kubernetes
   API and Grafana.
 
   This implies:
-    - The existing users defined for Kubernetes API Basic Auth in
-      (`/etc/kubernetes/htpasswd`) and for the Grafana admin will become
-      unusable
-    - A default admin user will be created in Dex, with the new
-      credentials `admin@metalk8s.invalid`:`password` which can be used to
-      access the MetalK8s UI and Grafana
-    - Procedures to edit and add new users can now be found
-      [here](https://metal-k8s.readthedocs.io/en/2.5.0/operation/account_administration.html)
+
+  - The existing users defined for Kubernetes API Basic Auth in
+    (`/etc/kubernetes/htpasswd`) and for the Grafana admin will become
+    unusable
+  - A default admin user will be created in Dex, with the new
+    credentials `admin@metalk8s.invalid`:`password` which can be used to
+    access the MetalK8s UI and Grafana
+  - Procedures to edit and add new users can now be found
+    [here](https://metal-k8s.readthedocs.io/en/2.5.0/operation/account_administration.html)
 
 - A new framework for persisting Cluster and Services Configurations (CSC) has
   been added to ensure configurations set by administrators are not lost during
@@ -1909,10 +1979,11 @@ kubeconfig for Salt master
 
   - User-provided configuration is now stored in ConfigMaps, and MetalK8s
     tooling will honor the values provided when deploying its services:
-      - Dex uses `metalk8s-auth/metalk8s-dex-config`
-      - Grafana uses `metalk8s-monitoring/metalk8s-grafana-config`
-      - Prometheus uses `metalk8s-monitoring/metalk8s-prometheus-config`
-      - Alertmanager uses `metalk8s-monitoring/metalk8s-alertmanager-config`
+
+    - Dex uses `metalk8s-auth/metalk8s-dex-config`
+    - Grafana uses `metalk8s-monitoring/metalk8s-grafana-config`
+    - Prometheus uses `metalk8s-monitoring/metalk8s-prometheus-config`
+    - Alertmanager uses `metalk8s-monitoring/metalk8s-alertmanager-config`
 
   - Documentation for changing and applying configuration values is
     found [here](https://metal-k8s.readthedocs.io/en/2.5.0/operation/cluster_and_service_configuration.html).
@@ -1928,234 +1999,244 @@ kubeconfig for Salt master
   offer a smoother experience.
 
 ### Features Added
+
 - Upgrade Calico to 3.12.0 (PR [#2253](https://github.com/scality/metalk8s/pull/2253))
 
 - [#2007](https://github.com/scality/metalk8s/issues/2007) - Deploy Dex in a
-MetalK8s cluster from stable Helm Charts
-(PR [#2025](https://github.com/scality/metalk8s/pull/2025))
+  MetalK8s cluster from stable Helm Charts
+  (PR [#2025](https://github.com/scality/metalk8s/pull/2025))
 
 - [#2015](https://github.com/scality/metalk8s/issues/2015) - Configure MetalK8s
-UI to require authentication through Dex (OIDC)
-(PR [#2042](https://github.com/scality/metalk8s/pull/2042))
+  UI to require authentication through Dex (OIDC)
+  (PR [#2042](https://github.com/scality/metalk8s/pull/2042))
 
 - [#2016](https://github.com/scality/metalk8s/issues/2016) - Brand the Dex GUI
-to match MetalK8s UI specifications
-(PR [#2062](https://github.com/scality/metalk8s/pull/2062))
+  to match MetalK8s UI specifications
+  (PR [#2062](https://github.com/scality/metalk8s/pull/2062))
 
 - [#2072](https://github.com/scality/metalk8s/issues/2072) - Remove support
-for Kubernetes API server basic authentication
-(PR [#2119](https://github.com/scality/metalk8s/pull/2119))
+  for Kubernetes API server basic authentication
+  (PR [#2119](https://github.com/scality/metalk8s/pull/2119))
 
 - [#2078](https://github.com/scality/metalk8s/issues/2078) - Store Dex
-authentication access_token in the browser localStorage
-(PR [#2088](https://github.com/scality/metalk8s/pull/2088))
+  authentication access_token in the browser localStorage
+  (PR [#2088](https://github.com/scality/metalk8s/pull/2088))
 
 - [#2255](https://github.com/scality/metalk8s/issues/2255) - Template and store
-replicas count for Prometheus, Grafana & Alertmanager as service configurations
-(PR [#2258](https://github.com/scality/metalk8s/pull/2258))
+  replicas count for Prometheus, Grafana & Alertmanager as service configurations
+  (PR [#2258](https://github.com/scality/metalk8s/pull/2258))
 
 - [#2261](https://github.com/scality/metalk8s/issues/2261) - Template and store
-Dex backend settings as service configurations
-(PR [#2274](https://github.com/scality/metalk8s/pull/2274))
+  Dex backend settings as service configurations
+  (PR [#2274](https://github.com/scality/metalk8s/pull/2274))
 
 - [#2262](https://github.com/scality/metalk8s/issues/2262) - Template and store
-Alertmanager Secret as a service configuration
-(PR [#2289](https://github.com/scality/metalk8s/pull/2289))
+  Alertmanager Secret as a service configuration
+  (PR [#2289](https://github.com/scality/metalk8s/pull/2289))
 
 - [#2328](https://github.com/scality/metalk8s/issues/2328) - Bump K8S version
-to 1.16.8 (PR [#2363](https://github.com/scality/metalk8s/pull/2363))
+  to 1.16.8 (PR [#2363](https://github.com/scality/metalk8s/pull/2363))
 
 - Enable OIDC based authentication for Grafana service
-(PR [#2378](https://github.com/scality/metalk8s/pull/2378))
+  (PR [#2378](https://github.com/scality/metalk8s/pull/2378))
 
 ### Documentation
+
 - [#2351](https://github.com/scality/metalk8s/issues/2351) - Update
-documentation with default credentials for Metalk8s UI and Grafana UI
-(PR [#2377](https://github.com/scality/metalk8s/pull/2377))
+  documentation with default credentials for Metalk8s UI and Grafana UI
+  (PR [#2377](https://github.com/scality/metalk8s/pull/2377))
 
 - [#2264](https://github.com/scality/metalk8s/issues/2264) - Add documentation
-on the list of Cluster and Service configurations
-(PR [#2291](https://github.com/scality/metalk8s/pull/2291))
+  on the list of Cluster and Service configurations
+  (PR [#2291](https://github.com/scality/metalk8s/pull/2291))
 
 ## Release 2.4.5 (in development)
 
 ## Release 2.4.4
 
 ### Features added
+
 - [#2561](https://github.com/scality/metalk8s/issues/2561) - install `kubectl`
-on all master nodes (PR [#2562](https://github.com/scality/metalk8s/pull/2562))
+  on all master nodes (PR [#2562](https://github.com/scality/metalk8s/pull/2562))
 
 ### Security fixes
-- Due to critical vulnerabilities (
-[CVE-2020-11652](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-11652)
-and
-[CVE-2020-11651](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-11651))
-with CVSS score of 10.0 affecting all Salt master versions inferior to
-`3000.2`, this release ships with all Saltstack updated to `3000.3`.
-Users, especially those who expose the Salt master to the Internet must
-therefore upgrade immediately.
 
-    [#650](https://github.com/scality/metalk8s/issues/650) - Upgrade Salt master
-    to version `3000.3`
-    (PR [#2549](https://github.com/scality/metalk8s/pull/2549))
+- Due to critical vulnerabilities (
+  [CVE-2020-11652](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-11652)
+  and
+  [CVE-2020-11651](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-11651))
+  with CVSS score of 10.0 affecting all Salt master versions inferior to
+  `3000.2`, this release ships with all Saltstack updated to `3000.3`.
+  Users, especially those who expose the Salt master to the Internet must
+  therefore upgrade immediately.
+
+      [#650](https://github.com/scality/metalk8s/issues/650) - Upgrade Salt master
+      to version `3000.3`
+      (PR [#2549](https://github.com/scality/metalk8s/pull/2549))
 
 - Due to an access control vulnerability
-[CVE-2020-13379](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13379)
-with CVSS score of 5.3 that was discovered affecting Grafana versions from
-`3.0.1` through `7.0.1`, this release ships with a Grafana version updated to
-`6.7.4`. For more, see [here](https://grafana.com/blog/2020/06/03/grafana-6.7.4-and-7.0.2-released-with-important-security-fix/)
+  [CVE-2020-13379](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13379)
+  with CVSS score of 5.3 that was discovered affecting Grafana versions from
+  `3.0.1` through `7.0.1`, this release ships with a Grafana version updated to
+  `6.7.4`. For more, see [here](https://grafana.com/blog/2020/06/03/grafana-6.7.4-and-7.0.2-released-with-important-security-fix/)
 
-    [#2600](https://github.com/scality/metalk8s/issues/2600) - Upgrade Grafana
-    to `6.7.4` (PR [#2605](https://github.com/scality/metalk8s/issues/2605))
+      [#2600](https://github.com/scality/metalk8s/issues/2600) - Upgrade Grafana
+      to `6.7.4` (PR [#2605](https://github.com/scality/metalk8s/issues/2605))
 
 - A potential risk for privilege escalation in SaltAPI described
-[here](https://github.com/scality/metalk8s/issues/2634) was fixed in this
-release.
+  [here](https://github.com/scality/metalk8s/issues/2634) was fixed in this
+  release.
 
-    [#2634](https://github.com/scality/metalk8s/issues/2634) - Prevent
-    impersonation in SaltAPI
-    (PR [#2642](https://github.com/scality/metalk8s/pull/2642))
+      [#2634](https://github.com/scality/metalk8s/issues/2634) - Prevent
+      impersonation in SaltAPI
+      (PR [#2642](https://github.com/scality/metalk8s/pull/2642))
 
-    [#1528](https://github.com/scality/metalk8s/issues/1528) and
-    [#2084](https://github.com/scality/metalk8s/issues/2084) - Tighten
-    storage-operator permissions against Salt
-    (PR [#2635](https://github.com/scality/metalk8s/pull/2635))
+      [#1528](https://github.com/scality/metalk8s/issues/1528) and
+      [#2084](https://github.com/scality/metalk8s/issues/2084) - Tighten
+      storage-operator permissions against Salt
+      (PR [#2635](https://github.com/scality/metalk8s/pull/2635))
 
 ### Enhancements
+
 - [#2589](https://github.com/scality/metalk8s/issues/2589) - Bump Kubernetes
-version to 1.15.12 (PR [#2595](https://github.com/scality/metalk8s/pull/2595))
+  version to 1.15.12 (PR [#2595](https://github.com/scality/metalk8s/pull/2595))
 
 - [#2029](https://github.com/scality/metalk8s/issues/2029) - Bump
-python-kubernetes client to v11
-(PR [#2554](https://github.com/scality/metalk8s/pull/2554))
+  python-kubernetes client to v11
+  (PR [#2554](https://github.com/scality/metalk8s/pull/2554))
 
 - Make etcd expansions more resilient
-(PR [#2147](https://github.com/scality/metalk8s/pull/2147))
+  (PR [#2147](https://github.com/scality/metalk8s/pull/2147))
 
 - [#2585](https://github.com/scality/metalk8s/issues/2585) - Add state to
-cleanup PrometheusRule CRs after upgrade/downgrade
-(PR [#2594](https://github.com/scality/metalk8s/pull/2594))
+  cleanup PrometheusRule CRs after upgrade/downgrade
+  (PR [#2594](https://github.com/scality/metalk8s/pull/2594))
 
 - [#2533](https://github.com/scality/metalk8s/issues/2533) - Use dedicated
-kubeconfig for Salt master
-(PR [#2534](https://github.com/scality/meltalk8s/pull/2534))
+  kubeconfig for Salt master
+  (PR [#2534](https://github.com/scality/meltalk8s/pull/2534))
 
 ### Bug fixes
 
 - [#2444](https://github.com/scality/metalk8s/issues/2444) - Fix flaky SLS
-rendering when missing a pillar key
-(PR [#2445](https://github.com/scality/metalk8s/pull/2445))
+  rendering when missing a pillar key
+  (PR [#2445](https://github.com/scality/metalk8s/pull/2445))
 
 - [#2524](https://github.com/scality/metalk8s/issues/2524) - Fix salt-minion
-upgrade and downgrade
-(PR [#2525](https://github.com/scality/metalk8s/pull/2525))
+  upgrade and downgrade
+  (PR [#2525](https://github.com/scality/metalk8s/pull/2525))
 
-- [#2551](https://github.com/scality/metalk8s/issues/2551)  Fix downgrade
-pre-check regarding the saltenv version
-(PR [#2552](https://github.com/scality/metalk8s/pull/2552))
+- [#2551](https://github.com/scality/metalk8s/issues/2551) Fix downgrade
+  pre-check regarding the saltenv version
+  (PR [#2552](https://github.com/scality/metalk8s/pull/2552))
 
 - [#2592](https://github.com/scality/metalk8s/issues/2592) - Fix invalid custom
-object listing in `metalk8s_kubernetes` Salt module
-(PR [#2593](https://github.com/scality/metalk8s/pull/2593))
+  object listing in `metalk8s_kubernetes` Salt module
+  (PR [#2593](https://github.com/scality/metalk8s/pull/2593))
 
 - Fix apiserver-proxy to no longer proxy to non-master nodes
-(PR [#2555](https://github.com/scality/metalk8s/pull/2555))
+  (PR [#2555](https://github.com/scality/metalk8s/pull/2555))
 
 - [#2530](https://github.com/scality/metalk8s/issues/2530) - Make cluster
-upgrade more robust to Pod disruption constraints
-(PR [#2531](https://github.com/scality/metalk8s/pull/2531))
+  upgrade more robust to Pod disruption constraints
+  (PR [#2531](https://github.com/scality/metalk8s/pull/2531))
 
 - [#2028](https://github.com/scality/metalk8s/issues/2028) - Improve the
-resilience of node deployment
-(PR [#2147](https://github.com/scality/metalk8s/pull/2147))
+  resilience of node deployment
+  (PR [#2147](https://github.com/scality/metalk8s/pull/2147))
 
 - Fix various issues in the bootstrap restore script
-(PR [#2061](https://github.com/scality/metalk8s/pull/2061))
+  (PR [#2061](https://github.com/scality/metalk8s/pull/2061))
 
 ## Release 2.4.3
 
 ### Features added
+
 - [#1993](https://github.com/scality/metalk8s/issues/1993) - Add Solutions
-management, CLI tooling to deploy Solutions (complex Kubernetes applications)
-(PR [#2279](https://github.com/scality/metalk8s/pull/2279))
+  management, CLI tooling to deploy Solutions (complex Kubernetes applications)
+  (PR [#2279](https://github.com/scality/metalk8s/pull/2279))
 
 ### Enhancements
+
 - Add `label_selector` in MetalK8s custom kubernetes salt module for listing
-kubernetes objects (PR [#2236](https://github.com/scality/metalk8s/pull/2236))
+  kubernetes objects (PR [#2236](https://github.com/scality/metalk8s/pull/2236))
 
 - [#2328](https://github.com/scality/metalk8s/issues/2328) - Bump K8S version
-to 1.15.11 (PR [#2362](https://github.com/scality/metalk8s/pull/2362))
+  to 1.15.11 (PR [#2362](https://github.com/scality/metalk8s/pull/2362))
 
 - Salt grains cache is now enabled
-(PR [#2417](https://github.com/scality/metalk8s/pull/2417)
+  (PR [#2417](https://github.com/scality/metalk8s/pull/2417)
 
 ### Bug fixes
+
 - [#2334](https://github.com/scality/metalk8s/issues/2334) - Add and
-install `yum-utils` package required for cluster expansion
-(PR [#2343](https://github.com/scality/metalk8s/pull/2343))
+  install `yum-utils` package required for cluster expansion
+  (PR [#2343](https://github.com/scality/metalk8s/pull/2343))
 
 - [#2245](https://github.com/scality/metalk8s/issues/2245) - Rephrase volume
-status from `Available` to `Ready`
-(PR [#2248](https://github.com/scality/metalk8s/pull/2248))
+  status from `Available` to `Ready`
+  (PR [#2248](https://github.com/scality/metalk8s/pull/2248))
 
 - [#2409](https://github.com/scality/metalk8s/issues/2409) - Deletion
-on pending volumes (PR [#2410](https://github.com/scality/metalk8s/pull/2410))
+  on pending volumes (PR [#2410](https://github.com/scality/metalk8s/pull/2410))
 
 ## Release 2.4.2
 
 ### Breaking changes
+
 - If `apiServer.host` is configured in `BootstrapConfiguration`, this is no
-longer used (and must no longer be defined).
+  longer used (and must no longer be defined).
 - If `apiServer.keepalived` is configured in `BootstrapConfiguration`, this is
-no longer used, and Keepalived is no longer deployed at all.
+  no longer used, and Keepalived is no longer deployed at all.
 - Generated `admin.conf` `KubeConfig` files point to the control-plane IP of the
-host on which they are generated. You can override this when using them using
-`kubectl`s `-s`/`--server` argument to point to another address.
+  host on which they are generated. You can override this when using them using
+  `kubectl`s `-s`/`--server` argument to point to another address.
 
 ### Features added
+
 - [#1891](https://github.com/scality/metalk8s/issues/1891) - Allow adding
-labels to *Volume*s from the UI
-(PRs [#1979](https://github.com/scality/metalk8s/pull/1979) and
-[#2066](https://github.com/scality/metalk8s/pull/2066))
+  labels to *Volume*s from the UI
+  (PRs [#1979](https://github.com/scality/metalk8s/pull/1979) and
+  [#2066](https://github.com/scality/metalk8s/pull/2066))
 
 - [#2049](https://github.com/scality/metalk8s/issues/2049) - Deploy
-[prometheus-adapter](https://github.com/DirectXMan12/k8s-prometheus-adapter/)
-to implement the `metrics.k8s.io` API, to support `kubectl top` and other
-consumers of this API
-(PR [#2057](https://github.com/scality/metalk8s/pull/2057))
+  [prometheus-adapter](https://github.com/DirectXMan12/k8s-prometheus-adapter/)
+  to implement the `metrics.k8s.io` API, to support `kubectl top` and other
+  consumers of this API
+  (PR [#2057](https://github.com/scality/metalk8s/pull/2057))
 
 - [#2103](https://github.com/scality/metalk8s/issues/2103) - Add a host-local
-`nginx` on every node to provide highly-available and load-balanced access to
-`kube-apiserver` (PR [#2106](https://github.com/scality/metalk8s/pull/2106))
+  `nginx` on every node to provide highly-available and load-balanced access to
+  `kube-apiserver` (PR [#2106](https://github.com/scality/metalk8s/pull/2106))
 
 - [#2052](https://github.com/scality/metalk8s/issues/2052) - Handle
-configuration of an HTTP proxy for `containerd` (PRs
-[#2071](https://github.com/scality/metalk8s/pull/2071) and
-[#2201](https://github.com/scality/metalk8s/pull/2201))
+  configuration of an HTTP proxy for `containerd` (PRs
+  [#2071](https://github.com/scality/metalk8s/pull/2071) and
+  [#2201](https://github.com/scality/metalk8s/pull/2201))
 
 - [#2149](https://github.com/scality/metalk8s/issues/2149) - Provide access to
-the product documentation from the UI
-(PR [#2176](https://github.com/scality/metalk8s/pull/2176))
+  the product documentation from the UI
+  (PR [#2176](https://github.com/scality/metalk8s/pull/2176))
 
 ### Bug fixes
 
 - [#2083](https://github.com/scality/metalk8s/issues/2083) +
-[#2102](https://github.com/scality/metalk8s/issues/2102) - Ensure safer
-approach when expanding the `etcd` cluster
-(PRs [#2099](https://github.com/scality/metalk8s/pull/2099) and
-[#2198](https://github.com/scality/metalk8s/pull/2198))
+  [#2102](https://github.com/scality/metalk8s/issues/2102) - Ensure safer
+  approach when expanding the `etcd` cluster
+  (PRs [#2099](https://github.com/scality/metalk8s/pull/2099) and
+  [#2198](https://github.com/scality/metalk8s/pull/2198))
 
 ## Release 2.4.1
 
 ### Features added
 
 - ~~[#1891](https://github.com/scality/metalk8s/issues/1891) - Allow adding
-labels to *Volume*s from the UI
-(PR [#1979](https://github.com/scality/metalk8s/pull/1979))~~ _Note: this only
-sets labels on the Volume object, not the created PV. Fixed in 2.4.2_
+  labels to *Volume*s from the UI
+  (PR [#1979](https://github.com/scality/metalk8s/pull/1979))~~ _Note: this only
+  sets labels on the Volume object, not the created PV. Fixed in 2.4.2_
 
 ### Bug fixes
 
 - [#1970](https://github.com/scality/metalk8s/issues/1970) - Ensure yum
-history, repositories and RPM databases are properly closed after a
-transaction (PR [#1971](https://github.com/scality/metalk8s/pull/1971))
+  history, repositories and RPM databases are properly closed after a
+  transaction (PR [#1971](https://github.com/scality/metalk8s/pull/1971))

--- a/ui/public/brand/email.html
+++ b/ui/public/brand/email.html
@@ -339,10 +339,7 @@
                                     "
                                   >
                                     <span style="font-weight: normal">
-                                      {{ .Alerts | len }} alert{{ if gt (len
-                                      .Alerts) 1 }}s{{ end }} for {{ range
-                                      .GroupLabels.SortedPairs }} {{ .Name }}={{
-                                      .Value }} {{ end }}</span
+                                      {{ .Alerts | len }} alert{{ if gt (len .Alerts) 1 }}s{{ end }} for {{ range .GroupLabels.SortedPairs }} {{ .Name }}={{ .Value }} {{ end }}</span
                                     >
                                   </td>
                                 </tr>
@@ -527,8 +524,7 @@
                                   "
                                 >
                                   <span style="font-weight: normal"
-                                    >{{ .Alerts.Firing | len }} Alert{{ if gt
-                                    (len .Alerts.Firing) 1 }}s{{ end }}
+                                    >{{ .Alerts.Firing | len }} Alert{{ if gt (len .Alerts.Firing) 1 }}s{{ end }}
                                     currently firing</span
                                   >
                                 </td>
@@ -623,16 +619,11 @@
                               </td>
                               <td>{{ .Labels.alertname }}</td>
                               <td>
-                                {{if .Annotations.description }} {{
-                                .Annotations.description }} {{ else if
-                                .Annotations.message }} {{ .Annotations.message
-                                }} {{ else if .Annotations.summary }} {{
-                                .Annotations.summary }} {{ else }} No
+                                {{if .Annotations.description }} {{ .Annotations.description }} {{ else if .Annotations.message }} {{ .Annotations.message }} {{ else if .Annotations.summary }} {{ .Annotations.summary }} {{ else }} No
                                 description {{ end }}
                               </td>
                               <td>
-                                {{ .StartsAt.Format "2006-01-02 15:04:05
-                                (Z07:00)" }}
+                                {{ .StartsAt.Format "2006-01-02 15:04:05 (Z07:00)" }}
                               </td>
                             </tr>
                             {{ end }}
@@ -857,8 +848,7 @@
                                   "
                                 >
                                   <span style="font-weight: normal"
-                                    >{{ .Alerts.Resolved | len }} Alert{{ if gt
-                                    (len .Alerts.Resolved) 1 }}s{{ end }}
+                                    >{{ .Alerts.Resolved | len }} Alert{{ if gt (len .Alerts.Resolved) 1 }}s{{ end }}
                                     resolved</span
                                   >
                                 </td>
@@ -955,17 +945,11 @@
                               </td>
                               <td>{{ .Labels.alertname }}</td>
                               <td>
-                                {{if .Annotations.description }} {{
-                                .Annotations.description }} {{ else if
-                                .Annotations.message }} {{ .Annotations.message
-                                }} {{ else if .Annotations.summary }} {{
-                                .Annotations.summary }} {{ else }} No
+                                {{if .Annotations.description }} {{ .Annotations.description }} {{ else if .Annotations.message }} {{ .Annotations.message }} {{ else if .Annotations.summary }} {{ .Annotations.summary }} {{ else }} No
                                 description {{ end }}
                               </td>
                               <td>
-                                {{ .StartsAt.Format "2006-01-02 15:04:05
-                                (Z07:00)" }} - {{ .EndsAt.Format "2006-01-02
-                                15:04:05 (Z07:00)" }}
+                                {{ .StartsAt.Format "2006-01-02 15:04:05 (Z07:00)" }} - {{ .EndsAt.Format "2006-01-02 15:04:05 (Z07:00)" }}
                               </td>
                             </tr>
                             {{ end }}

--- a/ui/src/alert-configuration/ConfigureAlerting.test.tsx
+++ b/ui/src/alert-configuration/ConfigureAlerting.test.tsx
@@ -121,7 +121,7 @@ const server = setupServer(
   ),
 
   rest.post(
-    'http://localhost/api/alertmanager/api/v1/alerts',
+    'http://localhost/api/alertmanager/api/v2/alerts',
     (req, res, ctx) => {
       const result = {
         status: 'success',

--- a/ui/src/alert-configuration/infrastructure/Metalk8sCSCAlertConfigurationStore.ts
+++ b/ui/src/alert-configuration/infrastructure/Metalk8sCSCAlertConfigurationStore.ts
@@ -550,7 +550,7 @@ export class Metalk8sCSCAlertConfigurationStore
     ${credsTemplate}.`;
 
     const alertFetchResponse = await fetch(
-      `${this.alertManagerApiBaseUrl}/api/v1/alerts`,
+      `${this.alertManagerApiBaseUrl}/api/v2/alerts`,
       {
         method: 'POST',
         headers: {


### PR DESCRIPTION
**Component**:

ui

**Context**: 

Following to Alert Manager Bump the test email feature from the UI wasn't working correctly (alertmanager v1 api has been deprecated).
