### PR TITLE
MK8S-150: Fix incorrect icons for Nodes and Volumes in dashboard and sidebar

### DIFF
--- a/ui/src/components/DashboardInventory.tsx
+++ b/ui/src/components/DashboardInventory.tsx
@@ -102,7 +102,7 @@ const DashboardInventory = () => {
                 <InventoryIcon>
                   <StatusWrapper status={nodesStatus}>
                     <Icon
-                      name="Exclamation-circle"
+                      name="Node-pdf"
                       color={getStatusColor(nodesStatus)}
                       ariaLabel={`Nodes status is ${nodesStatus}`}
                     />
@@ -137,7 +137,7 @@ const DashboardInventory = () => {
                 <InventoryIcon>
                   <StatusWrapper status={volumesStatus}>
                     <Icon
-                      name="Volume-backend"
+                      name="Volume-pdf"
                       color={getStatusColor(volumesStatus)}
                       ariaLabel={`Volumes status is ${volumesStatus}`}
                     />

--- a/ui/src/containers/Layout.tsx
+++ b/ui/src/containers/Layout.tsx
@@ -114,7 +114,7 @@ const Layout = () => {
         label: intl.formatMessage({
           id: 'nodes',
         }),
-        icon: <Icon name="Node-backend" />,
+        icon: <Icon name="Node-pdf" />,
         onClick: () => {
           navigate('/nodes');
         },
@@ -125,7 +125,7 @@ const Layout = () => {
         label: intl.formatMessage({
           id: 'volumes',
         }),
-        icon: <Icon name="Node-pdf" />,
+        icon: <Icon name="Volume-pdf" />,
         onClick: () => {
           navigate('/volumes');
         },


### PR DESCRIPTION
## Context
The Platform dashboard and sidebar were displaying incorrect icons for Nodes and Volumes sections.
Ticket: https://scality.atlassian.net/browse/MK8S-150

<img width="1503" height="1410" alt="image" src="https://github.com/user-attachments/assets/89dcd8d3-e971-41b2-b5f1-6ee16326fd98" />

