### PR TITLE
INTEGRATION [PR#4361 > development/128.0] build: bump kubernetes to 1.27.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 - Bump etcd version to [3.5.14](https://github.com/etcd-io/etcd/releases/tag/v3.5.14)
   (PR[#4361](https://github.com/scality/metalk8s/pull/4361))
 
+- Bump CoreDNS version to [v1.11.1](https://github.com/coredns/coredns/releases/tag/v1.11.1)
+  (PR[#4361](https://github.com/scality/metalk8s/pull/4361))
+
 ## Release 127.0.3
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Enhancements
 
+- Bump CoreDNS version to [v1.11.1](https://github.com/coredns/coredns/releases/tag/v1.11.1)
+  (PR[#4369](https://github.com/scality/metalk8s/pull/4369))
+
 - Bump etcd version to [3.5.14](https://github.com/etcd-io/etcd/releases/tag/v3.5.14)
   (PR[#4369](https://github.com/scality/metalk8s/pull/4369))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Enhancements
 
+- Bump Kubernetes version to
+  [1.28.11](https://github.com/kubernetes/kubernetes/releases/tag/v1.28.11)
+  (PR[#4369](https://github.com/scality/metalk8s/pull/4369))
+
 - Add configuration in fluentbit and loki to support auditd logs.
   Logs dashboard was updated to replace deprecated visualizations.
   (PR[#4348](https://github.com/scality/metalk8s/pull/4348))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,16 @@
 - Bump CoreDNS version to [v1.11.1](https://github.com/coredns/coredns/releases/tag/v1.11.1)
   (PR[#4369](https://github.com/scality/metalk8s/pull/4369))
 
-- Bump etcd version to [3.5.14](https://github.com/etcd-io/etcd/releases/tag/v3.5.14)
-  (PR[#4369](https://github.com/scality/metalk8s/pull/4369))
-
-- Bump Kubernetes version to
-  [1.28.11](https://github.com/kubernetes/kubernetes/releases/tag/v1.28.11)
-  (PR[#4369](https://github.com/scality/metalk8s/pull/4369))
-
 - Add configuration in fluentbit and loki to support auditd logs.
   Logs dashboard was updated to replace deprecated visualizations.
   (PR[#4348](https://github.com/scality/metalk8s/pull/4348))
 
 - Bump Kubernetes version to
-  [1.28.8](https://github.com/kubernetes/kubernetes/releases/tag/v1.28.8)
-  (PR[#4283](https://github.com/scality/metalk8s/pull/4283))
+  [1.28.11](https://github.com/kubernetes/kubernetes/releases/tag/v1.28.11)
+  (PR[#4369](https://github.com/scality/metalk8s/pull/4369))
 
-- Bump etcd version to [3.5.12](https://github.com/etcd-io/etcd/releases/tag/v3.5.12)
-  (PR[#4283](https://github.com/scality/metalk8s/pull/4283))
+- Bump etcd version to [3.5.14](https://github.com/etcd-io/etcd/releases/tag/v3.5.14)
+  (PR[#4369](https://github.com/scality/metalk8s/pull/4369))
 
 - Bump containerd to [1.6.31](https://github.com/containerd/containerd/releases/tag/v1.6.31)
   (PR[#4292](https://github.com/scality/metalk8s/pull/4292))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
   [1.27.15](https://github.com/kubernetes/kubernetes/releases/tag/v1.27.15)
   (PR[#4361](https://github.com/scality/metalk8s/pull/4361))
 
+- Bump etcd version to [3.5.14](https://github.com/etcd-io/etcd/releases/tag/v3.5.14)
+  (PR[#4361](https://github.com/scality/metalk8s/pull/4361))
+
 ## Release 127.0.3
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Enhancements
 
+- Bump etcd version to [3.5.14](https://github.com/etcd-io/etcd/releases/tag/v3.5.14)
+  (PR[#4369](https://github.com/scality/metalk8s/pull/4369))
+
 - Bump Kubernetes version to
   [1.28.11](https://github.com/kubernetes/kubernetes/releases/tag/v1.28.11)
   (PR[#4369](https://github.com/scality/metalk8s/pull/4369))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   and `metalk8s-keepalived` image to `alpine:3.20.1`
   (PR[#4362](https://github.com/scality/metalk8s/pull/4362))
 
+- Bump Kubernetes version to
+  [1.27.15](https://github.com/kubernetes/kubernetes/releases/tag/v1.27.15)
+  (PR[#4361](https://github.com/scality/metalk8s/pull/4361))
+
 ## Release 127.0.3
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@
 - Bump containerd to [1.6.31](https://github.com/containerd/containerd/releases/tag/v1.6.31)
   (PR[#4292](https://github.com/scality/metalk8s/pull/4292))
 
-- Bump Calico version to [3.27.3](https://github.com/projectcalico/calico/releases/tag/v3.27.3)
-  (PR[#4291](https://github.com/scality/metalk8s/pull/4291))
+- Bump Calico version to [3.28.0](https://github.com/projectcalico/calico/releases/tag/v3.28.0)
+  (PR[#4363](https://github.com/scality/metalk8s/pull/4363))
 
 - Bump kube-prometheus-stack chart version to
   [57.2.0](https://github.com/prometheus-community/helm-charts/releases/tag/kube-prometheus-stack-57.2.0)

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -125,8 +125,8 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     ),
     Image(
         name="coredns",
-        version="v1.10.1",
-        digest="sha256:a0ead06651cf580044aeb0a0feba63591858fb2e43ade8c9dea45a6a89ae7e5e",
+        version="v1.11.1",
+        digest="sha256:1eeb4c7316bacb1d4c8ead65571cd92dd21e27359f0d4917f1a5822a73b75db1",
     ),
     Image(
         name="dex",

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -76,7 +76,7 @@ ROCKY_BASE_IMAGE_SHA256: str = (
     "c464612ef7e3d54d658c3eaa4778b5cdc990ec7a4d9ab63b0f00c9994c6ce980"
 )
 
-ETCD_VERSION: str = "3.5.12"
+ETCD_VERSION: str = "3.5.14"
 ETCD_IMAGE_VERSION: str = f"{ETCD_VERSION}-0"
 NGINX_IMAGE_VERSION: str = "1.25.4-alpine"
 NODEJS_IMAGE_VERSION: str = "16.14.0"
@@ -136,7 +136,7 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     Image(
         name="etcd",
         version=ETCD_IMAGE_VERSION,
-        digest="sha256:44a8e24dcbba3470ee1fee21d5e88d128c936e9b55d4bc51fbef8086f8ed123b",
+        digest="sha256:661a9ab3d439dcf93593726a9ecbefa44e246709aa813a95d64c3848716710ce",
     ),
     Image(
         name="grafana",

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -20,7 +20,7 @@ Image = namedtuple("Image", ("name", "version", "digest"))
 
 K8S_VERSION_MAJOR: str = "1"
 K8S_VERSION_MINOR: str = "28"
-K8S_VERSION_PATCH: str = "8"
+K8S_VERSION_PATCH: str = "11"
 
 K8S_SHORT_VERSION: str = f"{K8S_VERSION_MAJOR}.{K8S_VERSION_MINOR}"
 K8S_VERSION: str = f"{K8S_SHORT_VERSION}.{K8S_VERSION_PATCH}"
@@ -151,22 +151,22 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     Image(
         name="kube-apiserver",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:7e7f3c806333528451a1e0bfdf17da0341adaea7d50a703db9c2005c474a97b9",
+        digest="sha256:aec9d1701c304eee8607d728a39baaa511d65bef6dd9861010618f63fbadeb10",
     ),
     Image(
         name="kube-controller-manager",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:f3d0e8da9d1532e081e719a985e89a0cfe1a29d127773ad8e2c2fee1dd10fd00",
+        digest="sha256:6014c3572ec683841bbb16f87b94da28ee0254b95e2dba2d1850d62bd0111f09",
     ),
     Image(
         name="kube-proxy",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:9e9dd46799712c58e1a49f973374ffa9ad4e5a6175896e5d805a8738bf5c5865",
+        digest="sha256:ae4b671d4cfc23dd75030bb4490207cd939b3b11a799bcb4119698cd712eb5b4",
     ),
     Image(
         name="kube-scheduler",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:4d61604f259d3c91d8b3ec7a6a999f5eae9aff371567151cd5165eaa698c6d7b",
+        digest="sha256:46cf7475c8daffb743c856a1aea0ddea35e5acd2418be18b1e22cf98d9c9b445",
     ),
     Image(
         name="kube-state-metrics",

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -76,7 +76,7 @@ ROCKY_BASE_IMAGE_SHA256: str = (
     "85fa0b733cfbcc6e9770829b69ebcc58f51ff71fc9c0f4f5cdf40e3c7f58ccad"
 )
 
-ETCD_VERSION: str = "3.5.7"
+ETCD_VERSION: str = "3.5.14"
 ETCD_IMAGE_VERSION: str = f"{ETCD_VERSION}-0"
 NGINX_IMAGE_VERSION: str = "1.25.2-alpine"
 NODEJS_IMAGE_VERSION: str = "16.14.0"
@@ -136,7 +136,7 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     Image(
         name="etcd",
         version=ETCD_IMAGE_VERSION,
-        digest="sha256:51eae8381dcb1078289fa7b4f3df2630cdc18d09fb56f8e56b41c40e191d6c83",
+        digest="sha256:661a9ab3d439dcf93593726a9ecbefa44e246709aa813a95d64c3848716710ce",
     ),
     Image(
         name="grafana",

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -20,7 +20,7 @@ Image = namedtuple("Image", ("name", "version", "digest"))
 
 K8S_VERSION_MAJOR: str = "1"
 K8S_VERSION_MINOR: str = "27"
-K8S_VERSION_PATCH: str = "6"
+K8S_VERSION_PATCH: str = "15"
 
 K8S_SHORT_VERSION: str = f"{K8S_VERSION_MAJOR}.{K8S_VERSION_MINOR}"
 K8S_VERSION: str = f"{K8S_SHORT_VERSION}.{K8S_VERSION_PATCH}"
@@ -151,22 +151,22 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     Image(
         name="kube-apiserver",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:5e7a0196a7908cb49bcbf751d2546a008c329ff1e70c26c1cd542e0ada4b623c",
+        digest="sha256:bbbc0eb287dbb7507948b1c05ac8f221d1a504e04572e61d4700ff18b2a3afd0",
     ),
     Image(
         name="kube-controller-manager",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:c76ca5b0cf607f82c54d51c3c6766da30c9a9f684065e1cac761ea9b07b74e97",
+        digest="sha256:9ff408d91018df95a8505149e778bc7815b261ba8798497ae9319beb2b73304a",
     ),
     Image(
         name="kube-proxy",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:8e9eff2f6d0b398f9ac5f5a15c1cb7d5f468f28d64a78d593d57f72a969a54ef",
+        digest="sha256:23c54b01075318fe6991b224192faf6d65e9412b954b335efe326977deb30332",
     ),
     Image(
         name="kube-scheduler",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:bb227512d96e93dd3fe356cef552cc3f78905f36330b762adde23c3f0943d57b",
+        digest="sha256:9a7746f46e126b23098a844b5e3df34ee44b14b666d540a1e92a21ca7bbaac99",
     ),
     Image(
         name="kube-state-metrics",


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #4361.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/128.0/improvement/bump-k8s-12715`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/128.0/improvement/bump-k8s-12715
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/128.0/improvement/bump-k8s-12715
```

Please always comment pull request #4361 instead of this one.