### PR TITLE
salt: Do no longer set bridge-nf-call-iptables sysctls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Bump coredns version to [1.12.2](https://github.com/coredns/coredns/releases/tag/v1.12.2)
   (PR[#4637](https://github.com/scality/metalk8s/pull/4637))
 
+- Do no longer enforce net.bridge.bridge-nf-call-ip6tables and
+  net.bridge.bridge-nf-call-iptables sysctls
+  (PR[#4724](https://github.com/scality/metalk8s/pull/4724))
+
 ## Release 131.0.5 (in development)
 
 ## Release 131.0.4

--- a/salt/metalk8s/defaults.yaml
+++ b/salt/metalk8s/defaults.yaml
@@ -31,8 +31,6 @@ kubeadm_preflight:
       - 2379
       - 2380
     sysctl_values:
-      net.bridge.bridge-nf-call-ip6tables: 1
-      net.bridge.bridge-nf-call-iptables: 1
       net.ipv4.ip_forward: 1
   recommended:
     packages:

--- a/salt/metalk8s/internal/preflight/mandatory.sls
+++ b/salt/metalk8s/internal/preflight/mandatory.sls
@@ -22,11 +22,6 @@ Enable {{ kubelet.container_engine }} service:
       - test: Check that the crictl socket answer
 {%- endif %}
 
-# required to set sysctl net.bridge.bridge-nf-call-iptables
-Add the module br_netfilter to kernel:
-  kmod.present:
-    - name: br_netfilter
-    - persist: True
 
 {%- for item, value in kubeadm_preflight.mandatory.sysctl_values.items() %}
 Set sysctl {{ item }} value to {{ value }}:
@@ -35,10 +30,6 @@ Set sysctl {{ item }} value to {{ value }}:
     - value: {{ value }}
     - config: /etc/sysctl.d/60-metalk8s.conf
     - check_priority: True
-    {%- if item in ("net.bridge.bridge-nf-call-ip6tables", "net.bridge.bridge-nf-call-iptables") %}
-    - require:
-      - kmod: Add the module br_netfilter to kernel
-    {%- endif %}
 {%- endfor %}
 
 {%- for swap_device in salt.mount.swaps().keys() %}


### PR DESCRIPTION
Thoses sysctls are not strictly needed for the cluster to work with Calico CNI and it may cause trouble when using ExternalIPs with a bridge interface