### PR TITLE
update UNIT_RANGE thresholds in constants.ts from 0 to 1 for B/s and µs

### DIFF
--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -112,7 +112,7 @@ export const DASHBOARD_QUANTILE_SYNC_ID = 'dashboard-quantile';
 export const CHART_COLOR_VALUES = Object.values(chartColors);
 export const UNIT_RANGE_BS = [
   {
-    threshold: 0,
+    threshold: 1,
     label: 'B/s',
   },
   {
@@ -135,7 +135,7 @@ export const UNIT_RANGE_BS = [
 
 export const UNIT_RANGE_SECONDS = [
   {
-    threshold: 0,
+    threshold: 1,
     label: 'µs',
   },
   {


### PR DESCRIPTION
Unit range with threshold at 0 is causing a 0 division 
