### PR TITLE
Update Kubernetes, etcd, and CoreDNS versions in preparation for release 133.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Enhancements
 
+- Bump Kubernetes version to [1.33.7](https://github.com/kubernetes/kubernetes/releases/tag/v1.33.7)
+  (PR[#4769](https://github.com/scality/metalk8s/pull/4769))
+
+- Bump etcd version to [3.5.26](https://github.com/etcd-io/etcd/releases/tag/v3.5.26)
+  (PR[#4769](https://github.com/scality/metalk8s/pull/4769))
+
+- Bump CoreDNS version to [1.12.4](https://github.com/coredns/coredns/releases/tag/v1.12.4)
+  (PR[#4769](https://github.com/scality/metalk8s/pull/4769))
+
 - Support etcd distroless images for Kubernetes 1.33+. Above etcd 3.5.21, etcd images are now distroless and upstreamed to the etcd project.
   (PR[#4740](https://github.com/scality/metalk8s/pull/4740))
 

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -19,7 +19,7 @@ Image = namedtuple("Image", ("name", "version", "digest"))
 # Project-wide versions {{{
 
 K8S_VERSION_MAJOR: str = "1"
-K8S_VERSION_MINOR: str = "32"
+K8S_VERSION_MINOR: str = "33"
 K8S_VERSION_PATCH: str = "7"
 
 K8S_SHORT_VERSION: str = f"{K8S_VERSION_MAJOR}.{K8S_VERSION_MINOR}"
@@ -80,7 +80,7 @@ ROCKY_BASE_IMAGE_9_SHA256: str = (
     "2cb86b2d8326a987546dc7fb393f43d43d478fea12ce3ce4accbda571f47f86b"
 )
 
-ETCD_VERSION: str = "3.5.21"
+ETCD_VERSION: str = "3.5.26"
 ETCD_IMAGE_VERSION: str = f"{ETCD_VERSION}-0"
 NGINX_IMAGE_VERSION: str = "1.27.5-alpine"
 NODEJS_IMAGE_VERSION: str = "20.11.1"
@@ -131,8 +131,8 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     ),
     Image(
         name="coredns",
-        version="v1.12.2",
-        digest="sha256:af8c8d35a5d184b386c4a6d1a012c8b218d40d1376474c7d071bb6c07201f47d",
+        version="v1.12.4",
+        digest="sha256:986f04c2e15e147d00bdd51e8c51bcef3644b13ff806be7d2ff1b261d6dfbae1",
     ),
     Image(
         name="dex",
@@ -142,7 +142,7 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     Image(
         name="etcd",
         version=ETCD_IMAGE_VERSION,
-        digest="sha256:d58c035df557080a27387d687092e3fc2b64c6d0e3162dc51453a115f847d121",
+        digest="sha256:97b4a5c4f11b202d6ea637e2b34654b11eb98bbebb23e15db797a74c7914a2d7",
     ),
     Image(
         name="grafana",
@@ -157,22 +157,22 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     Image(
         name="kube-apiserver",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:e04f6223d52f8041c46ef4545ccaf07894b1ca5851506a9142706d4206911f64",
+        digest="sha256:9585226cb85d1dc0f0ef5f7a75f04e4bc91ddd82de249533bd293aa3cf958dab",
     ),
     Image(
         name="kube-controller-manager",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:6c7f288ab0181e496606a43dbade954819af2b1e1c0552becf6903436e16ea75",
+        digest="sha256:9585226cb85d1dc0f0ef5f7a75f04e4bc91ddd82de249533bd293aa3cf958dab",
     ),
     Image(
         name="kube-proxy",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:8d589a18b5424f77a784ef2f00feffac0ef210414100822f1c120f0d7221def3",
+        digest="sha256:9585226cb85d1dc0f0ef5f7a75f04e4bc91ddd82de249533bd293aa3cf958dab",
     ),
     Image(
         name="kube-scheduler",
         version=_version_prefix(K8S_VERSION),
-        digest="sha256:1c35a970b4450b4285531495be82cda1f6549952f70d6e3de8db57c20a3da4ce",
+        digest="sha256:9585226cb85d1dc0f0ef5f7a75f04e4bc91ddd82de249533bd293aa3cf958dab",
     ),
     Image(
         name="kube-state-metrics",

--- a/scripts/backup.sh.in
+++ b/scripts/backup.sh.in
@@ -125,26 +125,19 @@ backup_etcd() {
     # Note: etcd image in Kubernetes 1.33+ is distroless (no shell), so we must
     # exec etcdctl directly without using "sh -c".
     # etcd 3.4+ defaults to API v3, so ETCDCTL_API=3 is no longer required.
+    # In distroless images, the root filesystem is read-only, so we save the
+    # snapshot to /var/lib/etcd which is a writable mounted volume.
     crictl exec -i "$etcd_container" \
         etcdctl \
         --endpoints=https://127.0.0.1:2379 \
         --cert=/etc/kubernetes/pki/etcd/salt-master-etcd-client.crt \
         --key=/etc/kubernetes/pki/etcd/salt-master-etcd-client.key \
         --cacert=/etc/kubernetes/pki/etcd/ca.crt \
-        snapshot save "$etcd_snapshot"
+        snapshot save "/var/lib/etcd/${etcd_snapshot}"
 
-    local -r rootfs_v1="/run/containerd/io.containerd.runtime.v1.linux/k8s.io/${etcd_container}/rootfs"
-    local -r rootfs_v2="/run/containerd/io.containerd.runtime.v2.task/k8s.io/${etcd_container}/rootfs"
-    local rootfs=''
-    if test -d "${rootfs_v2}"; then
-        rootfs="${rootfs_v2}"
-    elif test -d "${rootfs_v1}"; then
-        rootfs="${rootfs_v1}"
-    else
-        die "Unable to find etcd container rootfs"
-    fi
-
-    local -r snapshot_file="${rootfs}/${etcd_snapshot}"
+    # In distroless images, we need to retrieve the snapshot from the mounted
+    # volume path on the host (/var/lib/etcd), not from the container rootfs.
+    local -r snapshot_file="/var/lib/etcd/${etcd_snapshot}"
     if ! test -f "${snapshot_file}"; then
         die "etcd snapshot file not found"
     fi


### PR DESCRIPTION
Kubernetes v1.33.7

We pick the last patch version available at date while respecting the major.minor for these packages
etcd 3.5.26
CoreDNS v1.12.4