### PR TITLE
:zap: Use self-hosted runners for builds requiring more disk space

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,9 @@ jobs:
       skip: ${{ inputs.skip-devcontainer == true }}
 
   build:
-    runs-on: ubuntu-latest
+    # Use our self hosted runner since the github ones have not enough disk space
+    # (the disk is almost full even before building anything)
+    runs-on: ubuntu-24.04-4core
     needs:
       - build-devcontainer
     container:


### PR DESCRIPTION
(cherry picked from commit d120755934113d36ac4be4f90fcbb0991d8aa82f)