### PR TITLE
MK8S-139 : Extend the authentication section to PrometheusConfig and AlertManagerConfig

### DIFF
--- a/salt/metalk8s/addons/prometheus-operator/config/alertmanager.yaml
+++ b/salt/metalk8s/addons/prometheus-operator/config/alertmanager.yaml
@@ -13,6 +13,13 @@ spec:
   # Configure the Alertmanager Deployment
   deployment:
     replicas: 1
+  config:
+    enable_oidc_authentication: false
+    oidc:
+      issuer: "" # OIDC provider URL
+      audience: "" # Expected audience claim in the token
+      groupsClaim: "" # JWT claim name that carries user groups/roles
+      authorizedGroups: [] # Groups/roles allowed to access Alertmanager
   notification:
     config:
       global:

--- a/salt/metalk8s/addons/prometheus-operator/config/prometheus.yaml
+++ b/salt/metalk8s/addons/prometheus-operator/config/prometheus.yaml
@@ -11,6 +11,12 @@ spec:
     retention_time: "10d"
     retention_size: "0" # "0" to disable size-based retention
     enable_admin_api: false
+    enable_oidc_authentication: false
+    oidc:
+      issuer: "" # OIDC provider URL
+      audience: "" # Expected audience claim in the token
+      groupsClaim: "" # JWT claim name that carries user groups/roles
+      authorizedGroups: [] # Groups/roles allowed to access Prometheus
     serviceMonitor:
       kubelet:
         scrapeTimeout: 10s


### PR DESCRIPTION
**Component**: Salt


**Context**:  
The `PrometheusConfig` CRD will be extended with a new `enable_oidc_authentication` field and an `oidc` sub-configuration block.

This allows operators to declaratively configure OIDC authentication for the Prometheus service alongside the existing configuration.

The same apply for `AlertManagerConfig`.

**Summary**: 
This PR only extends the configuration. The next PR will be using Salt to deploy the required resources based on the values defined here.

**Acceptance criteria**: 

Ref: https://github.com/scality/citadel/pull/306