### PR TITLE
Enhance isVolumeProvisioned method to return detailed volume informat…

### DIFF
--- a/ui/src/services/k8s/Metalk8sLocalVolumeProvider.test.ts
+++ b/ui/src/services/k8s/Metalk8sLocalVolumeProvider.test.ts
@@ -29,6 +29,7 @@ describe('Metalk8sLocalVolumeProvider', () => {
     listNode: jest.fn(),
     listPersistentVolume: jest.fn(),
     deletePersistentVolume: jest.fn(),
+    readPersistentVolume: jest.fn(),
   } as unknown as CoreV1Api;
 
   beforeEach(() => {
@@ -239,6 +240,9 @@ describe('Metalk8sLocalVolumeProvider', () => {
       ).mockResolvedValue({
         status: { conditions: [{ type: 'Ready', status: 'True' }] },
       });
+      (mockCoreV1Api.readPersistentVolume as jest.Mock).mockResolvedValue({
+        status: { phase: 'Bound' },
+      });
       //E
       const result = await provider.isVolumeProvisioned({
         IP: '192.168.1.100',
@@ -248,7 +252,12 @@ describe('Metalk8sLocalVolumeProvider', () => {
         volumeName: 'test-volume',
       });
       //V
-      expect(result).toBe(true);
+      expect(result).toMatchObject({
+        IP: '192.168.1.100',
+        devicePath: '/dev/sda',
+        volumeType: VolumeType.Hardware,
+        nodeName: 'test-node',
+      });
     });
 
     it('should raise an error if the volume is failed to provisioned', async () => {

--- a/ui/src/services/k8s/Metalk8sLocalVolumeProvider.test.ts
+++ b/ui/src/services/k8s/Metalk8sLocalVolumeProvider.test.ts
@@ -233,12 +233,12 @@ describe('Metalk8sLocalVolumeProvider', () => {
       expect(result).toBe(false);
     });
 
-    it('should return true if the volume is provisioned', async () => {
+    it('should return volume if the volume is provisioned', async () => {
       //S
       (
         mockCustomObjectsApi.getClusterCustomObject as jest.Mock
       ).mockResolvedValue({
-        status: { conditions: [{ type: 'Ready', status: 'True' }] },
+        body: { status: { conditions: [{ type: 'Ready', status: 'True' }] } },
       });
       (mockCoreV1Api.readPersistentVolume as jest.Mock).mockResolvedValue({
         status: { phase: 'Bound' },
@@ -265,14 +265,16 @@ describe('Metalk8sLocalVolumeProvider', () => {
       (
         mockCustomObjectsApi.getClusterCustomObject as jest.Mock
       ).mockResolvedValue({
-        status: {
-          conditions: [
-            {
-              type: 'Ready',
-              status: 'False',
-              reason: 'Volume is not provisioned',
-            },
-          ],
+        body: {
+          status: {
+            conditions: [
+              {
+                type: 'Ready',
+                status: 'False',
+                reason: 'Volume is not provisioned',
+              },
+            ],
+          },
         },
       });
       //E+V
@@ -342,6 +344,11 @@ describe('Metalk8sLocalVolumeProvider', () => {
             nodeName: 'test-node',
             rawBlockDevice: { devicePath: '/dev/sda' },
             storageClassName: 'ssd-ext4',
+            template: {
+              metadata: {
+                labels: { 'xcore.scality.com/volume-type': 'data' },
+              },
+            },
           },
         },
       );

--- a/ui/src/services/k8s/Metalk8sLocalVolumeProvider.ts
+++ b/ui/src/services/k8s/Metalk8sLocalVolumeProvider.ts
@@ -133,7 +133,7 @@ export default class Metalk8sLocalVolumeProvider {
 
   public isVolumeProvisioned = async (
     localVolume: LocalVolume,
-  ): Promise<boolean> => {
+  ): Promise<false | LocalPersistentVolume> => {
     const volumeName = localVolume.volumeName;
 
     const token = await this.getToken();
@@ -169,7 +169,17 @@ export default class Metalk8sLocalVolumeProvider {
     }
 
     if (volumeStatus?.status === 'True') {
-      return true;
+      const token = await this.getToken();
+      const { coreV1 } = ApiK8s.updateApiServerConfig(this.apiUrl, token);
+      const k8sClient = coreV1;
+      const pv = await k8sClient.readPersistentVolume(volumeName);
+      return {
+        ...pv.body,
+        IP: localVolume.IP,
+        devicePath: localVolume.devicePath,
+        nodeName: localVolume.nodeName,
+        volumeType: localVolume.volumeType,
+      };
     }
 
     return false;

--- a/ui/src/services/k8s/Metalk8sLocalVolumeProvider.ts
+++ b/ui/src/services/k8s/Metalk8sLocalVolumeProvider.ts
@@ -150,7 +150,7 @@ export default class Metalk8sLocalVolumeProvider {
       throw new Error(`Failed to get volume ${volumeName}: ${volume.error}`);
     }
 
-    const volumeStatus = volume.status?.conditions?.find(
+    const volumeStatus = volume.body?.status?.conditions?.find(
       (condition) => condition.type === 'Ready',
     );
 
@@ -250,6 +250,11 @@ export default class Metalk8sLocalVolumeProvider {
         nodeName,
         rawBlockDevice: { devicePath },
         storageClassName,
+        template: {
+          metadata: {
+            labels: { 'xcore.scality.com/volume-type': 'data' },
+          },
+        },
       },
     });
     if (isError(volume)) {

--- a/ui/src/services/k8s/Metalk8sVolumeClient.generated.ts
+++ b/ui/src/services/k8s/Metalk8sVolumeClient.generated.ts
@@ -237,9 +237,8 @@ export class Metalk8sV1alpha1VolumeClient {
 
   async getMetalk8sV1alpha1Volume(
     Metalk8sV1alpha1VolumeName: string,
-  ): Promise<Result<Metalk8sV1alpha1Volume>> {
+  ): Promise<Result<{ body: Metalk8sV1alpha1Volume }>> {
     try {
-      // @ts-expect-error - FIXME when you are working on it
       return await this.customObjects.getClusterCustomObject(
         'storage.metalk8s.scality.com',
         'v1alpha1',


### PR DESCRIPTION
…ion instead of a boolean. Add readPersistentVolume mock for testing.

**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

**Summary**:

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
