### PR TITLE
ARTESCA-15417 // Fix issue with volume already exists

### DIFF
--- a/ui/src/services/k8s/Metalk8sLocalVolumeProvider.test.ts
+++ b/ui/src/services/k8s/Metalk8sLocalVolumeProvider.test.ts
@@ -372,9 +372,32 @@ describe('Metalk8sLocalVolumeProvider', () => {
 
     it('should raise an error if volume creation fails', async () => {
       //S
+      (mockCoreV1Api.listNode as jest.Mock).mockResolvedValue({
+        body: {
+          apiVersion: 'v1',
+          kind: 'NodeList',
+          items: [
+            {
+              metadata: {
+                name: 'test-node',
+              },
+              status: {
+                addresses: [{ type: 'InternalIP', address: '192.168.1.100' }],
+              },
+            },
+          ],
+        },
+      });
       (
         mockCustomObjectsApi.createClusterCustomObject as jest.Mock
-      ).mockRejectedValue(new Error('Error'));
+      ).mockResolvedValue({
+        error: {
+          message: 'Error',
+          body: {
+            code: 500,
+          },
+        },
+      });
       //E+V
       await expect(
         provider.attachHardwareVolume({
@@ -398,6 +421,50 @@ describe('Metalk8sLocalVolumeProvider', () => {
           type: HardwareDiskType.NVMe,
         }),
       ).rejects.toThrow('Failed to fetch nodes: Error');
+    });
+
+    it('should return volume info if volume already exists (409 conflict)', async () => {
+      //S
+      (mockCoreV1Api.listNode as jest.Mock).mockResolvedValue({
+        body: {
+          apiVersion: 'v1',
+          kind: 'NodeList',
+          items: [
+            {
+              metadata: {
+                name: 'test-node',
+              },
+              status: {
+                addresses: [{ type: 'InternalIP', address: '192.168.1.100' }],
+              },
+            },
+          ],
+        },
+      });
+      (
+        mockCustomObjectsApi.createClusterCustomObject as jest.Mock
+      ).mockResolvedValue({
+        error: {
+          body: {
+            code: 409,
+          },
+          message: 'Volume already exists',
+        },
+      });
+      //E
+      const result = await provider.attachHardwareVolume({
+        IP: '192.168.1.100',
+        devicePath: '/dev/sda',
+        type: HardwareDiskType.SATA,
+      });
+      //V
+      expect(result).toEqual({
+        IP: '192.168.1.100',
+        devicePath: '/dev/sda',
+        nodeName: 'test-node',
+        volumeType: VolumeType.Hardware,
+        volumeName: 'storage-data-192.168.1.100-dev-sda',
+      });
     });
   });
 });

--- a/ui/src/services/k8s/Metalk8sLocalVolumeProvider.ts
+++ b/ui/src/services/k8s/Metalk8sLocalVolumeProvider.ts
@@ -258,6 +258,17 @@ export default class Metalk8sLocalVolumeProvider {
         },
       },
     });
+
+    if (isError(volume) && volume.error.body.code === 409) {
+      return {
+        IP,
+        devicePath,
+        nodeName,
+        volumeType: VolumeType.Hardware,
+        volumeName,
+      };
+    }
+
     if (isError(volume)) {
       throw new Error(
         `Failed to attach hardware volume: ${volume.error.message}`,


### PR DESCRIPTION
**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

**Summary**:

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
