### PR TITLE
MK8S-140 - Salt deploy oauth2-proxy

### DIFF
--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -407,6 +407,11 @@ SALT_FILES: Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path("salt/metalk8s/addons/prometheus-operator/deployed/service-configuration.sls"),
     Path("salt/metalk8s/addons/prometheus-operator/deployed/thanos-chart.sls"),
     Path("salt/metalk8s/addons/prometheus-operator/deployed/thanos-query-sd-files.sls"),
+    Path("salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-rbac.sls"),
+    Path("salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-prometheus.sls"),
+    Path(
+        "salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-alertmanager.sls"
+    ),
     Path("salt/metalk8s/addons/ui/deployed/dependencies.sls"),
     Path("salt/metalk8s/addons/ui/deployed/ingress.sls"),
     Path("salt/metalk8s/addons/ui/deployed/init.sls"),

--- a/salt/metalk8s/addons/prometheus-operator/config/alertmanager.yaml
+++ b/salt/metalk8s/addons/prometheus-operator/config/alertmanager.yaml
@@ -20,6 +20,9 @@ spec:
       audience: "" # Expected audience claim in the token
       groupsClaim: "" # JWT claim name that carries user groups/roles
       authorizedGroups: [] # Groups/roles allowed to access Alertmanager
+      caSecret:
+        namespace: "" # Namespace of the secret containing the CA certificate (must be labeled with metalk8s.scality.com/oidc-ca: "true")
+        name: "" # Name of the secret containing the CA certificate
   notification:
     config:
       global:

--- a/salt/metalk8s/addons/prometheus-operator/config/prometheus.yaml
+++ b/salt/metalk8s/addons/prometheus-operator/config/prometheus.yaml
@@ -17,6 +17,9 @@ spec:
       audience: "" # Expected audience claim in the token
       groupsClaim: "" # JWT claim name that carries user groups/roles
       authorizedGroups: [] # Groups/roles allowed to access Prometheus
+      caSecret:
+        namespace: "" # Namespace of the secret containing the CA certificate (must be labeled with metalk8s.scality.com/oidc-ca: "true")
+        name: "" # Name of the secret containing the CA certificate
     serviceMonitor:
       kubelet:
         scrapeTimeout: 10s

--- a/salt/metalk8s/addons/prometheus-operator/deployed/init.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/init.sls
@@ -10,3 +10,6 @@ include:
   - .kube-alerts-rules
   - .thanos-query-sd-files
   - .thanos-chart
+  - .oidc-proxy-rbac
+  - .oidc-proxy-prometheus
+  - .oidc-proxy-alertmanager

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-alertmanager.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-alertmanager.sls
@@ -1,4 +1,5 @@
 {%- from "metalk8s/repo/macro.sls" import build_image_name with context %}
+{%- from "metalk8s/map.jinja" import coredns with context %}
 
 {%- set alertmanager_defaults = salt.slsutil.renderer(
         'salt://metalk8s/addons/prometheus-operator/config/alertmanager.yaml',
@@ -126,3 +127,25 @@ Ensure oauth2-proxy-alertmanager Service does not exist:
     - apiVersion: v1
 
 {%- endif %}
+
+Create alertmanager-proxy Service:
+  metalk8s_kubernetes.object_present:
+    - manifest:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: alertmanager-proxy
+          namespace: metalk8s-monitoring
+          labels:
+            app.kubernetes.io/managed-by: salt
+            app.kubernetes.io/part-of: metalk8s
+            heritage: metalk8s
+        spec:
+          type: ExternalName
+          {%- if alertmanager_oidc_enabled %}
+          externalName: oauth2-proxy-alertmanager.metalk8s-monitoring.svc.{{ coredns.cluster_domain }}
+          {%- else %}
+          externalName: prometheus-operator-alertmanager.metalk8s-monitoring.svc.{{ coredns.cluster_domain }}
+          {%- endif %}
+          ports:
+          - port: 9093

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-alertmanager.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-alertmanager.sls
@@ -42,7 +42,7 @@ Create oauth2-proxy-alertmanager Deployment:
               labels:
                 app: oauth2-proxy-alertmanager
             spec:
-              serviceAccountName: oidc-proxy
+              serviceAccountName: oidc-proxy-alertmanager
               {%- if ca_configured %}
               initContainers:
               - name: k8s-sidecar

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-alertmanager.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-alertmanager.sls
@@ -86,9 +86,9 @@ Create oauth2-proxy-alertmanager Deployment:
                 {%- if ca_configured %}
                 - --provider-ca-file=/tmp/secrets/{{ ca_file }}
                 {%- endif %}
-                - --http-address=0.0.0.0:4180
+                - --http-address=0.0.0.0:9093
                 ports:
-                - containerPort: 4180
+                - containerPort: 9093
                 volumeMounts:
                 - name: secrets-volume
                   mountPath: /tmp/secrets
@@ -111,7 +111,7 @@ Create oauth2-proxy-alertmanager Service:
           selector:
             app: oauth2-proxy-alertmanager
           ports:
-          - port: 4180
+          - port: 9093
 
 {%- else %}
 

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-alertmanager.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-alertmanager.sls
@@ -14,7 +14,11 @@
 {%- set alertmanager_oidc_enabled = alertmanager.spec.get('config', {}).get('enable_oidc_authentication', False) %}
 {%- set alertmanager_oidc = alertmanager.spec.get('config', {}).get('oidc', {}) %}
 
-{%- set ingress_ca_file = 'namespace_metalk8s-ingress.secret_ingress-control-plane-default-certificate.tls.crt' %}
+{%- set alertmanager_oidc_ca = alertmanager_oidc.get('caSecret', {}) %}
+{%- set ca_namespace = alertmanager_oidc_ca.get('namespace', '') %}
+{%- set ca_name = alertmanager_oidc_ca.get('name', '') %}
+{%- set ca_configured = ca_namespace and ca_name %}
+{%- set ca_file = 'namespace_' ~ ca_namespace ~ '.secret_' ~ ca_name ~ '.tls.crt' %}
 
 {%- if alertmanager_oidc_enabled %}
 
@@ -39,6 +43,7 @@ Create oauth2-proxy-alertmanager Deployment:
                 app: oauth2-proxy-alertmanager
             spec:
               serviceAccountName: oidc-proxy
+              {%- if ca_configured %}
               initContainers:
               - name: k8s-sidecar
                 image: {{ build_image_name("k8s-sidecar") }}
@@ -46,11 +51,11 @@ Create oauth2-proxy-alertmanager Deployment:
                 restartPolicy: Always
                 env:
                 - name: LABEL
-                  value: metalk8s.scality.com/version
+                  value: metalk8s.scality.com/oidc-ca
                 - name: FOLDER
                   value: /tmp/secrets
                 - name: NAMESPACE
-                  value: metalk8s-ingress
+                  value: {{ ca_namespace }}
                 - name: RESOURCE
                   value: secret
                 - name: UNIQUE_FILENAMES
@@ -58,6 +63,7 @@ Create oauth2-proxy-alertmanager Deployment:
                 volumeMounts:
                 - name: secrets-volume
                   mountPath: /tmp/secrets
+              {%- endif %}
               containers:
               - name: oauth2-proxy
                 image: {{ build_image_name("oauth2-proxy") }}
@@ -74,7 +80,9 @@ Create oauth2-proxy-alertmanager Deployment:
                 {%- for group in alertmanager_oidc.get('authorizedGroups', []) %}
                 - --allowed-group={{ group }}
                 {%- endfor %}
-                - --provider-ca-file=/tmp/secrets/{{ ingress_ca_file }}
+                {%- if ca_configured %}
+                - --provider-ca-file=/tmp/secrets/{{ ca_file }}
+                {%- endif %}
                 - --http-address=0.0.0.0:4180
                 ports:
                 - containerPort: 4180

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-alertmanager.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-alertmanager.sls
@@ -28,9 +28,6 @@ Create oauth2-proxy-alertmanager Deployment:
           namespace: metalk8s-monitoring
           labels:
             app: oauth2-proxy-alertmanager
-            app.kubernetes.io/managed-by: salt
-            app.kubernetes.io/part-of: metalk8s
-            heritage: metalk8s
         spec:
           replicas: 1
           selector:
@@ -99,9 +96,6 @@ Create oauth2-proxy-alertmanager Service:
           namespace: metalk8s-monitoring
           labels:
             app: oauth2-proxy-alertmanager
-            app.kubernetes.io/managed-by: salt
-            app.kubernetes.io/part-of: metalk8s
-            heritage: metalk8s
         spec:
           selector:
             app: oauth2-proxy-alertmanager

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-alertmanager.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-alertmanager.sls
@@ -15,9 +15,9 @@
 {%- set alertmanager_oidc = alertmanager.spec.get('config', {}).get('oidc', {}) %}
 
 {%- set alertmanager_oidc_ca = alertmanager_oidc.get('caSecret', {}) %}
-{%- set ca_namespace = alertmanager_oidc_ca.get('namespace', '') %}
-{%- set ca_name = alertmanager_oidc_ca.get('name', '') %}
-{%- set ca_configured = ca_namespace and ca_name %}
+{%- set ca_namespace = alertmanager_oidc_ca.get('namespace', 'metalk8s-ingress') %}
+{%- set ca_name = alertmanager_oidc_ca.get('name', 'ingress-control-plane-default-certificate') %}
+
 {%- set ca_file = 'namespace_' ~ ca_namespace ~ '.secret_' ~ ca_name ~ '.tls.crt' %}
 
 {%- if alertmanager_oidc_enabled %}
@@ -43,7 +43,6 @@ Create oauth2-proxy-alertmanager Deployment:
                 app: oauth2-proxy-alertmanager
             spec:
               serviceAccountName: oidc-proxy-alertmanager
-              {%- if ca_configured %}
               initContainers:
               - name: k8s-sidecar
                 image: {{ build_image_name("k8s-sidecar") }}
@@ -63,7 +62,6 @@ Create oauth2-proxy-alertmanager Deployment:
                 volumeMounts:
                 - name: secrets-volume
                   mountPath: /tmp/secrets
-              {%- endif %}
               containers:
               - name: oauth2-proxy
                 image: {{ build_image_name("oauth2-proxy") }}
@@ -83,9 +81,7 @@ Create oauth2-proxy-alertmanager Deployment:
                 {%- for group in alertmanager_oidc.get('authorizedGroups', []) %}
                 - --allowed-group={{ group }}
                 {%- endfor %}
-                {%- if ca_configured %}
                 - --provider-ca-file=/tmp/secrets/{{ ca_file }}
-                {%- endif %}
                 - --http-address=0.0.0.0:9093
                 ports:
                 - containerPort: 9093

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-alertmanager.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-alertmanager.sls
@@ -71,6 +71,9 @@ Create oauth2-proxy-alertmanager Deployment:
                 - --provider=oidc
                 - --oidc-issuer-url={{ alertmanager_oidc.get('issuer', '') }}
                 - --client-id={{ alertmanager_oidc.get('audience', '') }}
+                # cookie-secret is required by oauth2-proxy but never used since all
+                # authentication goes through JWT bearer tokens (--skip-jwt-bearer-tokens=true).
+                # Any valid base64-encoded 32-byte value works here.
                 - --cookie-secret=MDEyMzQ1Njc4OWFiY2RlZmdoaWprbG1ub3BxcnN0dXY=
                 - --client-secret=unused-but-required
                 - --skip-jwt-bearer-tokens=true

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-alertmanager.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-alertmanager.sls
@@ -1,0 +1,127 @@
+{%- from "metalk8s/map.jinja" import repo with context %}
+
+{%- set alertmanager_defaults = salt.slsutil.renderer(
+        'salt://metalk8s/addons/prometheus-operator/config/alertmanager.yaml',
+        saltenv=saltenv
+    )
+%}
+
+{%- set alertmanager = salt.metalk8s_service_configuration.get_service_conf(
+        'metalk8s-monitoring', 'metalk8s-alertmanager-config', alertmanager_defaults
+    )
+%}
+
+{%- set alertmanager_oidc_enabled = alertmanager.spec.get('config', {}).get('enable_oidc_authentication', False) %}
+{%- set alertmanager_oidc = alertmanager.spec.get('config', {}).get('oidc', {}) %}
+
+{%- set ingress_ca_file = 'namespace_metalk8s-ingress.secret_ingress-control-plane-default-certificate.tls.crt' %}
+
+{%- if alertmanager_oidc_enabled %}
+
+Create oauth2-proxy-alertmanager Deployment:
+  metalk8s_kubernetes.object_present:
+    - manifest:
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: oauth2-proxy-alertmanager
+          namespace: metalk8s-monitoring
+          labels:
+            app: oauth2-proxy-alertmanager
+            app.kubernetes.io/managed-by: salt
+            app.kubernetes.io/part-of: metalk8s
+            heritage: metalk8s
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: oauth2-proxy-alertmanager
+          template:
+            metadata:
+              labels:
+                app: oauth2-proxy-alertmanager
+            spec:
+              serviceAccountName: oidc-proxy
+              initContainers:
+              - name: k8s-sidecar
+                image: {{ repo.registry_endpoint }}/{{ saltenv }}/k8s-sidecar:1.28.0
+                imagePullPolicy: IfNotPresent
+                restartPolicy: Always
+                env:
+                - name: LABEL
+                  value: metalk8s.scality.com/version
+                - name: FOLDER
+                  value: /tmp/secrets
+                - name: NAMESPACE
+                  value: metalk8s-ingress
+                - name: RESOURCE
+                  value: secret
+                - name: UNIQUE_FILENAMES
+                  value: "true"
+                volumeMounts:
+                - name: secrets-volume
+                  mountPath: /tmp/secrets
+              containers:
+              - name: oauth2-proxy
+                image: {{ repo.registry_endpoint }}/{{ saltenv }}/oauth2-proxy/oauth2-proxy:v7.6.0
+                args:
+                - --provider=oidc
+                - --oidc-issuer-url={{ alertmanager_oidc.get('issuer', '') }}
+                - --client-id={{ alertmanager_oidc.get('audience', '') }}
+                - --cookie-secret=MDEyMzQ1Njc4OWFiY2RlZmdoaWprbG1ub3BxcnN0dXY=
+                - --client-secret=unused-but-required
+                - --skip-jwt-bearer-tokens=true
+                - --email-domain=*
+                - --upstream=http://prometheus-operator-alertmanager.metalk8s-monitoring.svc:9093
+                - --oidc-groups-claim={{ alertmanager_oidc.get('groupsClaim', 'roles') }}
+                {%- for group in alertmanager_oidc.get('authorizedGroups', []) %}
+                - --allowed-group={{ group }}
+                {%- endfor %}
+                - --provider-ca-file=/tmp/secrets/{{ ingress_ca_file }}
+                - --http-address=0.0.0.0:4180
+                ports:
+                - containerPort: 4180
+                volumeMounts:
+                - name: secrets-volume
+                  mountPath: /tmp/secrets
+                  readOnly: true
+              volumes:
+              - name: secrets-volume
+                emptyDir: {}
+
+Create oauth2-proxy-alertmanager Service:
+  metalk8s_kubernetes.object_present:
+    - manifest:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: oauth2-proxy-alertmanager
+          namespace: metalk8s-monitoring
+          labels:
+            app: oauth2-proxy-alertmanager
+            app.kubernetes.io/managed-by: salt
+            app.kubernetes.io/part-of: metalk8s
+            heritage: metalk8s
+        spec:
+          selector:
+            app: oauth2-proxy-alertmanager
+          ports:
+          - port: 4180
+
+{%- else %}
+
+Ensure oauth2-proxy-alertmanager Deployment does not exist:
+  metalk8s_kubernetes.object_absent:
+    - name: oauth2-proxy-alertmanager
+    - namespace: metalk8s-monitoring
+    - kind: Deployment
+    - apiVersion: apps/v1
+
+Ensure oauth2-proxy-alertmanager Service does not exist:
+  metalk8s_kubernetes.object_absent:
+    - name: oauth2-proxy-alertmanager
+    - namespace: metalk8s-monitoring
+    - kind: Service
+    - apiVersion: v1
+
+{%- endif %}

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-alertmanager.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-alertmanager.sls
@@ -1,4 +1,4 @@
-{%- from "metalk8s/map.jinja" import repo with context %}
+{%- from "metalk8s/repo/macro.sls" import build_image_name with context %}
 
 {%- set alertmanager_defaults = salt.slsutil.renderer(
         'salt://metalk8s/addons/prometheus-operator/config/alertmanager.yaml',
@@ -44,7 +44,7 @@ Create oauth2-proxy-alertmanager Deployment:
               serviceAccountName: oidc-proxy
               initContainers:
               - name: k8s-sidecar
-                image: {{ repo.registry_endpoint }}/{{ saltenv }}/k8s-sidecar:1.28.0
+                image: {{ build_image_name("k8s-sidecar") }}
                 imagePullPolicy: IfNotPresent
                 restartPolicy: Always
                 env:
@@ -63,7 +63,7 @@ Create oauth2-proxy-alertmanager Deployment:
                   mountPath: /tmp/secrets
               containers:
               - name: oauth2-proxy
-                image: {{ repo.registry_endpoint }}/{{ saltenv }}/oauth2-proxy/oauth2-proxy:v7.6.0
+                image: {{ build_image_name("oauth2-proxy") }}
                 args:
                 - --provider=oidc
                 - --oidc-issuer-url={{ alertmanager_oidc.get('issuer', '') }}

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-prometheus.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-prometheus.sls
@@ -1,0 +1,127 @@
+{%- from "metalk8s/map.jinja" import repo with context %}
+
+{%- set prometheus_defaults = salt.slsutil.renderer(
+        'salt://metalk8s/addons/prometheus-operator/config/prometheus.yaml',
+        saltenv=saltenv
+    )
+%}
+
+{%- set prometheus = salt.metalk8s_service_configuration.get_service_conf(
+        'metalk8s-monitoring', 'metalk8s-prometheus-config', prometheus_defaults
+    )
+%}
+
+{%- set prometheus_oidc_enabled = prometheus.spec.config.get('enable_oidc_authentication', False) %}
+{%- set prometheus_oidc = prometheus.spec.config.get('oidc', {}) %}
+
+{%- set ingress_ca_file = 'namespace_metalk8s-ingress.secret_ingress-control-plane-default-certificate.tls.crt' %}
+
+{%- if prometheus_oidc_enabled %}
+
+Create oauth2-proxy Deployment:
+  metalk8s_kubernetes.object_present:
+    - manifest:
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: oauth2-proxy
+          namespace: metalk8s-monitoring
+          labels:
+            app: oauth2-proxy
+            app.kubernetes.io/managed-by: salt
+            app.kubernetes.io/part-of: metalk8s
+            heritage: metalk8s
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: oauth2-proxy
+          template:
+            metadata:
+              labels:
+                app: oauth2-proxy
+            spec:
+              serviceAccountName: oidc-proxy
+              initContainers:
+              - name: k8s-sidecar
+                image: {{ repo.registry_endpoint }}/{{ saltenv }}/k8s-sidecar:1.28.0
+                imagePullPolicy: IfNotPresent
+                restartPolicy: Always
+                env:
+                - name: LABEL
+                  value: metalk8s.scality.com/version
+                - name: FOLDER
+                  value: /tmp/secrets
+                - name: NAMESPACE
+                  value: metalk8s-ingress
+                - name: RESOURCE
+                  value: secret
+                - name: UNIQUE_FILENAMES
+                  value: "true"
+                volumeMounts:
+                - name: secrets-volume
+                  mountPath: /tmp/secrets
+              containers:
+              - name: oauth2-proxy
+                image: {{ repo.registry_endpoint }}/{{ saltenv }}/oauth2-proxy/oauth2-proxy:v7.6.0
+                args:
+                - --provider=oidc
+                - --oidc-issuer-url={{ prometheus_oidc.get('issuer', '') }}
+                - --client-id={{ prometheus_oidc.get('audience', '') }}
+                - --cookie-secret=MDEyMzQ1Njc4OWFiY2RlZmdoaWprbG1ub3BxcnN0dXY=
+                - --client-secret=unused-but-required
+                - --skip-jwt-bearer-tokens=true
+                - --email-domain=*
+                - --upstream=http://thanos-query-http.metalk8s-monitoring.svc:10902
+                - --oidc-groups-claim={{ prometheus_oidc.get('groupsClaim', 'roles') }}
+                {%- for group in prometheus_oidc.get('authorizedGroups', []) %}
+                - --allowed-group={{ group }}
+                {%- endfor %}
+                - --provider-ca-file=/tmp/secrets/{{ ingress_ca_file }}
+                - --http-address=0.0.0.0:4180
+                ports:
+                - containerPort: 4180
+                volumeMounts:
+                - name: secrets-volume
+                  mountPath: /tmp/secrets
+                  readOnly: true
+              volumes:
+              - name: secrets-volume
+                emptyDir: {}
+
+Create oauth2-proxy Service:
+  metalk8s_kubernetes.object_present:
+    - manifest:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: oauth2-proxy
+          namespace: metalk8s-monitoring
+          labels:
+            app: oauth2-proxy
+            app.kubernetes.io/managed-by: salt
+            app.kubernetes.io/part-of: metalk8s
+            heritage: metalk8s
+        spec:
+          selector:
+            app: oauth2-proxy
+          ports:
+          - port: 4180
+
+{%- else %}
+
+Ensure oauth2-proxy Deployment does not exist:
+  metalk8s_kubernetes.object_absent:
+    - name: oauth2-proxy
+    - namespace: metalk8s-monitoring
+    - kind: Deployment
+    - apiVersion: apps/v1
+
+Ensure oauth2-proxy Service does not exist:
+  metalk8s_kubernetes.object_absent:
+    - name: oauth2-proxy
+    - namespace: metalk8s-monitoring
+    - kind: Service
+    - apiVersion: v1
+
+{%- endif %}

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-prometheus.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-prometheus.sls
@@ -1,4 +1,4 @@
-{%- from "metalk8s/map.jinja" import repo with context %}
+{%- from "metalk8s/repo/macro.sls" import build_image_name with context %}
 
 {%- set prometheus_defaults = salt.slsutil.renderer(
         'salt://metalk8s/addons/prometheus-operator/config/prometheus.yaml',
@@ -44,7 +44,7 @@ Create oauth2-proxy Deployment:
               serviceAccountName: oidc-proxy
               initContainers:
               - name: k8s-sidecar
-                image: {{ repo.registry_endpoint }}/{{ saltenv }}/k8s-sidecar:1.28.0
+                image: {{ build_image_name("k8s-sidecar") }}
                 imagePullPolicy: IfNotPresent
                 restartPolicy: Always
                 env:
@@ -63,7 +63,7 @@ Create oauth2-proxy Deployment:
                   mountPath: /tmp/secrets
               containers:
               - name: oauth2-proxy
-                image: {{ repo.registry_endpoint }}/{{ saltenv }}/oauth2-proxy/oauth2-proxy:v7.6.0
+                image: {{ build_image_name("oauth2-proxy") }}
                 args:
                 - --provider=oidc
                 - --oidc-issuer-url={{ prometheus_oidc.get('issuer', '') }}

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-prometheus.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-prometheus.sls
@@ -28,9 +28,6 @@ Create oauth2-proxy Deployment:
           namespace: metalk8s-monitoring
           labels:
             app: oauth2-proxy
-            app.kubernetes.io/managed-by: salt
-            app.kubernetes.io/part-of: metalk8s
-            heritage: metalk8s
         spec:
           replicas: 1
           selector:
@@ -99,9 +96,6 @@ Create oauth2-proxy Service:
           namespace: metalk8s-monitoring
           labels:
             app: oauth2-proxy
-            app.kubernetes.io/managed-by: salt
-            app.kubernetes.io/part-of: metalk8s
-            heritage: metalk8s
         spec:
           selector:
             app: oauth2-proxy

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-prometheus.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-prometheus.sls
@@ -14,7 +14,11 @@
 {%- set prometheus_oidc_enabled = prometheus.spec.config.get('enable_oidc_authentication', False) %}
 {%- set prometheus_oidc = prometheus.spec.config.get('oidc', {}) %}
 
-{%- set ingress_ca_file = 'namespace_metalk8s-ingress.secret_ingress-control-plane-default-certificate.tls.crt' %}
+{%- set prometheus_oidc_ca = prometheus_oidc.get('caSecret', {}) %}
+{%- set ca_namespace = prometheus_oidc_ca.get('namespace', '') %}
+{%- set ca_name = prometheus_oidc_ca.get('name', '') %}
+{%- set ca_configured = ca_namespace and ca_name %}
+{%- set ca_file = 'namespace_' ~ ca_namespace ~ '.secret_' ~ ca_name ~ '.tls.crt' %}
 
 {%- if prometheus_oidc_enabled %}
 
@@ -39,6 +43,7 @@ Create oauth2-proxy Deployment:
                 app: oauth2-proxy
             spec:
               serviceAccountName: oidc-proxy
+              {%- if ca_configured %}
               initContainers:
               - name: k8s-sidecar
                 image: {{ build_image_name("k8s-sidecar") }}
@@ -46,11 +51,11 @@ Create oauth2-proxy Deployment:
                 restartPolicy: Always
                 env:
                 - name: LABEL
-                  value: metalk8s.scality.com/version
+                  value: metalk8s.scality.com/oidc-ca
                 - name: FOLDER
                   value: /tmp/secrets
                 - name: NAMESPACE
-                  value: metalk8s-ingress
+                  value: {{ ca_namespace }}
                 - name: RESOURCE
                   value: secret
                 - name: UNIQUE_FILENAMES
@@ -58,6 +63,7 @@ Create oauth2-proxy Deployment:
                 volumeMounts:
                 - name: secrets-volume
                   mountPath: /tmp/secrets
+              {%- endif %}
               containers:
               - name: oauth2-proxy
                 image: {{ build_image_name("oauth2-proxy") }}
@@ -74,7 +80,9 @@ Create oauth2-proxy Deployment:
                 {%- for group in prometheus_oidc.get('authorizedGroups', []) %}
                 - --allowed-group={{ group }}
                 {%- endfor %}
-                - --provider-ca-file=/tmp/secrets/{{ ingress_ca_file }}
+                {%- if ca_configured %}
+                - --provider-ca-file=/tmp/secrets/{{ ca_file }}
+                {%- endif %}
                 - --http-address=0.0.0.0:4180
                 ports:
                 - containerPort: 4180

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-prometheus.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-prometheus.sls
@@ -12,8 +12,8 @@
     )
 %}
 
-{%- set prometheus_oidc_enabled = prometheus.spec.config.get('enable_oidc_authentication', False) %}
-{%- set prometheus_oidc = prometheus.spec.config.get('oidc', {}) %}
+{%- set prometheus_oidc_enabled = prometheus.spec.get('config', {}).get('enable_oidc_authentication', False) %}
+{%- set prometheus_oidc = prometheus.spec.get('config', {}).get('oidc', {}) %}
 
 {%- set prometheus_oidc_ca = prometheus_oidc.get('caSecret', {}) %}
 {%- set ca_namespace = prometheus_oidc_ca.get('namespace', 'metalk8s-ingress') %}

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-prometheus.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-prometheus.sls
@@ -71,6 +71,9 @@ Create oauth2-proxy Deployment:
                 - --provider=oidc
                 - --oidc-issuer-url={{ prometheus_oidc.get('issuer', '') }}
                 - --client-id={{ prometheus_oidc.get('audience', '') }}
+                # cookie-secret is required by oauth2-proxy but never used since all
+                # authentication goes through JWT bearer tokens (--skip-jwt-bearer-tokens=true).
+                # Any valid base64-encoded 32-byte value works here.
                 - --cookie-secret=MDEyMzQ1Njc4OWFiY2RlZmdoaWprbG1ub3BxcnN0dXY=
                 - --client-secret=unused-but-required
                 - --skip-jwt-bearer-tokens=true

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-prometheus.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-prometheus.sls
@@ -15,9 +15,8 @@
 {%- set prometheus_oidc = prometheus.spec.config.get('oidc', {}) %}
 
 {%- set prometheus_oidc_ca = prometheus_oidc.get('caSecret', {}) %}
-{%- set ca_namespace = prometheus_oidc_ca.get('namespace', '') %}
-{%- set ca_name = prometheus_oidc_ca.get('name', '') %}
-{%- set ca_configured = ca_namespace and ca_name %}
+{%- set ca_namespace = prometheus_oidc_ca.get('namespace', 'metalk8s-ingress') %}
+{%- set ca_name = prometheus_oidc_ca.get('name', 'ingress-control-plane-default-certificate') %}
 {%- set ca_file = 'namespace_' ~ ca_namespace ~ '.secret_' ~ ca_name ~ '.tls.crt' %}
 
 {%- if prometheus_oidc_enabled %}
@@ -43,7 +42,6 @@ Create oauth2-proxy-prometheus Deployment:
                 app: oauth2-proxy-prometheus
             spec:
               serviceAccountName: oidc-proxy-prometheus
-              {%- if ca_configured %}
               initContainers:
               - name: k8s-sidecar
                 image: {{ build_image_name("k8s-sidecar") }}
@@ -63,7 +61,6 @@ Create oauth2-proxy-prometheus Deployment:
                 volumeMounts:
                 - name: secrets-volume
                   mountPath: /tmp/secrets
-              {%- endif %}
               containers:
               - name: oauth2-proxy
                 image: {{ build_image_name("oauth2-proxy") }}
@@ -83,9 +80,7 @@ Create oauth2-proxy-prometheus Deployment:
                 {%- for group in prometheus_oidc.get('authorizedGroups', []) %}
                 - --allowed-group={{ group }}
                 {%- endfor %}
-                {%- if ca_configured %}
                 - --provider-ca-file=/tmp/secrets/{{ ca_file }}
-                {%- endif %}
                 - --http-address=0.0.0.0:10902
                 ports:
                 - containerPort: 10902

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-prometheus.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-prometheus.sls
@@ -22,25 +22,25 @@
 
 {%- if prometheus_oidc_enabled %}
 
-Create oauth2-proxy Deployment:
+Create oauth2-proxy-prometheus Deployment:
   metalk8s_kubernetes.object_present:
     - manifest:
         apiVersion: apps/v1
         kind: Deployment
         metadata:
-          name: oauth2-proxy
+          name: oauth2-proxy-prometheus
           namespace: metalk8s-monitoring
           labels:
-            app: oauth2-proxy
+            app: oauth2-proxy-prometheus
         spec:
           replicas: 1
           selector:
             matchLabels:
-              app: oauth2-proxy
+              app: oauth2-proxy-prometheus
           template:
             metadata:
               labels:
-                app: oauth2-proxy
+                app: oauth2-proxy-prometheus
             spec:
               serviceAccountName: oidc-proxy
               {%- if ca_configured %}
@@ -97,34 +97,34 @@ Create oauth2-proxy Deployment:
               - name: secrets-volume
                 emptyDir: {}
 
-Create oauth2-proxy Service:
+Create oauth2-proxy-prometheus Service:
   metalk8s_kubernetes.object_present:
     - manifest:
         apiVersion: v1
         kind: Service
         metadata:
-          name: oauth2-proxy
+          name: oauth2-proxy-prometheus
           namespace: metalk8s-monitoring
           labels:
-            app: oauth2-proxy
+            app: oauth2-proxy-prometheus
         spec:
           selector:
-            app: oauth2-proxy
+            app: oauth2-proxy-prometheus
           ports:
           - port: 4180
 
 {%- else %}
 
-Ensure oauth2-proxy Deployment does not exist:
+Ensure oauth2-proxy-prometheus Deployment does not exist:
   metalk8s_kubernetes.object_absent:
-    - name: oauth2-proxy
+    - name: oauth2-proxy-prometheus
     - namespace: metalk8s-monitoring
     - kind: Deployment
     - apiVersion: apps/v1
 
-Ensure oauth2-proxy Service does not exist:
+Ensure oauth2-proxy-prometheus Service does not exist:
   metalk8s_kubernetes.object_absent:
-    - name: oauth2-proxy
+    - name: oauth2-proxy-prometheus
     - namespace: metalk8s-monitoring
     - kind: Service
     - apiVersion: v1

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-prometheus.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-prometheus.sls
@@ -1,4 +1,5 @@
 {%- from "metalk8s/repo/macro.sls" import build_image_name with context %}
+{%- from "metalk8s/map.jinja" import coredns with context %}
 
 {%- set prometheus_defaults = salt.slsutil.renderer(
         'salt://metalk8s/addons/prometheus-operator/config/prometheus.yaml',
@@ -125,3 +126,25 @@ Ensure oauth2-proxy-prometheus Service does not exist:
     - apiVersion: v1
 
 {%- endif %}
+
+Create prometheus-proxy Service:
+  metalk8s_kubernetes.object_present:
+    - manifest:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: prometheus-proxy
+          namespace: metalk8s-monitoring
+          labels:
+            app.kubernetes.io/managed-by: salt
+            app.kubernetes.io/part-of: metalk8s
+            heritage: metalk8s
+        spec:
+          type: ExternalName
+          {%- if prometheus_oidc_enabled %}
+          externalName: oauth2-proxy-prometheus.metalk8s-monitoring.svc.{{ coredns.cluster_domain }}
+          {%- else %}
+          externalName: thanos-query-http.metalk8s-monitoring.svc.{{ coredns.cluster_domain }}
+          {%- endif %}
+          ports:
+          - port: 10902

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-prometheus.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-prometheus.sls
@@ -86,9 +86,9 @@ Create oauth2-proxy-prometheus Deployment:
                 {%- if ca_configured %}
                 - --provider-ca-file=/tmp/secrets/{{ ca_file }}
                 {%- endif %}
-                - --http-address=0.0.0.0:4180
+                - --http-address=0.0.0.0:10902
                 ports:
-                - containerPort: 4180
+                - containerPort: 10902
                 volumeMounts:
                 - name: secrets-volume
                   mountPath: /tmp/secrets
@@ -111,7 +111,7 @@ Create oauth2-proxy-prometheus Service:
           selector:
             app: oauth2-proxy-prometheus
           ports:
-          - port: 4180
+          - port: 10902
 
 {%- else %}
 

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-prometheus.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-prometheus.sls
@@ -42,7 +42,7 @@ Create oauth2-proxy-prometheus Deployment:
               labels:
                 app: oauth2-proxy-prometheus
             spec:
-              serviceAccountName: oidc-proxy
+              serviceAccountName: oidc-proxy-prometheus
               {%- if ca_configured %}
               initContainers:
               - name: k8s-sidecar

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-rbac.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-rbac.sls
@@ -1,0 +1,106 @@
+{%- from "metalk8s/map.jinja" import repo with context %}
+
+{%- set prometheus_defaults = salt.slsutil.renderer(
+        'salt://metalk8s/addons/prometheus-operator/config/prometheus.yaml',
+        saltenv=saltenv
+    )
+%}
+
+{%- set prometheus = salt.metalk8s_service_configuration.get_service_conf(
+        'metalk8s-monitoring', 'metalk8s-prometheus-config', prometheus_defaults
+    )
+%}
+
+{%- set alertmanager_defaults = salt.slsutil.renderer(
+        'salt://metalk8s/addons/prometheus-operator/config/alertmanager.yaml',
+        saltenv=saltenv
+    )
+%}
+
+{%- set alertmanager = salt.metalk8s_service_configuration.get_service_conf(
+        'metalk8s-monitoring', 'metalk8s-alertmanager-config', alertmanager_defaults
+    )
+%}
+
+{%- set prometheus_oidc_enabled = prometheus.spec.config.get('enable_oidc_authentication', False) %}
+{%- set alertmanager_oidc_enabled = alertmanager.spec.get('config', {}).get('enable_oidc_authentication', False) %}
+
+{%- set oidc_enabled = prometheus_oidc_enabled or alertmanager_oidc_enabled %}
+
+{%- if oidc_enabled %}
+
+Create oidc-proxy ServiceAccount:
+  metalk8s_kubernetes.object_present:
+    - manifest:
+        apiVersion: v1
+        kind: ServiceAccount
+        metadata:
+          name: oidc-proxy
+          namespace: metalk8s-monitoring
+          labels:
+            app.kubernetes.io/managed-by: salt
+            app.kubernetes.io/part-of: metalk8s
+            heritage: metalk8s
+
+Create oidc-proxy-secret-reader Role:
+  metalk8s_kubernetes.object_present:
+    - manifest:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: Role
+        metadata:
+          name: oidc-proxy-secret-reader
+          namespace: metalk8s-ingress
+          labels:
+            app.kubernetes.io/managed-by: salt
+            app.kubernetes.io/part-of: metalk8s
+            heritage: metalk8s
+        rules:
+        - apiGroups: [""]
+          resources: ["secrets"]
+          verbs: ["get", "list", "watch"]
+
+Create oidc-proxy-secret-reader-binding RoleBinding:
+  metalk8s_kubernetes.object_present:
+    - manifest:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        metadata:
+          name: oidc-proxy-secret-reader-binding
+          namespace: metalk8s-ingress
+          labels:
+            app.kubernetes.io/managed-by: salt
+            app.kubernetes.io/part-of: metalk8s
+            heritage: metalk8s
+        subjects:
+        - kind: ServiceAccount
+          name: oidc-proxy
+          namespace: metalk8s-monitoring
+        roleRef:
+          kind: Role
+          name: oidc-proxy-secret-reader
+          apiGroup: rbac.authorization.k8s.io
+
+{%- else %}
+
+Ensure oidc-proxy ServiceAccount does not exist:
+  metalk8s_kubernetes.object_absent:
+    - name: oidc-proxy
+    - namespace: metalk8s-monitoring
+    - kind: ServiceAccount
+    - apiVersion: v1
+
+Ensure oidc-proxy-secret-reader Role does not exist:
+  metalk8s_kubernetes.object_absent:
+    - name: oidc-proxy-secret-reader
+    - namespace: metalk8s-ingress
+    - kind: Role
+    - apiVersion: rbac.authorization.k8s.io/v1
+
+Ensure oidc-proxy-secret-reader-binding RoleBinding does not exist:
+  metalk8s_kubernetes.object_absent:
+    - name: oidc-proxy-secret-reader-binding
+    - namespace: metalk8s-ingress
+    - kind: RoleBinding
+    - apiVersion: rbac.authorization.k8s.io/v1
+
+{%- endif %}

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-rbac.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-rbac.sls
@@ -37,10 +37,6 @@ Create oidc-proxy ServiceAccount:
         metadata:
           name: oidc-proxy
           namespace: metalk8s-monitoring
-          labels:
-            app.kubernetes.io/managed-by: salt
-            app.kubernetes.io/part-of: metalk8s
-            heritage: metalk8s
 
 Create oidc-proxy-secret-reader Role:
   metalk8s_kubernetes.object_present:
@@ -50,10 +46,6 @@ Create oidc-proxy-secret-reader Role:
         metadata:
           name: oidc-proxy-secret-reader
           namespace: metalk8s-ingress
-          labels:
-            app.kubernetes.io/managed-by: salt
-            app.kubernetes.io/part-of: metalk8s
-            heritage: metalk8s
         rules:
         - apiGroups: [""]
           resources: ["secrets"]
@@ -67,10 +59,6 @@ Create oidc-proxy-secret-reader-binding RoleBinding:
         metadata:
           name: oidc-proxy-secret-reader-binding
           namespace: metalk8s-ingress
-          labels:
-            app.kubernetes.io/managed-by: salt
-            app.kubernetes.io/part-of: metalk8s
-            heritage: metalk8s
         subjects:
         - kind: ServiceAccount
           name: oidc-proxy

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-rbac.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-rbac.sls
@@ -23,80 +23,150 @@
 {%- set prometheus_oidc_enabled = prometheus.spec.config.get('enable_oidc_authentication', False) %}
 {%- set alertmanager_oidc_enabled = alertmanager.spec.get('config', {}).get('enable_oidc_authentication', False) %}
 
-{%- set oidc_enabled = prometheus_oidc_enabled or alertmanager_oidc_enabled %}
+{%- set prometheus_ca_namespace = prometheus.spec.config.get('oidc', {}).get('caSecret', {}).get('namespace', '') %}
+{%- set alertmanager_ca_namespace = alertmanager.spec.get('config', {}).get('oidc', {}).get('caSecret', {}).get('namespace', '') %}
 
-{%- set oidc_ca_namespace = prometheus.spec.config.get('oidc', {}).get('caSecret', {}).get('namespace', '') %}
-{%- if not oidc_ca_namespace %}
-  {%- set oidc_ca_namespace = alertmanager.spec.get('config', {}).get('oidc', {}).get('caSecret', {}).get('namespace', '') %}
-{%- endif %}
+{%- if prometheus_oidc_enabled %}
 
-{%- if oidc_enabled %}
-
-Create oidc-proxy ServiceAccount:
+Create oidc-proxy-prometheus ServiceAccount:
   metalk8s_kubernetes.object_present:
     - manifest:
         apiVersion: v1
         kind: ServiceAccount
         metadata:
-          name: oidc-proxy
+          name: oidc-proxy-prometheus
           namespace: metalk8s-monitoring
 
-{%- if oidc_ca_namespace %}
+{%- if prometheus_ca_namespace %}
 
-Create oidc-proxy-secret-reader Role in {{ oidc_ca_namespace }}:
+Create oidc-proxy-prometheus-secret-reader Role in {{ prometheus_ca_namespace }}:
   metalk8s_kubernetes.object_present:
     - manifest:
         apiVersion: rbac.authorization.k8s.io/v1
         kind: Role
         metadata:
-          name: oidc-proxy-secret-reader
-          namespace: {{ oidc_ca_namespace }}
+          name: oidc-proxy-prometheus-secret-reader
+          namespace: {{ prometheus_ca_namespace }}
         rules:
         - apiGroups: [""]
           resources: ["secrets"]
           verbs: ["get", "list", "watch"]
 
-Create oidc-proxy-secret-reader-binding RoleBinding in {{ oidc_ca_namespace }}:
+Create oidc-proxy-prometheus-secret-reader-binding RoleBinding in {{ prometheus_ca_namespace }}:
   metalk8s_kubernetes.object_present:
     - manifest:
         apiVersion: rbac.authorization.k8s.io/v1
         kind: RoleBinding
         metadata:
-          name: oidc-proxy-secret-reader-binding
-          namespace: {{ oidc_ca_namespace }}
+          name: oidc-proxy-prometheus-secret-reader-binding
+          namespace: {{ prometheus_ca_namespace }}
         subjects:
         - kind: ServiceAccount
-          name: oidc-proxy
+          name: oidc-proxy-prometheus
           namespace: metalk8s-monitoring
         roleRef:
           kind: Role
-          name: oidc-proxy-secret-reader
+          name: oidc-proxy-prometheus-secret-reader
           apiGroup: rbac.authorization.k8s.io
 
 {%- endif %}
 
 {%- else %}
 
-Ensure oidc-proxy ServiceAccount does not exist:
+Ensure oidc-proxy-prometheus ServiceAccount does not exist:
   metalk8s_kubernetes.object_absent:
-    - name: oidc-proxy
+    - name: oidc-proxy-prometheus
     - namespace: metalk8s-monitoring
     - kind: ServiceAccount
     - apiVersion: v1
 
-{%- if oidc_ca_namespace %}
+{%- if prometheus_ca_namespace %}
 
-Ensure oidc-proxy-secret-reader Role does not exist:
+Ensure oidc-proxy-prometheus-secret-reader Role does not exist in {{ prometheus_ca_namespace }}:
   metalk8s_kubernetes.object_absent:
-    - name: oidc-proxy-secret-reader
-    - namespace: {{ oidc_ca_namespace }}
+    - name: oidc-proxy-prometheus-secret-reader
+    - namespace: {{ prometheus_ca_namespace }}
     - kind: Role
     - apiVersion: rbac.authorization.k8s.io/v1
 
-Ensure oidc-proxy-secret-reader-binding RoleBinding does not exist:
+Ensure oidc-proxy-prometheus-secret-reader-binding RoleBinding does not exist in {{ prometheus_ca_namespace }}:
   metalk8s_kubernetes.object_absent:
-    - name: oidc-proxy-secret-reader-binding
-    - namespace: {{ oidc_ca_namespace }}
+    - name: oidc-proxy-prometheus-secret-reader-binding
+    - namespace: {{ prometheus_ca_namespace }}
+    - kind: RoleBinding
+    - apiVersion: rbac.authorization.k8s.io/v1
+
+{%- endif %}
+
+{%- endif %}
+
+{%- if alertmanager_oidc_enabled %}
+
+Create oidc-proxy-alertmanager ServiceAccount:
+  metalk8s_kubernetes.object_present:
+    - manifest:
+        apiVersion: v1
+        kind: ServiceAccount
+        metadata:
+          name: oidc-proxy-alertmanager
+          namespace: metalk8s-monitoring
+
+{%- if alertmanager_ca_namespace %}
+
+Create oidc-proxy-alertmanager-secret-reader Role in {{ alertmanager_ca_namespace }}:
+  metalk8s_kubernetes.object_present:
+    - manifest:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: Role
+        metadata:
+          name: oidc-proxy-alertmanager-secret-reader
+          namespace: {{ alertmanager_ca_namespace }}
+        rules:
+        - apiGroups: [""]
+          resources: ["secrets"]
+          verbs: ["get", "list", "watch"]
+
+Create oidc-proxy-alertmanager-secret-reader-binding RoleBinding in {{ alertmanager_ca_namespace }}:
+  metalk8s_kubernetes.object_present:
+    - manifest:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        metadata:
+          name: oidc-proxy-alertmanager-secret-reader-binding
+          namespace: {{ alertmanager_ca_namespace }}
+        subjects:
+        - kind: ServiceAccount
+          name: oidc-proxy-alertmanager
+          namespace: metalk8s-monitoring
+        roleRef:
+          kind: Role
+          name: oidc-proxy-alertmanager-secret-reader
+          apiGroup: rbac.authorization.k8s.io
+
+{%- endif %}
+
+{%- else %}
+
+Ensure oidc-proxy-alertmanager ServiceAccount does not exist:
+  metalk8s_kubernetes.object_absent:
+    - name: oidc-proxy-alertmanager
+    - namespace: metalk8s-monitoring
+    - kind: ServiceAccount
+    - apiVersion: v1
+
+{%- if alertmanager_ca_namespace %}
+
+Ensure oidc-proxy-alertmanager-secret-reader Role does not exist in {{ alertmanager_ca_namespace }}:
+  metalk8s_kubernetes.object_absent:
+    - name: oidc-proxy-alertmanager-secret-reader
+    - namespace: {{ alertmanager_ca_namespace }}
+    - kind: Role
+    - apiVersion: rbac.authorization.k8s.io/v1
+
+Ensure oidc-proxy-alertmanager-secret-reader-binding RoleBinding does not exist in {{ alertmanager_ca_namespace }}:
+  metalk8s_kubernetes.object_absent:
+    - name: oidc-proxy-alertmanager-secret-reader-binding
+    - namespace: {{ alertmanager_ca_namespace }}
     - kind: RoleBinding
     - apiVersion: rbac.authorization.k8s.io/v1
 

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-rbac.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-rbac.sls
@@ -1,5 +1,3 @@
-{%- from "metalk8s/map.jinja" import repo with context %}
-
 {%- set prometheus_defaults = salt.slsutil.renderer(
         'salt://metalk8s/addons/prometheus-operator/config/prometheus.yaml',
         saltenv=saltenv
@@ -27,6 +25,11 @@
 
 {%- set oidc_enabled = prometheus_oidc_enabled or alertmanager_oidc_enabled %}
 
+{%- set oidc_ca_namespace = prometheus.spec.config.get('oidc', {}).get('caSecret', {}).get('namespace', '') %}
+{%- if not oidc_ca_namespace %}
+  {%- set oidc_ca_namespace = alertmanager.spec.get('config', {}).get('oidc', {}).get('caSecret', {}).get('namespace', '') %}
+{%- endif %}
+
 {%- if oidc_enabled %}
 
 Create oidc-proxy ServiceAccount:
@@ -38,27 +41,29 @@ Create oidc-proxy ServiceAccount:
           name: oidc-proxy
           namespace: metalk8s-monitoring
 
-Create oidc-proxy-secret-reader Role:
+{%- if oidc_ca_namespace %}
+
+Create oidc-proxy-secret-reader Role in {{ oidc_ca_namespace }}:
   metalk8s_kubernetes.object_present:
     - manifest:
         apiVersion: rbac.authorization.k8s.io/v1
         kind: Role
         metadata:
           name: oidc-proxy-secret-reader
-          namespace: metalk8s-ingress
+          namespace: {{ oidc_ca_namespace }}
         rules:
         - apiGroups: [""]
           resources: ["secrets"]
           verbs: ["get", "list", "watch"]
 
-Create oidc-proxy-secret-reader-binding RoleBinding:
+Create oidc-proxy-secret-reader-binding RoleBinding in {{ oidc_ca_namespace }}:
   metalk8s_kubernetes.object_present:
     - manifest:
         apiVersion: rbac.authorization.k8s.io/v1
         kind: RoleBinding
         metadata:
           name: oidc-proxy-secret-reader-binding
-          namespace: metalk8s-ingress
+          namespace: {{ oidc_ca_namespace }}
         subjects:
         - kind: ServiceAccount
           name: oidc-proxy
@@ -67,6 +72,8 @@ Create oidc-proxy-secret-reader-binding RoleBinding:
           kind: Role
           name: oidc-proxy-secret-reader
           apiGroup: rbac.authorization.k8s.io
+
+{%- endif %}
 
 {%- else %}
 
@@ -77,18 +84,22 @@ Ensure oidc-proxy ServiceAccount does not exist:
     - kind: ServiceAccount
     - apiVersion: v1
 
+{%- if oidc_ca_namespace %}
+
 Ensure oidc-proxy-secret-reader Role does not exist:
   metalk8s_kubernetes.object_absent:
     - name: oidc-proxy-secret-reader
-    - namespace: metalk8s-ingress
+    - namespace: {{ oidc_ca_namespace }}
     - kind: Role
     - apiVersion: rbac.authorization.k8s.io/v1
 
 Ensure oidc-proxy-secret-reader-binding RoleBinding does not exist:
   metalk8s_kubernetes.object_absent:
     - name: oidc-proxy-secret-reader-binding
-    - namespace: metalk8s-ingress
+    - namespace: {{ oidc_ca_namespace }}
     - kind: RoleBinding
     - apiVersion: rbac.authorization.k8s.io/v1
+
+{%- endif %}
 
 {%- endif %}

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-rbac.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-rbac.sls
@@ -20,11 +20,11 @@
     )
 %}
 
-{%- set prometheus_oidc_enabled = prometheus.spec.config.get('enable_oidc_authentication', False) %}
+{%- set prometheus_oidc_enabled = prometheus.spec.get('config', {}).get('enable_oidc_authentication', False) %}
 {%- set alertmanager_oidc_enabled = alertmanager.spec.get('config', {}).get('enable_oidc_authentication', False) %}
 
-{%- set prometheus_ca_namespace = prometheus.spec.config.get('oidc', {}).get('caSecret', {}).get('namespace', '') %}
-{%- set alertmanager_ca_namespace = alertmanager.spec.get('config', {}).get('oidc', {}).get('caSecret', {}).get('namespace', '') %}
+{%- set prometheus_ca_namespace = prometheus.spec.get('config', {}).get('oidc', {}).get('caSecret', {}).get('namespace', 'metalk8s-ingress') %}
+{%- set alertmanager_ca_namespace = alertmanager.spec.get('config', {}).get('oidc', {}).get('caSecret', {}).get('namespace', 'metalk8s-ingress') %}
 
 {%- if prometheus_oidc_enabled %}
 
@@ -36,8 +36,6 @@ Create oidc-proxy-prometheus ServiceAccount:
         metadata:
           name: oidc-proxy-prometheus
           namespace: metalk8s-monitoring
-
-{%- if prometheus_ca_namespace %}
 
 Create oidc-proxy-prometheus-secret-reader Role in {{ prometheus_ca_namespace }}:
   metalk8s_kubernetes.object_present:
@@ -69,8 +67,6 @@ Create oidc-proxy-prometheus-secret-reader-binding RoleBinding in {{ prometheus_
           name: oidc-proxy-prometheus-secret-reader
           apiGroup: rbac.authorization.k8s.io
 
-{%- endif %}
-
 {%- else %}
 
 Ensure oidc-proxy-prometheus ServiceAccount does not exist:
@@ -79,8 +75,6 @@ Ensure oidc-proxy-prometheus ServiceAccount does not exist:
     - namespace: metalk8s-monitoring
     - kind: ServiceAccount
     - apiVersion: v1
-
-{%- if prometheus_ca_namespace %}
 
 Ensure oidc-proxy-prometheus-secret-reader Role does not exist in {{ prometheus_ca_namespace }}:
   metalk8s_kubernetes.object_absent:
@@ -98,8 +92,6 @@ Ensure oidc-proxy-prometheus-secret-reader-binding RoleBinding does not exist in
 
 {%- endif %}
 
-{%- endif %}
-
 {%- if alertmanager_oidc_enabled %}
 
 Create oidc-proxy-alertmanager ServiceAccount:
@@ -110,8 +102,6 @@ Create oidc-proxy-alertmanager ServiceAccount:
         metadata:
           name: oidc-proxy-alertmanager
           namespace: metalk8s-monitoring
-
-{%- if alertmanager_ca_namespace %}
 
 Create oidc-proxy-alertmanager-secret-reader Role in {{ alertmanager_ca_namespace }}:
   metalk8s_kubernetes.object_present:
@@ -143,8 +133,6 @@ Create oidc-proxy-alertmanager-secret-reader-binding RoleBinding in {{ alertmana
           name: oidc-proxy-alertmanager-secret-reader
           apiGroup: rbac.authorization.k8s.io
 
-{%- endif %}
-
 {%- else %}
 
 Ensure oidc-proxy-alertmanager ServiceAccount does not exist:
@@ -153,8 +141,6 @@ Ensure oidc-proxy-alertmanager ServiceAccount does not exist:
     - namespace: metalk8s-monitoring
     - kind: ServiceAccount
     - apiVersion: v1
-
-{%- if alertmanager_ca_namespace %}
 
 Ensure oidc-proxy-alertmanager-secret-reader Role does not exist in {{ alertmanager_ca_namespace }}:
   metalk8s_kubernetes.object_absent:
@@ -169,7 +155,5 @@ Ensure oidc-proxy-alertmanager-secret-reader-binding RoleBinding does not exist 
     - namespace: {{ alertmanager_ca_namespace }}
     - kind: RoleBinding
     - apiVersion: rbac.authorization.k8s.io/v1
-
-{%- endif %}
 
 {%- endif %}

--- a/salt/metalk8s/addons/ui/deployed/dependencies.sls
+++ b/salt/metalk8s/addons/ui/deployed/dependencies.sls
@@ -77,6 +77,42 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
+  name: oauth2-proxy
+  namespace: metalk8s-ui
+  labels:
+    app: metalk8s-ui
+    app.kubernetes.io/managed-by: salt
+    app.kubernetes.io/name: metalk8s-ui
+    app.kubernetes.io/part-of: metalk8s
+    heritage: metalk8s
+spec:
+  type: ExternalName
+  externalName: oauth2-proxy.metalk8s-monitoring.svc.{{ coredns.cluster_domain }}
+  ports:
+    - name: http
+      port: 4180
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: oauth2-proxy-alertmanager
+  namespace: metalk8s-ui
+  labels:
+    app: metalk8s-ui
+    app.kubernetes.io/managed-by: salt
+    app.kubernetes.io/name: metalk8s-ui
+    app.kubernetes.io/part-of: metalk8s
+    heritage: metalk8s
+spec:
+  type: ExternalName
+  externalName: oauth2-proxy-alertmanager.metalk8s-monitoring.svc.{{ coredns.cluster_domain }}
+  ports:
+    - name: http
+      port: 4180
+---
+kind: Service
+apiVersion: v1
+metadata:
   name: loki-api
   namespace: metalk8s-ui
   labels:

--- a/salt/metalk8s/addons/ui/deployed/dependencies.sls
+++ b/salt/metalk8s/addons/ui/deployed/dependencies.sls
@@ -2,32 +2,6 @@
 
 {%- from "metalk8s/map.jinja" import coredns with context %}
 
-{%- set prometheus_defaults = salt.slsutil.renderer(
-        'salt://metalk8s/addons/prometheus-operator/config/prometheus.yaml',
-        saltenv=saltenv
-    )
-%}
-
-{%- set prometheus = salt.metalk8s_service_configuration.get_service_conf(
-        'metalk8s-monitoring', 'metalk8s-prometheus-config', prometheus_defaults
-    )
-%}
-
-{%- set prometheus_oidc_enabled = prometheus.spec.config.get('enable_oidc_authentication', False) %}
-
-{%- set alertmanager_defaults = salt.slsutil.renderer(
-        'salt://metalk8s/addons/prometheus-operator/config/alertmanager.yaml',
-        saltenv=saltenv
-    )
-%}
-
-{%- set alertmanager = salt.metalk8s_service_configuration.get_service_conf(
-        'metalk8s-monitoring', 'metalk8s-alertmanager-config', alertmanager_defaults
-    )
-%}
-
-{%- set alertmanager_oidc_enabled = alertmanager.spec.get('config', {}).get('enable_oidc_authentication', False) %}
-
 kind: Service
 apiVersion: v1
 metadata:
@@ -77,11 +51,7 @@ metadata:
     heritage: metalk8s
 spec:
   type: ExternalName
-  {%- if prometheus_oidc_enabled %}
-  externalName: oauth2-proxy-prometheus.metalk8s-monitoring.svc.{{ coredns.cluster_domain }}
-  {%- else %}
-  externalName: thanos-query-http.metalk8s-monitoring.svc.{{ coredns.cluster_domain }}
-  {%- endif %}
+  externalName: prometheus-proxy.metalk8s-monitoring.svc.{{ coredns.cluster_domain }}
   ports:
     - name: http
       port: 10902
@@ -99,11 +69,7 @@ metadata:
     heritage: metalk8s
 spec:
   type: ExternalName
-  {%- if alertmanager_oidc_enabled %}
-  externalName: oauth2-proxy-alertmanager.metalk8s-monitoring.svc.{{ coredns.cluster_domain }}
-  {%- else %}
-  externalName: prometheus-operator-alertmanager.metalk8s-monitoring.svc.{{ coredns.cluster_domain }}
-  {%- endif %}
+  externalName: alertmanager-proxy.metalk8s-monitoring.svc.{{ coredns.cluster_domain }}
   ports:
     - name: http
       port: 9093

--- a/salt/metalk8s/addons/ui/deployed/dependencies.sls
+++ b/salt/metalk8s/addons/ui/deployed/dependencies.sls
@@ -2,6 +2,32 @@
 
 {%- from "metalk8s/map.jinja" import coredns with context %}
 
+{%- set prometheus_defaults = salt.slsutil.renderer(
+        'salt://metalk8s/addons/prometheus-operator/config/prometheus.yaml',
+        saltenv=saltenv
+    )
+%}
+
+{%- set prometheus = salt.metalk8s_service_configuration.get_service_conf(
+        'metalk8s-monitoring', 'metalk8s-prometheus-config', prometheus_defaults
+    )
+%}
+
+{%- set prometheus_oidc_enabled = prometheus.spec.config.get('enable_oidc_authentication', False) %}
+
+{%- set alertmanager_defaults = salt.slsutil.renderer(
+        'salt://metalk8s/addons/prometheus-operator/config/alertmanager.yaml',
+        saltenv=saltenv
+    )
+%}
+
+{%- set alertmanager = salt.metalk8s_service_configuration.get_service_conf(
+        'metalk8s-monitoring', 'metalk8s-alertmanager-config', alertmanager_defaults
+    )
+%}
+
+{%- set alertmanager_oidc_enabled = alertmanager.spec.get('config', {}).get('enable_oidc_authentication', False) %}
+
 kind: Service
 apiVersion: v1
 metadata:
@@ -51,10 +77,18 @@ metadata:
     heritage: metalk8s
 spec:
   type: ExternalName
+  {%- if prometheus_oidc_enabled %}
+  externalName: oauth2-proxy.metalk8s-monitoring.svc.{{ coredns.cluster_domain }}
+  {%- else %}
   externalName: thanos-query-http.metalk8s-monitoring.svc.{{ coredns.cluster_domain }}
+  {%- endif %}
   ports:
     - name: http
+      {%- if prometheus_oidc_enabled %}
+      port: 4180
+      {%- else %}
       port: 10902
+      {%- endif %}
 ---
 kind: Service
 apiVersion: v1
@@ -69,46 +103,18 @@ metadata:
     heritage: metalk8s
 spec:
   type: ExternalName
-  externalName: prometheus-operator-alertmanager.metalk8s-monitoring.svc.{{ coredns.cluster_domain }}
-  ports:
-    - name: http
-      port: 9093
----
-kind: Service
-apiVersion: v1
-metadata:
-  name: oauth2-proxy
-  namespace: metalk8s-ui
-  labels:
-    app: metalk8s-ui
-    app.kubernetes.io/managed-by: salt
-    app.kubernetes.io/name: metalk8s-ui
-    app.kubernetes.io/part-of: metalk8s
-    heritage: metalk8s
-spec:
-  type: ExternalName
-  externalName: oauth2-proxy.metalk8s-monitoring.svc.{{ coredns.cluster_domain }}
-  ports:
-    - name: http
-      port: 4180
----
-kind: Service
-apiVersion: v1
-metadata:
-  name: oauth2-proxy-alertmanager
-  namespace: metalk8s-ui
-  labels:
-    app: metalk8s-ui
-    app.kubernetes.io/managed-by: salt
-    app.kubernetes.io/name: metalk8s-ui
-    app.kubernetes.io/part-of: metalk8s
-    heritage: metalk8s
-spec:
-  type: ExternalName
+  {%- if alertmanager_oidc_enabled %}
   externalName: oauth2-proxy-alertmanager.metalk8s-monitoring.svc.{{ coredns.cluster_domain }}
+  {%- else %}
+  externalName: prometheus-operator-alertmanager.metalk8s-monitoring.svc.{{ coredns.cluster_domain }}
+  {%- endif %}
   ports:
     - name: http
+      {%- if alertmanager_oidc_enabled %}
       port: 4180
+      {%- else %}
+      port: 9093
+      {%- endif %}
 ---
 kind: Service
 apiVersion: v1

--- a/salt/metalk8s/addons/ui/deployed/dependencies.sls
+++ b/salt/metalk8s/addons/ui/deployed/dependencies.sls
@@ -78,17 +78,13 @@ metadata:
 spec:
   type: ExternalName
   {%- if prometheus_oidc_enabled %}
-  externalName: oauth2-proxy.metalk8s-monitoring.svc.{{ coredns.cluster_domain }}
+  externalName: oauth2-proxy-prometheus.metalk8s-monitoring.svc.{{ coredns.cluster_domain }}
   {%- else %}
   externalName: thanos-query-http.metalk8s-monitoring.svc.{{ coredns.cluster_domain }}
   {%- endif %}
   ports:
     - name: http
-      {%- if prometheus_oidc_enabled %}
-      port: 4180
-      {%- else %}
       port: 10902
-      {%- endif %}
 ---
 kind: Service
 apiVersion: v1
@@ -110,11 +106,7 @@ spec:
   {%- endif %}
   ports:
     - name: http
-      {%- if alertmanager_oidc_enabled %}
-      port: 4180
-      {%- else %}
       port: 9093
-      {%- endif %}
 ---
 kind: Service
 apiVersion: v1

--- a/salt/metalk8s/addons/ui/deployed/ingress.sls
+++ b/salt/metalk8s/addons/ui/deployed/ingress.sls
@@ -13,32 +13,6 @@
 {%- set stripped_base_path = metalk8s_ui_config.spec.basePath.strip('/') %}
 {%- set normalized_base_path = '/' ~ stripped_base_path %}
 
-{%- set prometheus_defaults = salt.slsutil.renderer(
-        'salt://metalk8s/addons/prometheus-operator/config/prometheus.yaml',
-        saltenv=saltenv
-    )
-%}
-
-{%- set prometheus = salt.metalk8s_service_configuration.get_service_conf(
-        'metalk8s-monitoring', 'metalk8s-prometheus-config', prometheus_defaults
-    )
-%}
-
-{%- set prometheus_oidc_enabled = prometheus.spec.config.get('enable_oidc_authentication', False) %}
-
-{%- set alertmanager_defaults = salt.slsutil.renderer(
-        'salt://metalk8s/addons/prometheus-operator/config/alertmanager.yaml',
-        saltenv=saltenv
-    )
-%}
-
-{%- set alertmanager = salt.metalk8s_service_configuration.get_service_conf(
-        'metalk8s-monitoring', 'metalk8s-alertmanager-config', alertmanager_defaults
-    )
-%}
-
-{%- set alertmanager_oidc_enabled = alertmanager.spec.get('config', {}).get('enable_oidc_authentication', False) %}
-
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -103,28 +77,16 @@ spec:
         pathType: Prefix
         backend:
           service:
-            {%- if prometheus_oidc_enabled %}
-            name: oauth2-proxy
-            port:
-              number: 4180
-            {%- else %}
             name: thanos-api
             port:
-              number: 10902
-            {%- endif %}
+              name: http
       - path: /api/alertmanager(/|$)(.*)
         pathType: Prefix
         backend:
           service:
-            {%- if alertmanager_oidc_enabled %}
-            name: oauth2-proxy-alertmanager
-            port:
-              number: 4180
-            {%- else %}
             name: alertmanager-api
             port:
-              number: 9093
-            {%- endif %}
+              name: http
       {%- if pillar.addons.loki.enabled %}
       - path: /api/loki(/|$)(.*)
         pathType: Prefix

--- a/salt/metalk8s/addons/ui/deployed/ingress.sls
+++ b/salt/metalk8s/addons/ui/deployed/ingress.sls
@@ -13,6 +13,32 @@
 {%- set stripped_base_path = metalk8s_ui_config.spec.basePath.strip('/') %}
 {%- set normalized_base_path = '/' ~ stripped_base_path %}
 
+{%- set prometheus_defaults = salt.slsutil.renderer(
+        'salt://metalk8s/addons/prometheus-operator/config/prometheus.yaml',
+        saltenv=saltenv
+    )
+%}
+
+{%- set prometheus = salt.metalk8s_service_configuration.get_service_conf(
+        'metalk8s-monitoring', 'metalk8s-prometheus-config', prometheus_defaults
+    )
+%}
+
+{%- set prometheus_oidc_enabled = prometheus.spec.config.get('enable_oidc_authentication', False) %}
+
+{%- set alertmanager_defaults = salt.slsutil.renderer(
+        'salt://metalk8s/addons/prometheus-operator/config/alertmanager.yaml',
+        saltenv=saltenv
+    )
+%}
+
+{%- set alertmanager = salt.metalk8s_service_configuration.get_service_conf(
+        'metalk8s-monitoring', 'metalk8s-alertmanager-config', alertmanager_defaults
+    )
+%}
+
+{%- set alertmanager_oidc_enabled = alertmanager.spec.get('config', {}).get('enable_oidc_authentication', False) %}
+
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -77,16 +103,28 @@ spec:
         pathType: Prefix
         backend:
           service:
+            {%- if prometheus_oidc_enabled %}
+            name: oauth2-proxy
+            port:
+              number: 4180
+            {%- else %}
             name: thanos-api
             port:
               number: 10902
+            {%- endif %}
       - path: /api/alertmanager(/|$)(.*)
         pathType: Prefix
         backend:
           service:
+            {%- if alertmanager_oidc_enabled %}
+            name: oauth2-proxy-alertmanager
+            port:
+              number: 4180
+            {%- else %}
             name: alertmanager-api
             port:
               number: 9093
+            {%- endif %}
       {%- if pillar.addons.loki.enabled %}
       - path: /api/loki(/|$)(.*)
         pathType: Prefix


### PR DESCRIPTION
**Component**: Salt

## Context

The `PrometheusConfig` and `AlertManagerConfig` CRDs have been extended (in a previous PR) with an `enable_oidc_authentication` flag and an `oidc` configuration block.

This PR deploys the Salt resources needed to support OIDC authentication for Prometheus and Alertmanager.

## Solution

### Stable proxy services (always created)

Instead of having the UI state conditionally point to different backends, this PR introduces two stable `ExternalName` services — always created by the prometheus-operator Salt state — that act as a routing layer:

| Service | OIDC enabled | OIDC disabled |
|---|---|---|
| `prometheus-proxy` | → `oauth2-proxy-prometheus` | → `thanos-query-http` |
| `alertmanager-proxy` | → `oauth2-proxy-alertmanager` | → `prometheus-operator-alertmanager` |

The UI Salt state always points to `prometheus-proxy` and `alertmanager-proxy`. **Toggling OIDC on/off only requires re-applying the prometheus-operator Salt state** — the UI state never needs to change.

### oauth2-proxy deployment (conditional)

When OIDC is enabled, a `oauth2-proxy` Deployment and Service are created for each of Prometheus and Alertmanager.

### RBAC (`oidc-proxy-rbac.sls`)

ServiceAccounts, Roles, and RoleBindings that allow the oauth2-proxy pods to read the CA certificate Secret from the configured namespace.

### Configurable CA certificate

A `caSecret` field has been added to the OIDC config in `prometheus.yaml` and `alertmanager.yaml`, so operators can point to any Kubernetes Secret containing the CA certificate. Defaults to the control plane ingress certificate in `metalk8s-ingress`.

## Future Work

- [ ] SLS Template Rendering Tests (Unit Tests)
- [x] Add oauth2-proxy image to MetalK8s build chain
- [ ] Restart script
- [ ] UI update to include auth token
- [ ] Documentation

## Acceptance Criteria

Ref: https://github.com/scality/citadel/pull/306