### PR TITLE
charts,salt: bump dex chart to 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@
 - Support etcd distroless images for Kubernetes 1.33+. Above etcd 3.5.21, etcd images are now distroless and upstreamed to the etcd project.
   (PR[#4740](https://github.com/scality/metalk8s/pull/4740))
 
+- Bump dex chart version to
+  [0.24.0](https://github.com/dexidp/helm-charts/releases/tag/dex-0.24.0)
+  Dex itself has been bumped accordingly to
+  [v2.44.0](https://github.com/dexidp/dex/releases/tag/v2.44.0)
+  (PR[#4774](https://github.com/scality/metalk8s/pull/4774))
+
 ## Release 132.0.0 (in development)
 
 ### Enhancements

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -136,8 +136,8 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     ),
     Image(
         name="dex",
-        version="v2.42.0",
-        digest="sha256:1b4a6eee8550240b0faedad04d984ca939513650e1d9bd423502c67355e3822f",
+        version="v2.44.0",
+        digest="sha256:5d0656fce7d453c0e3b2706abf40c0d0ce5b371fb0b73b3cf714d05f35fa5f86",
     ),
     Image(
         name="etcd",

--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,16 +1,16 @@
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "Use tpl for dynamic image values and add digest support"
+    - kind: changed
+      description: "Update Dex to 2.44.0"
   artifacthub.io/images: |
     - name: dex
-      image: ghcr.io/dexidp/dex:v2.42.0
+      image: ghcr.io/dexidp/dex:v2.44.0
 apiVersion: v2
-appVersion: 2.42.0
+appVersion: 2.44.0
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable
   connectors.
 home: https://dexidp.io/
-icon: https://dexidp.io/favicon.png
+icon: https://dexidp.io/favicons/favicon.png
 keywords:
 - oidc
 - oauth
@@ -26,4 +26,4 @@ sources:
 - https://github.com/dexidp/dex
 - https://github.com/dexidp/helm-charts/tree/master/charts/dex
 type: application
-version: 0.23.0
+version: 0.24.0

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -1,6 +1,6 @@
 # dex
 
-![version: 0.23.0](https://img.shields.io/badge/version-0.23.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.42.0](https://img.shields.io/badge/app%20version-2.42.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
+![version: 0.24.0](https://img.shields.io/badge/version-0.24.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.44.0](https://img.shields.io/badge/app%20version-2.44.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
 
 OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
 

--- a/salt/metalk8s/addons/dex/deployed/chart.sls
+++ b/salt/metalk8s/addons/dex/deployed/chart.sls
@@ -15,8 +15,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.42.0
-    helm.sh/chart: dex-0.23.0
+    app.kubernetes.io/version: 2.44.0
+    helm.sh/chart: dex-0.24.0
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -29,8 +29,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.42.0
-    helm.sh/chart: dex-0.23.0
+    app.kubernetes.io/version: 2.44.0
+    helm.sh/chart: dex-0.24.0
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -51,8 +51,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.42.0
-    helm.sh/chart: dex-0.23.0
+    app.kubernetes.io/version: 2.44.0
+    helm.sh/chart: dex-0.24.0
     heritage: metalk8s
   name: dex-cluster
   namespace: metalk8s-auth
@@ -73,8 +73,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.42.0
-    helm.sh/chart: dex-0.23.0
+    app.kubernetes.io/version: 2.44.0
+    helm.sh/chart: dex-0.24.0
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -94,8 +94,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.42.0
-    helm.sh/chart: dex-0.23.0
+    app.kubernetes.io/version: 2.44.0
+    helm.sh/chart: dex-0.24.0
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -116,8 +116,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.42.0
-    helm.sh/chart: dex-0.23.0
+    app.kubernetes.io/version: 2.44.0
+    helm.sh/chart: dex-0.24.0
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -152,8 +152,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.42.0
-    helm.sh/chart: dex-0.23.0
+    app.kubernetes.io/version: 2.44.0
+    helm.sh/chart: dex-0.24.0
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -194,7 +194,7 @@ spec:
         env:
         - name: KUBERNETES_POD_NAMESPACE
           value: metalk8s-auth
-        image: {% endraw -%}{{ build_image_name("dex", False) }}{%- raw %}:v2.42.0
+        image: {% endraw -%}{{ build_image_name("dex", False) }}{%- raw %}:v2.44.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -264,8 +264,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.42.0
-    helm.sh/chart: dex-0.23.0
+    app.kubernetes.io/version: 2.44.0
+    helm.sh/chart: dex-0.24.0
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth


### PR DESCRIPTION
Dex itself has been bumped to v2.44.0 accordingly.

Also updated the Salt file to use the new chart version.

The digest has been updated by pulling the image from the registry using:
```
gcrane digest dexidp/dex:v2.44.0
```