### PR TITLE
`MK8S-82` - `disk-management-agent`: Add machinery to include agent in deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 ### Enhancements
 
 - Install [disk-management-agent](https://github.com/scality/disk-management-agent) version
-  [v0.1.0](https://github.com/scality/disk-management-agent/releases/tag/v0.1.0) by default
+  [v0.0.1-beta.1](https://github.com/scality/disk-management-agent/releases/tag/v0.0.1-beta.1) by default
 
 - Bump Kubernetes version to [1.33.7](https://github.com/kubernetes/kubernetes/releases/tag/v1.33.7)
   (PR[#4769](https://github.com/scality/metalk8s/pull/4769))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
 
 ### Enhancements
 
+- Install [disk-management-agent](https://github.com/scality/disk-management-agent) version
+  [v0.1.0](https://github.com/scality/disk-management-agent/releases/tag/v0.1.0) by default
+
 - Bump Kubernetes version to [1.33.7](https://github.com/kubernetes/kubernetes/releases/tag/v1.33.7)
   (PR[#4769](https://github.com/scality/metalk8s/pull/4769))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 - Install [disk-management-agent](https://github.com/scality/disk-management-agent) version
   [v0.0.1-beta.1](https://github.com/scality/disk-management-agent/releases/tag/v0.0.1-beta.1) by default
+  (PR[#4826](https://github.com/scality/metalk8s/pull/4826))
 
 - Bump Kubernetes version to [1.33.7](https://github.com/kubernetes/kubernetes/releases/tag/v1.33.7)
   (PR[#4769](https://github.com/scality/metalk8s/pull/4769))

--- a/buildchain/buildchain/codegen.py
+++ b/buildchain/buildchain/codegen.py
@@ -416,8 +416,7 @@ def task_transform_codegen_kustomize_disk_management_agent() -> types.TaskDict:
 def codegen_kustomize_disk_management_agent() -> types.TaskDict:
     """Generate the SLS file for the Disk Management Agent."""
     target_sls = (
-        constants.ROOT
-        / "salt/metalk8s/addons/disk-management-agent/deployed/chart.sls"
+        constants.ROOT / "salt/metalk8s/addons/disk-management-agent/deployed/chart.sls"
     )
     template_file = constants.ROOT / "kustomizes/template.sls.in"
 

--- a/buildchain/buildchain/codegen.py
+++ b/buildchain/buildchain/codegen.py
@@ -378,6 +378,70 @@ def codegen_kustomize_crl_operator() -> types.TaskDict:
     return tpl_task_dict
 
 
+def task_get_codegen_kustomize_disk_management_agent() -> types.TaskDict:
+    """Generate the kustomize manifests output for the Disk Management Agent."""
+    kustomize_dir = constants.ROOT / "kustomizes/disk-management-agent"
+
+    cmd = f"kustomize build {kustomize_dir}"
+
+    return {
+        "doc": task_get_codegen_kustomize_disk_management_agent.__doc__,
+        "actions": [doit.action.CmdAction(cmd, cwd=constants.ROOT, save_out="stdout")],
+        "file_dep": list(utils.git_ls(kustomize_dir)),
+        "task_dep": ["check_for:kustomize"],
+    }
+
+
+def task_transform_codegen_kustomize_disk_management_agent() -> types.TaskDict:
+    """Transform the kustomize manifests output for the Disk Management Agent."""
+
+    def _transform(stdout: str) -> Dict[str, str]:
+        """Transform the kustomize output."""
+        return {
+            "output": stdout.strip().replace(
+                "disk-management-agent-system", "kube-system"
+            )
+        }
+
+    return {
+        "doc": task_transform_codegen_kustomize_disk_management_agent.__doc__,
+        "actions": [_transform],
+        "task_dep": ["get_codegen_kustomize_disk_management_agent"],
+        "getargs": {
+            "stdout": ("get_codegen_kustomize_disk_management_agent", "stdout"),
+        },
+    }
+
+
+def codegen_kustomize_disk_management_agent() -> types.TaskDict:
+    """Generate the SLS file for the Disk Management Agent."""
+    target_sls = (
+        constants.ROOT
+        / "salt/metalk8s/addons/disk-management-agent/deployed/chart.sls"
+    )
+    template_file = constants.ROOT / "kustomizes/template.sls.in"
+
+    tpl_task = targets.TemplateFile(
+        task_name="kustomize_disk-management-agent",
+        source=template_file,
+        destination=target_sls,
+    )
+    tpl_task_dict = tpl_task.task
+    tpl_task_dict.update(
+        {
+            "title": utils.title_with_subtask_name("CODEGEN"),
+            "task_dep": ["transform_codegen_kustomize_disk_management_agent"],
+            "getargs": {
+                "Manifests": (
+                    "transform_codegen_kustomize_disk_management_agent",
+                    "output",
+                ),
+            },
+        }
+    )
+    return tpl_task_dict
+
+
 # List of available code generation tasks.
 CODEGEN: Tuple[Callable[[], types.TaskDict], ...] = (
     codegen_storage_operator,
@@ -391,6 +455,7 @@ CODEGEN: Tuple[Callable[[], types.TaskDict], ...] = (
     codegen_chart_thanos,
     codegen_chart_cert_manager,
     codegen_kustomize_crl_operator,
+    codegen_kustomize_disk_management_agent,
 )
 
 

--- a/buildchain/buildchain/codegen.py
+++ b/buildchain/buildchain/codegen.py
@@ -401,8 +401,11 @@ def task_transform_codegen_kustomize_disk_management_agent() -> types.TaskDict:
         # 'metalk8s-storage-management' as kustomize does not allow easily to patch
         # every occurrence in "custom resources fields" like Certificate dnsNames.
         return {
-            "output": stdout.strip().replace(
-                "disk-management-agent-system", "metalk8s-storage-management"
+            "output": stdout.strip()
+            .replace("disk-management-agent-system", "metalk8s-storage-management")
+            .replace(
+                "SERVICE_NAME.SERVICE_NAMESPACE",
+                "disk-management-agent-metrics-service.metalk8s-storage-management",
             )
         }
 

--- a/buildchain/buildchain/codegen.py
+++ b/buildchain/buildchain/codegen.py
@@ -397,9 +397,12 @@ def task_transform_codegen_kustomize_disk_management_agent() -> types.TaskDict:
 
     def _transform(stdout: str) -> Dict[str, str]:
         """Transform the kustomize output."""
+        # Note: We have to replace the namespace 'disk-management-agent-system' by
+        # 'metalk8s-storage-management' as kustomize does not allow easily to patch
+        # every occurrence in "custom resources fields" like Certificate dnsNames.
         return {
             "output": stdout.strip().replace(
-                "disk-management-agent-system", "kube-system"
+                "disk-management-agent-system", "metalk8s-storage-management"
             )
         }
 

--- a/buildchain/buildchain/image.py
+++ b/buildchain/buildchain/image.py
@@ -223,6 +223,7 @@ IMGS_PER_REPOSITORY: Dict[str, List[str]] = {
     constants.SCALITY_REPOSITORY: [
         "ui-operator",
         "crl-operator",
+        "disk-management-agent",
     ],
 }
 

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -294,6 +294,8 @@ SALT_FILES: Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path("salt/metalk8s/addons/cert-manager/deployed/namespace.sls"),
     Path("salt/metalk8s/addons/crl-operator/deployed/chart.sls"),
     Path("salt/metalk8s/addons/crl-operator/deployed/init.sls"),
+    Path("salt/metalk8s/addons/disk-management-agent/deployed/chart.sls"),
+    Path("salt/metalk8s/addons/disk-management-agent/deployed/init.sls"),
     Path("salt/metalk8s/addons/dex/ca/init.sls"),
     Path("salt/metalk8s/addons/dex/ca/installed.sls"),
     Path("salt/metalk8s/addons/dex/ca/advertised.sls"),

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -296,6 +296,7 @@ SALT_FILES: Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path("salt/metalk8s/addons/crl-operator/deployed/init.sls"),
     Path("salt/metalk8s/addons/disk-management-agent/deployed/chart.sls"),
     Path("salt/metalk8s/addons/disk-management-agent/deployed/init.sls"),
+    Path("salt/metalk8s/addons/disk-management-agent/deployed/namespace.sls"),
     Path("salt/metalk8s/addons/dex/ca/init.sls"),
     Path("salt/metalk8s/addons/dex/ca/installed.sls"),
     Path("salt/metalk8s/addons/dex/ca/advertised.sls"),

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -315,8 +315,8 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     ),
     Image(
         name="disk-management-agent",
-        version="v0.1.0",
-        digest=None,
+        version="v0.0.1-alpha.1",
+        digest="sha256:4e70596029cd26c5630fa80198af0be3325e1b0035b04d25e528f5be5e961ae7",
     ),
 )
 

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -315,8 +315,8 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     ),
     Image(
         name="disk-management-agent",
-        version="v0.0.1-alpha.1",
-        digest="sha256:4e70596029cd26c5630fa80198af0be3325e1b0035b04d25e528f5be5e961ae7",
+        version="v0.0.1-beta.1",
+        digest="sha256:cb5a7843a1ab86a673d7617382d0da277c0e4c5142d173e7b75b0bab5162281d",
     ),
 )
 

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -313,6 +313,11 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
         version="v1.0.0",
         digest="sha256:86b4198036c1f83f1d9363a1e2ae78015482ca4fe60cd706939b8730c179ac8a",
     ),
+    Image(
+        name="disk-management-agent",
+        version="v0.1.0",
+        digest=None,
+    ),
 )
 
 CONTAINER_IMAGES_MAP = {image.name: image for image in CONTAINER_IMAGES}

--- a/kustomizes/disk-management-agent/delete_ns.yaml
+++ b/kustomizes/disk-management-agent/delete_ns.yaml
@@ -1,0 +1,5 @@
+$patch: delete
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: system

--- a/kustomizes/disk-management-agent/deploy_patch.yaml
+++ b/kustomizes/disk-management-agent/deploy_patch.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: not-important
+spec:
+  template:
+    spec:
+      tolerations:
+      - key: "node-role.kubernetes.io/bootstrap"
+        operator: "Exists"
+        effect: "NoSchedule"
+      - key: "node-role.kubernetes.io/infra"
+        operator: "Exists"
+        effect: "NoSchedule"
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"

--- a/kustomizes/disk-management-agent/kustomization.yaml
+++ b/kustomizes/disk-management-agent/kustomization.yaml
@@ -1,12 +1,12 @@
 namespace: kube-system
 
 resources:
-  - github.com/scality/disk-management-agent.git/config/default?ref=v0.1.0
+  - github.com/scality/disk-management-agent.git/config/default?ref=v0.0.1-beta.1
 
 images:
   - name: controller
     newName: '{% endraw -%}{{ build_image_name("disk-management-agent", False) }}{%- raw %}'
-    newTag: v0.1.0
+    newTag: v0.0.1-beta.1
 
 patches:
   - path: deploy_patch.yaml

--- a/kustomizes/disk-management-agent/kustomization.yaml
+++ b/kustomizes/disk-management-agent/kustomization.yaml
@@ -1,4 +1,4 @@
-namespace: kube-system
+namespace: metalk8s-storage-management
 
 resources:
   - github.com/scality/disk-management-agent.git/config/default?ref=v0.0.1-beta.1

--- a/kustomizes/disk-management-agent/kustomization.yaml
+++ b/kustomizes/disk-management-agent/kustomization.yaml
@@ -1,0 +1,15 @@
+namespace: kube-system
+
+resources:
+  - github.com/scality/disk-management-agent.git/config/default?ref=v0.1.0
+
+images:
+  - name: controller
+    newName: '{% endraw -%}{{ build_image_name("disk-management-agent", False) }}{%- raw %}'
+    newTag: v0.1.0
+
+patches:
+  - path: deploy_patch.yaml
+    target:
+      kind: DaemonSet
+  - path: delete_ns.yaml

--- a/salt/metalk8s/addons/disk-management-agent/deployed/chart.sls
+++ b/salt/metalk8s/addons/disk-management-agent/deployed/chart.sls
@@ -502,8 +502,8 @@ metadata:
   namespace: metalk8s-storage-management
 spec:
   dnsNames:
-  - SERVICE_NAME.SERVICE_NAMESPACE.svc
-  - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
+  - disk-management-agent-metrics-service.metalk8s-storage-management.svc
+  - disk-management-agent-metrics-service.metalk8s-storage-management.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: disk-management-agent-selfsigned-issuer

--- a/salt/metalk8s/addons/disk-management-agent/deployed/chart.sls
+++ b/salt/metalk8s/addons/disk-management-agent/deployed/chart.sls
@@ -1,0 +1,567 @@
+#!jinja | metalk8s_kubernetes
+{%- from "metalk8s/repo/macro.sls" import build_image_name with context %}
+
+{%- raw %}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: discoveredphysicaldisks.metalk8s.scality.com
+spec:
+  group: metalk8s.scality.com
+  names:
+    kind: DiscoveredPhysicalDisk
+    listKind: DiscoveredPhysicalDiskList
+    plural: discoveredphysicaldisks
+    singular: discoveredphysicaldisk
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.id
+      name: ID
+      type: string
+    - jsonPath: .spec.nodeName
+      name: Node
+      type: string
+    - jsonPath: .status.available
+      name: Available
+      type: boolean
+    - jsonPath: .status.type
+      name: Type
+      type: string
+    - jsonPath: .status.size
+      name: Size
+      type: integer
+    - jsonPath: .status.status
+      name: Status
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DiscoveredPhysicalDisk is the Schema for the discoveredphysicaldisks
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              DiscoveredPhysicalDiskSpec defines the desired state of DiscoveredPhysicalDisk.
+              It contains only immutable slot identifiers set at creation time.
+            properties:
+              controller:
+                description: Controller identifies the RAID controller managing this
+                  disk.
+                properties:
+                  id:
+                    description: ID is the controller index.
+                    type: integer
+                  type:
+                    description: Type is the controller type (e.g. "MegaRAID").
+                    type: string
+                required:
+                - id
+                - type
+                type: object
+              id:
+                description: ID is the disk identifier as reported by the controller
+                  (e.g. "0:1:2").
+                type: string
+              nodeName:
+                description: NodeName is the name of the node where this disk was
+                  discovered.
+                type: string
+              slot:
+                description: Slot describes the physical slot location of the disk.
+                properties:
+                  bay:
+                    description: Bay is the bay number.
+                    type: string
+                  enclosure:
+                    description: Enclosure is the enclosure number.
+                    type: string
+                  port:
+                    description: Port is the port number.
+                    type: string
+                required:
+                - bay
+                - enclosure
+                - port
+                type: object
+            required:
+            - controller
+            - id
+            - nodeName
+            - slot
+            type: object
+          status:
+            description: DiscoveredPhysicalDiskStatus defines the observed state of
+              DiscoveredPhysicalDisk.
+            properties:
+              available:
+                description: Available indicates whether the physical drive is present
+                  in the slot.
+                type: boolean
+              devicePath:
+                description: DevicePath is the OS device path (e.g. "/dev/sda").
+                type: string
+              jbod:
+                description: JBOD indicates whether the disk is in JBOD (passthrough)
+                  mode.
+                type: boolean
+              model:
+                description: Model is the disk model name.
+                type: string
+              permanentPath:
+                description: PermanentPath is the stable device path (e.g. "/dev/disk/by-id/wwn-0x...").
+                type: string
+              reason:
+                description: Reason provides additional context for the current status.
+                type: string
+              serial:
+                description: Serial is the disk serial number.
+                type: string
+              size:
+                description: Size is the disk capacity in bytes.
+                format: int64
+                type: integer
+              status:
+                description: Status is the current disk status.
+                type: string
+              type:
+                description: Type is the disk media type.
+                enum:
+                - HDD
+                - SSD
+                - NVMe
+                type: string
+              vendor:
+                description: Vendor is the disk manufacturer.
+                type: string
+              wwn:
+                description: WWN is the World Wide Name of the disk.
+                type: string
+            type: object
+        type: object
+    selectableFields:
+    - jsonPath: .spec.nodeName
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: disk-management-agent
+  name: disk-management-agent-controller-manager
+  namespace: metalk8s-storage-management
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: disk-management-agent
+  name: disk-management-agent-discoveredphysicaldisk-admin-role
+rules:
+- apiGroups:
+  - metalk8s.scality.com
+  resources:
+  - discoveredphysicaldisks
+  verbs:
+  - '*'
+- apiGroups:
+  - metalk8s.scality.com
+  resources:
+  - discoveredphysicaldisks/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: disk-management-agent
+  name: disk-management-agent-discoveredphysicaldisk-editor-role
+rules:
+- apiGroups:
+  - metalk8s.scality.com
+  resources:
+  - discoveredphysicaldisks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - metalk8s.scality.com
+  resources:
+  - discoveredphysicaldisks/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: disk-management-agent
+  name: disk-management-agent-discoveredphysicaldisk-viewer-role
+rules:
+- apiGroups:
+  - metalk8s.scality.com
+  resources:
+  - discoveredphysicaldisks
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metalk8s.scality.com
+  resources:
+  - discoveredphysicaldisks/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: disk-management-agent-manager-role
+rules:
+- apiGroups:
+  - metalk8s.scality.com
+  resources:
+  - discoveredphysicaldisks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - metalk8s.scality.com
+  resources:
+  - discoveredphysicaldisks/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - metalk8s.scality.com
+  resources:
+  - discoveredphysicaldisks/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: disk-management-agent-metrics-auth-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: disk-management-agent-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: disk-management-agent
+  name: disk-management-agent-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: disk-management-agent-manager-role
+subjects:
+- kind: ServiceAccount
+  name: disk-management-agent-controller-manager
+  namespace: metalk8s-storage-management
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: disk-management-agent-metrics-auth-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: disk-management-agent-metrics-auth-role
+subjects:
+- kind: ServiceAccount
+  name: disk-management-agent-controller-manager
+  namespace: metalk8s-storage-management
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: disk-management-agent
+    control-plane: controller-manager
+  name: disk-management-agent-metrics-service
+  namespace: metalk8s-storage-management
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/name: disk-management-agent
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: disk-management-agent
+  name: disk-management-agent-webhook-service
+  namespace: metalk8s-storage-management
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app.kubernetes.io/name: disk-management-agent
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: disk-management-agent
+    control-plane: controller-manager
+  name: disk-management-agent-controller-manager
+  namespace: metalk8s-storage-management
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: disk-management-agent
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app.kubernetes.io/name: disk-management-agent
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --metrics-bind-address=:8443
+        - --health-probe-bind-address=:8081
+        - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
+        command:
+        - /manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: STORCLI_PATH
+          value: /host/libexec/MegaRAID/storcli/storcli64
+        - name: PERCCLI_PATH
+          value: /host/libexec/MegaRAID/perccli/perccli64
+        - name: SSACLI_PATH
+          value: /host/libexec/ssacli
+        image: '{% endraw -%}{{ build_image_name("disk-management-agent", False) }}{%-
+          raw %}:v0.0.1-beta.1'
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          privileged: true
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /host/libexec/MegaRAID
+          name: megaraid
+          readOnly: true
+        - mountPath: /host/libexec/ssacli
+          name: ssacli
+          readOnly: true
+        - mountPath: /dev
+          name: dev
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: webhook-certs
+          readOnly: true
+      securityContext:
+        runAsNonRoot: false
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: disk-management-agent-controller-manager
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/bootstrap
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      volumes:
+      - hostPath:
+          path: /opt/MegaRAID/
+          type: DirectoryOrCreate
+        name: megaraid
+      - hostPath:
+          path: /usr/bin/ssacli
+          type: FileOrCreate
+        name: ssacli
+      - hostPath:
+          path: /dev
+          type: Directory
+        name: dev
+      - name: webhook-certs
+        secret:
+          secretName: webhook-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: disk-management-agent
+  name: disk-management-agent-metrics-certs
+  namespace: metalk8s-storage-management
+spec:
+  dnsNames:
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: disk-management-agent-selfsigned-issuer
+  secretName: metrics-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: disk-management-agent
+  name: disk-management-agent-serving-cert
+  namespace: metalk8s-storage-management
+spec:
+  dnsNames:
+  - disk-management-agent-webhook-service.metalk8s-storage-management.svc
+  - disk-management-agent-webhook-service.metalk8s-storage-management.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: disk-management-agent-selfsigned-issuer
+  secretName: webhook-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: disk-management-agent
+  name: disk-management-agent-selfsigned-issuer
+  namespace: metalk8s-storage-management
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: metalk8s-storage-management/disk-management-agent-serving-cert
+  name: disk-management-agent-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: disk-management-agent-webhook-service
+      namespace: metalk8s-storage-management
+      path: /validate-metalk8s-scality-com-v1alpha1-discoveredphysicaldisk
+  failurePolicy: Fail
+  name: vdiscoveredphysicaldisk-v1alpha1.kb.io
+  rules:
+  - apiGroups:
+    - metalk8s.scality.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - discoveredphysicaldisks
+  sideEffects: None
+{%- endraw %}

--- a/salt/metalk8s/addons/disk-management-agent/deployed/init.sls
+++ b/salt/metalk8s/addons/disk-management-agent/deployed/init.sls
@@ -1,10 +1,18 @@
 include:
   - metalk8s.addons.cert-manager.deployed
+  - .namespace
   - .chart
 
 Ensure cert-manager is ready before deploying disk-management-agent:
   test.succeed_without_changes:
     - require:
       - sls: metalk8s.addons.cert-manager.deployed
+    - require_in:
+      - sls: metalk8s.addons.disk-management-agent.deployed.chart
+
+Ensure namespace is created before deploying disk-management-agent:
+  test.succeed_without_changes:
+    - require:
+      - sls: metalk8s.addons.disk-management-agent.deployed.namespace
     - require_in:
       - sls: metalk8s.addons.disk-management-agent.deployed.chart

--- a/salt/metalk8s/addons/disk-management-agent/deployed/init.sls
+++ b/salt/metalk8s/addons/disk-management-agent/deployed/init.sls
@@ -1,0 +1,10 @@
+include:
+  - metalk8s.addons.cert-manager.deployed
+  - .chart
+
+Ensure cert-manager is ready before deploying disk-management-agent:
+  test.succeed_without_changes:
+    - require:
+      - sls: metalk8s.addons.cert-manager.deployed
+    - require_in:
+      - sls: metalk8s.addons.disk-management-agent.deployed.chart

--- a/salt/metalk8s/addons/disk-management-agent/deployed/init.sls
+++ b/salt/metalk8s/addons/disk-management-agent/deployed/init.sls
@@ -1,14 +1,6 @@
 include:
-  - metalk8s.addons.cert-manager.deployed
   - .namespace
   - .chart
-
-Ensure cert-manager is ready before deploying disk-management-agent:
-  test.succeed_without_changes:
-    - require:
-      - sls: metalk8s.addons.cert-manager.deployed
-    - require_in:
-      - sls: metalk8s.addons.disk-management-agent.deployed.chart
 
 Ensure namespace is created before deploying disk-management-agent:
   test.succeed_without_changes:

--- a/salt/metalk8s/addons/disk-management-agent/deployed/namespace.sls
+++ b/salt/metalk8s/addons/disk-management-agent/deployed/namespace.sls
@@ -1,0 +1,10 @@
+#!jinja | metalk8s_kubernetes
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metalk8s-storage-management
+  labels:
+    app.kubernetes.io/managed-by: salt
+    app.kubernetes.io/part-of: metalk8s
+    heritage: metalk8s

--- a/salt/metalk8s/deployed/init.sls
+++ b/salt/metalk8s/deployed/init.sls
@@ -15,3 +15,4 @@ include:
   - metalk8s.addons.logging.deployed
   - metalk8s.addons.alert-tree.deployed
   - metalk8s.addons.crl-operator.deployed
+  - metalk8s.addons.disk-management-agent.deployed

--- a/tests/post/features/sanity.feature
+++ b/tests/post/features/sanity.feature
@@ -57,6 +57,7 @@ Feature: Cluster Sanity Checks
         | metalk8s-ingress    | ingress-nginx-controller                     |
         | metalk8s-ingress    | ingress-nginx-control-plane-controller       |
         | metalk8s-monitoring | prometheus-operator-prometheus-node-exporter |
+        | kube-system         | disk-management-agent-controller-manager     |
 
     @volumes_provisioned
     Scenario Outline: StatefulSet has available replicas

--- a/tests/post/features/sanity.feature
+++ b/tests/post/features/sanity.feature
@@ -51,13 +51,13 @@ Feature: Cluster Sanity Checks
         Then the DaemonSet <name> in the <namespace> namespace has all desired Pods ready
 
         Examples:
-        | namespace           | name                                         |
-        | kube-system         | calico-node                                  |
-        | kube-system         | kube-proxy                                   |
-        | metalk8s-ingress    | ingress-nginx-controller                     |
-        | metalk8s-ingress    | ingress-nginx-control-plane-controller       |
-        | metalk8s-monitoring | prometheus-operator-prometheus-node-exporter |
-        | kube-system         | disk-management-agent-controller-manager     |
+        | namespace                   | name                                         |
+        | kube-system                 | calico-node                                  |
+        | kube-system                 | kube-proxy                                   |
+        | metalk8s-ingress            | ingress-nginx-controller                     |
+        | metalk8s-ingress            | ingress-nginx-control-plane-controller       |
+        | metalk8s-monitoring         | prometheus-operator-prometheus-node-exporter |
+        | metalk8s-storage-management | disk-management-agent-controller-manager     |
 
     @volumes_provisioned
     Scenario Outline: StatefulSet has available replicas


### PR DESCRIPTION
## Summary

Integrate the [disk-management-agent](https://github.com/scality/disk-management-agent) into MetalK8s, following the same kustomize-based pattern established by the CRL operator in PR #4692.

The disk-management-agent is a DaemonSet-based operator that discovers physical disks on each node using hardware management tools (MegaRAID storcli/perccli, HP ssacli) and exposes them as `DiscoveredPhysicalDisk` custom resources.

### What was done

- Added a kustomize overlay (`kustomizes/disk-management-agent/`) that pulls upstream manifests from the disk-management-agent repo, patches tolerations for MetalK8s node roles, removes the upstream namespace (deploys into `kube-system`), and overrides the container image
- Added Salt addon states (`salt/metalk8s/addons/disk-management-agent/`) with cert-manager as a prerequisite
- Wired the buildchain: image registry, codegen tasks (kustomize build + namespace transform + SLS rendering), salt tree, and versions
- Added DaemonSet sanity check in post-deploy tests
- Added CHANGELOG entry

### Open items

- **Version placeholder**: `v0.1.0` is used as a placeholder for both the kustomize ref and the image tag. To be updated once a release is published on the disk-management-agent repo.
- **Image digest**: Set to `None` in `versions.py` until the image is published to `ghcr.io/scality/disk-management-agent`.
