### PR TITLE
charts,salt,build: Bump ingress-nginx chart to 4.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@
 - Bump solution-operator-lib Go version to 1.24
   (PR[#4817](https://github.com/scality/metalk8s/pull/4817))
 
+- Bump ingress-nginx chart version to [4.15.0](https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-4.15.0)
+  and ingress-nginx controller to [v1.15.0](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.15.0)
+  (PR[#4824](https://github.com/scality/metalk8s/pull/4824))
+
 ### Bug Fixes
 
 - Fix a bug where part of the upgrade process would silently be skipped

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -188,8 +188,8 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     ),
     Image(
         name="nginx-ingress-controller",
-        version="v1.12.1",
-        digest="sha256:d2fbc4ec70d8aa2050dd91a91506e998765e86c96f32cffb56c503c9c34eed5b",
+        version="v1.15.0",
+        digest="sha256:4eea9a4cc2cb6ddcb7da14d377aaf452e68bd3dbe87fe280755d225c4d5e7e4e",
     ),
     Image(
         name="node-exporter",

--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -1,9 +1,9 @@
 annotations:
   artifacthub.io/changes: |
-    - Update Ingress-Nginx version controller-v1.12.1
+    - Update Ingress-Nginx version controller-v1.15.0
   artifacthub.io/prerelease: "false"
 apiVersion: v2
-appVersion: 1.12.1
+appVersion: 1.15.0
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and
   load balancer
 home: https://github.com/kubernetes/ingress-nginx
@@ -20,4 +20,4 @@ maintainers:
 name: ingress-nginx
 sources:
 - https://github.com/kubernetes/ingress-nginx
-version: 4.12.1
+version: 4.15.0

--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -2,7 +2,7 @@
 
 [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer
 
-![Version: 4.12.1](https://img.shields.io/badge/Version-4.12.1-informational?style=flat-square) ![AppVersion: 1.12.1](https://img.shields.io/badge/AppVersion-1.12.1-informational?style=flat-square)
+![Version: 4.15.0](https://img.shields.io/badge/Version-4.15.0-informational?style=flat-square) ![AppVersion: 1.15.0](https://img.shields.io/badge/AppVersion-1.15.0-informational?style=flat-square)
 
 To use, add `ingressClassName: nginx` spec field or the `kubernetes.io/ingress.class: nginx` annotation to your Ingress resources.
 
@@ -255,12 +255,17 @@ metadata:
 | controller.addHeaders | object | `{}` | Will add custom headers before sending response traffic to the client according to: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#add-headers |
 | controller.admissionWebhooks.annotations | object | `{}` |  |
 | controller.admissionWebhooks.certManager.admissionCert.duration | string | `""` |  |
+| controller.admissionWebhooks.certManager.admissionCert.revisionHistoryLimit | int | `0` | Revision history limit of the webhook certificate. Ref.: https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec |
 | controller.admissionWebhooks.certManager.enabled | bool | `false` |  |
 | controller.admissionWebhooks.certManager.rootCert.duration | string | `""` |  |
+| controller.admissionWebhooks.certManager.rootCert.revisionHistoryLimit | int | `0` | Revision history limit of the root certificate. Ref.: https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec |
 | controller.admissionWebhooks.certificate | string | `"/usr/local/certificates/cert"` |  |
+| controller.admissionWebhooks.createSecretJob.activeDeadlineSeconds | int | `0` | Deadline in seconds for the job to complete. Must be greater than 0 to enforce. If unset or 0, no deadline is enforced. |
 | controller.admissionWebhooks.createSecretJob.name | string | `"create"` |  |
 | controller.admissionWebhooks.createSecretJob.resources | object | `{}` |  |
 | controller.admissionWebhooks.createSecretJob.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for secret creation containers |
+| controller.admissionWebhooks.createSecretJob.volumeMounts | list | `[]` | Volume mounts for secret creation containers |
+| controller.admissionWebhooks.createSecretJob.volumes | list | `[]` | Volumes for secret creation pod |
 | controller.admissionWebhooks.enabled | bool | `true` |  |
 | controller.admissionWebhooks.extraEnvs | list | `[]` | Additional environment variables to set |
 | controller.admissionWebhooks.failurePolicy | string | `"Fail"` | Admission Webhook failure policy to use |
@@ -270,10 +275,10 @@ metadata:
 | controller.admissionWebhooks.namespaceSelector | object | `{}` |  |
 | controller.admissionWebhooks.objectSelector | object | `{}` |  |
 | controller.admissionWebhooks.patch.enabled | bool | `true` |  |
-| controller.admissionWebhooks.patch.image.digest | string | `"sha256:e8825994b7a2c7497375a9b945f386506ca6a3eda80b89b74ef2db743f66a5ea"` |  |
+| controller.admissionWebhooks.patch.image.digest | string | `"sha256:d7e8257f8d8bce64b6df55f81fba92011a6a77269b3350f8b997b152af348dba"` |  |
 | controller.admissionWebhooks.patch.image.image | string | `"ingress-nginx/kube-webhook-certgen"` |  |
 | controller.admissionWebhooks.patch.image.pullPolicy | string | `"IfNotPresent"` |  |
-| controller.admissionWebhooks.patch.image.tag | string | `"v1.5.2"` |  |
+| controller.admissionWebhooks.patch.image.tag | string | `"v1.6.8"` |  |
 | controller.admissionWebhooks.patch.labels | object | `{}` | Labels to be added to patch job resources |
 | controller.admissionWebhooks.patch.networkPolicy.enabled | bool | `false` | Enable 'networkPolicy' or not |
 | controller.admissionWebhooks.patch.nodeSelector."kubernetes.io/os" | string | `"linux"` |  |
@@ -281,15 +286,19 @@ metadata:
 | controller.admissionWebhooks.patch.priorityClassName | string | `""` | Provide a priority class name to the webhook patching job # |
 | controller.admissionWebhooks.patch.rbac | object | `{"create":true}` | Admission webhook patch job RBAC |
 | controller.admissionWebhooks.patch.rbac.create | bool | `true` | Create RBAC or not |
+| controller.admissionWebhooks.patch.runtimeClassName | string | `""` | Instruct the kubelet to use the named RuntimeClass to run the pod |
 | controller.admissionWebhooks.patch.securityContext | object | `{}` | Security context for secret creation & webhook patch pods |
 | controller.admissionWebhooks.patch.serviceAccount | object | `{"automountServiceAccountToken":true,"create":true,"name":""}` | Admission webhook patch job service account |
 | controller.admissionWebhooks.patch.serviceAccount.automountServiceAccountToken | bool | `true` | Auto-mount service account token or not |
 | controller.admissionWebhooks.patch.serviceAccount.create | bool | `true` | Create a service account or not |
 | controller.admissionWebhooks.patch.serviceAccount.name | string | `""` | Custom service account name |
 | controller.admissionWebhooks.patch.tolerations | list | `[]` |  |
+| controller.admissionWebhooks.patchWebhookJob.activeDeadlineSeconds | int | `0` | Deadline in seconds for the job to complete. Must be greater than 0 to enforce. If unset or 0, no deadline is enforced. |
 | controller.admissionWebhooks.patchWebhookJob.name | string | `"patch"` |  |
 | controller.admissionWebhooks.patchWebhookJob.resources | object | `{}` |  |
 | controller.admissionWebhooks.patchWebhookJob.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for webhook patch containers |
+| controller.admissionWebhooks.patchWebhookJob.volumeMounts | list | `[]` | Volume mounts for webhook patch containers |
+| controller.admissionWebhooks.patchWebhookJob.volumes | list | `[]` | Volumes for webhook patch pod |
 | controller.admissionWebhooks.port | int | `8443` |  |
 | controller.admissionWebhooks.service.annotations | object | `{}` |  |
 | controller.admissionWebhooks.service.externalIPs | list | `[]` |  |
@@ -326,7 +335,7 @@ metadata:
 | controller.extraArgs | object | `{}` | Additional command line arguments to pass to Ingress-Nginx Controller E.g. to specify the default SSL certificate you can use |
 | controller.extraContainers | list | `[]` | Additional containers to be added to the controller pod. See https://github.com/lemonldap-ng-controller/lemonldap-ng-controller as example. |
 | controller.extraEnvs | list | `[]` | Additional environment variables to set |
-| controller.extraInitContainers | list | `[]` | Containers, which are run before the app containers are started. |
+| controller.extraInitContainers | list | `[]` | Containers, which are run before the app containers are started. Values may contain Helm templates. |
 | controller.extraModules | list | `[]` | Modules, which are mounted into the core nginx image. |
 | controller.extraVolumeMounts | list | `[]` | Additional volumeMounts to the controller main container. |
 | controller.extraVolumes | list | `[]` | Additional volumes to the controller pod. |
@@ -340,8 +349,8 @@ metadata:
 | controller.hostname | object | `{}` | Optionally customize the pod hostname. |
 | controller.image.allowPrivilegeEscalation | bool | `false` |  |
 | controller.image.chroot | bool | `false` |  |
-| controller.image.digest | string | `"sha256:d2fbc4ec70d8aa2050dd91a91506e998765e86c96f32cffb56c503c9c34eed5b"` |  |
-| controller.image.digestChroot | string | `"sha256:90155c86548e0bb95b3abf1971cd687d8f5d43f340cfca0ad3484e2b8351096e"` |  |
+| controller.image.digest | string | `"sha256:4eea9a4cc2cb6ddcb7da14d377aaf452e68bd3dbe87fe280755d225c4d5e7e4e"` |  |
+| controller.image.digestChroot | string | `"sha256:8f3634837abc5c739baff6527934e08131e095317d69bf64d168e07aef53ac12"` |  |
 | controller.image.image | string | `"ingress-nginx/controller"` |  |
 | controller.image.pullPolicy | string | `"IfNotPresent"` |  |
 | controller.image.readOnlyRootFilesystem | bool | `false` |  |
@@ -349,7 +358,7 @@ metadata:
 | controller.image.runAsNonRoot | bool | `true` |  |
 | controller.image.runAsUser | int | `101` | This value must not be changed using the official image. uid=101(www-data) gid=82(www-data) groups=82(www-data) |
 | controller.image.seccompProfile.type | string | `"RuntimeDefault"` |  |
-| controller.image.tag | string | `"v1.12.1"` |  |
+| controller.image.tag | string | `"v1.15.0"` |  |
 | controller.ingressClass | string | `"nginx"` | For backwards compatibility with ingress.class annotation, use ingressClass. Algorithm is as follows, first ingressClassName is considered, if not present, controller looks for ingress.class annotation |
 | controller.ingressClassByName | bool | `false` | Process IngressClass per name (additionally as per spec.controller). |
 | controller.ingressClassResource | object | `{"aliases":[],"annotations":{},"controllerValue":"k8s.io/ingress-nginx","default":false,"enabled":true,"name":"nginx","parameters":{}}` | This section refers to the creation of the IngressClass resource. IngressClasses are immutable and cannot be changed after creation. We do not support namespaced IngressClasses, yet, so a ClusterRole and a ClusterRoleBinding is required. |
@@ -399,12 +408,18 @@ metadata:
 | controller.metrics.serviceMonitor.additionalLabels | object | `{}` |  |
 | controller.metrics.serviceMonitor.annotations | object | `{}` | Annotations to be added to the ServiceMonitor. |
 | controller.metrics.serviceMonitor.enabled | bool | `false` |  |
+| controller.metrics.serviceMonitor.labelLimit | int | `0` | Per-scrape limit on number of labels that will be accepted for a sample. |
+| controller.metrics.serviceMonitor.labelNameLengthLimit | int | `0` | Per-scrape limit on length of labels name that will be accepted for a sample. |
+| controller.metrics.serviceMonitor.labelValueLengthLimit | int | `0` | Per-scrape limit on length of labels value that will be accepted for a sample. |
 | controller.metrics.serviceMonitor.metricRelabelings | list | `[]` |  |
 | controller.metrics.serviceMonitor.namespace | string | `""` |  |
 | controller.metrics.serviceMonitor.namespaceSelector | object | `{}` |  |
 | controller.metrics.serviceMonitor.relabelings | list | `[]` |  |
+| controller.metrics.serviceMonitor.sampleLimit | int | `0` | Defines a per-scrape limit on the number of scraped samples that will be accepted. |
 | controller.metrics.serviceMonitor.scrapeInterval | string | `"30s"` |  |
+| controller.metrics.serviceMonitor.scrapeTimeout | string | `""` | Timeout after which the scrape is ended. Not being set if empty and therefore defaults to the global Prometheus scrape timeout. |
 | controller.metrics.serviceMonitor.targetLabels | list | `[]` |  |
+| controller.metrics.serviceMonitor.targetLimit | int | `0` | Defines a limit on the number of scraped targets that will be accepted. |
 | controller.minAvailable | int | `1` | Minimum available pods set in PodDisruptionBudget. Define either 'minAvailable' or 'maxUnavailable', never both. |
 | controller.minReadySeconds | int | `0` | `minReadySeconds` to avoid killing pods before we are ready # |
 | controller.name | string | `"controller"` |  |
@@ -429,28 +444,34 @@ metadata:
 | controller.readinessProbe.timeoutSeconds | int | `1` |  |
 | controller.replicaCount | int | `1` |  |
 | controller.reportNodeInternalIp | bool | `false` | Bare-metal considerations via the host network https://kubernetes.github.io/ingress-nginx/deploy/baremetal/#via-the-host-network Ingress status was blank because there is no Service exposing the Ingress-Nginx Controller in a configuration using the host network, the default --publish-service flag used in standard cloud setups does not apply |
+| controller.resizePolicy | list | `[]` | Resize policy for controller containers. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources |
 | controller.resources.requests.cpu | string | `"100m"` |  |
 | controller.resources.requests.memory | string | `"90Mi"` |  |
+| controller.runtimeClassName | string | `""` | Instruct the kubelet to use the named RuntimeClass to run the pod |
 | controller.scope.enabled | bool | `false` | Enable 'scope' or not |
 | controller.scope.namespace | string | `""` | Namespace to limit the controller to; defaults to $(POD_NAMESPACE) |
 | controller.scope.namespaceSelector | string | `""` | When scope.enabled == false, instead of watching all namespaces, we watching namespaces whose labels only match with namespaceSelector. Format like foo=bar. Defaults to empty, means watching all namespaces. |
 | controller.service.annotations | object | `{}` | Annotations to be added to the external controller service. See `controller.service.internal.annotations` for annotations to be added to the internal controller service. |
 | controller.service.appProtocol | bool | `true` | Declare the app protocol of the external HTTP and HTTPS listeners or not. Supersedes provider-specific annotations for declaring the backend protocol. Ref: https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol |
 | controller.service.clusterIP | string | `""` | Pre-defined cluster internal IP address of the external controller service. Take care of collisions with existing services. This value is immutable. Set once, it can not be changed without deleting and re-creating the service. Ref: https://kubernetes.io/docs/concepts/services-networking/service/#choosing-your-own-ip-address |
+| controller.service.clusterIPs | list | `[]` | Pre-defined cluster internal IP addresses of the external controller service. Take care of collisions with existing services. This value is immutable. Set once, it can not be changed without deleting and re-creating the service. Ref: https://kubernetes.io/docs/concepts/services-networking/service/#choosing-your-own-ip-address |
 | controller.service.enableHttp | bool | `true` | Enable the HTTP listener on both controller services or not. |
 | controller.service.enableHttps | bool | `true` | Enable the HTTPS listener on both controller services or not. |
 | controller.service.enabled | bool | `true` | Enable controller services or not. This does not influence the creation of either the admission webhook or the metrics service. |
 | controller.service.external.enabled | bool | `true` | Enable the external controller service or not. Useful for internal-only deployments. |
+| controller.service.external.labels | object | `{}` | Labels to be added to the external controller service. |
 | controller.service.externalIPs | list | `[]` | List of node IP addresses at which the external controller service is available. Ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips |
 | controller.service.externalTrafficPolicy | string | `""` | External traffic policy of the external controller service. Set to "Local" to preserve source IP on providers supporting it. Ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip |
 | controller.service.internal.annotations | object | `{}` | Annotations to be added to the internal controller service. Mandatory for the internal controller service to be created. Varies with the cloud service. Ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer |
 | controller.service.internal.appProtocol | bool | `true` | Declare the app protocol of the internal HTTP and HTTPS listeners or not. Supersedes provider-specific annotations for declaring the backend protocol. Ref: https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol |
 | controller.service.internal.clusterIP | string | `""` | Pre-defined cluster internal IP address of the internal controller service. Take care of collisions with existing services. This value is immutable. Set once, it can not be changed without deleting and re-creating the service. Ref: https://kubernetes.io/docs/concepts/services-networking/service/#choosing-your-own-ip-address |
+| controller.service.internal.clusterIPs | list | `[]` | Pre-defined cluster internal IP addresses of the internal controller service. Take care of collisions with existing services. This value is immutable. Set once, it can not be changed without deleting and re-creating the service. Ref: https://kubernetes.io/docs/concepts/services-networking/service/#choosing-your-own-ip-address |
 | controller.service.internal.enabled | bool | `false` | Enable the internal controller service or not. Remember to configure `controller.service.internal.annotations` when enabling this. |
 | controller.service.internal.externalIPs | list | `[]` | List of node IP addresses at which the internal controller service is available. Ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips |
 | controller.service.internal.externalTrafficPolicy | string | `""` | External traffic policy of the internal controller service. Set to "Local" to preserve source IP on providers supporting it. Ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip |
 | controller.service.internal.ipFamilies | list | `["IPv4"]` | List of IP families (e.g. IPv4, IPv6) assigned to the internal controller service. This field is usually assigned automatically based on cluster configuration and the `ipFamilyPolicy` field. Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services |
 | controller.service.internal.ipFamilyPolicy | string | `"SingleStack"` | Represents the dual-stack capabilities of the internal controller service. Possible values are SingleStack, PreferDualStack or RequireDualStack. Fields `ipFamilies` and `clusterIP` depend on the value of this field. Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services |
+| controller.service.internal.labels | object | `{}` | Labels to be added to the internal controller service. |
 | controller.service.internal.loadBalancerClass | string | `""` | Load balancer class of the internal controller service. Used by cloud providers to select a load balancer implementation other than the cloud provider default. Ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class |
 | controller.service.internal.loadBalancerIP | string | `""` | Deprecated: Pre-defined IP address of the internal controller service. Used by cloud providers to connect the resulting load balancer service to a pre-existing static IP. Ref: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer |
 | controller.service.internal.loadBalancerSourceRanges | list | `[]` | Restrict access to the internal controller service. Values must be CIDRs. Allows any source address by default. |
@@ -461,6 +482,7 @@ metadata:
 | controller.service.internal.ports | object | `{}` |  |
 | controller.service.internal.sessionAffinity | string | `""` | Session affinity of the internal controller service. Must be either "None" or "ClientIP" if set. Defaults to "None". Ref: https://kubernetes.io/docs/reference/networking/virtual-ips/#session-affinity |
 | controller.service.internal.targetPorts | object | `{}` |  |
+| controller.service.internal.trafficDistribution | string | `""` | Traffic distribution policy of the internal controller service. Set to "PreferClose" to route traffic to endpoints that are topologically closer to the client. Ref: https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution |
 | controller.service.internal.type | string | `""` | Type of the internal controller service. Defaults to the value of `controller.service.type`. Ref: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types |
 | controller.service.ipFamilies | list | `["IPv4"]` | List of IP families (e.g. IPv4, IPv6) assigned to the external controller service. This field is usually assigned automatically based on cluster configuration and the `ipFamilyPolicy` field. Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services |
 | controller.service.ipFamilyPolicy | string | `"SingleStack"` | Represents the dual-stack capabilities of the external controller service. Possible values are SingleStack, PreferDualStack or RequireDualStack. Fields `ipFamilies` and `clusterIP` depend on the value of this field. Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services |
@@ -477,6 +499,7 @@ metadata:
 | controller.service.sessionAffinity | string | `""` | Session affinity of the external controller service. Must be either "None" or "ClientIP" if set. Defaults to "None". Ref: https://kubernetes.io/docs/reference/networking/virtual-ips/#session-affinity |
 | controller.service.targetPorts.http | string | `"http"` | Port of the ingress controller the external HTTP listener is mapped to. |
 | controller.service.targetPorts.https | string | `"https"` | Port of the ingress controller the external HTTPS listener is mapped to. |
+| controller.service.trafficDistribution | string | `""` | Traffic distribution policy of the external controller service. Set to "PreferClose" to route traffic to endpoints that are topologically closer to the client. Ref: https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution |
 | controller.service.type | string | `"LoadBalancer"` | Type of the external controller service. Ref: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types |
 | controller.shareProcessNamespace | bool | `false` |  |
 | controller.sysctls | object | `{}` | sysctls for controller pods # Ref: https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/ |
@@ -536,7 +559,9 @@ metadata:
 | defaultBackend.readinessProbe.timeoutSeconds | int | `5` |  |
 | defaultBackend.replicaCount | int | `1` |  |
 | defaultBackend.resources | object | `{}` |  |
+| defaultBackend.runtimeClassName | string | `""` | Instruct the kubelet to use the named RuntimeClass to run the pod |
 | defaultBackend.service.annotations | object | `{}` |  |
+| defaultBackend.service.clusterIPs | list | `[]` | Pre-defined cluster internal IP addresses of the default backend service. Take care of collisions with existing services. This value is immutable. Set once, it can not be changed without deleting and re-creating the service. Ref: https://kubernetes.io/docs/concepts/services-networking/service/#choosing-your-own-ip-address |
 | defaultBackend.service.externalIPs | list | `[]` | List of IP addresses at which the default backend service is available # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips # |
 | defaultBackend.service.loadBalancerSourceRanges | list | `[]` |  |
 | defaultBackend.service.servicePort | int | `80` |  |

--- a/charts/ingress-nginx/changelog/helm-chart-4.10.5.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.10.5.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.10.5
+
+* Update Ingress-Nginx version controller-v1.10.5
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.10.4...helm-chart-4.10.5

--- a/charts/ingress-nginx/changelog/helm-chart-4.10.6.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.10.6.md
@@ -1,0 +1,10 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.10.6
+
+* CI: Fix chart testing. (#12260)
+* Update Ingress-Nginx version controller-v1.10.6
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.10.5...helm-chart-4.10.6

--- a/charts/ingress-nginx/changelog/helm-chart-4.11.3.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.11.3.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.11.3
+
+* Update Ingress-Nginx version controller-v1.11.3
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.11.2...helm-chart-4.11.3

--- a/charts/ingress-nginx/changelog/helm-chart-4.11.4.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.11.4.md
@@ -1,0 +1,10 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.11.4
+
+* CI: Fix chart testing. (#12259)
+* Update Ingress-Nginx version controller-v1.11.4
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.11.3...helm-chart-4.11.4

--- a/charts/ingress-nginx/changelog/helm-chart-4.11.5.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.11.5.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.11.5
+
+* Update Ingress-Nginx version controller-v1.11.5
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.11.4...helm-chart-4.11.5

--- a/charts/ingress-nginx/changelog/helm-chart-4.11.6.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.11.6.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.11.6
+
+* Update Ingress-Nginx version controller-v1.11.6
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.11.5...helm-chart-4.11.6

--- a/charts/ingress-nginx/changelog/helm-chart-4.11.7.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.11.7.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.11.7
+
+* Update Ingress-Nginx version controller-v1.11.7
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.11.6...helm-chart-4.11.7

--- a/charts/ingress-nginx/changelog/helm-chart-4.11.8.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.11.8.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.11.8
+
+* Update Ingress-Nginx version controller-v1.11.8
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.11.7...helm-chart-4.11.8

--- a/charts/ingress-nginx/changelog/helm-chart-4.12.2.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.12.2.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.12.2
+
+* Update Ingress-Nginx version controller-v1.12.2
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.12.1...helm-chart-4.12.2

--- a/charts/ingress-nginx/changelog/helm-chart-4.12.3.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.12.3.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.12.3
+
+* Update Ingress-Nginx version controller-v1.12.3
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.12.2...helm-chart-4.12.3

--- a/charts/ingress-nginx/changelog/helm-chart-4.12.4.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.12.4.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.12.4
+
+* Update Ingress-Nginx version controller-v1.12.4
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.12.3...helm-chart-4.12.4

--- a/charts/ingress-nginx/changelog/helm-chart-4.12.5.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.12.5.md
@@ -1,0 +1,10 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.12.5
+
+* Make: Add `helm-test` target. (#13660)
+* Update Ingress-Nginx version controller-v1.12.5
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.12.4...helm-chart-4.12.5

--- a/charts/ingress-nginx/changelog/helm-chart-4.12.6.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.12.6.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.12.6
+
+* Update Ingress-Nginx version controller-v1.12.6
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.12.5...helm-chart-4.12.6

--- a/charts/ingress-nginx/changelog/helm-chart-4.12.7.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.12.7.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.12.7
+
+* Update Ingress-Nginx version controller-v1.12.7
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.12.7...helm-chart-4.12.7

--- a/charts/ingress-nginx/changelog/helm-chart-4.12.8.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.12.8.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.12.8
+
+* Update Ingress-Nginx version controller-v1.12.8
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.12.7...helm-chart-4.12.8

--- a/charts/ingress-nginx/changelog/helm-chart-4.13.0.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.13.0.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.13.0
+
+* Update Ingress-Nginx version controller-v1.13.0
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.12.0...helm-chart-4.13.0

--- a/charts/ingress-nginx/changelog/helm-chart-4.13.1.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.13.1.md
@@ -1,0 +1,10 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.13.1
+
+* Make: Add `helm-test` target. (#13659)
+* Update Ingress-Nginx version controller-v1.13.1
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.13.0...helm-chart-4.13.1

--- a/charts/ingress-nginx/changelog/helm-chart-4.13.2.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.13.2.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.13.2
+
+* Update Ingress-Nginx version controller-v1.13.2
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.13.1...helm-chart-4.13.2

--- a/charts/ingress-nginx/changelog/helm-chart-4.13.3.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.13.3.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.13.3
+
+* Update Ingress-Nginx version controller-v1.13.3
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.13.2...helm-chart-4.13.3

--- a/charts/ingress-nginx/changelog/helm-chart-4.13.4.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.13.4.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.13.4
+
+* Update Ingress-Nginx version controller-v1.13.4
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.13.3...helm-chart-4.13.4

--- a/charts/ingress-nginx/changelog/helm-chart-4.13.5.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.13.5.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.13.5
+
+* Update Ingress-Nginx version controller-v1.13.5
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.13.4...helm-chart-4.13.5

--- a/charts/ingress-nginx/changelog/helm-chart-4.13.6.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.13.6.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.13.6
+
+* Update Ingress-Nginx version controller-v1.13.6
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.13.5...helm-chart-4.13.6

--- a/charts/ingress-nginx/changelog/helm-chart-4.13.7.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.13.7.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.13.7
+
+* Update Ingress-Nginx version controller-v1.13.7
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.13.6...helm-chart-4.13.7

--- a/charts/ingress-nginx/changelog/helm-chart-4.13.8.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.13.8.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.13.8
+
+* Update Ingress-Nginx version controller-v1.13.8
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.13.7...helm-chart-4.13.8

--- a/charts/ingress-nginx/changelog/helm-chart-4.14.0.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.14.0.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.14.0
+
+* Update Ingress-Nginx version controller-v1.14.0
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.13.3...helm-chart-4.14.0

--- a/charts/ingress-nginx/changelog/helm-chart-4.14.1.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.14.1.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.14.1
+
+* Update Ingress-Nginx version controller-v1.14.1
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.14.0...helm-chart-4.14.1

--- a/charts/ingress-nginx/changelog/helm-chart-4.14.2.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.14.2.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.14.2
+
+* Update Ingress-Nginx version controller-v1.14.2
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.14.2...helm-chart-4.14.2

--- a/charts/ingress-nginx/changelog/helm-chart-4.14.3.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.14.3.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.14.3
+
+* Update Ingress-Nginx version controller-v1.14.3
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.14.2...helm-chart-4.14.3

--- a/charts/ingress-nginx/changelog/helm-chart-4.14.4.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.14.4.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.14.4
+
+* Update Ingress-Nginx version controller-v1.14.4
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.14.3...helm-chart-4.14.4

--- a/charts/ingress-nginx/changelog/helm-chart-4.15.0.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.15.0.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.15.0
+
+* Update Ingress-Nginx version controller-v1.15.0
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.14.0...helm-chart-4.15.0

--- a/charts/ingress-nginx/ci/controller-service-internal-values.yaml
+++ b/charts/ingress-nginx/ci/controller-service-internal-values.yaml
@@ -9,5 +9,7 @@ controller:
 
     internal:
       enabled: true
+      labels:
+        external-dns.alpha.kubernetes.io/hostname: internal.example.com
       annotations:
         service.beta.kubernetes.io/aws-load-balancer-internal: "true"

--- a/charts/ingress-nginx/ci/controller-service-values.yaml
+++ b/charts/ingress-nginx/ci/controller-service-values.yaml
@@ -7,6 +7,10 @@ controller:
   service:
     type: NodePort
 
+    external:
+      labels:
+        external-dns.alpha.kubernetes.io/hostname: external.example.com
+
     nodePorts:
       tcp:
         9000: 30090

--- a/charts/ingress-nginx/cloudbuild.yaml
+++ b/charts/ingress-nginx/cloudbuild.yaml
@@ -1,0 +1,11 @@
+options:
+  # Ignore Prow provided substitutions.
+  substitution_option: ALLOW_LOOSE
+steps:
+- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260127-c1affcc8de
+  dir: charts
+  env:
+  - NAME=ingress-nginx
+  entrypoint: make
+  args:
+  - push

--- a/charts/ingress-nginx/templates/admission-webhooks/cert-manager.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/cert-manager.yaml
@@ -19,6 +19,9 @@ metadata:
 spec:
   secretName: {{ include "ingress-nginx.fullname" . }}-root-cert
   duration: {{ .Values.controller.admissionWebhooks.certManager.rootCert.duration | default "43800h0m0s" | quote }}
+  {{- if gt (.Values.controller.admissionWebhooks.certManager.rootCert.revisionHistoryLimit | int) 0 }}
+  revisionHistoryLimit: {{ .Values.controller.admissionWebhooks.certManager.rootCert.revisionHistoryLimit }}
+  {{- end }}
   issuerRef:
     name: {{ include "ingress-nginx.fullname" . }}-self-signed-issuer
   commonName: "ca.webhook.ingress-nginx"
@@ -47,6 +50,9 @@ metadata:
 spec:
   secretName: {{ include "ingress-nginx.admissionWebhooks.fullname" . }}
   duration: {{ .Values.controller.admissionWebhooks.certManager.admissionCert.duration | default "8760h0m0s" | quote }}
+  {{- if gt (.Values.controller.admissionWebhooks.certManager.admissionCert.revisionHistoryLimit | int) 0 }}
+  revisionHistoryLimit: {{ .Values.controller.admissionWebhooks.certManager.admissionCert.revisionHistoryLimit }}
+  {{- end }}
   issuerRef:
     {{- if .Values.controller.admissionWebhooks.certManager.issuerRef }}
     {{- toYaml .Values.controller.admissionWebhooks.certManager.issuerRef | nindent 4 }}

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -17,9 +17,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-{{- if .Capabilities.APIVersions.Has "batch/v1alpha1" }}
-  # Alpha feature since k8s 1.12
   ttlSecondsAfterFinished: 0
+{{- if gt (int .Values.controller.admissionWebhooks.createSecretJob.activeDeadlineSeconds) 0 }}
+  activeDeadlineSeconds: {{ .Values.controller.admissionWebhooks.createSecretJob.activeDeadlineSeconds }}
 {{- end }}
   template:
     metadata:
@@ -36,6 +36,9 @@ spec:
     spec:
     {{- if .Values.controller.admissionWebhooks.patch.priorityClassName }}
       priorityClassName: {{ .Values.controller.admissionWebhooks.patch.priorityClassName }}
+    {{- end }}
+    {{- if .Values.controller.admissionWebhooks.patch.runtimeClassName }}
+      runtimeClassName: {{ .Values.controller.admissionWebhooks.patch.runtimeClassName | quote }}
     {{- end }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
@@ -65,8 +68,12 @@ spec:
           {{- if .Values.controller.admissionWebhooks.createSecretJob.resources }}
           resources: {{ toYaml .Values.controller.admissionWebhooks.createSecretJob.resources | nindent 12 }}
           {{- end }}
+          {{- if .Values.controller.admissionWebhooks.createSecretJob.volumeMounts }}
+          volumeMounts: {{- toYaml .Values.controller.admissionWebhooks.createSecretJob.volumeMounts | nindent 12 }}
+          {{- end }}
       restartPolicy: OnFailure
       serviceAccountName: {{ include "ingress-nginx.admissionWebhooks.patch.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.controller.admissionWebhooks.patch.serviceAccount.automountServiceAccountToken }}
     {{- if .Values.controller.admissionWebhooks.patch.nodeSelector }}
       nodeSelector: {{ toYaml .Values.controller.admissionWebhooks.patch.nodeSelector | nindent 8 }}
     {{- end }}
@@ -75,5 +82,8 @@ spec:
     {{- end }}
     {{- if .Values.controller.admissionWebhooks.patch.securityContext }}
       securityContext: {{ toYaml .Values.controller.admissionWebhooks.patch.securityContext | nindent 8 }}
+    {{- end }}
+    {{- if .Values.controller.admissionWebhooks.createSecretJob.volumes }}
+      volumes: {{- toYaml .Values.controller.admissionWebhooks.createSecretJob.volumes | nindent 8 }}
     {{- end }}
 {{- end }}

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -17,9 +17,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-{{- if .Capabilities.APIVersions.Has "batch/v1alpha1" }}
-  # Alpha feature since k8s 1.12
   ttlSecondsAfterFinished: 0
+{{- if gt (int .Values.controller.admissionWebhooks.patchWebhookJob.activeDeadlineSeconds) 0 }}
+  activeDeadlineSeconds: {{ .Values.controller.admissionWebhooks.patchWebhookJob.activeDeadlineSeconds }}
 {{- end }}
   template:
     metadata:
@@ -36,6 +36,9 @@ spec:
     spec:
     {{- if .Values.controller.admissionWebhooks.patch.priorityClassName }}
       priorityClassName: {{ .Values.controller.admissionWebhooks.patch.priorityClassName }}
+    {{- end }}
+    {{- if .Values.controller.admissionWebhooks.patch.runtimeClassName }}
+      runtimeClassName: {{ .Values.controller.admissionWebhooks.patch.runtimeClassName | quote }}
     {{- end }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
@@ -67,8 +70,12 @@ spec:
           {{- if .Values.controller.admissionWebhooks.patchWebhookJob.resources }}
           resources: {{ toYaml .Values.controller.admissionWebhooks.patchWebhookJob.resources | nindent 12 }}
           {{- end }}
+          {{- if .Values.controller.admissionWebhooks.patchWebhookJob.volumeMounts }}
+          volumeMounts: {{- toYaml .Values.controller.admissionWebhooks.patchWebhookJob.volumeMounts | nindent 12 }}
+          {{- end }}
       restartPolicy: OnFailure
       serviceAccountName: {{ include "ingress-nginx.admissionWebhooks.patch.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.controller.admissionWebhooks.patch.serviceAccount.automountServiceAccountToken }}
     {{- if .Values.controller.admissionWebhooks.patch.nodeSelector }}
       nodeSelector: {{ toYaml .Values.controller.admissionWebhooks.patch.nodeSelector | nindent 8 }}
     {{- end }}
@@ -77,5 +84,8 @@ spec:
     {{- end }}
     {{- if .Values.controller.admissionWebhooks.patch.securityContext }}
       securityContext: {{ toYaml .Values.controller.admissionWebhooks.patch.securityContext | nindent 8 }}
+    {{- end }}
+    {{- if .Values.controller.admissionWebhooks.patchWebhookJob.volumes }}
+      volumes: {{- toYaml .Values.controller.admissionWebhooks.patchWebhookJob.volumes | nindent 8 }}
     {{- end }}
 {{- end }}

--- a/charts/ingress-nginx/templates/controller-daemonset.yaml
+++ b/charts/ingress-nginx/templates/controller-daemonset.yaml
@@ -57,6 +57,9 @@ spec:
     {{- if .Values.controller.priorityClassName }}
       priorityClassName: {{ .Values.controller.priorityClassName | quote }}
     {{- end }}
+    {{- if .Values.controller.runtimeClassName }}
+      runtimeClassName: {{ .Values.controller.runtimeClassName | quote }}
+    {{- end }}
     {{- if or .Values.controller.podSecurityContext .Values.controller.sysctls }}
       securityContext:
       {{- if .Values.controller.podSecurityContext }}
@@ -171,13 +174,18 @@ spec:
         {{- if .Values.controller.resources }}
           resources: {{ toYaml .Values.controller.resources | nindent 12 }}
         {{- end }}
+        {{- if semverCompare ">=1.33.0-0" .Capabilities.KubeVersion.Version }}
+        {{- if .Values.controller.resizePolicy }}
+          resizePolicy: {{ toYaml .Values.controller.resizePolicy | nindent 12 }}
+        {{- end }}
+        {{- end }}
       {{- if .Values.controller.extraContainers }}
         {{- toYaml .Values.controller.extraContainers | nindent 8 }}
       {{- end }}
     {{- if (or .Values.controller.extraInitContainers .Values.controller.extraModules) }}
       initContainers:
       {{- if .Values.controller.extraInitContainers }}
-        {{- toYaml .Values.controller.extraInitContainers | nindent 8 }}
+        {{- tpl (toYaml .Values.controller.extraInitContainers) $ | nindent 8 }}
       {{- end }}
       {{- if .Values.controller.extraModules }}
         {{- range .Values.controller.extraModules }}
@@ -202,6 +210,7 @@ spec:
       topologySpreadConstraints: {{ tpl (toYaml .Values.controller.topologySpreadConstraints) $ | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ template "ingress-nginx.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}
     {{- if (or .Values.controller.customTemplate.configMapName .Values.controller.extraVolumeMounts .Values.controller.admissionWebhooks.enabled .Values.controller.extraVolumes .Values.controller.extraModules) }}
       volumes:

--- a/charts/ingress-nginx/templates/controller-deployment.yaml
+++ b/charts/ingress-nginx/templates/controller-deployment.yaml
@@ -63,6 +63,9 @@ spec:
     {{- if .Values.controller.priorityClassName }}
       priorityClassName: {{ .Values.controller.priorityClassName | quote }}
     {{- end }}
+    {{- if .Values.controller.runtimeClassName }}
+      runtimeClassName: {{ .Values.controller.runtimeClassName | quote }}
+    {{- end }}
     {{- if or .Values.controller.podSecurityContext .Values.controller.sysctls }}
       securityContext:
       {{- if .Values.controller.podSecurityContext }}
@@ -177,13 +180,18 @@ spec:
         {{- if .Values.controller.resources }}
           resources: {{ toYaml .Values.controller.resources | nindent 12 }}
         {{- end }}
+        {{- if semverCompare ">=1.33.0-0" .Capabilities.KubeVersion.Version }}
+        {{- if .Values.controller.resizePolicy }}
+          resizePolicy: {{ toYaml .Values.controller.resizePolicy | nindent 12 }}
+        {{- end }}
+        {{- end }}
       {{- if .Values.controller.extraContainers }}
         {{- toYaml .Values.controller.extraContainers | nindent 8 }}
       {{- end }}
     {{- if (or .Values.controller.extraInitContainers .Values.controller.extraModules) }}
       initContainers:
       {{- if .Values.controller.extraInitContainers }}
-        {{- toYaml .Values.controller.extraInitContainers | nindent 8 }}
+        {{- tpl (toYaml .Values.controller.extraInitContainers) $ | nindent 8 }}
       {{- end }}
       {{- if .Values.controller.extraModules }}
         {{- range .Values.controller.extraModules }}
@@ -208,6 +216,7 @@ spec:
       topologySpreadConstraints: {{ tpl (toYaml .Values.controller.topologySpreadConstraints) $ | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ template "ingress-nginx.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}
     {{- if (or .Values.controller.customTemplate.configMapName .Values.controller.extraVolumeMounts .Values.controller.admissionWebhooks.enabled .Values.controller.extraVolumes .Values.controller.extraModules) }}
       volumes:

--- a/charts/ingress-nginx/templates/controller-service-internal.yaml
+++ b/charts/ingress-nginx/templates/controller-service-internal.yaml
@@ -12,12 +12,18 @@ metadata:
   {{- if .Values.controller.service.labels }}
     {{- toYaml .Values.controller.service.labels | nindent 4 }}
   {{- end }}
+  {{- if .Values.controller.service.internal.labels }}
+    {{- toYaml .Values.controller.service.internal.labels | nindent 4 }}
+  {{- end }}
   name: {{ include "ingress-nginx.controller.fullname" . }}-internal
   namespace: {{ include "ingress-nginx.namespace" . }}
 spec:
   type: {{ .Values.controller.service.internal.type | default .Values.controller.service.type }}
 {{- if .Values.controller.service.internal.clusterIP }}
   clusterIP: {{ .Values.controller.service.internal.clusterIP }}
+{{- end }}
+{{- if .Values.controller.service.internal.clusterIPs }}
+  clusterIPs: {{ toYaml .Values.controller.service.internal.clusterIPs | nindent 4 }}
 {{- end }}
 {{- if .Values.controller.service.internal.externalIPs }}
   externalIPs: {{ toYaml .Values.controller.service.internal.externalIPs | nindent 4 }}
@@ -42,6 +48,11 @@ spec:
 {{- end }}
 {{- if .Values.controller.service.internal.healthCheckNodePort }}
   healthCheckNodePort: {{ .Values.controller.service.internal.healthCheckNodePort }}
+{{- end }}
+{{- if semverCompare ">=1.31.0-0" .Capabilities.KubeVersion.Version -}}
+{{- if .Values.controller.service.internal.trafficDistribution }}
+  trafficDistribution: {{ .Values.controller.service.internal.trafficDistribution }}
+{{- end }}
 {{- end }}
 {{- if semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version -}}
 {{- if .Values.controller.service.internal.ipFamilyPolicy }}

--- a/charts/ingress-nginx/templates/controller-service.yaml
+++ b/charts/ingress-nginx/templates/controller-service.yaml
@@ -12,12 +12,18 @@ metadata:
   {{- if .Values.controller.service.labels }}
     {{- toYaml .Values.controller.service.labels | nindent 4 }}
   {{- end }}
+  {{- if .Values.controller.service.external.labels }}
+    {{- toYaml .Values.controller.service.external.labels | nindent 4 }}
+  {{- end }}
   name: {{ include "ingress-nginx.controller.fullname" . }}
   namespace: {{ include "ingress-nginx.namespace" . }}
 spec:
   type: {{ .Values.controller.service.type }}
 {{- if .Values.controller.service.clusterIP }}
   clusterIP: {{ .Values.controller.service.clusterIP }}
+{{- end }}
+{{- if .Values.controller.service.clusterIPs }}
+  clusterIPs: {{ toYaml .Values.controller.service.clusterIPs | nindent 4 }}
 {{- end }}
 {{- if .Values.controller.service.externalIPs }}
   externalIPs: {{ toYaml .Values.controller.service.externalIPs | nindent 4 }}
@@ -42,6 +48,11 @@ spec:
 {{- end }}
 {{- if .Values.controller.service.healthCheckNodePort }}
   healthCheckNodePort: {{ .Values.controller.service.healthCheckNodePort }}
+{{- end }}
+{{- if semverCompare ">=1.31.0-0" .Capabilities.KubeVersion.Version -}}
+{{- if .Values.controller.service.trafficDistribution }}
+  trafficDistribution: {{ .Values.controller.service.trafficDistribution }}
+{{- end }}
 {{- end }}
 {{- if semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version -}}
 {{- if .Values.controller.service.ipFamilyPolicy }}

--- a/charts/ingress-nginx/templates/controller-servicemonitor.yaml
+++ b/charts/ingress-nginx/templates/controller-servicemonitor.yaml
@@ -32,6 +32,9 @@ spec:
   endpoints:
   - port: {{ .Values.controller.metrics.portName }}
     interval: {{ .Values.controller.metrics.serviceMonitor.scrapeInterval }}
+    {{- if .Values.controller.metrics.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.controller.metrics.serviceMonitor.scrapeTimeout }}
+    {{- end }}
     {{- if .Values.controller.metrics.serviceMonitor.honorLabels }}
     honorLabels: true
     {{- end }}
@@ -46,5 +49,20 @@ spec:
   {{- end }}
   {{- if .Values.controller.metrics.serviceMonitor.targetLabels }}
   targetLabels: {{ toYaml .Values.controller.metrics.serviceMonitor.targetLabels | nindent 2 }}
+  {{- end }}
+  {{- if .Values.controller.metrics.serviceMonitor.labelLimit }}
+  labelLimit: {{ .Values.controller.metrics.serviceMonitor.labelLimit }}
+  {{- end }}
+  {{- if .Values.controller.metrics.serviceMonitor.labelNameLengthLimit }}
+  labelNameLengthLimit: {{ .Values.controller.metrics.serviceMonitor.labelNameLengthLimit }}
+  {{- end }}
+  {{- if .Values.controller.metrics.serviceMonitor.labelValueLengthLimit }}
+  labelValueLengthLimit: {{ .Values.controller.metrics.serviceMonitor.labelValueLengthLimit }}
+  {{- end }}
+  {{- if .Values.controller.metrics.serviceMonitor.sampleLimit }}
+  sampleLimit: {{ .Values.controller.metrics.serviceMonitor.sampleLimit }}
+  {{- end }}
+  {{- if .Values.controller.metrics.serviceMonitor.targetLimit }}
+  targetLimit: {{ .Values.controller.metrics.serviceMonitor.targetLimit }}
   {{- end }}
 {{- end }}

--- a/charts/ingress-nginx/templates/default-backend-deployment.yaml
+++ b/charts/ingress-nginx/templates/default-backend-deployment.yaml
@@ -45,6 +45,9 @@ spec:
     {{- if .Values.defaultBackend.priorityClassName }}
       priorityClassName: {{ .Values.defaultBackend.priorityClassName }}
     {{- end }}
+    {{- if .Values.defaultBackend.runtimeClassName }}
+      runtimeClassName: {{ .Values.defaultBackend.runtimeClassName | quote }}
+    {{- end }}
     {{- if .Values.defaultBackend.podSecurityContext }}
       securityContext: {{ toYaml .Values.defaultBackend.podSecurityContext | nindent 8 }}
     {{- end }}
@@ -103,6 +106,7 @@ spec:
       nodeSelector: {{ toYaml .Values.defaultBackend.nodeSelector | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ include "ingress-nginx.defaultBackend.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.defaultBackend.serviceAccount.automountServiceAccountToken }}
     {{- if .Values.defaultBackend.tolerations }}
       tolerations: {{ toYaml .Values.defaultBackend.tolerations | nindent 8 }}
     {{- end }}
@@ -114,6 +118,6 @@ spec:
     {{- end }}
       terminationGracePeriodSeconds: 60
     {{- if .Values.defaultBackend.extraVolumes }}
-      volumes: {{ toYaml .Values.defaultBackend.extraVolumes | nindent 8 }}
+      volumes: {{ tpl (toYaml .Values.defaultBackend.extraVolumes) $ | nindent 8 }}
     {{- end }}
 {{- end }}

--- a/charts/ingress-nginx/templates/default-backend-service.yaml
+++ b/charts/ingress-nginx/templates/default-backend-service.yaml
@@ -18,6 +18,9 @@ spec:
 {{- if .Values.defaultBackend.service.clusterIP }}
   clusterIP: {{ .Values.defaultBackend.service.clusterIP }}
 {{- end }}
+{{- if .Values.defaultBackend.service.clusterIPs }}
+  clusterIPs: {{ toYaml .Values.defaultBackend.service.clusterIPs | nindent 4 }}
+{{- end }}
 {{- if .Values.defaultBackend.service.externalIPs }}
   externalIPs: {{ toYaml .Values.defaultBackend.service.externalIPs | nindent 4 }}
 {{- end }}

--- a/charts/ingress-nginx/tests/admission-webhooks/cert-manager_test.yaml
+++ b/charts/ingress-nginx/tests/admission-webhooks/cert-manager_test.yaml
@@ -1,0 +1,34 @@
+suite: Admission Webhooks > CertManager
+templates:
+  - admission-webhooks/cert-manager.yaml
+
+tests:
+  - it: should not create a Certificate if `controller.admissionWebhooks.certManager.enabled` is false
+    set:
+      controller.admissionWebhooks.certManager.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create a Certificate if `controller.admissionWebhooks.certManager.enabled` is true
+    set:
+      controller.admissionWebhooks.certManager.enabled: true
+      controller.admissionWebhooks.certManager.issuerRef: ingress-nginx-issuer
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Certificate
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-ingress-nginx-admission
+
+  - it: should create a Certificate with `revisionHistoryLimit` if `controller.admissionWebhooks.certManager.admissionCert.revisionHistoryLimit` is set
+    set:
+      controller.admissionWebhooks.certManager.enabled: true
+      controller.admissionWebhooks.certManager.issuerRef: ingress-nginx-issuer
+      controller.admissionWebhooks.certManager.admissionCert.revisionHistoryLimit: 3
+    asserts:
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 3

--- a/charts/ingress-nginx/tests/admission-webhooks/job-patch/job-createSecret_test.yaml
+++ b/charts/ingress-nginx/tests/admission-webhooks/job-patch/job-createSecret_test.yaml
@@ -1,0 +1,78 @@
+suite: Admission Webhooks > Patch Job > Create Secret Job
+templates:
+  - admission-webhooks/job-patch/job-createSecret.yaml
+
+tests:
+  - it: should create a Job with token auto-mounting disabled if `controller.admissionWebhooks.patch.serviceAccount.automountServiceAccountToken` is false
+    set:
+      controller.admissionWebhooks.patch.serviceAccount.automountServiceAccountToken: false
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+
+  - it: should create a Job with `activeDeadlineSeconds` if `controller.admissionWebhooks.createSecretJob.activeDeadlineSeconds ` is set
+    set:
+      controller.admissionWebhooks.createSecretJob.activeDeadlineSeconds: 1
+    asserts:
+      - equal:
+          path: spec.activeDeadlineSeconds
+          value: 1
+
+  - it: should create a Job with custom volumes and volume mounts if `controller.admissionWebhooks.createSecretJob.volumes` and `controller.admissionWebhooks.createSecretJob.volumeMounts` are set
+    set:
+      controller.admissionWebhooks.patch.serviceAccount.automountServiceAccountToken: false
+      controller.admissionWebhooks.createSecretJob.volumeMounts:
+        - name: kube-api-access
+          mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          readOnly: true
+      controller.admissionWebhooks.createSecretJob.volumes:
+        - name: kube-api-access
+          projected:
+            defaultMode: 0444
+            sources:
+              - serviceAccountToken:
+                  path: token
+                  expirationSeconds: 3600
+              - configMap:
+                  name: kube-root-ca.crt
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+              - downwardAPI:
+                  items:
+                    - path: namespace
+                      fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts
+          value:
+            - name: kube-api-access
+              mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              readOnly: true
+      - equal:
+          path: spec.template.spec.volumes
+          value:
+            - name: kube-api-access
+              projected:
+                defaultMode: 0444
+                sources:
+                  - serviceAccountToken:
+                      path: token
+                      expirationSeconds: 3600
+                  - configMap:
+                      name: kube-root-ca.crt
+                      items:
+                        - key: ca.crt
+                          path: ca.crt
+                  - downwardAPI:
+                      items:
+                        - path: namespace
+                          fieldRef:
+                            apiVersion: v1
+                            fieldPath: metadata.namespace

--- a/charts/ingress-nginx/tests/admission-webhooks/job-patch/job-patchWebhook_test.yaml
+++ b/charts/ingress-nginx/tests/admission-webhooks/job-patch/job-patchWebhook_test.yaml
@@ -1,0 +1,78 @@
+suite: Admission Webhooks > Patch Job > Patch Webhook Job
+templates:
+  - admission-webhooks/job-patch/job-patchWebhook.yaml
+
+tests:
+  - it: should create a Job with token auto-mounting disabled if `controller.admissionWebhooks.patch.serviceAccount.automountServiceAccountToken` is false
+    set:
+      controller.admissionWebhooks.patch.serviceAccount.automountServiceAccountToken: false
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+
+  - it: should create a Job with `activeDeadlineSeconds` if `controller.admissionWebhooks.patchWebhookJob.activeDeadlineSeconds ` is set
+    set:
+      controller.admissionWebhooks.patchWebhookJob.activeDeadlineSeconds: 1
+    asserts:
+      - equal:
+          path: spec.activeDeadlineSeconds
+          value: 1
+
+  - it: should create a Job with custom volumes and volume mounts if `controller.admissionWebhooks.patchWebhookJob.volumes` and `controller.admissionWebhooks.patchWebhookJob.volumeMounts` are set
+    set:
+      controller.admissionWebhooks.patch.serviceAccount.automountServiceAccountToken: false
+      controller.admissionWebhooks.patchWebhookJob.volumeMounts:
+        - name: kube-api-access
+          mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          readOnly: true
+      controller.admissionWebhooks.patchWebhookJob.volumes:
+        - name: kube-api-access
+          projected:
+            defaultMode: 0444
+            sources:
+              - serviceAccountToken:
+                  path: token
+                  expirationSeconds: 3600
+              - configMap:
+                  name: kube-root-ca.crt
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+              - downwardAPI:
+                  items:
+                    - path: namespace
+                      fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts
+          value:
+            - name: kube-api-access
+              mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              readOnly: true
+      - equal:
+          path: spec.template.spec.volumes
+          value:
+            - name: kube-api-access
+              projected:
+                defaultMode: 0444
+                sources:
+                  - serviceAccountToken:
+                      path: token
+                      expirationSeconds: 3600
+                  - configMap:
+                      name: kube-root-ca.crt
+                      items:
+                        - key: ca.crt
+                          path: ca.crt
+                  - downwardAPI:
+                      items:
+                        - path: namespace
+                          fieldRef:
+                            apiVersion: v1
+                            fieldPath: metadata.namespace

--- a/charts/ingress-nginx/tests/controller-daemonset_test.yaml
+++ b/charts/ingress-nginx/tests/controller-daemonset_test.yaml
@@ -96,6 +96,24 @@ tests:
               maxSkew: 1
               whenUnsatisfiable: ScheduleAnyway
 
+  - it: should create a DaemonSet with templated init containers if `controller.extraInitContainers` contains Helm templates
+    set:
+      controller.kind: DaemonSet
+      controller.extraInitContainers:
+        - name: '{{ .Release.Name }}-init'
+          image: busybox
+          command:
+            - sh
+            - -c
+            - echo '{{ .Release.Namespace }}';
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: RELEASE-NAME-init
+      - contains:
+          path: spec.template.spec.initContainers[0].command
+          content: echo 'NAMESPACE';
+
   - it: should create a DaemonSet with affinity if `controller.affinity` is set
     set:
       controller.kind: DaemonSet
@@ -190,3 +208,41 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].image
           value: registry.k8s.io/ingress-nginx/controller:custom-tag@sha256:faa2d18687f734994b6bd9e309e7a73852a81c30e1b8f63165fcd4f0a087e3cd
+
+  - it: should create a DaemonSet with token auto-mounting disabled if `serviceAccount.automountServiceAccountToken` is false
+    set:
+      controller.kind: DaemonSet
+      serviceAccount.automountServiceAccountToken: false
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+
+  - it: should create a DaemonSet with a custom runtime if `controller.runtimeClassName` is set
+    set:
+      controller.kind: DaemonSet
+      controller.runtimeClassName: myClass
+    asserts:
+      - equal:
+          path: spec.template.spec.runtimeClassName
+          value: myClass
+
+  - it: should create a DaemonSet with resize policy if `controller.resizePolicy` is set
+    capabilities:
+      majorVersion: 1
+      minorVersion: 33
+    set:
+      controller.kind: DaemonSet
+      controller.resizePolicy:
+        - resourceName: cpu
+          restartPolicy: NotRequired
+        - resourceName: memory
+          restartPolicy: RestartContainer
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resizePolicy
+          value:
+            - resourceName: cpu
+              restartPolicy: NotRequired
+            - resourceName: memory
+              restartPolicy: RestartContainer

--- a/charts/ingress-nginx/tests/controller-deployment_test.yaml
+++ b/charts/ingress-nginx/tests/controller-deployment_test.yaml
@@ -119,6 +119,23 @@ tests:
               maxSkew: 1
               whenUnsatisfiable: ScheduleAnyway
 
+  - it: should create a Deployment with templated init containers if `controller.extraInitContainers` contains Helm templates
+    set:
+      controller.extraInitContainers:
+        - name: '{{ .Release.Name }}-init'
+          image: busybox
+          command:
+            - sh
+            - -c
+            - echo '{{ .Release.Namespace }}';
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: RELEASE-NAME-init
+      - contains:
+          path: spec.template.spec.initContainers[0].command
+          content: echo 'NAMESPACE';
+
   - it: should create a Deployment with affinity if `controller.affinity` is set
     set:
       controller.affinity:
@@ -215,3 +232,38 @@ tests:
       - equal:
           path: spec.progressDeadlineSeconds
           value: 111
+
+  - it: should create a Deployment with token auto-mounting disabled if `serviceAccount.automountServiceAccountToken` is false
+    set:
+      serviceAccount.automountServiceAccountToken: false
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+
+  - it: should create a Deployment with a custom runtime if `controller.runtimeClassName` is set
+    set:
+      controller.runtimeClassName: myClass
+    asserts:
+      - equal:
+          path: spec.template.spec.runtimeClassName
+          value: myClass
+
+  - it: should create a Deployment with resize policy if `controller.resizePolicy` is set
+    capabilities:
+      majorVersion: 1
+      minorVersion: 33
+    set:
+      controller.resizePolicy:
+        - resourceName: cpu
+          restartPolicy: NotRequired
+        - resourceName: memory
+          restartPolicy: RestartContainer
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resizePolicy
+          value:
+            - resourceName: cpu
+              restartPolicy: NotRequired
+            - resourceName: memory
+              restartPolicy: RestartContainer

--- a/charts/ingress-nginx/tests/controller-service-internal_test.yaml
+++ b/charts/ingress-nginx/tests/controller-service-internal_test.yaml
@@ -23,3 +23,53 @@ tests:
       - equal:
           path: metadata.name
           value: RELEASE-NAME-ingress-nginx-controller-internal
+
+  - it: should create a Service without `clusterIPs` if `controller.service.internal.clusterIPs` is not set
+    set:
+      controller.service.internal.enabled: true
+      controller.service.internal.annotations:
+        test.annotation: "true"
+    asserts:
+      - notExists:
+          path: spec.clusterIPs
+
+  - it: should create a Service with `clusterIPs` if `controller.service.internal.clusterIPs` is set
+    set:
+      controller.service.internal.enabled: true
+      controller.service.internal.annotations:
+        test.annotation: "true"
+      controller.service.internal.clusterIPs:
+        - 10.0.0.1
+        - fd00::1
+    asserts:
+      - equal:
+          path: spec.clusterIPs
+          value:
+            - 10.0.0.1
+            - fd00::1
+
+  - it: should create a Service with `trafficDistribution` if `controller.service.internal.trafficDistribution` is set
+    capabilities:
+      majorVersion: 1
+      minorVersion: 31
+    set:
+      controller.service.internal.enabled: true
+      controller.service.internal.annotations:
+        test.annotation: "true"
+      controller.service.internal.trafficDistribution: PreferClose
+    asserts:
+      - equal:
+          path: spec.trafficDistribution
+          value: PreferClose
+
+  - it: should create a Service with labels if `controller.service.internal.labels` is set
+    set:
+      controller.service.internal.enabled: true
+      controller.service.internal.annotations:
+        test.annotation: "true"
+      controller.service.internal.labels:
+        external-dns.alpha.kubernetes.io/hostname: internal.example.com
+    asserts:
+      - equal:
+          path: metadata.labels["external-dns.alpha.kubernetes.io/hostname"]
+          value: internal.example.com

--- a/charts/ingress-nginx/tests/controller-service_test.yaml
+++ b/charts/ingress-nginx/tests/controller-service_test.yaml
@@ -30,3 +30,45 @@ tests:
       - equal:
           path: spec.type
           value: NodePort
+
+  - it: should create a Service without `clusterIPs` if `controller.service.clusterIPs` is not set
+    set:
+      controller.service.external.enabled: true
+    asserts:
+      - notExists:
+          path: spec.clusterIPs
+
+  - it: should create a Service with `clusterIPs` if `controller.service.clusterIPs` is set
+    set:
+      controller.service.external.enabled: true
+      controller.service.clusterIPs:
+        - 10.0.0.1
+        - fd00::1
+    asserts:
+      - equal:
+          path: spec.clusterIPs
+          value:
+            - 10.0.0.1
+            - fd00::1
+
+  - it: should create a Service with `trafficDistribution` if `controller.service.trafficDistribution` is set
+    capabilities:
+      majorVersion: 1
+      minorVersion: 31
+    set:
+      controller.service.external.enabled: true
+      controller.service.trafficDistribution: PreferClose
+    asserts:
+      - equal:
+          path: spec.trafficDistribution
+          value: PreferClose
+
+  - it: should create a Service with labels if `controller.service.external.labels` is set
+    set:
+      controller.service.external.enabled: true
+      controller.service.external.labels:
+        external-dns.alpha.kubernetes.io/hostname: external.example.com
+    asserts:
+      - equal:
+          path: metadata.labels["external-dns.alpha.kubernetes.io/hostname"]
+          value: external.example.com

--- a/charts/ingress-nginx/tests/controller-servicemonitor_test.yaml
+++ b/charts/ingress-nginx/tests/controller-servicemonitor_test.yaml
@@ -27,3 +27,72 @@ tests:
           path: metadata.annotations
           value:
             my-little-annotation: test-value
+
+  - it: should create a ServiceMonitor with `labelLimit` if `controller.metrics.serviceMonitor.labelLimit` is set
+    set:
+      controller.metrics.enabled: true
+      controller.metrics.serviceMonitor.enabled: true
+      controller.metrics.serviceMonitor.labelLimit: 20
+    asserts:
+      - equal:
+          path: spec.labelLimit
+          value: 20
+
+  - it: should create a ServiceMonitor with `labelNameLengthLimit` if `controller.metrics.serviceMonitor.labelNameLengthLimit` is set
+    set:
+      controller.metrics.enabled: true
+      controller.metrics.serviceMonitor.enabled: true
+      controller.metrics.serviceMonitor.labelNameLengthLimit: 50
+    asserts:
+      - equal:
+          path: spec.labelNameLengthLimit
+          value: 50
+
+  - it: should create a ServiceMonitor with `labelValueLengthLimit` if `controller.metrics.serviceMonitor.labelValueLengthLimit` is set
+    set:
+      controller.metrics.enabled: true
+      controller.metrics.serviceMonitor.enabled: true
+      controller.metrics.serviceMonitor.labelValueLengthLimit: 50
+    asserts:
+      - equal:
+          path: spec.labelValueLengthLimit
+          value: 50
+
+  - it: should create a ServiceMonitor with `sampleLimit` if `controller.metrics.serviceMonitor.sampleLimit` is set
+    set:
+      controller.metrics.enabled: true
+      controller.metrics.serviceMonitor.enabled: true
+      controller.metrics.serviceMonitor.sampleLimit: 5000
+    asserts:
+      - equal:
+          path: spec.sampleLimit
+          value: 5000
+
+  - it: should create a ServiceMonitor with `targetLimit` if `controller.metrics.serviceMonitor.targetLimit` is set
+    set:
+      controller.metrics.enabled: true
+      controller.metrics.serviceMonitor.enabled: true
+      controller.metrics.serviceMonitor.targetLimit: 100
+    asserts:
+      - equal:
+          path: spec.targetLimit
+          value: 100
+
+  - it: should create a ServiceMonitor with `scrapeTimeout` if `controller.metrics.serviceMonitor.scrapeTimeout` is set
+    set:
+      controller.metrics.enabled: true
+      controller.metrics.serviceMonitor.enabled: true
+      controller.metrics.serviceMonitor.scrapeTimeout: 60s
+    asserts:
+      - equal:
+          path: spec.endpoints[0].scrapeTimeout
+          value: 60s
+
+  - it: should create a ServiceMonitor without `scrapeTimeout` if `controller.metrics.serviceMonitor.scrapeTimeout` is unset
+    set:
+      controller.metrics.enabled: true
+      controller.metrics.serviceMonitor.enabled: true
+      controller.metrics.serviceMonitor.scrapeTimeout: ""
+    asserts:
+      - notExists:
+          path: spec.endpoints[0].scrapeTimeout

--- a/charts/ingress-nginx/tests/default-backend-deployment_test.yaml
+++ b/charts/ingress-nginx/tests/default-backend-deployment_test.yaml
@@ -187,3 +187,35 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].image
           value: registry.k8s.io/defaultbackend-amd64:custom-tag@sha256:faa2d18687f734994b6bd9e309e7a73852a81c30e1b8f63165fcd4f0a087e3cd
+
+  - it: should create a Deployment with token auto-mounting disabled if `defaultBackend.serviceAccount.automountServiceAccountToken` is false
+    set:
+      defaultBackend.enabled: true
+      defaultBackend.serviceAccount.automountServiceAccountToken: false
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+
+  - it: should create a Deployment with extra volumes if `defaultBackend.extraVolumes` is set
+    set:
+      defaultBackend.enabled: true
+      defaultBackend.extraVolumes:
+        - name: extra-volume
+          configMap:
+            name: '{{ .Release.Name }}'
+      defaultBackend.extraVolumeMounts:
+        - name: extra-volume
+          mountPath: /extra
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes
+          value:
+            - name: extra-volume
+              configMap:
+                name: RELEASE-NAME
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts
+          value:
+            - name: extra-volume
+              mountPath: /extra

--- a/charts/ingress-nginx/tests/default-backend-service_test.yaml
+++ b/charts/ingress-nginx/tests/default-backend-service_test.yaml
@@ -30,3 +30,23 @@ tests:
       - equal:
           path: spec.ports[0].port
           value: 80
+
+  - it: should create a Service without `clusterIPs` if `defaultBackend.service.clusterIPs` is not set
+    set:
+      defaultBackend.enabled: true
+    asserts:
+      - notExists:
+          path: spec.clusterIPs
+
+  - it: should create a Service with `clusterIPs` if `defaultBackend.service.clusterIPs` is set
+    set:
+      defaultBackend.enabled: true
+      defaultBackend.service.clusterIPs:
+        - 10.0.0.1
+        - fd00::1
+    asserts:
+      - equal:
+          path: spec.clusterIPs
+          value:
+            - 10.0.0.1
+            - fd00::1

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -30,9 +30,9 @@ controller:
     ## for backwards compatibility consider setting the full image url via the repository value below
     ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
     ## repository:
-    tag: "v1.12.1"
-    digest: sha256:d2fbc4ec70d8aa2050dd91a91506e998765e86c96f32cffb56c503c9c34eed5b
-    digestChroot: sha256:90155c86548e0bb95b3abf1971cd687d8f5d43f340cfca0ad3484e2b8351096e
+    tag: "v1.15.0"
+    digest: sha256:4eea9a4cc2cb6ddcb7da14d377aaf452e68bd3dbe87fe280755d225c4d5e7e4e
+    digestChroot: sha256:8f3634837abc5c739baff6527934e08131e095317d69bf64d168e07aef53ac12
     pullPolicy: IfNotPresent
     runAsNonRoot: true
     # -- This value must not be changed using the official image.
@@ -78,6 +78,8 @@ controller:
   # By default, while using host network, name resolution uses the host's DNS. If you wish nginx-controller
   # to keep resolving names inside the k8s network, use ClusterFirstWithHostNet.
   dnsPolicy: ClusterFirst
+  # -- Instruct the kubelet to use the named RuntimeClass to run the pod
+  runtimeClassName: ""
   # -- Bare-metal considerations via the host network https://kubernetes.github.io/ingress-nginx/deploy/baremetal/#via-the-host-network
   # Ingress status was blank because there is no Service exposing the Ingress-Nginx Controller in a configuration using the host network, the default --publish-service flag used in standard cloud setups does not apply
   reportNodeInternalIp: false
@@ -399,6 +401,13 @@ controller:
     requests:
       cpu: 100m
       memory: 90Mi
+  # -- Resize policy for controller containers.
+  # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources
+  resizePolicy: []
+  # - resourceName: cpu
+  #   restartPolicy: NotRequired
+  # - resourceName: memory
+  #   restartPolicy: RestartContainer
   # Mutually exclusive with keda autoscaling
   autoscaling:
     enabled: false
@@ -486,6 +495,8 @@ controller:
     external:
       # -- Enable the external controller service or not. Useful for internal-only deployments.
       enabled: true
+      # -- Labels to be added to the external controller service.
+      labels: {}
     # -- Annotations to be added to the external controller service. See `controller.service.internal.annotations` for annotations to be added to the internal controller service.
     annotations: {}
     # -- Labels to be added to both controller services.
@@ -497,6 +508,10 @@ controller:
     # This value is immutable. Set once, it can not be changed without deleting and re-creating the service.
     # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#choosing-your-own-ip-address
     clusterIP: ""
+    # -- Pre-defined cluster internal IP addresses of the external controller service. Take care of collisions with existing services.
+    # This value is immutable. Set once, it can not be changed without deleting and re-creating the service.
+    # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#choosing-your-own-ip-address
+    clusterIPs: []
     # -- List of node IP addresses at which the external controller service is available.
     # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips
     externalIPs: []
@@ -523,6 +538,9 @@ controller:
     # Ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
     # healthCheckNodePort: 0
 
+    # -- Traffic distribution policy of the external controller service. Set to "PreferClose" to route traffic to endpoints that are topologically closer to the client.
+    # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution
+    trafficDistribution: ""
     # -- Represents the dual-stack capabilities of the external controller service. Possible values are SingleStack, PreferDualStack or RequireDualStack.
     # Fields `ipFamilies` and `clusterIP` depend on the value of this field.
     # Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services
@@ -566,6 +584,8 @@ controller:
     internal:
       # -- Enable the internal controller service or not. Remember to configure `controller.service.internal.annotations` when enabling this.
       enabled: false
+      # -- Labels to be added to the internal controller service.
+      labels: {}
       # -- Annotations to be added to the internal controller service. Mandatory for the internal controller service to be created. Varies with the cloud service.
       # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
       annotations: {}
@@ -577,6 +597,10 @@ controller:
       # This value is immutable. Set once, it can not be changed without deleting and re-creating the service.
       # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#choosing-your-own-ip-address
       clusterIP: ""
+      # -- Pre-defined cluster internal IP addresses of the internal controller service. Take care of collisions with existing services.
+      # This value is immutable. Set once, it can not be changed without deleting and re-creating the service.
+      # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#choosing-your-own-ip-address
+      clusterIPs: []
       # -- List of node IP addresses at which the internal controller service is available.
       # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips
       externalIPs: []
@@ -603,6 +627,9 @@ controller:
       # Ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
       # healthCheckNodePort: 0
 
+      # -- Traffic distribution policy of the internal controller service. Set to "PreferClose" to route traffic to endpoints that are topologically closer to the client.
+      # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution
+      trafficDistribution: ""
       # -- Represents the dual-stack capabilities of the internal controller service. Possible values are SingleStack, PreferDualStack or RequireDualStack.
       # Fields `ipFamilies` and `clusterIP` depend on the value of this field.
       # Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services
@@ -682,11 +709,17 @@ controller:
   #  - name: copy-portal-skins
   #    emptyDir: {}
 
-  # -- Containers, which are run before the app containers are started.
+  # -- Containers, which are run before the app containers are started. Values may contain Helm templates.
   extraInitContainers: []
   # - name: init-myservice
   #   image: busybox
   #   command: ['sh', '-c', 'until nslookup myservice; do echo waiting for myservice; sleep 2; done;']
+  # - name: init-dynamic
+  #   image: busybox
+  #   command:
+  #     - sh
+  #     - -c
+  #     - echo "Release={{ .Release.Name }} Namespace={{ .Release.Namespace }}"
 
   # -- Modules, which are mounted into the core nginx image.
   extraModules: []
@@ -754,6 +787,8 @@ controller:
       type: ClusterIP
     createSecretJob:
       name: create
+      # -- Deadline in seconds for the job to complete. Must be greater than 0 to enforce. If unset or 0, no deadline is enforced.
+      activeDeadlineSeconds: 0
       # -- Security context for secret creation containers
       securityContext:
         runAsNonRoot: true
@@ -773,8 +808,20 @@ controller:
       # requests:
       #   cpu: 10m
       #   memory: 20Mi
+      # -- Volume mounts for secret creation containers
+      volumeMounts: []
+      # - name: certs
+      #   mountPath: /etc/webhook/certs
+      #   readOnly: true
+      # -- Volumes for secret creation pod
+      volumes: []
+      # - name: certs
+      #   secret:
+      #     secretName: my-webhook-secret
     patchWebhookJob:
       name: patch
+      # -- Deadline in seconds for the job to complete. Must be greater than 0 to enforce. If unset or 0, no deadline is enforced.
+      activeDeadlineSeconds: 0
       # -- Security context for webhook patch containers
       securityContext:
         runAsNonRoot: true
@@ -788,6 +835,16 @@ controller:
             - ALL
         readOnlyRootFilesystem: true
       resources: {}
+      # -- Volume mounts for webhook patch containers
+      volumeMounts: []
+      # - name: certs
+      #   mountPath: /etc/webhook/certs
+      #   readOnly: true
+      # -- Volumes for webhook patch pod
+      volumes: []
+      # - name: certs
+      #   secret:
+      #     secretName: my-webhook-secret
     patch:
       enabled: true
       image:
@@ -796,12 +853,14 @@ controller:
         ## for backwards compatibility consider setting the full image url via the repository value below
         ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
         ## repository:
-        tag: v1.5.2
-        digest: sha256:e8825994b7a2c7497375a9b945f386506ca6a3eda80b89b74ef2db743f66a5ea
+        tag: v1.6.8
+        digest: sha256:d7e8257f8d8bce64b6df55f81fba92011a6a77269b3350f8b997b152af348dba
         pullPolicy: IfNotPresent
       # -- Provide a priority class name to the webhook patching job
       ##
       priorityClassName: ""
+      # -- Instruct the kubelet to use the named RuntimeClass to run the pod
+      runtimeClassName: ""
       podAnnotations: {}
       # NetworkPolicy for webhook patch
       networkPolicy:
@@ -833,9 +892,15 @@ controller:
       rootCert:
         # default to be 5y
         duration: ""
+        # -- Revision history limit of the root certificate.
+        # Ref.: https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec
+        revisionHistoryLimit: 0
       admissionCert:
         # default to be 1y
         duration: ""
+        # -- Revision history limit of the webhook certificate.
+        # Ref.: https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec
+        revisionHistoryLimit: 0
         # issuerRef:
         #   name: "issuer"
         #   kind: "ClusterIssuer"
@@ -878,10 +943,22 @@ controller:
       ## namespaceSelector:
       ##   any: true
       scrapeInterval: 30s
+      # -- Timeout after which the scrape is ended. Not being set if empty and therefore defaults to the global Prometheus scrape timeout.
+      scrapeTimeout: ""
       # honorLabels: true
       targetLabels: []
       relabelings: []
       metricRelabelings: []
+      # -- Per-scrape limit on number of labels that will be accepted for a sample.
+      labelLimit: 0
+      # -- Per-scrape limit on length of labels name that will be accepted for a sample.
+      labelNameLengthLimit: 0
+      # -- Per-scrape limit on length of labels value that will be accepted for a sample.
+      labelValueLengthLimit: 0
+      # -- Defines a per-scrape limit on the number of scraped samples that will be accepted.
+      sampleLimit: 0
+      # -- Defines a limit on the number of scraped targets that will be accepted.
+      targetLimit: 0
     prometheusRule:
       enabled: false
       additionalLabels: {}
@@ -1145,7 +1222,10 @@ defaultBackend:
   service:
     annotations: {}
     # clusterIP: ""
-
+    # -- Pre-defined cluster internal IP addresses of the default backend service. Take care of collisions with existing services.
+    # This value is immutable. Set once, it can not be changed without deleting and re-creating the service.
+    # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#choosing-your-own-ip-address
+    clusterIPs: []
     # -- List of IP addresses at which the default backend service is available
     ## Ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips
     ##
@@ -1155,6 +1235,8 @@ defaultBackend:
     servicePort: 80
     type: ClusterIP
   priorityClassName: ""
+  # -- Instruct the kubelet to use the named RuntimeClass to run the pod
+  runtimeClassName: ""
   # -- Labels to be added to the default backend resources
   labels: {}
 ## Enable RBAC as per https://github.com/kubernetes/ingress-nginx/blob/main/docs/deploy/rbac.md and https://github.com/kubernetes/ingress-nginx/issues/266

--- a/salt/metalk8s/addons/nginx-ingress-control-plane/deployed/chart.sls
+++ b/salt/metalk8s/addons/nginx-ingress-control-plane/deployed/chart.sls
@@ -17,8 +17,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.12.1
-    helm.sh/chart: ingress-nginx-4.12.1
+    app.kubernetes.io/version: 1.15.0
+    helm.sh/chart: ingress-nginx-4.15.0
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -31,8 +31,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.12.1
-    helm.sh/chart: ingress-nginx-4.12.1
+    app.kubernetes.io/version: 1.15.0
+    helm.sh/chart: ingress-nginx-4.15.0
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -116,8 +116,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.12.1
-    helm.sh/chart: ingress-nginx-4.12.1
+    app.kubernetes.io/version: 1.15.0
+    helm.sh/chart: ingress-nginx-4.15.0
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -139,8 +139,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.12.1
-    helm.sh/chart: ingress-nginx-4.12.1
+    app.kubernetes.io/version: 1.15.0
+    helm.sh/chart: ingress-nginx-4.15.0
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -232,8 +232,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.12.1
-    helm.sh/chart: ingress-nginx-4.12.1
+    app.kubernetes.io/version: 1.15.0
+    helm.sh/chart: ingress-nginx-4.15.0
     heritage: metalk8s
   name: ingress-nginx-control-plane
   namespace: metalk8s-ingress
@@ -255,8 +255,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.12.1
-    helm.sh/chart: ingress-nginx-4.12.1
+    app.kubernetes.io/version: 1.15.0
+    helm.sh/chart: ingress-nginx-4.15.0
     heritage: metalk8s
   name: ingress-nginx-control-plane-controller-metrics
   namespace: metalk8s-ingress
@@ -282,8 +282,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.12.1
-    helm.sh/chart: ingress-nginx-4.12.1
+    app.kubernetes.io/version: 1.15.0
+    helm.sh/chart: ingress-nginx-4.15.0
     heritage: metalk8s
   name: ingress-nginx-control-plane-controller
   namespace: metalk8s-ingress
@@ -313,8 +313,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.12.1
-    helm.sh/chart: ingress-nginx-4.12.1
+    app.kubernetes.io/version: 1.15.0
+    helm.sh/chart: ingress-nginx-4.15.0
     heritage: metalk8s
   name: ingress-nginx-control-plane-controller
   namespace: metalk8s-ingress
@@ -334,10 +334,11 @@ spec:
         app.kubernetes.io/managed-by: salt
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: metalk8s
-        app.kubernetes.io/version: 1.12.1
-        helm.sh/chart: ingress-nginx-4.12.1
+        app.kubernetes.io/version: 1.15.0
+        helm.sh/chart: ingress-nginx-4.15.0
         heritage: metalk8s
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - /nginx-ingress-controller
@@ -360,7 +361,7 @@ spec:
               fieldPath: metadata.namespace
         - name: LD_PRELOAD
           value: /usr/local/lib/libmimalloc.so
-        image: {% endraw -%}{{ build_image_name("nginx-ingress-controller", False) }}{%- raw %}:v1.12.1
+        image: {% endraw -%}{{ build_image_name("nginx-ingress-controller", False) }}{%- raw %}:v1.15.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -443,8 +444,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.12.1
-    helm.sh/chart: ingress-nginx-4.12.1
+    app.kubernetes.io/version: 1.15.0
+    helm.sh/chart: ingress-nginx-4.15.0
     heritage: metalk8s
   name: nginx-control-plane
   namespace: metalk8s-ingress
@@ -460,8 +461,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.12.1
-    helm.sh/chart: ingress-nginx-4.12.1
+    app.kubernetes.io/version: 1.15.0
+    helm.sh/chart: ingress-nginx-4.15.0
     heritage: metalk8s
     metalk8s.scality.com/monitor: ''
   name: ingress-nginx-control-plane-controller

--- a/salt/metalk8s/addons/nginx-ingress/deployed/chart.sls
+++ b/salt/metalk8s/addons/nginx-ingress/deployed/chart.sls
@@ -17,8 +17,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.12.1
-    helm.sh/chart: ingress-nginx-4.12.1
+    app.kubernetes.io/version: 1.15.0
+    helm.sh/chart: ingress-nginx-4.15.0
     heritage: metalk8s
   name: ingress-nginx
   namespace: metalk8s-ingress
@@ -31,8 +31,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.12.1
-    helm.sh/chart: ingress-nginx-4.12.1
+    app.kubernetes.io/version: 1.15.0
+    helm.sh/chart: ingress-nginx-4.15.0
     heritage: metalk8s
   name: ingress-nginx
   namespace: metalk8s-ingress
@@ -116,8 +116,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.12.1
-    helm.sh/chart: ingress-nginx-4.12.1
+    app.kubernetes.io/version: 1.15.0
+    helm.sh/chart: ingress-nginx-4.15.0
     heritage: metalk8s
   name: ingress-nginx
   namespace: metalk8s-ingress
@@ -139,8 +139,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.12.1
-    helm.sh/chart: ingress-nginx-4.12.1
+    app.kubernetes.io/version: 1.15.0
+    helm.sh/chart: ingress-nginx-4.15.0
     heritage: metalk8s
   name: ingress-nginx
   namespace: metalk8s-ingress
@@ -232,8 +232,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.12.1
-    helm.sh/chart: ingress-nginx-4.12.1
+    app.kubernetes.io/version: 1.15.0
+    helm.sh/chart: ingress-nginx-4.15.0
     heritage: metalk8s
   name: ingress-nginx
   namespace: metalk8s-ingress
@@ -255,8 +255,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.12.1
-    helm.sh/chart: ingress-nginx-4.12.1
+    app.kubernetes.io/version: 1.15.0
+    helm.sh/chart: ingress-nginx-4.15.0
     heritage: metalk8s
   name: ingress-nginx-controller-metrics
   namespace: metalk8s-ingress
@@ -282,8 +282,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.12.1
-    helm.sh/chart: ingress-nginx-4.12.1
+    app.kubernetes.io/version: 1.15.0
+    helm.sh/chart: ingress-nginx-4.15.0
     heritage: metalk8s
   name: ingress-nginx-controller
   namespace: metalk8s-ingress
@@ -317,8 +317,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.12.1
-    helm.sh/chart: ingress-nginx-4.12.1
+    app.kubernetes.io/version: 1.15.0
+    helm.sh/chart: ingress-nginx-4.15.0
     heritage: metalk8s
   name: ingress-nginx-controller
   namespace: metalk8s-ingress
@@ -338,10 +338,11 @@ spec:
         app.kubernetes.io/managed-by: salt
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: metalk8s
-        app.kubernetes.io/version: 1.12.1
-        helm.sh/chart: ingress-nginx-4.12.1
+        app.kubernetes.io/version: 1.15.0
+        helm.sh/chart: ingress-nginx-4.15.0
         heritage: metalk8s
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - /nginx-ingress-controller
@@ -366,7 +367,7 @@ spec:
               fieldPath: metadata.namespace
         - name: LD_PRELOAD
           value: /usr/local/lib/libmimalloc.so
-        image: {% endraw -%}{{ build_image_name("nginx-ingress-controller", False) }}{%- raw %}:v1.12.1
+        image: {% endraw -%}{{ build_image_name("nginx-ingress-controller", False) }}{%- raw %}:v1.15.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -447,8 +448,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.12.1
-    helm.sh/chart: ingress-nginx-4.12.1
+    app.kubernetes.io/version: 1.15.0
+    helm.sh/chart: ingress-nginx-4.15.0
     heritage: metalk8s
   name: nginx
   namespace: metalk8s-ingress
@@ -464,8 +465,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 1.12.1
-    helm.sh/chart: ingress-nginx-4.12.1
+    app.kubernetes.io/version: 1.15.0
+    helm.sh/chart: ingress-nginx-4.15.0
     heritage: metalk8s
     metalk8s.scality.com/monitor: ''
   name: ingress-nginx-controller


### PR DESCRIPTION
Bump ingress-nginx controller image: v1.12.1 → v1.15.0
Image digest updated in versions.py via gcrane.

SLS charts updated with ./doit.sh codegen

Closes: MK8S-102