### PR TITLE
INTEGRATION [PR#4378 > development/128.0] build: Bump Kubernetes version to 1.24.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
   (PR[#4362](https://github.com/scality/metalk8s/pull/4362))
 
 - Bump Kubernetes version to
-  [1.27.15](https://github.com/kubernetes/kubernetes/releases/tag/v1.27.15)
-  (PR[#4361](https://github.com/scality/metalk8s/pull/4361))
+  [1.27.16](https://github.com/kubernetes/kubernetes/releases/tag/v1.27.16)
+  (PR[#4381](https://github.com/scality/metalk8s/pull/4381))
 
 - Bump etcd version to [3.5.14](https://github.com/etcd-io/etcd/releases/tag/v3.5.14)
   (PR[#4361](https://github.com/scality/metalk8s/pull/4361))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Remove `nodes-darwin` MacOS related grafana dashboard
   (PR[4178](https://github.com/scality/metalk8s/pull/4178))
 
+- Bump Kubernetes version to
+  [1.25.16](https://github.com/kubernetes/kubernetes/releases/tag/v1.25.16)
+  (PR[#4379](https://github.com/scality/metalk8s/pull/4379))
+
 ### Bug fixes
 
 - Fix a bug in retry logic for ETCd backup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # CHANGELOG
 ## Release 124.1.7 (in development)
 
+### Enhancements
+
+- Bump Kubernetes version to
+  [1.24.17](https://github.com/kubernetes/kubernetes/releases/tag/v1.24.17)
+  (PR[#4378](https://github.com/scality/metalk8s/pull/4378))
+
 ## Release 124.1.6
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@
   (PR[#4348](https://github.com/scality/metalk8s/pull/4348))
 
 - Bump Kubernetes version to
-  [1.28.11](https://github.com/kubernetes/kubernetes/releases/tag/v1.28.11)
-  (PR[#4369](https://github.com/scality/metalk8s/pull/4369))
+  [1.28.12](https://github.com/kubernetes/kubernetes/releases/tag/v1.28.12)
+  (PR[#4382](https://github.com/scality/metalk8s/pull/4382))
 
 - Bump etcd version to [3.5.14](https://github.com/etcd-io/etcd/releases/tag/v3.5.14)
   (PR[#4369](https://github.com/scality/metalk8s/pull/4369))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Enhancements
 
+- Bump Kubernetes version to
+  [1.26.15](https://github.com/kubernetes/kubernetes/releases/tag/v1.26.15)
+  (PR[#4380](https://github.com/scality/metalk8s/pull/4380))
+
 - Update "Node Exporter Full" Dashboard
   (PR[#4268](https://github.com/scality/metalk8s/pull/4268))
 

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -20,7 +20,7 @@ Image = namedtuple("Image", ("name", "version", "digest"))
 
 K8S_VERSION_MAJOR: str = "1"
 K8S_VERSION_MINOR: str = "24"
-K8S_VERSION_PATCH: str = "13"
+K8S_VERSION_PATCH: str = "17"
 
 K8S_SHORT_VERSION: str = f"{K8S_VERSION_MAJOR}.{K8S_VERSION_MINOR}"
 K8S_VERSION: str = f"{K8S_SHORT_VERSION}.{K8S_VERSION_PATCH}"
@@ -152,22 +152,22 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     Image(
         name="kube-apiserver",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:a6291f66504b9ce087fb0c88453135e6a7b3aba791b1cf5aac2fb0914eec226d",
+        digest="sha256:4d0e1bda2a902a29d6d6d75038cc6f3dbea22a7c15136623c2de86b9ee6f24f0",
     ),
     Image(
         name="kube-controller-manager",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:5d5b724bba5301619c3d91a26087129f0c10f5fab11f51c9db246b309fbf86e8",
+        digest="sha256:b35b1b6c52e4af10f94982c347054cb85555eceb98191bec04f0588d1b7d4856",
     ),
     Image(
         name="kube-proxy",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:2f0df9a9723a314a5c85e9bedd5f1cdc28468655ed8e5d6393250e4acc886bb8",
+        digest="sha256:35ddd4cbbd37e810efaea900eeacdc830046220ab290ec7c7e7745424786085a",
     ),
     Image(
         name="kube-scheduler",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:3c4d859c18e6930c921732eb08a47d75392a0521b87cfba0826d46b9f1a84b58",
+        digest="sha256:c4cf0f525a9ca27210fd7b5fb1af82b7ae013f5ae87acff0cffe555f9570389a",
     ),
     Image(
         name="kube-state-metrics",

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -20,7 +20,7 @@ Image = namedtuple("Image", ("name", "version", "digest"))
 
 K8S_VERSION_MAJOR: str = "1"
 K8S_VERSION_MINOR: str = "25"
-K8S_VERSION_PATCH: str = "9"
+K8S_VERSION_PATCH: str = "16"
 
 K8S_SHORT_VERSION: str = f"{K8S_VERSION_MAJOR}.{K8S_VERSION_MINOR}"
 K8S_VERSION: str = f"{K8S_SHORT_VERSION}.{K8S_VERSION_PATCH}"
@@ -151,22 +151,22 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     Image(
         name="kube-apiserver",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:8f848ab4be2f3f29f220a9bb7e9152f77a8185bf2ad65e5204cc7b53aa456527",
+        digest="sha256:66a26024961a9686c93fccc053d27d688fd96cee4ed9fb811a08c49d4c3aa0a4",
     ),
     Image(
         name="kube-controller-manager",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:94379e018b183e739635fd27e31d793677ef65c5571d86d1d2a83f6a4a77b2b3",
+        digest="sha256:1eaaba877b1c12909e5e1c902e643f8e2bfeabc82f17af76b39be94483951331",
     ),
     Image(
         name="kube-proxy",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:df959d1975f5deb357e18e48d1603d8e9f3fa036642c12e63745b68eb7b2f248",
+        digest="sha256:7c8a8d9f252d7795c7ded69d9b02d3fced146ccb95a125b053ad1b2491e8b204",
     ),
     Image(
         name="kube-scheduler",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:51b7d5eb5c3128eac582d411438c65cd9aaebe993fd73703dedbbbe83bc02c1d",
+        digest="sha256:c119250d4420fc3929764a8320d1da57b987a1d1956e352e93a07dfcc95a1154",
     ),
     Image(
         name="kube-state-metrics",

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -20,7 +20,7 @@ Image = namedtuple("Image", ("name", "version", "digest"))
 
 K8S_VERSION_MAJOR: str = "1"
 K8S_VERSION_MINOR: str = "26"
-K8S_VERSION_PATCH: str = "5"
+K8S_VERSION_PATCH: str = "15"
 
 K8S_SHORT_VERSION: str = f"{K8S_VERSION_MAJOR}.{K8S_VERSION_MINOR}"
 K8S_VERSION: str = f"{K8S_SHORT_VERSION}.{K8S_VERSION_PATCH}"
@@ -151,22 +151,22 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     Image(
         name="kube-apiserver",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:6f89f3e9107e1b7010975137d072d601286d15fb64f572846a4145b9b0e0fc55",
+        digest="sha256:0dc6d5ba5863218a391de0952d27701d2715254b0fbfb3670cadd3074b057f8f",
     ),
     Image(
         name="kube-controller-manager",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:a6457911fa41c7706fa1aca6cb50352b1c3e90b70c9707f1e0b6363d3188b81a",
+        digest="sha256:ea4dd4c0905132110aca01e638d87f861dfa9db229c7022c583f4076ade0c23a",
     ),
     Image(
         name="kube-proxy",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:c9df3c07cfe4791905060417fefc09c5b8010ee2b46c13f27015c3f9d4397b6c",
+        digest="sha256:a9f441a6b440c634ccfe62530ab1c7ff2ea7ed3f577f91f6a71c7e2f51256410",
     ),
     Image(
         name="kube-scheduler",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:a3938384e78f260c79dc84e9149bb5d429e817fa9c6905c1471a1e14db527aab",
+        digest="sha256:6447dce5ea569c857b161436235292bc30280b3f83fda5df730b23b0812336dc",
     ),
     Image(
         name="kube-state-metrics",

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -20,7 +20,7 @@ Image = namedtuple("Image", ("name", "version", "digest"))
 
 K8S_VERSION_MAJOR: str = "1"
 K8S_VERSION_MINOR: str = "27"
-K8S_VERSION_PATCH: str = "15"
+K8S_VERSION_PATCH: str = "16"
 
 K8S_SHORT_VERSION: str = f"{K8S_VERSION_MAJOR}.{K8S_VERSION_MINOR}"
 K8S_VERSION: str = f"{K8S_SHORT_VERSION}.{K8S_VERSION_PATCH}"
@@ -151,22 +151,22 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     Image(
         name="kube-apiserver",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:bbbc0eb287dbb7507948b1c05ac8f221d1a504e04572e61d4700ff18b2a3afd0",
+        digest="sha256:77fe7968e3b27222e2719b3df7efa37494e0504497b865b19e2595ef5f790520",
     ),
     Image(
         name="kube-controller-manager",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:9ff408d91018df95a8505149e778bc7815b261ba8798497ae9319beb2b73304a",
+        digest="sha256:25ccfb06da9ceabfdfcb6826925b4ea0dc7b271beec5355ad49ca8687ebcad67",
     ),
     Image(
         name="kube-proxy",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:23c54b01075318fe6991b224192faf6d65e9412b954b335efe326977deb30332",
+        digest="sha256:f775c9f86ed22956ceae174ee9474aa8044f2a675b72124d566b7d7ac866b249",
     ),
     Image(
         name="kube-scheduler",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:9a7746f46e126b23098a844b5e3df34ee44b14b666d540a1e92a21ca7bbaac99",
+        digest="sha256:c36386d8885561c417e2bf59dbb38989e4dac25f3d2bd95f7d3fd7e475847a57",
     ),
     Image(
         name="kube-state-metrics",

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -20,7 +20,7 @@ Image = namedtuple("Image", ("name", "version", "digest"))
 
 K8S_VERSION_MAJOR: str = "1"
 K8S_VERSION_MINOR: str = "28"
-K8S_VERSION_PATCH: str = "11"
+K8S_VERSION_PATCH: str = "12"
 
 K8S_SHORT_VERSION: str = f"{K8S_VERSION_MAJOR}.{K8S_VERSION_MINOR}"
 K8S_VERSION: str = f"{K8S_SHORT_VERSION}.{K8S_VERSION_PATCH}"
@@ -151,22 +151,22 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     Image(
         name="kube-apiserver",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:aec9d1701c304eee8607d728a39baaa511d65bef6dd9861010618f63fbadeb10",
+        digest="sha256:ac3b6876d95fe7b7691e69f2161a5466adbe9d72d44f342d595674321ce16d23",
     ),
     Image(
         name="kube-controller-manager",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:6014c3572ec683841bbb16f87b94da28ee0254b95e2dba2d1850d62bd0111f09",
+        digest="sha256:996c6259e4405ab79083fbb52bcf53003691a50b579862bf29b3abaa468460db",
     ),
     Image(
         name="kube-proxy",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:ae4b671d4cfc23dd75030bb4490207cd939b3b11a799bcb4119698cd712eb5b4",
+        digest="sha256:7dd7829fa889ac805a0b1047eba04599fa5006bdbcb5cb9c8d14e1dc8910488b",
     ),
     Image(
         name="kube-scheduler",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:46cf7475c8daffb743c856a1aea0ddea35e5acd2418be18b1e22cf98d9c9b445",
+        digest="sha256:d93a3b5961248820beb5ec6dfb0320d12c0dba82fc48693d20d345754883551c",
     ),
     Image(
         name="kube-state-metrics",


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #4378.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/128.0/improvement/bump-k8s`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/128.0/improvement/bump-k8s
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/128.0/improvement/bump-k8s
```

Please always comment pull request #4378 instead of this one.