### PR TITLE
kubelet: add `containerLogMaxSize` to the configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
   with other systems
   (PR[#4330](https://github.com/scality/metalk8s/pull/4330))
 
+- The max log file size per container is raised to 50Mi. 
+  The default was 10 Mi.
+  (PR[#4336](https://github.com/scality/metalk8s/pull/4336))
+
 ### Bug fixes
 
 - Following to Alert Manager Bump the test email feature from the

--- a/salt/metalk8s/kubernetes/kubelet/standalone.sls
+++ b/salt/metalk8s/kubernetes/kubelet/standalone.sls
@@ -108,6 +108,7 @@ Create kubelet config file:
           cpu: 200m
           memory: 200Mi
         kubeReserved: {{ salt.metalk8s_os.get_kubereserved() | tojson }}
+        containerLogMaxSize: 50Mi # default is 10Mi
 {%- for key, value in kubelet.config.items() %}
         {{ key }}: {{ value }}
 {%- endfor %}


### PR DESCRIPTION
And bumping the default from `10Mi` to `50Mi`
