### PR TITLE
:arrow_up: bump the rocky base image used by metalk8s-utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,10 @@
   [3.2.0](https://github.com/grafana/loki/releases/tag/v3.2.0)
   (PR[#4450](https://github.com/scality/metalk8s/pull/4450))
 
+- Bump the rocky base image used by `metalk8s-utils`
+  image to `rockylinux:9.5-minimal`
+  (PR[#4483](https://github.com/scality/metalk8s/pull/4483))
+
 ## Release 128.0.1 (in development)
 
 ## Release 128.0.0

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -76,8 +76,8 @@ ROCKY_BASE_IMAGE_8_SHA256: str = (
     "6d2ede107b4f005a638728711dae05d5fbbfd8abd521cecf5ab61196b361c965"
 )
 ROCKY_BASE_IMAGE_9_SHA256: str = (
-    # rockylinux:9.4-minimal
-    "46a4a83a607bf0f86a5882a857ea4ed757a5f67eae938a29b9b4e86b21f241dd"
+    # rockylinux:9.5-minimal
+    "2cb86b2d8326a987546dc7fb393f43d43d478fea12ce3ce4accbda571f47f86b"
 )
 
 ETCD_VERSION: str = "3.5.15"


### PR DESCRIPTION
Bump rocky base image to 9.5