### PR TITLE
Use the devcontainer in the CI to build and tests

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/base:jammy
+FROM mcr.microsoft.com/devcontainers/base:noble
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
@@ -26,7 +26,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         npm \
         pkg-config \
         plantuml \
-        python3.10-gdbm \
         shellcheck \
         tk-dev \
         tmux \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -38,6 +38,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 USER vscode
 
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
 # Install helm
 ARG HELM_VERSION=3.14.4
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,6 +12,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         gawk \
         gcc \
         genisoimage \
+        gh \
         git \
         isomd5sum \
         libassuan-dev \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -58,7 +58,11 @@ RUN pyenv install 3.10.12 3.6.15 2.7 && \
     pyenv global 3.10.12 3.6.15 2.7
 
 # Install python libs
-RUN pyenv exec pip install "tox~=4.4.12" "pre-commit~=3.3.3" "virtualenv<20.22.0" "esbonio>=0.12.0"
+RUN pip3 install --no-cache-dir --upgrade pip && \
+    pip3.6 install --no-cache-dir --upgrade pip && \
+    pip3 install --no-cache-dir "tox~=4.4.12" "pre-commit~=3.3.3" "virtualenv<20.22.0" "esbonio>=0.12.0" && \
+    pip3.6 install --no-cache-dir "poetry~=1.1.15" && \
+    pyenv rehash
 
 # Install helm
 ARG HELM_VERSION=3.17.2

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -41,6 +41,11 @@ USER vscode
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 
+# NOTE: Due to a bug in recent babel version, it cannot work with
+# default UTC timezone
+# See: https://github.com/python-babel/babel/issues/990
+RUN sudo ln -fs /usr/share/zoneinfo/UTC /etc/localtime
+
 # Install helm
 ARG HELM_VERSION=3.14.4
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,6 +7,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         bash-completion \
         build-essential \
         curl \
+        docker.io \
         enchant-2 \
         gawk \
         gcc \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -46,6 +46,21 @@ ENV LC_ALL=C.UTF-8
 # See: https://github.com/python-babel/babel/issues/990
 RUN sudo ln -fs /usr/share/zoneinfo/UTC /etc/localtime
 
+ENV PYENV_ROOT="/usr/local/pyenv"
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+
+# Install pyenv
+RUN sudo git clone https://github.com/pyenv/pyenv.git $PYENV_ROOT && \
+    sudo chown $(id -u):$(id -g) -R $PYENV_ROOT && \
+    printf 'export PYENV_ROOT=%s\nexport PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"\nif command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi\n' $PYENV_ROOT | sudo tee -a /etc/bash.bashrc -a /etc/zsh/zshrc
+
+# Install pythons
+RUN pyenv install 3.10.12 3.6.15 2.7 && \
+    pyenv global 3.10.12 3.6.15 2.7
+
+# Install python libs
+RUN pyenv exec pip install "tox~=4.4.12" "pre-commit~=3.3.3" "virtualenv<20.22.0" "esbonio>=0.12.0"
+
 # Install helm
 ARG HELM_VERSION=3.17.2
 
@@ -68,18 +83,6 @@ ARG GOLANGCI_VERSION=1.54.2
 RUN curl --fail -L -o /tmp/install.sh https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh && \
     sudo bash /tmp/install.sh v${GOLANGCI_VERSION} && \
     rm -f /tmp/install.sh
-
-# Install pyenv
-RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    echo 'export PATH="$HOME/.pyenv/bin:$PATH"\nif command -v pyenv 1>/dev/null 2>&1; then\n eval "$(pyenv init -)"\nfi' | tee -a ~/.bashrc -a ~/.zshrc && \
-    export PATH="$HOME/.pyenv/bin:$PATH" && eval "$(pyenv init -)"
-
-# Install pythons
-RUN ~/.pyenv/bin/pyenv install 3.10.12 3.6.15 2.7 && \
-    ~/.pyenv/bin/pyenv global 3.10.12 3.6.15 2.7
-    
-# Install python libs
-RUN ~/.pyenv/bin/pyenv exec pip install "tox~=4.4.12" "pre-commit~=3.3.3" "virtualenv<20.22.0" "esbonio>=0.12.0"
 
 # Install crane
 ARG CRANE_VERSION=0.20.0

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -92,7 +92,7 @@ RUN curl --fail -L -o /tmp/install.sh https://raw.githubusercontent.com/golangci
     rm -f /tmp/install.sh
 
 # Install crane
-ARG CRANE_VERSION=0.20.0
+ARG CRANE_VERSION=0.20.3
 
 RUN curl --fail -L -o /tmp/crane.tar.gz https://github.com/google/go-containerregistry/releases/download/v${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz && \
     sudo tar -xzf /tmp/crane.tar.gz -C /usr/local/bin/ crane && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -70,11 +70,18 @@ RUN curl --fail -L -o /tmp/helm.tar.gz https://get.helm.sh/helm-v${HELM_VERSION}
 
 # Install go
 ARG GO_VERSION=1.20.14
+ENV GOROOT="/usr/local/go"
+# NOTE: We use a custom GOPATH so that we can use it both for vscode and root users
+ENV GOPATH="/usr/lib/go"
+ENV GOBIN="$GOPATH/bin"
+ENV PATH="$GOBIN:$GOROOT/bin:$PATH"
 
 RUN curl --fail -L -o /tmp/go.tar.gz https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz && \
-    sudo tar -C /usr/local -xzf /tmp/go.tar.gz && \
-    sudo ln -s /usr/local/go/bin/go /usr/local/bin/go && \
-    sudo ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt && \
+    sudo tar -C /usr/local/ -xzf /tmp/go.tar.gz && \
+    sudo mkdir -p $GOPATH && \
+    sudo chown $(id -u):$(id -g) -R $GOROOT $GOPATH && \
+    cd $GOROOT/bin && mv go go${GO_VERSION} && ln -s go${GO_VERSION} go && \
+    printf 'export PATH="%s:%s/bin:$PATH"\n' $GOBIN $GOROOT | sudo tee -a /etc/bash.bashrc -a /etc/zsh/zshrc && \
     rm -rf /tmp/go.tar.gz
 
 # Install golangci-lint
@@ -97,7 +104,7 @@ ARG SKOPEO_VERSION=1.15.1
 RUN curl --fail -L -o /tmp/skopeo.tar.gz https://github.com/containers/skopeo/archive/refs/tags/v${SKOPEO_VERSION}.tar.gz && \
     tar -zxvf /tmp/skopeo.tar.gz -C /tmp && \
     cd /tmp/skopeo-${SKOPEO_VERSION} && \
-    sudo make bin/skopeo && \
+    sudo "PATH=$PATH" make bin/skopeo && \
     sudo mv bin/skopeo /usr/local/bin/ && \
     cd && \
     rm -rf /tmp/skopeo.tar.gz /tmp/skopeo-${SKOPEO_VERSION}

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -47,7 +47,7 @@ ENV LC_ALL=C.UTF-8
 RUN sudo ln -fs /usr/share/zoneinfo/UTC /etc/localtime
 
 # Install helm
-ARG HELM_VERSION=3.14.4
+ARG HELM_VERSION=3.17.2
 
 RUN curl --fail -L -o /tmp/helm.tar.gz https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
     sudo tar -zxvf /tmp/helm.tar.gz -C /usr/local/bin/ linux-amd64/helm --strip-components 1 && \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,10 @@
 {
   "name": "metalk8s",
   "build": {
-    "dockerfile": "Dockerfile"
+    "dockerfile": "Dockerfile",
+    "options": [
+      "--platform=linux/amd64"
+    ]
   },
   "features": {
     "ghcr.io/devcontainers/features/sshd:1": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,9 @@
     "dockerfile": "Dockerfile",
     "options": [
       "--platform=linux/amd64"
+    ],
+    "cacheFrom": [
+      "type=gha,scope=devcontainer"
     ]
   },
   "features": {

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -13,12 +13,6 @@ if [ "$CODESPACES" = "true" ]; then
   git reset --hard HEAD
 fi
 
-# NOTE: Due to a bug in recent babel version, it cannot work with
-# default UTC timezone
-# See: https://github.com/python-babel/babel/issues/990
-echo "Updating localtime"
-sudo ln -fs /usr/share/zoneinfo/UTC /etc/localtime
-
 echo "Install pre-commit hooks"
 pre-commit install
 

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -14,6 +14,6 @@ if [ "$CODESPACES" = "true" ]; then
 fi
 
 echo "Install pre-commit hooks"
-pre-commit install
+pre-commit install --install-hooks
 
 echo "End of setup"

--- a/.github/changed-files.yaml
+++ b/.github/changed-files.yaml
@@ -74,7 +74,6 @@ build:
   - "!solution-operator-lib/**"
   # Filter out devX and tools
   - "!.pre-commit-config.yaml"
-  - "!.devcontainer/**"
   - "!.gitignore"
   - "!LICENSE"
   - "!README.md"

--- a/.github/changed-files.yaml
+++ b/.github/changed-files.yaml
@@ -36,6 +36,7 @@ unit-tests-storage-operator:
 unit-tests-salt:
   - salt/**
   - tox.ini
+  - .devcontainer/**
 
 unit-tests-lib-alert-tree:
   - tools/lib-alert-tree/**

--- a/.github/changed-files.yaml
+++ b/.github/changed-files.yaml
@@ -9,6 +9,7 @@ docs:
   - tools/lib-alert-tree/**
   - tools/rule_extractor/alerting_rules.json
   - tox.ini
+  - .devcontainer/**
 
 shell-ui:
   - shell-ui/**

--- a/.github/changed-files.yaml
+++ b/.github/changed-files.yaml
@@ -31,6 +31,7 @@ unit-tests-metalk8s-operator:
 
 unit-tests-storage-operator:
   - storage-operator/**
+  - .devcontainer/**
 
 unit-tests-salt:
   - salt/**

--- a/.github/changed-files.yaml
+++ b/.github/changed-files.yaml
@@ -40,6 +40,7 @@ unit-tests-salt:
 
 unit-tests-lib-alert-tree:
   - tools/lib-alert-tree/**
+  - .devcontainer/**
 
 integration-tests-ui:
   - *ui

--- a/.github/changed-files.yaml
+++ b/.github/changed-files.yaml
@@ -27,6 +27,7 @@ unit-tests-crd-client-generator:
 
 unit-tests-metalk8s-operator:
   - operator/**
+  - .devcontainer/**
 
 unit-tests-storage-operator:
   - storage-operator/**

--- a/.github/workflows/build-devcontainer.yaml
+++ b/.github/workflows/build-devcontainer.yaml
@@ -1,0 +1,39 @@
+name: build devcontainer
+
+on:
+  workflow_call:
+    inputs:
+      skip:
+        type: boolean
+        required: false
+        default: false
+        description: 'Skip the build and publish'
+
+jobs:
+  build-and-publish-devcontainer:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to the registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build dev container
+        # NOTE: We only skip this and not the full Job
+        # otherwise step that "need" it will not be started
+        if: ${{ ! inputs.skip }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .devcontainer/
+          push: true
+          tags: ghcr.io/${{ github.repository }}/devcontainer:${{ github.sha }}
+          cache-from: type=gha,scope=devcontainer
+          cache-to: type=gha,mode=max,scope=devcontainer

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -8,6 +8,11 @@ on:
         default: ${{ github.ref }}
         required: false
         type: string
+      build-devcontainer:
+        description: "True will build the devcontainer"
+        default: true
+        required: false
+        type: boolean
     secrets:
       ARTIFACTS_USER:
         required: true
@@ -15,23 +20,38 @@ on:
         required: true
 
 jobs:
+  build-devcontainer:
+    uses: ./.github/workflows/build-devcontainer.yaml
+    secrets: inherit
+    with:
+      # NOTE: We check "!= true" instead of just checking the value
+      # since by default when the workflow is call with "workflow dispatch"
+      # the input will (sadly) be "" and not use the default value
+      skip: ${{ inputs.build-devcontainer != true }}
+
   docs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    needs:
+      - build-devcontainer
+    container:
+      image: ghcr.io/${{ github.repository }}/devcontainer:${{ github.sha }}
+      # We have to use `root` for the moment
+      # Sees: https://github.com/actions/checkout/issues/1575
+      # Could work with a user with 1001 id but not for docker
+      options: --user root
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
-      - name: Install Python 3
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-      - name: Install deps
-        run: |
-          export DEBIAN_FRONTEND=noninteractive
-          sudo apt-get update
-          sudo apt-get install --no-install-recommends -y plantuml
-          python3.10 -m pip install tox~=4.0.19
+      - name: Set safe directory (since container is root and not user 1001)
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: Build documentation for ReadTheDocs
         env:
           # Fake that we are building in a ReadTheDocs environment

--- a/.github/workflows/build-shell-ui.yaml
+++ b/.github/workflows/build-shell-ui.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   shell-ui:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,11 @@ on:
         default: ${{github.ref}}
         required: false
         type: string
+      build-devcontainer:
+        description: "True will build the devcontainer"
+        default: true
+        required: false
+        type: boolean
     outputs:
       artifact-name:
         description: "artifacts name"
@@ -24,6 +29,15 @@ on:
   workflow_dispatch:
 
 jobs:
+  build-devcontainer:
+    uses: ./.github/workflows/build-devcontainer.yaml
+    secrets: inherit
+    with:
+      # NOTE: We check "!= true" instead of just checking the value
+      # since by default when the workflow is call with "workflow dispatch"
+      # the input will (sadly) be "" and not use the default value
+      skip: ${{ inputs.build-devcontainer != true }}
+
   build:
     runs-on: ubuntu-20.04
     outputs:
@@ -113,7 +127,7 @@ jobs:
           password: ${{ secrets.ARTIFACTS_PASSWORD }}
           source: artifacts
       - name: Cleanup build tree
-        run: ./doit.sh clean && test ! -d _build
+        run: cd "${{ github.workspace }}" && ./doit.sh clean && test ! -d _build
 
   build-shell-ui:
     uses: ./.github/workflows/build-shell-ui.yaml

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,18 +39,34 @@ jobs:
       skip: ${{ inputs.build-devcontainer != true }}
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    needs:
+      - build-devcontainer
+    container:
+      image: ghcr.io/${{ github.repository }}/devcontainer:${{ github.sha }}
+      # We have to use `root` for the moment
+      # Sees: https://github.com/actions/checkout/issues/1575
+      # Could work with a user with 1001 id but not for docker
+      options: --user root
+      volumes:
+        # This "ugly" workaround is needed for now because we use a container to run the job
+        # so we use docker-in-docker but by default github mount the workspace in the container
+        # not at the same location
+        # - on the host it's on github.workspace => /home/runner/work/artesca/artesca
+        # - in the container it's on GITHUB_WORKSPACE => /__w/artesca/artesca
+        # Which means if we want to creata docker with bind mount we need to use the host path
+        # that's why we also mount the workspace in the container at the same location
+        - ${{ github.workspace }}:${{ github.workspace }}
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    defaults:
+      run:
+        shell: bash
     outputs:
       artifact-name: ${{ steps.upload.outputs.name }}
       artifact-link: ${{ steps.upload.outputs.link }}
     steps:
-      - name: Cleanup some unused ressources
-        # Because of the large number of images we embed in the ISO
-        # the disk space available start to be a problem.
-        # Let's remove some unused ressources to free some space.
-        run: |-
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /usr/share/dotnet
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -63,47 +79,10 @@ jobs:
           # NOTE: We fetch depth so that we can put the right `GIT` reference
           # in the product.txt
           fetch-depth: 0
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Install Python 3
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-      - name: setup cache for pip
-        uses: actions/cache@v4
-        env:
-          cache-name: pip-packages
-        with:
-          path: ~/.cache/pip/
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('buildchain/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - name: Install deps
-        run: |
-          export DEBIAN_FRONTEND=noninteractive
-          sudo apt-get update
-          sudo apt-get install --no-install-recommends -y \
-            genisoimage \
-            isomd5sum \
-            hardlink \
-            libgpgme-dev libassuan-dev libbtrfs-dev pkg-config libdevmapper-dev
-      - name: Install skopeo
-        # NOTE: We install skopeo from sources since the version available in "classic"
-        #      repositories is too old and not compatible with docker > 1.25 (which is the one embedded
-        #      in the image we use here)
-        env:
-          SKOPEO_VERSION: 1.15.1
-        run: |
-          curl -Lo skopeo.tar.gz https://github.com/containers/skopeo/archive/refs/tags/v${SKOPEO_VERSION}.tar.gz && \
-          tar -zxf skopeo.tar.gz && \
-          cd skopeo-${SKOPEO_VERSION} && \
-          make bin/skopeo && \
-          sudo mv bin/skopeo /usr/local/bin/ && \
-          cd .. && rm -rf skopeo.tar.gz skopeo-${SKOPEO_VERSION}
+      - name: Set safe directory (since container is root and not user 1001)
+        run: git config --global --add safe.directory ${{ github.workspace }}
       - name: Build everything
-        run: ./doit.sh -n 4 --verbosity 2 --failure-verbosity 2
+        run: cd "${{ github.workspace }}" && ./doit.sh -n 4 --verbosity 2 --failure-verbosity 2
       - name: Prepare artifacts
         env:
           DEST_DIR: "artifacts"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -124,7 +124,7 @@ jobs:
       build-devcontainer: false
 
   write-final-status:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs:
       - build
       - build-shell-ui

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -115,10 +115,13 @@ jobs:
       ref: ${{ inputs.ref }}
 
   build-docs:
+    needs:
+      - build-devcontainer
     uses: ./.github/workflows/build-docs.yaml
     secrets: inherit
     with:
       ref: ${{ inputs.ref }}
+      build-devcontainer: false
 
   write-final-status:
     runs-on: ubuntu-20.04

--- a/.github/workflows/crons.yaml
+++ b/.github/workflows/crons.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   crons:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/downgrade-test.yaml
+++ b/.github/workflows/downgrade-test.yaml
@@ -31,7 +31,7 @@ jobs:
   downgrade:
     # We need to use a large runner so that we have known runner IPs
     # It allows us to filter authorized IPs on the machines we spawn
-    runs-on: ubuntu-22.04-4core
+    runs-on: ubuntu-24.04-4core
     env:
       NAME: downgrade-${{ inputs.type }}
     steps:

--- a/.github/workflows/lifecycle-dev.yaml
+++ b/.github/workflows/lifecycle-dev.yaml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   get-dev-artifacts-url:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       artifacts-url: ${{ steps.artifacts.outputs.link }}
     steps:

--- a/.github/workflows/lifecycle-promoted.yaml
+++ b/.github/workflows/lifecycle-promoted.yaml
@@ -30,7 +30,7 @@ jobs:
   snapshot-upgrade:
     # We need to use a large runner so that we have known runner IPs
     # It allows us to filter authorized IPs on the machines we spawn
-    runs-on: ubuntu-22.04-4core
+    runs-on: ubuntu-24.04-4core
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/multi-node-test.yaml
+++ b/.github/workflows/multi-node-test.yaml
@@ -81,7 +81,7 @@ jobs:
   multi-node:
     # We need to use a large runner so that we have known runner IPs
     # It allows us to filter authorized IPs on the machines we spawn
-    runs-on: ubuntu-22.04-4core
+    runs-on: ubuntu-24.04-4core
     env:
       SSH_PRIVATE_KEY: "~/.ssh/terraform"
       NODES_COUNT: ${{ inputs.nodes-count }}
@@ -376,7 +376,7 @@ jobs:
       - multi-node
     # We need to use a large runner so that we have known runner IPs
     # It allows us to filter authorized IPs on the machines we spawn
-    runs-on: ubuntu-22.04-4core
+    runs-on: ubuntu-24.04-4core
     if: always()
     steps:
       - name: Checkout

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   retrieve-info:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       artifacts-link: ${{ inputs.artifacts-url || steps.artifacts.outputs.link }}
       version_major: ${{ steps.get-version.outputs.version_major }}
@@ -49,7 +49,7 @@ jobs:
           echo "version_full=$VERSION_MAJOR.$VERSION_MINOR.$VERSION_PATCH-$VERSION_SUFFIX" >> $GITHUB_OUTPUT
 
   compute-lifecycle-promoted-matrix:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - retrieve-info
     env:
@@ -97,7 +97,7 @@ jobs:
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
   compute-lifecycle-dev-matrix:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - retrieve-info
     env:
@@ -232,7 +232,7 @@ jobs:
       artifacts-url: ${{ needs.retrieve-info.outputs.artifacts-link }}
 
   write-final-status:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - lifecycle-promoted
       - lifecycle-dev

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -307,19 +307,28 @@ jobs:
         run: make test
 
   unit_tests_salt:
-    needs: changed-files
+    runs-on: ubuntu-latest
+    needs:
+      - build-devcontainer
+      - changed-files
+    container:
+      image: ghcr.io/${{ github.repository }}/devcontainer:${{ github.sha }}
+      # We have to use `root` for the moment
+      # Sees: https://github.com/actions/checkout/issues/1575
+      # Could work with a user with 1001 id but not for docker
+      options: --user root
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    defaults:
+      run:
+        shell: bash
     if: needs.changed-files.outputs.unit-tests-salt == 'true'
-    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Python 3.6
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.6"
-      - name: Install deps
-        run: |
-          pip install tox
+      - name: Set safe directory (since container is root and not user 1001)
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: Run all salt unit tests
         run: tox -e unit-tests
 

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -253,32 +253,29 @@ jobs:
         run: npm run test --no-update-notifier
 
   unit_tests_metalk8s_operator:
-    needs: changed-files
-    if: needs.changed-files.outputs.unit-tests-metalk8s-operator == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    needs:
+      - build-devcontainer
+      - changed-files
+    container:
+      image: ghcr.io/${{ github.repository }}/devcontainer:${{ github.sha }}
+      # We have to use `root` for the moment
+      # Sees: https://github.com/actions/checkout/issues/1575
+      # Could work with a user with 1001 id but not for docker
+      options: --user root
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     defaults:
       run:
+        shell: bash
         working-directory: "operator"
+    if: needs.changed-files.outputs.unit-tests-metalk8s-operator == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: "1.20.14"
-      - name: Cache Go modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-go-modules
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+      - name: Set safe directory (since container is root and not user 1001)
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: Run all MetalK8s operator unit and integration tests
         run: make test
 

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -79,17 +79,29 @@ jobs:
             echo "${!changed_files_var}"
           done
 
+  build-devcontainer:
+    uses: ./.github/workflows/build-devcontainer.yaml
+    secrets: inherit
+
   build:
-    needs: changed-files
+    needs:
+      - build-devcontainer
+      - changed-files
     if: needs.changed-files.outputs.build == 'true'
     uses: ./.github/workflows/build.yaml
+    with:
+      build-devcontainer: false
     secrets: inherit
 
   build-docs:
-    needs: changed-files
+    needs:
+      - build-devcontainer
+      - changed-files
     # Build of docs is triggered by "build" so do not re-trigger it
     if: needs.changed-files.outputs.docs == 'true' && needs.changed-files.outputs.build != 'true'
     uses: ./.github/workflows/build-docs.yaml
+    with:
+      build-devcontainer: false
     secrets: inherit
 
   build-shell-ui:

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -148,7 +148,7 @@ jobs:
   unit_tests_ui:
     needs: changed-files
     if: needs.changed-files.outputs.unit-tests-ui == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -191,7 +191,7 @@ jobs:
   unit_tests_shell_ui:
     needs: changed-files
     if: needs.changed-files.outputs.unit-tests-shell-ui == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -224,7 +224,7 @@ jobs:
   unit_tests_crd_client_generator:
     needs: changed-files
     if: needs.changed-files.outputs.unit-tests-crd-client-generator == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: "tools/crd-client-generator-js"
@@ -364,7 +364,7 @@ jobs:
   build_integration_container_nginx:
     needs: changed-files
     if: needs.changed-files.outputs.integration-tests-ui == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions: write-all
     steps:
       - name: Checkout
@@ -433,7 +433,7 @@ jobs:
           tags: ghcr.io/${{ github.repository_owner }}/metalk8s-nginx-integration-tests:${{ github.sha }}
 
   integration_tests_ui:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs:
       - build_integration_container_nginx
       - changed-files
@@ -513,7 +513,7 @@ jobs:
           source: upload
 
   write-final-status:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs:
       - changed-files
       - build-docs

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -122,36 +122,26 @@ jobs:
       artifacts-url: ${{ needs.build.outputs.artifact-link }}
 
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    needs:
+      - build-devcontainer
+    container:
+      image: ghcr.io/${{ github.repository }}/devcontainer:${{ github.sha }}
+      # We have to use `root` for the moment
+      # Sees: https://github.com/actions/checkout/issues/1575
+      # Could work with a user with 1001 id but not for docker
+      options: --user root
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Python 3
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-      # NOTE: Today python3.6 is needed by some lint steps
-      - name: Install Python 3.6
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.6"
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: "1.20.14"
-      - name: Install deps
-        run: |
-          export DEBIAN_FRONTEND=noninteractive
-          sudo apt-get update
-          sudo apt-get install --no-install-recommends -y shellcheck python2.7-minimal
-          python3.10 -m pip install tox~=4.0.11
-      - name: Install Helm
-        env:
-          HELM_VERSION: "3.10.0"
-        run: |
-          sudo curl -O https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz \
-              && sudo tar -zxvf helm-v${HELM_VERSION}-linux-amd64.tar.gz \
-              && sudo mv linux-amd64/helm /usr/local/bin/helm
+      - name: Set safe directory (since container is root and not user 1001)
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: Run all linting targets
         run: ./doit.sh lint
 

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -333,21 +333,29 @@ jobs:
         run: tox -e unit-tests
 
   unit_tests_lib_alert_tree:
-    needs: changed-files
-    if: needs.changed-files.outputs.unit-tests-lib-alert-tree == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    needs:
+      - build-devcontainer
+      - changed-files
+    container:
+      image: ghcr.io/${{ github.repository }}/devcontainer:${{ github.sha }}
+      # We have to use `root` for the moment
+      # Sees: https://github.com/actions/checkout/issues/1575
+      # Could work with a user with 1001 id but not for docker
+      options: --user root
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     defaults:
       run:
+        shell: bash
         working-directory: "tools/lib-alert-tree"
+    if: needs.changed-files.outputs.unit-tests-lib-alert-tree == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Python 3
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.6"
-      - name: Install deps
-        run: python3.6 -m pip install poetry~=1.1.9
+      - name: Set safe directory (since container is root and not user 1001)
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: Install lib_alert_tree
         run: poetry install -E cli
       - name: Run all lib_alert_tree unit tests

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -280,32 +280,29 @@ jobs:
         run: make test
 
   unit_tests_storage_operator:
-    needs: changed-files
-    if: needs.changed-files.outputs.unit-tests-storage-operator == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    needs:
+      - build-devcontainer
+      - changed-files
+    container:
+      image: ghcr.io/${{ github.repository }}/devcontainer:${{ github.sha }}
+      # We have to use `root` for the moment
+      # Sees: https://github.com/actions/checkout/issues/1575
+      # Could work with a user with 1001 id but not for docker
+      options: --user root
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     defaults:
       run:
+        shell: bash
         working-directory: "storage-operator"
+    if: needs.changed-files.outputs.unit-tests-storage-operator == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: "1.20.14"
-      - name: Cache Go modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-go-modules
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+      - name: Set safe directory (since container is root and not user 1001)
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: Run all storage-operator unit and integration tests
         run: make test
 

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -20,7 +20,7 @@ jobs:
     needs:
       - build
       - generate-sbom
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       artifact-link: ${{ steps.promote.outputs.link }}
     steps:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   publish-shell-ui:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/single-node-test.yaml
+++ b/.github/workflows/single-node-test.yaml
@@ -83,7 +83,7 @@ jobs:
   single-node:
     # We need to use a large runner so that we have known runner IPs
     # It allows us to filter authorized IPs on the machines we spawn
-    runs-on: ubuntu-22.04-4core
+    runs-on: ubuntu-24.04-4core
     env:
       SSH_PRIVATE_KEY: "~/.ssh/terraform"
     steps:
@@ -290,7 +290,7 @@ jobs:
   destroy-single-node-cluster:
     needs:
       - single-node
-    runs-on: ubuntu-22.04-4core
+    runs-on: ubuntu-24.04-4core
     if: always()
     steps:
       - name: Checkout

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -31,7 +31,7 @@ jobs:
   upgrade:
     # We need to use a large runner so that we have known runner IPs
     # It allows us to filter authorized IPs on the machines we spawn
-    runs-on: ubuntu-22.04-4core
+    runs-on: ubuntu-24.04-4core
     env:
       NAME: upgrade-${{ inputs.type }}
     steps:

--- a/buildchain/buildchain/lint.py
+++ b/buildchain/buildchain/lint.py
@@ -72,7 +72,11 @@ def lint_python() -> types.TaskDict:
         *constants.ROOT.glob("salt/_roster/*.py"),
     ]
     cmd = " ".join(map(shlex.quote, ["tox", "-e", "lint", "--", "pylint"]))
-    env = {"PATH": os.environ["PATH"], "OSTYPE": os.uname().sysname}
+    env = {
+        "PATH": os.environ["PATH"],
+        "HOME": os.environ["HOME"],
+        "OSTYPE": os.uname().sysname,
+    }
     return {
         "name": "python",
         "title": utils.title_with_subtask_name("LINT"),

--- a/docs/entrypoint.sh
+++ b/docs/entrypoint.sh
@@ -12,5 +12,7 @@ if ! grep -q "$TARGET_UID" /etc/passwd; then
   useradd -u "$TARGET_UID" -g "$TARGET_GID" tempuser
 fi
 
+git config --global --add safe.directory /usr/src/metalk8s
+
 sudo chown -R "$TARGET_UID:$TARGET_GID" /tmp/tox
 sudo -u "$(id -u -n "$TARGET_UID")" -E TOX_USER_CONFIG_FILE=tox.ini TOX_CONFIG_FILE=tox.ini tox --workdir /tmp/tox -e docs -- "$@" >&2

--- a/scripts/restore.sh.in
+++ b/scripts/restore.sh.in
@@ -330,7 +330,7 @@ fi
 
 run "Determine the OS" determine_os
 run "Extract backup archive '$BACKUP_ARCHIVE'" extract_archive
-[ $CHECK_INTEGRITY -eq 0 ] || run "Checking backup archive integrity" check_integrity
+[ "$CHECK_INTEGRITY" -eq 0 ] || run "Checking backup archive integrity" check_integrity
 run "Pre-minion system tests" pre_minion_checks
 run "Disabling Salt minion service" disable_salt_minion_service
 run "Stopping Salt minion service" stop_salt_minion_service


### PR DESCRIPTION
# Context

Today in MetalK8s we use python3.6 since it's the version embedded by default with Rocky 8 - and it's also the version used by Salt we embed -.

The issue is that GitHub runners newer than Ubuntu 20.04 no longer support Python3.6 and Ubuntu 20.04 runners will be dropped soon (see https://github.com/actions/runner-images/issues/11101) .

# Solution

We decided to build a devcontainer that can be used for development but also to build the product, this way we ensure that the devcontainer can always build the product and we no longer depend on Github runners OS versions.

The devcontainer image is built in the CI, pushed and cached to ghcr registry.