### PR TITLE
build: update go and alertmanager for metalk8s-alert-logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@
 
 ### Enhancements
 
+- Bump go version to
+  [1.24](https://golang.org/doc/devel/release.html#go1.24.minor)
+  and alertmanager go library version to
+  [0.27.0](https://github.com/prometheus/alertmanager/releases/tag/v0.27.0)
+  in `metalk8s-alert-logger` image
+  (PR[#4524](https://github.com/scality/metalk8s/pull/4524))
+
 - Implement super-admin user and bind admin to built-in cluster-admins role
   (PR[#4418](https://github.com/scality/metalk8s/pull/4418))
 

--- a/images/metalk8s-alert-logger/Dockerfile
+++ b/images/metalk8s-alert-logger/Dockerfile
@@ -1,12 +1,12 @@
 ARG BASE_IMAGE=docker.io/alpine
 
 ARG BUILD_IMAGE_NAME=golang
-ARG BUILD_IMAGE_TAG=1.17.0-alpine
+ARG BUILD_IMAGE_TAG=1.24.0-alpine
 FROM ${BUILD_IMAGE_NAME}:${BUILD_IMAGE_TAG} AS builder
 
 ENV CGO_ENABLED=0
 
-ARG ALERTMANAGER_VERSION=v0.26.0
+ARG ALERTMANAGER_VERSION=v0.27.0
 ARG PKG_PATH=/go/src/metalk8s-alert-logger/
 
 RUN mkdir -p "$PKG_PATH"
@@ -16,7 +16,7 @@ COPY main.go go.mod "$PKG_PATH"
 WORKDIR "$PKG_PATH"
 
 RUN sed -i "s/@@ALERTMANAGER_VERSION@@/$ALERTMANAGER_VERSION/g" go.mod \
-  && go mod tidy -go=1.16 && go mod tidy -go=1.17 \
+  && go mod tidy -go=1.24 \
   && go install
 
 FROM ${BASE_IMAGE}

--- a/images/metalk8s-alert-logger/go.mod
+++ b/images/metalk8s-alert-logger/go.mod
@@ -1,5 +1,5 @@
 module metalk8s-alert-logger
 
-go 1.17
+go 1.24
 
 require github.com/prometheus/alertmanager @@ALERTMANAGER_VERSION@@


### PR DESCRIPTION
goes from
``` ✔ Scanned for vulnerabilities     [80 vulnerability matches]  
   ├── by severity: 9 critical, 41 high, 28 medium, 1 low, 0 negligible (1 unknown)
   └── by status:   80 fixed, 0 not-fixed, 0 ignored
```

to

``` ✔ Scanned for vulnerabilities     [9 vulnerability matches]  
   ├── by severity: 0 critical, 2 high, 7 medium, 0 low, 0 negligible
   └── by status:   9 fixed, 0 not-fixed, 0 ignored
```

remaining:

```NAME                        INSTALLED  FIXED-IN  TYPE       VULNERABILITY        SEVERITY 
google.golang.org/protobuf  v1.32.0    1.33.0    go-module  GHSA-8r3f-844c-mc37  Medium    
libcrypto3                  3.3.2-r0   3.3.2-r1  apk        CVE-2024-9143        Medium    
libcrypto3                  3.3.2-r0   3.3.2-r2  apk        CVE-2024-13176       Medium    
libcrypto3                  3.3.2-r0   3.3.3-r0  apk        CVE-2024-12797       Medium    
libssl3                     3.3.2-r0   3.3.2-r1  apk        CVE-2024-9143        Medium    
libssl3                     3.3.2-r0   3.3.2-r2  apk        CVE-2024-13176       Medium    
libssl3                     3.3.2-r0   3.3.3-r0  apk        CVE-2024-12797       Medium    
musl                        1.2.5-r0   1.2.5-r1  apk        CVE-2025-26519       High      
musl-utils                  1.2.5-r0   1.2.5-r1  apk        CVE-2025-26519       High
```
apk libs need an update in alpine afaik