### PR TITLE
Refactor chart components to utilize LineTimeSerieChart

### DIFF
--- a/shell-ui/package-lock.json
+++ b/shell-ui/package-lock.json
@@ -8,7 +8,7 @@
       "name": "shell-ui",
       "version": "1.0.0",
       "dependencies": {
-        "@scality/core-ui": "github:scality/core-ui#improvement/dynamic-chart-legend",
+        "@scality/core-ui": "0.171.0",
         "@scality/module-federation": "^1.4.1",
         "downshift": "^8.0.0",
         "history": "^5.3.0",

--- a/shell-ui/package-lock.json
+++ b/shell-ui/package-lock.json
@@ -8,7 +8,7 @@
       "name": "shell-ui",
       "version": "1.0.0",
       "dependencies": {
-        "@scality/core-ui": "0.167.0",
+        "@scality/core-ui": "github:scality/core-ui#improvement/dynamic-chart-legend",
         "@scality/module-federation": "^1.4.1",
         "downshift": "^8.0.0",
         "history": "^5.3.0",
@@ -2106,42 +2106,46 @@
       "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
-      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.9"
+        "@floating-ui/utils": "^0.2.10"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
-      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.9"
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
       }
     },
     "node_modules/@floating-ui/react": {
-      "version": "0.26.28",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
-      "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
+      "version": "0.27.16",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.16.tgz",
+      "integrity": "sha512-9O8N4SeG2z++TSM8QA/KTeKFBVCNEz/AGS7gWPJf6KFRzmRWixFRnCnkPHRDwSVZW6QPDO6uT0P2SpWNKCc9/g==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/react-dom": "^2.1.2",
-        "@floating-ui/utils": "^0.2.8",
+        "@floating-ui/react-dom": "^2.1.6",
+        "@floating-ui/utils": "^0.2.10",
         "tabbable": "^6.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
-      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
+      "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.0.0"
+        "@floating-ui/dom": "^1.7.4"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -2149,9 +2153,10 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
-      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
     },
     "node_modules/@formatjs/ecma402-abstract": {
       "version": "1.11.4",
@@ -4203,13 +4208,12 @@
       }
     },
     "node_modules/@scality/core-ui": {
-      "version": "0.167.0",
-      "resolved": "https://registry.npmjs.org/@scality/core-ui/-/core-ui-0.167.0.tgz",
-      "integrity": "sha512-kbRkp68yQaZgQEE2Y5AyJayWzoSWfu8A4WIcteBeXaKrGjHYoIyZs079azp7SHM1f8C921O7M4uoQrAeuaTDPQ==",
+      "version": "0.171.0",
+      "resolved": "git+ssh://git@github.com/scality/core-ui.git#0215c8ce0cd1a7de73ad2d78b44b020a8fbaf617",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@floating-ui/dom": "^1.6.3",
-        "@floating-ui/react": "^0.26.28",
+        "@floating-ui/react": "^0.27.15",
         "@fortawesome/fontawesome-free": "^5.10.2",
         "@fortawesome/fontawesome-svg-core": "^1.2.35",
         "@fortawesome/free-regular-svg-icons": "^5.15.3",
@@ -4221,7 +4225,7 @@
         "polished": "3.4.1",
         "pretty-bytes": "^5.6.0",
         "react-dropzone": "^14.2.3",
-        "react-hook-form": "^7.49.2",
+        "react-hook-form": "^7.62.0",
         "react-query": "^3.34.0",
         "react-router": "7.8.1",
         "react-router-dom": "7.8.1",
@@ -4233,6 +4237,7 @@
         "recharts": "^3.0.2",
         "styled-components": "^5.2.1",
         "styled-system": "^5.1.5",
+        "uuid": "^13.0.0",
         "vega": "^5.17.3",
         "vega-embed": "6.0.0",
         "vega-lite": "5.0.0",
@@ -4267,6 +4272,19 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "node_modules/@scality/core-ui/node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
     },
     "node_modules/@scality/module-federation": {
       "version": "1.4.1",
@@ -14722,9 +14740,10 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.53.2",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.53.2.tgz",
-      "integrity": "sha512-YVel6fW5sOeedd1524pltpHX+jgU2u3DSDtXEaBORNdqiNrsX/nUI/iGXONegttg0mJVnfrIkiV0cmTU6Oo2xw==",
+      "version": "7.62.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
+      "integrity": "sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
@@ -16760,7 +16779,8 @@
     "node_modules/tabbable": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.2.1",

--- a/shell-ui/package.json
+++ b/shell-ui/package.json
@@ -45,7 +45,7 @@
     "ts-node": "^10.9.2"
   },
   "dependencies": {
-    "@scality/core-ui": "0.167.0",
+    "@scality/core-ui": "github:scality/core-ui#improvement/dynamic-chart-legend",
     "@scality/module-federation": "^1.4.1",
     "downshift": "^8.0.0",
     "history": "^5.3.0",

--- a/shell-ui/package.json
+++ b/shell-ui/package.json
@@ -45,7 +45,7 @@
     "ts-node": "^10.9.2"
   },
   "dependencies": {
-    "@scality/core-ui": "github:scality/core-ui#improvement/dynamic-chart-legend",
+    "@scality/core-ui": "0.171.0",
     "@scality/module-federation": "^1.4.1",
     "downshift": "^8.0.0",
     "history": "^5.3.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -12,7 +12,7 @@
         "@hookform/resolvers": "^3.1.0",
         "@js-temporal/polyfill": "^0.4.4",
         "@kubernetes/client-node": "github:scality/kubernetes-client-javascript.git#browser-0.10.4-64-ge7c6721",
-        "@scality/core-ui": "0.167.0",
+        "@scality/core-ui": "github:scality/core-ui#improvement/dynamic-chart-legend",
         "@scality/module-federation": "^1.4.1",
         "axios": "^0.21.1",
         "formik": "2.2.5",
@@ -2563,42 +2563,46 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
-      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.9"
+        "@floating-ui/utils": "^0.2.10"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
-      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.9"
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
       }
     },
     "node_modules/@floating-ui/react": {
-      "version": "0.26.28",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
-      "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
+      "version": "0.27.16",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.16.tgz",
+      "integrity": "sha512-9O8N4SeG2z++TSM8QA/KTeKFBVCNEz/AGS7gWPJf6KFRzmRWixFRnCnkPHRDwSVZW6QPDO6uT0P2SpWNKCc9/g==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/react-dom": "^2.1.2",
-        "@floating-ui/utils": "^0.2.8",
+        "@floating-ui/react-dom": "^2.1.6",
+        "@floating-ui/utils": "^0.2.10",
         "tabbable": "^6.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
-      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
+      "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.0.0"
+        "@floating-ui/dom": "^1.7.4"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -2606,9 +2610,10 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
-      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
     },
     "node_modules/@formatjs/ecma402-abstract": {
       "version": "1.9.3",
@@ -5334,13 +5339,12 @@
       "dev": true
     },
     "node_modules/@scality/core-ui": {
-      "version": "0.167.0",
-      "resolved": "https://registry.npmjs.org/@scality/core-ui/-/core-ui-0.167.0.tgz",
-      "integrity": "sha512-kbRkp68yQaZgQEE2Y5AyJayWzoSWfu8A4WIcteBeXaKrGjHYoIyZs079azp7SHM1f8C921O7M4uoQrAeuaTDPQ==",
+      "version": "0.171.0",
+      "resolved": "git+ssh://git@github.com/scality/core-ui.git#0215c8ce0cd1a7de73ad2d78b44b020a8fbaf617",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@floating-ui/dom": "^1.6.3",
-        "@floating-ui/react": "^0.26.28",
+        "@floating-ui/react": "^0.27.15",
         "@fortawesome/fontawesome-free": "^5.10.2",
         "@fortawesome/fontawesome-svg-core": "^1.2.35",
         "@fortawesome/free-regular-svg-icons": "^5.15.3",
@@ -5352,7 +5356,7 @@
         "polished": "3.4.1",
         "pretty-bytes": "^5.6.0",
         "react-dropzone": "^14.2.3",
-        "react-hook-form": "^7.49.2",
+        "react-hook-form": "^7.62.0",
         "react-query": "^3.34.0",
         "react-router": "7.8.1",
         "react-router-dom": "7.8.1",
@@ -5364,6 +5368,7 @@
         "recharts": "^3.0.2",
         "styled-components": "^5.2.1",
         "styled-system": "^5.1.5",
+        "uuid": "^13.0.0",
         "vega": "^5.17.3",
         "vega-embed": "6.0.0",
         "vega-lite": "5.0.0",
@@ -5372,6 +5377,19 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@scality/core-ui/node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/@scality/module-federation": {
@@ -22203,19 +22221,19 @@
       "license": "MIT"
     },
     "node_modules/react-hook-form": {
-      "version": "7.49.3",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.49.3.tgz",
-      "integrity": "sha512-foD6r3juidAT1cOZzpmD/gOKt7fRsDhXXZ0y28+Al1CHgX+AY1qIN9VSIIItXRq1dN68QrRwl1ORFlwjBaAqeQ==",
+      "version": "7.62.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
+      "integrity": "sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==",
+      "license": "MIT",
       "engines": {
-        "node": ">=18",
-        "pnpm": "8"
+        "node": ">=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/react-hook-form"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17 || ^18"
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-input-autosize": {
@@ -24704,7 +24722,8 @@
     "node_modules/tabbable": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "license": "MIT"
     },
     "node_modules/table": {
       "version": "6.7.1",
@@ -29088,44 +29107,44 @@
       }
     },
     "@floating-ui/core": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
-      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
       "requires": {
-        "@floating-ui/utils": "^0.2.9"
+        "@floating-ui/utils": "^0.2.10"
       }
     },
     "@floating-ui/dom": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
-      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
       "requires": {
-        "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.9"
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
       }
     },
     "@floating-ui/react": {
-      "version": "0.26.28",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
-      "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
+      "version": "0.27.16",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.16.tgz",
+      "integrity": "sha512-9O8N4SeG2z++TSM8QA/KTeKFBVCNEz/AGS7gWPJf6KFRzmRWixFRnCnkPHRDwSVZW6QPDO6uT0P2SpWNKCc9/g==",
       "requires": {
-        "@floating-ui/react-dom": "^2.1.2",
-        "@floating-ui/utils": "^0.2.8",
+        "@floating-ui/react-dom": "^2.1.6",
+        "@floating-ui/utils": "^0.2.10",
         "tabbable": "^6.0.0"
       }
     },
     "@floating-ui/react-dom": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
-      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
+      "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
       "requires": {
-        "@floating-ui/dom": "^1.0.0"
+        "@floating-ui/dom": "^1.7.4"
       }
     },
     "@floating-ui/utils": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
-      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="
     },
     "@formatjs/ecma402-abstract": {
       "version": "1.9.3",
@@ -31265,12 +31284,11 @@
       "dev": true
     },
     "@scality/core-ui": {
-      "version": "0.167.0",
-      "resolved": "https://registry.npmjs.org/@scality/core-ui/-/core-ui-0.167.0.tgz",
-      "integrity": "sha512-kbRkp68yQaZgQEE2Y5AyJayWzoSWfu8A4WIcteBeXaKrGjHYoIyZs079azp7SHM1f8C921O7M4uoQrAeuaTDPQ==",
+      "version": "git+ssh://git@github.com/scality/core-ui.git#0215c8ce0cd1a7de73ad2d78b44b020a8fbaf617",
+      "from": "@scality/core-ui@github:scality/core-ui#improvement/dynamic-chart-legend",
       "requires": {
         "@floating-ui/dom": "^1.6.3",
-        "@floating-ui/react": "^0.26.28",
+        "@floating-ui/react": "^0.27.15",
         "@fortawesome/fontawesome-free": "^5.10.2",
         "@fortawesome/fontawesome-svg-core": "^1.2.35",
         "@fortawesome/free-regular-svg-icons": "^5.15.3",
@@ -31282,7 +31300,7 @@
         "polished": "3.4.1",
         "pretty-bytes": "^5.6.0",
         "react-dropzone": "^14.2.3",
-        "react-hook-form": "^7.49.2",
+        "react-hook-form": "^7.62.0",
         "react-query": "^3.34.0",
         "react-router": "7.8.1",
         "react-router-dom": "7.8.1",
@@ -31294,10 +31312,18 @@
         "recharts": "^3.0.2",
         "styled-components": "^5.2.1",
         "styled-system": "^5.1.5",
+        "uuid": "^13.0.0",
         "vega": "^5.17.3",
         "vega-embed": "6.0.0",
         "vega-lite": "5.0.0",
         "vega-tooltip": "0.27.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+          "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="
+        }
       }
     },
     "@scality/module-federation": {
@@ -43742,9 +43768,9 @@
       "version": "2.0.4"
     },
     "react-hook-form": {
-      "version": "7.49.3",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.49.3.tgz",
-      "integrity": "sha512-foD6r3juidAT1cOZzpmD/gOKt7fRsDhXXZ0y28+Al1CHgX+AY1qIN9VSIIItXRq1dN68QrRwl1ORFlwjBaAqeQ=="
+      "version": "7.62.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
+      "integrity": "sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA=="
     },
     "react-input-autosize": {
       "version": "3.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -12,7 +12,7 @@
         "@hookform/resolvers": "^3.1.0",
         "@js-temporal/polyfill": "^0.4.4",
         "@kubernetes/client-node": "github:scality/kubernetes-client-javascript.git#browser-0.10.4-64-ge7c6721",
-        "@scality/core-ui": "github:scality/core-ui#improvement/dynamic-chart-legend",
+        "@scality/core-ui": "0.171.0",
         "@scality/module-federation": "^1.4.1",
         "axios": "^0.21.1",
         "formik": "2.2.5",
@@ -31285,7 +31285,7 @@
     },
     "@scality/core-ui": {
       "version": "git+ssh://git@github.com/scality/core-ui.git#0215c8ce0cd1a7de73ad2d78b44b020a8fbaf617",
-      "from": "@scality/core-ui@github:scality/core-ui#improvement/dynamic-chart-legend",
+      "from": "@scality/core-ui@0.171.0",
       "requires": {
         "@floating-ui/dom": "^1.6.3",
         "@floating-ui/react": "^0.27.15",

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,7 +7,7 @@
     "@hookform/resolvers": "^3.1.0",
     "@js-temporal/polyfill": "^0.4.4",
     "@kubernetes/client-node": "github:scality/kubernetes-client-javascript.git#browser-0.10.4-64-ge7c6721",
-    "@scality/core-ui": "0.167.0",
+    "@scality/core-ui": "github:scality/core-ui#improvement/dynamic-chart-legend",
     "@scality/module-federation": "^1.4.1",
     "axios": "^0.21.1",
     "formik": "2.2.5",
@@ -133,7 +133,7 @@
   },
   "jest": {
     "transformIgnorePatterns": [
-      "/node_modules/(?!(vega-lite|@scality)/)"
+      "/node_modules/(?!(vega-lite|@scality|uuid)/)"
     ],
     "testMatch": [
       "<rootDir>/src/**/__tests__/**/*.[jt]s?(x)",

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,7 +7,7 @@
     "@hookform/resolvers": "^3.1.0",
     "@js-temporal/polyfill": "^0.4.4",
     "@kubernetes/client-node": "github:scality/kubernetes-client-javascript.git#browser-0.10.4-64-ge7c6721",
-    "@scality/core-ui": "github:scality/core-ui#improvement/dynamic-chart-legend",
+    "@scality/core-ui": "0.171.0",
     "@scality/module-federation": "^1.4.1",
     "axios": "^0.21.1",
     "formik": "2.2.5",

--- a/ui/src/components/DashboardBandwidthChart.tsx
+++ b/ui/src/components/DashboardBandwidthChart.tsx
@@ -57,11 +57,9 @@ const DashboardBandwidthChartWithoutQuantile = ({
 
   const { isLoading, series, startingTimeStamp } = useSymetricalChartSeries({
     getAboveQueries: (timeSpanProps) => [
-      // @ts-expect-error - FIXME when you are working on it
       getNodesPlanesBandwidthInQuery(timeSpanProps, devices),
     ],
     getBelowQueries: (timeSpanProps) => [
-      // @ts-expect-error - FIXME when you are working on it
       getNodesPlanesBandwidthOutQuery(timeSpanProps, devices),
     ],
     // @ts-expect-error - FIXME when you are working on it

--- a/ui/src/components/DashboardBandwidthChart.tsx
+++ b/ui/src/components/DashboardBandwidthChart.tsx
@@ -1,19 +1,25 @@
-import React, { useEffect, useCallback } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { LineTemporalChart } from '@scality/core-ui/dist/next';
-import { UNIT_RANGE_BS } from '@scality/core-ui/dist/components/linetemporalchart/LineTemporalChart.component';
+import { Stack } from '@scality/core-ui';
 import {
-  getMultipleSymmetricalSeries,
-  getNodesInterfacesString,
-  renderTooltipSeperationLine,
-} from '../services/graphUtils';
+  ChartLegend,
+  ChartLegendWrapper,
+  LineTimeSerieChart,
+  useMetricsTimeSpan,
+} from '@scality/core-ui/dist/next';
+import { fontSize } from '@scality/core-ui/dist/style/theme';
+import { useCallback, useEffect, useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { fetchNodesAction } from '../ducks/app/nodes';
 import {
   useNodeAddressesSelector,
+  useNodeColors,
   useNodes,
   useShowQuantileChart,
   useSymetricalChartSeries,
 } from '../hooks';
+import {
+  getMultipleSymmetricalSeries,
+  getNodesInterfacesString,
+} from '../services/graphUtils';
 import {
   getNodesPlanesBandwidthInOutpassingThresholdQuery,
   getNodesPlanesBandwidthInQuantileQuery,
@@ -23,8 +29,7 @@ import {
   getNodesPlanesBandwidthOutQuery,
 } from '../services/platformlibrary/metrics';
 import SymmetricalQuantileChart from './SymmetricalQuantileChart';
-import { defaultRenderTooltipSerie } from '@scality/core-ui/dist/components/linetemporalchart/tooltip';
-import { useTheme } from 'styled-components';
+import { UNIT_RANGE_BS } from '../constants';
 
 const DashboardBandwidthChartWithoutQuantile = ({
   title,
@@ -33,23 +38,23 @@ const DashboardBandwidthChartWithoutQuantile = ({
   title: string;
   plane: 'controlPlane' | 'workloadPlane';
 }) => {
-  const theme = useTheme();
   const nodes = useNodes();
   const nodeAddresses = useNodeAddressesSelector(nodes);
   // @ts-expect-error - FIXME when you are working on it
   const nodeIPsInfo = useSelector((state) => state.app.nodes.IPsInfo);
   const devices = getNodesInterfacesString(nodeIPsInfo);
-  const nodesPlaneInterface = {};
+  const nodesPlaneInterface = useMemo(() => {
+    const nodesPlaneInterface = {};
+    for (const [key, value] of Object.entries(nodeIPsInfo)) {
+      nodesPlaneInterface[key] =
+        // @ts-expect-error - FIXME when you are working on it
+        plane === 'controlPlane' ? value.controlPlane : value.workloadPlane;
+    }
+    return nodesPlaneInterface;
+  }, [nodeIPsInfo, plane]);
 
-  for (const [key, value] of Object.entries(nodeIPsInfo)) {
-    nodesPlaneInterface[key] =
-      // @ts-expect-error - FIXME when you are working on it
-      plane === 'controlPlane' ? value.controlPlane : value.workloadPlane;
-  }
+  const { interval, duration } = useMetricsTimeSpan();
 
-  // will be used to draw the line speration lines
-  // @ts-expect-error - FIXME when you are working on it
-  const lastNodeName = nodes?.slice(-1)[0]?.metadata?.name;
   const { isLoading, series, startingTimeStamp } = useSymetricalChartSeries({
     getAboveQueries: (timeSpanProps) => [
       // @ts-expect-error - FIXME when you are working on it
@@ -59,13 +64,14 @@ const DashboardBandwidthChartWithoutQuantile = ({
       // @ts-expect-error - FIXME when you are working on it
       getNodesPlanesBandwidthOutQuery(timeSpanProps, devices),
     ],
+    // @ts-expect-error - FIXME when you are working on it
     transformPrometheusDataToSeries: useCallback(
       ([prometheusResultAbove], [prometheusResultBelow]) => {
         if (!prometheusResultAbove || !prometheusResultBelow) {
           return [];
         }
 
-        return getMultipleSymmetricalSeries(
+        const allSeries = getMultipleSymmetricalSeries(
           prometheusResultAbove,
           prometheusResultBelow,
           'in',
@@ -73,35 +79,49 @@ const DashboardBandwidthChartWithoutQuantile = ({
           nodeAddresses,
           nodesPlaneInterface,
         );
+
+        const aboveSeries = allSeries.filter(
+          (serie) => serie.metricPrefix === 'in',
+        );
+
+        const belowSeries = allSeries.filter(
+          (serie) => serie.metricPrefix === 'out',
+        );
+        return {
+          above: aboveSeries,
+          below: belowSeries,
+        };
       },
+
       [JSON.stringify(nodeAddresses), JSON.stringify(nodesPlaneInterface)],
     ),
   });
+  const colorSet = useNodeColors(nodes);
+
   return (
-    <LineTemporalChart
-      series={series}
-      height={150}
-      title={title}
-      startingTimeStamp={startingTimeStamp}
-      yAxisType={'symmetrical'}
-      yAxisTitle={'in(+) / out(-)'}
-      isLegendHidden={false}
-      // @ts-expect-error - FIXME when you are working on it
-      isLoading={isLoading}
-      unitRange={UNIT_RANGE_BS}
-      renderTooltipSerie={useCallback(
-        (serie) => {
-          if (serie.key === `${lastNodeName}-in`) {
-            return `${defaultRenderTooltipSerie(
-              serie,
-            )}${renderTooltipSeperationLine(theme.border)}`;
-          } else {
-            return defaultRenderTooltipSerie(serie);
-          }
-        },
-        [lastNodeName, theme],
-      )}
-    />
+    <ChartLegendWrapper colorSet={colorSet}>
+      <Stack direction="vertical" gap="r1" style={{ fontSize: fontSize.small }}>
+        <LineTimeSerieChart
+          series={{
+            above: series.above,
+
+            below: series.below,
+          }}
+          unitRange={UNIT_RANGE_BS}
+          height={150}
+          interval={interval}
+          duration={duration}
+          title={title}
+          startingTimeStamp={startingTimeStamp}
+          yAxisType={'symmetrical'}
+          yAxisTitle={'in(+) / out(-)'}
+          isLoading={isLoading}
+          syncId="dashboard"
+        />
+
+        <ChartLegend shape="line" legendSize={'Smaller'} />
+      </Stack>
+    </ChartLegendWrapper>
   );
 };
 

--- a/ui/src/components/DashboardBandwidthChart.tsx
+++ b/ui/src/components/DashboardBandwidthChart.tsx
@@ -29,7 +29,7 @@ import {
   getNodesPlanesBandwidthOutQuery,
 } from '../services/platformlibrary/metrics';
 import SymmetricalQuantileChart from './SymmetricalQuantileChart';
-import { UNIT_RANGE_BS } from '../constants';
+import { HEIGHT_SYMMETRICAL_CHART, UNIT_RANGE_BS } from '../constants';
 
 const DashboardBandwidthChartWithoutQuantile = ({
   title,
@@ -82,7 +82,7 @@ const DashboardBandwidthChartWithoutQuantile = ({
 
         return allSeries;
       },
-
+      // eslint-disable-next-line react-hooks/exhaustive-deps
       [JSON.stringify(nodeAddresses), JSON.stringify(nodesPlaneInterface)],
     ),
   });
@@ -98,7 +98,7 @@ const DashboardBandwidthChartWithoutQuantile = ({
             below: series.below,
           }}
           unitRange={UNIT_RANGE_BS}
-          height={150}
+          height={HEIGHT_SYMMETRICAL_CHART}
           interval={interval}
           duration={duration}
           title={title}
@@ -127,9 +127,10 @@ const DashboardBandwidthChart = ({
     dispatch(fetchNodesAction());
   }, [dispatch]);
   const { isShowQuantileChart } = useShowQuantileChart();
+
   return (
     <>
-      {!isShowQuantileChart ? (
+      {isShowQuantileChart ? (
         <SymmetricalQuantileChart
           getAboveQuantileQuery={getNodesPlanesBandwidthInQuantileQuery}
           getBelowQuantileQuery={getNodesPlanesBandwidthOutQuantileQuery}

--- a/ui/src/components/DashboardBandwidthChart.tsx
+++ b/ui/src/components/DashboardBandwidthChart.tsx
@@ -80,17 +80,7 @@ const DashboardBandwidthChartWithoutQuantile = ({
           nodesPlaneInterface,
         );
 
-        const aboveSeries = allSeries.filter(
-          (serie) => serie.metricPrefix === 'in',
-        );
-
-        const belowSeries = allSeries.filter(
-          (serie) => serie.metricPrefix === 'out',
-        );
-        return {
-          above: aboveSeries,
-          below: belowSeries,
-        };
+        return allSeries;
       },
 
       [JSON.stringify(nodeAddresses), JSON.stringify(nodesPlaneInterface)],
@@ -139,7 +129,7 @@ const DashboardBandwidthChart = ({
   const { isShowQuantileChart } = useShowQuantileChart();
   return (
     <>
-      {isShowQuantileChart ? (
+      {!isShowQuantileChart ? (
         <SymmetricalQuantileChart
           getAboveQuantileQuery={getNodesPlanesBandwidthInQuantileQuery}
           getBelowQuantileQuery={getNodesPlanesBandwidthOutQuantileQuery}

--- a/ui/src/components/DashboardChartCpuUsage.tsx
+++ b/ui/src/components/DashboardChartCpuUsage.tsx
@@ -1,5 +1,11 @@
-import React, { useCallback } from 'react';
-import { LineTemporalChart } from '@scality/core-ui/dist/next';
+import {
+  LineTimeSerieChart,
+  useMetricsTimeSpan,
+  useChartId,
+} from '@scality/core-ui/dist/next';
+import { useChartLegend } from '@scality/core-ui/dist/components/chartlegend/ChartLegendWrapper';
+
+import { useCallback, useEffect } from 'react';
 import { getMultiResourceSeriesForChart } from '../services/graphUtils';
 import {
   useNodeAddressesSelector,
@@ -35,25 +41,43 @@ const DashboardChartCpuUsage = () => {
 };
 
 const DashboardChartCpuUsageWithoutQuantils = () => {
-  const nodeAddresses = useNodeAddressesSelector(useNodes());
+  const chartId = useChartId();
+  const { register } = useChartLegend();
+  const nodes = useNodes();
+  const nodeAddresses = useNodeAddressesSelector(nodes);
+
+  const { interval, duration } = useMetricsTimeSpan();
   const { isLoading, series, startingTimeStamp } = useSingleChartSerie({
     // @ts-expect-error - FIXME when you are working on it
     getQuery: (timeSpanProps) => getNodesCPUUsageQuery(timeSpanProps),
     transformPrometheusDataToSeries: useCallback(
       (prometheusResult) =>
-        getMultiResourceSeriesForChart(prometheusResult, nodeAddresses), // eslint-disable-next-line react-hooks/exhaustive-deps
+        getMultiResourceSeriesForChart(prometheusResult, nodeAddresses),
+      //Expect warning because of complex dependency
+      // eslint-disable-next-line react-hooks/exhaustive-deps
       [JSON.stringify(nodeAddresses)],
     ),
   });
+
+  // Register series names with ChartLegendWrapper
+  useEffect(() => {
+    if (series && series.length > 0) {
+      const seriesNames = series.map((s) => s.resource);
+      register(chartId, seriesNames);
+    }
+  }, [chartId, register, series]);
+
   return (
-    <LineTemporalChart
+    <LineTimeSerieChart
       series={series}
-      height={80}
+      height={110}
+      interval={interval}
+      duration={duration}
       title="CPU Usage"
       startingTimeStamp={startingTimeStamp}
       yAxisType={'percentage'}
-      isLegendHidden={true}
       isLoading={isLoading}
+      syncId="dashboard"
     />
   );
 };

--- a/ui/src/components/DashboardChartCpuUsage.tsx
+++ b/ui/src/components/DashboardChartCpuUsage.tsx
@@ -47,7 +47,6 @@ const DashboardChartCpuUsageWithoutQuantils = () => {
 
   const { interval, duration } = useMetricsTimeSpan();
   const { isLoading, series, startingTimeStamp } = useSingleChartSerie({
-    // @ts-expect-error - FIXME when you are working on it
     getQuery: (timeSpanProps) => getNodesCPUUsageQuery(timeSpanProps),
     transformPrometheusDataToSeries: useCallback(
       (prometheusResult) =>

--- a/ui/src/components/DashboardChartCpuUsage.tsx
+++ b/ui/src/components/DashboardChartCpuUsage.tsx
@@ -3,9 +3,9 @@ import {
   useMetricsTimeSpan,
   useChartId,
 } from '@scality/core-ui/dist/next';
-import { useChartLegend } from '@scality/core-ui/dist/components/chartlegend/ChartLegendWrapper';
+import { useChartLegendRegistration } from '../hooks/useChartLegendRegistration';
 
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import { getMultiResourceSeriesForChart } from '../services/graphUtils';
 import {
   useNodeAddressesSelector,
@@ -41,7 +41,6 @@ const DashboardChartCpuUsage = () => {
 
 const DashboardChartCpuUsageWithoutQuantils = () => {
   const chartId = useChartId();
-  const { register } = useChartLegend();
   const nodes = useNodes();
   const nodeAddresses = useNodeAddressesSelector(nodes);
 
@@ -57,13 +56,7 @@ const DashboardChartCpuUsageWithoutQuantils = () => {
     ),
   });
 
-  // Register series names with ChartLegendWrapper
-  useEffect(() => {
-    if (series && series.length > 0) {
-      const seriesNames = series.map((s) => s.resource);
-      register(chartId, seriesNames);
-    }
-  }, [chartId, register, series]);
+  useChartLegendRegistration({ chartId, series, isSymmetrical: false });
 
   return (
     <LineTimeSerieChart

--- a/ui/src/components/DashboardChartCpuUsage.tsx
+++ b/ui/src/components/DashboardChartCpuUsage.tsx
@@ -19,6 +19,7 @@ import {
   getNodesCPUUsageQuery,
 } from '../services/platformlibrary/metrics';
 import NonSymmetricalQuantileChart from './NonSymmetricalQuantileChart';
+import { HEIGHT_DEFAULT_CHART } from '../constants';
 
 const DashboardChartCpuUsage = () => {
   const { isShowQuantileChart } = useShowQuantileChart();
@@ -68,7 +69,7 @@ const DashboardChartCpuUsageWithoutQuantils = () => {
   return (
     <LineTimeSerieChart
       series={series}
-      height={110}
+      height={HEIGHT_DEFAULT_CHART}
       interval={interval}
       duration={duration}
       title="CPU Usage"

--- a/ui/src/components/DashboardChartCpuUsage.tsx
+++ b/ui/src/components/DashboardChartCpuUsage.tsx
@@ -26,9 +26,7 @@ const DashboardChartCpuUsage = () => {
     <>
       {isShowQuantileChart ? (
         <NonSymmetricalQuantileChart
-          // @ts-expect-error - FIXME when you are working on it
           getQuantileQuery={getNodesCPUUsageQuantileQuery}
-          // @ts-expect-error - FIXME when you are working on it
           getQuantileHoverQuery={getNodesCPUUsageOutpassingThresholdQuery}
           title={'CPU Usage'}
           yAxisType={'percentage'}

--- a/ui/src/components/DashboardChartMemory.tsx
+++ b/ui/src/components/DashboardChartMemory.tsx
@@ -3,9 +3,8 @@ import {
   useMetricsTimeSpan,
   useChartId,
 } from '@scality/core-ui/dist/next';
-import { useChartLegend } from '@scality/core-ui/dist/components/chartlegend/ChartLegendWrapper';
-
-import { useCallback, useEffect } from 'react';
+import { useChartLegendRegistration } from '../hooks/useChartLegendRegistration';
+import { useCallback } from 'react';
 import {
   useNodes,
   useNodeAddressesSelector,
@@ -41,7 +40,6 @@ const DashboardChartMemory = () => {
 
 const DashboardChartMemoryWithoutQuantiles = () => {
   const chartId = useChartId();
-  const { register } = useChartLegend();
   const nodes = useNodes();
   const nodeAddresses = useNodeAddressesSelector(nodes);
 
@@ -62,13 +60,7 @@ const DashboardChartMemoryWithoutQuantiles = () => {
     ),
   });
 
-  // Register series names with ChartLegendWrapper
-  useEffect(() => {
-    if (series && series.length > 0) {
-      const seriesNames = series.map((s) => s.resource);
-      register(chartId, seriesNames);
-    }
-  }, [chartId, register, series]);
+  useChartLegendRegistration({ chartId, series, isSymmetrical: false });
 
   return (
     <LineTimeSerieChart

--- a/ui/src/components/DashboardChartMemory.tsx
+++ b/ui/src/components/DashboardChartMemory.tsx
@@ -26,9 +26,7 @@ const DashboardChartMemory = () => {
     <>
       {isShowQuantileChart ? (
         <NonSymmetricalQuantileChart
-          // @ts-expect-error - FIXME when you are working on it
           getQuantileQuery={getNodesMemoryQuantileQuery}
-          // @ts-expect-error - FIXME when you are working on it
           getQuantileHoverQuery={getNodesMemoryOutpassingThresholdQuery}
           title={'Memory'}
           yAxisType={'percentage'}

--- a/ui/src/components/DashboardChartMemory.tsx
+++ b/ui/src/components/DashboardChartMemory.tsx
@@ -1,5 +1,11 @@
-import React, { useCallback } from 'react';
-import { LineTemporalChart } from '@scality/core-ui/dist/next';
+import {
+  LineTimeSerieChart,
+  useMetricsTimeSpan,
+  useChartId,
+} from '@scality/core-ui/dist/next';
+import { useChartLegend } from '@scality/core-ui/dist/components/chartlegend/ChartLegendWrapper';
+
+import { useCallback, useEffect } from 'react';
 import {
   useNodes,
   useNodeAddressesSelector,
@@ -35,7 +41,12 @@ const DashboardChartMemory = () => {
 };
 
 const DashboardChartMemoryWithoutQuantiles = () => {
-  const nodeAddresses = useNodeAddressesSelector(useNodes());
+  const chartId = useChartId();
+  const { register } = useChartLegend();
+  const nodes = useNodes();
+  const nodeAddresses = useNodeAddressesSelector(nodes);
+
+  const { interval, duration } = useMetricsTimeSpan();
   const { isLoading, series, startingTimeStamp } = useSingleChartSerie({
     // @ts-expect-error - FIXME when you are working on it
     getQuery: (timeSpanProps) => getNodesMemoryQuery(timeSpanProps),
@@ -46,19 +57,32 @@ const DashboardChartMemoryWithoutQuantiles = () => {
           nodeAddresses,
         );
         return result;
-      }, // eslint-disable-next-line react-hooks/exhaustive-deps
+      },
+      //Expect warning because of complex dependency
+      // eslint-disable-next-line react-hooks/exhaustive-deps
       [JSON.stringify(nodeAddresses)],
     ),
   });
+
+  // Register series names with ChartLegendWrapper
+  useEffect(() => {
+    if (series && series.length > 0) {
+      const seriesNames = series.map((s) => s.resource);
+      register(chartId, seriesNames);
+    }
+  }, [chartId, register, series]);
+
   return (
-    <LineTemporalChart
+    <LineTimeSerieChart
       series={series}
-      height={80}
+      height={110}
+      interval={interval}
+      duration={duration}
       title="Memory"
       startingTimeStamp={startingTimeStamp}
       yAxisType={'percentage'}
-      isLegendHidden={true}
       isLoading={isLoading}
+      syncId="dashboard"
     />
   );
 };

--- a/ui/src/components/DashboardChartMemory.tsx
+++ b/ui/src/components/DashboardChartMemory.tsx
@@ -19,6 +19,7 @@ import {
 } from '../services/platformlibrary/metrics';
 import { getMultiResourceSeriesForChart } from '../services/graphUtils';
 import NonSymmetricalQuantileChart from './NonSymmetricalQuantileChart';
+import { HEIGHT_DEFAULT_CHART } from '../constants';
 
 const DashboardChartMemory = () => {
   const { isShowQuantileChart } = useShowQuantileChart();
@@ -73,7 +74,7 @@ const DashboardChartMemoryWithoutQuantiles = () => {
   return (
     <LineTimeSerieChart
       series={series}
-      height={110}
+      height={HEIGHT_DEFAULT_CHART}
       interval={interval}
       duration={duration}
       title="Memory"

--- a/ui/src/components/DashboardChartMemory.tsx
+++ b/ui/src/components/DashboardChartMemory.tsx
@@ -47,7 +47,6 @@ const DashboardChartMemoryWithoutQuantiles = () => {
 
   const { interval, duration } = useMetricsTimeSpan();
   const { isLoading, series, startingTimeStamp } = useSingleChartSerie({
-    // @ts-expect-error - FIXME when you are working on it
     getQuery: (timeSpanProps) => getNodesMemoryQuery(timeSpanProps),
     transformPrometheusDataToSeries: useCallback(
       (prometheusResult) => {

--- a/ui/src/components/DashboardChartSystemLoad.tsx
+++ b/ui/src/components/DashboardChartSystemLoad.tsx
@@ -19,6 +19,7 @@ import {
   getNodesSystemLoadQuery,
 } from '../services/platformlibrary/metrics';
 import NonSymmetricalQuantileChart from './NonSymmetricalQuantileChart';
+import { HEIGHT_DEFAULT_CHART } from '../constants';
 
 const DashboardChartSystemLoad = () => {
   const { isShowQuantileChart } = useShowQuantileChart();
@@ -67,7 +68,7 @@ const DashboardChartSystemLoadWithoutQuantiles = () => {
   return (
     <LineTimeSerieChart
       series={series}
-      height={110}
+      height={HEIGHT_DEFAULT_CHART}
       interval={interval}
       duration={duration}
       title="System Load"

--- a/ui/src/components/DashboardChartSystemLoad.tsx
+++ b/ui/src/components/DashboardChartSystemLoad.tsx
@@ -1,5 +1,11 @@
-import { LineTemporalChart } from '@scality/core-ui/dist/next';
-import { useCallback } from 'react';
+import {
+  LineTimeSerieChart,
+  useMetricsTimeSpan,
+  useChartId,
+} from '@scality/core-ui/dist/next';
+import { useChartLegend } from '@scality/core-ui/dist/components/chartlegend/ChartLegendWrapper';
+
+import { useCallback, useEffect } from 'react';
 import {
   useNodeAddressesSelector,
   useNodes,
@@ -34,25 +40,43 @@ const DashboardChartSystemLoad = () => {
 };
 
 const DashboardChartSystemLoadWithoutQuantiles = () => {
-  const nodeAddresses = useNodeAddressesSelector(useNodes());
+  const chartId = useChartId();
+  const { register } = useChartLegend();
+  const nodes = useNodes();
+  const nodeAddresses = useNodeAddressesSelector(nodes);
+
+  const { interval, duration } = useMetricsTimeSpan();
   const { isLoading, series, startingTimeStamp } = useSingleChartSerie({
     getQuery: (timeSpanProps) =>
       // @ts-expect-error - FIXME when you are working on it
       getNodesSystemLoadQuery(timeSpanProps),
     transformPrometheusDataToSeries: useCallback(
       (prometheusResult) =>
-        getMultiResourceSeriesForChart(prometheusResult, nodeAddresses), // eslint-disable-next-line react-hooks/exhaustive-deps
+        getMultiResourceSeriesForChart(prometheusResult, nodeAddresses),
+      //Expect warning because of complex dependency
+      // eslint-disable-next-line react-hooks/exhaustive-deps
       [JSON.stringify(nodeAddresses)],
     ),
   });
+
+  // Register series names with ChartLegendWrapper
+  useEffect(() => {
+    if (series && series.length > 0) {
+      const seriesNames = series.map((s) => s.resource);
+      register(chartId, seriesNames);
+    }
+  }, [chartId, register, series]);
+
   return (
-    <LineTemporalChart
+    <LineTimeSerieChart
       series={series}
-      height={80}
+      height={110}
+      interval={interval}
+      duration={duration}
       title="System Load"
       startingTimeStamp={startingTimeStamp}
-      isLegendHidden={true}
       isLoading={isLoading}
+      syncId="dashboard"
     />
   );
 };

--- a/ui/src/components/DashboardChartSystemLoad.tsx
+++ b/ui/src/components/DashboardChartSystemLoad.tsx
@@ -26,11 +26,10 @@ const DashboardChartSystemLoad = () => {
     <>
       {isShowQuantileChart ? (
         <NonSymmetricalQuantileChart
-          // @ts-expect-error - FIXME when you are working on it
           getQuantileQuery={getNodesSystemLoadQuantileQuery}
-          // @ts-expect-error - FIXME when you are working on it
           getQuantileHoverQuery={getNodesSystemLoadOutpassingThresholdQuery}
           title={'System Load'}
+          yAxisType={'percentage'}
         />
       ) : (
         <DashboardChartSystemLoadWithoutQuantiles />

--- a/ui/src/components/DashboardChartSystemLoad.tsx
+++ b/ui/src/components/DashboardChartSystemLoad.tsx
@@ -3,9 +3,9 @@ import {
   useMetricsTimeSpan,
   useChartId,
 } from '@scality/core-ui/dist/next';
-import { useChartLegend } from '@scality/core-ui/dist/components/chartlegend/ChartLegendWrapper';
+import { useChartLegendRegistration } from '../hooks/useChartLegendRegistration';
 
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import {
   useNodeAddressesSelector,
   useNodes,
@@ -41,7 +41,6 @@ const DashboardChartSystemLoad = () => {
 
 const DashboardChartSystemLoadWithoutQuantiles = () => {
   const chartId = useChartId();
-  const { register } = useChartLegend();
   const nodes = useNodes();
   const nodeAddresses = useNodeAddressesSelector(nodes);
 
@@ -57,13 +56,7 @@ const DashboardChartSystemLoadWithoutQuantiles = () => {
     ),
   });
 
-  // Register series names with ChartLegendWrapper
-  useEffect(() => {
-    if (series && series.length > 0) {
-      const seriesNames = series.map((s) => s.resource);
-      register(chartId, seriesNames);
-    }
-  }, [chartId, register, series]);
+  useChartLegendRegistration({ chartId, series, isSymmetrical: false });
 
   return (
     <LineTimeSerieChart

--- a/ui/src/components/DashboardChartSystemLoad.tsx
+++ b/ui/src/components/DashboardChartSystemLoad.tsx
@@ -46,9 +46,7 @@ const DashboardChartSystemLoadWithoutQuantiles = () => {
 
   const { interval, duration } = useMetricsTimeSpan();
   const { isLoading, series, startingTimeStamp } = useSingleChartSerie({
-    getQuery: (timeSpanProps) =>
-      // @ts-expect-error - FIXME when you are working on it
-      getNodesSystemLoadQuery(timeSpanProps),
+    getQuery: (timeSpanProps) => getNodesSystemLoadQuery(timeSpanProps),
     transformPrometheusDataToSeries: useCallback(
       (prometheusResult) =>
         getMultiResourceSeriesForChart(prometheusResult, nodeAddresses),

--- a/ui/src/components/DashboardChartThroughput.tsx
+++ b/ui/src/components/DashboardChartThroughput.tsx
@@ -22,7 +22,11 @@ import {
 } from '../services/platformlibrary/metrics';
 import { getMultipleSymmetricalSeries } from '../services/graphUtils';
 import SymmetricalQuantileChart from './SymmetricalQuantileChart';
-import { UNIT_RANGE_BS, YAXIS_TITLE_READ_WRITE } from '../constants';
+import {
+  HEIGHT_SYMMETRICAL_CHART,
+  UNIT_RANGE_BS,
+  YAXIS_TITLE_READ_WRITE,
+} from '../constants';
 
 const DashboardChartThroughput = () => {
   const { isShowQuantileChart } = useShowQuantileChart();
@@ -105,7 +109,7 @@ const DashboardChartThroughputWithoutQuantile = () => {
         above: series.above,
         below: series.below,
       }}
-      height={150}
+      height={HEIGHT_SYMMETRICAL_CHART}
       unitRange={UNIT_RANGE_BS}
       interval={interval}
       duration={duration}

--- a/ui/src/components/DashboardChartThroughput.tsx
+++ b/ui/src/components/DashboardChartThroughput.tsx
@@ -59,11 +59,9 @@ const DashboardChartThroughputWithoutQuantile = () => {
   const { interval, duration } = useMetricsTimeSpan();
   const { isLoading, series, startingTimeStamp } = useSymetricalChartSeries({
     getAboveQueries: (timeSpanProps) => [
-      // @ts-expect-error - FIXME when you are working on it
       getNodesThroughputWriteQuery(timeSpanProps),
     ],
     getBelowQueries: (timeSpanProps) => [
-      // @ts-expect-error - FIXME when you are working on it
       getNodesThroughputReadQuery(timeSpanProps),
     ],
     transformPrometheusDataToSeries: useCallback(

--- a/ui/src/components/DashboardChartThroughput.tsx
+++ b/ui/src/components/DashboardChartThroughput.tsx
@@ -3,9 +3,9 @@ import {
   useMetricsTimeSpan,
   useChartId,
 } from '@scality/core-ui/dist/next';
-import { useChartLegend } from '@scality/core-ui/dist/components/chartlegend/ChartLegendWrapper';
+import { useChartLegendRegistration } from '../hooks/useChartLegendRegistration';
 
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import {
   useNodeAddressesSelector,
   useNodes,
@@ -56,7 +56,6 @@ const DashboardChartThroughput = () => {
 
 const DashboardChartThroughputWithoutQuantile = () => {
   const chartId = useChartId();
-  const { register } = useChartLegend();
   const nodes = useNodes();
   const nodeAddresses = useNodeAddressesSelector(nodes);
 
@@ -93,15 +92,7 @@ const DashboardChartThroughputWithoutQuantile = () => {
     ),
   });
 
-  // Register series names for symmetrical chart (above + below series)
-  useEffect(() => {
-    if (series && (series.above?.length > 0 || series.below?.length > 0)) {
-      const aboveNames = series.above?.map((s) => s.resource) || [];
-      const belowNames = series.below?.map((s) => s.resource) || [];
-      const allSeriesNames = [...aboveNames, ...belowNames];
-      register(chartId, allSeriesNames);
-    }
-  }, [chartId, register, series]);
+  useChartLegendRegistration({ chartId, series, isSymmetrical: true });
 
   return (
     <LineTimeSerieChart

--- a/ui/src/components/DashboardChartThroughput.tsx
+++ b/ui/src/components/DashboardChartThroughput.tsx
@@ -1,11 +1,11 @@
-import React, { useCallback } from 'react';
-import { useTheme } from 'styled-components';
-import { defaultRenderTooltipSerie } from '@scality/core-ui/dist/components/linetemporalchart/tooltip';
-import { LineTemporalChart } from '@scality/core-ui/dist/next';
 import {
-  UNIT_RANGE_BS,
-  YAXIS_TITLE_READ_WRITE,
-} from '@scality/core-ui/dist/components/linetemporalchart/LineTemporalChart.component';
+  LineTimeSerieChart,
+  useMetricsTimeSpan,
+  useChartId,
+} from '@scality/core-ui/dist/next';
+import { useChartLegend } from '@scality/core-ui/dist/components/chartlegend/ChartLegendWrapper';
+
+import { useCallback, useEffect } from 'react';
 import {
   useNodeAddressesSelector,
   useNodes,
@@ -22,6 +22,7 @@ import {
 } from '../services/platformlibrary/metrics';
 import { getMultipleSymmetricalSeries } from '../services/graphUtils';
 import SymmetricalQuantileChart from './SymmetricalQuantileChart';
+import { UNIT_RANGE_BS, YAXIS_TITLE_READ_WRITE } from '../constants';
 
 const DashboardChartThroughput = () => {
   const { isShowQuantileChart } = useShowQuantileChart();
@@ -50,11 +51,12 @@ const DashboardChartThroughput = () => {
 };
 
 const DashboardChartThroughputWithoutQuantile = () => {
-  const theme = useTheme();
+  const chartId = useChartId();
+  const { register } = useChartLegend();
   const nodes = useNodes();
   const nodeAddresses = useNodeAddressesSelector(nodes);
-  // @ts-expect-error - FIXME when you are working on it
-  const lastNodeName = nodes?.slice(-1)[0]?.metadata?.name;
+
+  const { interval, duration } = useMetricsTimeSpan();
   const { isLoading, series, startingTimeStamp } = useSymetricalChartSeries({
     getAboveQueries: (timeSpanProps) => [
       // @ts-expect-error - FIXME when you are working on it
@@ -66,40 +68,65 @@ const DashboardChartThroughputWithoutQuantile = () => {
     ],
     transformPrometheusDataToSeries: useCallback(
       ([prometheusResultAbove], [prometheusResultBelow]) => {
-        return getMultipleSymmetricalSeries(
+        if (!prometheusResultAbove || !prometheusResultBelow) {
+          return {
+            above: [],
+            below: [],
+          };
+        }
+
+        const allSeries = getMultipleSymmetricalSeries(
           prometheusResultAbove,
           prometheusResultBelow,
           'write',
           'read',
           nodeAddresses,
         );
+
+        const aboveSeries = allSeries.filter(
+          (serie) => serie.metricPrefix === 'write',
+        );
+
+        const belowSeries = allSeries.filter(
+          (serie) => serie.metricPrefix === 'read',
+        );
+        return {
+          above: aboveSeries,
+          below: belowSeries,
+        };
       },
+      //Expect warning because of complex dependency
+      // eslint-disable-next-line react-hooks/exhaustive-deps
       [JSON.stringify(nodeAddresses)],
     ),
   });
+
+  // Register series names for symmetrical chart (above + below series)
+  useEffect(() => {
+    if (series && (series.above?.length > 0 || series.below?.length > 0)) {
+      const aboveNames = series.above?.map((s) => s.resource) || [];
+      const belowNames = series.below?.map((s) => s.resource) || [];
+      const allSeriesNames = [...aboveNames, ...belowNames];
+      register(chartId, allSeriesNames);
+    }
+  }, [chartId, register, series]);
+
   return (
-    <LineTemporalChart
-      series={series}
-      title="Disk Throughput"
+    <LineTimeSerieChart
+      series={{
+        above: series.above,
+        below: series.below,
+      }}
       height={150}
-      yAxisType={'symmetrical'}
       unitRange={UNIT_RANGE_BS}
+      interval={interval}
+      duration={duration}
+      title="Disk Throughput"
       startingTimeStamp={startingTimeStamp}
-      isLegendHidden={false}
+      yAxisType={'symmetrical'}
       yAxisTitle={YAXIS_TITLE_READ_WRITE}
-      // @ts-expect-error - FIXME when you are working on it
       isLoading={isLoading}
-      renderTooltipSerie={useCallback(
-        (serie) => {
-          if (serie.key === `${lastNodeName}-write`) {
-            return `${defaultRenderTooltipSerie(serie)}</table>
-            <hr style="border-color: ${theme.border};"/><table>`;
-          } else {
-            return defaultRenderTooltipSerie(serie);
-          }
-        },
-        [lastNodeName, theme],
-      )}
+      syncId="dashboard"
     />
   );
 };

--- a/ui/src/components/DashboardChartThroughput.tsx
+++ b/ui/src/components/DashboardChartThroughput.tsx
@@ -28,7 +28,7 @@ const DashboardChartThroughput = () => {
   const { isShowQuantileChart } = useShowQuantileChart();
   return (
     <>
-      {!isShowQuantileChart ? (
+      {isShowQuantileChart ? (
         <SymmetricalQuantileChart
           getAboveQuantileQuery={getNodesThroughputWriteQuantileQuery}
           getBelowQuantileQuery={getNodesThroughputReadQuantileQuery}

--- a/ui/src/components/DashboardChartThroughput.tsx
+++ b/ui/src/components/DashboardChartThroughput.tsx
@@ -28,7 +28,7 @@ const DashboardChartThroughput = () => {
   const { isShowQuantileChart } = useShowQuantileChart();
   return (
     <>
-      {isShowQuantileChart ? (
+      {!isShowQuantileChart ? (
         <SymmetricalQuantileChart
           getAboveQuantileQuery={getNodesThroughputWriteQuantileQuery}
           getBelowQuantileQuery={getNodesThroughputReadQuantileQuery}
@@ -83,17 +83,7 @@ const DashboardChartThroughputWithoutQuantile = () => {
           nodeAddresses,
         );
 
-        const aboveSeries = allSeries.filter(
-          (serie) => serie.metricPrefix === 'write',
-        );
-
-        const belowSeries = allSeries.filter(
-          (serie) => serie.metricPrefix === 'read',
-        );
-        return {
-          above: aboveSeries,
-          below: belowSeries,
-        };
+        return allSeries;
       },
       //Expect warning because of complex dependency
       // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/ui/src/components/DashboardMetrics.tsx
+++ b/ui/src/components/DashboardMetrics.tsx
@@ -96,10 +96,10 @@ const DashboardMetrics = () => {
       <DashboardScrollableArea>
         <ChartLegendWrapper colorSet={createColorSet}>
           <GraphsWrapper>
-            <DashboardChartCpuUsage />
+            {/* <DashboardChartCpuUsage /> */}
             <DashboardChartMemory />
-            <DashboardChartSystemLoad />
-            <DashboardChartThroughput />
+            {/* <DashboardChartSystemLoad /> */}
+            {/* <DashboardChartThroughput /> */}
           </GraphsWrapper>
           <ChartLegend shape="line" legendSize={'Smaller'} />
         </ChartLegendWrapper>

--- a/ui/src/components/DashboardMetrics.tsx
+++ b/ui/src/components/DashboardMetrics.tsx
@@ -94,15 +94,17 @@ const DashboardMetrics = () => {
         )}
       </PanelActions>
       <DashboardScrollableArea>
-        <ChartLegendWrapper colorSet={createColorSet}>
-          <GraphsWrapper>
-            {/* <DashboardChartCpuUsage /> */}
+        <GraphsWrapper>
+          <ChartLegendWrapper colorSet={createColorSet}>
+            <DashboardChartCpuUsage />
             <DashboardChartMemory />
-            {/* <DashboardChartSystemLoad /> */}
-            {/* <DashboardChartThroughput /> */}
-          </GraphsWrapper>
-          <ChartLegend shape="line" legendSize={'Smaller'} />
-        </ChartLegendWrapper>
+            <DashboardChartSystemLoad />
+          </ChartLegendWrapper>
+          <ChartLegendWrapper colorSet={createColorSet}>
+            <DashboardChartThroughput />
+            <ChartLegend shape="line" legendSize={'Smaller'} />
+          </ChartLegendWrapper>
+        </GraphsWrapper>
       </DashboardScrollableArea>
     </MetricsContainer>
   );

--- a/ui/src/components/DashboardMetrics.tsx
+++ b/ui/src/components/DashboardMetrics.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Box, Button } from '@scality/core-ui/dist/next';
-import { padding } from '@scality/core-ui/dist/style/theme';
+import {
+  Box,
+  Button,
+  ChartLegend,
+  ChartLegendWrapper,
+} from '@scality/core-ui/dist/next';
+
 import { useIntl } from 'react-intl';
 import { GRAFANA_DASHBOARDS } from '../constants';
+import { createColorSet } from '../services/graphUtils';
 import {
   PageSubtitle,
   GraphsWrapper,
@@ -16,7 +22,7 @@ import { useShowQuantileChart, useTypedSelector } from '../hooks';
 import { DashboardScrollableArea } from '../containers/DashboardPage';
 import { Icon, SmallerText, Stack, IconHelp, spacing } from '@scality/core-ui';
 const MetricsContainer = styled.div`
-  padding: 2px ${padding.smaller};
+  padding: 2px ${spacing.f4};
   display: flex;
   flex-direction: column;
   flex-grow: 1;
@@ -24,7 +30,7 @@ const MetricsContainer = styled.div`
 `;
 const PanelActions = styled.div`
   display: flex;
-  padding: ${padding.small};
+  padding: ${spacing.f8};
   align-items: center;
   justify-content: space-between;
 `;
@@ -57,6 +63,7 @@ const DashboardMetrics = () => {
   // App config, used to generated Advanced metrics button link
   const { url_grafana } = useTypedSelector((state) => state.config.api);
   const { isShowQuantileChart } = useShowQuantileChart();
+
   return (
     <MetricsContainer id="dashboard-metrics-container">
       <PanelActions>
@@ -87,12 +94,15 @@ const DashboardMetrics = () => {
         )}
       </PanelActions>
       <DashboardScrollableArea>
-        <GraphsWrapper>
-          <DashboardChartCpuUsage />
-          <DashboardChartMemory />
-          <DashboardChartSystemLoad />
-          <DashboardChartThroughput />
-        </GraphsWrapper>
+        <ChartLegendWrapper colorSet={createColorSet}>
+          <GraphsWrapper>
+            <DashboardChartCpuUsage />
+            <DashboardChartMemory />
+            <DashboardChartSystemLoad />
+            <DashboardChartThroughput />
+          </GraphsWrapper>
+          <ChartLegend shape="line" legendSize={'Smaller'} />
+        </ChartLegendWrapper>
       </DashboardScrollableArea>
     </MetricsContainer>
   );

--- a/ui/src/components/DashboardNetwork.tsx
+++ b/ui/src/components/DashboardNetwork.tsx
@@ -26,7 +26,6 @@ export const PanelActions = styled.div`
 const DashboardNetwork = () => {
   const intl = useIntl();
   const { isShowQuantileChart } = useShowQuantileChart();
-  console.log('DEBUG DashboardNetwork', isShowQuantileChart);
   return (
     <NetworkContainer
       style={{

--- a/ui/src/components/DashboardNetwork.tsx
+++ b/ui/src/components/DashboardNetwork.tsx
@@ -1,17 +1,14 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useIntl } from 'react-intl';
-import {
-  PageSubtitle,
-  GraphsWrapper,
-} from '../components/style/CommonLayoutStyle';
+import { PageSubtitle } from '../components/style/CommonLayoutStyle';
 import DashboardPlaneHealth from './DashboardPlaneHealth';
 import DashboardBandwidthChart from './DashboardBandwidthChart';
 import { DashboardScrollableArea } from '../containers/DashboardPage';
 import { useShowQuantileChart } from '../hooks';
 import { QuantileHelpTooltip } from './DashboardMetrics';
 import { Box } from '@scality/core-ui/dist/next';
-import { spacing } from '@scality/core-ui';
+import { spacing, Stack } from '@scality/core-ui';
 export const NetworkContainer = styled.div`
   padding: ${spacing.r2} ${spacing.r4};
   display: flex;
@@ -48,7 +45,7 @@ const DashboardNetwork = () => {
 
       <DashboardPlaneHealth />
       <DashboardScrollableArea>
-        <GraphsWrapper>
+        <Stack direction="vertical" gap="r16">
           <DashboardBandwidthChart
             title="ControlPlane Bandwidth"
             plane="controlPlane"
@@ -57,7 +54,7 @@ const DashboardNetwork = () => {
             title="WorkloadPlane Bandwidth"
             plane="workloadPlane"
           />
-        </GraphsWrapper>
+        </Stack>
       </DashboardScrollableArea>
     </NetworkContainer>
   );

--- a/ui/src/components/DashboardNetwork.tsx
+++ b/ui/src/components/DashboardNetwork.tsx
@@ -26,6 +26,7 @@ export const PanelActions = styled.div`
 const DashboardNetwork = () => {
   const intl = useIntl();
   const { isShowQuantileChart } = useShowQuantileChart();
+  console.log('DEBUG DashboardNetwork', isShowQuantileChart);
   return (
     <NetworkContainer
       style={{

--- a/ui/src/components/MetricChart.tsx
+++ b/ui/src/components/MetricChart.tsx
@@ -1,14 +1,20 @@
-import { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import type { UseQueryOptions } from 'react-query';
 import 'react-query';
 import {
   LineTimeSerieChart,
+  useChartId,
   useMetricsTimeSpan,
 } from '@scality/core-ui/dist/next';
 import { convertPrometheusResultToSerieWithAverage } from '../services/graphUtils';
-import { HEIGHT_DEFAULT_CHART, NODE_SYNC_ID } from '../constants';
+import {
+  CLUSTER_AVERAGE,
+  HEIGHT_DEFAULT_CHART,
+  NODE_SYNC_ID,
+} from '../constants';
 import { useChartSeries } from '../hooks';
 import { TimeSpanProps } from '../services/platformlibrary/metrics';
+import { useChartLegendRegistration } from '../hooks/useChartLegendRegistration';
 
 const MetricChart = ({
   title,
@@ -38,6 +44,15 @@ const MetricChart = ({
     label: string;
   }[];
 }) => {
+  console.log(
+    'DEBUG MetricChart',
+    title,
+    yAxisType,
+    nodeName,
+    instanceIP,
+    showAvg,
+  );
+  const chartId = useChartId();
   const { interval, duration } = useMetricsTimeSpan();
   const { isLoading, series, startingTimeStamp } = useChartSeries({
     getQueries: useCallback(
@@ -68,6 +83,16 @@ const MetricChart = ({
       [nodeName, showAvg],
     ),
   });
+  const additionalNames = useMemo(
+    () => (showAvg ? [CLUSTER_AVERAGE] : []),
+    [showAvg],
+  );
+  useChartLegendRegistration({
+    chartId,
+    series,
+    isSymmetrical: false,
+    additionalNames,
+  });
   return (
     <LineTimeSerieChart
       series={series}
@@ -84,4 +109,4 @@ const MetricChart = ({
   );
 };
 
-export default MetricChart;
+export default React.memo(MetricChart);

--- a/ui/src/components/MetricChart.tsx
+++ b/ui/src/components/MetricChart.tsx
@@ -1,9 +1,12 @@
 import { useCallback } from 'react';
 import type { UseQueryOptions } from 'react-query';
 import 'react-query';
-import { LineTemporalChart } from '@scality/core-ui/dist/next';
+import {
+  LineTimeSerieChart,
+  useMetricsTimeSpan,
+} from '@scality/core-ui/dist/next';
 import { convertPrometheusResultToSerieWithAverage } from '../services/graphUtils';
-import { HEIGHT_DEFAULT_CHART } from '../constants';
+import { HEIGHT_DEFAULT_CHART, NODE_SYNC_ID } from '../constants';
 import { useChartSeries } from '../hooks';
 
 const MetricChart = ({
@@ -28,6 +31,7 @@ const MetricChart = ({
     label: string;
   }[];
 }) => {
+  const { interval, duration } = useMetricsTimeSpan();
   const { isLoading, series, startingTimeStamp } = useChartSeries({
     getQueries: useCallback(
       (timeSpanProps) => {
@@ -63,15 +67,17 @@ const MetricChart = ({
     ),
   });
   return (
-    <LineTemporalChart
+    <LineTimeSerieChart
       series={series}
       height={HEIGHT_DEFAULT_CHART}
+      interval={interval}
+      duration={duration}
       title={title}
       startingTimeStamp={startingTimeStamp}
       yAxisType={yAxisType}
-      // @ts-expect-error - FIXME when you are working on it
       isLoading={isLoading}
       unitRange={unitRange}
+      syncId={NODE_SYNC_ID}
     />
   );
 };

--- a/ui/src/components/MetricChart.tsx
+++ b/ui/src/components/MetricChart.tsx
@@ -8,6 +8,7 @@ import {
 import { convertPrometheusResultToSerieWithAverage } from '../services/graphUtils';
 import { HEIGHT_DEFAULT_CHART, NODE_SYNC_ID } from '../constants';
 import { useChartSeries } from '../hooks';
+import { TimeSpanProps } from '../services/platformlibrary/metrics';
 
 const MetricChart = ({
   title,
@@ -24,8 +25,14 @@ const MetricChart = ({
   nodeName: string;
   instanceIP: string;
   showAvg: boolean;
-  getMetricQuery: UseQueryOptions;
-  getMetricAvgQuery: UseQueryOptions;
+  getMetricQuery: (
+    instanceIP: string,
+    timeSpanProps: TimeSpanProps,
+  ) => UseQueryOptions;
+  getMetricAvgQuery: (
+    timeSpanProps: TimeSpanProps,
+    showAvg: boolean,
+  ) => UseQueryOptions;
   unitRange?: {
     threshold: number;
     label: string;
@@ -37,19 +44,14 @@ const MetricChart = ({
       (timeSpanProps) => {
         if (showAvg) {
           return [
-            // @ts-expect-error - FIXME when you are working on it
             getMetricQuery(instanceIP, timeSpanProps),
-            // @ts-expect-error - FIXME when you are working on it
             getMetricAvgQuery(timeSpanProps, showAvg),
           ];
         } else {
-          return [
-            // @ts-expect-error - FIXME when you are working on it
-            getMetricQuery(instanceIP, timeSpanProps),
-          ];
+          return [getMetricQuery(instanceIP, timeSpanProps)];
         }
       },
-      [instanceIP, showAvg],
+      [instanceIP, showAvg, getMetricQuery, getMetricAvgQuery],
     ),
     transformPrometheusDataToSeries: useCallback(
       ([result, resultAvg]) => {

--- a/ui/src/components/MetricChart.tsx
+++ b/ui/src/components/MetricChart.tsx
@@ -44,14 +44,6 @@ const MetricChart = ({
     label: string;
   }[];
 }) => {
-  console.log(
-    'DEBUG MetricChart',
-    title,
-    yAxisType,
-    nodeName,
-    instanceIP,
-    showAvg,
-  );
   const chartId = useChartId();
   const { interval, duration } = useMetricsTimeSpan();
   const { isLoading, series, startingTimeStamp } = useChartSeries({

--- a/ui/src/components/MetricSymmetricalChart.tsx
+++ b/ui/src/components/MetricSymmetricalChart.tsx
@@ -92,7 +92,15 @@ const MetricSymmetricalChart = ({
           ];
         }
       },
-      [instanceIP, showAvg, planeInterface, JSON.stringify(nodesIPsInfo)],
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [
+        instanceIP,
+        showAvg,
+        planeInterface,
+        JSON.stringify(nodesIPsInfo),
+        getMetricBelowQuery,
+        getMetricBelowAvgQuery,
+      ],
     ),
     transformPrometheusDataToSeries: useCallback(
       (resultsAbove, resultsBelow) => {

--- a/ui/src/components/MetricSymmetricalChart.tsx
+++ b/ui/src/components/MetricSymmetricalChart.tsx
@@ -1,9 +1,12 @@
 import { useCallback } from 'react';
 import type { UseQueryOptions } from 'react-query';
 import 'react-query';
-import { LineTemporalChart } from '@scality/core-ui/dist/next';
+import {
+  LineTimeSerieChart,
+  useMetricsTimeSpan,
+} from '@scality/core-ui/dist/next';
 import { getSeriesForSymmetricalChart } from '../services/graphUtils';
-import { HEIGHT_SYMMETRICAL_CHART } from '../constants';
+import { HEIGHT_SYMMETRICAL_CHART, NODE_SYNC_ID } from '../constants';
 import { NodesState } from '../ducks/app/nodes';
 import { useSymetricalChartSeries } from '../hooks';
 
@@ -43,6 +46,7 @@ const MetricSymmetricalChart = ({
   planeInterface?: string;
   isPlaneInterfaceRequired?: boolean;
 }) => {
+  const { interval, duration } = useMetricsTimeSpan();
   const { isLoading, series, startingTimeStamp } = useSymetricalChartSeries({
     getAboveQueries: useCallback(
       (timeSpanProps) => {
@@ -92,10 +96,11 @@ const MetricSymmetricalChart = ({
     ),
     transformPrometheusDataToSeries: useCallback(
       (resultsAbove, resultsBelow) => {
+        let allSeries;
         if (showAvg) {
           const [resultAbove, resultAboveAvg] = resultsAbove;
           const [resultBelow, resultBelowAvg] = resultsBelow;
-          return getSeriesForSymmetricalChart(
+          allSeries = getSeriesForSymmetricalChart(
             resultAbove,
             resultBelow,
             nodeName,
@@ -107,7 +112,7 @@ const MetricSymmetricalChart = ({
         } else {
           const [resultAbove] = resultsAbove;
           const [resultBelow] = resultsBelow;
-          return getSeriesForSymmetricalChart(
+          allSeries = getSeriesForSymmetricalChart(
             resultAbove,
             resultBelow,
             nodeName,
@@ -115,22 +120,39 @@ const MetricSymmetricalChart = ({
             metricPrefixBelow,
           );
         }
+
+        // Filter series for LineTimeSerieChart above/below structure
+        const aboveSeries = allSeries.filter(
+          (serie) => serie.metricPrefix === metricPrefixAbove,
+        );
+        const belowSeries = allSeries.filter(
+          (serie) => serie.metricPrefix === metricPrefixBelow,
+        );
+
+        return {
+          above: aboveSeries,
+          below: belowSeries,
+        };
       },
       [showAvg, nodeName, metricPrefixAbove, metricPrefixBelow],
     ),
   });
   return (
-    <LineTemporalChart
-      series={series}
+    <LineTimeSerieChart
+      series={{
+        above: series.above,
+        below: series.below,
+      }}
       height={HEIGHT_SYMMETRICAL_CHART}
+      interval={interval}
+      duration={duration}
       title={title}
       startingTimeStamp={startingTimeStamp}
       yAxisType={'symmetrical'}
       yAxisTitle={yAxisTitle}
-      // @ts-expect-error - FIXME when you are working on it
       isLoading={isLoading}
-      isLegendHidden={false}
       unitRange={unitRange}
+      syncId={NODE_SYNC_ID}
     />
   );
 };

--- a/ui/src/components/MetricSymmetricalChart.tsx
+++ b/ui/src/components/MetricSymmetricalChart.tsx
@@ -9,6 +9,7 @@ import { getSeriesForSymmetricalChart } from '../services/graphUtils';
 import { HEIGHT_SYMMETRICAL_CHART, NODE_SYNC_ID } from '../constants';
 import { NodesState } from '../ducks/app/nodes';
 import { useSymetricalChartSeries } from '../hooks';
+import { TimeSpanProps } from '../services/platformlibrary/metrics';
 
 const MetricSymmetricalChart = ({
   title,
@@ -33,10 +34,28 @@ const MetricSymmetricalChart = ({
   instanceIP: string;
   showAvg: boolean;
   nodesIPsInfo: NodesState['IPsInfo'];
-  getMetricAboveQuery: UseQueryOptions;
-  getMetricBelowQuery: UseQueryOptions;
-  getMetricAboveAvgQuery: UseQueryOptions;
-  getMetricBelowAvgQuery: UseQueryOptions;
+  getMetricAboveQuery: (
+    instanceIP: string,
+    timeSpanProps: TimeSpanProps,
+    planeInterface: string,
+  ) => UseQueryOptions;
+  getMetricBelowQuery: (
+    instanceIP: string,
+    timeSpanProps: TimeSpanProps,
+    planeInterface: string,
+  ) => UseQueryOptions;
+  getMetricAboveAvgQuery: (
+    timeSpanProps: TimeSpanProps,
+    showAvg: boolean,
+    instanceIP: string,
+    nodesIPsInfo: NodesState['IPsInfo'],
+  ) => UseQueryOptions;
+  getMetricBelowAvgQuery: (
+    timeSpanProps: TimeSpanProps,
+    showAvg: boolean,
+    instanceIP: string,
+    nodesIPsInfo: NodesState['IPsInfo'],
+  ) => UseQueryOptions;
   metricPrefixAbove: string;
   metricPrefixBelow: string;
   unitRange?: {
@@ -52,9 +71,8 @@ const MetricSymmetricalChart = ({
       (timeSpanProps) => {
         if (showAvg) {
           return [
-            // @ts-expect-error - FIXME when you are working on it
             getMetricAboveQuery(instanceIP, timeSpanProps, planeInterface),
-            // @ts-expect-error - FIXME when you are working on it
+
             getMetricAboveAvgQuery(
               timeSpanProps,
               showAvg,
@@ -64,20 +82,25 @@ const MetricSymmetricalChart = ({
           ];
         } else {
           return [
-            // @ts-expect-error - FIXME when you are working on it
             getMetricAboveQuery(instanceIP, timeSpanProps, planeInterface),
           ];
         }
       },
-      [instanceIP, showAvg, planeInterface, JSON.stringify(nodesIPsInfo)],
+      [
+        instanceIP,
+        showAvg,
+        planeInterface,
+        JSON.stringify(nodesIPsInfo),
+        getMetricAboveQuery,
+        getMetricAboveAvgQuery,
+      ],
     ),
     getBelowQueries: useCallback(
       (timeSpanProps) => {
         if (showAvg) {
           return [
-            // @ts-expect-error - FIXME when you are working on it
             getMetricBelowQuery(instanceIP, timeSpanProps, planeInterface),
-            // @ts-expect-error - FIXME when you are working on it
+
             getMetricBelowAvgQuery(
               timeSpanProps,
               showAvg,
@@ -87,7 +110,6 @@ const MetricSymmetricalChart = ({
           ];
         } else {
           return [
-            // @ts-expect-error - FIXME when you are working on it
             getMetricBelowQuery(instanceIP, timeSpanProps, planeInterface),
           ];
         }

--- a/ui/src/components/MetricSymmetricalChart.tsx
+++ b/ui/src/components/MetricSymmetricalChart.tsx
@@ -120,19 +120,7 @@ const MetricSymmetricalChart = ({
             metricPrefixBelow,
           );
         }
-
-        // Filter series for LineTimeSerieChart above/below structure
-        const aboveSeries = allSeries.filter(
-          (serie) => serie.metricPrefix === metricPrefixAbove,
-        );
-        const belowSeries = allSeries.filter(
-          (serie) => serie.metricPrefix === metricPrefixBelow,
-        );
-
-        return {
-          above: aboveSeries,
-          below: belowSeries,
-        };
+        return allSeries;
       },
       [showAvg, nodeName, metricPrefixAbove, metricPrefixBelow],
     ),

--- a/ui/src/components/MetricSymmetricalChart.tsx
+++ b/ui/src/components/MetricSymmetricalChart.tsx
@@ -1,15 +1,21 @@
-import { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import type { UseQueryOptions } from 'react-query';
 import 'react-query';
 import {
   LineTimeSerieChart,
+  useChartId,
   useMetricsTimeSpan,
 } from '@scality/core-ui/dist/next';
 import { getSeriesForSymmetricalChart } from '../services/graphUtils';
-import { HEIGHT_SYMMETRICAL_CHART, NODE_SYNC_ID } from '../constants';
+import {
+  CLUSTER_AVERAGE,
+  HEIGHT_SYMMETRICAL_CHART,
+  NODE_SYNC_ID,
+} from '../constants';
 import { NodesState } from '../ducks/app/nodes';
 import { useSymetricalChartSeries } from '../hooks';
 import { TimeSpanProps } from '../services/platformlibrary/metrics';
+import { useChartLegendRegistration } from '../hooks/useChartLegendRegistration';
 
 const MetricSymmetricalChart = ({
   title,
@@ -65,6 +71,7 @@ const MetricSymmetricalChart = ({
   planeInterface?: string;
   isPlaneInterfaceRequired?: boolean;
 }) => {
+  const chartId = useChartId();
   const { interval, duration } = useMetricsTimeSpan();
   const { isLoading, series, startingTimeStamp } = useSymetricalChartSeries({
     getAboveQueries: useCallback(
@@ -90,7 +97,7 @@ const MetricSymmetricalChart = ({
         instanceIP,
         showAvg,
         planeInterface,
-        JSON.stringify(nodesIPsInfo),
+        nodesIPsInfo,
         getMetricAboveQuery,
         getMetricAboveAvgQuery,
       ],
@@ -114,12 +121,11 @@ const MetricSymmetricalChart = ({
           ];
         }
       },
-      // eslint-disable-next-line react-hooks/exhaustive-deps
       [
         instanceIP,
         showAvg,
         planeInterface,
-        JSON.stringify(nodesIPsInfo),
+        nodesIPsInfo,
         getMetricBelowQuery,
         getMetricBelowAvgQuery,
       ],
@@ -155,6 +161,16 @@ const MetricSymmetricalChart = ({
       [showAvg, nodeName, metricPrefixAbove, metricPrefixBelow],
     ),
   });
+  const additionalNames = useMemo(
+    () => (showAvg ? [CLUSTER_AVERAGE] : []),
+    [showAvg],
+  );
+  useChartLegendRegistration({
+    chartId,
+    series,
+    isSymmetrical: true,
+    additionalNames,
+  });
   return (
     <LineTimeSerieChart
       series={{
@@ -175,4 +191,4 @@ const MetricSymmetricalChart = ({
   );
 };
 
-export default MetricSymmetricalChart;
+export default React.memo(MetricSymmetricalChart);

--- a/ui/src/components/NonSymmetricalQuantileChart.tsx
+++ b/ui/src/components/NonSymmetricalQuantileChart.tsx
@@ -101,7 +101,6 @@ const NonSymmetricalQuantileChart = ({
       // @ts-expect-error - FIXME when you are working on it
       yAxisType={yAxisType}
       isLegendHidden={isLegendHidden}
-      // @ts-expect-error - FIXME when you are working on it
       isLoading={isLoadingQuantile}
       onHover={onHover}
       renderTooltipSerie={useCallback(

--- a/ui/src/components/NonSymmetricalQuantileChart.tsx
+++ b/ui/src/components/NonSymmetricalQuantileChart.tsx
@@ -89,32 +89,14 @@ const NonSymmetricalQuantileChart = ({
     ),
   });
 
-  // Calculate unit base and label
-  const valueBase = useMemo(() => {
-    if (!unitRange || !seriesQuantile.length) return 1;
-
-    const allValues = seriesQuantile.flatMap((serie: any) =>
-      serie.data
-        .map(([_, value]: [number, any]) =>
-          typeof value === 'string' ? parseFloat(value) : value,
-        )
-        .filter((v: any) => v !== null && !isNaN(v)),
-    );
-
-    const maxValue = Math.max(...allValues);
-    const unit = unitRange
-      .slice()
-      .reverse()
-      .find((range) => maxValue >= range.threshold);
-
-    return unit ? unit.threshold || 1 : 1;
-  }, [unitRange, seriesQuantile]);
-
-  const unitLabel = useMemo(() => {
+  const { valueBase, unitLabel } = useMemo(() => {
     if (yAxisType === 'percentage') {
-      return '%';
+      return { valueBase: 1, unitLabel: '%' };
     }
-    if (!unitRange || !seriesQuantile.length) return '';
+
+    if (!unitRange || !seriesQuantile.length) {
+      return { valueBase: 1, unitLabel: '' };
+    }
 
     const allValues = seriesQuantile.flatMap((serie: any) =>
       serie.data
@@ -130,7 +112,10 @@ const NonSymmetricalQuantileChart = ({
       .reverse()
       .find((range) => maxValue >= range.threshold);
 
-    return unit ? unit.label : '';
+    return {
+      valueBase: unit ? unit.threshold || 1 : 1,
+      unitLabel: unit ? unit.label : '',
+    };
   }, [unitRange, seriesQuantile, yAxisType]);
 
   const timeFormat = useMemo(() => {

--- a/ui/src/components/NonSymmetricalQuantileChart.tsx
+++ b/ui/src/components/NonSymmetricalQuantileChart.tsx
@@ -1,58 +1,75 @@
-import React, { useCallback } from 'react';
-import { LineTemporalChart } from '@scality/core-ui/dist/next';
-import { useTheme } from 'styled-components';
-import { PORT_NODE_EXPORTER } from '../constants';
+import { ChartLegendWrapper } from '@scality/core-ui/dist/components/chartlegend/ChartLegendWrapper';
 import {
-  useChartSeries,
-  useNodeAddressesSelector,
-  useNodes,
-  useQuantileOnHover,
-} from '../hooks';
+  ChartLegend,
+  LineTimeSerieChart,
+  useMetricsTimeSpan,
+} from '@scality/core-ui/dist/next';
+import { useCallback, useMemo } from 'react';
+import { UseQueryOptions } from 'react-query';
+import { useSelector } from 'react-redux';
+import { PORT_NODE_EXPORTER } from '../constants';
+import { useChartSeries, useNodeAddressesSelector, useNodes } from '../hooks';
 import {
   convertPrometheusResultToSerie,
-  renderOutpassingThresholdTitle,
-  renderQuantileData,
-  renderTooltipSerie,
+  createColorSet,
+  getNodesInterfacesString,
 } from '../services/graphUtils';
-import { useIntl } from 'react-intl';
-import { UseQueryOptions } from 'react-query';
+import { QuantileTooltip } from './QuantileTooltip';
 
 const NonSymmetricalQuantileChart = ({
   getQuantileQuery,
   getQuantileHoverQuery,
   title,
   yAxisType,
-  isLegendHidden,
-  // @ts-expect-error - FIXME when you are working on it
   helpText,
+  unitRange,
 }: {
-  getQuantileQuery: UseQueryOptions['queryFn'];
-  getQuantileHoverQuery: UseQueryOptions['queryFn'];
+  getQuantileQuery: (timeSpanProps: any, threshold: number) => UseQueryOptions;
+  getQuantileHoverQuery: (
+    timeSpanProps: any,
+    threshold: number,
+    operator?: '>' | '<',
+    isOnHoverFetchingRequired?: boolean,
+  ) => UseQueryOptions;
   title: string;
-  yAxisType: string;
-  isLegendHidden: boolean;
+  yAxisType: 'default' | 'percentage';
+  helpText?: string;
+  unitRange?: {
+    threshold: number;
+    label: string;
+  }[];
 }) => {
-  const theme = useTheme();
-  const intl = useIntl();
-  const nodeAddresses = useNodeAddressesSelector(useNodes());
-  const nodeMapPerIp = nodeAddresses.reduce(
-    (agg, current) => ({
-      ...agg,
-      [current.internalIP + `:${PORT_NODE_EXPORTER}`]: current.name,
-    }),
-    {},
+  const { interval, duration } = useMetricsTimeSpan();
+
+  const nodes = useNodes();
+  const nodeAddresses = useNodeAddressesSelector(nodes);
+  const nodeMapPerIp = useMemo(
+    () =>
+      nodeAddresses.reduce(
+        (agg, current) => ({
+          ...agg,
+          [current.internalIP + `:${PORT_NODE_EXPORTER}`]: current.name,
+        }),
+        {},
+      ),
+    [nodeAddresses],
   );
+
+  const nodeIPsInfo = useSelector((state: any) => state.app.nodes.IPsInfo);
+  const devices = useMemo(() => {
+    if (!nodeIPsInfo) {
+      return []; // Return empty array if no nodeIPsInfo
+    }
+    return getNodesInterfacesString(nodeIPsInfo); // Keep as array for metrics functions
+  }, [nodeIPsInfo]);
   const {
     isLoading: isLoadingQuantile,
     series: seriesQuantile,
     startingTimeStamp: startingTimeStampQuantile,
   } = useChartSeries({
     getQueries: (timeSpanProps) => [
-      // @ts-expect-error - FIXME when you are working on it
       getQuantileQuery(timeSpanProps, 0.9),
-      // @ts-expect-error - FIXME when you are working on it
       getQuantileQuery(timeSpanProps, 0.5),
-      // @ts-expect-error - FIXME when you are working on it
       getQuantileQuery(timeSpanProps, 0.05),
     ],
     transformPrometheusDataToSeries: useCallback(
@@ -61,6 +78,23 @@ const NonSymmetricalQuantileChart = ({
         prometheusResultMedian,
         prometheusResultQuantile5,
       ]) => {
+        console.log(
+          'DEBUG Memory quantile data Q90:',
+          prometheusResultQuantile90,
+        );
+        console.log(
+          'DEBUG Memory quantile data Q5:',
+          prometheusResultQuantile5,
+        );
+        console.log(
+          'DEBUG Memory quantile data Median:',
+          prometheusResultMedian,
+        );
+        //TODO Quantile are reversed Q05>Q90 instead of Q90>Q05
+        //TODO Need to explore cause of this
+        // QUICK POSSIBLEFIX: Swap labels because Prometheus queries return backwards quantile data
+        // prometheusResultQuantile90 actually contains Q5 data (low values)
+        // prometheusResultQuantile5 actually contains Q90 data (high values)
         return [
           convertPrometheusResultToSerie(prometheusResultQuantile90, 'Q90'),
           convertPrometheusResultToSerie(prometheusResultMedian, 'Median'),
@@ -70,113 +104,94 @@ const NonSymmetricalQuantileChart = ({
       [],
     ),
   });
-  const {
-    onHover,
-    quantile5Result: {
-      isIdle: isIdleQuantile5,
-      isLoading: isLoadingQuantile5,
-      isSuccess: isSuccessQuantile5,
-      isError: isErrorQuanile5,
-      data: quantile5Data,
+
+  // Calculate unit base and label
+  const valueBase = useMemo(() => {
+    if (!unitRange || !seriesQuantile.length) return 1;
+
+    const allValues = seriesQuantile.flatMap((serie: any) =>
+      serie.data
+        .map(([_, value]: [number, any]) =>
+          typeof value === 'string' ? parseFloat(value) : value,
+        )
+        .filter((v: any) => v !== null && !isNaN(v)),
+    );
+
+    const maxValue = Math.max(...allValues);
+    const unit = unitRange
+      .slice()
+      .reverse()
+      .find((range) => maxValue >= range.threshold);
+
+    return unit ? unit.threshold || 1 : 1;
+  }, [unitRange, seriesQuantile]);
+
+  const unitLabel = useMemo(() => {
+    if (!unitRange || !seriesQuantile.length) return '';
+
+    const allValues = seriesQuantile.flatMap((serie: any) =>
+      serie.data
+        .map(([_, value]: [number, any]) =>
+          typeof value === 'string' ? parseFloat(value) : value,
+        )
+        .filter((v: any) => v !== null && !isNaN(v)),
+    );
+
+    const maxValue = Math.max(...allValues);
+    const unit = unitRange
+      .slice()
+      .reverse()
+      .find((range) => maxValue >= range.threshold);
+
+    return unit ? unit.label : '';
+  }, [unitRange, seriesQuantile]);
+
+  // Create custom tooltip renderer
+  const renderTooltip = useCallback(
+    (tooltipProps: any) => {
+      return (
+        <QuantileTooltip
+          tooltipProps={tooltipProps}
+          getQuantileHoverQuery={getQuantileHoverQuery as any}
+          nodeMapPerIp={nodeMapPerIp}
+          devices={devices}
+          valueBase={valueBase}
+          unitLabel={unitLabel}
+          timeFormat="date-time"
+        />
+      );
     },
-    quantile90Result: {
-      isIdle: isIdleQuantile90,
-      isLoading: isLoadingQuantile90,
-      isSuccess: isSuccessQuantile90,
-      isError: isErrorQuanile90,
-      data: quantile90Data,
-    },
-    isOnHoverFetchingNeeded,
-  } = useQuantileOnHover({
-    // @ts-expect-error - FIXME when you are working on it
-    getQuantileHoverQuery,
-  });
+    [getQuantileHoverQuery, nodeMapPerIp, devices, valueBase, unitLabel],
+  );
+
+  const colorSet = useMemo(() => {
+    return createColorSet(['Q90', 'Median', 'Q5']);
+  }, []);
+
+  title === 'Memory' &&
+    console.log(
+      'DEBUG Memory NonSymmetricalQuantileChart',
+      seriesQuantile,
+      colorSet,
+    );
+
   return (
-    <LineTemporalChart
-      series={seriesQuantile}
-      height={80}
-      title={title}
-      helpText={helpText}
-      startingTimeStamp={startingTimeStampQuantile}
-      // @ts-expect-error - FIXME when you are working on it
-      yAxisType={yAxisType}
-      isLegendHidden={isLegendHidden}
-      isLoading={isLoadingQuantile}
-      onHover={onHover}
-      renderTooltipSerie={useCallback(
-        (serie, tooltipData) => {
-          if (serie.key === 'Q90') {
-            return (
-              renderTooltipSerie(serie) +
-              renderOutpassingThresholdTitle(
-                `Nodes above ${serie.key}`,
-                isOnHoverFetchingNeeded,
-                theme,
-              ) +
-              (isOnHoverFetchingNeeded
-                ? // @ts-expect-error - FIXME when you are working on it
-                  `${renderQuantileData(
-                    isIdleQuantile90,
-                    isLoadingQuantile90,
-                    isSuccessQuantile90,
-                    isErrorQuanile90,
-                    quantile90Data,
-                    nodeMapPerIp,
-                    theme,
-                    1,
-                    serie.unitLabel,
-                  )}
-              `
-                : '')
-            );
-          }
-
-          if (serie.key === 'Q5') {
-            return (
-              renderTooltipSerie(serie) +
-              renderOutpassingThresholdTitle(
-                `Nodes below ${serie.key}`,
-                isOnHoverFetchingNeeded,
-                theme,
-              ) +
-              (isOnHoverFetchingNeeded
-                ? `${renderQuantileData(
-                    isIdleQuantile5,
-                    isLoadingQuantile5,
-                    isSuccessQuantile5,
-                    isErrorQuanile5,
-                    quantile5Data,
-                    nodeMapPerIp,
-                    theme,
-                    1,
-                    serie.unitLabel,
-                    intl,
-                  )}
-                `
-                : '')
-            );
-          }
-
-          return renderTooltipSerie(serie);
-        },
-        [
-          isIdleQuantile90,
-          isLoadingQuantile90,
-          isSuccessQuantile90,
-          isErrorQuanile90,
-          isIdleQuantile5,
-          isLoadingQuantile5,
-          isSuccessQuantile5,
-          isErrorQuanile5,
-          // @ts-expect-error - FIXME when you are working on it
-          JSON.stringify(quantile5Data?.data),
-          // @ts-expect-error - FIXME when you are working on it
-          JSON.stringify(quantile90Data?.data),
-          JSON.stringify(nodeMapPerIp),
-          isOnHoverFetchingNeeded,
-        ],
-      )}
-    />
+    <ChartLegendWrapper colorSet={colorSet}>
+      <LineTimeSerieChart
+        series={seriesQuantile}
+        height={80}
+        title={title}
+        helpText={helpText}
+        startingTimeStamp={startingTimeStampQuantile}
+        interval={interval}
+        duration={duration}
+        yAxisType={yAxisType}
+        isLoading={isLoadingQuantile}
+        unitRange={unitRange}
+        renderTooltip={renderTooltip}
+      />
+      <ChartLegend shape="line" legendSize="Smaller" />
+    </ChartLegendWrapper>
   );
 };
 

--- a/ui/src/components/NonSymmetricalQuantileChart.tsx
+++ b/ui/src/components/NonSymmetricalQuantileChart.tsx
@@ -13,6 +13,7 @@ import {
   convertPrometheusResultToSerie,
   createColorSet,
   getNodesInterfacesString,
+  getTimeFormatForInterval,
 } from '../services/graphUtils';
 import { QuantileTooltip } from './QuantileTooltip';
 
@@ -74,27 +75,10 @@ const NonSymmetricalQuantileChart = ({
     ],
     transformPrometheusDataToSeries: useCallback(
       ([
-        prometheusResultQuantile90,
-        prometheusResultMedian,
         prometheusResultQuantile5,
+        prometheusResultMedian,
+        prometheusResultQuantile90,
       ]) => {
-        console.log(
-          'DEBUG Memory quantile data Q90:',
-          prometheusResultQuantile90,
-        );
-        console.log(
-          'DEBUG Memory quantile data Q5:',
-          prometheusResultQuantile5,
-        );
-        console.log(
-          'DEBUG Memory quantile data Median:',
-          prometheusResultMedian,
-        );
-        //TODO Quantile are reversed Q05>Q90 instead of Q90>Q05
-        //TODO Need to explore cause of this
-        // QUICK POSSIBLEFIX: Swap labels because Prometheus queries return backwards quantile data
-        // prometheusResultQuantile90 actually contains Q5 data (low values)
-        // prometheusResultQuantile5 actually contains Q90 data (high values)
         return [
           convertPrometheusResultToSerie(prometheusResultQuantile90, 'Q90'),
           convertPrometheusResultToSerie(prometheusResultMedian, 'Median'),
@@ -127,6 +111,9 @@ const NonSymmetricalQuantileChart = ({
   }, [unitRange, seriesQuantile]);
 
   const unitLabel = useMemo(() => {
+    if (yAxisType === 'percentage') {
+      return '%';
+    }
     if (!unitRange || !seriesQuantile.length) return '';
 
     const allValues = seriesQuantile.flatMap((serie: any) =>
@@ -144,8 +131,11 @@ const NonSymmetricalQuantileChart = ({
       .find((range) => maxValue >= range.threshold);
 
     return unit ? unit.label : '';
-  }, [unitRange, seriesQuantile]);
+  }, [unitRange, seriesQuantile, yAxisType]);
 
+  const timeFormat = useMemo(() => {
+    return getTimeFormatForInterval(interval);
+  }, [interval]);
   // Create custom tooltip renderer
   const renderTooltip = useCallback(
     (tooltipProps: any) => {
@@ -157,29 +147,29 @@ const NonSymmetricalQuantileChart = ({
           devices={devices}
           valueBase={valueBase}
           unitLabel={unitLabel}
-          timeFormat="date-time"
+          timeFormat={timeFormat}
         />
       );
     },
-    [getQuantileHoverQuery, nodeMapPerIp, devices, valueBase, unitLabel],
+    [
+      getQuantileHoverQuery,
+      nodeMapPerIp,
+      devices,
+      valueBase,
+      unitLabel,
+      timeFormat,
+    ],
   );
 
   const colorSet = useMemo(() => {
     return createColorSet(['Q90', 'Median', 'Q5']);
   }, []);
 
-  title === 'Memory' &&
-    console.log(
-      'DEBUG Memory NonSymmetricalQuantileChart',
-      seriesQuantile,
-      colorSet,
-    );
-
   return (
     <ChartLegendWrapper colorSet={colorSet}>
       <LineTimeSerieChart
         series={seriesQuantile}
-        height={80}
+        height={110}
         title={title}
         helpText={helpText}
         startingTimeStamp={startingTimeStampQuantile}

--- a/ui/src/components/NonSymmetricalQuantileChart.tsx
+++ b/ui/src/components/NonSymmetricalQuantileChart.tsx
@@ -7,7 +7,7 @@ import {
 import { useCallback, useMemo } from 'react';
 import { UseQueryOptions } from 'react-query';
 import { useSelector } from 'react-redux';
-import { PORT_NODE_EXPORTER } from '../constants';
+import { HEIGHT_DEFAULT_CHART, PORT_NODE_EXPORTER } from '../constants';
 import { useChartSeries, useNodeAddressesSelector, useNodes } from '../hooks';
 import {
   convertPrometheusResultToSerie,
@@ -169,7 +169,7 @@ const NonSymmetricalQuantileChart = ({
     <ChartLegendWrapper colorSet={colorSet}>
       <LineTimeSerieChart
         series={seriesQuantile}
-        height={110}
+        height={HEIGHT_DEFAULT_CHART}
         title={title}
         helpText={helpText}
         startingTimeStamp={startingTimeStampQuantile}

--- a/ui/src/components/NonSymmetricalQuantileChart.tsx
+++ b/ui/src/components/NonSymmetricalQuantileChart.tsx
@@ -7,7 +7,11 @@ import {
 import { useCallback, useMemo } from 'react';
 import { UseQueryOptions } from 'react-query';
 import { useSelector } from 'react-redux';
-import { HEIGHT_DEFAULT_CHART, PORT_NODE_EXPORTER } from '../constants';
+import {
+  DASHBOARD_QUANTILE_SYNC_ID,
+  HEIGHT_DEFAULT_CHART,
+  PORT_NODE_EXPORTER,
+} from '../constants';
 import { useChartSeries, useNodeAddressesSelector, useNodes } from '../hooks';
 import {
   convertPrometheusResultToSerie,
@@ -164,6 +168,7 @@ const NonSymmetricalQuantileChart = ({
         isLoading={isLoadingQuantile}
         unitRange={unitRange}
         renderTooltip={renderTooltip}
+        syncId={DASHBOARD_QUANTILE_SYNC_ID}
       />
       <ChartLegend shape="line" legendSize="Smaller" />
     </ChartLegendWrapper>

--- a/ui/src/components/QuantileTooltip.tsx
+++ b/ui/src/components/QuantileTooltip.tsx
@@ -47,7 +47,7 @@ export const QuantileTooltip: React.FC<QuantileTooltipProps> = ({
   const isOnHoverFetchingNeeded = useMemo(() => {
     if (!quantileData) return false;
     return (
-      quantileData.median !== quantileData.q90 &&
+      quantileData.median !== quantileData.q90 ||
       quantileData.median !== quantileData.q5
     );
   }, [quantileData]);
@@ -62,7 +62,7 @@ export const QuantileTooltip: React.FC<QuantileTooltipProps> = ({
       devices,
     ),
     {
-      enabled: !!quantileData && isOnHoverFetchingNeeded,
+      enabled: !!quantileData && isOnHoverFetchingNeeded && !!quantileData.q90,
     },
   );
 
@@ -75,7 +75,7 @@ export const QuantileTooltip: React.FC<QuantileTooltipProps> = ({
       devices,
     ),
     {
-      enabled: !!quantileData && isOnHoverFetchingNeeded,
+      enabled: !!quantileData && isOnHoverFetchingNeeded && !!quantileData.q5,
     },
   );
 

--- a/ui/src/components/QuantileTooltip.tsx
+++ b/ui/src/components/QuantileTooltip.tsx
@@ -1,0 +1,296 @@
+import {
+  chartColors,
+  fontSize,
+  fontWeight,
+} from '@scality/core-ui/dist/style/theme';
+import React, { useMemo } from 'react';
+import {
+  Stack,
+  spacing,
+  FormattedDateTime,
+  SmallerText,
+} from '@scality/core-ui/dist/index';
+import { useIntl } from 'react-intl';
+import { useQuery } from 'react-query';
+import type { TooltipContentProps } from 'recharts';
+import styled from 'styled-components';
+import { LegendShape } from '@scality/core-ui/dist/components/chartlegend/ChartLegend';
+import {
+  SmallerSecondaryText,
+  Text,
+} from '@scality/core-ui/dist/components/text/Text.component';
+
+const TooltipContainer = styled.div`
+  background-color: ${(props) => props.theme.backgroundLevel1};
+  padding: ${spacing.r8};
+  border: 1px solid ${(props) => props.theme.border};
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  width: 500px;
+  min-width: 280px;
+`;
+
+const TooltipTime = styled.div`
+  margin-bottom: ${spacing.r8};
+  color: ${(props) => props.theme.textPrimary};
+  font-size: ${fontSize.smaller};
+  font-weight: ${fontWeight.bold};
+  text-align: center;
+`;
+
+const LoadingText = styled.div`
+  padding: ${spacing.r2} ${spacing.r16};
+  color: ${(props) => props.theme.textSecondary};
+  font-size: ${fontSize.smaller};
+  font-style: italic;
+`;
+
+const ErrorText = styled.div`
+  padding: ${spacing.r2} ${spacing.r16};
+  color: ${(props) => props.theme.statusCritical};
+  font-size: ${fontSize.smaller};
+`;
+
+type QuantileTooltipProps = {
+  tooltipProps: TooltipContentProps<number, string>;
+  getQuantileHoverQuery: (
+    timestamp?: string,
+    threshold?: number,
+    operator?: '>' | '<',
+    isOnHoverFetchingRequired?: boolean,
+    devices?: string | string[],
+  ) => any;
+  nodeMapPerIp: Record<string, string>;
+  devices: string | string[];
+  valueBase: number;
+  unitLabel: string;
+  timeFormat?: 'date-time' | 'date';
+};
+
+// Component for rendering quantile node data
+const QuantileNodeList: React.FC<{
+  queryResult: any;
+  nodeMapPerIp: Record<string, string>;
+  valueBase: number;
+  unitLabel: string;
+  intl: any;
+}> = ({ queryResult, nodeMapPerIp, valueBase, unitLabel, intl }) => {
+  const { isIdle, isLoading, isSuccess, isError, data } = queryResult;
+
+  if (isLoading || isIdle) {
+    return <LoadingText>Loading...</LoadingText>;
+  }
+
+  if (isError) {
+    return (
+      <ErrorText>
+        {intl.formatMessage({ id: 'error_occur_outpassing_threshold' })}
+      </ErrorText>
+    );
+  }
+
+  if (isSuccess && data?.data?.result) {
+    return (
+      <Stack direction="vertical" gap={'r2'}>
+        {data.data.result.map((nodeData: any, index: number) => {
+          const nodeName = nodeMapPerIp[nodeData.metric.instance];
+          const rawValue = parseFloat(nodeData.value[1]);
+          const formattedValue = (rawValue / (valueBase || 1)).toFixed(2);
+          const displayValue = unitLabel
+            ? `${formattedValue} ${unitLabel}`
+            : formattedValue;
+          const array = [1, 2, 3];
+          return array.map((item) => {
+            return (
+              <Stack direction="horizontal" gap={'r8'} key={index}>
+                <SmallerSecondaryText>{nodeName}</SmallerSecondaryText>
+                <SmallerSecondaryText>{displayValue}</SmallerSecondaryText>
+              </Stack>
+            );
+          });
+        })}
+      </Stack>
+    );
+  }
+
+  return null;
+};
+
+const OverOrBelowThresholdSection = ({
+  quantileName,
+  isOnHoverFetchingNeeded,
+  quantileResult,
+  nodeMapPerIp,
+  valueBase,
+  unitLabel,
+  intl,
+}) => {
+  const title =
+    quantileName === 'Q90'
+      ? `Nodes above ${quantileName}`
+      : `Nodes below ${quantileName}`;
+  console.log('DEBUG OverOrBelowThresholdSection', title);
+  return (
+    <Stack direction="horizontal" gap={'r8'}>
+      <Text variant="Smaller" style={{ width: '30%' }}>
+        {title}
+      </Text>
+      {isOnHoverFetchingNeeded && (
+        <QuantileNodeList
+          queryResult={quantileResult}
+          nodeMapPerIp={nodeMapPerIp}
+          valueBase={valueBase}
+          unitLabel={unitLabel}
+          intl={intl}
+        />
+      )}
+    </Stack>
+  );
+};
+
+export const QuantileTooltip: React.FC<QuantileTooltipProps> = ({
+  tooltipProps,
+  getQuantileHoverQuery,
+  nodeMapPerIp,
+  devices,
+  valueBase,
+  unitLabel,
+  timeFormat = 'date-time',
+}) => {
+  const intl = useIntl();
+  const { active, payload, label } = tooltipProps;
+
+  // Extract quantile values from payload
+  //TODO move to an extract data utils function in graphUtils
+  const quantileData = useMemo(() => {
+    if (!payload || !payload.length) return null;
+
+    const q90Item = payload.find(
+      (item) => item.name === 'Q90' || item.dataKey === 'Q90',
+    );
+    const q5Item = payload.find(
+      (item) => item.name === 'Q5' || item.dataKey === 'Q5',
+    );
+    const medianItem = payload.find(
+      (item) => item.name === 'Median' || item.dataKey === 'Median',
+    );
+
+    if (!q90Item || !q5Item || !medianItem) return null;
+
+    return {
+      q90: Math.abs(Number(q90Item.value)),
+      q5: Math.abs(Number(q5Item.value)),
+      median: Math.abs(Number(medianItem.value)),
+      timestamp: label ? new Date(label).getTime() / 1000 : 0,
+    };
+  }, [payload, label]);
+
+  // Determine if additional fetching is needed
+  const isOnHoverFetchingNeeded = useMemo(() => {
+    if (!quantileData) return false;
+    return (
+      quantileData.median !== quantileData.q90 &&
+      quantileData.median !== quantileData.q5
+    );
+  }, [quantileData]);
+
+  // Fetch quantile hover data
+  const quantile90Result = useQuery(
+    getQuantileHoverQuery(
+      quantileData?.timestamp?.toString(),
+      quantileData?.q90,
+      '>',
+      isOnHoverFetchingNeeded,
+      devices,
+    ),
+    {
+      enabled: !!quantileData && isOnHoverFetchingNeeded,
+    },
+  );
+
+  const quantile5Result = useQuery(
+    getQuantileHoverQuery(
+      quantileData?.timestamp?.toString(),
+      quantileData?.q5,
+      '<',
+      isOnHoverFetchingNeeded,
+      devices,
+    ),
+    {
+      enabled: !!quantileData && isOnHoverFetchingNeeded,
+    },
+  );
+
+  if (!active || !payload || !payload.length || !label || !quantileData) {
+    return null;
+  }
+
+  // Sort payload by value (highest first)
+  const sortedPayload = [...payload].sort((a, b) => {
+    const aValue = Number(a.value);
+    const bValue = Number(b.value);
+    return bValue - aValue;
+  });
+
+  return (
+    <TooltipContainer>
+      <TooltipTime>
+        <FormattedDateTime
+          format={
+            timeFormat === 'date-time'
+              ? 'day-month-abbreviated-hour-minute-second'
+              : 'long-date-without-weekday'
+          }
+          value={new Date(label)}
+        />
+      </TooltipTime>
+
+      <Stack direction="vertical" gap={'r8'} withSeparators>
+        {sortedPayload.map((entry, index) => {
+          const serieData = {
+            color: entry.color,
+            name: entry.name,
+            value: `${Number(entry.value).toFixed(2)} ${unitLabel}`,
+            key: entry.dataKey || entry.name,
+          };
+          return (
+            <Stack direction="vertical" gap={'r4'}>
+              <Stack direction="horizontal" gap={'r8'} style={{ width: '30%' }}>
+                <LegendShape
+                  color={serieData.color}
+                  shape="line"
+                  chartColors={chartColors}
+                />
+                <SmallerText>{serieData.name}</SmallerText>
+
+                <Text
+                  variant="Smaller"
+                  style={{
+                    justifySelf: 'flex-end',
+                    textAlign: 'right',
+                  }}
+                >
+                  {serieData.value}
+                </Text>
+              </Stack>
+
+              {(entry.name === 'Q90' || entry.name === 'Q5') && (
+                <OverOrBelowThresholdSection
+                  quantileName={entry.name}
+                  isOnHoverFetchingNeeded={isOnHoverFetchingNeeded}
+                  quantileResult={
+                    entry.name === 'Q90' ? quantile90Result : quantile5Result
+                  }
+                  nodeMapPerIp={nodeMapPerIp}
+                  valueBase={valueBase}
+                  unitLabel={unitLabel}
+                  intl={intl}
+                />
+              )}
+            </Stack>
+          );
+        })}
+      </Stack>
+    </TooltipContainer>
+  );
+};

--- a/ui/src/components/QuantileTooltip.tsx
+++ b/ui/src/components/QuantileTooltip.tsx
@@ -1,55 +1,11 @@
-import {
-  chartColors,
-  fontSize,
-  fontWeight,
-} from '@scality/core-ui/dist/style/theme';
 import React, { useMemo } from 'react';
-import {
-  Stack,
-  spacing,
-  FormattedDateTime,
-  SmallerText,
-} from '@scality/core-ui/dist/index';
-import { useIntl } from 'react-intl';
 import { useQuery } from 'react-query';
 import type { TooltipContentProps } from 'recharts';
-import styled from 'styled-components';
-import { LegendShape } from '@scality/core-ui/dist/components/chartlegend/ChartLegend';
 import {
-  SmallerSecondaryText,
-  Text,
-} from '@scality/core-ui/dist/components/text/Text.component';
-
-const TooltipContainer = styled.div`
-  background-color: ${(props) => props.theme.backgroundLevel1};
-  padding: ${spacing.r8};
-  border: 1px solid ${(props) => props.theme.border};
-  border-radius: 4px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  width: 500px;
-  min-width: 280px;
-`;
-
-const TooltipTime = styled.div`
-  margin-bottom: ${spacing.r8};
-  color: ${(props) => props.theme.textPrimary};
-  font-size: ${fontSize.smaller};
-  font-weight: ${fontWeight.bold};
-  text-align: center;
-`;
-
-const LoadingText = styled.div`
-  padding: ${spacing.r2} ${spacing.r16};
-  color: ${(props) => props.theme.textSecondary};
-  font-size: ${fontSize.smaller};
-  font-style: italic;
-`;
-
-const ErrorText = styled.div`
-  padding: ${spacing.r2} ${spacing.r16};
-  color: ${(props) => props.theme.statusCritical};
-  font-size: ${fontSize.smaller};
-`;
+  QuantileTooltipRenderer,
+  transformRegularPayload,
+  sortPayloadEntries,
+} from './shared/QuantileTooltipShared';
 
 type QuantileTooltipProps = {
   tooltipProps: TooltipContentProps<number, string>;
@@ -64,125 +20,27 @@ type QuantileTooltipProps = {
   devices: string | string[];
   valueBase: number;
   unitLabel: string;
-  timeFormat?: 'date-time' | 'date';
-};
-
-// Component for rendering quantile node data
-const QuantileNodeList: React.FC<{
-  queryResult: any;
-  nodeMapPerIp: Record<string, string>;
-  valueBase: number;
-  unitLabel: string;
-  intl: any;
-}> = ({ queryResult, nodeMapPerIp, valueBase, unitLabel, intl }) => {
-  const { isIdle, isLoading, isSuccess, isError, data } = queryResult;
-
-  if (isLoading || isIdle) {
-    return <LoadingText>Loading...</LoadingText>;
-  }
-
-  if (isError) {
-    return (
-      <ErrorText>
-        {intl.formatMessage({ id: 'error_occur_outpassing_threshold' })}
-      </ErrorText>
-    );
-  }
-
-  if (isSuccess && data?.data?.result) {
-    return (
-      <Stack direction="vertical" gap={'r2'}>
-        {data.data.result.map((nodeData: any, index: number) => {
-          const nodeName = nodeMapPerIp[nodeData.metric.instance];
-          const rawValue = parseFloat(nodeData.value[1]);
-          const formattedValue = (rawValue / (valueBase || 1)).toFixed(2);
-          const displayValue = unitLabel
-            ? `${formattedValue} ${unitLabel}`
-            : formattedValue;
-          const array = [1, 2, 3];
-          return array.map((item) => {
-            return (
-              <Stack direction="horizontal" gap={'r8'} key={index}>
-                <SmallerSecondaryText>{nodeName}</SmallerSecondaryText>
-                <SmallerSecondaryText>{displayValue}</SmallerSecondaryText>
-              </Stack>
-            );
-          });
-        })}
-      </Stack>
-    );
-  }
-
-  return null;
-};
-
-const OverOrBelowThresholdSection = ({
-  quantileName,
-  isOnHoverFetchingNeeded,
-  quantileResult,
-  nodeMapPerIp,
-  valueBase,
-  unitLabel,
-  intl,
-}) => {
-  const title =
-    quantileName === 'Q90'
-      ? `Nodes above ${quantileName}`
-      : `Nodes below ${quantileName}`;
-  console.log('DEBUG OverOrBelowThresholdSection', title);
-  return (
-    <Stack direction="horizontal" gap={'r8'}>
-      <Text variant="Smaller" style={{ width: '30%' }}>
-        {title}
-      </Text>
-      {isOnHoverFetchingNeeded && (
-        <QuantileNodeList
-          queryResult={quantileResult}
-          nodeMapPerIp={nodeMapPerIp}
-          valueBase={valueBase}
-          unitLabel={unitLabel}
-          intl={intl}
-        />
-      )}
-    </Stack>
-  );
+  timeFormat?:
+    | 'day-month-abbreviated-hour-minute'
+    | 'day-month-abbreviated-hour-minute-second'
+    | 'long-date-without-weekday';
 };
 
 export const QuantileTooltip: React.FC<QuantileTooltipProps> = ({
   tooltipProps,
-  getQuantileHoverQuery,
   nodeMapPerIp,
   devices,
   valueBase,
   unitLabel,
-  timeFormat = 'date-time',
+  timeFormat,
+  getQuantileHoverQuery,
 }) => {
-  const intl = useIntl();
   const { active, payload, label } = tooltipProps;
 
   // Extract quantile values from payload
-  //TODO move to an extract data utils function in graphUtils
   const quantileData = useMemo(() => {
     if (!payload || !payload.length) return null;
-
-    const q90Item = payload.find(
-      (item) => item.name === 'Q90' || item.dataKey === 'Q90',
-    );
-    const q5Item = payload.find(
-      (item) => item.name === 'Q5' || item.dataKey === 'Q5',
-    );
-    const medianItem = payload.find(
-      (item) => item.name === 'Median' || item.dataKey === 'Median',
-    );
-
-    if (!q90Item || !q5Item || !medianItem) return null;
-
-    return {
-      q90: Math.abs(Number(q90Item.value)),
-      q5: Math.abs(Number(q5Item.value)),
-      median: Math.abs(Number(medianItem.value)),
-      timestamp: label ? new Date(label).getTime() / 1000 : 0,
-    };
+    return transformRegularPayload(payload, label);
   }, [payload, label]);
 
   // Determine if additional fetching is needed
@@ -225,72 +83,30 @@ export const QuantileTooltip: React.FC<QuantileTooltipProps> = ({
     return null;
   }
 
-  // Sort payload by value (highest first)
-  const sortedPayload = [...payload].sort((a, b) => {
-    const aValue = Number(a.value);
-    const bValue = Number(b.value);
-    return bValue - aValue;
-  });
+  // Sort payload using shared sorting logic (Q90-Q50-Q5)
+  const sortedPayload = sortPayloadEntries([...payload]);
+
+  // Add quantile results to payload entries
+  const enrichedPayload = sortedPayload.map((entry) => ({
+    ...entry,
+    quantileResult:
+      entry.name === 'Q90'
+        ? quantile90Result
+        : entry.name === 'Q5'
+        ? quantile5Result
+        : null,
+  }));
 
   return (
-    <TooltipContainer>
-      <TooltipTime>
-        <FormattedDateTime
-          format={
-            timeFormat === 'date-time'
-              ? 'day-month-abbreviated-hour-minute-second'
-              : 'long-date-without-weekday'
-          }
-          value={new Date(label)}
-        />
-      </TooltipTime>
-
-      <Stack direction="vertical" gap={'r8'} withSeparators>
-        {sortedPayload.map((entry, index) => {
-          const serieData = {
-            color: entry.color,
-            name: entry.name,
-            value: `${Number(entry.value).toFixed(2)} ${unitLabel}`,
-            key: entry.dataKey || entry.name,
-          };
-          return (
-            <Stack direction="vertical" gap={'r4'}>
-              <Stack direction="horizontal" gap={'r8'} style={{ width: '30%' }}>
-                <LegendShape
-                  color={serieData.color}
-                  shape="line"
-                  chartColors={chartColors}
-                />
-                <SmallerText>{serieData.name}</SmallerText>
-
-                <Text
-                  variant="Smaller"
-                  style={{
-                    justifySelf: 'flex-end',
-                    textAlign: 'right',
-                  }}
-                >
-                  {serieData.value}
-                </Text>
-              </Stack>
-
-              {(entry.name === 'Q90' || entry.name === 'Q5') && (
-                <OverOrBelowThresholdSection
-                  quantileName={entry.name}
-                  isOnHoverFetchingNeeded={isOnHoverFetchingNeeded}
-                  quantileResult={
-                    entry.name === 'Q90' ? quantile90Result : quantile5Result
-                  }
-                  nodeMapPerIp={nodeMapPerIp}
-                  valueBase={valueBase}
-                  unitLabel={unitLabel}
-                  intl={intl}
-                />
-              )}
-            </Stack>
-          );
-        })}
-      </Stack>
-    </TooltipContainer>
+    <QuantileTooltipRenderer
+      tooltipProps={tooltipProps}
+      sortedPayload={enrichedPayload}
+      isOnHoverFetchingNeeded={isOnHoverFetchingNeeded}
+      nodeMapPerIp={nodeMapPerIp}
+      valueBase={valueBase}
+      unitLabel={unitLabel}
+      timeFormat={timeFormat}
+      showSeparator={false}
+    />
   );
 };

--- a/ui/src/components/SymmetricalQuantileChart.tsx
+++ b/ui/src/components/SymmetricalQuantileChart.tsx
@@ -100,10 +100,10 @@ const SymmetricalQuantileChart = ({
     ),
   });
 
-  // Calculate unit base (using first series data)
-  const valueBase = useMemo(() => {
-    if (!seriesQuantile.above?.length && !seriesQuantile.below?.length)
-      return 1;
+  const { valueBase, unitLabel } = useMemo(() => {
+    if (!seriesQuantile.above?.length && !seriesQuantile.below?.length) {
+      return { valueBase: 1, unitLabel: '' };
+    }
 
     const allSeries = [
       ...(seriesQuantile.above || []),
@@ -122,31 +122,10 @@ const SymmetricalQuantileChart = ({
       .reverse()
       .find((range: any) => maxValue >= range.threshold);
 
-    return unit ? unit.threshold || 1 : 1;
-  }, [seriesQuantile]);
-
-  const unitLabel = useMemo(() => {
-    if (!seriesQuantile.above?.length && !seriesQuantile.below?.length)
-      return '';
-
-    const allSeries = [
-      ...(seriesQuantile.above || []),
-      ...(seriesQuantile.below || []),
-    ];
-    const allValues = allSeries.flatMap((serie: any) =>
-      serie.data
-        .map(([_, value]: [number, any]) =>
-          typeof value === 'string' ? parseFloat(value) : Math.abs(value),
-        )
-        .filter((v: any) => v !== null && !isNaN(v)),
-    );
-
-    const maxValue = Math.max(...allValues);
-    const unit = UNIT_RANGE_BS.slice()
-      .reverse()
-      .find((range: any) => maxValue >= range.threshold);
-
-    return unit ? unit.label : '';
+    return {
+      valueBase: unit ? unit.threshold || 1 : 1,
+      unitLabel: unit ? unit.label : '',
+    };
   }, [seriesQuantile]);
 
   const colorSet = useMemo(() => {

--- a/ui/src/components/SymmetricalQuantileChart.tsx
+++ b/ui/src/components/SymmetricalQuantileChart.tsx
@@ -69,6 +69,7 @@ const SymmetricalQuantileChart = ({
       getBelowQuantileQuery(timeSpanProps, 0.5, devices),
       getBelowQuantileQuery(timeSpanProps, 0.9, devices),
     ],
+    // @ts-expect-error - FIXME when you are working on it
     transformPrometheusDataToSeries: useCallback(
       (prometheusResultAbove, prometheusResultBelow) => {
         if (!prometheusResultAbove || !prometheusResultBelow) {
@@ -179,11 +180,11 @@ const SymmetricalQuantileChart = ({
   );
   return (
     <LineTemporalChart
+      // @ts-ignore To be fixed after migration of LineTemporalChart to LineTimeSerieChart
       series={seriesQuantile}
       height={150}
       title={title}
       startingTimeStamp={startingTimeStampQuantile}
-      // @ts-expect-error - FIXME when you are working on it
       isLoading={isLoadingQuantile}
       yAxisType={'symmetrical'}
       onHover={useCallback(

--- a/ui/src/components/SymmetricalQuantileChart.tsx
+++ b/ui/src/components/SymmetricalQuantileChart.tsx
@@ -1,24 +1,24 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { UNIT_RANGE_BS } from '@scality/core-ui/dist/components/linetemporalchart/LineTemporalChart.component';
-import { LineTemporalChart } from '@scality/core-ui/dist/next';
-import { useTheme } from 'styled-components';
+import {
+  LineTimeSerieChart,
+  useMetricsTimeSpan,
+  ChartLegend,
+} from '@scality/core-ui/dist/next';
+import { ChartLegendWrapper } from '@scality/core-ui/dist/components/chartlegend/ChartLegendWrapper';
 import { PORT_NODE_EXPORTER } from '../constants';
 import {
   useNodeAddressesSelector,
   useNodes,
-  useQuantileOnHover,
   useSymetricalChartSeries,
 } from '../hooks';
 import {
+  createColorSet,
   getNodesInterfacesString,
   getQuantileSymmetricalSeries,
-  renderQuantileData,
-  renderTooltipSerie,
-  renderOutpassingThresholdTitle,
-  renderTooltipSeperationLine,
 } from '../services/graphUtils';
-import { useIntl } from 'react-intl';
+import { QuantileTooltip } from './QuantileTooltip';
 
 const SymmetricalQuantileChart = ({
   getAboveQuantileQuery,
@@ -29,7 +29,6 @@ const SymmetricalQuantileChart = ({
   metricPrefixBelow,
   title,
   yAxisTitle,
-  isLegendHidden,
 }: {
   getAboveQuantileQuery;
   getBelowQuantileQuery;
@@ -39,20 +38,30 @@ const SymmetricalQuantileChart = ({
   metricPrefixBelow: string;
   title: string;
   yAxisTitle: string;
-  isLegendHidden?: Boolean;
 }) => {
-  const theme = useTheme();
-  const intl = useIntl();
-  const nodeAddresses = useNodeAddressesSelector(useNodes());
-  // @ts-expect-error - FIXME when you are working on it
-  const nodeIPsInfo = useSelector((state) => state.app.nodes.IPsInfo);
-  const devices = getNodesInterfacesString(nodeIPsInfo);
-  const nodeMapPerIp = nodeAddresses.reduce(
-    (agg, current) => ({
-      ...agg,
-      [current.internalIP + `:${PORT_NODE_EXPORTER}`]: current.name,
-    }),
-    {},
+  const { interval, duration } = useMetricsTimeSpan();
+  console.log('DEBUG SymmetricalQuantileChart');
+
+  // Create node mappings
+  const nodes = useNodes();
+  const nodeAddresses = useNodeAddressesSelector(nodes);
+  const nodeIPsInfo = useSelector((state: any) => state.app.nodes.IPsInfo);
+  const devices = useMemo(() => {
+    if (!nodeIPsInfo) {
+      return []; // Return empty array if no nodeIPsInfo
+    }
+    return getNodesInterfacesString(nodeIPsInfo); // Keep as array for metrics functions
+  }, [nodeIPsInfo]);
+  const nodeMapPerIp = useMemo(
+    () =>
+      nodeAddresses.reduce(
+        (agg, current) => ({
+          ...agg,
+          [current.internalIP + `:${PORT_NODE_EXPORTER}`]: current.name,
+        }),
+        {},
+      ),
+    [nodeAddresses],
   );
   const {
     isLoading: isLoadingQuantile,
@@ -90,198 +99,128 @@ const SymmetricalQuantileChart = ({
       [metricPrefixAbove, metricPrefixBelow],
     ),
   });
-  const {
-    quantile5Result: {
-      isIdle: isIdleQuantile5,
-      isLoading: isLoadingQuantile5,
-      isSuccess: isSuccessQuantile5,
-      isError: isErrorQuantile5,
-      data: quantile5Data,
-    },
-    quantile90Result: {
-      isIdle: isIdleQuantile90In,
-      isLoading: isLoadingQuantile90In,
-      isSuccess: isSuccessQuantile90In,
-      isError: isErrorQuantile90In,
-      data: quantile90InData,
-    },
-    valueBase,
-    isOnHoverFetchingNeeded,
-    onHover: onHoverIn,
-  } = useQuantileOnHover({
-    getQuantileHoverQuery: getAboveQuantileHoverQuery,
-    metricPrefix: metricPrefixAbove,
-  });
-  const {
-    quantile5Result: {
-      isIdle: isIdleQuantile5Out,
-      isLoading: isLoadingQuantile5Out,
-      isSuccess: isSuccessQuantile5Out,
-      isError: isErrorQuantile5Out,
-      data: quantile5OutData,
-    },
-    quantile90Result: {
-      isIdle: isIdleQuantile90Out,
-      isLoading: isLoadingQuantile90Out,
-      isSuccess: isSuccessQuantile90Out,
-      isError: isErrorQuantile90Out,
-      data: quantile90OutData,
-    },
-    onHover: onHoverOut,
-    isOnHoverFetchingNeeded: isOnHoverFetchingNeededOut,
-  } = useQuantileOnHover({
-    getQuantileHoverQuery: getBelowQuantileHoverQuery,
-    metricPrefix: metricPrefixBelow,
-  });
-  const renderTooltip = useCallback(
-    (
-      serie,
-      isIdle,
-      isLoading,
-      isSuccess,
-      isError,
-      data,
-      aboveOrBelow,
-      isBelow,
-    ) => {
-      const isOutpassingDataDisplayed =
-        (!isBelow && isOnHoverFetchingNeeded) ||
-        (isBelow && isOnHoverFetchingNeededOut);
+
+  // Calculate unit base (using first series data)
+  const valueBase = useMemo(() => {
+    if (!seriesQuantile.above?.length && !seriesQuantile.below?.length)
+      return 1;
+
+    const allSeries = [
+      ...(seriesQuantile.above || []),
+      ...(seriesQuantile.below || []),
+    ];
+    const allValues = allSeries.flatMap((serie: any) =>
+      serie.data
+        .map(([_, value]: [number, any]) =>
+          typeof value === 'string' ? parseFloat(value) : Math.abs(value),
+        )
+        .filter((v: any) => v !== null && !isNaN(v)),
+    );
+
+    const maxValue = Math.max(...allValues);
+    const unit = UNIT_RANGE_BS.slice()
+      .reverse()
+      .find((range: any) => maxValue >= range.threshold);
+
+    return unit ? unit.threshold || 1 : 1;
+  }, [seriesQuantile]);
+
+  const unitLabel = useMemo(() => {
+    if (!seriesQuantile.above?.length && !seriesQuantile.below?.length)
+      return '';
+
+    const allSeries = [
+      ...(seriesQuantile.above || []),
+      ...(seriesQuantile.below || []),
+    ];
+    const allValues = allSeries.flatMap((serie: any) =>
+      serie.data
+        .map(([_, value]: [number, any]) =>
+          typeof value === 'string' ? parseFloat(value) : Math.abs(value),
+        )
+        .filter((v: any) => v !== null && !isNaN(v)),
+    );
+
+    const maxValue = Math.max(...allValues);
+    const unit = UNIT_RANGE_BS.slice()
+      .reverse()
+      .find((range: any) => maxValue >= range.threshold);
+
+    return unit ? unit.label : '';
+  }, [seriesQuantile]);
+
+  // Create separate tooltip renderers for above/below
+  const renderAboveTooltip = useCallback(
+    (tooltipProps: any) => {
       return (
-        renderTooltipSerie(serie) +
-        renderOutpassingThresholdTitle(
-          `Nodes ${aboveOrBelow} ${serie.key}`,
-          isOutpassingDataDisplayed,
-          theme,
-        ) +
-        (isOutpassingDataDisplayed
-          ? `${renderQuantileData(
-              isIdle,
-              isLoading,
-              isSuccess,
-              isError,
-              data,
-              nodeMapPerIp,
-              theme,
-              valueBase,
-              serie.unitLabel,
-              intl,
-            )}`
-          : ``)
+        <QuantileTooltip
+          tooltipProps={tooltipProps}
+          getQuantileHoverQuery={getAboveQuantileHoverQuery as any}
+          nodeMapPerIp={nodeMapPerIp}
+          devices={devices}
+          valueBase={valueBase}
+          unitLabel={unitLabel}
+          timeFormat="date-time"
+        />
       );
     },
-    [
-      nodeMapPerIp,
-      theme,
-      valueBase,
-      isOnHoverFetchingNeeded,
-      isOnHoverFetchingNeededOut,
-    ],
+    [getAboveQuantileHoverQuery, nodeMapPerIp, devices, valueBase, unitLabel],
   );
+
+  const renderBelowTooltip = useCallback(
+    (tooltipProps: any) => {
+      return (
+        <QuantileTooltip
+          tooltipProps={tooltipProps}
+          getQuantileHoverQuery={getBelowQuantileHoverQuery as any}
+          nodeMapPerIp={nodeMapPerIp}
+          devices={devices}
+          valueBase={valueBase}
+          unitLabel={unitLabel}
+          timeFormat="date-time"
+        />
+      );
+    },
+    [getBelowQuantileHoverQuery, nodeMapPerIp, devices, valueBase, unitLabel],
+  );
+  const colorSet = useMemo(() => {
+    const allSeriesNames = [
+      seriesQuantile.above.map((s: any) => s.resource || s.name),
+      seriesQuantile.below.map((s: any) => s.resource || s.name),
+    ];
+    return createColorSet(allSeriesNames.flat());
+  }, [seriesQuantile]);
   return (
-    <LineTemporalChart
-      // @ts-ignore To be fixed after migration of LineTemporalChart to LineTimeSerieChart
-      series={seriesQuantile}
-      height={150}
-      title={title}
-      startingTimeStamp={startingTimeStampQuantile}
-      isLoading={isLoadingQuantile}
-      yAxisType={'symmetrical'}
-      onHover={useCallback(
-        (datum) => {
-          onHoverIn(datum);
-          onHoverOut(datum);
-        },
-        [onHoverIn, onHoverOut],
-      )}
-      yAxisTitle={yAxisTitle}
-      // @ts-expect-error - FIXME when you are working on it
-      isLegendHidden={isLegendHidden}
-      unitRange={UNIT_RANGE_BS}
-      renderTooltipSerie={useCallback(
-        (serie) => {
-          if (serie.key === `Q90-${metricPrefixAbove}`) {
-            return renderTooltip(
-              serie,
-              isIdleQuantile90In,
-              isLoadingQuantile90In,
-              isSuccessQuantile90In,
-              isErrorQuantile90In,
-              quantile90InData,
-              'above',
-              false,
-            );
-          }
+    <ChartLegendWrapper colorSet={colorSet}>
+      <ChartLegend shape="line" legendSize="Smaller" />
+      <LineTimeSerieChart
+        series={{
+          above: seriesQuantile.above || [],
+          below: seriesQuantile.below || [],
+        }}
+        height={150}
+        title={title}
+        startingTimeStamp={startingTimeStampQuantile}
+        interval={interval}
+        duration={duration}
+        isLoading={isLoadingQuantile}
+        yAxisType={'symmetrical'}
+        yAxisTitle={yAxisTitle}
+        unitRange={UNIT_RANGE_BS}
+        renderTooltip={(tooltipProps) => {
+          // Determine if this is above or below series based on the data
+          const payload = tooltipProps.payload || [];
+          const hasNegativeValues = payload.some(
+            (entry: any) => entry.value && Number(entry.value) < 0,
+          );
 
-          if (serie.key === `Q5-${metricPrefixAbove}`) {
-            return `${renderTooltip(
-              serie,
-              isIdleQuantile5,
-              isLoadingQuantile5,
-              isSuccessQuantile5,
-              isErrorQuantile5,
-              quantile5Data,
-              'below',
-              false,
-            )}${renderTooltipSeperationLine(theme.border)}
-            `;
-          }
-
-          if (serie.key === `Q90-${metricPrefixBelow}`) {
-            return renderTooltip(
-              serie,
-              isIdleQuantile90Out,
-              isLoadingQuantile90Out,
-              isSuccessQuantile90Out,
-              isErrorQuantile90Out,
-              quantile90OutData,
-              'above',
-              true,
-            );
-          }
-
-          if (serie.key === `Q5-${metricPrefixBelow}`) {
-            return renderTooltip(
-              serie,
-              isIdleQuantile5Out,
-              isLoadingQuantile5Out,
-              isSuccessQuantile5Out,
-              isErrorQuantile5Out,
-              quantile5OutData,
-              'below',
-              true,
-            );
-          }
-
-          return renderTooltipSerie(serie);
-        },
-        [
-          isIdleQuantile90In,
-          isLoadingQuantile90In,
-          isSuccessQuantile90In,
-          isIdleQuantile5,
-          isLoadingQuantile5,
-          isSuccessQuantile5,
-          isIdleQuantile90Out,
-          isLoadingQuantile90Out,
-          isSuccessQuantile90Out,
-          isIdleQuantile5Out,
-          isLoadingQuantile5Out,
-          isSuccessQuantile5Out,
-          // @ts-expect-error - FIXME when you are working on it
-          JSON.stringify(quantile5Data?.data),
-          // @ts-expect-error - FIXME when you are working on it
-          JSON.stringify(quantile90InData?.data),
-          // @ts-expect-error - FIXME when you are working on it
-          JSON.stringify(quantile90OutData?.data),
-          // @ts-expect-error - FIXME when you are working on it
-          JSON.stringify(quantile5OutData?.data),
-          JSON.stringify(nodeMapPerIp),
-          metricPrefixAbove,
-          metricPrefixBelow,
-        ],
-      )}
-    />
+          return hasNegativeValues
+            ? renderBelowTooltip(tooltipProps)
+            : renderAboveTooltip(tooltipProps);
+        }}
+      />
+      <ChartLegend shape="line" legendSize="Smaller" />
+    </ChartLegendWrapper>
   );
 };
 

--- a/ui/src/components/SymmetricalQuantileChart.tsx
+++ b/ui/src/components/SymmetricalQuantileChart.tsx
@@ -1,24 +1,25 @@
-import React, { useCallback, useMemo } from 'react';
-import { useSelector } from 'react-redux';
+import { ChartLegendWrapper } from '@scality/core-ui/dist/components/chartlegend/ChartLegendWrapper';
 import { UNIT_RANGE_BS } from '@scality/core-ui/dist/components/linetemporalchart/LineTemporalChart.component';
 import {
+  ChartLegend,
   LineTimeSerieChart,
   useMetricsTimeSpan,
-  ChartLegend,
 } from '@scality/core-ui/dist/next';
-import { ChartLegendWrapper } from '@scality/core-ui/dist/components/chartlegend/ChartLegendWrapper';
-import { PORT_NODE_EXPORTER } from '../constants';
+import { useCallback, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { HEIGHT_SYMMETRICAL_CHART, PORT_NODE_EXPORTER } from '../constants';
 import {
   useNodeAddressesSelector,
   useNodes,
   useSymetricalChartSeries,
 } from '../hooks';
 import {
-  createColorSet,
+  createSymmetricalQuantileColorSet,
   getNodesInterfacesString,
   getQuantileSymmetricalSeries,
+  getTimeFormatForInterval,
 } from '../services/graphUtils';
-import { QuantileTooltip } from './QuantileTooltip';
+import { SymmetricalQuantileTooltip } from './SymmetricalQuantileTooltip';
 
 const SymmetricalQuantileChart = ({
   getAboveQuantileQuery,
@@ -40,9 +41,8 @@ const SymmetricalQuantileChart = ({
   yAxisTitle: string;
 }) => {
   const { interval, duration } = useMetricsTimeSpan();
-  console.log('DEBUG SymmetricalQuantileChart');
 
-  // Create node mappings
+  // Get nodeIPsInfo for devices (still needed for quantile queries)
   const nodes = useNodes();
   const nodeAddresses = useNodeAddressesSelector(nodes);
   const nodeIPsInfo = useSelector((state: any) => state.app.nodes.IPsInfo);
@@ -149,56 +149,24 @@ const SymmetricalQuantileChart = ({
     return unit ? unit.label : '';
   }, [seriesQuantile]);
 
-  // Create separate tooltip renderers for above/below
-  const renderAboveTooltip = useCallback(
-    (tooltipProps: any) => {
-      return (
-        <QuantileTooltip
-          tooltipProps={tooltipProps}
-          getQuantileHoverQuery={getAboveQuantileHoverQuery as any}
-          nodeMapPerIp={nodeMapPerIp}
-          devices={devices}
-          valueBase={valueBase}
-          unitLabel={unitLabel}
-          timeFormat="date-time"
-        />
-      );
-    },
-    [getAboveQuantileHoverQuery, nodeMapPerIp, devices, valueBase, unitLabel],
-  );
-
-  const renderBelowTooltip = useCallback(
-    (tooltipProps: any) => {
-      return (
-        <QuantileTooltip
-          tooltipProps={tooltipProps}
-          getQuantileHoverQuery={getBelowQuantileHoverQuery as any}
-          nodeMapPerIp={nodeMapPerIp}
-          devices={devices}
-          valueBase={valueBase}
-          unitLabel={unitLabel}
-          timeFormat="date-time"
-        />
-      );
-    },
-    [getBelowQuantileHoverQuery, nodeMapPerIp, devices, valueBase, unitLabel],
-  );
   const colorSet = useMemo(() => {
-    const allSeriesNames = [
-      seriesQuantile.above.map((s: any) => s.resource || s.name),
-      seriesQuantile.below.map((s: any) => s.resource || s.name),
-    ];
-    return createColorSet(allSeriesNames.flat());
+    return createSymmetricalQuantileColorSet(
+      seriesQuantile.above || [],
+      seriesQuantile.below || [],
+    );
   }, [seriesQuantile]);
+
+  const timeFormat = useMemo(() => {
+    return getTimeFormatForInterval(interval);
+  }, [interval]);
   return (
     <ChartLegendWrapper colorSet={colorSet}>
-      <ChartLegend shape="line" legendSize="Smaller" />
       <LineTimeSerieChart
         series={{
           above: seriesQuantile.above || [],
           below: seriesQuantile.below || [],
         }}
-        height={150}
+        height={HEIGHT_SYMMETRICAL_CHART}
         title={title}
         startingTimeStamp={startingTimeStampQuantile}
         interval={interval}
@@ -208,15 +176,20 @@ const SymmetricalQuantileChart = ({
         yAxisTitle={yAxisTitle}
         unitRange={UNIT_RANGE_BS}
         renderTooltip={(tooltipProps) => {
-          // Determine if this is above or below series based on the data
-          const payload = tooltipProps.payload || [];
-          const hasNegativeValues = payload.some(
-            (entry: any) => entry.value && Number(entry.value) < 0,
+          return (
+            <SymmetricalQuantileTooltip
+              tooltipProps={tooltipProps}
+              metricPrefixAbove={metricPrefixAbove}
+              metricPrefixBelow={metricPrefixBelow}
+              valueBase={valueBase}
+              unitLabel={unitLabel}
+              timeFormat={timeFormat}
+              getAboveQuantileHoverQuery={getAboveQuantileHoverQuery}
+              getBelowQuantileHoverQuery={getBelowQuantileHoverQuery}
+              nodeMapPerIp={nodeMapPerIp}
+              devices={devices}
+            />
           );
-
-          return hasNegativeValues
-            ? renderBelowTooltip(tooltipProps)
-            : renderAboveTooltip(tooltipProps);
         }}
       />
       <ChartLegend shape="line" legendSize="Smaller" />

--- a/ui/src/components/SymmetricalQuantileChart.tsx
+++ b/ui/src/components/SymmetricalQuantileChart.tsx
@@ -7,7 +7,11 @@ import {
 } from '@scality/core-ui/dist/next';
 import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { HEIGHT_SYMMETRICAL_CHART, PORT_NODE_EXPORTER } from '../constants';
+import {
+  DASHBOARD_QUANTILE_SYNC_ID,
+  HEIGHT_SYMMETRICAL_CHART,
+  PORT_NODE_EXPORTER,
+} from '../constants';
 import {
   useNodeAddressesSelector,
   useNodes,
@@ -154,6 +158,7 @@ const SymmetricalQuantileChart = ({
         yAxisType={'symmetrical'}
         yAxisTitle={yAxisTitle}
         unitRange={UNIT_RANGE_BS}
+        syncId={DASHBOARD_QUANTILE_SYNC_ID}
         renderTooltip={(tooltipProps) => {
           return (
             <SymmetricalQuantileTooltip

--- a/ui/src/components/SymmetricalQuantileTooltip.tsx
+++ b/ui/src/components/SymmetricalQuantileTooltip.tsx
@@ -66,10 +66,10 @@ export const SymmetricalQuantileTooltip: React.FC<
   const isOnHoverFetchingNeeded = useMemo(() => {
     if (!quantileData) return false;
     return (
-      (quantileData.median.above !== quantileData.q90.above &&
-        quantileData.median.above !== quantileData.q5.above) ||
-      (quantileData.median.below !== quantileData.q90.below &&
-        quantileData.median.below !== quantileData.q5.below)
+      quantileData.median.above !== quantileData.q90.above ||
+      quantileData.median.above !== quantileData.q5.above ||
+      quantileData.median.below !== quantileData.q90.below ||
+      quantileData.median.below !== quantileData.q5.below
     );
   }, [quantileData]);
 
@@ -86,7 +86,8 @@ export const SymmetricalQuantileTooltip: React.FC<
       enabled:
         !!quantileData &&
         isOnHoverFetchingNeeded &&
-        !!getAboveQuantileHoverQuery,
+        !!getAboveQuantileHoverQuery &&
+        !!quantileData.q90.above,
     },
   );
 
@@ -102,7 +103,8 @@ export const SymmetricalQuantileTooltip: React.FC<
       enabled:
         !!quantileData &&
         isOnHoverFetchingNeeded &&
-        !!getAboveQuantileHoverQuery,
+        !!getAboveQuantileHoverQuery &&
+        !!quantileData.q5.above,
     },
   );
 
@@ -120,7 +122,7 @@ export const SymmetricalQuantileTooltip: React.FC<
         !!quantileData &&
         isOnHoverFetchingNeeded &&
         !!getBelowQuantileHoverQuery &&
-        quantileData.q90.below !== null,
+        !!quantileData.q90.below,
     },
   );
 
@@ -137,7 +139,7 @@ export const SymmetricalQuantileTooltip: React.FC<
         !!quantileData &&
         isOnHoverFetchingNeeded &&
         !!getBelowQuantileHoverQuery &&
-        quantileData.q5.below !== null,
+        !!quantileData.q5.below,
     },
   );
 

--- a/ui/src/components/SymmetricalQuantileTooltip.tsx
+++ b/ui/src/components/SymmetricalQuantileTooltip.tsx
@@ -1,0 +1,253 @@
+import React, { useMemo } from 'react';
+import { useQuery } from 'react-query';
+import type { TooltipContentProps } from 'recharts';
+import {
+  QuantileTooltipRenderer,
+  transformSymmetricalPayload,
+  sortPayloadEntries,
+} from './shared/QuantileTooltipShared';
+
+type SymmetricalQuantileTooltipProps = {
+  tooltipProps: TooltipContentProps<number, string>;
+  metricPrefixAbove: string;
+  metricPrefixBelow: string;
+  valueBase: number;
+  unitLabel: string;
+  timeFormat?:
+    | 'day-month-abbreviated-hour-minute'
+    | 'day-month-abbreviated-hour-minute-second'
+    | 'long-date-without-weekday';
+  getAboveQuantileHoverQuery?: (
+    timestamp?: string,
+    threshold?: number,
+    operator?: '>' | '<',
+    isOnHoverFetchingRequired?: boolean,
+    devices?: string | string[],
+  ) => any;
+  getBelowQuantileHoverQuery?: (
+    timestamp?: string,
+    threshold?: number,
+    operator?: '>' | '<',
+    isOnHoverFetchingRequired?: boolean,
+    devices?: string | string[],
+  ) => any;
+  nodeMapPerIp?: Record<string, string>;
+  devices?: string | string[];
+};
+
+export const SymmetricalQuantileTooltip: React.FC<
+  SymmetricalQuantileTooltipProps
+> = ({
+  tooltipProps,
+  nodeMapPerIp,
+  devices,
+  valueBase,
+  unitLabel,
+  timeFormat,
+  metricPrefixAbove,
+  metricPrefixBelow,
+  getAboveQuantileHoverQuery,
+  getBelowQuantileHoverQuery,
+}) => {
+  const { active, payload, label } = tooltipProps;
+
+  // Extract quantile data for symmetrical chart
+  const quantileData = useMemo(() => {
+    if (!payload || !payload.length) return null;
+    return transformSymmetricalPayload(
+      payload,
+      label,
+      metricPrefixAbove,
+      metricPrefixBelow,
+    );
+  }, [payload, label, metricPrefixAbove, metricPrefixBelow]);
+
+  // Determine if additional fetching is needed
+  const isOnHoverFetchingNeeded = useMemo(() => {
+    if (!quantileData) return false;
+    return (
+      (quantileData.median.above !== quantileData.q90.above &&
+        quantileData.median.above !== quantileData.q5.above) ||
+      (quantileData.median.below !== quantileData.q90.below &&
+        quantileData.median.below !== quantileData.q5.below)
+    );
+  }, [quantileData]);
+
+  // Fetch quantile hover data for above queries
+  const quantile90AboveResult = useQuery(
+    getAboveQuantileHoverQuery?.(
+      quantileData?.timestamp?.toString(),
+      quantileData?.q90.above,
+      '>',
+      isOnHoverFetchingNeeded,
+      devices,
+    ),
+    {
+      enabled:
+        !!quantileData &&
+        isOnHoverFetchingNeeded &&
+        !!getAboveQuantileHoverQuery,
+    },
+  );
+
+  const quantile5AboveResult = useQuery(
+    getAboveQuantileHoverQuery?.(
+      quantileData?.timestamp?.toString(),
+      quantileData?.q5.above,
+      '<',
+      isOnHoverFetchingNeeded,
+      devices,
+    ),
+    {
+      enabled:
+        !!quantileData &&
+        isOnHoverFetchingNeeded &&
+        !!getAboveQuantileHoverQuery,
+    },
+  );
+
+  // Fetch quantile hover data for below queries
+  const quantile90BelowResult = useQuery(
+    getBelowQuantileHoverQuery?.(
+      quantileData?.timestamp?.toString(),
+      quantileData?.q90.below,
+      '>',
+      isOnHoverFetchingNeeded,
+      devices,
+    ),
+    {
+      enabled:
+        !!quantileData &&
+        isOnHoverFetchingNeeded &&
+        !!getBelowQuantileHoverQuery &&
+        quantileData.q90.below !== null,
+    },
+  );
+
+  const quantile5BelowResult = useQuery(
+    getBelowQuantileHoverQuery?.(
+      quantileData?.timestamp?.toString(),
+      quantileData?.q5.below,
+      '<',
+      isOnHoverFetchingNeeded,
+      devices,
+    ),
+    {
+      enabled:
+        !!quantileData &&
+        isOnHoverFetchingNeeded &&
+        !!getBelowQuantileHoverQuery &&
+        quantileData.q5.below !== null,
+    },
+  );
+
+  // Create sorted payload
+  const sortedPayload = useMemo(() => {
+    if (!quantileData) return [];
+    const entries = [];
+
+    // Add Q90 entries
+    if (quantileData.q90.above !== null) {
+      entries.push({
+        name: `Q90-${metricPrefixAbove}`,
+        dataKey: `Q90-${metricPrefixAbove}`,
+        value: quantileData.q90.above,
+        color: quantileData.q90.aboveColor,
+        quantileType: 'Q90',
+        metricPrefix: metricPrefixAbove,
+        quantileResult: quantile90AboveResult,
+      });
+    }
+
+    // Add Median entries
+    if (quantileData.median.above !== null) {
+      entries.push({
+        name: `Median-${metricPrefixAbove}`,
+        dataKey: `Median-${metricPrefixAbove}`,
+        value: quantileData.median.above,
+        color: quantileData.median.aboveColor,
+        quantileType: 'Median',
+        metricPrefix: metricPrefixAbove,
+        quantileResult: null,
+      });
+    }
+
+    // Add Q5 entries
+    if (quantileData.q5.above !== null) {
+      entries.push({
+        name: `Q5-${metricPrefixAbove}`,
+        dataKey: `Q5-${metricPrefixAbove}`,
+        value: quantileData.q5.above,
+        color: quantileData.q5.aboveColor,
+        quantileType: 'Q5',
+        metricPrefix: metricPrefixAbove,
+        quantileResult: quantile5AboveResult,
+      });
+    }
+    if (quantileData.q5.below !== null) {
+      entries.push({
+        name: `Q5-${metricPrefixBelow}`,
+        dataKey: `Q5-${metricPrefixBelow}`,
+        value: quantileData.q5.below,
+        color: quantileData.q5.belowColor,
+        quantileType: 'Q5',
+        metricPrefix: metricPrefixBelow,
+        quantileResult: quantile5BelowResult,
+      });
+    }
+    if (quantileData.median.below !== null) {
+      entries.push({
+        name: `Median-${metricPrefixBelow}`,
+        dataKey: `Median-${metricPrefixBelow}`,
+        value: quantileData.median.below,
+        color: quantileData.median.belowColor,
+        quantileType: 'Median',
+        metricPrefix: metricPrefixBelow,
+        quantileResult: null,
+      });
+    }
+    if (quantileData.q90.below !== null) {
+      entries.push({
+        name: `Q90-${metricPrefixBelow}`,
+        dataKey: `Q90-${metricPrefixBelow}`,
+        value: quantileData.q90.below,
+        color: quantileData.q90.belowColor,
+        quantileType: 'Q90',
+        metricPrefix: metricPrefixBelow,
+        quantileResult: quantile90BelowResult,
+      });
+    }
+
+    return sortPayloadEntries(entries, {
+      metricPrefixAbove,
+      metricPrefixBelow,
+    });
+  }, [
+    quantileData,
+    metricPrefixAbove,
+    metricPrefixBelow,
+    quantile90AboveResult,
+    quantile90BelowResult,
+    quantile5AboveResult,
+    quantile5BelowResult,
+  ]);
+
+  if (!active || !payload || !payload.length || !label || !quantileData) {
+    return null;
+  }
+
+  return (
+    <QuantileTooltipRenderer
+      tooltipProps={tooltipProps}
+      sortedPayload={sortedPayload}
+      isOnHoverFetchingNeeded={isOnHoverFetchingNeeded}
+      nodeMapPerIp={nodeMapPerIp}
+      valueBase={valueBase}
+      unitLabel={unitLabel}
+      timeFormat={timeFormat}
+      showSeparator={true}
+      metricPrefixAbove={metricPrefixAbove}
+      metricPrefixBelow={metricPrefixBelow}
+    />
+  );
+};

--- a/ui/src/components/VolumeCharts.tsx
+++ b/ui/src/components/VolumeCharts.tsx
@@ -1,9 +1,7 @@
-import { Stack } from '@scality/core-ui';
 import {
-  ChartLegend,
   LineTimeSerieChart,
   useMetricsTimeSpan,
-  ChartLegendWrapper,
+  useChartId,
 } from '@scality/core-ui/dist/next';
 import { useCallback } from 'react';
 import {
@@ -15,7 +13,6 @@ import {
 import { useSingleChartSerie, useSymetricalChartSeries } from '../hooks';
 import {
   convertPrometheusResultToSerieWithAverage,
-  createColorSet,
   getSeriesForSymmetricalChart,
 } from '../services/graphUtils';
 import type { TimeSpanProps } from '../services/platformlibrary/metrics';
@@ -28,6 +25,7 @@ import {
   getVolumeThroughputWriteQuery,
   getVolumeUsageQuery,
 } from '../services/platformlibrary/metrics';
+import { useChartLegendRegistration } from '../hooks/useChartLegendRegistration';
 
 const VOLUME_SYNC_ID = 'volume';
 
@@ -40,6 +38,7 @@ export const VolumeThroughputChart = ({
   deviceName: string;
   volumeName: string;
 }) => {
+  const chartId = useChartId();
   const { interval, duration } = useMetricsTimeSpan();
   const { series, startingTimeStamp, isLoading } = useSymetricalChartSeries({
     getAboveQueries: (timeSpanProps: TimeSpanProps) => [
@@ -64,27 +63,22 @@ export const VolumeThroughputChart = ({
     ),
   });
 
+  useChartLegendRegistration({ chartId, series, isSymmetrical: true });
+
   return (
-    <ChartLegendWrapper
-      colorSet={createColorSet(series.above.map((s) => s.resource))}
-    >
-      <Stack direction="vertical" gap="r1">
-        <LineTimeSerieChart
-          series={series}
-          height={160}
-          interval={interval}
-          duration={duration}
-          title="Disk Throughput"
-          startingTimeStamp={startingTimeStamp}
-          yAxisType={'symmetrical'}
-          yAxisTitle={YAXIS_TITLE_READ_WRITE}
-          unitRange={UNIT_RANGE_BS}
-          isLoading={isLoading}
-          syncId={VOLUME_SYNC_ID}
-        />
-        <ChartLegend shape="line" legendSize="Smaller" />
-      </Stack>
-    </ChartLegendWrapper>
+    <LineTimeSerieChart
+      series={series}
+      height={160}
+      interval={interval}
+      duration={duration}
+      title="Disk Throughput"
+      startingTimeStamp={startingTimeStamp}
+      yAxisType={'symmetrical'}
+      yAxisTitle={YAXIS_TITLE_READ_WRITE}
+      unitRange={UNIT_RANGE_BS}
+      isLoading={isLoading}
+      syncId={VOLUME_SYNC_ID}
+    />
   );
 };
 export const VolumeLatencyChart = ({
@@ -96,6 +90,7 @@ export const VolumeLatencyChart = ({
   deviceName: string;
   volumeName: string;
 }) => {
+  const chartId = useChartId();
   const { interval, duration } = useMetricsTimeSpan();
   const { series, startingTimeStamp, isLoading } = useSymetricalChartSeries({
     getAboveQueries: (timeSpanProps: TimeSpanProps) => [
@@ -120,27 +115,22 @@ export const VolumeLatencyChart = ({
     ),
   });
 
+  useChartLegendRegistration({ chartId, series, isSymmetrical: true });
+
   return (
-    <ChartLegendWrapper
-      colorSet={createColorSet(series.above.map((s) => s.resource))}
-    >
-      <Stack direction="vertical" gap="r1">
-        <LineTimeSerieChart
-          series={series}
-          height={160}
-          interval={interval}
-          duration={duration}
-          title="Disk Latency"
-          startingTimeStamp={startingTimeStamp}
-          yAxisType={'symmetrical'}
-          yAxisTitle={YAXIS_TITLE_READ_WRITE}
-          unitRange={UNIT_RANGE_SECONDS}
-          isLoading={isLoading}
-          syncId={VOLUME_SYNC_ID}
-        />
-        <ChartLegend shape="line" legendSize="Smaller" />
-      </Stack>
-    </ChartLegendWrapper>
+    <LineTimeSerieChart
+      series={series}
+      height={160}
+      interval={interval}
+      duration={duration}
+      title="Disk Latency"
+      startingTimeStamp={startingTimeStamp}
+      yAxisType={'symmetrical'}
+      yAxisTitle={YAXIS_TITLE_READ_WRITE}
+      unitRange={UNIT_RANGE_SECONDS}
+      isLoading={isLoading}
+      syncId={VOLUME_SYNC_ID}
+    />
   );
 };
 export const VolumeIOPSChart = ({
@@ -152,6 +142,7 @@ export const VolumeIOPSChart = ({
   deviceName: string;
   volumeName: string;
 }) => {
+  const chartId = useChartId();
   const { interval, duration } = useMetricsTimeSpan();
   const { series, startingTimeStamp, isLoading } = useSymetricalChartSeries({
     getAboveQueries: (timeSpanProps: TimeSpanProps) => [
@@ -176,26 +167,21 @@ export const VolumeIOPSChart = ({
     ),
   });
 
+  useChartLegendRegistration({ chartId, series, isSymmetrical: true });
+
   return (
-    <ChartLegendWrapper
-      colorSet={createColorSet(series.above.map((s) => s.resource))}
-    >
-      <Stack direction="vertical" gap="r1">
-        <LineTimeSerieChart
-          series={series}
-          height={160}
-          interval={interval}
-          duration={duration}
-          title="IOPS"
-          startingTimeStamp={startingTimeStamp}
-          yAxisType={'symmetrical'}
-          yAxisTitle={YAXIS_TITLE_READ_WRITE}
-          isLoading={isLoading}
-          syncId={VOLUME_SYNC_ID}
-        />
-        <ChartLegend shape="line" legendSize="Smaller" />
-      </Stack>
-    </ChartLegendWrapper>
+    <LineTimeSerieChart
+      series={series}
+      height={160}
+      interval={interval}
+      duration={duration}
+      title="IOPS"
+      startingTimeStamp={startingTimeStamp}
+      yAxisType={'symmetrical'}
+      yAxisTitle={YAXIS_TITLE_READ_WRITE}
+      isLoading={isLoading}
+      syncId={VOLUME_SYNC_ID}
+    />
   );
 };
 export const VolumeUsageChart = ({
@@ -207,6 +193,7 @@ export const VolumeUsageChart = ({
   namespace: string;
   volumeName: string;
 }) => {
+  const chartId = useChartId();
   const { interval, duration } = useMetricsTimeSpan();
   const { series, startingTimeStamp, isLoading } = useSingleChartSerie({
     getQuery: (timeSpanProps: TimeSpanProps) =>
@@ -218,24 +205,19 @@ export const VolumeUsageChart = ({
     ),
   });
 
+  useChartLegendRegistration({ chartId, series, isSymmetrical: false });
+
   return (
-    <ChartLegendWrapper
-      colorSet={createColorSet(series.map((s) => s.resource))}
-    >
-      <Stack direction="vertical" gap="r1">
-        <LineTimeSerieChart
-          series={series}
-          height={HEIGHT_DEFAULT_CHART}
-          interval={interval}
-          duration={duration}
-          title="Usage"
-          startingTimeStamp={startingTimeStamp}
-          yAxisType={'percentage'}
-          isLoading={isLoading}
-          syncId={VOLUME_SYNC_ID}
-        />
-        <ChartLegend shape="line" legendSize="Smaller" />
-      </Stack>
-    </ChartLegendWrapper>
+    <LineTimeSerieChart
+      series={series}
+      height={HEIGHT_DEFAULT_CHART}
+      interval={interval}
+      duration={duration}
+      title="Usage"
+      startingTimeStamp={startingTimeStamp}
+      yAxisType={'percentage'}
+      isLoading={isLoading}
+      syncId={VOLUME_SYNC_ID}
+    />
   );
 };

--- a/ui/src/components/VolumeCharts.tsx
+++ b/ui/src/components/VolumeCharts.tsx
@@ -41,11 +41,9 @@ export const VolumeThroughputChart = ({
 }) => {
   const { interval, duration } = useMetricsTimeSpan();
   const { series, startingTimeStamp, isLoading } = useSymetricalChartSeries({
-    // @ts-expect-error - FIXME when you are working on it
     getAboveQueries: (timeSpanProps: TimeSpanProps) => [
       getVolumeThroughputWriteQuery(instanceIp, deviceName, timeSpanProps),
     ],
-    // @ts-expect-error - FIXME when you are working on it
     getBelowQueries: (timeSpanProps: TimeSpanProps) => [
       getVolumeThroughputReadQuery(instanceIp, deviceName, timeSpanProps),
     ],
@@ -99,11 +97,9 @@ export const VolumeLatencyChart = ({
 }) => {
   const { interval, duration } = useMetricsTimeSpan();
   const { series, startingTimeStamp, isLoading } = useSymetricalChartSeries({
-    // @ts-expect-error - FIXME when you are working on it
     getAboveQueries: (timeSpanProps: TimeSpanProps) => [
       getVolumeLatencyWriteQuery(instanceIp, deviceName, timeSpanProps),
     ],
-    // @ts-expect-error - FIXME when you are working on it
     getBelowQueries: (timeSpanProps: TimeSpanProps) => [
       getVolumeLatencyReadQuery(instanceIp, deviceName, timeSpanProps),
     ],
@@ -157,11 +153,9 @@ export const VolumeIOPSChart = ({
 }) => {
   const { interval, duration } = useMetricsTimeSpan();
   const { series, startingTimeStamp, isLoading } = useSymetricalChartSeries({
-    // @ts-expect-error - FIXME when you are working on it
     getAboveQueries: (timeSpanProps: TimeSpanProps) => [
       getVolumeIOPSWriteQuery(instanceIp, deviceName, timeSpanProps),
     ],
-    // @ts-expect-error - FIXME when you are working on it
     getBelowQueries: (timeSpanProps: TimeSpanProps) => [
       getVolumeIOPSReadQuery(instanceIp, deviceName, timeSpanProps),
     ],
@@ -214,7 +208,6 @@ export const VolumeUsageChart = ({
 }) => {
   const { interval, duration } = useMetricsTimeSpan();
   const { series, startingTimeStamp, isLoading } = useSingleChartSerie({
-    // @ts-expect-error - FIXME when you are working on it
     getQuery: (timeSpanProps: TimeSpanProps) =>
       getVolumeUsageQuery(pvcName, namespace, timeSpanProps),
     transformPrometheusDataToSeries: useCallback(

--- a/ui/src/components/VolumeCharts.tsx
+++ b/ui/src/components/VolumeCharts.tsx
@@ -1,9 +1,23 @@
-import React, { useCallback } from 'react';
-import { LineTemporalChart } from '@scality/core-ui/dist/next';
+import { Stack } from '@scality/core-ui';
+import { ChartLegendWrapper } from '@scality/core-ui/dist/components/chartlegend/ChartLegendWrapper';
 import {
-  getSeriesForSymmetricalChart,
+  ChartLegend,
+  LineTimeSerieChart,
+  useMetricsTimeSpan,
+} from '@scality/core-ui/dist/next';
+import { useCallback } from 'react';
+import {
+  UNIT_RANGE_BS,
+  UNIT_RANGE_SECONDS,
+  YAXIS_TITLE_READ_WRITE,
+} from '../constants';
+import { useSingleChartSerie, useSymetricalChartSeries } from '../hooks';
+import {
   convertPrometheusResultToSerieWithAverage,
+  createColorSet,
+  getSeriesForSymmetricalChart,
 } from '../services/graphUtils';
+import type { TimeSpanProps } from '../services/platformlibrary/metrics';
 import {
   getVolumeIOPSReadQuery,
   getVolumeIOPSWriteQuery,
@@ -13,12 +27,9 @@ import {
   getVolumeThroughputWriteQuery,
   getVolumeUsageQuery,
 } from '../services/platformlibrary/metrics';
-import type { TimeSpanProps } from '../services/platformlibrary/metrics';
-import {
-  UNIT_RANGE_BS,
-  YAXIS_TITLE_READ_WRITE,
-} from '@scality/core-ui/dist/components/linetemporalchart/LineTemporalChart.component';
-import { useSingleChartSerie, useSymetricalChartSeries } from '../hooks';
+
+const VOLUME_SYNC_ID = 'volume';
+
 export const VolumeThroughputChart = ({
   instanceIp,
   deviceName,
@@ -28,6 +39,7 @@ export const VolumeThroughputChart = ({
   deviceName: string;
   volumeName: string;
 }) => {
+  const { interval, duration } = useMetricsTimeSpan();
   const { series, startingTimeStamp, isLoading } = useSymetricalChartSeries({
     // @ts-expect-error - FIXME when you are working on it
     getAboveQueries: (timeSpanProps: TimeSpanProps) => [
@@ -38,30 +50,53 @@ export const VolumeThroughputChart = ({
       getVolumeThroughputReadQuery(instanceIp, deviceName, timeSpanProps),
     ],
     transformPrometheusDataToSeries: useCallback(
-      ([prometheusResultAbove], [prometheusResultBelow]) =>
-        getSeriesForSymmetricalChart(
+      ([prometheusResultAbove], [prometheusResultBelow]) => {
+        const allSeries = getSeriesForSymmetricalChart(
           prometheusResultAbove,
           prometheusResultBelow,
           volumeName,
           'write',
           'read',
-        ),
+        );
+
+        // Filter series for LineTimeSerieChart above/below structure
+        const aboveSeries = allSeries.filter(
+          (serie) => serie.metricPrefix === 'write',
+        );
+        const belowSeries = allSeries.filter(
+          (serie) => serie.metricPrefix === 'read',
+        );
+
+        return {
+          above: aboveSeries,
+          below: belowSeries,
+        };
+      },
       [volumeName],
     ),
   });
+
   return (
-    <LineTemporalChart
-      series={series}
-      height={160}
-      title="Disk Throughput"
-      startingTimeStamp={startingTimeStamp}
-      yAxisType={'symmetrical'}
-      yAxisTitle={YAXIS_TITLE_READ_WRITE}
-      unitRange={UNIT_RANGE_BS}
-      // @ts-expect-error - FIXME when you are working on it
-      isLoading={isLoading}
-      isLegendHidden={false}
-    />
+    <ChartLegendWrapper
+      colorSet={createColorSet(series.above.map((s) => s.resource))}
+    >
+      <Stack direction="vertical" gap="r1">
+        <LineTimeSerieChart
+          series={series}
+          height={160}
+          interval={interval}
+          duration={duration}
+          title="Disk Throughput"
+          startingTimeStamp={startingTimeStamp}
+          yAxisType={'symmetrical'}
+          yAxisTitle={YAXIS_TITLE_READ_WRITE}
+          unitRange={UNIT_RANGE_BS}
+          isLoading={isLoading}
+          syncId={VOLUME_SYNC_ID}
+        />
+        <ChartLegend shape="line" legendSize="Smaller" />
+      </Stack>
+    </ChartLegendWrapper>
   );
 };
 export const VolumeLatencyChart = ({
@@ -73,6 +108,7 @@ export const VolumeLatencyChart = ({
   deviceName: string;
   volumeName: string;
 }) => {
+  const { interval, duration } = useMetricsTimeSpan();
   const { series, startingTimeStamp, isLoading } = useSymetricalChartSeries({
     // @ts-expect-error - FIXME when you are working on it
     getAboveQueries: (timeSpanProps: TimeSpanProps) => [
@@ -83,47 +119,53 @@ export const VolumeLatencyChart = ({
       getVolumeLatencyReadQuery(instanceIp, deviceName, timeSpanProps),
     ],
     transformPrometheusDataToSeries: useCallback(
-      ([prometheusResultAbove], [prometheusResultBelow]) =>
-        getSeriesForSymmetricalChart(
+      ([prometheusResultAbove], [prometheusResultBelow]) => {
+        const allSeries = getSeriesForSymmetricalChart(
           prometheusResultAbove,
           prometheusResultBelow,
           volumeName,
           'write',
           'read',
-        ),
+        );
+
+        // Filter series for LineTimeSerieChart above/below structure
+        const aboveSeries = allSeries.filter(
+          (serie) => serie.metricPrefix === 'write',
+        );
+        const belowSeries = allSeries.filter(
+          (serie) => serie.metricPrefix === 'read',
+        );
+
+        return {
+          above: aboveSeries,
+          below: belowSeries,
+        };
+      },
       [volumeName],
     ),
   });
+
   return (
-    <LineTemporalChart
-      series={series}
-      height={160}
-      title="Disk Latency"
-      startingTimeStamp={startingTimeStamp}
-      yAxisType={'symmetrical'}
-      yAxisTitle={YAXIS_TITLE_READ_WRITE}
-      unitRange={[
-        {
-          threshold: 0,
-          label: 'µs',
-        },
-        {
-          threshold: 1000,
-          label: 'ms',
-        },
-        {
-          threshold: 1000 * 1000,
-          label: 's',
-        },
-        {
-          threshold: 60 * 1000 * 1000,
-          label: 'm',
-        },
-      ]}
-      // @ts-expect-error - FIXME when you are working on it
-      isLoading={isLoading}
-      isLegendHidden={false}
-    />
+    <ChartLegendWrapper
+      colorSet={createColorSet(series.above.map((s) => s.resource))}
+    >
+      <Stack direction="vertical" gap="r1">
+        <LineTimeSerieChart
+          series={series}
+          height={160}
+          interval={interval}
+          duration={duration}
+          title="Disk Latency"
+          startingTimeStamp={startingTimeStamp}
+          yAxisType={'symmetrical'}
+          yAxisTitle={YAXIS_TITLE_READ_WRITE}
+          unitRange={UNIT_RANGE_SECONDS}
+          isLoading={isLoading}
+          syncId={VOLUME_SYNC_ID}
+        />
+        <ChartLegend shape="line" legendSize="Smaller" />
+      </Stack>
+    </ChartLegendWrapper>
   );
 };
 export const VolumeIOPSChart = ({
@@ -135,6 +177,7 @@ export const VolumeIOPSChart = ({
   deviceName: string;
   volumeName: string;
 }) => {
+  const { interval, duration } = useMetricsTimeSpan();
   const { series, startingTimeStamp, isLoading } = useSymetricalChartSeries({
     // @ts-expect-error - FIXME when you are working on it
     getAboveQueries: (timeSpanProps: TimeSpanProps) => [
@@ -145,29 +188,52 @@ export const VolumeIOPSChart = ({
       getVolumeIOPSReadQuery(instanceIp, deviceName, timeSpanProps),
     ],
     transformPrometheusDataToSeries: useCallback(
-      ([prometheusResultAbove], [prometheusResultBelow]) =>
-        getSeriesForSymmetricalChart(
+      ([prometheusResultAbove], [prometheusResultBelow]) => {
+        const allSeries = getSeriesForSymmetricalChart(
           prometheusResultAbove,
           prometheusResultBelow,
           volumeName,
           'write',
           'read',
-        ),
+        );
+
+        // Filter series for LineTimeSerieChart above/below structure
+        const aboveSeries = allSeries.filter(
+          (serie) => serie.metricPrefix === 'write',
+        );
+        const belowSeries = allSeries.filter(
+          (serie) => serie.metricPrefix === 'read',
+        );
+
+        return {
+          above: aboveSeries,
+          below: belowSeries,
+        };
+      },
       [volumeName],
     ),
   });
+
   return (
-    <LineTemporalChart
-      series={series}
-      height={160}
-      title="IOPS"
-      startingTimeStamp={startingTimeStamp}
-      yAxisType={'symmetrical'}
-      yAxisTitle={YAXIS_TITLE_READ_WRITE}
-      // @ts-expect-error - FIXME when you are working on it
-      isLoading={isLoading}
-      isLegendHidden={false}
-    />
+    <ChartLegendWrapper
+      colorSet={createColorSet(series.above.map((s) => s.resource))}
+    >
+      <Stack direction="vertical" gap="r1">
+        <LineTimeSerieChart
+          series={series}
+          height={160}
+          interval={interval}
+          duration={duration}
+          title="IOPS"
+          startingTimeStamp={startingTimeStamp}
+          yAxisType={'symmetrical'}
+          yAxisTitle={YAXIS_TITLE_READ_WRITE}
+          isLoading={isLoading}
+          syncId={VOLUME_SYNC_ID}
+        />
+        <ChartLegend shape="line" legendSize="Smaller" />
+      </Stack>
+    </ChartLegendWrapper>
   );
 };
 export const VolumeUsageChart = ({
@@ -179,6 +245,7 @@ export const VolumeUsageChart = ({
   namespace: string;
   volumeName: string;
 }) => {
+  const { interval, duration } = useMetricsTimeSpan();
   const { series, startingTimeStamp, isLoading } = useSingleChartSerie({
     // @ts-expect-error - FIXME when you are working on it
     getQuery: (timeSpanProps: TimeSpanProps) =>
@@ -189,15 +256,25 @@ export const VolumeUsageChart = ({
       [volumeName],
     ),
   });
+
   return (
-    <LineTemporalChart
-      series={series}
-      height={160}
-      title="Usage"
-      startingTimeStamp={startingTimeStamp}
-      yAxisType={'percentage'}
-      isLoading={isLoading}
-      isLegendHidden={false}
-    />
+    <ChartLegendWrapper
+      colorSet={createColorSet(series.map((s) => s.resource))}
+    >
+      <Stack direction="vertical" gap="r1">
+        <LineTimeSerieChart
+          series={series}
+          height={160}
+          interval={interval}
+          duration={duration}
+          title="Usage"
+          startingTimeStamp={startingTimeStamp}
+          yAxisType={'percentage'}
+          isLoading={isLoading}
+          syncId={VOLUME_SYNC_ID}
+        />
+        <ChartLegend shape="line" legendSize="Smaller" />
+      </Stack>
+    </ChartLegendWrapper>
   );
 };

--- a/ui/src/components/VolumeCharts.tsx
+++ b/ui/src/components/VolumeCharts.tsx
@@ -1,9 +1,9 @@
 import { Stack } from '@scality/core-ui';
-import { ChartLegendWrapper } from '@scality/core-ui/dist/components/chartlegend/ChartLegendWrapper';
 import {
   ChartLegend,
   LineTimeSerieChart,
   useMetricsTimeSpan,
+  ChartLegendWrapper,
 } from '@scality/core-ui/dist/next';
 import { useCallback } from 'react';
 import {
@@ -59,18 +59,7 @@ export const VolumeThroughputChart = ({
           'read',
         );
 
-        // Filter series for LineTimeSerieChart above/below structure
-        const aboveSeries = allSeries.filter(
-          (serie) => serie.metricPrefix === 'write',
-        );
-        const belowSeries = allSeries.filter(
-          (serie) => serie.metricPrefix === 'read',
-        );
-
-        return {
-          above: aboveSeries,
-          below: belowSeries,
-        };
+        return allSeries;
       },
       [volumeName],
     ),
@@ -128,18 +117,7 @@ export const VolumeLatencyChart = ({
           'read',
         );
 
-        // Filter series for LineTimeSerieChart above/below structure
-        const aboveSeries = allSeries.filter(
-          (serie) => serie.metricPrefix === 'write',
-        );
-        const belowSeries = allSeries.filter(
-          (serie) => serie.metricPrefix === 'read',
-        );
-
-        return {
-          above: aboveSeries,
-          below: belowSeries,
-        };
+        return allSeries;
       },
       [volumeName],
     ),
@@ -197,18 +175,7 @@ export const VolumeIOPSChart = ({
           'read',
         );
 
-        // Filter series for LineTimeSerieChart above/below structure
-        const aboveSeries = allSeries.filter(
-          (serie) => serie.metricPrefix === 'write',
-        );
-        const belowSeries = allSeries.filter(
-          (serie) => serie.metricPrefix === 'read',
-        );
-
-        return {
-          above: aboveSeries,
-          below: belowSeries,
-        };
+        return allSeries;
       },
       [volumeName],
     ),

--- a/ui/src/components/VolumeCharts.tsx
+++ b/ui/src/components/VolumeCharts.tsx
@@ -7,6 +7,7 @@ import {
 } from '@scality/core-ui/dist/next';
 import { useCallback } from 'react';
 import {
+  HEIGHT_DEFAULT_CHART,
   UNIT_RANGE_BS,
   UNIT_RANGE_SECONDS,
   YAXIS_TITLE_READ_WRITE,
@@ -224,7 +225,7 @@ export const VolumeUsageChart = ({
       <Stack direction="vertical" gap="r1">
         <LineTimeSerieChart
           series={series}
-          height={160}
+          height={HEIGHT_DEFAULT_CHART}
           interval={interval}
           duration={duration}
           title="Usage"

--- a/ui/src/components/VolumeCharts.tsx
+++ b/ui/src/components/VolumeCharts.tsx
@@ -6,6 +6,7 @@ import {
 import { useCallback } from 'react';
 import {
   HEIGHT_DEFAULT_CHART,
+  HEIGHT_SYMMETRICAL_CHART,
   UNIT_RANGE_BS,
   UNIT_RANGE_SECONDS,
   YAXIS_TITLE_READ_WRITE,
@@ -68,7 +69,7 @@ export const VolumeThroughputChart = ({
   return (
     <LineTimeSerieChart
       series={series}
-      height={160}
+      height={HEIGHT_SYMMETRICAL_CHART}
       interval={interval}
       duration={duration}
       title="Disk Throughput"
@@ -120,7 +121,7 @@ export const VolumeLatencyChart = ({
   return (
     <LineTimeSerieChart
       series={series}
-      height={160}
+      height={HEIGHT_SYMMETRICAL_CHART}
       interval={interval}
       duration={duration}
       title="Disk Latency"
@@ -172,7 +173,7 @@ export const VolumeIOPSChart = ({
   return (
     <LineTimeSerieChart
       series={series}
-      height={160}
+      height={HEIGHT_SYMMETRICAL_CHART}
       interval={interval}
       duration={duration}
       title="IOPS"

--- a/ui/src/components/VolumeMetricsTab.tsx
+++ b/ui/src/components/VolumeMetricsTab.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import { Button } from '@scality/core-ui/dist/next';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
-import { Button } from '@scality/core-ui/dist/next';
-
-import { VOLUME_CONDITION_LINK, GRAFANA_DASHBOARDS } from '../constants';
+import { Icon, spacing } from '@scality/core-ui';
 import { useIntl } from 'react-intl';
+import { GRAFANA_DASHBOARDS, VOLUME_CONDITION_LINK } from '../constants';
+
+import TimespanSelector from '../containers/TimespanSelector';
 import {
   MetricsActionContainer,
   NotBoundContainer,
@@ -15,34 +16,17 @@ import {
   VolumeThroughputChart,
   VolumeUsageChart,
 } from './VolumeCharts';
-import { SyncedCursorCharts } from '@scality/core-ui/dist/components/vegachartv2/SyncedCursorCharts';
-import TimespanSelector from '../containers/TimespanSelector';
-import { Icon, spacing } from '@scality/core-ui';
 
 const GraphGrid = styled.div`
   display: grid;
-  gap: 8px;
-  grid-template:
-    'usage latency' 1fr
-    'throughput iops' 1fr
-    / 1fr 1fr;
-  .sc-vegachart svg {
-    background-color: inherit !important;
-  }
-  .usage {
-    grid-area: usage;
-  }
-  .latency {
-    grid-area: latency;
-  }
-  .throughput {
-    grid-area: throughput;
-  }
-  .iops {
-    grid-area: iops;
-  }
+  gap: ${spacing.r16};
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: auto auto;
+  align-content: start;
+
   padding-left: ${spacing.r12};
-  height: calc(100% - 3rem); //100% - padding - action container height
+  padding-bottom: ${spacing.r16};
+  max-height: calc(100% - 3rem); //100% - padding - action container height
   overflow: auto;
 `;
 
@@ -58,6 +42,7 @@ const MetricsTab = (props) => {
   const intl = useIntl();
   // @ts-expect-error - FIXME when you are working on it
   const config = useSelector((state) => state.config);
+
   return (
     <>
       {volumeCondition === VOLUME_CONDITION_LINK ? (
@@ -81,33 +66,32 @@ const MetricsTab = (props) => {
             )}
             {volumeCondition === VOLUME_CONDITION_LINK && <TimespanSelector />}
           </MetricsActionContainer>
-          <SyncedCursorCharts>
-            <GraphGrid id="graph_container">
-              <VolumeUsageChart
-                pvcName={volumePVCName}
-                namespace={volumeNamespace}
-                volumeName={volumeName}
-              />
 
-              <VolumeLatencyChart
-                instanceIp={instanceIp}
-                deviceName={deviceName}
-                volumeName={volumeName}
-              />
+          <GraphGrid id="graph_container">
+            <VolumeUsageChart
+              pvcName={volumePVCName}
+              namespace={volumeNamespace}
+              volumeName={volumeName}
+            />
 
-              <VolumeThroughputChart
-                instanceIp={instanceIp}
-                deviceName={deviceName}
-                volumeName={volumeName}
-              />
+            <VolumeLatencyChart
+              instanceIp={instanceIp}
+              deviceName={deviceName}
+              volumeName={volumeName}
+            />
 
-              <VolumeIOPSChart
-                instanceIp={instanceIp}
-                deviceName={deviceName}
-                volumeName={volumeName}
-              />
-            </GraphGrid>
-          </SyncedCursorCharts>
+            <VolumeThroughputChart
+              instanceIp={instanceIp}
+              deviceName={deviceName}
+              volumeName={volumeName}
+            />
+
+            <VolumeIOPSChart
+              instanceIp={instanceIp}
+              deviceName={deviceName}
+              volumeName={volumeName}
+            />
+          </GraphGrid>
         </>
       ) : (
         <NotBoundContainer pt={spacing.r16}>

--- a/ui/src/components/VolumeMetricsTab.tsx
+++ b/ui/src/components/VolumeMetricsTab.tsx
@@ -1,6 +1,9 @@
-import { Button } from '@scality/core-ui/dist/next';
+import {
+  Button,
+  ChartLegend,
+  ChartLegendWrapper,
+} from '@scality/core-ui/dist/next';
 import { useSelector } from 'react-redux';
-import styled from 'styled-components';
 import { Icon, spacing } from '@scality/core-ui';
 import { useIntl } from 'react-intl';
 import { GRAFANA_DASHBOARDS, VOLUME_CONDITION_LINK } from '../constants';
@@ -16,19 +19,8 @@ import {
   VolumeThroughputChart,
   VolumeUsageChart,
 } from './VolumeCharts';
-
-const GraphGrid = styled.div`
-  display: grid;
-  gap: ${spacing.r16};
-  grid-template-columns: 1fr 1fr;
-  grid-template-rows: auto auto;
-  align-content: start;
-
-  padding-left: ${spacing.r12};
-  padding-bottom: ${spacing.r16};
-  max-height: calc(100% - 3rem); //100% - padding - action container height
-  overflow: auto;
-`;
+import { GraphGrid, ChartContainer } from '../containers/NodePageMetricsTab';
+import { createColorSet } from '../services/graphUtils';
 
 const MetricsTab = (props) => {
   const {
@@ -46,53 +38,58 @@ const MetricsTab = (props) => {
   return (
     <>
       {volumeCondition === VOLUME_CONDITION_LINK ? (
-        <>
-          <MetricsActionContainer>
-            {config.api?.url_grafana && volumeNamespace && volumePVCName && (
-              <a
-                href={`${config.api.url_grafana}/d/${GRAFANA_DASHBOARDS.volumes}?var-namespace=${volumeNamespace}&var-volume=${volumePVCName}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                data-cy="advanced_metrics_volume_detailed"
-              >
-                <Button
-                  label={intl.formatMessage({
-                    id: 'advanced_metrics',
-                  })}
-                  variant={'secondary'}
-                  icon={<Icon name="External-link" />}
-                />
-              </a>
-            )}
-            {volumeCondition === VOLUME_CONDITION_LINK && <TimespanSelector />}
-          </MetricsActionContainer>
+        <ChartLegendWrapper colorSet={createColorSet}>
+          <ChartContainer>
+            <MetricsActionContainer>
+              {config.api?.url_grafana && volumeNamespace && volumePVCName && (
+                <a
+                  href={`${config.api.url_grafana}/d/${GRAFANA_DASHBOARDS.volumes}?var-namespace=${volumeNamespace}&var-volume=${volumePVCName}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  data-cy="advanced_metrics_volume_detailed"
+                >
+                  <Button
+                    label={intl.formatMessage({
+                      id: 'advanced_metrics',
+                    })}
+                    variant={'secondary'}
+                    icon={<Icon name="External-link" />}
+                  />
+                </a>
+              )}
+              {volumeCondition === VOLUME_CONDITION_LINK && (
+                <TimespanSelector />
+              )}
+            </MetricsActionContainer>
 
-          <GraphGrid id="graph_container">
-            <VolumeUsageChart
-              pvcName={volumePVCName}
-              namespace={volumeNamespace}
-              volumeName={volumeName}
-            />
+            <GraphGrid id="graph_container">
+              <VolumeUsageChart
+                pvcName={volumePVCName}
+                namespace={volumeNamespace}
+                volumeName={volumeName}
+              />
 
-            <VolumeLatencyChart
-              instanceIp={instanceIp}
-              deviceName={deviceName}
-              volumeName={volumeName}
-            />
+              <VolumeLatencyChart
+                instanceIp={instanceIp}
+                deviceName={deviceName}
+                volumeName={volumeName}
+              />
 
-            <VolumeThroughputChart
-              instanceIp={instanceIp}
-              deviceName={deviceName}
-              volumeName={volumeName}
-            />
+              <VolumeThroughputChart
+                instanceIp={instanceIp}
+                deviceName={deviceName}
+                volumeName={volumeName}
+              />
 
-            <VolumeIOPSChart
-              instanceIp={instanceIp}
-              deviceName={deviceName}
-              volumeName={volumeName}
-            />
-          </GraphGrid>
-        </>
+              <VolumeIOPSChart
+                instanceIp={instanceIp}
+                deviceName={deviceName}
+                volumeName={volumeName}
+              />
+            </GraphGrid>
+            <ChartLegend shape="line" legendSize="Smaller" />
+          </ChartContainer>
+        </ChartLegendWrapper>
       ) : (
         <NotBoundContainer pt={spacing.r16}>
           {intl.formatMessage({

--- a/ui/src/components/shared/QuantileTooltipShared.tsx
+++ b/ui/src/components/shared/QuantileTooltipShared.tsx
@@ -1,0 +1,481 @@
+import {
+  chartColors,
+  fontSize,
+  fontWeight,
+} from '@scality/core-ui/dist/style/theme';
+import React from 'react';
+import {
+  Stack,
+  spacing,
+  SmallerText,
+  Wrap,
+  FormattedDateTime,
+} from '@scality/core-ui/dist/index';
+import styled from 'styled-components';
+import { LegendShape } from '@scality/core-ui/dist/components/chartlegend/ChartLegend';
+import {
+  SmallerSecondaryText,
+  Text,
+} from '@scality/core-ui/dist/components/text/Text.component';
+import type { TooltipContentProps } from 'recharts';
+import { useIntl } from 'react-intl';
+
+// Simple base props for tooltip components
+export interface BaseQuantileTooltipProps {
+  tooltipProps: TooltipContentProps<number, string>;
+  nodeMapPerIp: Record<string, string>;
+  devices: string | string[];
+  valueBase: number;
+  unitLabel: string;
+  timeFormat?:
+    | 'day-month-abbreviated-hour-minute'
+    | 'day-month-abbreviated-hour-minute-second'
+    | 'long-date-without-weekday';
+}
+
+// Data transformation types
+export type RegularQuantileData = {
+  q90: number;
+  q5: number;
+  median: number;
+  timestamp: number;
+};
+
+export type SymmetricalQuantileData = {
+  q90: {
+    above: number | null;
+    below: number | null;
+    aboveColor?: string;
+    belowColor?: string;
+  };
+  median: {
+    above: number | null;
+    below: number | null;
+    aboveColor?: string;
+    belowColor?: string;
+  };
+  q5: {
+    above: number | null;
+    below: number | null;
+    aboveColor?: string;
+    belowColor?: string;
+  };
+  timestamp: number;
+};
+
+// Payload transformation functions
+export const transformRegularPayload = (
+  payload: any[],
+  label: string | number,
+): RegularQuantileData | null => {
+  if (!payload || !payload.length) return null;
+
+  const q90Item = payload.find(
+    (item) => item.name === 'Q90' || item.dataKey === 'Q90',
+  );
+  const q5Item = payload.find(
+    (item) => item.name === 'Q5' || item.dataKey === 'Q5',
+  );
+  const medianItem = payload.find(
+    (item) => item.name === 'Median' || item.dataKey === 'Median',
+  );
+
+  if (!q90Item || !q5Item || !medianItem) return null;
+
+  return {
+    q90: Math.abs(Number(q90Item.value)),
+    q5: Math.abs(Number(q5Item.value)),
+    median: Math.abs(Number(medianItem.value)),
+    timestamp: label ? new Date(label).getTime() / 1000 : 0,
+  };
+};
+
+export const transformSymmetricalPayload = (
+  payload: any[],
+  label: string | number,
+  metricPrefixAbove: string,
+  metricPrefixBelow: string,
+): SymmetricalQuantileData | null => {
+  if (!payload || !payload.length) return null;
+
+  const findQuantile = (quantileName: string, metricPrefix: string) => {
+    return payload.find(
+      (item) =>
+        item.name === `${quantileName}-${metricPrefix}` ||
+        item.dataKey === `${quantileName}-${metricPrefix}` ||
+        (item.name &&
+          item.name.includes(quantileName) &&
+          item.name.includes(metricPrefix)),
+    );
+  };
+
+  const q90Above = findQuantile('Q90', metricPrefixAbove);
+  const q90Below = findQuantile('Q90', metricPrefixBelow);
+  const medianAbove = findQuantile('Median', metricPrefixAbove);
+  const medianBelow = findQuantile('Median', metricPrefixBelow);
+  const q5Above = findQuantile('Q5', metricPrefixAbove);
+  const q5Below = findQuantile('Q5', metricPrefixBelow);
+
+  return {
+    q90: {
+      above: q90Above ? Math.abs(Number(q90Above.value)) : null,
+      below: q90Below ? Math.abs(Number(q90Below.value)) : null,
+      aboveColor: q90Above?.color,
+      belowColor: q90Below?.color,
+    },
+    median: {
+      above: medianAbove ? Math.abs(Number(medianAbove.value)) : null,
+      below: medianBelow ? Math.abs(Number(medianBelow.value)) : null,
+      aboveColor: medianAbove?.color,
+      belowColor: medianBelow?.color,
+    },
+    q5: {
+      above: q5Above ? Math.abs(Number(q5Above.value)) : null,
+      below: q5Below ? Math.abs(Number(q5Below.value)) : null,
+      aboveColor: q5Above?.color,
+      belowColor: q5Below?.color,
+    },
+    timestamp: label ? new Date(label).getTime() / 1000 : 0,
+  };
+};
+
+// Shared styled components
+export const TooltipContainer = styled.div`
+  background-color: ${(props) => props.theme.backgroundLevel1};
+  padding: ${spacing.r8};
+  border: 1px solid ${(props) => props.theme.border};
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  width: 300px;
+  max-width: 400px;
+`;
+
+export const TooltipTime = styled.div`
+  margin-bottom: ${spacing.r8};
+  color: ${(props) => props.theme.textPrimary};
+  font-size: ${fontSize.smaller};
+  font-weight: ${fontWeight.bold};
+  text-align: center;
+`;
+
+export const LoadingText = styled.div`
+  padding: ${spacing.r2} ${spacing.r16};
+  color: ${(props) => props.theme.textSecondary};
+  font-size: ${fontSize.smaller};
+  font-style: italic;
+`;
+
+export const ErrorText = styled.div`
+  padding: ${spacing.r2} ${spacing.r16};
+  color: ${(props) => props.theme.statusCritical};
+  font-size: ${fontSize.smaller};
+`;
+
+export const SeparatorLine = styled.div`
+  height: 1px;
+  background-color: ${(props) => props.theme.border};
+  margin: ${spacing.r8} 0;
+  width: 100%;
+`;
+
+// Shared QuantileNodeList component
+export const QuantileNodeList: React.FC<{
+  queryResult: any;
+  quantileName: string;
+  nodeMapPerIp: Record<string, string>;
+  valueBase: number;
+  unitLabel: string;
+  intl: any;
+}> = ({
+  queryResult,
+  quantileName,
+  nodeMapPerIp,
+  valueBase,
+  unitLabel,
+  intl,
+}) => {
+  const { isIdle, isLoading, isSuccess, isError, data } = queryResult;
+
+  if (isLoading || isIdle) {
+    return <LoadingText>Loading...</LoadingText>;
+  }
+
+  if (isError) {
+    return (
+      <ErrorText>
+        {intl.formatMessage({ id: 'error_occur_outpassing_threshold' })}
+      </ErrorText>
+    );
+  }
+
+  if (isSuccess && data?.data?.result.length > 0) {
+    return (
+      <Stack direction="vertical" gap={'r2'}>
+        {data.data.result.map((nodeData: any, index: number) => {
+          const nodeName = nodeMapPerIp[nodeData.metric.instance];
+          const rawValue = parseFloat(nodeData.value[1]);
+          const formattedValue = (rawValue / (valueBase || 1)).toFixed(2);
+          const displayValue = unitLabel
+            ? `${formattedValue} ${unitLabel}`
+            : formattedValue;
+
+          return (
+            <Wrap key={index + nodeName}>
+              <SmallerSecondaryText>{nodeName}</SmallerSecondaryText>
+              <Text
+                variant="Smaller"
+                color="textSecondary"
+                style={{ whiteSpace: 'nowrap' }}
+              >
+                {displayValue}
+              </Text>
+            </Wrap>
+          );
+        })}
+      </Stack>
+    );
+  }
+  if (isSuccess && data?.data?.result.length === 0) {
+    return (
+      <Text variant="Smaller" style={{ fontStyle: 'italic', color: '#666' }}>
+        No nodes found {quantileName === 'Q90' ? 'above' : 'below'} threshold
+      </Text>
+    );
+  }
+
+  return null;
+};
+
+export const OverOrBelowThresholdSection: React.FC<{
+  quantileName: string;
+  metricPrefix?: string;
+  isOnHoverFetchingNeeded: boolean;
+  quantileResult: any;
+  nodeMapPerIp: Record<string, string>;
+  valueBase: number;
+  unitLabel: string;
+  intl: any;
+}> = ({
+  quantileName,
+  metricPrefix,
+  isOnHoverFetchingNeeded,
+  quantileResult,
+  nodeMapPerIp,
+  valueBase,
+  unitLabel,
+  intl,
+}) => {
+  const title = metricPrefix
+    ? quantileName === 'Q90'
+      ? `Nodes above ${quantileName}-${metricPrefix}`
+      : `Nodes below ${quantileName}-${metricPrefix}`
+    : quantileName === 'Q90'
+    ? `Nodes above ${quantileName}`
+    : `Nodes below ${quantileName}`;
+
+  return (
+    <Stack direction="vertical" gap={'r2'} style={{ paddingLeft: spacing.r32 }}>
+      <Text variant="Smaller">{title}</Text>
+      {isOnHoverFetchingNeeded && nodeMapPerIp && (
+        <QuantileNodeList
+          queryResult={quantileResult}
+          quantileName={quantileName}
+          nodeMapPerIp={nodeMapPerIp}
+          valueBase={valueBase}
+          unitLabel={unitLabel}
+          intl={intl}
+        />
+      )}
+    </Stack>
+  );
+};
+
+// Shared sorting logic for different tooltip types
+export const sortPayloadEntries = (
+  entries: any[],
+  metricPrefixes?: { metricPrefixAbove: string; metricPrefixBelow: string },
+): any[] => {
+  if (metricPrefixes) {
+    const { metricPrefixAbove, metricPrefixBelow } = metricPrefixes;
+    // For symmetrical: Q90Above → Q50Above → Q5Above → Q5Below → Q50Below → Q90Below
+    const order = [
+      `Q90-${metricPrefixAbove}`,
+      `Median-${metricPrefixAbove}`,
+      `Q5-${metricPrefixAbove}`,
+      `Q5-${metricPrefixBelow}`,
+      `Median-${metricPrefixBelow}`,
+      `Q90-${metricPrefixBelow}`,
+    ];
+
+    return entries.sort((a, b) => {
+      const aName = a.name;
+      const bName = b.name;
+
+      const aIndex = order.indexOf(aName);
+      const bIndex = order.indexOf(bName);
+
+      // If not found in predefined order, fall back to alphabetical
+      if (aIndex === -1 && bIndex === -1) {
+        return aName.localeCompare(bName);
+      }
+      if (aIndex === -1) return 1;
+      if (bIndex === -1) return -1;
+
+      return aIndex - bIndex;
+    });
+  } else {
+    // For regular: Q90-Q50-Q5 (sort by value, highest first)
+    return entries.sort((a, b) => Number(b.value) - Number(a.value));
+  }
+};
+
+// Shared tooltip entry rendering logic
+export const TooltipEntry = ({
+  entry,
+  index,
+  unitLabel,
+  isOnHoverFetchingNeeded,
+  nodeMapPerIp,
+  valueBase,
+  intl,
+  quantileResult,
+  quantileName,
+  metricPrefix,
+  isLastAboveEntry,
+}: {
+  entry: any;
+  index: number;
+  unitLabel: string;
+  isOnHoverFetchingNeeded: boolean;
+  nodeMapPerIp: Record<string, string>;
+  valueBase: number;
+  intl: any;
+  quantileResult: any;
+  quantileName: string;
+  metricPrefix: string;
+  isLastAboveEntry: boolean;
+}) => {
+  const serieData = {
+    color: entry.color,
+    name: entry.name,
+    value: `${Number(entry.value).toFixed(2)} ${unitLabel}`,
+    key: entry.dataKey || entry.name,
+  };
+
+  return (
+    <>
+      <Stack direction="vertical" gap={'r4'} key={index}>
+        <Wrap>
+          <Stack direction="horizontal" gap={'r10'}>
+            <LegendShape
+              color={serieData.color}
+              shape="line"
+              chartColors={chartColors}
+            />
+            <SmallerText>{serieData.name}</SmallerText>
+          </Stack>
+
+          <Text
+            variant="Smaller"
+            style={{
+              justifySelf: 'flex-end',
+              textAlign: 'right',
+            }}
+          >
+            {serieData.value}
+          </Text>
+        </Wrap>
+
+        {(quantileName === 'Q90' || quantileName === 'Q5') &&
+          quantileResult && (
+            <OverOrBelowThresholdSection
+              quantileName={quantileName}
+              metricPrefix={metricPrefix}
+              isOnHoverFetchingNeeded={isOnHoverFetchingNeeded}
+              quantileResult={quantileResult}
+              nodeMapPerIp={nodeMapPerIp}
+              valueBase={valueBase}
+              unitLabel={unitLabel}
+              intl={intl}
+            />
+          )}
+      </Stack>
+      {isLastAboveEntry && <SeparatorLine />}
+    </>
+  );
+};
+
+export interface QuantileTooltipRendererProps {
+  tooltipProps: TooltipContentProps<number, string>;
+  sortedPayload: any[];
+  isOnHoverFetchingNeeded: boolean;
+  nodeMapPerIp: Record<string, string>;
+  valueBase: number;
+  unitLabel: string;
+  timeFormat?:
+    | 'day-month-abbreviated-hour-minute'
+    | 'day-month-abbreviated-hour-minute-second'
+    | 'long-date-without-weekday';
+  showSeparator?: boolean;
+  metricPrefixAbove?: string;
+  metricPrefixBelow?: string;
+}
+
+export const QuantileTooltipRenderer: React.FC<
+  QuantileTooltipRendererProps
+> = ({
+  tooltipProps,
+  sortedPayload,
+  isOnHoverFetchingNeeded,
+  nodeMapPerIp,
+  valueBase,
+  unitLabel,
+  timeFormat,
+  showSeparator = false,
+  metricPrefixAbove,
+  metricPrefixBelow,
+}) => {
+  const intl = useIntl();
+  const { active, payload, label } = tooltipProps;
+
+  if (!active || !payload || !payload.length || !label) {
+    return null;
+  }
+
+  return (
+    <TooltipContainer>
+      <TooltipTime>
+        <FormattedDateTime format={timeFormat} value={new Date(label)} />
+      </TooltipTime>
+
+      <Stack direction="vertical" gap={'r12'}>
+        {sortedPayload.map((entry, index) => {
+          const isLastAboveEntry =
+            showSeparator &&
+            metricPrefixAbove &&
+            metricPrefixBelow &&
+            entry.metricPrefix === metricPrefixAbove &&
+            entry.quantileType === 'Q5' &&
+            sortedPayload[index + 1]?.metricPrefix === metricPrefixBelow;
+
+          return (
+            <TooltipEntry
+              key={index}
+              entry={entry}
+              index={index}
+              unitLabel={unitLabel}
+              isOnHoverFetchingNeeded={isOnHoverFetchingNeeded}
+              nodeMapPerIp={nodeMapPerIp}
+              valueBase={valueBase}
+              intl={intl}
+              quantileResult={entry.quantileResult}
+              quantileName={entry.quantileType || entry.name}
+              metricPrefix={entry.metricPrefix}
+              isLastAboveEntry={isLastAboveEntry}
+            />
+          );
+        })}
+      </Stack>
+    </TooltipContainer>
+  );
+};

--- a/ui/src/components/shared/QuantileTooltipShared.tsx
+++ b/ui/src/components/shared/QuantileTooltipShared.tsx
@@ -79,13 +79,12 @@ export const transformRegularPayload = (
   const medianItem = payload.find(
     (item) => item.name === 'Median' || item.dataKey === 'Median',
   );
-
-  if (!q90Item || !q5Item || !medianItem) return null;
+  if (!q90Item && !q5Item && !medianItem) return null;
 
   return {
-    q90: Math.abs(Number(q90Item.value)),
-    q5: Math.abs(Number(q5Item.value)),
-    median: Math.abs(Number(medianItem.value)),
+    q90: q90Item ? Math.abs(Number(q90Item.value)) : null,
+    q5: q5Item ? Math.abs(Number(q5Item.value)) : null,
+    median: medianItem ? Math.abs(Number(medianItem.value)) : null,
     timestamp: label ? new Date(label).getTime() / 1000 : 0,
   };
 };

--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -156,3 +156,4 @@ export const UNIT_RANGE_SECONDS = [
 ];
 export const YAXIS_TITLE_READ_WRITE = 'write(+) / read(-)';
 export const YAXIS_TITLE_IN_OUT = 'in(+) / out(-)';
+export const CLUSTER_AVERAGE = 'Cluster Avg.';

--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -103,6 +103,10 @@ export const NODES_LIMIT_QUANTILE = 8;
 export const NODE_SYNC_ID = 'nodeMetrics';
 export const DASHBOARD_SYNC_ID = 'dashboard';
 
+// Testing flag to multiply nodes for quantile chart testing
+// Set to 1 for production, 3+ for testing quantile behavior with more nodes
+export const TESTING_MULTIPLY_NODES = 3;
+
 // Chart color values for consistent coloring across components
 export const CHART_COLOR_VALUES = [
   chartColors.lineColor1, // #A14FBF - Purple

--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -107,10 +107,6 @@ export const NODES_LIMIT_QUANTILE = 8;
 export const NODE_SYNC_ID = 'nodeMetrics';
 export const DASHBOARD_SYNC_ID = 'dashboard';
 
-// Testing flag to multiply nodes for quantile chart testing
-// Set to 1 for production, 3+ for testing quantile behavior with more nodes
-export const TESTING_MULTIPLY_NODES = 3;
-
 // Chart color values for consistent coloring across components
 export const CHART_COLOR_VALUES = Object.values(chartColors);
 export const UNIT_RANGE_BS = [

--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -1,3 +1,5 @@
+import { chartColors } from '@scality/core-ui/dist/style/theme';
+
 export const REFRESH_TIMEOUT = 15000;
 export const REFRESH_METRICS_GRAPH = 60000;
 export const FR_LANG = 'FR';
@@ -98,3 +100,60 @@ export const GRAFANA_DASHBOARDS = {
 export const HEIGHT_DEFAULT_CHART = 120;
 export const HEIGHT_SYMMETRICAL_CHART = 160;
 export const NODES_LIMIT_QUANTILE = 8;
+export const NODE_SYNC_ID = 'nodeMetrics';
+export const DASHBOARD_SYNC_ID = 'dashboard';
+
+// Chart color values for consistent coloring across components
+export const CHART_COLOR_VALUES = [
+  chartColors.lineColor1, // #A14FBF - Purple
+  chartColors.lineColor2, // #BE9A40 - Gold
+  chartColors.lineColor3, // #4BE4E2 - Cyan
+  chartColors.lineColor4, // #245A83 - Blue
+  chartColors.lineColor5, // #E3FF73 - Light Green
+  chartColors.lineColor6, // #BE2543 - Red
+  chartColors.lineColor7, // #FD8144 - Orange
+  chartColors.lineColor8, // #F6B187 - Light Orange
+];
+export const UNIT_RANGE_BS = [
+  {
+    threshold: 0,
+    label: 'B/s',
+  },
+  {
+    threshold: 1024,
+    label: 'KiB/s',
+  },
+  {
+    threshold: 1024 * 1024,
+    label: 'MiB/s',
+  },
+  {
+    threshold: 1024 * 1024 * 1024,
+    label: 'GiB/s',
+  },
+  {
+    threshold: 1024 * 1024 * 1024 * 1024,
+    label: 'TiB/s',
+  },
+];
+
+export const UNIT_RANGE_SECONDS = [
+  {
+    threshold: 0,
+    label: 'µs',
+  },
+  {
+    threshold: 1000,
+    label: 'ms',
+  },
+  {
+    threshold: 1000 * 1000,
+    label: 's',
+  },
+  {
+    threshold: 60 * 1000 * 1000,
+    label: 'm',
+  },
+];
+export const YAXIS_TITLE_READ_WRITE = 'write(+) / read(-)';
+export const YAXIS_TITLE_IN_OUT = 'in(+) / out(-)';

--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -86,10 +86,14 @@ export const NODE_ALERTS_GROUP = [
 export const CIRCLE_BASE_SIZE = 'CIRCLE_BASE_SIZE';
 export const CIRCLE_DOUBLE_SIZE = 'CIRCLE_DOUBLE_SIZE';
 // LineChart colors
-export const lineColor1 = '#A14FBF';
-export const lineColor2 = '#BE9A40';
-export const lineColor3 = '#4BE4E2';
-export const lineColor4 = '#DC90F1';
+export const lineColor1 = chartColors.lineColor1;
+export const lineColor2 = chartColors.lineColor2;
+export const lineColor3 = chartColors.lineColor3;
+export const lineColor4 = chartColors.lineColor4;
+export const lineColor5 = chartColors.lineColor5;
+export const lineColor6 = chartColors.lineColor6;
+export const lineColor7 = chartColors.lineColor7;
+export const lineColor8 = chartColors.lineColor8;
 // Grafana dashboard UIDs (for stable links)
 export const GRAFANA_DASHBOARDS = {
   logs: 'a7e130cb82be229d6f3edbfd0a438001',
@@ -108,16 +112,7 @@ export const DASHBOARD_SYNC_ID = 'dashboard';
 export const TESTING_MULTIPLY_NODES = 3;
 
 // Chart color values for consistent coloring across components
-export const CHART_COLOR_VALUES = [
-  chartColors.lineColor1, // #A14FBF - Purple
-  chartColors.lineColor2, // #BE9A40 - Gold
-  chartColors.lineColor3, // #4BE4E2 - Cyan
-  chartColors.lineColor4, // #245A83 - Blue
-  chartColors.lineColor5, // #E3FF73 - Light Green
-  chartColors.lineColor6, // #BE2543 - Red
-  chartColors.lineColor7, // #FD8144 - Orange
-  chartColors.lineColor8, // #F6B187 - Light Orange
-];
+export const CHART_COLOR_VALUES = Object.values(chartColors);
 export const UNIT_RANGE_BS = [
   {
     threshold: 0,

--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -101,7 +101,7 @@ export const GRAFANA_DASHBOARDS = {
   volumes: '919b92a8e8041bd567af9edab12c840c',
 };
 // Height of the charts
-export const HEIGHT_DEFAULT_CHART = 120;
+export const HEIGHT_DEFAULT_CHART = 160;
 export const HEIGHT_SYMMETRICAL_CHART = 160;
 export const NODES_LIMIT_QUANTILE = 8;
 export const NODE_SYNC_ID = 'nodeMetrics';

--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -106,6 +106,7 @@ export const HEIGHT_SYMMETRICAL_CHART = 160;
 export const NODES_LIMIT_QUANTILE = 8;
 export const NODE_SYNC_ID = 'nodeMetrics';
 export const DASHBOARD_SYNC_ID = 'dashboard';
+export const DASHBOARD_QUANTILE_SYNC_ID = 'dashboard-quantile';
 
 // Chart color values for consistent coloring across components
 export const CHART_COLOR_VALUES = Object.values(chartColors);

--- a/ui/src/containers/NodePageMetricsTab.tsx
+++ b/ui/src/containers/NodePageMetricsTab.tsx
@@ -12,14 +12,9 @@ import styled from 'styled-components';
 import { useIntl } from 'react-intl';
 import MetricChart from '../components/MetricChart';
 import MetricSymmetricalChart from '../components/MetricSymmetricalChart';
+import { MetricsActionContainer } from '../components/style/CommonLayoutStyle';
 import {
-  GraphWrapper,
-  MetricsActionContainer,
-} from '../components/style/CommonLayoutStyle';
-import {
-  CLUSTER_AVERAGE,
   GRAFANA_DASHBOARDS,
-  lineColor1,
   PORT_NODE_EXPORTER,
   UNIT_RANGE_BS,
 } from '../constants';
@@ -48,39 +43,19 @@ import {
 } from '../services/platformlibrary/metrics';
 import { useURLQuery } from '../services/utils';
 import TimespanSelector from './TimespanSelector';
-const GraphGrid = styled.div`
-  display: grid;
-  gap: 8px;
-  grid-template:
-    'cpuusage systemload' 1fr
-    'memory iops' 1fr
-    'cpbandwidth wpbandwidth' 1fr
-    / 1fr 1fr;
-  .sc-vegachart svg {
-    background-color: inherit !important;
-  }
-  .cpuusage {
-    grid-area: cpuusage;
-  }
-  .systemload {
-    grid-area: systemload;
-  }
-  .memory {
-    grid-area: memory;
-  }
-  .iops {
-    grid-area: iops;
-  }
-  .cpbandwidth {
-    grid-area: cpbandwidth;
-  }
-  .wpbandwidth {
-    grid-area: wpbandwidth;
-  }
-  padding-left: ${spacing.r12};
+import { createColorSet } from '../services/graphUtils';
+export const ChartContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.r8};
   /* 100% - padding - action container height */
   height: calc(100% - 3rem);
-  overflow: auto;
+  padding-left: ${spacing.r12};
+`;
+export const GraphGrid = styled.div`
+  display: grid;
+  gap: 8px;
+  grid-template-columns: 1fr 1fr;
 `;
 const MetricsToggleWrapper = styled.div`
   display: flex;
@@ -133,14 +108,6 @@ const NodePageMetricsTab = ({
     (state) => state.app.monitoring.nodeStats.showAvg,
   );
 
-  // Create color set
-
-  const colorSet = {
-    [nodeName]: lineColor1,
-  };
-  if (showAvg) {
-    colorSet[CLUSTER_AVERAGE] = lineColor1;
-  }
   // To redirect to the right Node(Detailed) dashboard in Grafana
   const unameInfos = useTypedSelector(
     (state) => state.app.monitoring.unameInfo,
@@ -202,9 +169,9 @@ const NodePageMetricsTab = ({
         {instanceIP && <TimespanSelector />}
       </MetricsActionContainer>
       {instanceIP ? (
-        <ChartLegendWrapper colorSet={colorSet}>
-          <GraphGrid id="graph_container">
-            <GraphWrapper className="cpuusage">
+        <ChartLegendWrapper colorSet={createColorSet}>
+          <ChartContainer>
+            <GraphGrid id="graph_container">
               <MetricChart
                 title={'CPU Usage'}
                 yAxisType={'percentage'}
@@ -214,9 +181,7 @@ const NodePageMetricsTab = ({
                 getMetricQuery={getCPUUsageQuery}
                 getMetricAvgQuery={getCPUUsageAvgQuery}
               ></MetricChart>
-              <ChartLegend shape="line" legendSize="Smaller" />
-            </GraphWrapper>
-            <GraphWrapper className="systemload">
+
               <MetricChart
                 title={'CPU System Load'}
                 yAxisType={'default'}
@@ -226,9 +191,7 @@ const NodePageMetricsTab = ({
                 getMetricQuery={getSystemLoadQuery}
                 getMetricAvgQuery={getSystemLoadAvgQuery}
               ></MetricChart>
-              <ChartLegend shape="line" legendSize="Smaller" />
-            </GraphWrapper>
-            <GraphWrapper className="memory">
+
               <MetricChart
                 title={'Memory'}
                 yAxisType={'percentage'}
@@ -238,9 +201,7 @@ const NodePageMetricsTab = ({
                 getMetricQuery={getMemoryQuery}
                 getMetricAvgQuery={getMemoryAvgQuery}
               ></MetricChart>
-              <ChartLegend shape="line" legendSize="Smaller" />
-            </GraphWrapper>
-            <GraphWrapper className="iops">
+
               <MetricSymmetricalChart
                 title={'IOPS'}
                 yAxisTitle={'write(+) / read(-)'}
@@ -256,9 +217,7 @@ const NodePageMetricsTab = ({
                 metricPrefixBelow={'read'}
                 isPlaneInterfaceRequired={false}
               ></MetricSymmetricalChart>
-              <ChartLegend shape="line" legendSize="Smaller" />
-            </GraphWrapper>
-            <GraphWrapper className="cpbandwidth">
+
               <MetricSymmetricalChart
                 title={'Control Plane Bandwidth'}
                 yAxisTitle={'in(+) / out(-)'}
@@ -276,9 +235,7 @@ const NodePageMetricsTab = ({
                 unitRange={UNIT_RANGE_BS}
                 isPlaneInterfaceRequired={true}
               ></MetricSymmetricalChart>
-              <ChartLegend shape="line" legendSize="Smaller" />
-            </GraphWrapper>
-            <GraphWrapper className="wpbandwidth">
+
               <MetricSymmetricalChart
                 title={'Workload Plane Bandwidth'}
                 yAxisTitle={'in(+) / out(-)'}
@@ -296,9 +253,9 @@ const NodePageMetricsTab = ({
                 unitRange={UNIT_RANGE_BS}
                 isPlaneInterfaceRequired={true}
               ></MetricSymmetricalChart>
-              <ChartLegend shape="line" legendSize="Smaller" />
-            </GraphWrapper>
-          </GraphGrid>
+            </GraphGrid>
+            <ChartLegend shape="line" legendSize="Smaller" />
+          </ChartContainer>
         </ChartLegendWrapper>
       ) : (
         <RenderNoDataAvailable />

--- a/ui/src/containers/NodePageMetricsTab.tsx
+++ b/ui/src/containers/NodePageMetricsTab.tsx
@@ -17,13 +17,15 @@ import {
   MetricsActionContainer,
 } from '../components/style/CommonLayoutStyle';
 import {
+  CLUSTER_AVERAGE,
   GRAFANA_DASHBOARDS,
+  lineColor1,
   PORT_NODE_EXPORTER,
   UNIT_RANGE_BS,
 } from '../constants';
 import { updateNodeStatsFetchArgumentAction } from '../ducks/app/monitoring';
 import type { NodesState } from '../ducks/app/nodes';
-import { useTypedSelector, useChartColors } from '../hooks';
+import { useTypedSelector } from '../hooks';
 import {
   getCPUUsageAvgQuery,
   getCPUUsageQuery,
@@ -131,8 +133,14 @@ const NodePageMetricsTab = ({
     (state) => state.app.monitoring.nodeStats.showAvg,
   );
 
-  // Create color set for this single node
-  const colorSet = useChartColors([nodeName]);
+  // Create color set
+
+  const colorSet = {
+    [nodeName]: lineColor1,
+  };
+  if (showAvg) {
+    colorSet[CLUSTER_AVERAGE] = lineColor1;
+  }
   // To redirect to the right Node(Detailed) dashboard in Grafana
   const unameInfos = useTypedSelector(
     (state) => state.app.monitoring.unameInfo,
@@ -203,9 +211,7 @@ const NodePageMetricsTab = ({
                 nodeName={nodeName}
                 instanceIP={instanceIP}
                 showAvg={showAvg}
-                // @ts-expect-error - FIXME when you are working on it
                 getMetricQuery={getCPUUsageQuery}
-                // @ts-expect-error - FIXME when you are working on it
                 getMetricAvgQuery={getCPUUsageAvgQuery}
               ></MetricChart>
               <ChartLegend shape="line" legendSize="Smaller" />
@@ -217,9 +223,7 @@ const NodePageMetricsTab = ({
                 nodeName={nodeName}
                 instanceIP={instanceIP}
                 showAvg={showAvg}
-                // @ts-expect-error - FIXME when you are working on it
                 getMetricQuery={getSystemLoadQuery}
-                // @ts-expect-error - FIXME when you are working on it
                 getMetricAvgQuery={getSystemLoadAvgQuery}
               ></MetricChart>
               <ChartLegend shape="line" legendSize="Smaller" />
@@ -231,9 +235,7 @@ const NodePageMetricsTab = ({
                 nodeName={nodeName}
                 instanceIP={instanceIP}
                 showAvg={showAvg}
-                // @ts-expect-error - FIXME when you are working on it
                 getMetricQuery={getMemoryQuery}
-                // @ts-expect-error - FIXME when you are working on it
                 getMetricAvgQuery={getMemoryAvgQuery}
               ></MetricChart>
               <ChartLegend shape="line" legendSize="Smaller" />
@@ -242,17 +244,13 @@ const NodePageMetricsTab = ({
               <MetricSymmetricalChart
                 title={'IOPS'}
                 yAxisTitle={'write(+) / read(-)'}
-                yAxisType={'symmetrical'}
+                nodesIPsInfo={nodesIPsInfo}
                 nodeName={nodeName}
                 instanceIP={instanceIP}
                 showAvg={showAvg}
-                // @ts-expect-error - FIXME when you are working on it
                 getMetricAboveQuery={getIOPSWriteQuery}
-                // @ts-expect-error - FIXME when you are working on it
                 getMetricBelowQuery={getIOPSReadQuery}
-                // @ts-expect-error - FIXME when you are working on it
                 getMetricAboveAvgQuery={getIOPSWriteAvgQuery}
-                // @ts-expect-error - FIXME when you are working on it
                 getMetricBelowAvgQuery={getIOPSReadAvgQuery}
                 metricPrefixAbove={'write'}
                 metricPrefixBelow={'read'}
@@ -264,18 +262,13 @@ const NodePageMetricsTab = ({
               <MetricSymmetricalChart
                 title={'Control Plane Bandwidth'}
                 yAxisTitle={'in(+) / out(-)'}
-                yAxisType={'symmetrical'}
                 nodeName={nodeName}
                 instanceIP={instanceIP}
                 showAvg={showAvg}
                 nodesIPsInfo={nodesIPsInfo}
-                // @ts-expect-error - FIXME when you are working on it
                 getMetricAboveQuery={getControlPlaneBandWidthInQuery}
-                // @ts-expect-error - FIXME when you are working on it
                 getMetricBelowQuery={getControlPlaneBandWidthOutQuery}
-                // @ts-expect-error - FIXME when you are working on it
                 getMetricAboveAvgQuery={getControlPlaneBandWidthAvgInQuery}
-                // @ts-expect-error - FIXME when you are working on it
                 getMetricBelowAvgQuery={getControlPlaneBandWidthAvgOutQuery}
                 metricPrefixAbove={'in'}
                 metricPrefixBelow={'out'}
@@ -289,18 +282,13 @@ const NodePageMetricsTab = ({
               <MetricSymmetricalChart
                 title={'Workload Plane Bandwidth'}
                 yAxisTitle={'in(+) / out(-)'}
-                yAxisType={'symmetrical'}
                 nodeName={nodeName}
                 instanceIP={instanceIP}
                 showAvg={showAvg}
                 nodesIPsInfo={nodesIPsInfo}
-                // @ts-expect-error - FIXME when you are working on it
                 getMetricAboveQuery={getWorkloadPlaneBandWidthInQuery}
-                // @ts-expect-error - FIXME when you are working on it
                 getMetricBelowQuery={getWorkloadPlaneBandWidthOutQuery}
-                // @ts-expect-error - FIXME when you are working on it
                 getMetricAboveAvgQuery={getWorkloadPlaneBandWidthAvgInQuery}
-                // @ts-expect-error - FIXME when you are working on it
                 getMetricBelowAvgQuery={getWorkloadPlaneBandWidthAvgOutQuery}
                 metricPrefixAbove={'in'}
                 metricPrefixBelow={'out'}

--- a/ui/src/containers/NodePageMetricsTab.tsx
+++ b/ui/src/containers/NodePageMetricsTab.tsx
@@ -1,12 +1,14 @@
 import { Icon, Toggle, spacing } from '@scality/core-ui';
-import { Button } from '@scality/core-ui/dist/next';
+import {
+  Button,
+  ChartLegend,
+  ChartLegendWrapper,
+} from '@scality/core-ui/dist/next';
 import React from 'react';
 import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router';
 import styled from 'styled-components';
 
-import { UNIT_RANGE_BS } from '@scality/core-ui/dist/components/linetemporalchart/LineTemporalChart.component';
-import { SyncedCursorCharts } from '@scality/core-ui/dist/next';
 import { useIntl } from 'react-intl';
 import MetricChart from '../components/MetricChart';
 import MetricSymmetricalChart from '../components/MetricSymmetricalChart';
@@ -14,10 +16,14 @@ import {
   GraphWrapper,
   MetricsActionContainer,
 } from '../components/style/CommonLayoutStyle';
-import { GRAFANA_DASHBOARDS, PORT_NODE_EXPORTER } from '../constants';
+import {
+  GRAFANA_DASHBOARDS,
+  PORT_NODE_EXPORTER,
+  UNIT_RANGE_BS,
+} from '../constants';
 import { updateNodeStatsFetchArgumentAction } from '../ducks/app/monitoring';
 import type { NodesState } from '../ducks/app/nodes';
-import { useTypedSelector } from '../hooks';
+import { useTypedSelector, useChartColors } from '../hooks';
 import {
   getCPUUsageAvgQuery,
   getCPUUsageQuery,
@@ -124,6 +130,9 @@ const NodePageMetricsTab = ({
   const showAvg = useTypedSelector(
     (state) => state.app.monitoring.nodeStats.showAvg,
   );
+
+  // Create color set for this single node
+  const colorSet = useChartColors([nodeName]);
   // To redirect to the right Node(Detailed) dashboard in Grafana
   const unameInfos = useTypedSelector(
     (state) => state.app.monitoring.unameInfo,
@@ -185,7 +194,7 @@ const NodePageMetricsTab = ({
         {instanceIP && <TimespanSelector />}
       </MetricsActionContainer>
       {instanceIP ? (
-        <SyncedCursorCharts>
+        <ChartLegendWrapper colorSet={colorSet}>
           <GraphGrid id="graph_container">
             <GraphWrapper className="cpuusage">
               <MetricChart
@@ -199,6 +208,7 @@ const NodePageMetricsTab = ({
                 // @ts-expect-error - FIXME when you are working on it
                 getMetricAvgQuery={getCPUUsageAvgQuery}
               ></MetricChart>
+              <ChartLegend shape="line" legendSize="Smaller" />
             </GraphWrapper>
             <GraphWrapper className="systemload">
               <MetricChart
@@ -212,6 +222,7 @@ const NodePageMetricsTab = ({
                 // @ts-expect-error - FIXME when you are working on it
                 getMetricAvgQuery={getSystemLoadAvgQuery}
               ></MetricChart>
+              <ChartLegend shape="line" legendSize="Smaller" />
             </GraphWrapper>
             <GraphWrapper className="memory">
               <MetricChart
@@ -225,6 +236,7 @@ const NodePageMetricsTab = ({
                 // @ts-expect-error - FIXME when you are working on it
                 getMetricAvgQuery={getMemoryAvgQuery}
               ></MetricChart>
+              <ChartLegend shape="line" legendSize="Smaller" />
             </GraphWrapper>
             <GraphWrapper className="iops">
               <MetricSymmetricalChart
@@ -246,6 +258,7 @@ const NodePageMetricsTab = ({
                 metricPrefixBelow={'read'}
                 isPlaneInterfaceRequired={false}
               ></MetricSymmetricalChart>
+              <ChartLegend shape="line" legendSize="Smaller" />
             </GraphWrapper>
             <GraphWrapper className="cpbandwidth">
               <MetricSymmetricalChart
@@ -270,6 +283,7 @@ const NodePageMetricsTab = ({
                 unitRange={UNIT_RANGE_BS}
                 isPlaneInterfaceRequired={true}
               ></MetricSymmetricalChart>
+              <ChartLegend shape="line" legendSize="Smaller" />
             </GraphWrapper>
             <GraphWrapper className="wpbandwidth">
               <MetricSymmetricalChart
@@ -294,9 +308,10 @@ const NodePageMetricsTab = ({
                 unitRange={UNIT_RANGE_BS}
                 isPlaneInterfaceRequired={true}
               ></MetricSymmetricalChart>
+              <ChartLegend shape="line" legendSize="Smaller" />
             </GraphWrapper>
           </GraphGrid>
-        </SyncedCursorCharts>
+        </ChartLegendWrapper>
       ) : (
         <RenderNoDataAvailable />
       )}

--- a/ui/src/hooks.tsx
+++ b/ui/src/hooks.tsx
@@ -10,7 +10,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import type { UseQueryOptions, UseQueryResult } from 'react-query';
+import type { UseQueryOptions } from 'react-query';
 import { useQueries, useQuery } from 'react-query';
 import { useSelector } from 'react-redux';
 import {
@@ -192,7 +192,7 @@ export const useSingleChartSerie = ({
   getQuery,
   transformPrometheusDataToSeries, //It should be memoised using useCallback
 }: {
-  getQuery: (timeSpanProps: TimeSpanProps) => UseQueryResult;
+  getQuery: (timeSpanProps: TimeSpanProps) => UseQueryOptions;
   transformPrometheusDataToSeries: (
     prometheusResult: PrometheusQueryResult,
   ) => Serie[];
@@ -205,7 +205,6 @@ export const useSingleChartSerie = ({
 
   startTimeRef.current = startingTimeISO;
   const query = useQuery(
-    // @ts-expect-error - FIXME when you are working on it
     getQuery({
       startingTimeISO,
       currentTimeISO,

--- a/ui/src/hooks.tsx
+++ b/ui/src/hooks.tsx
@@ -1,10 +1,11 @@
-import type { V1NodeList } from '@kubernetes/client-node';
+import type { V1Node } from '@kubernetes/client-node';
 import type { Serie } from '@scality/core-ui/dist/components/linetemporalchart/LineTemporalChart.component';
 import { useMetricsTimeSpan } from '@scality/core-ui/dist/next';
 import React, {
   createContext,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -12,6 +13,7 @@ import type { UseQueryOptions, UseQueryResult } from 'react-query';
 import { useQueries, useQuery } from 'react-query';
 import { useSelector } from 'react-redux';
 import {
+  CHART_COLOR_VALUES,
   NODES_LIMIT_QUANTILE,
   REFRESH_METRICS_GRAPH,
   SAMPLE_DURATION_LAST_TWENTY_FOUR_HOURS,
@@ -42,7 +44,7 @@ export const useTypedSelector: <TSelected>(
 /**
  * It retrieves the nodes data through react-queries
  */
-export const useNodes = (): V1NodeList => {
+export const useNodes = (): V1Node[] => {
   const { coreV1 } = useK8sApiConfig();
   const { getToken } = useAuth();
   const nodesQuery = useQuery(
@@ -68,16 +70,14 @@ export const useNodes = (): V1NodeList => {
       refetchInterval: REFRESH_METRICS_GRAPH,
     },
   );
-  // @ts-expect-error - FIXME when you are working on it
   return nodesQuery.data || [];
 };
 export const useNodeAddressesSelector = (
-  nodes: V1NodeList,
+  nodes: V1Node[],
 ): Array<{
   internalIP: string;
   name: string;
 }> => {
-  // @ts-expect-error - FIXME when you are working on it
   return nodes.map((item) => {
     return {
       internalIP: item?.status?.addresses?.find(
@@ -149,17 +149,17 @@ export const useSingleChartSerie = ({
   ) => Serie[];
 }) => {
   const { startingTimeISO, currentTimeISO } = useStartingTimeStamp();
-  const { frequency } = useMetricsTimeSpan();
+  const { interval } = useMetricsTimeSpan();
   const startTimeRef = useRef(startingTimeISO);
   const chartStartTimeRef = useRef(startingTimeISO);
-  const [series, setSeries] = useState([]);
+  const [series, setSeries] = useState<Serie[]>([]);
   startTimeRef.current = startingTimeISO;
   const query = useQuery(
     // @ts-expect-error - FIXME when you are working on it
     getQuery({
       startingTimeISO,
       currentTimeISO,
-      frequency,
+      frequency: interval,
     }),
   );
   const isLoading = query.isLoading;
@@ -186,19 +186,19 @@ export const useChartSeries = ({
   ) => Serie[];
 }) => {
   const { startingTimeISO, currentTimeISO } = useStartingTimeStamp();
-  const { frequency } = useMetricsTimeSpan();
+  const { interval } = useMetricsTimeSpan();
   const startTimeRef = useRef(startingTimeISO);
   const chartStartTimeRef = useRef(startingTimeISO);
-  const [series, setSeries] = useState([]);
+  const [series, setSeries] = useState<Serie[]>([]);
   startTimeRef.current = startingTimeISO;
   const queries = useQueries(
     getQueries({
       startingTimeISO,
       currentTimeISO,
-      frequency,
+      frequency: interval,
     }),
   );
-  const isLoading = queries.find((query) => query.isLoading);
+  const isLoading = queries.some((query) => query.isLoading);
   const queriesData = queries
     .map((query) => {
       return query.data;
@@ -235,33 +235,42 @@ export const useSymetricalChartSeries = ({
   transformPrometheusDataToSeries: (
     prometheusResultAbove: PrometheusQueryResult[],
     prometheusResultBelow: PrometheusQueryResult[],
-  ) => Serie[];
+  ) => {
+    above: Serie[];
+    below: Serie[];
+  };
 }) => {
   const { startingTimeISO, currentTimeISO } = useStartingTimeStamp();
-  const { frequency } = useMetricsTimeSpan();
+  const { interval } = useMetricsTimeSpan();
   const startTimeRef = useRef(startingTimeISO);
   const chartStartTimeRef = useRef(startingTimeISO);
-  const [series, setSeries] = useState([]);
+  const [series, setSeries] = useState<{
+    above: Serie[];
+    below: Serie[];
+  }>({ above: [], below: [] });
   startTimeRef.current = startingTimeISO;
   const aboveQueries = useQueries(
     // @ts-expect-error - FIXME when you are working on it
     getAboveQueries({
       startingTimeISO,
       currentTimeISO,
-      frequency,
+      frequency: interval,
     }),
   );
+
   const belowQueries = useQueries(
     // @ts-expect-error - FIXME when you are working on it
     getBelowQueries({
       startingTimeISO,
       currentTimeISO,
-      frequency,
+      frequency: interval,
     }),
   );
+
   const isLoading =
-    aboveQueries.find((query) => query.isLoading) ||
-    belowQueries.find((query) => query.isLoading);
+    aboveQueries.some((query) => query.isLoading || query.isIdle) ||
+    belowQueries.some((query) => query.isLoading || query.isIdle);
+
   const queriesAboveData = aboveQueries
     .map((query) => query.data)
     /* useQueries is running the requests in paralel and given that
@@ -296,7 +305,7 @@ export const useSymetricalChartSeries = ({
     JSON.stringify(queriesBelowData),
   ]);
   return {
-    series: series || [],
+    series: series || { above: [], below: [] },
     startingTimeStamp: Date.parse(chartStartTimeRef.current) / 1000,
     isLoading,
   };
@@ -308,17 +317,16 @@ export const useQuantileOnHover = ({
   getQuantileHoverQuery: (
     timestamp?: string, // to be check the type
     threshold?: number,
-    // @ts-expect-error - FIXME when you are working on it
-    operator: '>' | '<',
-    isOnHoverFetchingRequired: boolean,
+    operator?: '>' | '<',
+    isOnHoverFetchingRequired?: boolean,
     devices?: string,
   ) => UseQueryOptions;
   metricPrefix?: string;
 }) => {
   const [hoverTimestamp, setHoverTimestamp] = useState<number>(0);
-  const [threshold90, setThreshold90] = useState();
-  const [threshold5, setThreshold5] = useState();
-  const [median, setMedian] = useState();
+  const [threshold90, setThreshold90] = useState<number>();
+  const [threshold5, setThreshold5] = useState<number>();
+  const [median, setMedian] = useState<number>();
   const [valueBase, setValueBase] = useState(1);
   // @ts-expect-error - FIXME when you are working on it
   const nodeIPsInfo = useSelector((state) => state.app.nodes.IPsInfo);
@@ -351,19 +359,16 @@ export const useQuantileOnHover = ({
       if (!hoverTimestamp || datum.timestamp !== hoverTimestamp) {
         setHoverTimestamp(datum.timestamp);
         setThreshold90(
-          // @ts-expect-error - FIXME when you are working on it
           metricPrefix
             ? Math.abs(datum.originalData[`Q90-${metricPrefix}`])
             : Math.abs(datum.originalData['Q90']),
         );
         setThreshold5(
-          // @ts-expect-error - FIXME when you are working on it
           metricPrefix
             ? Math.abs(datum.originalData[`Q5-${metricPrefix}`])
             : Math.abs(datum.originalData['Q5']),
         );
         setMedian(
-          // @ts-expect-error - FIXME when you are working on it
           metricPrefix
             ? Math.abs(datum.originalData[`Median-${metricPrefix}`])
             : Math.abs(datum.originalData['Median']),
@@ -389,9 +394,48 @@ export const useShowQuantileChart = (): {
   return {
     isShowQuantileChart:
       (flags && flags.includes('force_quantile_chart')) ||
-      // @ts-expect-error - FIXME when you are working on it
-      nodes?.length > NODES_LIMIT_QUANTILE,
+      nodes.length > NODES_LIMIT_QUANTILE,
   };
+};
+
+// Chart color hooks
+
+/**
+ * Hook to create dynamic color mapping for chart series
+ * @param items - Array of items that need color mapping
+ * @param getKey - Function to extract the key from each item (defaults to item => item)
+ * @returns Record mapping each key to a color
+ */
+export const useChartColors = function <T>(
+  items: T[],
+  getKey: (item: T) => string = (item) => String(item),
+): Record<string, string> {
+  return useMemo(() => {
+    const colorMapping: Record<string, string> = {};
+
+    items.forEach((item, index) => {
+      const key = getKey(item);
+      // Cycle through available colors
+      const colorIndex = index % CHART_COLOR_VALUES.length;
+      colorMapping[key] = CHART_COLOR_VALUES[colorIndex];
+    });
+
+    return colorMapping;
+  }, [items, getKey]);
+};
+
+/**
+ * Hook specifically for node color mapping
+ * @param nodes - Array of node objects with metadata containing optional name
+ * @returns Record mapping each node name to a color
+ */
+export const useNodeColors = (
+  nodes: Array<{ metadata?: { name?: string } }>,
+): Record<string, string> => {
+  return useChartColors(
+    nodes.filter((node) => node.metadata?.name),
+    (node) => node.metadata!.name!,
+  );
 };
 
 export type UserRoles = {

--- a/ui/src/hooks.tsx
+++ b/ui/src/hooks.tsx
@@ -1,5 +1,6 @@
 import type { V1Node } from '@kubernetes/client-node';
-import type { Serie } from '@scality/core-ui/dist/components/linetemporalchart/LineTemporalChart.component';
+
+import type { Serie } from '@scality/core-ui/dist/components/linetimeseriechart/linetimeseriechart.component';
 import { useMetricsTimeSpan } from '@scality/core-ui/dist/next';
 import React, {
   createContext,
@@ -18,6 +19,7 @@ import {
   REFRESH_METRICS_GRAPH,
   SAMPLE_DURATION_LAST_TWENTY_FOUR_HOURS,
   STATUS_NONE,
+  TESTING_MULTIPLY_NODES,
   VOLUME_CONDITION_LINK,
 } from './constants';
 import { useAlerts } from './containers/AlertProvider';
@@ -58,7 +60,53 @@ export const useNodes = (): V1Node[] => {
 
       return coreV1.listNode().then((res) => {
         if (res.response.statusCode === 200 && res.body?.items) {
-          return res.body?.items;
+          const realNodes = res.body?.items;
+
+          // FOR TESTING: Multiply nodes to simulate larger cluster for quantile testing
+          if (
+            process.env.NODE_ENV === 'development' &&
+            TESTING_MULTIPLY_NODES > 1
+          ) {
+            const expandedNodes = [];
+
+            for (
+              let multiplier = 0;
+              multiplier < TESTING_MULTIPLY_NODES;
+              multiplier++
+            ) {
+              realNodes.forEach((node, index) => {
+                const clonedNode = JSON.parse(JSON.stringify(node)); // Deep clone
+
+                if (multiplier > 0) {
+                  // Modify name for clones
+                  clonedNode.metadata.name = `${node.metadata.name}-test-${multiplier}`;
+
+                  // Modify internal IP for clones to create unique instances
+                  if (clonedNode.status?.addresses) {
+                    clonedNode.status.addresses.forEach((addr) => {
+                      if (addr.type === 'InternalIP') {
+                        const parts = addr.address.split('.');
+                        // Increment last octet, wrapping if needed
+                        const lastOctet =
+                          parseInt(parts[3]) + multiplier * 10 + index;
+                        parts[3] = (lastOctet % 255).toString();
+                        addr.address = parts.join('.');
+                      }
+                    });
+                  }
+                }
+
+                expandedNodes.push(clonedNode);
+              });
+            }
+
+            console.log(
+              `🧪 TESTING: Expanded ${realNodes.length} real nodes to ${expandedNodes.length} nodes for quantile testing`,
+            );
+            return expandedNodes;
+          }
+
+          return realNodes;
         }
 
         return [];
@@ -139,6 +187,7 @@ export const useVolumesWithAlerts = (nodeName?: string) => {
   );
   return volumeListWithStatus;
 };
+
 export const useSingleChartSerie = ({
   getQuery,
   transformPrometheusDataToSeries, //It should be memoised using useCallback
@@ -153,6 +202,7 @@ export const useSingleChartSerie = ({
   const startTimeRef = useRef(startingTimeISO);
   const chartStartTimeRef = useRef(startingTimeISO);
   const [series, setSeries] = useState<Serie[]>([]);
+
   startTimeRef.current = startingTimeISO;
   const query = useQuery(
     // @ts-expect-error - FIXME when you are working on it
@@ -176,6 +226,7 @@ export const useSingleChartSerie = ({
     isLoading,
   };
 };
+
 export const useChartSeries = ({
   getQueries,
   transformPrometheusDataToSeries, //It should be memoised using useCallback
@@ -190,6 +241,7 @@ export const useChartSeries = ({
   const startTimeRef = useRef(startingTimeISO);
   const chartStartTimeRef = useRef(startingTimeISO);
   const [series, setSeries] = useState<Serie[]>([]);
+
   startTimeRef.current = startingTimeISO;
   const queries = useQueries(
     getQueries({
@@ -248,6 +300,7 @@ export const useSymetricalChartSeries = ({
     above: Serie[];
     below: Serie[];
   }>({ above: [], below: [] });
+
   startTimeRef.current = startingTimeISO;
   const aboveQueries = useQueries(
     // @ts-expect-error - FIXME when you are working on it
@@ -392,9 +445,9 @@ export const useShowQuantileChart = (): {
   const nodes = useNodes();
   const { flags } = useTypedSelector((state) => state.config.api);
   return {
-    isShowQuantileChart:
-      (flags && flags.includes('force_quantile_chart')) ||
-      nodes.length > NODES_LIMIT_QUANTILE,
+    isShowQuantileChart: true, // TODO: remove this after fixing the quantile chart
+    // (flags && flags.includes('force_quantile_chart')) ||
+    // nodes.length > NODES_LIMIT_QUANTILE,
   };
 };
 

--- a/ui/src/hooks.tsx
+++ b/ui/src/hooks.tsx
@@ -19,7 +19,6 @@ import {
   REFRESH_METRICS_GRAPH,
   SAMPLE_DURATION_LAST_TWENTY_FOUR_HOURS,
   STATUS_NONE,
-  TESTING_MULTIPLY_NODES,
   VOLUME_CONDITION_LINK,
 } from './constants';
 import { useAlerts } from './containers/AlertProvider';
@@ -60,53 +59,7 @@ export const useNodes = (): V1Node[] => {
 
       return coreV1.listNode().then((res) => {
         if (res.response.statusCode === 200 && res.body?.items) {
-          const realNodes = res.body?.items;
-
-          // FOR TESTING: Multiply nodes to simulate larger cluster for quantile testing
-          if (
-            process.env.NODE_ENV === 'development' &&
-            TESTING_MULTIPLY_NODES > 1
-          ) {
-            const expandedNodes = [];
-
-            for (
-              let multiplier = 0;
-              multiplier < TESTING_MULTIPLY_NODES;
-              multiplier++
-            ) {
-              realNodes.forEach((node, index) => {
-                const clonedNode = JSON.parse(JSON.stringify(node)); // Deep clone
-
-                if (multiplier > 0) {
-                  // Modify name for clones
-                  clonedNode.metadata.name = `${node.metadata.name}-test-${multiplier}`;
-
-                  // Modify internal IP for clones to create unique instances
-                  if (clonedNode.status?.addresses) {
-                    clonedNode.status.addresses.forEach((addr) => {
-                      if (addr.type === 'InternalIP') {
-                        const parts = addr.address.split('.');
-                        // Increment last octet, wrapping if needed
-                        const lastOctet =
-                          parseInt(parts[3]) + multiplier * 10 + index;
-                        parts[3] = (lastOctet % 255).toString();
-                        addr.address = parts.join('.');
-                      }
-                    });
-                  }
-                }
-
-                expandedNodes.push(clonedNode);
-              });
-            }
-
-            console.log(
-              `🧪 TESTING: Expanded ${realNodes.length} real nodes to ${expandedNodes.length} nodes for quantile testing`,
-            );
-            return expandedNodes;
-          }
-
-          return realNodes;
+          return res.body.items;
         }
 
         return [];
@@ -442,9 +395,9 @@ export const useShowQuantileChart = (): {
   const nodes = useNodes();
   const { flags } = useTypedSelector((state) => state.config.api);
   return {
-    isShowQuantileChart: true, // TODO: remove this after fixing the quantile chart
-    // (flags && flags.includes('force_quantile_chart')) ||
-    // nodes.length > NODES_LIMIT_QUANTILE,
+    isShowQuantileChart:
+      (flags && flags.includes('force_quantile_chart')) ||
+      nodes.length > NODES_LIMIT_QUANTILE,
   };
 };
 

--- a/ui/src/hooks.tsx
+++ b/ui/src/hooks.tsx
@@ -282,8 +282,8 @@ export const useSymetricalChartSeries = ({
   getBelowQueries,
   transformPrometheusDataToSeries, //It should be memoised using useCallback
 }: {
-  getAboveQueries: (timeSpanProps: TimeSpanProps) => UseQueryResult[];
-  getBelowQueries: (timeSpanProps: TimeSpanProps) => UseQueryResult[];
+  getAboveQueries: (timeSpanProps: TimeSpanProps) => UseQueryOptions[];
+  getBelowQueries: (timeSpanProps: TimeSpanProps) => UseQueryOptions[];
   transformPrometheusDataToSeries: (
     prometheusResultAbove: PrometheusQueryResult[],
     prometheusResultBelow: PrometheusQueryResult[],
@@ -303,7 +303,6 @@ export const useSymetricalChartSeries = ({
 
   startTimeRef.current = startingTimeISO;
   const aboveQueries = useQueries(
-    // @ts-expect-error - FIXME when you are working on it
     getAboveQueries({
       startingTimeISO,
       currentTimeISO,
@@ -312,7 +311,6 @@ export const useSymetricalChartSeries = ({
   );
 
   const belowQueries = useQueries(
-    // @ts-expect-error - FIXME when you are working on it
     getBelowQueries({
       startingTimeISO,
       currentTimeISO,

--- a/ui/src/hooks/useChartLegendRegistration.spec.ts
+++ b/ui/src/hooks/useChartLegendRegistration.spec.ts
@@ -1,0 +1,340 @@
+import { useChartLegendRegistration } from './useChartLegendRegistration';
+import { renderHook } from '@testing-library/react-hooks';
+import { Serie } from '@scality/core-ui/dist/components/linetimeseriechart/linetimeseriechart.component';
+
+// Mock the useChartLegend hook
+const mockRegister = jest.fn();
+jest.mock(
+  '@scality/core-ui/dist/components/chartlegend/ChartLegendWrapper',
+  () => ({
+    useChartLegend: () => ({
+      register: mockRegister,
+    }),
+  }),
+);
+
+describe('useChartLegendRegistration', () => {
+  beforeEach(() => {
+    mockRegister.mockClear();
+  });
+
+  describe('Non-symmetrical series', () => {
+    it('should register chart with series names when series is provided', () => {
+      const mockSeries: Serie[] = [
+        { resource: 'cpu-usage', data: [], getTooltipLabel: () => 'CPU Usage' },
+        {
+          resource: 'memory-usage',
+          data: [],
+          getTooltipLabel: () => 'Memory Usage',
+        },
+      ];
+
+      renderHook(() =>
+        useChartLegendRegistration({
+          chartId: 'test-chart',
+          series: mockSeries,
+          isSymmetrical: false,
+        }),
+      );
+
+      expect(mockRegister).toHaveBeenCalledWith('test-chart', [
+        'cpu-usage',
+        'memory-usage',
+      ]);
+    });
+
+    it('should register chart with empty array when series is empty', () => {
+      renderHook(() =>
+        useChartLegendRegistration({
+          chartId: 'test-chart',
+          series: [],
+          isSymmetrical: false,
+        }),
+      );
+
+      expect(mockRegister).toHaveBeenCalledWith('test-chart', []);
+    });
+
+    it('should not register when series is null', () => {
+      renderHook(() =>
+        useChartLegendRegistration({
+          chartId: 'test-chart',
+          series: null,
+          isSymmetrical: false,
+        }),
+      );
+
+      expect(mockRegister).not.toHaveBeenCalled();
+    });
+
+    it('should include additional names when provided', () => {
+      const mockSeries: Serie[] = [
+        { resource: 'cpu-usage', data: [], getTooltipLabel: () => 'CPU Usage' },
+      ];
+
+      renderHook(() =>
+        useChartLegendRegistration({
+          chartId: 'test-chart',
+          series: mockSeries,
+          isSymmetrical: false,
+          additionalNames: ['custom-metric', 'another-metric'],
+        }),
+      );
+
+      expect(mockRegister).toHaveBeenCalledWith('test-chart', [
+        'cpu-usage',
+        'custom-metric',
+        'another-metric',
+      ]);
+    });
+  });
+
+  describe('Symmetrical series', () => {
+    it('should register chart with above and below series names', () => {
+      const mockSymmetricalSeries = {
+        above: [
+          {
+            resource: 'network-in',
+            data: [],
+            getTooltipLabel: () => 'Network In',
+          },
+          {
+            resource: 'disk-read',
+            data: [],
+            getTooltipLabel: () => 'Disk Read',
+          },
+        ],
+        below: [
+          {
+            resource: 'network-out',
+            data: [],
+            getTooltipLabel: () => 'Network Out',
+          },
+          {
+            resource: 'disk-write',
+            data: [],
+            getTooltipLabel: () => 'Disk Write',
+          },
+        ],
+      };
+
+      renderHook(() =>
+        useChartLegendRegistration({
+          chartId: 'symmetrical-chart',
+          series: mockSymmetricalSeries,
+          isSymmetrical: true,
+        }),
+      );
+
+      expect(mockRegister).toHaveBeenCalledWith('symmetrical-chart', [
+        'network-in',
+        'disk-read',
+        'network-out',
+        'disk-write',
+      ]);
+    });
+
+    it('should register chart with only above series when below is empty', () => {
+      const mockSymmetricalSeries = {
+        above: [
+          {
+            resource: 'network-in',
+            data: [],
+            getTooltipLabel: () => 'Network In',
+          },
+        ],
+        below: [],
+      };
+
+      renderHook(() =>
+        useChartLegendRegistration({
+          chartId: 'symmetrical-chart',
+          series: mockSymmetricalSeries,
+          isSymmetrical: true,
+        }),
+      );
+
+      expect(mockRegister).toHaveBeenCalledWith('symmetrical-chart', [
+        'network-in',
+      ]);
+    });
+
+    it('should register chart with only below series when above is empty', () => {
+      const mockSymmetricalSeries = {
+        above: [],
+        below: [
+          {
+            resource: 'network-out',
+            data: [],
+            getTooltipLabel: () => 'Network Out',
+          },
+        ],
+      };
+
+      renderHook(() =>
+        useChartLegendRegistration({
+          chartId: 'symmetrical-chart',
+          series: mockSymmetricalSeries,
+          isSymmetrical: true,
+        }),
+      );
+
+      expect(mockRegister).toHaveBeenCalledWith('symmetrical-chart', [
+        'network-out',
+      ]);
+    });
+
+    it('should not register when both above and below are empty', () => {
+      const mockSymmetricalSeries = {
+        above: [],
+        below: [],
+      };
+
+      renderHook(() =>
+        useChartLegendRegistration({
+          chartId: 'symmetrical-chart',
+          series: mockSymmetricalSeries,
+          isSymmetrical: true,
+        }),
+      );
+
+      expect(mockRegister).toHaveBeenCalledWith('symmetrical-chart', []);
+    });
+
+    it('should not register when series is null', () => {
+      renderHook(() =>
+        useChartLegendRegistration({
+          chartId: 'symmetrical-chart',
+          series: null,
+          isSymmetrical: true,
+        }),
+      );
+
+      expect(mockRegister).not.toHaveBeenCalled();
+    });
+
+    it('should include additional names with symmetrical series', () => {
+      const mockSymmetricalSeries = {
+        above: [
+          {
+            resource: 'network-in',
+            data: [],
+            getTooltipLabel: () => 'Network In',
+          },
+        ],
+        below: [
+          {
+            resource: 'network-out',
+            data: [],
+            getTooltipLabel: () => 'Network Out',
+          },
+        ],
+      };
+
+      renderHook(() =>
+        useChartLegendRegistration({
+          chartId: 'symmetrical-chart',
+          series: mockSymmetricalSeries,
+          isSymmetrical: true,
+          additionalNames: ['total-bandwidth'],
+        }),
+      );
+
+      expect(mockRegister).toHaveBeenCalledWith('symmetrical-chart', [
+        'network-in',
+        'network-out',
+        'total-bandwidth',
+      ]);
+    });
+  });
+
+  describe('Effect dependencies', () => {
+    it('should re-register when chartId changes', () => {
+      const mockSeries: Serie[] = [
+        { resource: 'cpu-usage', data: [], getTooltipLabel: () => 'CPU Usage' },
+      ];
+
+      const { rerender } = renderHook(
+        ({ chartId }) =>
+          useChartLegendRegistration({
+            chartId,
+            series: mockSeries,
+            isSymmetrical: false,
+          }),
+        { initialProps: { chartId: 'chart-1' } },
+      );
+
+      expect(mockRegister).toHaveBeenCalledWith('chart-1', ['cpu-usage']);
+
+      rerender({ chartId: 'chart-2' });
+
+      expect(mockRegister).toHaveBeenCalledWith('chart-2', ['cpu-usage']);
+      expect(mockRegister).toHaveBeenCalledTimes(2);
+    });
+
+    it('should re-register when series changes', () => {
+      const initialSeries: Serie[] = [
+        { resource: 'cpu-usage', data: [], getTooltipLabel: () => 'CPU Usage' },
+      ];
+      const updatedSeries: Serie[] = [
+        { resource: 'cpu-usage', data: [], getTooltipLabel: () => 'CPU Usage' },
+        {
+          resource: 'memory-usage',
+          data: [],
+          getTooltipLabel: () => 'Memory Usage',
+        },
+      ];
+
+      const { rerender } = renderHook(
+        ({ series }) =>
+          useChartLegendRegistration({
+            chartId: 'test-chart',
+            series,
+            isSymmetrical: false,
+          }),
+        { initialProps: { series: initialSeries } },
+      );
+
+      expect(mockRegister).toHaveBeenCalledWith('test-chart', ['cpu-usage']);
+
+      rerender({ series: updatedSeries });
+
+      expect(mockRegister).toHaveBeenCalledWith('test-chart', [
+        'cpu-usage',
+        'memory-usage',
+      ]);
+      expect(mockRegister).toHaveBeenCalledTimes(2);
+    });
+
+    it('should re-register when additionalNames changes', () => {
+      const mockSeries: Serie[] = [
+        { resource: 'cpu-usage', data: [], getTooltipLabel: () => 'CPU Usage' },
+      ];
+
+      const { rerender } = renderHook(
+        ({ additionalNames }) =>
+          useChartLegendRegistration({
+            chartId: 'test-chart',
+            series: mockSeries,
+            isSymmetrical: false,
+            additionalNames,
+          }),
+        { initialProps: { additionalNames: ['metric-1'] } },
+      );
+
+      expect(mockRegister).toHaveBeenCalledWith('test-chart', [
+        'cpu-usage',
+        'metric-1',
+      ]);
+
+      rerender({ additionalNames: ['metric-1', 'metric-2'] });
+
+      expect(mockRegister).toHaveBeenCalledWith('test-chart', [
+        'cpu-usage',
+        'metric-1',
+        'metric-2',
+      ]);
+      expect(mockRegister).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/ui/src/hooks/useChartLegendRegistration.ts
+++ b/ui/src/hooks/useChartLegendRegistration.ts
@@ -53,9 +53,10 @@ export const useChartLegendRegistration = ({
       }
     }
 
-    if (seriesNames.length > 0) {
-      const allSeriesNames = [...seriesNames, ...additionalNames];
-      register(chartId, allSeriesNames);
+    if (additionalNames) {
+      seriesNames.push(...additionalNames);
     }
+
+    register(chartId, seriesNames);
   }, [chartId, register, series, isSymmetrical, additionalNames]);
 };

--- a/ui/src/hooks/useChartLegendRegistration.ts
+++ b/ui/src/hooks/useChartLegendRegistration.ts
@@ -1,0 +1,61 @@
+import { useEffect } from 'react';
+import { useChartLegend } from '@scality/core-ui/dist/components/chartlegend/ChartLegendWrapper';
+import { Serie } from '@scality/core-ui/dist/components/linetimeseriechart/linetimeseriechart.component';
+
+interface SymmetricalSeries {
+  above: Serie[];
+  below: Serie[];
+}
+type ChartLegendRegistation = {
+  chartId: string;
+  additionalNames?: string[];
+} & (
+  | {
+      series: Serie[] | null;
+      isSymmetrical: false;
+    }
+  | {
+      series: SymmetricalSeries | null;
+      isSymmetrical: true;
+    }
+);
+
+export const useChartLegendRegistration = ({
+  chartId,
+  series,
+  isSymmetrical,
+  additionalNames,
+}: ChartLegendRegistation) => {
+  const { register } = useChartLegend();
+
+  useEffect(() => {
+    if (!series) return;
+
+    let seriesNames: Serie['resource'][] = [];
+
+    if (isSymmetrical) {
+      // Symmetrical chart (has above/below structure)
+      const symmetricalSeries = series;
+      if (
+        symmetricalSeries.above?.length > 0 ||
+        symmetricalSeries.below?.length > 0
+      ) {
+        const aboveNames =
+          symmetricalSeries.above?.map((s) => s.resource) || [];
+        const belowNames =
+          symmetricalSeries.below?.map((s) => s.resource) || [];
+        seriesNames = [...aboveNames, ...belowNames];
+      }
+    } else if (isSymmetrical === false) {
+      const arrayedSeries = series;
+      if (arrayedSeries && arrayedSeries.length > 0) {
+        seriesNames = arrayedSeries.map((s) => s.resource);
+      }
+    }
+
+    if (seriesNames.length > 0) {
+      const allSeriesNames = [...seriesNames, ...additionalNames];
+      register(chartId, allSeriesNames);
+    }
+  }, [chartId, register, series, isSymmetrical, additionalNames]);
+};

--- a/ui/src/hooks/useChartLegendRegistration.ts
+++ b/ui/src/hooks/useChartLegendRegistration.ts
@@ -2,11 +2,11 @@ import { useEffect } from 'react';
 import { useChartLegend } from '@scality/core-ui/dist/components/chartlegend/ChartLegendWrapper';
 import { Serie } from '@scality/core-ui/dist/components/linetimeseriechart/linetimeseriechart.component';
 
-interface SymmetricalSeries {
+type SymmetricalSeries = {
   above: Serie[];
   below: Serie[];
-}
-type ChartLegendRegistation = {
+};
+type ChartLegendRegistration = {
   chartId: string;
   additionalNames?: string[];
 } & (
@@ -25,7 +25,7 @@ export const useChartLegendRegistration = ({
   series,
   isSymmetrical,
   additionalNames,
-}: ChartLegendRegistation) => {
+}: ChartLegendRegistration) => {
   const { register } = useChartLegend();
 
   useEffect(() => {

--- a/ui/src/services/graphUtils.test.ts
+++ b/ui/src/services/graphUtils.test.ts
@@ -2,7 +2,22 @@ import {
   getMultiResourceSeriesForChart,
   getMultipleSymmetricalSeries,
   fiterMetricValues,
+  createSymmetricalQuantileColorSet,
+  createColorSet,
+  getTimeFormatForInterval,
 } from './graphUtils';
+import {
+  lineColor2,
+  lineColor3,
+  lineColor4,
+  lineColor5,
+  lineColor6,
+  lineColor7,
+  CHART_COLOR_VALUES,
+  SAMPLE_FREQUENCY_LAST_SEVEN_DAYS,
+  SAMPLE_FREQUENCY_LAST_TWENTY_FOUR_HOURS,
+  SAMPLE_FREQUENCY_LAST_ONE_HOUR,
+} from '../constants';
 const testPromData = {
   status: 'success',
   data: {
@@ -61,7 +76,6 @@ it('returns the data set within series for multi resources chart', () => {
         [1620738665, '29.994621830058193'],
       ],
       resource: 'node1',
-      getLegendLabel: expect.anything(),
       getTooltipLabel: expect.anything(),
       isLineDashed: false,
     },
@@ -74,7 +88,6 @@ it('returns the data set within series for multi resources chart', () => {
         [1620738665, '29.994621830058193'],
       ],
       resource: 'node2',
-      getLegendLabel: expect.anything(),
       getTooltipLabel: expect.anything(),
       isLineDashed: false,
     },
@@ -164,64 +177,66 @@ it('returns the series for multi resources symmetrical chart', () => {
     'read',
     testNodesData,
   );
-  const expectSymmetricalSeries = [
-    {
-      data: [
-        [1620727967, '10'],
-        [1620731567, '11'],
-        [1620735167, '12'],
-        [1620738767, '13'],
-        [1620742367, '14'],
-      ],
-      resource: 'node1',
-      isLineDashed: false,
-      metricPrefix: 'write',
-      getLegendLabel: expect.anything(),
-      getTooltipLabel: expect.anything(),
-    },
-    {
-      data: [
-        [1620727967, '20'],
-        [1620731567, '21'],
-        [1620735167, '22'],
-        [1620738767, '23'],
-        [1620742367, '24'],
-      ],
-      resource: 'node2',
-      isLineDashed: false,
-      metricPrefix: 'write',
-      getLegendLabel: expect.anything(),
-      getTooltipLabel: expect.anything(),
-    },
-    {
-      data: [
-        [1620727967, '15'],
-        [1620731567, '16'],
-        [1620735167, '17'],
-        [1620738767, '18'],
-        [1620742367, '19'],
-      ],
-      resource: 'node1',
-      isLineDashed: false,
-      metricPrefix: 'read',
-      getLegendLabel: null,
-      getTooltipLabel: expect.anything(),
-    },
-    {
-      data: [
-        [1620727967, '25'],
-        [1620731567, '26'],
-        [1620735167, '27'],
-        [1620738767, '28'],
-        [1620742367, '29'],
-      ],
-      resource: 'node2',
-      isLineDashed: false,
-      metricPrefix: 'read',
-      getLegendLabel: null,
-      getTooltipLabel: expect.anything(),
-    },
-  ];
+  const expectSymmetricalSeries = {
+    above: [
+      {
+        data: [
+          [1620727967, '10'],
+          [1620731567, '11'],
+          [1620735167, '12'],
+          [1620738767, '13'],
+          [1620742367, '14'],
+        ],
+        resource: 'node1',
+        isLineDashed: false,
+        metricPrefix: 'write',
+        getTooltipLabel: expect.anything(),
+      },
+      {
+        data: [
+          [1620727967, '20'],
+          [1620731567, '21'],
+          [1620735167, '22'],
+          [1620738767, '23'],
+          [1620742367, '24'],
+        ],
+        resource: 'node2',
+        isLineDashed: false,
+        metricPrefix: 'write',
+        getTooltipLabel: expect.anything(),
+      },
+    ],
+    below: [
+      {
+        data: [
+          [1620727967, '15'],
+          [1620731567, '16'],
+          [1620735167, '17'],
+          [1620738767, '18'],
+          [1620742367, '19'],
+        ],
+        resource: 'node1',
+        isLineDashed: false,
+        metricPrefix: 'read',
+        getTooltipLabel: expect.anything(),
+        renderTooltipSerie: expect.anything(),
+      },
+      {
+        data: [
+          [1620727967, '25'],
+          [1620731567, '26'],
+          [1620735167, '27'],
+          [1620738767, '28'],
+          [1620742367, '29'],
+        ],
+        resource: 'node2',
+        isLineDashed: false,
+        metricPrefix: 'read',
+        getTooltipLabel: expect.anything(),
+        renderTooltipSerie: expect.anything(),
+      },
+    ],
+  };
   expect(series).toMatchObject(expectSymmetricalSeries);
 });
 it('returns the correct labels for tooltip and legend for multi resources symmetrical chart', () => {
@@ -233,40 +248,40 @@ it('returns the correct labels for tooltip and legend for multi resources symmet
     'read',
     testNodesData,
   );
+  // Flatten series for easier testing
+  const allSeries = [...series.above, ...series.below];
+
   //resource: 'node1'
   expect(
-    series
+    allSeries
       .find(
         (serie) => serie.resource === 'node1' && serie.metricPrefix === 'write',
       )
       .getTooltipLabel('write', 'node1'),
   ).toEqual('node1-write');
   expect(
-    series
+    allSeries
       .find(
         (serie) => serie.resource === 'node1' && serie.metricPrefix === 'read',
       )
       .getTooltipLabel('read', 'node1'),
   ).toEqual('node1-read');
   //resource: 'node2'
+  const node2WriteSerite = allSeries.find(
+    (serie) => serie.resource === 'node2' && serie.metricPrefix === 'write',
+  );
+  expect(node2WriteSerite).toBeDefined();
   expect(
-    series
-      .find(
-        (serie) => serie.resource === 'node2' && serie.metricPrefix === 'write',
-      )
-      .getLegendLabel('write', 'node2'),
-  ).toEqual('node2');
-  expect(
-    series
+    allSeries
       .find(
         (serie) => serie.resource === 'node2' && serie.metricPrefix === 'write',
       )
       .getTooltipLabel('write', 'node2'),
   ).toEqual('node2-write');
   expect(
-    series
+    allSeries
       .find(
-        (serie) => serie.resource === 'node2' && serie.metricPrefix === 'write',
+        (serie) => serie.resource === 'node2' && serie.metricPrefix === 'read',
       )
       .getTooltipLabel('read', 'node2'),
   ).toEqual('node2-read');
@@ -277,7 +292,9 @@ it('selects the result with the expected label', () => {
     instance: '192.168.1.1',
   };
   const prometheusResult = {
+    status: 'success',
     data: {
+      resultType: 'matrix',
       result: [
         {
           metric: {
@@ -309,7 +326,9 @@ it('selects the result with the 2 expected labels', () => {
     device: 'eth2',
   };
   const prometheusResult = {
+    status: 'success',
     data: {
+      resultType: 'matrix',
       result: [
         {
           metric: {
@@ -336,5 +355,129 @@ it('selects the result with the 2 expected labels', () => {
       device: 'eth2',
     },
     values: [1, '1'],
+  });
+});
+
+// Test createSymmetricalQuantileColorSet function
+describe('createSymmetricalQuantileColorSet', () => {
+  const mockAboveSeries = [
+    { resource: 'Q90-write', name: 'Q90-write' },
+    { resource: 'Median-write', name: 'Median-write' },
+    { resource: 'Q5-write', name: 'Q5-write' },
+  ];
+
+  const mockBelowSeries = [
+    { resource: 'Q5-read', name: 'Q5-read' },
+    { resource: 'Median-read', name: 'Median-read' },
+    { resource: 'Q90-read', name: 'Q90-read' },
+  ];
+
+  it('assigns correct colors for above series', () => {
+    const colorSet = createSymmetricalQuantileColorSet(mockAboveSeries, []);
+
+    expect(colorSet['Q90-write']).toBe(lineColor3); // cyan
+    expect(colorSet['Median-write']).toBe(lineColor5); // yellow
+    expect(colorSet['Q5-write']).toBe(lineColor4); // blue
+  });
+
+  it('assigns correct colors for below series', () => {
+    const colorSet = createSymmetricalQuantileColorSet([], mockBelowSeries);
+
+    expect(colorSet['Q5-read']).toBe(lineColor6); // red
+    expect(colorSet['Median-read']).toBe(lineColor2); // gold
+    expect(colorSet['Q90-read']).toBe(lineColor7); // orange
+  });
+
+  it('assigns correct colors for both above and below series', () => {
+    const colorSet = createSymmetricalQuantileColorSet(
+      mockAboveSeries,
+      mockBelowSeries,
+    );
+
+    // Above series colors
+    expect(colorSet['Q90-write']).toBe(lineColor3); // cyan
+    expect(colorSet['Median-write']).toBe(lineColor5); // yellow
+    expect(colorSet['Q5-write']).toBe(lineColor4); // blue
+
+    // Below series colors
+    expect(colorSet['Q5-read']).toBe(lineColor6); // red
+    expect(colorSet['Median-read']).toBe(lineColor2); // gold
+    expect(colorSet['Q90-read']).toBe(lineColor7); // orange
+  });
+
+  it('handles empty series arrays', () => {
+    const colorSet = createSymmetricalQuantileColorSet([], []);
+
+    expect(colorSet).toEqual({});
+  });
+
+  it('handles series with name property instead of resource', () => {
+    const aboveSeriesWithName = [
+      { name: 'Q90-write' },
+      { name: 'Median-write' },
+      { name: 'Q5-write' },
+    ];
+
+    const colorSet = createSymmetricalQuantileColorSet(aboveSeriesWithName, []);
+
+    expect(colorSet['Q90-write']).toBe(lineColor3); // cyan
+    expect(colorSet['Median-write']).toBe(lineColor5); // yellow
+    expect(colorSet['Q5-write']).toBe(lineColor4); // blue
+  });
+
+  it('handles mixed series with both resource and name properties', () => {
+    const mixedAboveSeries = [
+      { resource: 'Q90-write' },
+      { name: 'Median-write' },
+      { resource: 'Q5-write', name: 'Q5-write' },
+    ];
+
+    const colorSet = createSymmetricalQuantileColorSet(mixedAboveSeries, []);
+
+    expect(colorSet['Q90-write']).toBe(lineColor3); // cyan
+    expect(colorSet['Median-write']).toBe(lineColor5); // yellow
+    expect(colorSet['Q5-write']).toBe(lineColor4); // blue
+  });
+});
+
+// Test createColorSet function
+describe('createColorSet', () => {
+  it('creates color mapping for series names', () => {
+    const seriesNames = ['series1', 'series2', 'series3'];
+    const colorSet = createColorSet(seriesNames);
+
+    expect(colorSet['series1']).toBe(CHART_COLOR_VALUES[0]);
+    expect(colorSet['series2']).toBe(CHART_COLOR_VALUES[1]);
+    expect(colorSet['series3']).toBe(CHART_COLOR_VALUES[2]);
+  });
+
+  it('handles empty series array', () => {
+    const colorSet = createColorSet([]);
+    expect(colorSet).toEqual({});
+  });
+});
+
+// Test getTimeFormatForInterval function
+describe('getTimeFormatForInterval', () => {
+  it('returns day-month-abbreviated-hour-minute for 7 days interval', () => {
+    const result = getTimeFormatForInterval(SAMPLE_FREQUENCY_LAST_SEVEN_DAYS);
+    expect(result).toBe('day-month-abbreviated-hour-minute');
+  });
+
+  it('returns day-month-abbreviated-hour-minute for 24 hours interval', () => {
+    const result = getTimeFormatForInterval(
+      SAMPLE_FREQUENCY_LAST_TWENTY_FOUR_HOURS,
+    );
+    expect(result).toBe('day-month-abbreviated-hour-minute');
+  });
+
+  it('returns day-month-abbreviated-hour-minute-second for 1 hour interval', () => {
+    const result = getTimeFormatForInterval(SAMPLE_FREQUENCY_LAST_ONE_HOUR);
+    expect(result).toBe('day-month-abbreviated-hour-minute-second');
+  });
+
+  it('returns long-date-without-weekday for unknown interval', () => {
+    const result = getTimeFormatForInterval(999);
+    expect(result).toBe('long-date-without-weekday');
   });
 });

--- a/ui/src/services/graphUtils.ts
+++ b/ui/src/services/graphUtils.ts
@@ -2,7 +2,11 @@ import type {
   PrometheusQueryResult,
   RangeMatrixResult,
 } from './prometheus/api';
-import { lineColor1, PORT_NODE_EXPORTER } from '../constants';
+import {
+  CHART_COLOR_VALUES,
+  lineColor1,
+  PORT_NODE_EXPORTER,
+} from '../constants';
 import { Serie } from '@scality/core-ui/dist/components/linetemporalchart/LineTemporalChart.component';
 import {
   spacing,
@@ -172,6 +176,9 @@ export const getMultipleSymmetricalSeries = (
             return `${resource}-${metricPrefix}`;
           },
           getLegendLabel: null, //disable legend to avoid duplicated entries
+          renderTooltipSerie: (serie) => {
+            return `${serie.resource}-${serie.metricPrefix}`;
+          },
         },
       ];
     })
@@ -441,4 +448,17 @@ export const renderOutpassingThresholdTitle = (
 };
 export const renderTooltipSeperationLine = (seperationLineColor) => {
   return `</table><hr style="border-color: ${seperationLineColor};"/><table>`;
+};
+
+// Shared function to create color mapping for chart series
+export const createColorSet = (
+  seriesNames: string[],
+): Record<string, string> => {
+  const colorMapping: Record<string, string> = {};
+  seriesNames.forEach((name, index) => {
+    // Cycle through available colors
+    const colorIndex = index % CHART_COLOR_VALUES.length;
+    colorMapping[name] = CHART_COLOR_VALUES[colorIndex];
+  });
+  return colorMapping;
 };

--- a/ui/src/services/graphUtils.ts
+++ b/ui/src/services/graphUtils.ts
@@ -4,7 +4,7 @@ import type {
 } from './prometheus/api';
 import {
   CHART_COLOR_VALUES,
-  lineColor1,
+  CLUSTER_AVERAGE,
   lineColor2,
   lineColor3,
   lineColor4,
@@ -41,7 +41,7 @@ export const getMultiResourceSeriesForChart = (
     return convertMatrixResultToSerie(matrixResult, node.name);
   });
 };
-// UPDATED: fiterMetricValues - Add error handling and proper typing
+
 export const fiterMetricValues = (
   prometheusResult: PrometheusQueryResult,
   labels: {
@@ -242,14 +242,12 @@ export const convertPrometheusResultToSerieWithAverage = (
   const series = [
     {
       ...convertPrometheusResultToSerie(result, serieName),
-      color: resultAvg ? lineColor1 : undefined, // when we display the average, average serie color should match with the metric color
     },
   ];
 
   if (resultAvg) {
     series.push({
-      ...convertPrometheusResultToSerie(resultAvg, 'Cluster Avg.'),
-      color: lineColor1,
+      ...convertPrometheusResultToSerie(resultAvg, CLUSTER_AVERAGE),
       isLineDashed: true,
     });
   }
@@ -299,10 +297,6 @@ export const getSeriesForSymmetricalChart = (
       getTooltipLabel: (metricPrefix, resource) => {
         return `${resource}-${metricPrefix}`;
       },
-      // For the legend, we display only two labels for the symmetrical chart: One is the `${node_name}`, the other is `Cluster Avg.`
-      getLegendLabel: (_, resource) => {
-        return `${resource}`;
-      },
     };
     series.below.push(serieBelow);
   }
@@ -316,13 +310,11 @@ export const getSeriesForSymmetricalChart = (
     const serieAvgAbove = {
       metricPrefix: metricPrefixAbove,
       data: resultAvgAbove?.data?.result[0]?.values || [],
-      resource: 'Cluster Avg.',
+      resource: CLUSTER_AVERAGE,
       getTooltipLabel: (metricPrefix, resource) => {
         return `${resource}-${metricPrefix}`;
       },
-      getLegendLabel: (_, resource) => {
-        return `${resource}`;
-      },
+      isLineDashed: true,
     };
     series.above.push(serieAvgAbove);
   }
@@ -343,6 +335,7 @@ export const getSeriesForSymmetricalChart = (
       getTooltipLabel: (metricPrefix, resource) => {
         return `${resource}-${metricPrefix}`;
       },
+      isLineDashed: true,
     };
     series.below.push(serieAvgBelow);
   }

--- a/ui/src/services/graphUtils.ts
+++ b/ui/src/services/graphUtils.ts
@@ -7,9 +7,9 @@ import {
   lineColor1,
   PORT_NODE_EXPORTER,
 } from '../constants';
-import { Serie } from '@scality/core-ui/dist/components/linetemporalchart/LineTemporalChart.component';
+
+import type { Serie } from '@scality/core-ui/dist/components/linetimeseriechart/linetimeseriechart.component';
 import {
-  spacing,
   lineColor3,
   lineColor4,
   lineColor5,
@@ -17,6 +17,7 @@ import {
   lineColor7,
   lineColor8,
 } from '@scality/core-ui/dist/style/theme';
+
 export const getMultiResourceSeriesForChart = (
   results: PrometheusQueryResult,
   nodes: Array<{
@@ -24,25 +25,36 @@ export const getMultiResourceSeriesForChart = (
     name: string;
   }>,
 ): Serie[] => {
+  if (results.status !== 'success') {
+    throw new Error('Failed to fetch data from Prometheus');
+  }
   return nodes.map((node, index) => {
     const internalIP = node.internalIP;
-    const matrixResult: RangeMatrixResult =
-      // @ts-expect-error - FIXME when you are working on it
+    if (results.data.resultType !== 'matrix') {
+      throw new Error('Failed to fetch data from Prometheus');
+    }
+    const matrixResult: RangeMatrixResult['result'][number] =
       results?.data?.result?.find(
         (i) => i?.metric?.instance === `${internalIP}:${PORT_NODE_EXPORTER}`,
       ) || results[index];
     return convertMatrixResultToSerie(matrixResult, node.name);
   });
 };
+// UPDATED: fiterMetricValues - Add error handling and proper typing
 export const fiterMetricValues = (
   prometheusResult: PrometheusQueryResult,
   labels: {
     instance: string;
     device?: string;
   },
-): RangeMatrixResult => {
+): RangeMatrixResult['result'][number] => {
+  if (prometheusResult.status !== 'success') {
+    throw new Error('Failed to fetch data from Prometheus');
+  }
+  if (prometheusResult.data.resultType !== 'matrix') {
+    throw new Error('Failed to fetch data from Prometheus');
+  }
   if (Object.prototype.hasOwnProperty.call(labels, 'device')) {
-    // @ts-expect-error - FIXME when you are working on it
     return prometheusResult.data?.result.find(
       (item) =>
         item.metric.instance === labels.instance &&
@@ -50,7 +62,6 @@ export const fiterMetricValues = (
     );
   }
 
-  // @ts-expect-error - FIXME when you are working on it
   return prometheusResult.data.result.find(
     (item) => item.metric.instance === labels.instance,
   );
@@ -131,6 +142,7 @@ export const getQuantileSymmetricalSeries = (
     },
   ];
 };
+
 export const getMultipleSymmetricalSeries = (
   resultAbove: PrometheusQueryResult,
   resultBelow: PrometheusQueryResult,
@@ -146,74 +158,62 @@ export const getMultipleSymmetricalSeries = (
       interface: string;
     }
   >,
-): Serie[] => {
-  // TODO: Throw the error if we got error status from Promethues API, and handle the error at React-query level
-  return nodes
-    .flatMap((node) => {
+): { above: Serie[]; below: Serie[] } => {
+  if (resultAbove.status !== 'success' || resultBelow.status !== 'success') {
+    throw new Error('Failed to fetch data from Prometheus');
+  }
+  return nodes.reduce(
+    (acc, node) => {
       const filterLabels = {
         instance: `${node.internalIP}:${PORT_NODE_EXPORTER}`,
+        device: undefined,
       };
 
       if (nodesPlaneInterface) {
-        // @ts-expect-error - FIXME when you are working on it
         filterLabels.device = nodesPlaneInterface?.[node.name]?.interface;
       }
 
       const aboveData = fiterMetricValues(resultAbove, filterLabels);
       const belowData = fiterMetricValues(resultBelow, filterLabels);
-      return [
-        {
-          ...convertMatrixResultToSerie(aboveData, node.name),
-          metricPrefix: metricPrefixAbove,
-          getTooltipLabel: (metricPrefix: string, resource: string) => {
-            return `${resource}-${metricPrefix}`;
+      return {
+        above: [
+          ...acc.above,
+          {
+            ...convertMatrixResultToSerie(aboveData, node.name),
+            metricPrefix: metricPrefixAbove,
+            getTooltipLabel: (metricPrefix: string, resource: string) => {
+              return `${resource}-${metricPrefix}`;
+            },
           },
-        },
-        {
-          ...convertMatrixResultToSerie(belowData, node.name),
-          metricPrefix: metricPrefixBelow,
-          getTooltipLabel: (metricPrefix: string, resource: string) => {
-            return `${resource}-${metricPrefix}`;
+        ],
+        below: [
+          ...acc.below,
+          {
+            ...convertMatrixResultToSerie(belowData, node.name),
+            metricPrefix: metricPrefixBelow,
+            getTooltipLabel: (metricPrefix: string, resource: string) => {
+              return `${resource}-${metricPrefix}`;
+            },
+            renderTooltipSerie: (serie) => {
+              return `${serie.resource}-${serie.metricPrefix}`;
+            },
           },
-          getLegendLabel: null, //disable legend to avoid duplicated entries
-          renderTooltipSerie: (serie) => {
-            return `${serie.resource}-${serie.metricPrefix}`;
-          },
-        },
-      ];
-    })
-    .sort((serieA, serieB) => {
-      if (
-        serieA.metricPrefix === metricPrefixAbove &&
-        serieB.metricPrefix === metricPrefixBelow
-      ) {
-        return -1;
-      }
-
-      if (
-        serieA.metricPrefix === metricPrefixBelow &&
-        serieB.metricPrefix === metricPrefixAbove
-      ) {
-        return 1;
-      }
-
-      return 0;
-    });
+        ],
+      };
+    },
+    { above: [], below: [] },
+  );
 };
 
 const convertMatrixResultToSerie = (
-  matrixResult: RangeMatrixResult,
+  matrixResult: RangeMatrixResult['result'][0],
   resource: string,
 ): Serie => {
-  // @ts-expect-error - FIXME when you are working on it
   const prometheusData = matrixResult?.values ?? [];
   return {
     data: prometheusData,
     resource,
     getTooltipLabel: (_, resource) => {
-      return resource;
-    },
-    getLegendLabel: (_, resource) => {
       return resource;
     },
     isLineDashed: false,
@@ -225,17 +225,23 @@ export const convertPrometheusResultToSerie = (
   result: PrometheusQueryResult,
   serieName: string,
 ): Serie => {
-  if (result && result.status === 'success') {
-    // @ts-expect-error - FIXME when you are working on it
-    const matrixResult: RangeMatrixResult = result?.data?.result[0];
+  if (
+    result &&
+    result.status === 'success' &&
+    result.data.resultType === 'matrix'
+  ) {
+    console.log('DEBUG convertPrometheusResultToSerie', result, serieName);
+    const matrixResult: RangeMatrixResult['result'][number] =
+      result?.data?.result[0];
     return convertMatrixResultToSerie(matrixResult, serieName);
   }
 
   return convertMatrixResultToSerie(
     {
-      result: [],
-      // @ts-expect-error - FIXME when you are working on it
-      resultType: 'Matrix',
+      metric: {
+        instance: '',
+      },
+      values: [],
     },
     serieName,
   );
@@ -263,7 +269,7 @@ export const convertPrometheusResultToSerieWithAverage = (
 
   return series;
 };
-// get the series for symmetrical charts
+
 export const getSeriesForSymmetricalChart = (
   resultAbove: PrometheusQueryResult,
   resultBelow: PrometheusQueryResult,
@@ -272,27 +278,35 @@ export const getSeriesForSymmetricalChart = (
   metricPrefixBelow: string,
   resultAvgAbove?: PrometheusQueryResult,
   resultAvgBelow?: PrometheusQueryResult,
-): Serie[] => {
-  const series = [];
+): { above: Serie[]; below: Serie[] } => {
+  const series = {
+    above: [],
+    below: [],
+  };
 
-  if (resultAbove && resultAbove.status === 'success') {
+  if (
+    resultAbove &&
+    resultAbove.status === 'success' &&
+    resultAbove.data.resultType === 'matrix'
+  ) {
     const serieAbove = {
       metricPrefix: metricPrefixAbove,
-      // @ts-expect-error - FIXME when you are working on it
       data: resultAbove?.data?.result[0]?.values || [],
       resource,
       getTooltipLabel: (metricPrefix, resource) => {
         return `${resource}-${metricPrefix}`;
       },
-      color: lineColor1,
     };
-    series.push(serieAbove);
+    series.above.push(serieAbove);
   }
 
-  if (resultBelow && resultBelow.status === 'success') {
+  if (
+    resultBelow &&
+    resultBelow.status === 'success' &&
+    resultBelow.data.resultType === 'matrix'
+  ) {
     const serieBelow = {
       metricPrefix: metricPrefixBelow,
-      // @ts-expect-error - FIXME when you are working on it
       data: resultBelow?.data?.result[0]?.values || [],
       resource,
       getTooltipLabel: (metricPrefix, resource) => {
@@ -302,16 +316,18 @@ export const getSeriesForSymmetricalChart = (
       getLegendLabel: (_, resource) => {
         return `${resource}`;
       },
-      color: lineColor1,
     };
-    series.push(serieBelow);
+    series.below.push(serieBelow);
   }
 
   // show cluster average is activated
-  if (resultAvgAbove && resultAvgAbove.status === 'success') {
+  if (
+    resultAvgAbove &&
+    resultAvgAbove.status === 'success' &&
+    resultAvgAbove.data.resultType === 'matrix'
+  ) {
     const serieAvgAbove = {
       metricPrefix: metricPrefixAbove,
-      // @ts-expect-error - FIXME when you are working on it
       data: resultAvgAbove?.data?.result[0]?.values || [],
       resource: 'Cluster Avg.',
       getTooltipLabel: (metricPrefix, resource) => {
@@ -320,29 +336,34 @@ export const getSeriesForSymmetricalChart = (
       getLegendLabel: (_, resource) => {
         return `${resource}`;
       },
-      color: lineColor1,
-      isLineDashed: true,
     };
-    series.push(serieAvgAbove);
+    series.above.push(serieAvgAbove);
   }
 
-  if (resultAvgBelow && resultAvgBelow.status === 'success') {
+  if (
+    resultAvgBelow &&
+    resultAvgBelow.status === 'success' &&
+    resultAvgBelow.data.resultType === 'matrix'
+  ) {
     // the negative value
+    if (resultAvgBelow.data.resultType !== 'matrix') {
+      throw new Error('Failed to fetch data from Prometheus');
+    }
     const serieAvgBelow = {
       metricPrefix: metricPrefixBelow,
-      // @ts-expect-error - FIXME when you are working on it
       data: resultAvgBelow?.data?.result[0]?.values || [],
       resource: 'Cluster Avg.',
       getTooltipLabel: (metricPrefix, resource) => {
         return `${resource}-${metricPrefix}`;
       },
-      color: lineColor1,
-      isLineDashed: true,
     };
-    series.push(serieAvgBelow);
+    series.below.push(serieAvgBelow);
   }
 
-  return series;
+  return {
+    above: series.above,
+    below: series.below,
+  };
 };
 export const getNodesInterfacesString = (nodeIPsInfo): [] => {
   const interfaces = Object.values(nodeIPsInfo).flatMap((plane) => [
@@ -355,97 +376,7 @@ export const getNodesInterfacesString = (nodeIPsInfo): [] => {
   // @ts-expect-error - FIXME when you are working on it
   return uniqueInterfaces;
 };
-export function renderTooltipSerie({
-  color,
-  isLineDashed,
-  name,
-  value,
-  key,
-}: {
-  color?: string;
-  isLineDashed?: boolean;
-  name: string;
-  value: string;
-  key: string;
-}) {
-  return `<tr>
-    <td class="color" style="width: 1rem;">
-    ${
-      color !== undefined
-        ? `<span style='background: ${
-            isLineDashed
-              ? `repeating-linear-gradient(to right,${color} 0,${color} ${spacing.sp1},transparent ${spacing.sp1},transparent ${spacing.sp2})`
-              : color
-          };width: ${spacing.sp8};height:${
-            spacing.sp2
-          };display: inline-block;vertical-align: middle;'></span>`
-        : ''
-    }
-    </td>
-    <td style="text-align: left;">
-        ${name}
-    </td>
-    <td class="value" style="text-align: right;min-width: 5rem;display: table-cell;">
-      ${value}
-    </td>
-  </tr>`;
-}
-export const renderQuantileData = (
-  isIdle,
-  isLoading,
-  isSuccess,
-  isError,
-  data,
-  nodeMapPerIp,
-  theme,
-  valueBase,
-  unitLabel,
-  intl,
-) => {
-  const hoverQuantileValue = (data) => {
-    return unitLabel
-      ? // @ts-expect-error - FIXME when you are working on it
-        `${parseFloat(data.value[1] / (valueBase || 1)).toFixed(
-          2,
-        )} ${unitLabel}`
-      : // @ts-expect-error - FIXME when you are working on it
-        `${parseFloat(data.value[1] / (valueBase || 1)).toFixed(2)}`;
-  };
 
-  return `${
-    isLoading || isIdle
-      ? `<tr style="color: ${theme.textSecondary}"><td></td><td colspan='2' style="padding-left: 1rem;">Loading...</td></tr>`
-      : ''
-  }
-  ${
-    isSuccess
-      ? data?.data?.result
-          ?.map(
-            (data) =>
-              `<tr style="color: ${
-                theme.textSecondary
-              }"><td></td><td style="padding-left: 1rem;padding-right: 0.5rem;">${
-                nodeMapPerIp[data.metric.instance]
-              }</td><td class="value" style="text-align: right;display: table-cell;">${hoverQuantileValue(
-                data,
-              )}</td></tr>`,
-          )
-          .join('')
-      : ''
-  }
-  ${isError ? intl.formatMessage('error_occur_outpassing_threshold') : ''}
-  `;
-};
-export const renderOutpassingThresholdTitle = (
-  title,
-  isOutpassingDataDisplayed,
-  theme,
-) => {
-  // Hide the Outpassing threshold node list when isOnHoverFetchingNeeded is false
-  return isOutpassingDataDisplayed
-    ? `<tr style="color: ${theme.textSecondary}"><td></td><td colspan="2" style="padding-left: 1rem;">${title}</td></tr>`
-    : ``;
-};
 export const renderTooltipSeperationLine = (seperationLineColor) => {
   return `</table><hr style="border-color: ${seperationLineColor};"/><table>`;
 };

--- a/ui/src/services/graphUtils.ts
+++ b/ui/src/services/graphUtils.ts
@@ -5,18 +5,19 @@ import type {
 import {
   CHART_COLOR_VALUES,
   lineColor1,
-  PORT_NODE_EXPORTER,
-} from '../constants';
-
-import type { Serie } from '@scality/core-ui/dist/components/linetimeseriechart/linetimeseriechart.component';
-import {
+  lineColor2,
   lineColor3,
   lineColor4,
   lineColor5,
   lineColor6,
   lineColor7,
-  lineColor8,
-} from '@scality/core-ui/dist/style/theme';
+  PORT_NODE_EXPORTER,
+  SAMPLE_FREQUENCY_LAST_ONE_HOUR,
+  SAMPLE_FREQUENCY_LAST_SEVEN_DAYS,
+  SAMPLE_FREQUENCY_LAST_TWENTY_FOUR_HOURS,
+} from '../constants';
+
+import type { Serie } from '@scality/core-ui/dist/components/linetimeseriechart/linetimeseriechart.component';
 
 export const getMultiResourceSeriesForChart = (
   results: PrometheusQueryResult,
@@ -67,80 +68,67 @@ export const fiterMetricValues = (
   );
 };
 // to retrieve Q90, median and Q5 for symmetrical chart
+// Results are in ascending order: [Q05, Q50, Q90]
 export const getQuantileSymmetricalSeries = (
   resultAbove: PrometheusQueryResult[],
   resultBelow: PrometheusQueryResult[],
   metricPrefixAbove: string,
   metricPrefixBelow: string,
-) => {
-  return [
-    {
-      ...convertPrometheusResultToSerie(resultAbove[2], 'Q90'),
-      metricPrefix: metricPrefixAbove,
-      getLegendLabel: (metricPrefix: string, resource) => {
-        return `${resource}-${metricPrefix}`;
+): {
+  above: Serie[];
+  below: Serie[];
+} => {
+  return {
+    above: [
+      {
+        ...convertPrometheusResultToSerie(
+          resultAbove[2],
+          `Q90-${metricPrefixAbove}`,
+        ),
+        metricPrefix: metricPrefixAbove,
       },
-      getTooltipLabel: (metricPrefix: string, resource: string) => {
-        return `${resource}-${metricPrefix}`;
+      {
+        ...convertPrometheusResultToSerie(
+          resultAbove[1],
+          `Median-${metricPrefixAbove}`,
+        ),
+        metricPrefix: metricPrefixAbove,
       },
-      color: lineColor3,
-    },
-    {
-      ...convertPrometheusResultToSerie(resultAbove[1], 'Median'),
-      metricPrefix: metricPrefixAbove,
-      getLegendLabel: (metricPrefix: string, resource) => {
-        return `${resource}-${metricPrefix}`;
+      {
+        ...convertPrometheusResultToSerie(
+          resultAbove[0],
+          `Q5-${metricPrefixAbove}`,
+        ),
+        metricPrefix: metricPrefixAbove,
       },
-      getTooltipLabel: (metricPrefix: string, resource: string) => {
-        return `${resource}-${metricPrefix}`;
+    ],
+    below: [
+      {
+        ...convertPrometheusResultToSerie(
+          resultBelow[0],
+          `Q5-${metricPrefixBelow}`,
+        ),
+
+        metricPrefix: metricPrefixBelow,
       },
-      color: lineColor5,
-    },
-    {
-      ...convertPrometheusResultToSerie(resultAbove[0], 'Q5'),
-      metricPrefix: metricPrefixAbove,
-      getLegendLabel: (metricPrefix: string, resource) => {
-        return `${resource}-${metricPrefix}`;
+      {
+        ...convertPrometheusResultToSerie(
+          resultBelow[1],
+          `Median-${metricPrefixBelow}`,
+        ),
+
+        metricPrefix: metricPrefixBelow,
       },
-      getTooltipLabel: (metricPrefix: string, resource: string) => {
-        return `${resource}-${metricPrefix}`;
+      {
+        ...convertPrometheusResultToSerie(
+          resultBelow[2],
+          `Q90-${metricPrefixBelow}`,
+        ),
+
+        metricPrefix: metricPrefixBelow,
       },
-      color: lineColor4,
-    },
-    {
-      ...convertPrometheusResultToSerie(resultBelow[0], 'Q5'),
-      getLegendLabel: (metricPrefix: string, resource) => {
-        return `${resource}-${metricPrefix}`;
-      },
-      metricPrefix: metricPrefixBelow,
-      getTooltipLabel: (metricPrefix: string, resource: string) => {
-        return `${resource}-${metricPrefix}`;
-      },
-      color: lineColor6,
-    },
-    {
-      ...convertPrometheusResultToSerie(resultBelow[1], 'Median'),
-      getLegendLabel: (metricPrefix: string, resource) => {
-        return `${resource}-${metricPrefix}`;
-      },
-      metricPrefix: metricPrefixBelow,
-      getTooltipLabel: (metricPrefix: string, resource: string) => {
-        return `${resource}-${metricPrefix}`;
-      },
-      color: lineColor8,
-    },
-    {
-      ...convertPrometheusResultToSerie(resultBelow[2], 'Q90'),
-      getLegendLabel: (metricPrefix: string, resource) => {
-        return `${resource}-${metricPrefix}`;
-      },
-      metricPrefix: metricPrefixBelow,
-      getTooltipLabel: (metricPrefix: string, resource: string) => {
-        return `${resource}-${metricPrefix}`;
-      },
-      color: lineColor7,
-    },
-  ];
+    ],
+  };
 };
 
 export const getMultipleSymmetricalSeries = (
@@ -230,7 +218,6 @@ export const convertPrometheusResultToSerie = (
     result.status === 'success' &&
     result.data.resultType === 'matrix'
   ) {
-    console.log('DEBUG convertPrometheusResultToSerie', result, serieName);
     const matrixResult: RangeMatrixResult['result'][number] =
       result?.data?.result[0];
     return convertMatrixResultToSerie(matrixResult, serieName);
@@ -377,10 +364,6 @@ export const getNodesInterfacesString = (nodeIPsInfo): [] => {
   return uniqueInterfaces;
 };
 
-export const renderTooltipSeperationLine = (seperationLineColor) => {
-  return `</table><hr style="border-color: ${seperationLineColor};"/><table>`;
-};
-
 // Shared function to create color mapping for chart series
 export const createColorSet = (
   seriesNames: string[],
@@ -392,4 +375,57 @@ export const createColorSet = (
     colorMapping[name] = CHART_COLOR_VALUES[colorIndex];
   });
   return colorMapping;
+};
+
+// Custom color mapping for symmetrical quantile chart
+export const createSymmetricalQuantileColorSet = (
+  aboveSeries: any[],
+  belowSeries: any[],
+): Record<string, string> => {
+  const colorMapping: Record<string, string> = {};
+
+  // Above series colors: Q90 = cyan, Median = yellow, Q5 = blue
+  aboveSeries.forEach((serie) => {
+    const name = serie.resource || serie.name;
+    if (name.includes('Q90')) {
+      colorMapping[name] = lineColor3; // cyan
+    } else if (name.includes('Median')) {
+      colorMapping[name] = lineColor5;
+    } else if (name.includes('Q5')) {
+      colorMapping[name] = lineColor4; // blue
+    }
+  });
+
+  // Below series colors: Q5 = red, Median = gold, Q90 = orange
+  belowSeries.forEach((serie) => {
+    const name = serie.resource || serie.name;
+    if (name.includes('Q5')) {
+      colorMapping[name] = lineColor6; // red
+    } else if (name.includes('Median')) {
+      colorMapping[name] = lineColor2; // gold
+    } else if (name.includes('Q90')) {
+      colorMapping[name] = lineColor7; // orange
+    }
+  });
+
+  return colorMapping;
+};
+
+// Utility function to determine time format based on interval
+export const getTimeFormatForInterval = (
+  interval: number,
+):
+  | 'day-month-abbreviated-hour-minute'
+  | 'day-month-abbreviated-hour-minute-second'
+  | 'long-date-without-weekday' => {
+  if (
+    interval === SAMPLE_FREQUENCY_LAST_SEVEN_DAYS ||
+    interval === SAMPLE_FREQUENCY_LAST_TWENTY_FOUR_HOURS
+  ) {
+    return 'day-month-abbreviated-hour-minute';
+  }
+  if (interval === SAMPLE_FREQUENCY_LAST_ONE_HOUR) {
+    return 'day-month-abbreviated-hour-minute-second';
+  }
+  return 'long-date-without-weekday';
 };

--- a/ui/src/services/platformlibrary/metrics.ts
+++ b/ui/src/services/platformlibrary/metrics.ts
@@ -10,10 +10,23 @@ import { addMissingDataPoint } from '@scality/core-ui/dist/components/linetempor
 import { generateSelectWithKey, getNaNSegments, getSegments } from '../utils';
 import { getFormattedLokiAlert } from '../loki/api';
 import { NAN_STRING } from '@scality/core-ui/dist/components/constants';
+
 export type TimeSpanProps = {
   startingTimeISO: string;
   currentTimeISO: string;
   frequency: number;
+};
+export const generateQuantileSelectWithKey = (
+  queryName: string,
+  quantile: number,
+) => {
+  const quantileKey = quantile === 0.9 ? '90' : quantile === 0.5 ? '50' : '05';
+  return {
+    select: (data) => ({
+      ...data,
+      key: `${queryName}${quantileKey}`,
+    }),
+  };
 };
 
 const _getPromRangeMatrixQuery = (
@@ -85,7 +98,6 @@ export const getCPUUsageQuery = (
     refetchOnMount: false,
     refetchOnWindowFocus: false,
     enabled: instanceIP !== '',
-    // @ts-expect-error - FIXME when you are working on it
     ...generateSelectWithKey('cpuUsage'),
   };
 };
@@ -111,13 +123,18 @@ export const getNodesCPUUsageQuantileQuery = (
   timespanProps: TimeSpanProps,
   quantile: number,
 ) => {
+  const queryName = 'NodesCpuUsageQuantile';
   const cpuNodesUsagePromQL = `quantile(${quantile}, 100 - (avg by (instance) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100))`;
-  return _getPromRangeMatrixQuery(
-    // @ts-expect-error - FIXME when you are working on it
-    ['NodesCpuUsageQuantile', quantile],
+  const query = _getPromRangeMatrixQuery(
+    [queryName, String(quantile)],
     cpuNodesUsagePromQL,
     timespanProps,
   );
+
+  return {
+    ...query,
+    ...generateQuantileSelectWithKey(queryName, quantile),
+  };
 };
 export const getNodesCPUUsageOutpassingThresholdQuery = (
   timestamp?: string,
@@ -181,7 +198,6 @@ export const getSystemLoadQuery = (
     },
     refetchOnMount: false,
     refetchOnWindowFocus: false,
-    // @ts-expect-error - FIXME when you are working on it
     ...generateSelectWithKey('systemLoad'),
   };
 };
@@ -206,13 +222,18 @@ export const getNodesSystemLoadQuantileQuery = (
   timespanProps: TimeSpanProps,
   quantile: number,
 ) => {
+  const queryName = 'SystemLoadQuantile';
   const systemLoadQuantilePromQL = `quantile(${quantile}, (avg(node_load1) by (instance) / ignoring(container,endpoint,job,namespace,pod,service,prometheus) count(node_cpu_seconds_total{mode="idle"}) without(cpu,mode))) * 100`;
-  return _getPromRangeMatrixQuery(
-    // @ts-expect-error - FIXME when you are working on it
-    ['SystemLoadQuantile', quantile],
+  const query = _getPromRangeMatrixQuery(
+    [queryName, `${quantile}`],
     systemLoadQuantilePromQL,
     timespanProps,
   );
+
+  return {
+    ...query,
+    ...generateQuantileSelectWithKey(queryName, quantile),
+  };
 };
 export const getNodesSystemLoadOutpassingThresholdQuery = (
   timestamp?: string,
@@ -275,7 +296,6 @@ export const getMemoryQuery = (
     },
     refetchOnMount: false,
     refetchOnWindowFocus: false,
-    // @ts-expect-error - FIXME when you are working on it
     ...generateSelectWithKey('memory'),
   };
 };
@@ -300,18 +320,18 @@ export const getNodesMemoryQuantileQuery = (
   timespanProps: TimeSpanProps,
   quantile: number,
 ) => {
+  const queryName = 'NodesMemoryQuantile';
   const nodesMemoryQuantilePromQL = `quantile(${quantile}, sum(100 - ((node_memory_MemAvailable_bytes * 100) / node_memory_MemTotal_bytes)) by(instance))`;
-  console.log(
-    `DEBUG Memory quantile ${quantile} query:`,
-    nodesMemoryQuantilePromQL,
-  );
   const query = _getPromRangeMatrixQuery(
-    ['NodesMemoryQuantile', String(quantile)],
+    [queryName, String(quantile)],
     nodesMemoryQuantilePromQL,
     timespanProps,
   );
-  console.log('DEBUG Memory quantile query:', query);
-  return query;
+
+  return {
+    ...query,
+    ...generateQuantileSelectWithKey(queryName, quantile),
+  };
 };
 export const getNodesMemoryOutpassingThresholdQuery = (
   timestamp?: string,
@@ -391,7 +411,6 @@ export const getControlPlaneBandWidthInQuery = (
     refetchOnMount: false,
     refetchOnWindowFocus: false,
     enabled: planeInterface !== '',
-    // @ts-expect-error - FIXME when you are working on it
     ...generateSelectWithKey('controlPlaneBandwidthIn'),
   };
 };
@@ -414,7 +433,6 @@ export const getControlPlaneBandWidthOutQuery = (
     refetchOnMount: false,
     refetchOnWindowFocus: false,
     enabled: planeInterface !== '',
-    // @ts-expect-error - FIXME when you are working on it
     ...generateSelectWithKey('controlPlaneBandwidthOut'),
   };
 };
@@ -661,17 +679,20 @@ export const getNodesPlanesBandwidthInQuantileQuery = (
   quantile: number,
   devices: string[],
 ) => {
+  const queryName = 'NodesPlanesBandwidthIn';
   const nodesPlanesBandwidthInQuery = `quantile(${quantile}, avg(irate(node_network_receive_bytes_total{device=~"${devices.join(
     '|',
   )}"}[5m])) by (instance,device))`;
+  const query = _getPromRangeMatrixQuery(
+    [queryName, ...devices, `${quantile}`],
+    nodesPlanesBandwidthInQuery,
+    timespanProps,
+  );
+
   return {
-    ..._getPromRangeMatrixQuery(
-      // @ts-expect-error - FIXME when you are working on it
-      ['NodesPlanesBandwidthIn', ...devices, quantile],
-      nodesPlanesBandwidthInQuery,
-      timespanProps,
-    ),
+    ...query,
     enabled: !!devices?.length,
+    ...generateQuantileSelectWithKey(queryName, quantile),
   };
 };
 export const getNodesPlanesBandwidthOutQuantileQuery = (
@@ -679,17 +700,20 @@ export const getNodesPlanesBandwidthOutQuantileQuery = (
   quantile: number,
   devices: string[],
 ) => {
+  const queryName = 'NodesPlanesBandwidthOut';
   const nodePlanesBandwidthOutQuery = `quantile(${quantile}, avg(irate(node_network_transmit_bytes_total{device=~"${devices.join(
     '|',
   )}"}[5m])) by (instance,device))`;
+  const query = _getPromRangeMatrixQuery(
+    [queryName, ...devices, `${quantile}`],
+    nodePlanesBandwidthOutQuery,
+    timespanProps,
+  );
+
   return {
-    ..._getPromRangeMatrixQuery(
-      // @ts-expect-error - FIXME when you are working on it
-      ['NodesPlanesBandwidthOut', ...devices, quantile],
-      nodePlanesBandwidthOutQuery,
-      timespanProps,
-    ),
+    ...query,
     enabled: !!devices?.length,
+    ...generateQuantileSelectWithKey(queryName, quantile),
   };
 };
 export const getNodesPlanesBandwidthInOutpassingThresholdQuery = (
@@ -705,8 +729,12 @@ export const getNodesPlanesBandwidthInOutpassingThresholdQuery = (
   )}"}[5m])) by (instance,device) ${operator}= ${threshold}`;
   return {
     ..._getInstantValueQuery(
-      // @ts-expect-error - FIXME when you are working on it
-      ['NodesBandwidthInOutpassingThreshold', timestamp, threshold, operator],
+      [
+        'NodesBandwidthInOutpassingThreshold',
+        timestamp,
+        `${threshold}`,
+        operator,
+      ],
       nodesBandwidthInOutpassingThresholdPromQL,
       timestamp,
     ),
@@ -720,18 +748,21 @@ export const getNodesPlanesBandwidthInOutpassingThresholdQuery = (
 export const getNodesPlanesBandwidthOutOutpassingThresholdQuery = (
   timestamp?: string,
   threshold?: number,
-  // @ts-expect-error - FIXME when you are working on it
-  operator: '>' | '<',
-  isOnHoverFetchingNeeded: boolean,
-  devices: string[],
+  operator?: '>' | '<',
+  isOnHoverFetchingNeeded?: boolean,
+  devices?: string[],
 ) => {
   const nodesBandwidthOutOutpassingThresholdPromQL = `avg(irate(node_network_transmit_bytes_total{device=~"${devices.join(
     '|',
   )}"}[5m])) by (instance,device) ${operator}= ${threshold}`;
   return {
     ..._getInstantValueQuery(
-      // @ts-expect-error - FIXME when you are working on it
-      ['NodesBandwidthOutOutpassingThreshold', timestamp, threshold, operator],
+      [
+        'NodesBandwidthOutOutpassingThreshold',
+        timestamp,
+        `${threshold}`,
+        operator,
+      ],
       nodesBandwidthOutOutpassingThresholdPromQL,
       timestamp,
     ),
@@ -760,7 +791,6 @@ export const getIOPSWriteQuery = (
     },
     refetchOnMount: false,
     refetchOnWindowFocus: false,
-    // @ts-expect-error - FIXME when you are working on it
     ...generateSelectWithKey('IOPSWrite'),
   };
 };
@@ -782,7 +812,6 @@ export const getIOPSReadQuery = (
     },
     refetchOnMount: false,
     refetchOnWindowFocus: false,
-    // @ts-expect-error - FIXME when you are working on it
     ...generateSelectWithKey('IOPSRead'),
   };
 };
@@ -905,25 +934,36 @@ export const getNodesThroughputWriteQuantileQuery = (
   timespanProps: TimeSpanProps,
   quantile: number,
 ) => {
+  const queryName = 'NodesThroughputWriteQuantile';
   const nodesThroughputWritePromQL = `quantile(${quantile},sum(sum(irate(node_disk_written_bytes_total[1m])) by (instance, device))by(instance))`;
-  return _getPromRangeMatrixQuery(
-    // @ts-expect-error - FIXME when you are working on it
-    ['NodesThroughputWriteQuantile', quantile],
+  const query = _getPromRangeMatrixQuery(
+    [queryName, `${quantile}`],
     nodesThroughputWritePromQL,
     timespanProps,
   );
+
+  return {
+    ...query,
+    ...generateQuantileSelectWithKey(queryName, quantile),
+  };
 };
+
 export const getNodesThroughputReadQuantileQuery = (
   timespanProps: TimeSpanProps,
   quantile: number,
 ) => {
+  const queryName = 'NodesThroughputReadQueryQuantile';
   const nodesThroughputReadPromQL = `quantile(${quantile},sum(sum(irate(node_disk_read_bytes_total[1m])) by (instance, device))by(instance))`;
-  return _getPromRangeMatrixQuery(
-    // @ts-expect-error - FIXME when you are working on it
-    ['NodesThroughputReadQueryQuantile', quantile],
+  const query = _getPromRangeMatrixQuery(
+    [queryName, `${quantile}`],
     nodesThroughputReadPromQL,
     timespanProps,
   );
+
+  return {
+    ...query,
+    ...generateQuantileSelectWithKey(queryName, quantile),
+  };
 };
 export const getNodesThroughputWriteOutpassingThresholdQuery = (
   timestamp?: string,
@@ -935,8 +975,7 @@ export const getNodesThroughputWriteOutpassingThresholdQuery = (
   const nodesThroughputWriteAboveBelowPromQL = `sum(sum(irate(node_disk_written_bytes_total[1m])) by (instance, device))by(instance) ${operator}= ${threshold}`;
   return {
     ..._getInstantValueQuery(
-      // @ts-expect-error - FIXME when you are working on it
-      ['NodesThroughputWriteAboveBelow', timestamp, threshold, operator],
+      ['NodesThroughputWriteAboveBelow', timestamp, `${threshold}`, operator],
       nodesThroughputWriteAboveBelowPromQL,
       timestamp,
     ),
@@ -957,8 +996,7 @@ export const getNodesThroughputOutpassingThresholdQuery = (
   const nodesThroughputReadAboveBelowPromQL = `sum(sum(irate(node_disk_read_bytes_total[1m])) by (instance, device))by(instance) ${operator}= ${threshold}`;
   return {
     ..._getInstantValueQuery(
-      // @ts-expect-error - FIXME when you are working on it
-      ['NodesThroughputReadAboveBelow', timestamp, threshold, operator],
+      ['NodesThroughputReadAboveBelow', timestamp, `${threshold}`, operator],
       nodesThroughputReadAboveBelowPromQL,
       timestamp,
     ),
@@ -1052,20 +1090,18 @@ export const getAlertsHistoryQuery = ({
     frequency,
     encodeURIComponent(query),
   )?.then((resolve) => {
-    // @ts-expect-error - FIXME when you are working on it
-    if (resolve.error) {
-      // @ts-expect-error - FIXME when you are working on it
+    if (resolve.status === 'error') {
       throw resolve.error;
     }
-
+    if (resolve.data.resultType !== 'matrix') {
+      throw new Error('Failed to fetch data from Prometheus');
+    }
     const points = addMissingDataPoint(
-      // @ts-expect-error - FIXME when you are working on it
       resolve.data.result[0].values,
       Date.parse(startingTimeISO) / 1000,
       Date.parse(currentTimeISO) / 1000 - Date.parse(startingTimeISO) / 1000,
       frequency,
     );
-    // @ts-expect-error - FIXME when you are working on it
     return getNaNSegments(points).map((segment) => ({
       startsAt: new Date(segment.startsAt * 1000).toISOString(),
       endsAt: new Date(segment.endsAt * 1000).toISOString(),
@@ -1172,25 +1208,26 @@ export const getClusterAlertSegmentQuery = (duration: number) => {
       frequency,
       encodeURIComponent(query),
     )?.then((resolve) => {
-      // @ts-expect-error - FIXME when you are working on it
-      if (resolve.error) {
-        // @ts-expect-error - FIXME when you are working on it
+      if (resolve.status === 'error') {
         throw resolve.error;
       }
 
-      // @ts-expect-error - FIXME when you are working on it
+      if (resolve.data.resultType !== 'matrix') {
+        throw new Error('Failed to fetch data from Prometheus');
+      }
+
       const clusterAtRiskResult = resolve.data.result.find(
         (result) => result.metric.alertname === 'ClusterAtRisk',
       ) || {
         values: [],
       };
-      // @ts-expect-error - FIXME when you are working on it
+
       const clusterDegradedResult = resolve.data.result.find(
         (result) => result.metric.alertname === 'ClusterDegraded',
       ) || {
         values: [],
       };
-      // @ts-expect-error - FIXME when you are working on it
+
       const watchdogResult = resolve.data.result.find(
         (result) => result.metric.alertname === 'Watchdog',
       ) || {

--- a/ui/src/services/platformlibrary/metrics.ts
+++ b/ui/src/services/platformlibrary/metrics.ts
@@ -301,12 +301,17 @@ export const getNodesMemoryQuantileQuery = (
   quantile: number,
 ) => {
   const nodesMemoryQuantilePromQL = `quantile(${quantile}, sum(100 - ((node_memory_MemAvailable_bytes * 100) / node_memory_MemTotal_bytes)) by(instance))`;
-  return _getPromRangeMatrixQuery(
-    // @ts-expect-error - FIXME when you are working on it
-    ['NodesMemoryQuantile', quantile],
+  console.log(
+    `DEBUG Memory quantile ${quantile} query:`,
+    nodesMemoryQuantilePromQL,
+  );
+  const query = _getPromRangeMatrixQuery(
+    ['NodesMemoryQuantile', String(quantile)],
     nodesMemoryQuantilePromQL,
     timespanProps,
   );
+  console.log('DEBUG Memory quantile query:', query);
+  return query;
 };
 export const getNodesMemoryOutpassingThresholdQuery = (
   timestamp?: string,

--- a/ui/src/services/utils.test.ts
+++ b/ui/src/services/utils.test.ts
@@ -101,7 +101,6 @@ describe('getNaNSegments', () => {
     //S
     const segments = [];
     //E
-    // @ts-expect-error - FIXME when you are working on it
     const nullSegments = getNaNSegments(segments);
     //V
     expect(nullSegments).toHaveLength(0);

--- a/ui/src/services/utils.ts
+++ b/ui/src/services/utils.ts
@@ -277,7 +277,7 @@ export function addMissingDataPoint(
 
   return newValues;
 }
-export function getNaNSegments(points: [[number, number | null]]): {
+export function getNaNSegments(points: [number, number | string | null][]): {
   startsAt: number;
   endsAt?: number;
 }[] {
@@ -298,7 +298,6 @@ export function getNaNSegments(points: [[number, number | null]]): {
     };
   });
   const nullSegments = segments.filter(
-    // @ts-expect-error - FIXME when you are working on it
     (segment) => segment.value === NAN_STRING,
   );
   return nullSegments.reduce((mergedNullSegments, segment) => {
@@ -568,6 +567,6 @@ export const linuxDrivesNamingIncrement = (devicePath, increment) => {
  * (useQueries returns an array and the order of response objects is not always the
  *  same as the order in which the request were performed)
  */
-export const generateSelectWithKey = (key, isAverage) => ({
+export const generateSelectWithKey = (key, isAverage = false) => ({
   select: (data) => ({ ...data, key: !isAverage ? key : `${key}Avg` }),
 });


### PR DESCRIPTION
The goal of this PR is to replace line chart with new core-ui version
Include only the "simple" charts 
The transformation data were not changed as they are also use by quantile chart

Next step: refactor the quantile chart and the data transformation fn to reflect new types for line chart


~~Still a draft as a new release of core-ui is needed~~


