### PR TITLE
MK8S-68: replace slack channel by #squad-metalk8s

### DIFF
--- a/.github/workflows/crons.yaml
+++ b/.github/workflows/crons.yaml
@@ -92,7 +92,7 @@ jobs:
         if: matrix.type == 'retry' && steps.retry.outputs.was-retried == 'true'
         uses: slackapi/slack-github-action@v1
         with:
-          channel-id: '#squad-supsetup-alerts'
+          channel-id: '#squad-metalk8s'
           slack-message: |
             Nightly retry triggered for ${{ matrix.branch }}
             Job: ${{ matrix.name }}
@@ -106,7 +106,7 @@ jobs:
         if: matrix.type == 'retry' && steps.retry.outputs.retry-count != '' && fromJSON(steps.retry.outputs.retry-count) >= fromJSON(env.MAX_RETRIES)
         uses: slackapi/slack-github-action@v1
         with:
-          channel-id: '#squad-supsetup-alerts'
+          channel-id: '#squad-metalk8s'
           slack-message: |
             ⚠️ MANUAL ACTION REQUIRED ⚠️
             Nightly for ${{ matrix.branch }} failed after ${{ steps.retry.outputs.retry-count }} retry attempts


### PR DESCRIPTION
Changed the Slack notification channel for nightly retry jobs and manual action alerts from `#squad-supsetup-alerts` to `#squad-metalk8s` in `.github/workflows/crons.yaml`.