### PR TITLE
images,packages: Move to our own saltstack repository

### DIFF
--- a/images/metalk8s-utils/configure-repos.sh
+++ b/images/metalk8s-utils/configure-repos.sh
@@ -16,9 +16,8 @@ EOF
 
 cat > /etc/yum.repos.d/saltstack.repo << EOF
 [saltstack]
-name=SaltStack repo for RHEL/CentOS \$releasever
-baseurl=https://repo.saltproject.io/py3/redhat/\$releasever/\$basearch/archive/$SALT_VERSION
+name=Scality SaltStack repo for RHEL/CentOS \$releasever
+baseurl=https://downloads.scality.com/repository/redhat/\$releasever/saltstack/$SALT_VERSION
 enabled=1
-gpgcheck=1
-gpgkey=https://repo.saltproject.io/py3/redhat/\$releasever/\$basearch/archive/$SALT_VERSION/SALTSTACK-GPG-KEY.pub
+gpgcheck=0
 EOF

--- a/images/salt-master/Dockerfile
+++ b/images/salt-master/Dockerfile
@@ -9,12 +9,10 @@ ARG SALT_VERSION
 
 # Install Saltstack and other dependencies
 RUN printf "[saltstack-repo]\n\
-name=SaltStack repo for RHEL/CentOS \$releasever\n\
-baseurl=https://repo.saltproject.io/py3/redhat/\$releasever/\$basearch/archive/%s\n\
+name=Scality SaltStack repo for RHEL/CentOS \$releasever\n\
+baseurl=https://downloads.scality.com/repository/redhat/\$releasever/saltstack/%s\n\
 enabled=1\n\
-gpgcheck=1\n\
-gpgkey=https://repo.saltproject.io/py3/redhat/\$releasever/\$basearch/archive/%s/SALTSTACK-GPG-KEY.pub\n" ${SALT_VERSION} ${SALT_VERSION} >/etc/yum.repos.d/saltstack.repo \
- && rpm --import https://repo.saltproject.io/py3/redhat/8/x86_64/archive/${SALT_VERSION}/SALTSTACK-GPG-KEY.pub \
+gpgcheck=0\n" ${SALT_VERSION} ${SALT_VERSION} >/etc/yum.repos.d/saltstack.repo \
  && dnf clean expire-cache \
  && dnf update -y \
  && dnf install -y glibc-all-langpacks langpacks-en \

--- a/packages/redhat/7/Dockerfile
+++ b/packages/redhat/7/Dockerfile
@@ -19,9 +19,9 @@ RUN sed -i s/@K8S_SHORT_VERSION@/$K8S_SHORT_VERSION/ /etc/yum.repos.d/kubernetes
 
 ENV GOROOT /usr/local/go
 
-RUN yum install -y --setopt=skip_missing_names_on_install=False \
+RUN yum install -y --setopt=skip_missing_names_on_install=False epel-release && \
+    yum install -y --setopt=skip_missing_names_on_install=False \
         createrepo \
-        epel-release \
         python36-rpm \
         rpm-build \
         rpmdevtools \

--- a/packages/redhat/common/yum_repositories/saltstack.repo
+++ b/packages/redhat/common/yum_repositories/saltstack.repo
@@ -1,6 +1,6 @@
 [saltstack]
-name=SaltStack repo for RHEL/CentOS $releasever
-baseurl=https://repo.saltproject.io/py3/redhat/$releasever/$basearch/archive/@SALT_VERSION@
+name=Scality SaltStack repo for RHEL/CentOS $releasever
+baseurl=https://downloads.scality.com/repository/redhat/$releasever/saltstack/@SALT_VERSION@
 enabled=1
 gpgcheck=1
-gpgkey=https://repo.saltproject.io/py3/redhat/$releasever/$basearch/archive/@SALT_VERSION@/SALTSTACK-GPG-KEY.pub
+gpgkey=https://downloads.scality.com/repository/redhat/$releasever/saltstack/@SALT_VERSION@/SALTSTACK-GPG-KEY.pub


### PR DESCRIPTION
Saltstack RPM repo has migrated but the old Salt versions has been dropped so let's move to our own repository