### PR TITLE
ARTESCA-14623 // use deviceName instead of metadata-name…

### DIFF
--- a/ui/src/services/k8s/Metalk8sLocalVolumeProvider.test.ts
+++ b/ui/src/services/k8s/Metalk8sLocalVolumeProvider.test.ts
@@ -85,6 +85,7 @@ describe('Metalk8sLocalVolumeProvider', () => {
                 nodeName: 'test-node',
                 lvmLogicalVolume: { vgName: 'test-lvm', size: '10Gi' },
               },
+              status: { deviceName: 'test-lvm' },
             },
             {
               metadata: { name: 'test-sparseLoop' },
@@ -94,6 +95,7 @@ describe('Metalk8sLocalVolumeProvider', () => {
                   size: '1Gi',
                 },
               },
+              status: { deviceName: 'test-sparseLoop' },
             },
           ],
         },

--- a/ui/src/services/k8s/Metalk8sLocalVolumeProvider.ts
+++ b/ui/src/services/k8s/Metalk8sLocalVolumeProvider.ts
@@ -61,7 +61,7 @@ export default class Metalk8sLocalVolumeProvider {
               ...isLocalPv,
               IP: nodeIP.address,
               devicePath:
-                item.spec?.rawBlockDevice?.devicePath || item.metadata['name'],
+                item.spec?.rawBlockDevice?.devicePath || item.status.deviceName,
               nodeName: item.spec.nodeName,
               volumeType: item.spec.rawBlockDevice
                 ? VolumeType.Hardware


### PR DESCRIPTION
This pull request includes changes to the `Metalk8sLocalVolumeProvider` class and its corresponding tests to improve the handling of device names.

Improvements to handling of device names:

* [`ui/src/services/k8s/Metalk8sLocalVolumeProvider.ts`](diffhunk://#diff-e44438ade3329cc009d6bee2782ab1d0d14947ca7851fd377af6c0d568074e11L64-R64): Modified the `devicePath` property to use `item.status.deviceName` instead of `item.metadata['name']`.

Updates to tests:

* [`ui/src/services/k8s/Metalk8sLocalVolumeProvider.test.ts`](diffhunk://#diff-32a69fa7691943a6e6bbf104746aaa3639d2a53f6ef6c66853a0fb956b68759bR88): Added `status` property with `deviceName` to the test cases for better coverage of the new `devicePath` logic. [[1]](diffhunk://#diff-32a69fa7691943a6e6bbf104746aaa3639d2a53f6ef6c66853a0fb956b68759bR88) [[2]](diffhunk://#diff-32a69fa7691943a6e6bbf104746aaa3639d2a53f6ef6c66853a0fb956b68759bR98)
