### PR TITLE
INTEGRATION [PR#4378 > development/126.0] build: Bump Kubernetes version to 1.24.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Remove `nodes-darwin` MacOS related grafana dashboard
   (PR[4178](https://github.com/scality/metalk8s/pull/4178))
 
+- Bump Kubernetes version to
+  [1.25.16](https://github.com/kubernetes/kubernetes/releases/tag/v1.25.16)
+  (PR[#4379](https://github.com/scality/metalk8s/pull/4379))
+
 ### Bug fixes
 
 - Fix a bug in retry logic for ETCd backup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # CHANGELOG
 ## Release 124.1.7 (in development)
 
+### Enhancements
+
+- Bump Kubernetes version to
+  [1.24.17](https://github.com/kubernetes/kubernetes/releases/tag/v1.24.17)
+  (PR[#4378](https://github.com/scality/metalk8s/pull/4378))
+
 ## Release 124.1.6
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Enhancements
 
+- Bump Kubernetes version to
+  [1.26.15](https://github.com/kubernetes/kubernetes/releases/tag/v1.26.15)
+  (PR[#4380](https://github.com/scality/metalk8s/pull/4380))
+
 - Update "Node Exporter Full" Dashboard
   (PR[#4268](https://github.com/scality/metalk8s/pull/4268))
 

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -20,7 +20,7 @@ Image = namedtuple("Image", ("name", "version", "digest"))
 
 K8S_VERSION_MAJOR: str = "1"
 K8S_VERSION_MINOR: str = "24"
-K8S_VERSION_PATCH: str = "13"
+K8S_VERSION_PATCH: str = "17"
 
 K8S_SHORT_VERSION: str = f"{K8S_VERSION_MAJOR}.{K8S_VERSION_MINOR}"
 K8S_VERSION: str = f"{K8S_SHORT_VERSION}.{K8S_VERSION_PATCH}"
@@ -152,22 +152,22 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     Image(
         name="kube-apiserver",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:a6291f66504b9ce087fb0c88453135e6a7b3aba791b1cf5aac2fb0914eec226d",
+        digest="sha256:4d0e1bda2a902a29d6d6d75038cc6f3dbea22a7c15136623c2de86b9ee6f24f0",
     ),
     Image(
         name="kube-controller-manager",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:5d5b724bba5301619c3d91a26087129f0c10f5fab11f51c9db246b309fbf86e8",
+        digest="sha256:b35b1b6c52e4af10f94982c347054cb85555eceb98191bec04f0588d1b7d4856",
     ),
     Image(
         name="kube-proxy",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:2f0df9a9723a314a5c85e9bedd5f1cdc28468655ed8e5d6393250e4acc886bb8",
+        digest="sha256:35ddd4cbbd37e810efaea900eeacdc830046220ab290ec7c7e7745424786085a",
     ),
     Image(
         name="kube-scheduler",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:3c4d859c18e6930c921732eb08a47d75392a0521b87cfba0826d46b9f1a84b58",
+        digest="sha256:c4cf0f525a9ca27210fd7b5fb1af82b7ae013f5ae87acff0cffe555f9570389a",
     ),
     Image(
         name="kube-state-metrics",

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -20,7 +20,7 @@ Image = namedtuple("Image", ("name", "version", "digest"))
 
 K8S_VERSION_MAJOR: str = "1"
 K8S_VERSION_MINOR: str = "25"
-K8S_VERSION_PATCH: str = "9"
+K8S_VERSION_PATCH: str = "16"
 
 K8S_SHORT_VERSION: str = f"{K8S_VERSION_MAJOR}.{K8S_VERSION_MINOR}"
 K8S_VERSION: str = f"{K8S_SHORT_VERSION}.{K8S_VERSION_PATCH}"
@@ -151,22 +151,22 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     Image(
         name="kube-apiserver",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:8f848ab4be2f3f29f220a9bb7e9152f77a8185bf2ad65e5204cc7b53aa456527",
+        digest="sha256:66a26024961a9686c93fccc053d27d688fd96cee4ed9fb811a08c49d4c3aa0a4",
     ),
     Image(
         name="kube-controller-manager",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:94379e018b183e739635fd27e31d793677ef65c5571d86d1d2a83f6a4a77b2b3",
+        digest="sha256:1eaaba877b1c12909e5e1c902e643f8e2bfeabc82f17af76b39be94483951331",
     ),
     Image(
         name="kube-proxy",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:df959d1975f5deb357e18e48d1603d8e9f3fa036642c12e63745b68eb7b2f248",
+        digest="sha256:7c8a8d9f252d7795c7ded69d9b02d3fced146ccb95a125b053ad1b2491e8b204",
     ),
     Image(
         name="kube-scheduler",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:51b7d5eb5c3128eac582d411438c65cd9aaebe993fd73703dedbbbe83bc02c1d",
+        digest="sha256:c119250d4420fc3929764a8320d1da57b987a1d1956e352e93a07dfcc95a1154",
     ),
     Image(
         name="kube-state-metrics",

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -20,7 +20,7 @@ Image = namedtuple("Image", ("name", "version", "digest"))
 
 K8S_VERSION_MAJOR: str = "1"
 K8S_VERSION_MINOR: str = "26"
-K8S_VERSION_PATCH: str = "5"
+K8S_VERSION_PATCH: str = "15"
 
 K8S_SHORT_VERSION: str = f"{K8S_VERSION_MAJOR}.{K8S_VERSION_MINOR}"
 K8S_VERSION: str = f"{K8S_SHORT_VERSION}.{K8S_VERSION_PATCH}"
@@ -151,22 +151,22 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     Image(
         name="kube-apiserver",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:6f89f3e9107e1b7010975137d072d601286d15fb64f572846a4145b9b0e0fc55",
+        digest="sha256:0dc6d5ba5863218a391de0952d27701d2715254b0fbfb3670cadd3074b057f8f",
     ),
     Image(
         name="kube-controller-manager",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:a6457911fa41c7706fa1aca6cb50352b1c3e90b70c9707f1e0b6363d3188b81a",
+        digest="sha256:ea4dd4c0905132110aca01e638d87f861dfa9db229c7022c583f4076ade0c23a",
     ),
     Image(
         name="kube-proxy",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:c9df3c07cfe4791905060417fefc09c5b8010ee2b46c13f27015c3f9d4397b6c",
+        digest="sha256:a9f441a6b440c634ccfe62530ab1c7ff2ea7ed3f577f91f6a71c7e2f51256410",
     ),
     Image(
         name="kube-scheduler",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:a3938384e78f260c79dc84e9149bb5d429e817fa9c6905c1471a1e14db527aab",
+        digest="sha256:6447dce5ea569c857b161436235292bc30280b3f83fda5df730b23b0812336dc",
     ),
     Image(
         name="kube-state-metrics",


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #4378.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/126.0/improvement/bump-k8s`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/126.0/improvement/bump-k8s
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/126.0/improvement/bump-k8s
```

Please always comment pull request #4378 instead of this one.