### PR TITLE
Handle AbortError from firefox.

### DIFF
--- a/shell-ui/src/FederatedApp.tsx
+++ b/shell-ui/src/FederatedApp.tsx
@@ -408,6 +408,14 @@ const AppProviderWrapper = () => {
           );
         }
         if (error instanceof Error) {
+          if (error.message.includes('AbortError: The operation was aborted')) {
+            return (
+              <>
+                Loading of the application has been aborted due to a redirection
+                in progress.
+              </>
+            );
+          }
           return (
             <ErrorPage500
               data-cy="sc-error-page500"


### PR DESCRIPTION
Display message explaining what is happening:
Firefox throw an error when the loading of the page is aborted due to a redirection.

**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

**Summary**:

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
