### PR TITLE
operator,storage-operator: pin Go toolchain to 1.24.13 to fix CI lint failures

### DIFF
--- a/operator/go.mod
+++ b/operator/go.mod
@@ -1,6 +1,7 @@
 module github.com/scality/metalk8s/operator
 
 go 1.22.0
+toolchain go1.24.13
 
 require (
 	github.com/go-logr/logr v1.4.1

--- a/storage-operator/go.mod
+++ b/storage-operator/go.mod
@@ -1,6 +1,7 @@
 module github.com/scality/metalk8s/storage-operator
 
 go 1.22.0
+toolchain go1.24.13
 
 require (
 	github.com/go-logr/logr v1.4.1


### PR DESCRIPTION
Add explicit 'toolchain go1.24.13' directive to both operator and
storage-operator go.mod files to prevent Go's automatic toolchain
selection from choosing incompatible versions.

Problem:
  After Go 1.26.0 release (Feb 10, 2026), Go's toolchain selection
  algorithm started automatically choosing Go 1.25.7 instead of 1.24.13.
  Go 1.25.7 is incompatible with golang.org/x/tools v0.20.0, causing
  all CI lint jobs to fail with:
    invalid array length -delta * delta (constant -256 of type int64)

  This affects ALL branches based on development/131.0.

Root cause:
  Go's algorithm prefers 'latest patch before most recent version'.
  Before Feb 10: [1.24.13, 1.25.7] → chooses 1.24.13 (before 1.25)
  After Feb 10:  [1.24.13, 1.25.7, 1.26.0] → chooses 1.25.7 (before 1.26)

Solution:
  Pin toolchain to go1.24.13 (latest Go 1.24 patch) to ensure:
  - Reproducible builds
  - Consistent CI behavior
  - Compatibility with current dependencies

  The directive is placed immediately after 'go' line as per Go
  best practices: https://go.dev/doc/toolchain

Files modified:
  - operator/go.mod: Added toolchain directive
  - storage-operator/go.mod: Added toolchain directive

This is a minimal fix to unblock CI. A proper Go 1.26 bump will be
done in a separate ticket with full dependency updates.

References:
- Go toolchain selection: https://go.dev/doc/toolchain
- Algorithm source: https://go.dev/src/cmd/go/internal/toolchain/switch.go
- Bug in x/tools v0.20.0: tokeninternal.go:64

Fixes: MK8S-131