### PR TITLE
chart, salt: Add annotations to fluent-bit pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@
 - Implement ability to add certificates to fluent-bit by mounting a fluent-bit-certs secret
   (PR[#4812](https://github.com/scality/metalk8s/pull/4812))
 
+- Ensure fluent-bit pods are restarted when its configmap or secret is modified
+  (PR[#4834](https://github.com/scality/metalk8s/pull/4834))
+
 ### Bug Fixes
 
 - Fix a bug where part of the upgrade process would silently be skipped

--- a/charts/fluent-bit.yaml
+++ b/charts/fluent-bit.yaml
@@ -5,9 +5,8 @@ image:
 existingConfigMap: fluent-bit
 
 podAnnotations:
-  prometheus.io/scrape: "true"
-  prometheus.io/port: "2020"
-  prometheus.io/path: /api/v1/metrics/prometheus
+  checksum/config: '__slot__:salt:metalk8s_kubernetes.get_object_digest(kind="ConfigMap", apiVersion="v1", namespace="metalk8s-logging", name="fluent-bit", path="data:fluent-bit.conf")'
+  checksum/secret: '__slot__:salt:metalk8s_kubernetes.get_object_digest(kind="Secret", apiVersion="v1", namespace="metalk8s-logging", name="fluent-bit-certs")'
 
 resources: '__var__(fluent_bit.spec.deployment.resources)'
 

--- a/charts/fluent-bit.yaml
+++ b/charts/fluent-bit.yaml
@@ -6,7 +6,7 @@ existingConfigMap: fluent-bit
 
 podAnnotations:
   checksum/config: '__slot__:salt:metalk8s_kubernetes.get_object_digest(kind="ConfigMap", apiVersion="v1", namespace="metalk8s-logging", name="fluent-bit", path="data:fluent-bit.conf")'
-  checksum/secret: '__slot__:salt:metalk8s_kubernetes.get_object_digest(kind="Secret", apiVersion="v1", namespace="metalk8s-logging", name="fluent-bit-certs")'
+  checksum/secret: '__slot__:salt:metalk8s_kubernetes.get_object_digest(kind="Secret", apiVersion="v1", namespace="metalk8s-logging", name="fluent-bit-certs", path="data", ignore_not_found=True)'
 
 resources: '__var__(fluent_bit.spec.deployment.resources)'
 

--- a/salt/_modules/metalk8s_kubernetes.py
+++ b/salt/_modules/metalk8s_kubernetes.py
@@ -410,7 +410,9 @@ def list_objects(
     return result.to_dict()["items"]
 
 
-def get_object_digest(path=None, checksum="sha256", *args, **kwargs):
+def get_object_digest(
+    path=None, checksum="sha256", ignore_not_found=False, *args, **kwargs
+):
     """
     Helper to get the digest of one kubernetes object or from a specific key
     of this object using a path
@@ -432,7 +434,11 @@ def get_object_digest(path=None, checksum="sha256", *args, **kwargs):
         obj = salt.utils.data.traverse_dict_and_list(obj, path, delimiter=":")
 
         if not obj:
-            raise CommandExecutionError(f'Unable to find key "{path}" in the object')
+            if not ignore_not_found:
+                raise CommandExecutionError(
+                    f'Unable to find key "{path}" in the object'
+                )
+            return ""
 
     if isinstance(obj, dict):
         obj = json.dumps(obj, sort_keys=True)

--- a/salt/metalk8s/addons/logging/fluent-bit/deployed/chart.sls
+++ b/salt/metalk8s/addons/logging/fluent-bit/deployed/chart.sls
@@ -1697,7 +1697,8 @@ spec:
         checksum/config: __slot__:salt:metalk8s_kubernetes.get_object_digest(kind="ConfigMap",
           apiVersion="v1", namespace="metalk8s-logging", name="fluent-bit", path="data:fluent-bit.conf")
         checksum/secret: __slot__:salt:metalk8s_kubernetes.get_object_digest(kind="Secret",
-          apiVersion="v1", namespace="metalk8s-logging", name="fluent-bit-certs")
+          apiVersion="v1", namespace="metalk8s-logging", name="fluent-bit-certs",
+          path="data", ignore_not_found=True)
       labels:
         app.kubernetes.io/instance: fluent-bit
         app.kubernetes.io/name: fluent-bit

--- a/salt/metalk8s/addons/logging/fluent-bit/deployed/chart.sls
+++ b/salt/metalk8s/addons/logging/fluent-bit/deployed/chart.sls
@@ -1694,10 +1694,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-        prometheus.io/path: /api/v1/metrics/prometheus
-        prometheus.io/port: '2020'
-        prometheus.io/scrape: 'true'
+        checksum/config: __slot__:salt:metalk8s_kubernetes.get_object_digest(kind="ConfigMap",
+          apiVersion="v1", namespace="metalk8s-logging", name="fluent-bit", path="data:fluent-bit.conf")
+        checksum/secret: __slot__:salt:metalk8s_kubernetes.get_object_digest(kind="Secret",
+          apiVersion="v1", namespace="metalk8s-logging", name="fluent-bit-certs")
       labels:
         app.kubernetes.io/instance: fluent-bit
         app.kubernetes.io/name: fluent-bit

--- a/salt/metalk8s/addons/logging/fluent-bit/deployed/secret.sls
+++ b/salt/metalk8s/addons/logging/fluent-bit/deployed/secret.sls
@@ -19,6 +19,7 @@ Create metalk8s-fluent-bit-certs Secret:
         metadata:
           name: fluent-bit-certs
           namespace: metalk8s-logging
+        data: {}
 
 {%- else %}
 

--- a/salt/tests/unit/modules/files/test_metalk8s_kubernetes.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_kubernetes.yaml
@@ -702,6 +702,28 @@ get_object_digest:
     raises: True
     result: 'Unable to find key "metadata:invalid:path" in the object'
 
+  # ignore_not_found = true and path points to an empty dict
+  - obj:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: my_secret
+      data: {}
+    path: 'data'
+    ignore_not_found: True
+    result: ''
+
+  # ignore_not_found = true but there is a typo in the path
+  - obj:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: my_secret
+      data: {}
+    path: 'daat'
+    ignore_not_found: True
+    result: ''
+
 check_object_ready:
   # Simple Pod Ready
   - obj:


### PR DESCRIPTION
What/How: Add annotations containing configmap and secret to fluent-bit pod
Why: so it is restarted whenever these objects are updated.

MK8S-203
