### PR TITLE
ARTESCA-7317: enable webhook on deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # CHANGELOG
 ## Release 124.1.7 (in development)
 
+### Additions
+
+- Add an option on solution to add a volume named `cert` to a
+  deployment. The volume is originally to enable webhook in
+  the deployment.
+  (PR[#4384](https://github.com/scality/metalk8s/pull/4384))
+
 ### Enhancements
 
 - Bump Kubernetes version to

--- a/salt/metalk8s/orchestrate/solutions/files/operator/deployment.yaml.j2
+++ b/salt/metalk8s/orchestrate/solutions/files/operator/deployment.yaml.j2
@@ -49,7 +49,18 @@ spec:
           volumeMounts:
             - name: operator-config
               mountPath: /etc/config
+{%- if webhook_enabled is defined and webhook_enabled %}
+            - name: cert
+              mountPath: /cert
+              readOnly: true
+{%- endif %}
       volumes:
         - name: operator-config
           configMap:
             name: {{ solution }}-operator-config
+{%- if webhook_enabled is defined and webhook_enabled %}
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: {{ solution }}-cert
+{%- endif %}

--- a/salt/metalk8s/orchestrate/solutions/prepare-environment.sls
+++ b/salt/metalk8s/orchestrate/solutions/prepare-environment.sls
@@ -1,6 +1,7 @@
 {%- from "metalk8s/map.jinja" import repo with context %}
 
 {%- set env_name = pillar.orchestrate.env_name %}
+{%- set webhook_enabled = pillar.orchestrate.webhook_enabled %}
 
 {%- macro deploy_operator(namespace, name, solution) %}
 
@@ -65,6 +66,7 @@ Apply Operator Deployment for Solution {{ solution.name }}:
         image_name: {{ solution.manifest.spec.operator.image.name }}
         image_tag: {{ solution.manifest.spec.operator.image.tag }}
         repository: {{ repo.registry_endpoint ~ '/' ~ solution.id }}
+        webhook_enabled: {{ webhook_enabled }}
     - require:
         - metalk8s_kubernetes: Apply Operator ConfigMap for Solution {{ solution.name }}
 

--- a/salt/tests/unit/formulas/config.yaml
+++ b/salt/tests/unit/formulas/config.yaml
@@ -753,6 +753,15 @@ metalk8s:
                   image_name: example-operator
                   image_tag: "1.2.3"
 
+              "Example Solution v1.2.3 with webhook":
+                extra_context:
+                  <<: *base_context_solution_operator_files
+                  repository: >-
+                    metalk8s-registry-from-config.invalid/example-solution-1.2.3
+                  image_name: example-operator-webhook
+                  image_tag: "1.2.3"
+                  webhook_enabled: true
+
           role_binding.yaml.j2:
             _cases:
               "Example Solution v1.2.3 (see ../../prepare-environment.sls)":

--- a/scripts/solutions.sh
+++ b/scripts/solutions.sh
@@ -19,6 +19,7 @@ NAMESPACE=''
 SOLUTION=''
 VERBOSE=${VERBOSE:-0}
 VERSION=''
+WEBHOOK_ENABLED=${WEBHOOK_ENABLED:-false}
 
 export KUBECONFIG
 
@@ -94,6 +95,7 @@ usage() {
     echo "                        name)"
     echo "    -s, --solution      Name of the Solution to add"
     echo "    -V, --version       Version of the Solution to add"
+    echo "    -w, --webhook       Enable webhook validation"
     echo
     echo "  delete-solution     Delete a Solution from an Environment"
     echo "    -n, --name          Name of the Environment to delete the"
@@ -122,9 +124,10 @@ LONG_OPTS='
     namespace:,
     solution:,
     verbose,
-    version:
+    version:,
+    webhook,
 '
-SHORT_OPTS='a:d:hl:n:N:s:vV:'
+SHORT_OPTS='a:d:hl:n:N:s:vV:w'
 
 if ! options=$(getopt --options "$SHORT_OPTS" --long "$LONG_OPTS" -- "$@"); then
     echo 1>&2 "Incorrect arguments provided"
@@ -180,6 +183,9 @@ while :; do
         -V|--version)
             shift
             VERSION=$1
+            ;;
+        -w|--webhook)
+            WEBHOOK_ENABLED=true
             ;;
         --)
             shift
@@ -437,7 +443,8 @@ add_solution() {
     local -ra pillar=(
         "{"
         "  'orchestrate': {"
-        "    'env_name': '$NAME'"
+        "    'env_name': '$NAME',"
+        "    'webhook_enabled': $WEBHOOK_ENABLED"
         "  }"
         "}"
     )


### PR DESCRIPTION
Add volume to use secret to configure webhook in a deployment. This volume is configured when solution.sh is executed with the flag `-w` or `--webhook`.

(cherry picked from commit f047356a43d508b796e4c9740f28de6a026b00a5)