### PR TITLE
MK8S-25: Disable HTTP directory listing for RPM repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 
 ### Bug Fixes
 
+- Disable HTTP directory listing for RPM repository to improve security
+  (PR[#4651](https://github.com/scality/metalk8s/pull/4651))
+
 - Fix a Bug where NodeSystemSaturation alert triggers too early after only 15 minutes of high load
   (PR[#4641](https://github.com/scality/metalk8s/pull/4641))
 

--- a/salt/metalk8s/repo/configured.sls
+++ b/salt/metalk8s/repo/configured.sls
@@ -15,6 +15,7 @@ Generate repositories nginx configuration:
     - defaults:
         listening_address: {{ grains.metalk8s.control_plane_ip }}
         listening_port: {{ repo.port }}
+        archives: {{ archives }}
 
 Deploy common container registry nginx configuration:
   file.managed:

--- a/salt/metalk8s/repo/files/nginx.conf.j2
+++ b/salt/metalk8s/repo/files/nginx.conf.j2
@@ -2,9 +2,24 @@ server {
     listen       {{ listening_address }}:{{ listening_port }};
     server_name  localhost;
 
+    # Return 200 OK for root path health checks
+    location = / {
+        return 200 '';
+        add_header Content-Type text/plain;
+    }
+
+    # Return 200 OK for saltenv path health checks
+    {%- for env in archives.keys() %}
+    location = /{{ env }}/ {
+        return 200 '';
+        add_header Content-Type text/plain;
+    }
+    {%- endfor %}
+
     location / {
         root   /var/www/repositories;
-        autoindex on;
+        # Security fix: Disable directory listing to prevent exposing repository structure
+        autoindex off;
     }
 
     include conf.d/*.inc;

--- a/salt/tests/unit/formulas/config.yaml
+++ b/salt/tests/unit/formulas/config.yaml
@@ -882,6 +882,7 @@ metalk8s:
             extra_context:
               listening_address: "10.0.0.1"
               listening_port: 8080
+              archives: *example_archives
 
       repositories-manifest.yaml.j2:
         _cases:


### PR DESCRIPTION
Security fix to prevent exposing repository structure on port 8080. Changed autoindex from on to off in nginx configuration.

Related: RD-680
