### PR TITLE
MK8S-143 - Add oauth2-proxy to the buildchain

### DIFF
--- a/buildchain/buildchain/constants.py
+++ b/buildchain/buildchain/constants.py
@@ -32,6 +32,7 @@ PROMETHEUS_OPERATOR_REPOSITORY: str = "quay.io/prometheus-operator"
 PROMETHEUS_REPOSITORY: str = "quay.io/prometheus"
 THANOS_REPOSITORY: str = "quay.io/thanos"
 CERT_MANAGER_REPOSITORY: str = "quay.io/jetstack"
+OAUTH2_PROXY_REPOSITORY: str = "quay.io/oauth2-proxy"
 SCALITY_REPOSITORY: str = "ghcr.io/scality"
 
 # Paths {{{

--- a/buildchain/buildchain/image.py
+++ b/buildchain/buildchain/image.py
@@ -217,6 +217,9 @@ IMGS_PER_REPOSITORY: Dict[str, List[str]] = {
         "cert-manager-cainjector",
         "cert-manager-acmesolver",
     ],
+    constants.OAUTH2_PROXY_REPOSITORY: [
+        "oauth2-proxy",
+    ],
     constants.SCALITY_REPOSITORY: [
         "ui-operator",
         "crl-operator",

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -197,6 +197,11 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
         digest="sha256:4032c6d5bfd752342c3e631c2f1de93ba6b86c41db6b167b9a35372c139e7706",
     ),
     Image(
+        name="oauth2-proxy",
+        version="v7.14.3",
+        digest="sha256:68336da945bdaff799262c8d14fb1d1aa9354df5e02b87e0955addc040344618",
+    ),
+    Image(
         name="pause",
         version="3.10",
         # Do not check the digest for this image, since this one is re-published


### PR DESCRIPTION
**Component**: builds 

**Context**: 
Adding oauth2-proxy image to MetalK8s for OIDC authentication support. The image needs to be embedded in the ISO and pulled from the local container registry during deployment.

**Summary**:

- Added **oauth2-proxy latest v7.14.3** to the buildchain with pinned SHA256 digest for security and reproducibility

- Configured image repository mapping to quay.io/oauth2-proxy

- Image will be pulled during ISO build and served via static nginx registry at deployment time

- Digest verification ensures exact image binary: sha256:68336da945bdaff799262c8d14fb1d1aa9354df5e02b87e0955addc040344618


**Acceptance criteria**: 
✅ Image can be referenced in Salt states via build_image_name("oauth2-proxy")




( will need label metalk8s.scality.com/oidc-ca: "true" to be set on secret in the next PR )