### PR TITLE
Enhance token expiration handling. Implement a double-check mechanism…

### DIFF
--- a/shell-ui/src/auth/AuthProvider.tsx
+++ b/shell-ui/src/auth/AuthProvider.tsx
@@ -165,27 +165,51 @@ export function useAuth(): {
     const auth = useOauth2Auth(); // todo add support for OAuth2Proxy
 
     const { config } = useShellConfig();
-    //Force logout when token is expired or we are missing expires_at claims
+
+    const hasExpiredDate = auth.userData?.expires_at;
+    const userIsExpired = auth.userData?.expired || !hasExpiredDate;
+    const shouldEnableQuery = !!(
+      auth.userData &&
+      userIsExpired &&
+      // @ts-expect-error - window.isLoggingOut is a temp flag to prevent multiple logout attempts
+      !window.isLoggingOut
+    );
+
+    // Handle token expiration with a double-check mechanism.
+    //
+    // Problem: React state (auth.userData) and localStorage can get out of sync.
+    // When silent renew refreshes the token in localStorage, React state still shows
+    // the old expired token until the next re-render. This would incorrectly trigger
+    // a logout even though a valid token exists in localStorage.
+    //
+    // Solution: Before removing the user, read directly from localStorage via
+    // userManager.getUser() to verify the token is actually expired.
     useQuery({
       queryKey: ['removeUser'],
       queryFn: () => {
-        // This query might be executed when useAuth is rendered simultaneously by 2 different components
-        // react-query is supposed to prevent this but in practice under certain conditions a race condition might trigger it twice
-        // We need to make sure we don't call removeUser twice in this case (which would cause a redirect loop)
-        // @ts-expect-error - FIXME when you are working on it
-        window.loggingOut = true;
-        return auth.userManager.removeUser().then(() => {
-          location.reload();
+        // Prevent concurrent logout attempts from multiple components
+        // @ts-expect-error - window.isLoggingOut is a temp flag
+        window.isLoggingOut = true;
+
+        // Double-check expiration against localStorage (source of truth)
+        return auth.userManager.getUser().then((user) => {
+          const isActuallyExpired = user?.expired || !user?.expires_at;
+
+          if (isActuallyExpired) {
+            // Token is genuinely expired in localStorage - log out
+            return auth.userManager.removeUser().then(() => {
+              location.reload();
+            });
+          }
+
+          // Token in localStorage is valid (silent renew succeeded).
+          // React state will catch up on next render - no action needed.
+          // @ts-expect-error - reset the flag since we're not actually logging out
+          window.isLoggingOut = false;
+          return Promise.resolve();
         });
       },
-      enabled: !!(
-        auth &&
-        auth.userManager &&
-        auth.userData &&
-        (auth.userData.expired || !auth.userData.expires_at) &&
-        // @ts-expect-error - FIXME when you are working on it
-        !window.loggingOut
-      ),
+      enabled: shouldEnableQuery,
     });
 
     if (!auth || !auth.userData) {


### PR DESCRIPTION
## Summary
Fix token refresh race condition causing UI reload loops when multiple browser tabs are open.
Fix race condition between React state and localStorage during silent token renewal
Implement double-check mechanism to verify token expiration before logging out
Prevent unnecessary page reloads when focusing inactive tabs after token renewal
## Context
### The Problem
When using the application with multiple browser tabs, users experienced a "flashing" reload loop when focusing an inactive tab after a silent token renewal occurred.
Root cause: React state (auth.userData) and localStorage can get out of sync. When silent renew refreshes the token in localStorage, React state still shows the old expired token until the next re-render. The expiration check would see the stale React state and incorrectly trigger a logout, even though a valid token exists in localStorage.

### The Solution
Before removing the user and reloading, we now double-check the token expiration directly against localStorage (the source of truth) via userManager.getUser()

## Changes
Added double-check mechanism in useQuery to verify token is genuinely expired in localStorage before logging out
Reset window.isLoggingOut flag when token is actually valid (prevents blocking future logout attempts)
Improved code comments explaining the race condition and solution
Renamed window.loggingOut to window.isLoggingOut for clarity
Removed debug console.log statements

## Test Plan
1. Open the application in two browser tabs
2. Wait for token silent renewal to occur (or set a short token expiration for testing)
3. Focus the inactive tab — should NOT trigger reload loops
4. Log out in one tab — the other tab should reload and show login page
5. Verify normal login/logout flow still works with a single tab

