### PR TITLE
buildchain,charts,salt: bump fluent-bit chart to 0.55.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@
 - Support etcd distroless images for Kubernetes 1.33+. Above etcd 3.5.21, etcd images are now distroless and upstreamed to the etcd project.
   (PR[#4740](https://github.com/scality/metalk8s/pull/4740))
 
+- Bump dex chart version to
+  [0.24.0](https://github.com/dexidp/helm-charts/releases/tag/dex-0.24.0)
+  Dex itself has been bumped accordingly to
+  [v2.44.0](https://github.com/dexidp/dex/releases/tag/v2.44.0)
+  (PR[#4774](https://github.com/scality/metalk8s/pull/4774))
+
 ## Release 132.0.0 (in development)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
   Dex itself has been bumped accordingly to
   [v2.44.0](https://github.com/dexidp/dex/releases/tag/v2.44.0)
   (PR[#4774](https://github.com/scality/metalk8s/pull/4774))
+  
+- Bump Fluent Bit image version to [4.2.2](https://github.com/fluent/fluent-bit/releases/tag/v4.2.2)
+  and Fluent Bit Helm chart version to [0.55.0](https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.55.0)
+  (PR[#4777](https://github.com/scality/metalk8s/pull/4777))
 
 ## Release 132.0.0 (in development)
 

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -279,8 +279,8 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     ),
     Image(
         name="fluent-bit",
-        version="4.0.3",
-        digest="sha256:d6cc0a0a45a4fc61acde53939ed91672ed6fada7bb87710976309c0831232a79",
+        version="4.2.2",
+        digest="sha256:7d727245767ae632eb296c2ff4d206bf2e205b5f244c1f37b8fdd61f9fb33985",
     ),
     Image(
         name="cert-manager-controller",

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -136,8 +136,8 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     ),
     Image(
         name="dex",
-        version="v2.42.0",
-        digest="sha256:1b4a6eee8550240b0faedad04d984ca939513650e1d9bd423502c67355e3822f",
+        version="v2.44.0",
+        digest="sha256:5d0656fce7d453c0e3b2706abf40c0d0ce5b371fb0b73b3cf714d05f35fa5f86",
     ),
     Image(
         name="etcd",

--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,16 +1,16 @@
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "Use tpl for dynamic image values and add digest support"
+    - kind: changed
+      description: "Update Dex to 2.44.0"
   artifacthub.io/images: |
     - name: dex
-      image: ghcr.io/dexidp/dex:v2.42.0
+      image: ghcr.io/dexidp/dex:v2.44.0
 apiVersion: v2
-appVersion: 2.42.0
+appVersion: 2.44.0
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable
   connectors.
 home: https://dexidp.io/
-icon: https://dexidp.io/favicon.png
+icon: https://dexidp.io/favicons/favicon.png
 keywords:
 - oidc
 - oauth
@@ -26,4 +26,4 @@ sources:
 - https://github.com/dexidp/dex
 - https://github.com/dexidp/helm-charts/tree/master/charts/dex
 type: application
-version: 0.23.0
+version: 0.24.0

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -1,6 +1,6 @@
 # dex
 
-![version: 0.23.0](https://img.shields.io/badge/version-0.23.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.42.0](https://img.shields.io/badge/app%20version-2.42.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
+![version: 0.24.0](https://img.shields.io/badge/version-0.24.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.44.0](https://img.shields.io/badge/app%20version-2.44.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
 
 OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
 

--- a/charts/fluent-bit/CHANGELOG.md
+++ b/charts/fluent-bit/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Fluent Bit Helm Chart Changelog
+
+> [!NOTE]
+> All notable changes to this project will be documented in this file; the format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!--
+### Added - For new features.
+### Changed - For changes in existing functionality.
+### Deprecated - For soon-to-be removed features.
+### Removed - For now removed features.
+### Fixed - For any bug fixes.
+### Security - In case of vulnerabilities.
+-->
+
+## [UNRELEASED]
+
+## [v0.55.0] - 2026-01-22
+
+### Changed
+
+- Update Fluent Bit OCI image to [4.2.2](https://github.com/fluent/fluent-bit/releases/tag/v4.2.2). ([#684](https://github.com/fluent/helm-charts/pull/684)) _@stevehipwell_
+
+## [v0.54.1] - 2026-01-06
+
+### Changed
+
+- Update Fluent Bit OCI image to [4.1.1](https://github.com/fluent/fluent-bit/releases/tag/v4.1.1). ([#639](https://github.com/fluent/helm-charts/pull/666)) _@Xelus22_
+
+## [v0.54.0] - 2025-10-09
+
+### Changed
+
+- Update Fluent Bit OCI image to [4.1.0](https://github.com/fluent/fluent-bit/releases/tag/v4.1.0). ([#639](https://github.com/fluent/helm-charts/pull/639)) _@timonegk_
+
+<!--
+RELEASE LINKS
+-->
+[UNRELEASED]: https://github.com/fluent/helm-charts/tree/main/charts/fluent-bit
+[v0.55.0]: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.55.0
+[v0.54.1]: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.54.1
+[v0.54.0]: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.54.0

--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -1,10 +1,10 @@
 annotations:
-  artifacthub.io/changes: |
-    - kind: added
-      description: "Add VPA controlledValues option"
+  artifacthub.io/changes: |-
+    - kind: changed
+      description: "Update Fluent Bit OCI image to 4.2.2."
 apiVersion: v1
-appVersion: 4.0.3
-description: Fast and lightweight log processor and forwarder or Linux, OSX and BSD
+appVersion: 4.2.2
+description: Fast and lightweight log processor and forwarder for Linux, OSX and BSD
   family operating systems.
 home: https://fluentbit.io/
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/fluentd/fluentbit/icon/fluentbit-icon-color.svg
@@ -24,4 +24,4 @@ maintainers:
 name: fluent-bit
 sources:
 - https://github.com/fluent/fluent-bit/
-version: 0.50.0
+version: 0.55.0

--- a/charts/fluent-bit/README.md
+++ b/charts/fluent-bit/README.md
@@ -1,29 +1,212 @@
-# Fluent Bit Helm chart
+# fluent-bit
 
-[Fluent Bit](https://fluentbit.io) is a fast and lightweight log processor and forwarder or Linux, OSX and BSD family operating systems.
+![Version: 0.55.0](https://img.shields.io/badge/Version-0.55.0-informational?style=flat-square) ![AppVersion: 4.2.2](https://img.shields.io/badge/AppVersion-4.2.2-informational?style=flat-square)
 
-## Installation
+Fast and lightweight log processor and forwarder for Linux, OSX and BSD family operating systems.
 
-To add the `fluent` helm repo, run:
+**Homepage:** <https://fluentbit.io/>
 
-```sh
-helm repo add fluent https://fluent.github.io/helm-charts
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| edsiper | <eduardo@calyptia.com> |  |
+| naseemkullah | <naseem@transit.app> |  |
+| Towmeykaw | <towmeykaw@gmail.com> |  |
+| stevehipwell | <steve.hipwell@gmail.com> |  |
+
+## Source Code
+
+* <https://github.com/fluent/fluent-bit/>
+
+## Installing the Chart
+
+### OCI Repository
+
+To install the chart using the recommended OCI method you can use the following command.
+
+```shell
+helm upgrade --install fluent-bit oci://ghcr.io/fluent/helm-charts/fluent-bit --version 0.55.0
 ```
 
-To install a release named `fluent-bit`, run:
+#### Verification
 
-```sh
-helm install fluent-bit fluent/fluent-bit
+As the OCI chart release is signed by [Cosign](https://github.com/sigstore/cosign) you can verify the chart before installing it by running the following command.
+
+```shell
+cosign verify --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp 'https://github\.com/action-stars/helm-workflows/\.github/workflows/release\.yaml@.+' --certificate-github-workflow-repository fluent/helm-charts --certificate-github-workflow-name Release ghcr.io/fluent/helm-charts/fluent-bit:0.55.0
 ```
 
-## Chart values
+### Non-OCI Repository
 
-```sh
-helm show values fluent/fluent-bit
+Alternatively you can use the legacy non-OCI method via the following commands.
+
+```shell
+helm repo add fluent https://fluent.github.io/helm-charts/
+helm upgrade --install fluent-bit fluent/fluent-bit --version 0.55.0
 ```
 
-## Using Lua scripts
-Fluent Bit allows us to build filter to modify the incoming records using custom [Lua scripts.](https://docs.fluentbit.io/manual/pipeline/filters/lua)
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| annotations | object | `{}` |  |
+| args[0] | string | `"--workdir=/fluent-bit/etc"` |  |
+| args[1] | string | `"--config=/fluent-bit/etc/conf/fluent-bit.conf"` |  |
+| autoscaling.behavior | object | `{}` |  |
+| autoscaling.customRules | list | `[]` |  |
+| autoscaling.enabled | bool | `false` |  |
+| autoscaling.maxReplicas | int | `3` |  |
+| autoscaling.minReplicas | int | `1` |  |
+| autoscaling.targetCPUUtilizationPercentage | int | `75` |  |
+| autoscaling.vpa.annotations | object | `{}` |  |
+| autoscaling.vpa.controlledResources | list | `[]` |  |
+| autoscaling.vpa.controlledValues | string | `nil` |  |
+| autoscaling.vpa.enabled | bool | `false` |  |
+| autoscaling.vpa.maxAllowed | object | `{}` |  |
+| autoscaling.vpa.minAllowed | object | `{}` |  |
+| autoscaling.vpa.updatePolicy.updateMode | string | `"Auto"` |  |
+| command[0] | string | `"/fluent-bit/bin/fluent-bit"` |  |
+| config.customParsers | string | `"[PARSER]\n    Name docker_no_time\n    Format json\n    Time_Keep Off\n    Time_Key time\n    Time_Format %Y-%m-%dT%H:%M:%S.%L\n"` |  |
+| config.extraFiles | object | `{}` |  |
+| config.filters | string | `"[FILTER]\n    Name kubernetes\n    Match kube.*\n    Merge_Log On\n    Keep_Log Off\n    K8S-Logging.Parser On\n    K8S-Logging.Exclude On\n"` |  |
+| config.inputs | string | `"[INPUT]\n    Name tail\n    Path /var/log/containers/*.log\n    multiline.parser docker, cri\n    Tag kube.*\n    Mem_Buf_Limit 5MB\n    Skip_Long_Lines On\n\n[INPUT]\n    Name systemd\n    Tag host.*\n    Systemd_Filter _SYSTEMD_UNIT=kubelet.service\n    Read_From_Tail On\n"` |  |
+| config.outputs | string | `"[OUTPUT]\n    Name es\n    Match kube.*\n    Host elasticsearch-master\n    Logstash_Format On\n    Retry_Limit False\n\n[OUTPUT]\n    Name es\n    Match host.*\n    Host elasticsearch-master\n    Logstash_Format On\n    Logstash_Prefix node\n    Retry_Limit False\n"` |  |
+| config.service | string | `"[SERVICE]\n    Daemon Off\n    Flush {{ .Values.flush }}\n    Log_Level {{ .Values.logLevel }}\n    Parsers_File /fluent-bit/etc/parsers.conf\n    Parsers_File /fluent-bit/etc/conf/custom_parsers.conf\n    HTTP_Server On\n    HTTP_Listen 0.0.0.0\n    HTTP_Port {{ .Values.metricsPort }}\n    Health_Check On\n"` |  |
+| config.upstream | object | `{}` |  |
+| daemonSetVolumeMounts[0].mountPath | string | `"/var/log"` |  |
+| daemonSetVolumeMounts[0].name | string | `"varlog"` |  |
+| daemonSetVolumeMounts[1].mountPath | string | `"/var/lib/docker/containers"` |  |
+| daemonSetVolumeMounts[1].name | string | `"varlibdockercontainers"` |  |
+| daemonSetVolumeMounts[1].readOnly | bool | `true` |  |
+| daemonSetVolumeMounts[2].mountPath | string | `"/etc/machine-id"` |  |
+| daemonSetVolumeMounts[2].name | string | `"etcmachineid"` |  |
+| daemonSetVolumeMounts[2].readOnly | bool | `true` |  |
+| daemonSetVolumes[0].hostPath.path | string | `"/var/log"` |  |
+| daemonSetVolumes[0].name | string | `"varlog"` |  |
+| daemonSetVolumes[1].hostPath.path | string | `"/var/lib/docker/containers"` |  |
+| daemonSetVolumes[1].name | string | `"varlibdockercontainers"` |  |
+| daemonSetVolumes[2].hostPath.path | string | `"/etc/machine-id"` |  |
+| daemonSetVolumes[2].hostPath.type | string | `"File"` |  |
+| daemonSetVolumes[2].name | string | `"etcmachineid"` |  |
+| dashboards.annotations | object | `{}` |  |
+| dashboards.deterministicUid | bool | `false` |  |
+| dashboards.enabled | bool | `false` |  |
+| dashboards.labelKey | string | `"grafana_dashboard"` |  |
+| dashboards.labelValue | int | `1` |  |
+| dashboards.namespace | string | `""` |  |
+| dnsConfig | object | `{}` |  |
+| dnsPolicy | string | `"ClusterFirst"` |  |
+| env | list | `[]` |  |
+| envFrom | list | `[]` |  |
+| envWithTpl | list | `[]` |  |
+| existingConfigMap | string | `""` |  |
+| extraContainers | list | `[]` |  |
+| extraPorts | list | `[]` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
+| flush | int | `1` |  |
+| fullnameOverride | string | `""` |  |
+| hostAliases | list | `[]` |  |
+| hostNetwork | bool | `false` |  |
+| hotReload.enabled | bool | `false` |  |
+| hotReload.extraWatchVolumes | list | `[]` |  |
+| hotReload.image.digest | string | `nil` |  |
+| hotReload.image.pullPolicy | string | `"IfNotPresent"` |  |
+| hotReload.image.repository | string | `"ghcr.io/jimmidyson/configmap-reload"` |  |
+| hotReload.image.tag | string | `"v0.15.0"` |  |
+| hotReload.resources | object | `{}` |  |
+| hotReload.securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| hotReload.securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| hotReload.securityContext.privileged | bool | `false` |  |
+| hotReload.securityContext.readOnlyRootFilesystem | bool | `true` |  |
+| hotReload.securityContext.runAsGroup | int | `65532` |  |
+| hotReload.securityContext.runAsNonRoot | bool | `true` |  |
+| hotReload.securityContext.runAsUser | int | `65532` |  |
+| image.digest | string | `nil` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"cr.fluentbit.io/fluent/fluent-bit"` |  |
+| image.tag | string | `nil` |  |
+| imagePullSecrets | list | `[]` |  |
+| ingress.annotations | object | `{}` |  |
+| ingress.enabled | bool | `false` |  |
+| ingress.extraHosts | list | `[]` |  |
+| ingress.hosts | list | `[]` |  |
+| ingress.ingressClassName | string | `""` |  |
+| ingress.tls | list | `[]` |  |
+| initContainers | list | `[]` |  |
+| kind | string | `"DaemonSet"` | DaemonSet or Deployment |
+| labels | object | `{}` |  |
+| lifecycle | object | `{}` |  |
+| livenessProbe.httpGet.path | string | `"/"` |  |
+| livenessProbe.httpGet.port | string | `"http"` |  |
+| logLevel | string | `"info"` |  |
+| luaScripts | object | `{}` |  |
+| metricsPort | int | `2020` |  |
+| minReadySeconds | string | `nil` |  |
+| nameOverride | string | `""` |  |
+| networkPolicy.enabled | bool | `false` |  |
+| nodeSelector | object | `{}` |  |
+| openShift.enabled | bool | `false` |  |
+| openShift.securityContextConstraints.annotations | object | `{}` |  |
+| openShift.securityContextConstraints.create | bool | `true` |  |
+| openShift.securityContextConstraints.existingName | string | `""` |  |
+| openShift.securityContextConstraints.name | string | `""` |  |
+| openShift.securityContextConstraints.runAsUser.type | string | `"RunAsAny"` |  |
+| openShift.securityContextConstraints.seLinuxContext.type | string | `"MustRunAs"` |  |
+| podAnnotations | object | `{}` |  |
+| podDisruptionBudget.annotations | object | `{}` |  |
+| podDisruptionBudget.enabled | bool | `false` |  |
+| podDisruptionBudget.maxUnavailable | string | `"30%"` |  |
+| podLabels | object | `{}` |  |
+| podSecurityContext | object | `{}` |  |
+| podSecurityPolicy.annotations | object | `{}` |  |
+| podSecurityPolicy.create | bool | `false` |  |
+| podSecurityPolicy.runAsUser.rule | string | `"RunAsAny"` |  |
+| podSecurityPolicy.seLinux.rule | string | `"RunAsAny"` |  |
+| priorityClassName | string | `""` |  |
+| prometheusRule.enabled | bool | `false` |  |
+| rbac.create | bool | `true` |  |
+| rbac.eventsAccess | bool | `false` |  |
+| rbac.nodeAccess | bool | `false` |  |
+| readinessProbe.httpGet.path | string | `"/api/v1/health"` |  |
+| readinessProbe.httpGet.port | string | `"http"` |  |
+| replicaCount | int | `1` | Only applicable if kind=Deployment |
+| resources | object | `{}` |  |
+| securityContext | object | `{}` |  |
+| service.annotations | object | `{}` |  |
+| service.externalIPs | list | `[]` |  |
+| service.internalTrafficPolicy | string | `nil` |  |
+| service.labels | object | `{}` |  |
+| service.loadBalancerClass | string | `nil` |  |
+| service.loadBalancerIP | string | `nil` |  |
+| service.loadBalancerSourceRanges | list | `[]` |  |
+| service.port | int | `2020` |  |
+| service.type | string | `"ClusterIP"` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.automountServiceAccountToken | string | `nil` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `nil` |  |
+| serviceMonitor.additionalEndpoints | list | `[]` |  |
+| serviceMonitor.enabled | bool | `false` |  |
+| terminationGracePeriodSeconds | string | `nil` |  |
+| testFramework.enabled | bool | `true` |  |
+| testFramework.image.digest | string | `nil` |  |
+| testFramework.image.pullPolicy | string | `"Always"` |  |
+| testFramework.image.repository | string | `"busybox"` |  |
+| testFramework.image.tag | string | `"latest"` |  |
+| testFramework.namespace | string | `nil` |  |
+| tolerations | list | `[]` |  |
+| updateStrategy | object | `{}` |  |
+| volumeMounts[0].mountPath | string | `"/fluent-bit/etc/conf"` |  |
+| volumeMounts[0].name | string | `"config"` |  |
+
+## Usage
+
+### Using Lua Scripts
+
+Fluent Bit allows us to provide a filter to modify the incoming records using custom [Lua scripts.](https://docs.fluentbit.io/manual/pipeline/filters/lua)
 
 ### How to use Lua scripts with this Chart
 
@@ -48,10 +231,16 @@ config:
         script  /fluent-bit/scripts/filter_example.lua
         call    filter_name
 ```
+
 Under the hood, the chart will:
+
 - Create a configmap using `luaScripts`.
 - Add a volumeMounts for each Lua scripts using the path `/fluent-bit/scripts/<script>`.
 - Add the Lua script's configmap as volume to the pod.
 
-### Note
-Remember to set the `script` attribute in the filter using `/fluent-bit/scripts/`, otherwise the file will not be found by fluent bit.
+> [!NOTE]
+> Remember to set the `script` attribute in the filter using `/fluent-bit/scripts/`, otherwise the file will not be found by fluent bit.
+
+----------------------------------------------
+
+Autogenerated from chart metadata using [helm-docs](https://github.com/norwoodj/helm-docs/).

--- a/charts/fluent-bit/RELEASE.md
+++ b/charts/fluent-bit/RELEASE.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Update Fluent Bit OCI image to [4.2.2](https://github.com/fluent/fluent-bit/releases/tag/v4.2.2). ([#684](https://github.com/fluent/helm-charts/pull/684)) _@stevehipwell_

--- a/charts/fluent-bit/_docs.md
+++ b/charts/fluent-bit/_docs.md
@@ -1,0 +1,38 @@
+## Usage
+
+### Using Lua Scripts
+
+Fluent Bit allows us to provide a filter to modify the incoming records using custom [Lua scripts.](https://docs.fluentbit.io/manual/pipeline/filters/lua)
+
+### How to use Lua scripts with this Chart
+
+First, you should add your Lua scripts to `luaScripts` in values.yaml, templating is supported.
+
+```yaml
+luaScripts:
+  filter_example.lua: |
+    function filter_name(tag, timestamp, record)
+        -- put your lua code here.
+    end
+```
+
+After that, the Lua scripts will be ready to be used as filters. So next step is to add your Fluent bit [filter](https://docs.fluentbit.io/manual/concepts/data-pipeline/filter) to `config.filters` in values.yaml, for example:
+
+```yaml
+config:
+  filters: |
+    [FILTER]
+        Name    lua
+        Match   <your-tag>
+        script  /fluent-bit/scripts/filter_example.lua
+        call    filter_name
+```
+
+Under the hood, the chart will:
+
+- Create a configmap using `luaScripts`.
+- Add a volumeMounts for each Lua scripts using the path `/fluent-bit/scripts/<script>`.
+- Add the Lua script's configmap as volume to the pod.
+
+> [!NOTE]
+> Remember to set the `script` attribute in the filter using `/fluent-bit/scripts/`, otherwise the file will not be found by fluent bit.

--- a/charts/fluent-bit/templates/serviceaccount.yaml
+++ b/charts/fluent-bit/templates/serviceaccount.yaml
@@ -10,4 +10,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- if ne .Values.serviceAccount.automountServiceAccountToken nil }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 {{- end -}}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -31,6 +31,7 @@ serviceAccount:
   create: true
   annotations: {}
   name:
+  automountServiceAccountToken:
 
 rbac:
   create: true
@@ -519,8 +520,18 @@ hotReload:
   enabled: false
   image:
     repository: ghcr.io/jimmidyson/configmap-reload
-    tag: v0.14.0
+    tag: v0.15.0
     digest:
     pullPolicy: IfNotPresent
   resources: {}
   extraWatchVolumes: []
+  securityContext:
+    privileged: false
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    capabilities:
+      drop:
+        - ALL

--- a/salt/metalk8s/addons/dex/deployed/chart.sls
+++ b/salt/metalk8s/addons/dex/deployed/chart.sls
@@ -15,8 +15,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.42.0
-    helm.sh/chart: dex-0.23.0
+    app.kubernetes.io/version: 2.44.0
+    helm.sh/chart: dex-0.24.0
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -29,8 +29,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.42.0
-    helm.sh/chart: dex-0.23.0
+    app.kubernetes.io/version: 2.44.0
+    helm.sh/chart: dex-0.24.0
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -51,8 +51,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.42.0
-    helm.sh/chart: dex-0.23.0
+    app.kubernetes.io/version: 2.44.0
+    helm.sh/chart: dex-0.24.0
     heritage: metalk8s
   name: dex-cluster
   namespace: metalk8s-auth
@@ -73,8 +73,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.42.0
-    helm.sh/chart: dex-0.23.0
+    app.kubernetes.io/version: 2.44.0
+    helm.sh/chart: dex-0.24.0
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -94,8 +94,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.42.0
-    helm.sh/chart: dex-0.23.0
+    app.kubernetes.io/version: 2.44.0
+    helm.sh/chart: dex-0.24.0
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -116,8 +116,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.42.0
-    helm.sh/chart: dex-0.23.0
+    app.kubernetes.io/version: 2.44.0
+    helm.sh/chart: dex-0.24.0
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -152,8 +152,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.42.0
-    helm.sh/chart: dex-0.23.0
+    app.kubernetes.io/version: 2.44.0
+    helm.sh/chart: dex-0.24.0
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -194,7 +194,7 @@ spec:
         env:
         - name: KUBERNETES_POD_NAMESPACE
           value: metalk8s-auth
-        image: {% endraw -%}{{ build_image_name("dex", False) }}{%- raw %}:v2.42.0
+        image: {% endraw -%}{{ build_image_name("dex", False) }}{%- raw %}:v2.44.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -264,8 +264,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 2.42.0
-    helm.sh/chart: dex-0.23.0
+    app.kubernetes.io/version: 2.44.0
+    helm.sh/chart: dex-0.24.0
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth

--- a/salt/metalk8s/addons/logging/fluent-bit/deployed/chart.sls
+++ b/salt/metalk8s/addons/logging/fluent-bit/deployed/chart.sls
@@ -15,8 +15,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: fluent-bit
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 4.0.3
-    helm.sh/chart: fluent-bit-0.50.0
+    app.kubernetes.io/version: 4.2.2
+    helm.sh/chart: fluent-bit-0.55.0
     heritage: metalk8s
   name: fluent-bit
   namespace: metalk8s-logging
@@ -1596,9 +1596,9 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: fluent-bit
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 4.0.3
+    app.kubernetes.io/version: 4.2.2
     grafana_dashboard: '1'
-    helm.sh/chart: fluent-bit-0.50.0
+    helm.sh/chart: fluent-bit-0.55.0
     heritage: metalk8s
   name: fluent-bit-dashboard-fluent-bit
   namespace: metalk8s-logging
@@ -1611,8 +1611,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: fluent-bit
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 4.0.3
-    helm.sh/chart: fluent-bit-0.50.0
+    app.kubernetes.io/version: 4.2.2
+    helm.sh/chart: fluent-bit-0.55.0
     heritage: metalk8s
   name: fluent-bit
   namespace: metalk8s-logging
@@ -1635,8 +1635,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: fluent-bit
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 4.0.3
-    helm.sh/chart: fluent-bit-0.50.0
+    app.kubernetes.io/version: 4.2.2
+    helm.sh/chart: fluent-bit-0.55.0
     heritage: metalk8s
   name: fluent-bit
   namespace: metalk8s-logging
@@ -1657,8 +1657,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: fluent-bit
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 4.0.3
-    helm.sh/chart: fluent-bit-0.50.0
+    app.kubernetes.io/version: 4.2.2
+    helm.sh/chart: fluent-bit-0.55.0
     heritage: metalk8s
   name: fluent-bit
   namespace: metalk8s-logging
@@ -1681,8 +1681,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: fluent-bit
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 4.0.3
-    helm.sh/chart: fluent-bit-0.50.0
+    app.kubernetes.io/version: 4.2.2
+    helm.sh/chart: fluent-bit-0.55.0
     heritage: metalk8s
   name: fluent-bit
   namespace: metalk8s-logging
@@ -1708,7 +1708,7 @@ spec:
         - --config=/fluent-bit/etc/conf/fluent-bit.conf
         command:
         - /fluent-bit/bin/fluent-bit
-        image: {% endraw -%}{{ build_image_name("fluent-bit", False) }}{%- raw %}:4.0.3
+        image: {% endraw -%}{{ build_image_name("fluent-bit", False) }}{%- raw %}:4.2.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -1773,8 +1773,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: fluent-bit
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 4.0.3
-    helm.sh/chart: fluent-bit-0.50.0
+    app.kubernetes.io/version: 4.2.2
+    helm.sh/chart: fluent-bit-0.55.0
     heritage: metalk8s
     metalk8s.scality.com/monitor: ''
   name: fluent-bit


### PR DESCRIPTION
Fluent Bit itself has been bumped to v4.2.2 accordingly.
Also updated the Salt file to use the new chart version.

The digest has been updated accordingly by pulling the image from the registry using:
```
gcrane digest fluent/fluent-bit:v4.2.2
```