### PR TITLE
.github: Switch to GCP runner instead of large GH runner

### DIFF
--- a/.github/workflows/downgrade-test.yaml
+++ b/.github/workflows/downgrade-test.yaml
@@ -29,9 +29,9 @@ env:
 
 jobs:
   downgrade:
-    # We need to use a large runner so that we have known runner IPs
-    # It allows us to filter authorized IPs on the machines we spawn
-    runs-on: ubuntu-24.04-4core
+    # We need to use those specific gcloud runner so that we have
+    # known runner IPs
+    runs-on: [self-hosted, ubuntu, large, jammy, gcloud]
     env:
       NAME: downgrade-${{ inputs.type }}
     steps:

--- a/.github/workflows/lifecycle-promoted.yaml
+++ b/.github/workflows/lifecycle-promoted.yaml
@@ -28,9 +28,9 @@ env:
 
 jobs:
   snapshot-upgrade:
-    # We need to use a large runner so that we have known runner IPs
-    # It allows us to filter authorized IPs on the machines we spawn
-    runs-on: ubuntu-24.04-4core
+    # We need to use those specific gcloud runner so that we have
+    # known runner IPs
+    runs-on: [self-hosted, ubuntu, large, jammy, gcloud]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/multi-node-test.yaml
+++ b/.github/workflows/multi-node-test.yaml
@@ -79,9 +79,9 @@ env:
 
 jobs:
   multi-node:
-    # We need to use a large runner so that we have known runner IPs
-    # It allows us to filter authorized IPs on the machines we spawn
-    runs-on: ubuntu-24.04-4core
+    # We need to use those specific gcloud runner so that we have
+    # known runner IPs
+    runs-on: [self-hosted, ubuntu, large, jammy, gcloud]
     env:
       SSH_PRIVATE_KEY: "~/.ssh/terraform"
       NODES_COUNT: ${{ inputs.nodes-count }}
@@ -374,9 +374,9 @@ jobs:
   destroy-multi-node-cluster:
     needs:
       - multi-node
-    # We need to use a large runner so that we have known runner IPs
-    # It allows us to filter authorized IPs on the machines we spawn
-    runs-on: ubuntu-24.04-4core
+    # We need to use those specific gcloud runner so that we have
+    # known runner IPs
+    runs-on: [self-hosted, ubuntu, large, jammy, gcloud]
     if: always()
     steps:
       - name: Checkout

--- a/.github/workflows/single-node-test.yaml
+++ b/.github/workflows/single-node-test.yaml
@@ -81,9 +81,9 @@ env:
 
 jobs:
   single-node:
-    # We need to use a large runner so that we have known runner IPs
-    # It allows us to filter authorized IPs on the machines we spawn
-    runs-on: ubuntu-24.04-4core
+    # We need to use those specific gcloud runner so that we have
+    # known runner IPs
+    runs-on: [self-hosted, ubuntu, large, jammy, gcloud]
     env:
       SSH_PRIVATE_KEY: "~/.ssh/terraform"
     steps:
@@ -290,7 +290,9 @@ jobs:
   destroy-single-node-cluster:
     needs:
       - single-node
-    runs-on: ubuntu-24.04-4core
+    # We need to use those specific gcloud runner so that we have
+    # known runner IPs
+    runs-on: [self-hosted, ubuntu, large, jammy, gcloud]
     if: always()
     steps:
       - name: Checkout

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -29,9 +29,9 @@ env:
 
 jobs:
   upgrade:
-    # We need to use a large runner so that we have known runner IPs
-    # It allows us to filter authorized IPs on the machines we spawn
-    runs-on: ubuntu-24.04-4core
+    # We need to use those specific gcloud runner so that we have
+    # known runner IPs
+    runs-on: [self-hosted, ubuntu, large, jammy, gcloud]
     env:
       NAME: upgrade-${{ inputs.type }}
     steps:


### PR DESCRIPTION
It seems we have from time to time connection issue between large GH runner and OVH Cloud, which is not the case with GCP runner. This commit switches the runner to GCP.