### PR TITLE
ARTESCA-14946: Publish the shell-ui SBOM

### DIFF
--- a/.github/workflows/build-shell-ui.yaml
+++ b/.github/workflows/build-shell-ui.yaml
@@ -41,8 +41,33 @@ jobs:
         run: >
           docker save shell-ui:v$SHELL_UI_VERSION |
           gzip > shell-ui.tar.gz
+      - name: Install syft tool to build the sbom
+        run: |
+          SYFT_VERSION="1.19.0"
+          SYFT_INSTALLER="syft_${SYFT_VERSION}_linux_amd64.deb"
+          SYFT_CHECKSUM="f3667d6abfa97a1e5614882f81e0a0b090f0047e0df7025b568fa87b6d95ac58"
+          wget https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/${SYFT_INSTALLER}
+          ACTUAL_CHECKSUM=$(sha256sum ${SYFT_INSTALLER} | cut -d ' ' -f1)
+          if [ "$ACTUAL_CHECKSUM" != "$SYFT_CHECKSUM" ]; then
+            echo "ERROR: Checksum verification failed for ${SYFT_INSTALLER}"
+            echo "Expected: ${SYFT_CHECKSUM}"
+            echo "Got:      ${ACTUAL_CHECKSUM}"
+            exit 1
+          fi
+          sudo dpkg -i ${SYFT_INSTALLER}
+      - name: "build Software Bill of materials (SBOM)"
+        run: |
+          set -x
+          cd shell-ui
+          syft scan dir:./ --source-name=shell-ui --source-version "$SHELL_UI_VERSION" --output cyclonedx-json=../shell.tar.sbom.spdx.json
+
       - name: Prepare artifacts
-        run: mkdir -p "artifacts/images" && mv shell-ui.tar.gz artifacts/images/ && mv shell.tar artifacts/images/
+        run: |
+          mkdir -p "artifacts/images"
+          mv shell-ui.tar.gz artifacts/images/
+          mv shell.tar artifacts/images/
+          mv shell.tar.sbom.spdx.json artifacts/images/
+
       - name: Upload artifacts
         uses: scality/action-artifacts@v4
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -58,6 +58,10 @@ jobs:
         run: >
           curl --fail -LO -u ${{ secrets.ARTIFACTS_USER }}:${{ secrets.ARTIFACTS_PASSWORD }}
           ${{ inputs.artifacts-url || steps.artifacts.outputs.link }}/images/shell.tar
+      - name: Retrieve shell SBOM from artifacts
+        run: >
+          curl --fail -LO -u ${{ secrets.ARTIFACTS_USER }}:${{ secrets.ARTIFACTS_PASSWORD }}
+          ${{ inputs.artifacts-url || steps.artifacts.outputs.link }}/images/shell.tar.sbom.spdx.json
       - name: Load shell-ui image
         run: docker load < shell-ui.tar.gz
       - name: Retrieve product.txt from artifacts
@@ -149,5 +153,6 @@ jobs:
           draft: false
           files: |
             shell.tar
+            shell.tar.sbom.spdx.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Build the Software Bill of Material (SBOM) for shell-ui during pre-merge using SYFT. Publish it next to the shell ui tarball in the github release.

This is to be used in the RING as part of the RING SBOM.

CI:

**Context**: In order to build SBOM of the RING, we need to get the SBOM from all its component. Since shell-ui is used in this repository, we need to deliver an SBOM for this tool.

**Summary**: 
- Build the SBOM
- Release it

**Acceptance criteria**:  SBOM ids built and released


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: ARTESCA-14946
See: RING-49709