### PR TITLE
rework micro app routing

### DIFF
--- a/shell-ui/src/FederatedApp.tsx
+++ b/shell-ui/src/FederatedApp.tsx
@@ -8,23 +8,15 @@ import {
   FederatedComponentProps,
   SolutionUI,
 } from '@scality/module-federation';
-import React, {
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useTransition,
-  useRef,
-  useState,
-} from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { QueryClient } from 'react-query';
-import { BrowserRouter, Route, Routes, useLocation } from 'react-router';
+import { BrowserRouter, Route, Routes } from 'react-router';
 
 import { loadShare } from '@module-federation/enhanced/runtime';
 import { useQuery } from 'react-query';
-import NotificationCenterProvider from './NotificationCenterProvider';
 import { AuthConfigProvider, useAuthConfig } from './auth/AuthConfigProvider';
-import { AuthProvider, useAuth } from './auth/AuthProvider';
+import { AuthProvider } from './auth/AuthProvider';
 import { FirstTimeLoginProvider } from './auth/FirstTimeLoginProvider';
 import {
   ShellAlerts,
@@ -35,9 +27,8 @@ import {
 import './index.css';
 import {
   ConfigurationProvider,
-  FederatedView,
   useConfigRetriever,
-  useDiscoveredViews,
+  useFederatedRoutes,
 } from './initFederation/ConfigurationProviders';
 import {
   ShellConfigProvider,
@@ -48,6 +39,7 @@ import { ShellThemeSelectorProvider } from './initFederation/ShellThemeSelectorP
 import { UIListProvider } from './initFederation/UIListProvider';
 import { SolutionsNavbar } from './navbar';
 import { LanguageProvider, useLanguage } from './navbar/lang';
+import NotificationCenterProvider from './NotificationCenterProvider';
 import { QueryClientProvider } from './QueryClientProvider';
 
 /**
@@ -73,19 +65,14 @@ export type FederatedAppProps = {
   shellAlerts: ShellAlerts;
 };
 
-function FederatedRoute({
-  url,
-  scope,
-  module,
-  app,
-  groups,
-}: FederatedComponentProps & {
-  groups?: string[];
+type FederatedRouteProps = Pick<FederatedComponentProps, 'scope' | 'module'> & {
   app: SolutionUI;
-}) {
+};
+function FederatedRoute({ scope, module, app }: FederatedRouteProps) {
   const { retrieveConfiguration } = useConfigRetriever();
   const { setAuthConfig } = useAuthConfig();
   const { language } = useLanguage();
+
   useEffect(() => {
     const runtimeAppConfig = retrieveConfiguration<Record<string, unknown>>({
       configType: 'run',
@@ -96,50 +83,23 @@ function FederatedRoute({
       setAuthConfig(runtimeAppConfig.spec.auth);
     }
   }, [retrieveConfiguration]);
-  return (
-    <ErrorBoundary
-      FallbackComponent={() => (
-        <ErrorPage500 data-cy="sc-error-page500" locale={language} />
-      )}
-    >
-      <ProtectedFederatedRoute
-        url={url}
-        scope={scope}
-        module={module}
-        app={app}
-        groups={groups}
-      />
-    </ErrorBoundary>
-  );
-}
-
-function ProtectedFederatedRoute({
-  url,
-  scope,
-  module,
-  app,
-  groups,
-}: FederatedComponentProps & {
-  groups?: string[];
-  app: SolutionUI;
-}) {
-  const { userData } = useAuth();
-  const { retrieveConfiguration } = useConfigRetriever();
 
   const federatedAppProps: FederatedAppProps = {
     shellHooks,
     shellAlerts,
   };
 
-  if (
-    userData &&
-    (groups?.some((group) => userData.groups.includes(group)) ?? true)
-  ) {
-    const appBuildConfig = retrieveConfiguration<'build'>({
-      configType: 'build',
-      name: app.name,
-    });
-    return (
+  const appBuildConfig = retrieveConfiguration<'build'>({
+    configType: 'build',
+    name: app.name,
+  });
+
+  return (
+    <ErrorBoundary
+      FallbackComponent={() => (
+        <ErrorPage500 data-cy="sc-error-page500" locale={language} />
+      )}
+    >
       <FederatedComponent
         url={`${app.url}${appBuildConfig?.spec.remoteEntryPath}?version=${app.version}`}
         module={module}
@@ -147,25 +107,18 @@ function ProtectedFederatedRoute({
         scope={scope}
         app={app}
       />
-    );
-  }
-
-  return <></>;
+    </ErrorBoundary>
+  );
 }
 
 function InternalRouter() {
-  const discoveredViews = useDiscoveredViews();
-  const { retrieveConfiguration } = useConfigRetriever();
+  const federatedRoutes = useFederatedRoutes();
 
   const routes = useMemo(
     () =>
-      (
-        discoveredViews.filter(
-          (discoveredView) => discoveredView.isFederated,
-        ) as FederatedView[]
-      )
-        //Sort the exact and strict routes first, to make sure to match the exact first.
-        .sort((a, b) => {
+      //Sort the exact and strict routes first, to make sure to match the exact first.
+      federatedRoutes
+        .toSorted((a, b) => {
           if (a.view.exact && !b.view.exact) {
             return -1;
           }
@@ -183,30 +136,15 @@ function InternalRouter() {
           }
           return 0;
         })
-
-        .map(({ app, view, groups }) => ({
+        .map(({ app, view }) => ({
           path: app.appHistoryBasePath + view.path,
           basename: app.appHistoryBasePath,
-          exact: view.exact,
-          strict: view.strict,
           sensitive: view.sensitive,
           element: (
-            <FederatedRoute
-              url={
-                app.url +
-                retrieveConfiguration<'build'>({
-                  configType: 'build',
-                  name: app.name,
-                })?.spec.remoteEntryPath
-              }
-              module={view.module}
-              scope={view.scope}
-              app={app}
-              groups={groups}
-            />
+            <FederatedRoute module={view.module} scope={view.scope} app={app} />
           ),
         })),
-    [JSON.stringify(discoveredViews)],
+    [JSON.stringify(federatedRoutes)],
   );
 
   return (

--- a/shell-ui/src/initFederation/ConfigurationProviders.spec.tsx
+++ b/shell-ui/src/initFederation/ConfigurationProviders.spec.tsx
@@ -1,0 +1,356 @@
+import { waitFor } from '@testing-library/dom';
+import { renderHook } from '@testing-library/react';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { QueryClient } from 'react-query';
+import { QueryClientProvider } from '../QueryClientProvider';
+import type { BuildtimeWebFinger, View } from './ConfigurationProviders';
+import {
+  ConfigurationProvider,
+  useFederatedRoutes,
+} from './ConfigurationProviders';
+import { UIListProvider } from './UIListProvider';
+
+const testService = 'http://10.0.0.1/uilist.json';
+
+const testLocalUI = {
+  kind: 'test-ui',
+  name: 'test.local',
+  version: '1.0.0',
+  url: 'http://test.local.test',
+  appHistoryBasePath: '',
+};
+
+const addonUIV1 = {
+  kind: 'addon-ui',
+  name: 'addon-v1.local',
+  version: '1.0.0',
+  url: 'http://addon-v1.local.test',
+  appHistoryBasePath: '/addon-v1',
+};
+
+const addonUIV2 = {
+  kind: 'addon-ui',
+  name: 'addon-v2.local',
+  version: '2.0.0',
+  url: 'http://addon-v2.local.test',
+  appHistoryBasePath: '/addon-v2',
+};
+
+const externalHookUI = {
+  kind: 'external-hook-ui',
+  name: 'external-hook.local',
+  version: '1.0.0',
+  url: 'http://external-hook.local.test',
+  appHistoryBasePath: '/external-hook',
+};
+
+const singleDeployedUI = [testLocalUI];
+const allDeployedUIs = [testLocalUI, addonUIV1, addonUIV2, externalHookUI];
+
+const createMockBuildConfig = (
+  kind: string,
+  views: Record<string, View>,
+): BuildtimeWebFinger => ({
+  kind: 'MicroAppConfiguration',
+  apiVersion: 'ui.scality.com/v1alpha1',
+  metadata: {
+    kind,
+  },
+  spec: {
+    remoteEntryPath: '/mf-manifest.json',
+    views,
+    hooks: {},
+    components: {},
+  },
+});
+
+const createRuntimeAppConfig = (kind: string, name: string, spec = {}) => {
+  return {
+    kind: 'MicroAppRuntimeConfiguration',
+    apiVersion: 'ui.scality.com/v1alpha1',
+    metadata: {
+      kind,
+      name,
+    },
+    spec: spec,
+  };
+};
+
+const server = setupServer(
+  rest.get(`${testService}`, (req, res, ctx) => {
+    return res(ctx.json(singleDeployedUI));
+  }),
+  rest.get(
+    `http://test.local.test/.well-known/micro-app-configuration`,
+    (req, res, ctx) => {
+      return res(
+        ctx.json(
+          createMockBuildConfig('test-ui', {
+            overview: {
+              path: '/',
+              exact: true,
+              label: {
+                en: 'Overview',
+                fr: 'Vue générale',
+              },
+              module: './FederableApp',
+              scope: 'artesca',
+            },
+          }),
+        ),
+      );
+    },
+  ),
+  rest.get(
+    `http://test.local.test/.well-known/runtime-app-configuration`,
+    (req, res, ctx) => {
+      return res(ctx.json(createRuntimeAppConfig('test-ui', 'test.local')));
+    },
+  ),
+);
+
+describe('useFederatedRoutes', () => {
+  beforeAll(() =>
+    server.listen({
+      onUnhandledRequest: 'error',
+    }),
+  );
+  afterEach(() => server.resetHandlers());
+
+  const wrapper = ({ children }) => {
+    return (
+      <QueryClientProvider client={new QueryClient()}>
+        <UIListProvider discoveryURL={testService}>
+          <ConfigurationProvider>{children}</ConfigurationProvider>
+        </UIListProvider>
+      </QueryClientProvider>
+    );
+  };
+
+  it('should retrieve a single federated route', async () => {
+    const { result } = renderHook(() => useFederatedRoutes(), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current).toStrictEqual([
+        {
+          app: {
+            appHistoryBasePath: '',
+            kind: 'test-ui',
+            name: 'test.local',
+            url: 'http://test.local.test',
+            version: '1.0.0',
+          },
+          kind: 'test-ui',
+          view: {
+            exact: true,
+            label: {
+              en: 'Overview',
+              fr: 'Vue générale',
+            },
+            module: './FederableApp',
+            path: '/',
+            scope: 'artesca',
+          },
+        },
+      ]);
+    });
+  });
+
+  it('should retrieve federated routes with same kind', async () => {
+    const configs = {
+      'http://test.local.test/.well-known/micro-app-configuration':
+        createMockBuildConfig('test-ui', {
+          overview: {
+            path: '/',
+            exact: true,
+            label: {
+              en: 'Overview',
+              fr: 'Vue générale',
+            },
+            module: './FederableApp',
+            scope: 'artesca',
+          },
+        }),
+      'http://test.local.test/.well-known/runtime-app-configuration':
+        createRuntimeAppConfig('test-ui', 'test.local'),
+      'http://addon-v1.local.test/.well-known/micro-app-configuration':
+        createMockBuildConfig('addon-ui', {
+          addon1: {
+            path: '/addon-v1',
+            exact: true,
+            label: {
+              en: 'Addon v1',
+              fr: 'Addon v1',
+            },
+            module: './AddonApp',
+            scope: 'addon1',
+          },
+        }),
+      'http://addon-v1.local.test/.well-known/runtime-app-configuration':
+        createRuntimeAppConfig('addon-ui', 'addon-v1.local'),
+      'http://addon-v2.local.test/.well-known/micro-app-configuration':
+        createMockBuildConfig('addon-ui', {
+          addon2: {
+            path: '/addon-v2',
+            exact: true,
+            label: {
+              en: 'Addon v2',
+              fr: 'Addon v2',
+            },
+            module: './AddonApp',
+            scope: 'addon2',
+          },
+        }),
+      'http://addon-v2.local.test/.well-known/runtime-app-configuration':
+        createRuntimeAppConfig('addon-ui', 'addon-v2.local'),
+      'http://external-hook.local.test/.well-known/micro-app-configuration':
+        createMockBuildConfig('external-hook-ui', {
+          externalHook: {
+            path: '/external-hook',
+            exact: true,
+            label: {
+              en: 'External hook',
+              fr: 'External hook',
+            },
+            module: './ExternalHookApp',
+            scope: 'external-hook',
+          },
+        }),
+      'http://external-hook.local.test/.well-known/runtime-app-configuration':
+        createRuntimeAppConfig('external-hook-ui', 'external-hook.local'),
+    };
+    server.use(
+      rest.get(`${testService}`, (req, res, ctx) => {
+        return res(ctx.json(allDeployedUIs));
+      }),
+      ...Object.entries(configs).map(([url, config]) =>
+        rest.get(url, (req, res, ctx) => {
+          return res(ctx.json(config));
+        }),
+      ),
+    );
+
+    const { result } = renderHook(() => useFederatedRoutes(), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current).toStrictEqual([
+        {
+          app: {
+            appHistoryBasePath: '',
+            kind: 'test-ui',
+            name: 'test.local',
+            url: 'http://test.local.test',
+            version: '1.0.0',
+          },
+          kind: 'test-ui',
+          view: {
+            exact: true,
+            label: {
+              en: 'Overview',
+              fr: 'Vue générale',
+            },
+            module: './FederableApp',
+            path: '/',
+            scope: 'artesca',
+          },
+        },
+        {
+          app: {
+            appHistoryBasePath: '/addon-v1',
+            kind: 'addon-ui',
+            name: 'addon-v1.local',
+            url: 'http://addon-v1.local.test',
+            version: '1.0.0',
+          },
+          kind: 'addon-ui',
+          view: {
+            exact: true,
+            label: {
+              en: 'Addon v1',
+              fr: 'Addon v1',
+            },
+            module: './AddonApp',
+            path: '/addon-v1',
+            scope: 'addon1',
+          },
+        },
+        {
+          app: {
+            appHistoryBasePath: '/addon-v2',
+            kind: 'addon-ui',
+            name: 'addon-v2.local',
+            url: 'http://addon-v2.local.test',
+            version: '2.0.0',
+          },
+          kind: 'addon-ui',
+          view: {
+            exact: true,
+            label: {
+              en: 'Addon v2',
+              fr: 'Addon v2',
+            },
+            module: './AddonApp',
+            path: '/addon-v2',
+            scope: 'addon2',
+          },
+        },
+        {
+          app: {
+            appHistoryBasePath: '/external-hook',
+            kind: 'external-hook-ui',
+            name: 'external-hook.local',
+            url: 'http://external-hook.local.test',
+            version: '1.0.0',
+          },
+          kind: 'external-hook-ui',
+          view: {
+            exact: true,
+            label: {
+              en: 'External hook',
+              fr: 'External hook',
+            },
+            module: './ExternalHookApp',
+            path: '/external-hook',
+            scope: 'external-hook',
+          },
+        },
+      ]);
+    });
+  });
+
+  it('should failed when the kind of the app does not match the kind of the webFinger', async () => {
+    server.use(
+      rest.get(`${testService}`, (req, res, ctx) => {
+        return res(ctx.json(singleDeployedUI));
+      }),
+      rest.get(
+        `http://test.local.test/.well-known/micro-app-configuration`,
+        (req, res, ctx) => {
+          return res(ctx.json(createMockBuildConfig('test-ui', {})));
+        },
+      ),
+      rest.get(
+        `http://test.local.test/.well-known/runtime-app-configuration`,
+        (req, res, ctx) => {
+          return res(
+            ctx.json(
+              createRuntimeAppConfig('wrong-kind-test-ui', 'test.local'),
+            ),
+          );
+        },
+      ),
+    );
+
+    const { result } = renderHook(() => useFederatedRoutes(), {
+      wrapper,
+    });
+    await waitFor(() => {
+      expect(result.current).toStrictEqual([]);
+    });
+  });
+});

--- a/shell-ui/src/initFederation/ConfigurationProviders.tsx
+++ b/shell-ui/src/initFederation/ConfigurationProviders.tsx
@@ -353,6 +353,14 @@ export function useFederatedRoutes(): FederatedRoute[] {
   const { retrieveDeployedApps } = useDeployedAppsRetriever();
   const deployedApps = retrieveDeployedApps();
 
+  deployedApps.forEach((app) => {
+    if (app.appHistoryBasePath.endsWith('/')) {
+      throw new Error(
+        `appHistoryBasePath of app ${app.name} ends with a /, this is not allowed`,
+      );
+    }
+  });
+
   const federatedRoutes = deployedApps.flatMap((app) => {
     const appBuildConfig = retrieveConfiguration<'build'>({
       configType: 'build',

--- a/shell-ui/src/initFederation/ConfigurationProviders.tsx
+++ b/shell-ui/src/initFederation/ConfigurationProviders.tsx
@@ -64,11 +64,21 @@ export type BuildtimeWebFinger = {
     instanceNameAdapter?: FederatedModuleInfo;
   };
 };
+
+export type EnrichedBuildtimeWebFinger = BuildtimeWebFinger & {
+  metadata: {
+    // This information is not present in the original webFinger, it's filled by the ConfigurationProvider
+    url: string;
+  };
+};
 export function useConfigRetriever(): {
   retrieveConfiguration: <T extends 'build' | Record<string, unknown>>(arg0: {
     configType: T extends 'build' ? 'build' : 'run';
     name: string;
-  }) => (T extends 'build' ? BuildtimeWebFinger : RuntimeWebFinger<T>) | null;
+    url?: string;
+  }) =>
+    | (T extends 'build' ? EnrichedBuildtimeWebFinger : RuntimeWebFinger<T>)
+    | null;
 } {
   const { state: webFingerContextValue } = useWebFingersStore();
   const { retrieveDeployedApps } = useDeployedAppsRetriever();
@@ -81,7 +91,7 @@ export function useConfigRetriever(): {
 
   return {
     // @ts-expect-error - impossible to type
-    retrieveConfiguration: ({ configType, name }) => {
+    retrieveConfiguration: ({ configType, name, url }) => {
       if (configType !== 'build' && configType !== 'run') {
         throw new Error(
           `Invalid configType : it should be build or run but received ${configType}`,
@@ -108,13 +118,24 @@ export function useConfigRetriever(): {
         })
         .map((webFinger) => webFinger.data);
       ///TODO validate web fingers against JsonSchemas
-      const config = configs.find(
-        (webFinger) =>
-          (webFinger.kind === 'MicroAppRuntimeConfiguration' &&
-            webFinger.metadata.name === name) ||
-          (webFinger.kind === 'MicroAppConfiguration' &&
-            webFinger.metadata.kind === apps[0].kind),
-      );
+      const config = configs.find((webFinger) => {
+        if (
+          webFinger.kind === 'MicroAppRuntimeConfiguration' &&
+          webFinger.metadata.name === name
+        ) {
+          return true;
+        }
+        if (
+          webFinger.kind === 'MicroAppConfiguration' &&
+          webFinger.metadata.kind === apps[0].kind
+        ) {
+          if (url) {
+            return webFinger.metadata.url === url;
+          }
+          return true;
+        }
+        return false;
+      });
 
       if (!config) {
         const listOfKnownConfigurations = JSON.stringify(configs, null, 2);
@@ -145,7 +166,9 @@ export function useConfig<T extends 'build' | Record<string, unknown>>({
 }: {
   configType: T extends 'build' ? 'build' : 'run';
   name: string;
-}): null | T extends 'build' ? BuildtimeWebFinger : RuntimeWebFinger<T> {
+}): null | T extends 'build'
+  ? EnrichedBuildtimeWebFinger
+  : RuntimeWebFinger<T> {
   // Utiliser le nouveau hook useWebFingersStore
   const { state: webFingerContextValue } = useWebFingersStore();
 
@@ -191,7 +214,7 @@ export type ViewDefinition = FederatedView | NonFederatedView;
 class WebFingersStore {
   private listeners: Set<() => void> = new Set();
   private _state: UseQueryResult<
-    BuildtimeWebFinger | RuntimeWebFinger<Record<string, unknown>>,
+    EnrichedBuildtimeWebFinger | RuntimeWebFinger<Record<string, unknown>>,
     unknown
   >[] = [];
 
@@ -208,11 +231,11 @@ class WebFingersStore {
 
   private isStateEqual(
     currentState: UseQueryResult<
-      BuildtimeWebFinger | RuntimeWebFinger<Record<string, unknown>>,
+      EnrichedBuildtimeWebFinger | RuntimeWebFinger<Record<string, unknown>>,
       unknown
     >[],
     newState: UseQueryResult<
-      BuildtimeWebFinger | RuntimeWebFinger<Record<string, unknown>>,
+      EnrichedBuildtimeWebFinger | RuntimeWebFinger<Record<string, unknown>>,
       unknown
     >[],
   ) {
@@ -227,7 +250,7 @@ class WebFingersStore {
 
   updateState = (
     newState: UseQueryResult<
-      BuildtimeWebFinger | RuntimeWebFinger<Record<string, unknown>>,
+      EnrichedBuildtimeWebFinger | RuntimeWebFinger<Record<string, unknown>>,
       unknown
     >[],
   ) => {
@@ -256,7 +279,7 @@ export function useDiscoveredViews(): ViewDefinition[] {
   const { retrieveConfiguration } = useConfigRetriever();
   const { retrieveDeployedApps } = useDeployedAppsRetriever();
   const { config: shellConfig } = useShellConfig();
-  const deployedApps = retrieveDeployedApps();
+
   const discoveredViews = [
     ...shellConfig.navbar.main.map((entry) => ({
       ...entry,
@@ -318,9 +341,44 @@ export function useDiscoveredViews(): ViewDefinition[] {
 
     return [];
   }) as ViewDefinition[];
-
   return discoveredViews;
 }
+
+type FederatedRoute = {
+  app: SolutionUI;
+  view: View;
+};
+export function useFederatedRoutes(): FederatedRoute[] {
+  const { retrieveConfiguration } = useConfigRetriever();
+  const { retrieveDeployedApps } = useDeployedAppsRetriever();
+  const deployedApps = retrieveDeployedApps();
+
+  const federatedRoutes = deployedApps.flatMap((app) => {
+    const appBuildConfig = retrieveConfiguration<'build'>({
+      configType: 'build',
+      name: app.name,
+      url: app.url,
+    });
+
+    if (!appBuildConfig) {
+      return [];
+    }
+
+    const routesFromSingleApp = Object.entries(appBuildConfig.spec.views).map(
+      ([view]) => {
+        return {
+          kind: app.kind,
+          view: appBuildConfig.spec.views[view],
+          app,
+        };
+      },
+    );
+    return routesFromSingleApp;
+  });
+
+  return federatedRoutes;
+}
+
 export const useLinkOpener = () => {
   const navigate = useShellHistory();
   return {
@@ -361,6 +419,7 @@ export const ConfigurationProvider = ({
 }) => {
   const { updateWebFingersState } = useWebFingersStore();
   const deployedUIs = useDeployedApps();
+
   const results = useQueries(
     deployedUIs.flatMap((ui) => [
       {
@@ -369,9 +428,29 @@ export const ConfigurationProvider = ({
         queryFn: () => {
           return fetch(
             `${ui.url}/.well-known/micro-app-configuration?version=${ui.version}`,
-          ).then((r) => {
+          ).then(async (r) => {
             if (r.ok) {
-              return r.json() as Promise<BuildtimeWebFinger>;
+              const json: BuildtimeWebFinger = await r.json();
+
+              // @ts-expect-error - At this point, the url is not defined, but the user may define it by error
+              // so we are going to check and warn the user if needed.
+              const shouldNotBeDefinedUrl = json.metadata.url;
+
+              if (shouldNotBeDefinedUrl != null) {
+                console.warn(
+                  `MicroApp's MicroAppConfiguration url is already set to ${shouldNotBeDefinedUrl}.
+                  This information will be overridden by the value discovered in discoveryUrl.`,
+                );
+              }
+
+              const enrichedJson: EnrichedBuildtimeWebFinger = {
+                ...json,
+                metadata: {
+                  ...json.metadata,
+                  url: ui.url,
+                },
+              };
+              return enrichedJson;
             } else {
               return Promise.reject();
             }
@@ -403,6 +482,7 @@ export const ConfigurationProvider = ({
   }, [results]);
 
   const statuses = Array.from(new Set(results.map((result) => result.status)));
+
   const globalStatus = statuses.includes('error')
     ? 'error'
     : statuses.includes('loading')

--- a/shell-ui/src/initFederation/ConfigurationProviders.tsx
+++ b/shell-ui/src/initFederation/ConfigurationProviders.tsx
@@ -353,36 +353,38 @@ export function useFederatedRoutes(): FederatedRoute[] {
   const { retrieveDeployedApps } = useDeployedAppsRetriever();
   const deployedApps = retrieveDeployedApps();
 
-  deployedApps.forEach((app) => {
-    if (app.appHistoryBasePath.endsWith('/')) {
-      throw new Error(
-        `appHistoryBasePath of app ${app.name} ends with a /, this is not allowed`,
+  const federatedRoutes = React.useMemo(() => {
+    return deployedApps.flatMap((app) => {
+      // Validate base path once per app during iteration
+      if (app.appHistoryBasePath.endsWith('/')) {
+        throw new Error(
+          `appHistoryBasePath of app ${app.name} ends with a /, this is not allowed`,
+        );
+      }
+
+      const appBuildConfig = retrieveConfiguration<'build'>({
+        configType: 'build',
+        name: app.name,
+        url: app.url,
+      });
+
+      if (!appBuildConfig) {
+        return [];
+      }
+
+      const routesFromSingleApp = Object.entries(appBuildConfig.spec.views).map(
+        ([view]) => {
+          return {
+            kind: app.kind,
+            view: appBuildConfig.spec.views[view],
+            app,
+          };
+        },
       );
-    }
-  });
 
-  const federatedRoutes = deployedApps.flatMap((app) => {
-    const appBuildConfig = retrieveConfiguration<'build'>({
-      configType: 'build',
-      name: app.name,
-      url: app.url,
+      return routesFromSingleApp;
     });
-
-    if (!appBuildConfig) {
-      return [];
-    }
-
-    const routesFromSingleApp = Object.entries(appBuildConfig.spec.views).map(
-      ([view]) => {
-        return {
-          kind: app.kind,
-          view: appBuildConfig.spec.views[view],
-          app,
-        };
-      },
-    );
-    return routesFromSingleApp;
-  });
+  }, [deployedApps, retrieveConfiguration]);
 
   return federatedRoutes;
 }

--- a/shell-ui/tsconfig.json
+++ b/shell-ui/tsconfig.json
@@ -4,10 +4,10 @@
 
     /* Basic Options */
     // "incremental": true,                         /* Enable incremental compilation */
-    "target": "ES2021" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "target": "ES2023" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     "lib": [
-      "es2021",
+      "es2023",
       "DOM",
       "dom.iterable"
     ] /* Specify library files to be included in the compilation. */,


### PR DESCRIPTION
**Context**: 

The goal of this PR is to prepare the ability to load several versions of the same micro app and be able to load micro app from a micro app.
To achieve that, we need to  : 
- Be able to rely only on the discoveryUrl to render the Route instead of mixing it with the value of the config.json.
- Rework the way we render the micro app's `Routes`
 (see: `InternalRouter` in `shell-ui/src/FederatedApp.tsx`)

In the previous implementation we use `useDiscoveredViews` to render the Routes and render the navbar entries.
This was convenient because we reuse the hooks for the rendering the `Navbar` (see: `useFederatedNavbarEntries`) and rendering the routes (DRY) but also cause some unnecessary coupling.
The route need to be exposed in the navbar in order to be accessible in the UI.

In a close futur, we want to be able to render some FederatedComponent without it to be exposed in the navbar.
For example, we might want to switch micro app with a selector instead of click on the navbar.

Here are some notable change made : 
- we keep `useDiscoveredViews` for the navbar entries
- we create `useFederatedRoutes` to compute the federatedRoutes
- we add the url from where the micro app has been fetch in the metadata (cf: `EnrichedBuildtimeWebFinger`)in order to be able to find the right micro app config since we can now have several time the same app.

Those changes simplify a lot the `FederatedApp.tsx` however we lost the capability to render only `Routes` which the user have access because this information is only present on the config.json. It means that we rely on the API to filter what the user can or not do (it's already the case). The Navbar will still render only the correct entries though.

I've also add a checking to warn the user when `appHistoryBasePath` is not correct.