### PR TITLE
Add python3-boto3 as a dependency to metalk8s-sosreport when rhel is 8 or superior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   due to another component modifying the wanted object
   (PR[#4317](https://github.com/scality/metalk8s/pull/4317))
 
+- `sosreport` now can be used with the option `--upload-protocol s3`
+  to save reports directly in S3 buckets
+  (PR[#4328](https://github.com/scality/metalk8s/pull/4328))
+
 ### Bug fixes
 
 - Following to Alert Manager Bump the test email feature from the

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -407,6 +407,7 @@ PACKAGES: Dict[str, Any] = {
                 version=NONSUFFIXED_VERSION,
                 release=f"{SOSREPORT_RELEASE}.el8",
             ),
+            PackageVersion(name="python3-boto3"),
             PackageVersion(name="python3-m2crypto", override="m2crypto"),
             PackageVersion(name="python3-dnf-plugin-versionlock"),
             PackageVersion(name="python3-psutil", override="python36-psutil"),

--- a/packages/redhat/common/metalk8s-sosreport.spec
+++ b/packages/redhat/common/metalk8s-sosreport.spec
@@ -11,6 +11,7 @@ BuildRequires: /usr/bin/pathfix.py
 Requires: sos >= 4.0
 Requires: python3 >= 3.6
 Requires: python3-requests
+Requires: python3-boto3 >= 1.6
 %else
 Requires: sos >= 3.1, sos < 4.0
 Requires: python >= 2.6, python < 2.8


### PR DESCRIPTION
Add python3-boto3 as a dependency to metalk8s-sosreport when rhel is 8 or superior

It will allow to use `sos report --upload-protocol s3 ...`, and save reports directly in S3 buckets.