### PR TITLE
Add ability to add `ServiceMonitor` for solutions operator

### DIFF
--- a/.github/workflows/multi-node-test.yaml
+++ b/.github/workflows/multi-node-test.yaml
@@ -62,7 +62,7 @@ on:
         description: "The solution version to install"
         required: false
         type: string
-        default: "1.1.0"
+        default: "1.1.1"
       solution-base-url:
         description: "The URL to download the solution"
         required: false

--- a/.github/workflows/multi-node-test.yaml
+++ b/.github/workflows/multi-node-test.yaml
@@ -62,7 +62,7 @@ on:
         description: "The solution version to install"
         required: false
         type: string
-        default: "1.0.2"
+        default: "1.1.0"
       solution-base-url:
         description: "The URL to download the solution"
         required: false

--- a/.github/workflows/single-node-test.yaml
+++ b/.github/workflows/single-node-test.yaml
@@ -226,7 +226,7 @@ jobs:
         if: inputs.test-solution
         uses: ./.github/actions/bastion-tests
         with:
-          PYTEST_FILTERS: "solution"
+          PYTEST_FILTERS: "solution-upgrade"
       - name: Run tests from Bastion
         uses: ./.github/actions/bastion-tests
         with:

--- a/.github/workflows/single-node-test.yaml
+++ b/.github/workflows/single-node-test.yaml
@@ -59,7 +59,7 @@ on:
         description: "The solution version to install"
         required: false
         type: string
-        default: "1.0.2"
+        default: "1.1.0"
       solution-base-url:
         description: "The URL to download the solution"
         required: false
@@ -74,7 +74,7 @@ on:
         description: "The next solution version to upgrade to (only used when `test-solution` enabled)"
         required: false
         type: string
-        default: "1.0.3"
+        default: "1.1.1"
 
 env:
   NAME: single-node-${{ inputs.os }}-${{ inputs.setup-idp && 'idp' || 'no-idp' }}-${{ inputs.setup-logging && 'logging' || 'no-logging' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@
   and Loki image version to [3.6.5](https://github.com/grafana/loki/releases/tag/v3.6.5)
   (PR[#4792](https://github.com/scality/metalk8s/pull/4792))
 
+- Allow to enable metrics collection for the solutions operators
+  (PR[#4813](https://github.com/scality/metalk8s/pull/4813))
+
 ### Bug Fixes
 
 - Fix a bug where part of the upgrade process would silently be skipped

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -619,8 +619,22 @@ SALT_FILES: Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path("salt/metalk8s/orchestrate/solutions/deploy-components.sls"),
     Path("salt/metalk8s/orchestrate/solutions/files/operator/configmap.yaml.j2"),
     Path("salt/metalk8s/orchestrate/solutions/files/operator/deployment.yaml.j2"),
+    Path(
+        "salt/metalk8s/orchestrate/solutions/files/operator/"
+        "metrics_auth_clusterrole.yaml.j2"
+    ),
+    Path(
+        "salt/metalk8s/orchestrate/solutions/files/operator/"
+        "metrics_auth_clusterrolebinding.yaml.j2"
+    ),
+    Path(
+        "salt/metalk8s/orchestrate/solutions/files/operator/metrics_certificate.yaml.j2"
+    ),
+    Path("salt/metalk8s/orchestrate/solutions/files/operator/metrics_issuer.yaml.j2"),
+    Path("salt/metalk8s/orchestrate/solutions/files/operator/metrics_service.yaml.j2"),
     Path("salt/metalk8s/orchestrate/solutions/files/operator/role_binding.yaml.j2"),
     Path("salt/metalk8s/orchestrate/solutions/files/operator/service_account.yaml.j2"),
+    Path("salt/metalk8s/orchestrate/solutions/files/operator/service_monitor.yaml.j2"),
     Path("salt/metalk8s/archives/configured.sls"),
     Path("salt/metalk8s/archives/init.sls"),
     Path("salt/metalk8s/archives/mounted.sls"),

--- a/docs/developer/solutions/operator.rst
+++ b/docs/developer/solutions/operator.rst
@@ -43,12 +43,32 @@ Most of these files are generated when using the Operator SDK.
 Monitoring
 ^^^^^^^^^^
 
-MetalK8s does not handle the monitoring of a Solution application, which means:
+MetalK8s can automatically create a ``Service`` and ``ServiceMonitor`` to
+expose operator metrics to Prometheus. This is opt-in: add a ``metrics``
+section under ``spec.operator`` in the solution ``manifest.yaml``:
 
-- the user, manually or through the Solution UI, should create ``Service`` and
-  ``ServiceMonitor`` objects for each Operator instance
-- Operators should create ``Service`` and ``ServiceMonitor`` objects for each
-  deployed component they own
+.. code-block:: yaml
+
+   spec:
+     operator:
+       metrics:
+         enabled: true        # default: false
+         scheme: https        # default: "https", available: "http" or "https"
+         port: 8443           # default: 8443 for HTTPS, 8080 for HTTP
+         path: /metrics       # default: "/metrics"
+
+When ``enabled`` is ``true``, MetalK8s will:
+
+- add a ``containerPort`` to the operator Deployment
+- create a ``ClusterIP`` Service named ``<solution>-operator-metrics``
+- create a ``ServiceMonitor`` named ``<solution>-operator`` with the label
+  ``metalk8s.scality.com/monitor: ''`` for Prometheus discovery
+
+When ``scheme`` is ``https``, the ``ServiceMonitor`` is configured with
+``bearerTokenFile`` authentication and ``insecureSkipVerify: true``.
+
+Operators should still create ``Service`` and ``ServiceMonitor`` objects for
+each deployed component they own.
 
 The `Prometheus Operator`_ deployed by MetalK8s has cluster-scoped permissions,
 and is able to read the aforementioned ``ServiceMonitor`` objects

--- a/salt/metalk8s/orchestrate/solutions/files/operator/deployment.yaml.j2
+++ b/salt/metalk8s/orchestrate/solutions/files/operator/deployment.yaml.j2
@@ -34,7 +34,19 @@ spec:
           command:
           - {{ solution }}-operator
           - --config=/etc/config/operator.yaml
+{%- if metrics_enabled is defined and metrics_enabled %}
+          - --metrics-bind-address=:{{ metrics_port }}
+  {%- if metrics_scheme == "https" %}
+          - --metrics-cert-path=/tmp/k8s-metrics-server/metrics-certs
+  {%- endif %}
+{%- endif %}
           imagePullPolicy: Always
+{%- if metrics_enabled is defined and metrics_enabled %}
+          ports:
+            - containerPort: {{ metrics_port }}
+              name: {{ metrics_scheme }}
+              protocol: TCP
+{%- endif %}
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -54,6 +66,11 @@ spec:
               mountPath: /cert
               readOnly: true
 {%- endif %}
+{%- if metrics_enabled is defined and metrics_enabled and metrics_scheme == "https" %}
+            - name: metrics-cert
+              mountPath: /tmp/k8s-metrics-server/metrics-certs
+              readOnly: true
+{%- endif %}
       volumes:
         - name: operator-config
           configMap:
@@ -63,4 +80,10 @@ spec:
           secret:
             defaultMode: 420
             secretName: {{ solution }}-cert
+{%- endif %}
+{%- if metrics_enabled is defined and metrics_enabled and metrics_scheme == "https" %}
+        - name: metrics-cert
+          secret:
+            defaultMode: 420
+            secretName: {{ solution }}-operator-metrics-cert
 {%- endif %}

--- a/salt/metalk8s/orchestrate/solutions/files/operator/metrics_auth_clusterrole.yaml.j2
+++ b/salt/metalk8s/orchestrate/solutions/files/operator/metrics_auth_clusterrole.yaml.j2
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ solution }}-operator-metrics-auth
+  labels:
+    app: {{ solution }}-operator
+    app.kubernetes.io/name: {{ solution }}-operator
+    app.kubernetes.io/instance: {{ solution }}-operator
+    app.kubernetes.io/version: {{ version }}
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/part-of: {{ solution }}
+rules:
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create

--- a/salt/metalk8s/orchestrate/solutions/files/operator/metrics_auth_clusterrolebinding.yaml.j2
+++ b/salt/metalk8s/orchestrate/solutions/files/operator/metrics_auth_clusterrolebinding.yaml.j2
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ solution }}-operator-metrics-auth
+  labels:
+    app: {{ solution }}-operator
+    app.kubernetes.io/name: {{ solution }}-operator
+    app.kubernetes.io/instance: {{ solution }}-operator
+    app.kubernetes.io/version: {{ version }}
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/part-of: {{ solution }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ solution }}-operator
+    namespace: {{ namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ solution }}-operator-metrics-auth
+  apiGroup: rbac.authorization.k8s.io

--- a/salt/metalk8s/orchestrate/solutions/files/operator/metrics_certificate.yaml.j2
+++ b/salt/metalk8s/orchestrate/solutions/files/operator/metrics_certificate.yaml.j2
@@ -1,0 +1,20 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ solution }}-operator-metrics-cert
+  namespace: {{ namespace }}
+  labels:
+    app: {{ solution }}-operator
+    app.kubernetes.io/name: {{ solution }}-operator
+    app.kubernetes.io/instance: {{ solution }}-operator
+    app.kubernetes.io/version: {{ version }}
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/part-of: {{ solution }}
+spec:
+  secretName: {{ solution }}-operator-metrics-cert
+  issuerRef:
+    kind: Issuer
+    name: {{ solution }}-operator-metrics-issuer
+  dnsNames:
+    - {{ solution }}-operator-metrics.{{ namespace }}.svc
+    - {{ solution }}-operator-metrics.{{ namespace }}.svc.cluster.local

--- a/salt/metalk8s/orchestrate/solutions/files/operator/metrics_issuer.yaml.j2
+++ b/salt/metalk8s/orchestrate/solutions/files/operator/metrics_issuer.yaml.j2
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ solution }}-operator-metrics-issuer
+  namespace: {{ namespace }}
+  labels:
+    app: {{ solution }}-operator
+    app.kubernetes.io/name: {{ solution }}-operator
+    app.kubernetes.io/instance: {{ solution }}-operator
+    app.kubernetes.io/version: {{ version }}
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/part-of: {{ solution }}
+spec:
+  selfSigned: {}

--- a/salt/metalk8s/orchestrate/solutions/files/operator/metrics_service.yaml.j2
+++ b/salt/metalk8s/orchestrate/solutions/files/operator/metrics_service.yaml.j2
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ solution }}-operator-metrics
+  namespace: {{ namespace }}
+  labels:
+    app: {{ solution }}-operator
+    app.kubernetes.io/name: {{ solution }}-operator
+    app.kubernetes.io/instance: {{ solution }}-operator
+    app.kubernetes.io/version: {{ version }}
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/part-of: {{ solution }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: {{ metrics_scheme }}
+      port: {{ metrics_port }}
+      protocol: TCP
+      targetPort: {{ metrics_port }}
+  selector:
+    app.kubernetes.io/name: {{ solution }}-operator

--- a/salt/metalk8s/orchestrate/solutions/files/operator/service_monitor.yaml.j2
+++ b/salt/metalk8s/orchestrate/solutions/files/operator/service_monitor.yaml.j2
@@ -1,0 +1,29 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ solution }}-operator
+  namespace: {{ namespace }}
+  labels:
+    app: {{ solution }}-operator
+    app.kubernetes.io/name: {{ solution }}-operator
+    app.kubernetes.io/instance: {{ solution }}-operator
+    app.kubernetes.io/version: {{ version }}
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/part-of: {{ solution }}
+    metalk8s.scality.com/monitor: ''
+spec:
+  endpoints:
+    - path: {{ metrics_path }}
+      port: {{ metrics_scheme }}
+{%- if metrics_scheme == "https" %}
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
+{%- endif %}
+  namespaceSelector:
+    matchNames:
+      - {{ namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ solution }}-operator

--- a/salt/metalk8s/orchestrate/solutions/prepare-environment.sls
+++ b/salt/metalk8s/orchestrate/solutions/prepare-environment.sls
@@ -55,6 +55,70 @@ Apply Operator ConfigMap for Solution {{ solution.name }}:
         registry: {{ repo.registry_endpoint }}
         version: {{ solution.version }}
 
+{%- set metrics = solution.manifest.spec.operator.get('metrics', {}) %}
+{%- set metrics_enabled = metrics.get('enabled', False) %}
+{%- if metrics_enabled %}
+  {%- set metrics_scheme = metrics.get('scheme', 'https') %}
+  {%- set metrics_path = metrics.get('path', '/metrics') %}
+  {%- if metrics_scheme == 'https' %}
+    {%- set metrics_port = metrics.get('port', 8443) %}
+  {%- else %}
+    {%- set metrics_port = metrics.get('port', 8080) %}
+  {%- endif %}
+{%- endif %}
+
+{%- if metrics_enabled %}
+
+Apply Operator Metrics Auth ClusterRole for Solution {{ solution.name }}:
+  metalk8s_kubernetes.object_present:
+    - name: salt://{{ slspath }}/files/operator/metrics_auth_clusterrole.yaml.j2
+    - template: jinja
+    - defaults:
+        solution: {{ name }}
+        version: {{ solution.version }}
+
+Apply Operator Metrics Auth ClusterRoleBinding for Solution {{ solution.name }}:
+  metalk8s_kubernetes.object_present:
+    - name: salt://{{ slspath }}/files/operator/metrics_auth_clusterrolebinding.yaml.j2
+    - template: jinja
+    - defaults:
+        solution: {{ name }}
+        namespace: {{ namespace }}
+        version: {{ solution.version }}
+    - require:
+        - metalk8s_kubernetes: Apply ServiceAccount for Operator of Solution {{ solution.name }}
+        - metalk8s_kubernetes: Apply Operator Metrics Auth ClusterRole for Solution {{ solution.name }}
+    - require_in:
+        - metalk8s_kubernetes: Apply Operator Deployment for Solution {{ solution.name }}
+
+  {%- if metrics_scheme == 'https' %}
+
+Apply Operator Metrics Issuer for Solution {{ solution.name }}:
+  metalk8s_kubernetes.object_present:
+    - name: salt://{{ slspath }}/files/operator/metrics_issuer.yaml.j2
+    - template: jinja
+    - defaults:
+        solution: {{ name }}
+        namespace: {{ namespace }}
+        version: {{ solution.version }}
+
+Apply Operator Metrics Certificate for Solution {{ solution.name }}:
+  metalk8s_kubernetes.object_present:
+    - name: salt://{{ slspath }}/files/operator/metrics_certificate.yaml.j2
+    - template: jinja
+    - defaults:
+        solution: {{ name }}
+        namespace: {{ namespace }}
+        version: {{ solution.version }}
+    - require:
+        - metalk8s_kubernetes: Apply Operator Metrics Issuer for Solution {{ solution.name }}
+    - require_in:
+        - metalk8s_kubernetes: Apply Operator Deployment for Solution {{ solution.name }}
+
+  {%- endif %}
+
+{%- endif %}
+
 Apply Operator Deployment for Solution {{ solution.name }}:
   metalk8s_kubernetes.object_present:
     - name: salt://{{ slspath }}/files/operator/deployment.yaml.j2
@@ -67,8 +131,44 @@ Apply Operator Deployment for Solution {{ solution.name }}:
         image_tag: {{ solution.manifest.spec.operator.image.tag }}
         repository: {{ repo.registry_endpoint ~ '/' ~ solution.id }}
         webhook_enabled: {{ webhook_enabled }}
+        metrics_enabled: {{ metrics_enabled }}
+{%- if metrics_enabled %}
+        metrics_port: {{ metrics_port }}
+        metrics_scheme: {{ metrics_scheme }}
+{%- endif %}
     - require:
         - metalk8s_kubernetes: Apply Operator ConfigMap for Solution {{ solution.name }}
+
+{%- if metrics_enabled %}
+
+Apply Operator Metrics Service for Solution {{ solution.name }}:
+  metalk8s_kubernetes.object_present:
+    - name: salt://{{ slspath }}/files/operator/metrics_service.yaml.j2
+    - template: jinja
+    - defaults:
+        solution: {{ name }}
+        namespace: {{ namespace }}
+        version: {{ solution.version }}
+        metrics_port: {{ metrics_port }}
+        metrics_scheme: {{ metrics_scheme }}
+    - require:
+        - metalk8s_kubernetes: Apply Operator Deployment for Solution {{ solution.name }}
+
+Apply Operator ServiceMonitor for Solution {{ solution.name }}:
+  metalk8s_kubernetes.object_present:
+    - name: salt://{{ slspath }}/files/operator/service_monitor.yaml.j2
+    - template: jinja
+    - defaults:
+        solution: {{ name }}
+        namespace: {{ namespace }}
+        version: {{ solution.version }}
+        metrics_port: {{ metrics_port }}
+        metrics_scheme: {{ metrics_scheme }}
+        metrics_path: {{ metrics_path }}
+    - require:
+        - metalk8s_kubernetes: Apply Operator Metrics Service for Solution {{ solution.name }}
+
+{%- endif %}
 
 {%- endmacro %}
 

--- a/salt/tests/unit/formulas/config.yaml
+++ b/salt/tests/unit/formulas/config.yaml
@@ -761,6 +761,17 @@ metalk8s:
                   image_tag: "1.2.3"
                   webhook_enabled: true
 
+              "Example Solution v1.2.3 with metrics":
+                extra_context:
+                  <<: *base_context_solution_operator_files
+                  repository: >-
+                    metalk8s-registry-from-config.invalid/example-solution-1.2.3
+                  image_name: example-operator
+                  image_tag: "1.2.3"
+                  metrics_enabled: true
+                  metrics_port: 8443
+                  metrics_scheme: https
+
           role_binding.yaml.j2:
             _cases:
               "Example Solution v1.2.3 (see ../../prepare-environment.sls)":
@@ -768,6 +779,60 @@ metalk8s:
                   <<: *base_context_solution_operator_files
                   role_kind: ClusterRole
                   role_name: example-role
+
+          metrics_service.yaml.j2:
+            _cases:
+              "Example Solution v1.2.3 with HTTPS metrics":
+                extra_context:
+                  <<: *base_context_solution_operator_files
+                  metrics_port: 8443
+                  metrics_scheme: https
+
+              "Example Solution v1.2.3 with HTTP metrics":
+                extra_context:
+                  <<: *base_context_solution_operator_files
+                  metrics_port: 8080
+                  metrics_scheme: http
+
+          service_monitor.yaml.j2:
+            _cases:
+              "Example Solution v1.2.3 with HTTPS metrics":
+                extra_context:
+                  <<: *base_context_solution_operator_files
+                  metrics_port: 8443
+                  metrics_scheme: https
+                  metrics_path: /metrics
+
+              "Example Solution v1.2.3 with HTTP metrics":
+                extra_context:
+                  <<: *base_context_solution_operator_files
+                  metrics_port: 8080
+                  metrics_scheme: http
+                  metrics_path: /metrics
+
+          metrics_auth_clusterrole.yaml.j2:
+            _cases:
+              "Example Solution v1.2.3":
+                extra_context:
+                  <<: *base_context_solution_operator_files
+
+          metrics_auth_clusterrolebinding.yaml.j2:
+            _cases:
+              "Example Solution v1.2.3":
+                extra_context:
+                  <<: *base_context_solution_operator_files
+
+          metrics_issuer.yaml.j2:
+            _cases:
+              "Example Solution v1.2.3":
+                extra_context:
+                  <<: *base_context_solution_operator_files
+
+          metrics_certificate.yaml.j2:
+            _cases:
+              "Example Solution v1.2.3":
+                extra_context:
+                  <<: *base_context_solution_operator_files
 
     upgrade:
       init.sls:

--- a/tests/post/features/solutions.feature
+++ b/tests/post/features/solutions.feature
@@ -7,14 +7,14 @@ Feature: Solutions
         And the Solution Configuration file is absent
         When we import a Solution archive '/var/tmp/example-solution.iso'
         Then Solution archive 'example-solution' is imported correctly
-        And Solution 'example-solution' version '1.0.2' is available
-        When we activate Solution 'example-solution' version '1.0.2'
-        Then Solution 'example-solution' version '1.0.2' is activated
-        And CRD 'versionservers.example-solution.metalk8s.scality.com' exists in Kubernetes API
-        And CRD 'clockservers.example-solution.metalk8s.scality.com' exists in Kubernetes API
+        And Solution 'example-solution' version '1.1.0' is available
+        When we activate Solution 'example-solution' version '1.1.0'
+        Then Solution 'example-solution' version '1.1.0' is activated
+        And CRD 'versionservers.metalk8s-solution-example.scality.com' exists in Kubernetes API
+        And CRD 'clockservers.metalk8s-solution-example.scality.com' exists in Kubernetes API
         When we create a solution environment 'example-environment'
         Then solution environment 'example-environment' is available
-        When we deploy Solution 'example-solution' in environment 'example-environment' with version '1.0.2'
+        When we deploy Solution 'example-solution' in environment 'example-environment' with version '1.1.0'
         Then we have 1 running pod labeled 'app=example-solution-operator' in namespace 'example-environment'
         When we deactivate Solution 'example-solution'
         And we delete Solution 'example-solution' in environment 'example-environment'

--- a/tests/post/features/solutions.feature
+++ b/tests/post/features/solutions.feature
@@ -23,3 +23,39 @@ Feature: Solutions
         And we delete the Solution Configuration file
         Then we have no Solution 'example-solution' archive mounted
         And we have no Solution Configuration file present
+
+    @solution-upgrade
+    Scenario: Upgrade Solution
+        Given the Kubernetes API is available
+        And no Solution 'example-solution' is imported
+        And no Solution environment 'example-environment' is available
+        And the Solution Configuration file is absent
+        When we import a Solution archive '/var/tmp/example-solution.iso'
+        Then Solution archive 'example-solution' is imported correctly
+        And Solution 'example-solution' version '1.1.0' is available
+        When we activate Solution 'example-solution' version '1.1.0'
+        Then Solution 'example-solution' version '1.1.0' is activated
+        And CRD 'versionservers.metalk8s-solution-example.scality.com' exists in Kubernetes API
+        And CRD 'clockservers.metalk8s-solution-example.scality.com' exists in Kubernetes API
+        When we create a solution environment 'example-environment'
+        Then solution environment 'example-environment' is available
+        When we deploy Solution 'example-solution' in environment 'example-environment' with version '1.1.0'
+        Then we have 1 running pod labeled 'app=example-solution-operator' in namespace 'example-environment'
+        When we import a Solution archive '/var/tmp/example-solution-next.iso'
+        Then Solution archive 'example-solution-next' is imported correctly
+        And Solution 'example-solution-next' version '1.1.1' is available
+        When we activate Solution 'example-solution-next' version '1.1.1'
+        Then Solution 'example-solution-next' version '1.1.1' is activated
+        And CRD 'versionservers.example-solution-next.metalk8s.scality.com' exists in Kubernetes API
+        And CRD 'clockservers.example-solution-next.metalk8s.scality.com' exists in Kubernetes API
+        When we deploy Solution 'example-solution' in environment 'example-environment' with version '1.1.1'
+        Then we have 1 running pod labeled 'app=example-solution-operator,app.kubernetes.io/version=1.1.1' in namespace 'example-environment'
+        When we unimport Solution archive '/var/tmp/example-solution.iso'
+        Then we have 1 running pod labeled 'app=example-solution-operator' in namespace 'example-environment'
+        When we deactivate Solution 'example-solution'
+        And we delete Solution 'example-solution' in environment 'example-environment'
+        And we delete Solution environment 'example-environment'
+        And we unimport Solution archive '/var/tmp/example-solution-next.iso'
+        And we delete the Solution Configuration file
+        Then we have no Solution 'example-solution' archive mounted
+        And we have no Solution Configuration file present


### PR DESCRIPTION
- Add ability to deploy ServiceMonitor and associated resource for operator managed by solution framework
- Add missing solution upgrade tests
- Add tests with new example solution version that enable the metric feature

Fixes: MK8S-136, #1857 