### PR TITLE
operator,storage-operator: pin Go toolchain to `1.22.12` and bump envtest to `release-0.19`

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -55,6 +55,10 @@ IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.30.0
 
+# Force Go toolchain version to prevent automatic selection issues
+# See: https://go.dev/doc/toolchain
+export GOTOOLCHAIN = go1.22.12
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -211,7 +215,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.4.2
 CONTROLLER_TOOLS_VERSION ?= v0.15.0
-ENVTEST_VERSION ?= release-0.18
+ENVTEST_VERSION ?= release-0.19
 GOLANGCI_LINT_VERSION ?= v1.59.1
 
 .PHONY: kustomize

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -1,6 +1,7 @@
 module github.com/scality/metalk8s/operator
 
 go 1.22.0
+toolchain go1.22.12
 
 require (
 	github.com/go-logr/logr v1.4.1

--- a/storage-operator/Makefile
+++ b/storage-operator/Makefile
@@ -55,6 +55,10 @@ IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.30.0
 
+# Force Go toolchain version to prevent automatic selection issues
+# See: https://go.dev/doc/toolchain
+export GOTOOLCHAIN = go1.22.12
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -211,7 +215,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.4.2
 CONTROLLER_TOOLS_VERSION ?= v0.15.0
-ENVTEST_VERSION ?= release-0.18
+ENVTEST_VERSION ?= release-0.19
 GOLANGCI_LINT_VERSION ?= v1.59.1
 
 .PHONY: kustomize

--- a/storage-operator/go.mod
+++ b/storage-operator/go.mod
@@ -1,6 +1,7 @@
 module github.com/scality/metalk8s/storage-operator
 
 go 1.22.0
+toolchain go1.22.12
 
 require (
 	github.com/go-logr/logr v1.4.1


### PR DESCRIPTION
Add explicit Go `1.22.12` toolchain enforcement and upgrade setup-envtest to fix CI lint and test failures.

**Problem:**
- After Go `1.26.0` release (Feb 10, 2026), Go's toolchain selection
  algorithm started automatically choosing Go `1.25.7` instead of `1.22.x`.
- Go `1.25.7` is incompatible with `golang.org/x/tools v0.20.0`,
  causing all CI lint/test jobs to fail with:
    `invalid array length -delta * delta (constant -256 of type int64)`

  Additionally, setup-envtest `release-0.18` had GCS access issues causing
  unit tests to fail with "401 Unauthorized" when downloading
  kubebuilder-tools.

  This affects ALL branches based on development/131.0.

**Root cause:**
  Go's algorithm prefers 'latest patch before most recent version'.
  Before Feb 10: `[1.22.x, 1.25.7]` → chooses `1.22.x` (before `1.25`)
  After Feb 10:  `[1.22.x, 1.25.7, 1.26.0]` → chooses `1.25.7` (before `1.26`)

**Solution (3-part fix):**
  1. Add `toolchain go1.22.12` directive in go.mod files
  2. Export `GOTOOLCHAIN=go1.22.12` globally in Makefiles
  3. Bump `ENVTEST_VERSION` from `release-0.18` to `release-0.19`

  Using `go1.22.12` (latest patch of `1.22`) aligns with our go.mod
  requirement (go `1.22.0`) and avoids the `x/tools v0.20.0` bug.

  Upgrading to setup-envtest `release-0.19` fixes GCS access issues
  and allows unit tests to download kubebuilder-tools successfully.

**Files modified:**
  - `operator/go.mod` and `storage-operator/go.mod`: Added `toolchain` directive
  - `operator/Makefile`: Added `export GOTOOLCHAIN` + bumped `ENVTEST_VERSION`
  - `storage-operator/go.mod`: Added `toolchain` directive
  - `storage-operator/Makefile`: Added `export GOTOOLCHAIN` + bumped `ENVTEST_VERSION`

This is a minimal fix to unblock CI. A proper Go `1.26` bump will be
done in a separate ticket with full dependency updates.

**References:**
- Go toolchain selection: https://go.dev/doc/toolchain
- Algorithm source: https://go.dev/src/cmd/go/internal/toolchain/switch.go
- Bug in x/tools v0.20.0: `tokeninternal.go:64`

Fixes: MK8S-131