### PR TITLE
improve instance name ux

### DIFF
--- a/shell-ui/src/navbar/EditableDeploymentName.spec.tsx
+++ b/shell-ui/src/navbar/EditableDeploymentName.spec.tsx
@@ -1,0 +1,160 @@
+import type { PropsWithChildren } from 'react';
+import React from 'react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+import { jest } from '@jest/globals';
+import userEvent from '@testing-library/user-event';
+import { CoreUiThemeProvider } from '@scality/core-ui/dist/components/coreuithemeprovider/CoreUiThemeProvider';
+import { coreUIAvailableThemes } from '@scality/core-ui/dist/style/theme';
+
+import { EditableDeploymentName } from './EditableDeploymentName';
+
+const Wrapper = ({ children }: PropsWithChildren) => (
+  <CoreUiThemeProvider theme={coreUIAvailableThemes.darkRebrand}>{children}</CoreUiThemeProvider>
+);
+
+function renderEditable(
+  props: Partial<React.ComponentProps<typeof EditableDeploymentName>> & {
+    onChange?: jest.Mock;
+  } = {},
+) {
+  const onChange = props.onChange ?? jest.fn();
+  render(
+    <EditableDeploymentName
+      name={props.name ?? 'prod-cluster'}
+      isPropagating={props.isPropagating ?? false}
+      onChange={onChange}
+    />,
+    { wrapper: Wrapper },
+  );
+  return { onChange };
+}
+
+async function openEditMode(name = 'prod-cluster') {
+  await userEvent.click(screen.getByRole('button', { name }));
+}
+
+describe('EditableDeploymentName', () => {
+  it('shows deployment name in view mode', () => {
+    renderEditable({ name: 'my-deployment' });
+    expect(screen.getByRole('button', { name: 'my-deployment' })).toBeInTheDocument();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('enters edit mode on click and focuses input with current name', async () => {
+    renderEditable({ name: 'alpha' });
+    await openEditMode('alpha');
+    const input = screen.getByRole('textbox', { name: 'Deployment name' });
+    expect(input).toBeInTheDocument();
+    await waitFor(() => {
+      expect(input).toHaveValue('alpha');
+    });
+  });
+
+  it('closes edit mode on Escape without opening modal or calling onChange', async () => {
+    const { onChange } = renderEditable();
+    await openEditMode();
+    await userEvent.type(screen.getByRole('textbox', { name: 'Deployment name' }), 'new-name');
+    await userEvent.keyboard('{Escape}');
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('closes edit mode on Enter when value unchanged (no modal, no onChange)', async () => {
+    const { onChange } = renderEditable({ name: 'same' });
+    await userEvent.click(screen.getByRole('button', { name: 'same' }));
+    await userEvent.keyboard('{Enter}');
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('closes edit mode on blur when only whitespace (no modal, no onChange)', async () => {
+    const { onChange } = renderEditable({ name: 'same' });
+    await userEvent.click(screen.getByRole('button', { name: 'same' }));
+    await userEvent.clear(screen.getByRole('textbox', { name: 'Deployment name' }));
+    await userEvent.type(screen.getByRole('textbox', { name: 'Deployment name' }), '   ');
+    await userEvent.tab();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('opens confirm modal on Enter when name trimmed differs', async () => {
+    const { onChange } = renderEditable();
+    await openEditMode();
+    const input = screen.getByRole('textbox', { name: 'Deployment name' });
+    await userEvent.clear(input);
+    await userEvent.type(input, 'new-cluster');
+    await userEvent.keyboard('{Enter}');
+    await waitFor(() => {
+      expect(screen.getByRole('dialog', { name: 'Rename deployment?' })).toBeInTheDocument();
+    });
+    expect(within(screen.getByRole('dialog')).getByText('prod-cluster')).toBeInTheDocument();
+    expect(within(screen.getByRole('dialog')).getByText('new-cluster')).toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('calls onChange with trimmed name when Rename is confirmed', async () => {
+    const { onChange } = renderEditable();
+    await openEditMode();
+    const input = screen.getByRole('textbox', { name: 'Deployment name' });
+    await userEvent.clear(input);
+    await userEvent.type(input, '  renamed  ');
+    await userEvent.keyboard('{Enter}');
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+    await userEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Rename' }));
+    expect(onChange).toHaveBeenCalledWith('renamed');
+  });
+
+  it('closes modal on Cancel without calling onChange', async () => {
+    const { onChange } = renderEditable();
+    await openEditMode();
+    const input = screen.getByRole('textbox', { name: 'Deployment name' });
+    await userEvent.clear(input);
+    await userEvent.type(input, 'x');
+    await userEvent.keyboard('{Enter}');
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+    await userEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Cancel' }));
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('does not enter edit mode when propagating', async () => {
+    const { onChange } = renderEditable({ isPropagating: true });
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.getByText('prod-cluster')).toBeInTheDocument();
+    await userEvent.click(screen.getByText('prod-cluster'));
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('starts edit from keyboard Enter on trigger when focusable', async () => {
+    renderEditable();
+    const trigger = screen.getByRole('button', { name: 'prod-cluster' });
+    await act(async () => {
+      trigger.focus();
+    });
+    await userEvent.keyboard('{Enter}');
+    expect(screen.getByRole('textbox', { name: 'Deployment name' })).toBeInTheDocument();
+  });
+
+  it('updates displayed name when name prop changes in view mode', () => {
+    const { rerender } = render(
+      <CoreUiThemeProvider theme={coreUIAvailableThemes.darkRebrand}>
+        <EditableDeploymentName name="v1" isPropagating={false} onChange={() => {}} />
+      </CoreUiThemeProvider>,
+    );
+    expect(screen.getByRole('button', { name: 'v1' })).toBeInTheDocument();
+    rerender(
+      <CoreUiThemeProvider theme={coreUIAvailableThemes.darkRebrand}>
+        <EditableDeploymentName name="v2" isPropagating={false} onChange={() => {}} />
+      </CoreUiThemeProvider>,
+    );
+    expect(screen.getByRole('button', { name: 'v2' })).toBeInTheDocument();
+  });
+});

--- a/shell-ui/src/navbar/EditableDeploymentName.spec.tsx
+++ b/shell-ui/src/navbar/EditableDeploymentName.spec.tsx
@@ -1,32 +1,50 @@
-import type { PropsWithChildren } from 'react';
-import React from 'react';
+import type { ComponentProps, PropsWithChildren } from 'react';
 import { act, render, screen, waitFor, within } from '@testing-library/react';
 import { jest } from '@jest/globals';
 import userEvent from '@testing-library/user-event';
+import { QueryClient } from 'react-query';
 import { CoreUiThemeProvider } from '@scality/core-ui/dist/components/coreuithemeprovider/CoreUiThemeProvider';
 import { coreUIAvailableThemes } from '@scality/core-ui/dist/style/theme';
 
+import { QueryClientProvider } from '../QueryClientProvider';
 import { EditableDeploymentName } from './EditableDeploymentName';
+import type { InstanceNameAdapter } from './InstanceName';
 
-const Wrapper = ({ children }: PropsWithChildren) => (
-  <CoreUiThemeProvider theme={coreUIAvailableThemes.darkRebrand}>{children}</CoreUiThemeProvider>
-);
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+type SetInstanceNameFn = (name: string) => Promise<void>;
 
 function renderEditable(
-  props: Partial<React.ComponentProps<typeof EditableDeploymentName>> & {
-    onChange?: jest.Mock;
+  props: Partial<ComponentProps<typeof EditableDeploymentName>> & {
+    setInstanceName?: jest.MockedFunction<SetInstanceNameFn>;
   } = {},
 ) {
-  const onChange = props.onChange ?? jest.fn();
+  const queryClient = createTestQueryClient();
+  const setInstanceName =
+    props.setInstanceName ?? (jest.fn() as jest.MockedFunction<SetInstanceNameFn>).mockResolvedValue(undefined);
+
+  const Wrapper = ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={queryClient}>
+      <CoreUiThemeProvider theme={coreUIAvailableThemes.darkRebrand}>{children}</CoreUiThemeProvider>
+    </QueryClientProvider>
+  );
+
   render(
     <EditableDeploymentName
       name={props.name ?? 'prod-cluster'}
-      isPropagating={props.isPropagating ?? false}
-      onChange={onChange}
+      checkInstanceName={props.checkInstanceName}
+      setInstanceName={setInstanceName}
     />,
     { wrapper: Wrapper },
   );
-  return { onChange };
+  return { setInstanceName };
 }
 
 async function openEditMode(name = 'prod-cluster') {
@@ -50,38 +68,95 @@ describe('EditableDeploymentName', () => {
     });
   });
 
-  it('closes edit mode on Escape without opening modal or calling onChange', async () => {
-    const { onChange } = renderEditable();
+  it('closes edit mode on Escape without opening modal or calling setInstanceName', async () => {
+    const { setInstanceName } = renderEditable();
     await openEditMode();
     await userEvent.type(screen.getByRole('textbox', { name: 'Deployment name' }), 'new-name');
     await userEvent.keyboard('{Escape}');
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-    expect(onChange).not.toHaveBeenCalled();
+    expect(setInstanceName).not.toHaveBeenCalled();
   });
 
-  it('closes edit mode on Enter when value unchanged (no modal, no onChange)', async () => {
-    const { onChange } = renderEditable({ name: 'same' });
+  it('closes edit mode on Enter when value unchanged (no modal, no setInstanceName)', async () => {
+    const { setInstanceName } = renderEditable({ name: 'same' });
     await userEvent.click(screen.getByRole('button', { name: 'same' }));
     await userEvent.keyboard('{Enter}');
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-    expect(onChange).not.toHaveBeenCalled();
+    expect(setInstanceName).not.toHaveBeenCalled();
   });
 
-  it('closes edit mode on blur when only whitespace (no modal, no onChange)', async () => {
-    const { onChange } = renderEditable({ name: 'same' });
+  it('closes edit mode on blur when only whitespace (no modal, no setInstanceName)', async () => {
+    const { setInstanceName } = renderEditable({ name: 'same' });
     await userEvent.click(screen.getByRole('button', { name: 'same' }));
     await userEvent.clear(screen.getByRole('textbox', { name: 'Deployment name' }));
     await userEvent.type(screen.getByRole('textbox', { name: 'Deployment name' }), '   ');
     await userEvent.tab();
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-    expect(onChange).not.toHaveBeenCalled();
+    expect(setInstanceName).not.toHaveBeenCalled();
+  });
+
+  it('shows inline validation error when checkInstanceName reports an error', async () => {
+    const checkInstanceName: InstanceNameAdapter['checkInstanceName'] = jest.fn(() => ({
+      hasError: true,
+      message: 'Invalid deployment name',
+    }));
+    renderEditable({ checkInstanceName });
+    await openEditMode();
+    const input = screen.getByRole('textbox', { name: 'Deployment name' });
+    await userEvent.clear(input);
+    await userEvent.type(input, 'bad-value');
+    await userEvent.keyboard('{Enter}');
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent('Invalid deployment name');
+    expect(alert).toHaveAttribute('id', 'name-error');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(checkInstanceName).toHaveBeenCalledWith('bad-value');
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('shows danger banner in modal when setInstanceName rejects with Error', async () => {
+    const { setInstanceName } = renderEditable({
+      setInstanceName: (jest.fn() as jest.MockedFunction<SetInstanceNameFn>).mockRejectedValue(
+        new Error('K8s not available'),
+      ),
+    });
+    await openEditMode();
+    const input = screen.getByRole('textbox', { name: 'Deployment name' });
+    await userEvent.clear(input);
+    await userEvent.type(input, 'new-name');
+    await userEvent.keyboard('{Enter}');
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+    await userEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Rename' }));
+    const dialog = screen.getByRole('dialog');
+    await waitFor(() => {
+      expect(within(dialog).getByText('K8s not available')).toBeInTheDocument();
+    });
+    expect(within(dialog).getByText('Error renaming deployment')).toBeInTheDocument();
+    expect(setInstanceName).toHaveBeenCalledWith('new-name');
+  });
+
+  it('shows default banner message when setInstanceName rejects with a non-Error value', async () => {
+    const setInstanceName = (jest.fn() as jest.MockedFunction<SetInstanceNameFn>).mockRejectedValue('unknown');
+    renderEditable({ setInstanceName });
+    await openEditMode();
+    const input = screen.getByRole('textbox', { name: 'Deployment name' });
+    await userEvent.clear(input);
+    await userEvent.type(input, 'new-name');
+    await userEvent.keyboard('{Enter}');
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+    await userEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Rename' }));
+    const dialog = screen.getByRole('dialog');
+    await waitFor(() => {
+      expect(within(dialog).getByText('An error occurred while updating the deployment name')).toBeInTheDocument();
+    });
+    expect(setInstanceName).toHaveBeenCalledWith('new-name');
   });
 
   it('opens confirm modal on Enter when name trimmed differs', async () => {
-    const { onChange } = renderEditable();
+    const { setInstanceName } = renderEditable();
     await openEditMode();
     const input = screen.getByRole('textbox', { name: 'Deployment name' });
     await userEvent.clear(input);
@@ -92,11 +167,11 @@ describe('EditableDeploymentName', () => {
     });
     expect(within(screen.getByRole('dialog')).getByText('prod-cluster')).toBeInTheDocument();
     expect(within(screen.getByRole('dialog')).getByText('new-cluster')).toBeInTheDocument();
-    expect(onChange).not.toHaveBeenCalled();
+    expect(setInstanceName).not.toHaveBeenCalled();
   });
 
-  it('calls onChange with trimmed name when Rename is confirmed', async () => {
-    const { onChange } = renderEditable();
+  it('calls setInstanceName with trimmed name when Rename is confirmed', async () => {
+    const { setInstanceName } = renderEditable();
     await openEditMode();
     const input = screen.getByRole('textbox', { name: 'Deployment name' });
     await userEvent.clear(input);
@@ -106,11 +181,14 @@ describe('EditableDeploymentName', () => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
     await userEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Rename' }));
-    expect(onChange).toHaveBeenCalledWith('renamed');
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+    expect(setInstanceName).toHaveBeenCalledWith('renamed');
   });
 
-  it('closes modal on Cancel without calling onChange', async () => {
-    const { onChange } = renderEditable();
+  it('closes modal on Cancel without calling setInstanceName', async () => {
+    const { setInstanceName } = renderEditable();
     await openEditMode();
     const input = screen.getByRole('textbox', { name: 'Deployment name' });
     await userEvent.clear(input);
@@ -121,16 +199,30 @@ describe('EditableDeploymentName', () => {
     await waitFor(() => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
-    expect(onChange).not.toHaveBeenCalled();
+    expect(setInstanceName).not.toHaveBeenCalled();
   });
 
-  it('does not enter edit mode when propagating', async () => {
-    const { onChange } = renderEditable({ isPropagating: true });
+  it('does not enter edit mode while rename is in progress', async () => {
+    const setInstanceName = jest
+      .fn()
+      .mockImplementation((): Promise<void> => new Promise(() => {})) as jest.MockedFunction<SetInstanceNameFn>;
+    renderEditable({ setInstanceName });
+    await openEditMode();
+    const input = screen.getByRole('textbox', { name: 'Deployment name' });
+    await userEvent.clear(input);
+    await userEvent.type(input, 'x');
+    await userEvent.keyboard('{Enter}');
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+    await userEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Rename' }));
+    await waitFor(() => expect(setInstanceName).toHaveBeenCalled());
+    await userEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Cancel' }));
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
     expect(screen.getByText('prod-cluster')).toBeInTheDocument();
     await userEvent.click(screen.getByText('prod-cluster'));
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
-    expect(onChange).not.toHaveBeenCalled();
+    expect(setInstanceName).toHaveBeenCalledTimes(1);
   });
 
   it('starts edit from keyboard Enter on trigger when focusable', async () => {
@@ -144,17 +236,23 @@ describe('EditableDeploymentName', () => {
   });
 
   it('updates displayed name when name prop changes in view mode', () => {
+    const queryClient = createTestQueryClient();
+    const setInstanceName = (jest.fn() as jest.MockedFunction<SetInstanceNameFn>).mockResolvedValue(undefined);
     const { rerender } = render(
-      <CoreUiThemeProvider theme={coreUIAvailableThemes.darkRebrand}>
-        <EditableDeploymentName name="v1" isPropagating={false} onChange={() => {}} />
-      </CoreUiThemeProvider>,
+      <QueryClientProvider client={queryClient}>
+        <CoreUiThemeProvider theme={coreUIAvailableThemes.darkRebrand}>
+          <EditableDeploymentName name="before-change" setInstanceName={setInstanceName} />
+        </CoreUiThemeProvider>
+      </QueryClientProvider>,
     );
-    expect(screen.getByRole('button', { name: 'v1' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'before-change' })).toBeInTheDocument();
     rerender(
-      <CoreUiThemeProvider theme={coreUIAvailableThemes.darkRebrand}>
-        <EditableDeploymentName name="v2" isPropagating={false} onChange={() => {}} />
-      </CoreUiThemeProvider>,
+      <QueryClientProvider client={queryClient}>
+        <CoreUiThemeProvider theme={coreUIAvailableThemes.darkRebrand}>
+          <EditableDeploymentName name="after-change" setInstanceName={setInstanceName} />
+        </CoreUiThemeProvider>
+      </QueryClientProvider>,
     );
-    expect(screen.getByRole('button', { name: 'v2' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'after-change' })).toBeInTheDocument();
   });
 });

--- a/shell-ui/src/navbar/EditableDeploymentName.tsx
+++ b/shell-ui/src/navbar/EditableDeploymentName.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useRef, useState } from 'react';
+import styled from 'styled-components';
+import { Modal } from '@scality/core-ui/dist/components/modal/Modal.component';
+import { Text } from '@scality/core-ui/dist/components/text/Text.component';
+import { Stack } from '@scality/core-ui/dist/spacing';
+import { Tooltip } from '@scality/core-ui/dist/components/tooltip/Tooltip.component';
+import { InfoMessage } from '@scality/core-ui/dist/components/infomessage/InfoMessage.component';
+import { SecondaryText } from '@scality/core-ui/dist/components/text/Text.component';
+import { Loader } from '@scality/core-ui/dist/components/loader/Loader.component';
+import { Button } from '@scality/core-ui/dist/components/buttonv2/Buttonv2.component';
+import { Box } from '@scality/core-ui/dist/components/box/Box';
+
+import { spacing } from '@scality/core-ui/dist/spacing';
+
+const ModalDivider = styled.hr`
+  border: none;
+  border-top: 1px solid ${(props) => props.theme.backgroundLevel3};
+  margin: 0;
+`;
+
+const InlineLoaderWrapper = styled.span`
+  display: inline-flex;
+  align-items: center;
+  svg {
+    width: 1.25em;
+    height: 1.25em;
+  }
+`;
+
+const NameInput = styled.input`
+  font-size: 1rem;
+  font-family: 'Lato';
+  color: ${(props) => props.theme.textPrimary};
+  background: ${(props) => props.theme.backgroundLevel2};
+  border: 1px solid ${(props) => props.theme.infoPrimary};
+  border-radius: ${spacing.r4};
+  padding: ${spacing.r4} ${spacing.r8};
+  outline: none;
+  min-width: 180px;
+
+  &:focus {
+    border-color: ${(props) => props.theme.selectedActive};
+    box-shadow: 0 0 0 2px ${(props) => props.theme.selectedActive}33;
+  }
+`;
+
+const KeyValueGrid = styled.dl`
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: ${spacing.r8} ${spacing.r16};
+  margin: 0;
+`;
+
+const KeyLabel = styled.dt`
+  color: ${(props) => props.theme.textSecondary};
+  margin: 0;
+`;
+
+const KeyValue = styled.dd`
+  color: ${(props) => props.theme.textPrimary};
+  margin: 0;
+`;
+
+/** Pill around deployment name: typography + interactive hover chrome */
+const NameTrigger = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: ${spacing.r4};
+  padding: ${spacing.r4} ${spacing.r8};
+  border-radius: ${spacing.r16};
+  border: 1px solid transparent;
+  background: ${(props) => props.theme.backgroundLevel3};
+  font-size: 1rem;
+  font-family: 'Lato';
+  color: ${(props) => props.theme.textPrimary};
+  white-space: nowrap;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, opacity 0.15s ease;
+
+  &[data-disabled='true'] {
+    opacity: 0.6;
+  }
+
+  &:not([data-disabled='true']):hover {
+    border-color: ${(props) => props.theme.infoPrimary};
+    background: ${(props) => props.theme.highlight};
+  }
+`;
+
+export function EditableDeploymentName({
+  name,
+  isPropagating,
+  onChange,
+}: {
+  name: string;
+  isPropagating: boolean;
+  onChange: (newName: string) => void;
+}) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [pendingName, setPendingName] = useState(name);
+  const [modalOpen, setModalOpen] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isEditing) {
+      setPendingName(name);
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [isEditing, name]);
+
+  const handleEditStart = () => {
+    if (isPropagating) {
+      return;
+    }
+    setIsEditing(true);
+  };
+
+  const submit = () => {
+    const trimmed = pendingName.trim();
+    if (trimmed && trimmed !== name) {
+      setIsEditing(false);
+      setModalOpen(true);
+    } else {
+      setIsEditing(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      submit();
+    } else if (e.key === 'Escape') {
+      setIsEditing(false);
+    }
+  };
+
+  const handleConfirm = () => {
+    onChange(pendingName.trim());
+    setModalOpen(false);
+  };
+
+  const handleModalCancel = () => {
+    setModalOpen(false);
+  };
+
+  return (
+    <>
+      <Box gap={spacing.r4} style={{ alignItems: 'center' }}>
+        {isEditing ? (
+          <NameInput
+            ref={inputRef}
+            value={pendingName}
+            onChange={(e) => setPendingName(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onBlur={submit}
+            aria-label="Deployment name"
+          />
+        ) : (
+          <Tooltip
+            overlay={isPropagating ? 'Cannot edit while propagating' : 'Edit deployment name'}
+            placement="bottom"
+          >
+            <NameTrigger
+              data-disabled={isPropagating || modalOpen ? 'true' : undefined}
+              onClick={handleEditStart}
+              role={isPropagating ? undefined : 'button'}
+              tabIndex={isPropagating ? undefined : 0}
+              onKeyDown={(e) => !isPropagating && e.key === 'Enter' && handleEditStart()}
+            >
+              {modalOpen ? pendingName.trim() : name}
+              {isPropagating && (
+                <InlineLoaderWrapper>
+                  <Loader size="smaller" />
+                </InlineLoaderWrapper>
+              )}
+            </NameTrigger>
+          </Tooltip>
+        )}
+      </Box>
+
+      <Modal
+        isOpen={modalOpen}
+        close={handleModalCancel}
+        title="Rename deployment?"
+        footer={
+          <Stack gap="r8" direction="horizontal" style={{ justifyContent: 'flex-end' }}>
+            <Button variant="outline" label="Cancel" onClick={handleModalCancel} />
+            <Button variant="primary" label="Rename" onClick={handleConfirm} />
+          </Stack>
+        }
+      >
+        <Stack direction="vertical" gap="r24" style={{ width: '500px' }}>
+          <InfoMessage
+            title="About deployment names"
+            content="The deployment name is a label for this instance, visible in the UI and potentially shared with external systems. It is auto-generated at installation. Renaming it early helps distinguish this deployment from others when several are running in parallel."
+          />
+          <Text>Are you sure you want to rename this deployment?</Text>
+          <KeyValueGrid>
+            <KeyLabel>Current name</KeyLabel>
+            <KeyValue>{name}</KeyValue>
+            <KeyLabel>New name</KeyLabel>
+            <KeyValue>{pendingName.trim()}</KeyValue>
+          </KeyValueGrid>
+          <ModalDivider />
+          <Text style={{ fontStyle: 'italic' }}>
+            <SecondaryText>This change may take a few minutes to propagate across all services.</SecondaryText>
+          </Text>
+        </Stack>
+      </Modal>
+    </>
+  );
+}

--- a/shell-ui/src/navbar/EditableDeploymentName.tsx
+++ b/shell-ui/src/navbar/EditableDeploymentName.tsx
@@ -11,6 +11,9 @@ import { Button } from '@scality/core-ui/dist/components/buttonv2/Buttonv2.compo
 import { Box } from '@scality/core-ui/dist/components/box/Box';
 
 import { spacing } from '@scality/core-ui/dist/spacing';
+import { Banner } from '@scality/core-ui/dist/components/banner/Banner.component';
+import type { InstanceNameAdapter } from './InstanceName';
+import { useMutation, useQueryClient } from 'react-query';
 
 const ModalDivider = styled.hr`
   border: none;
@@ -27,6 +30,23 @@ const InlineLoaderWrapper = styled.span`
   }
 `;
 
+const ValidationInputWrapper = styled.div`
+  position: relative;
+`;
+
+const ValidationError = styled.p`
+  position: absolute;
+  top: 100%;
+  left: 0;
+  margin: ${spacing.r4} 0 0;
+  padding: ${spacing.r2} ${spacing.r8};
+  font-size: 0.75rem;
+  color: ${(props) => props.theme.statusCritical};
+  background: ${(props) => props.theme.backgroundLevel1};
+  border-radius: ${spacing.r4};
+  white-space: nowrap;
+`;
+
 const NameInput = styled.input`
   font-size: 1rem;
   font-family: 'Lato';
@@ -41,6 +61,11 @@ const NameInput = styled.input`
   &:focus {
     border-color: ${(props) => props.theme.selectedActive};
     box-shadow: 0 0 0 2px ${(props) => props.theme.selectedActive}33;
+  }
+
+  &[aria-invalid='true'] {
+    border-color: ${(props) => props.theme.statusCritical};
+    box-shadow: 0 0 0 2px ${(props) => props.theme.statusCritical}33;
   }
 `;
 
@@ -61,7 +86,6 @@ const KeyValue = styled.dd`
   margin: 0;
 `;
 
-/** Pill around deployment name: typography + interactive hover chrome */
 const NameTrigger = styled.span`
   display: inline-flex;
   align-items: center;
@@ -89,17 +113,21 @@ const NameTrigger = styled.span`
 
 export function EditableDeploymentName({
   name,
-  isPropagating,
-  onChange,
+  checkInstanceName,
+  setInstanceName,
 }: {
   name: string;
-  isPropagating: boolean;
-  onChange: (newName: string) => void;
+  checkInstanceName?: InstanceNameAdapter['checkInstanceName'];
+  setInstanceName: (name: string) => Promise<void>;
 }) {
+  const queryClient = useQueryClient();
   const [isEditing, setIsEditing] = useState(false);
   const [pendingName, setPendingName] = useState(name);
   const [modalOpen, setModalOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const [inputValidationError, setInputValidationError] = useState<string | undefined>(undefined);
+
+  const [setInstanceNameErrorMessage, setSetInstanceNameErrorMessage] = useState<string | undefined>(undefined);
 
   useEffect(() => {
     if (isEditing) {
@@ -109,8 +137,30 @@ export function EditableDeploymentName({
     }
   }, [isEditing, name]);
 
+  const mutation = useMutation({
+    mutationFn: async ({ value }: { value: string }) => {
+      return setInstanceName(value);
+    },
+    onSuccess: () => {
+      setSetInstanceNameErrorMessage(undefined);
+    },
+    onError: (error) => {
+      let errorMessage = 'An error occurred while updating the deployment name';
+      if (error instanceof Error) {
+        errorMessage = error.message;
+        setSetInstanceNameErrorMessage(errorMessage);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries(['instanceName']);
+    },
+  });
+
+  const isMutationLoading = mutation.isLoading;
+  const showInputError = !!inputValidationError;
+
   const handleEditStart = () => {
-    if (isPropagating) {
+    if (isMutationLoading) {
       return;
     }
     setIsEditing(true);
@@ -118,6 +168,14 @@ export function EditableDeploymentName({
 
   const submit = () => {
     const trimmed = pendingName.trim();
+    const validationResult = checkInstanceName ? checkInstanceName(trimmed) : ({ hasError: false } as const);
+    if (validationResult.hasError === true) {
+      setInputValidationError(validationResult.message);
+      return;
+    }
+
+    setInputValidationError(undefined);
+
     if (trimmed && trimmed !== name) {
       setIsEditing(false);
       setModalOpen(true);
@@ -135,7 +193,7 @@ export function EditableDeploymentName({
   };
 
   const handleConfirm = () => {
-    onChange(pendingName.trim());
+    mutation.mutate({ value: pendingName.trim() });
     setModalOpen(false);
   };
 
@@ -147,28 +205,36 @@ export function EditableDeploymentName({
     <>
       <Box gap={spacing.r4} style={{ alignItems: 'center' }}>
         {isEditing ? (
-          <NameInput
-            ref={inputRef}
-            value={pendingName}
-            onChange={(e) => setPendingName(e.target.value)}
-            onKeyDown={handleKeyDown}
-            onBlur={submit}
-            aria-label="Deployment name"
-          />
+          <ValidationInputWrapper>
+            <NameInput
+              ref={inputRef}
+              value={pendingName}
+              onChange={(e) => setPendingName(e.target.value)}
+              onKeyDown={handleKeyDown}
+              onBlur={submit}
+              aria-label="Deployment name"
+              aria-invalid={showInputError ? 'true' : 'false'}
+            />
+            {showInputError && inputValidationError && (
+              <ValidationError id="name-error" role="alert">
+                {inputValidationError}
+              </ValidationError>
+            )}
+          </ValidationInputWrapper>
         ) : (
           <Tooltip
-            overlay={isPropagating ? 'Cannot edit while propagating' : 'Edit deployment name'}
+            overlay={isMutationLoading ? 'Cannot edit while propagating' : 'Edit deployment name'}
             placement="bottom"
           >
             <NameTrigger
-              data-disabled={isPropagating || modalOpen ? 'true' : undefined}
+              data-disabled={isMutationLoading || modalOpen ? 'true' : undefined}
               onClick={handleEditStart}
-              role={isPropagating ? undefined : 'button'}
-              tabIndex={isPropagating ? undefined : 0}
-              onKeyDown={(e) => !isPropagating && e.key === 'Enter' && handleEditStart()}
+              role={isMutationLoading ? undefined : 'button'}
+              tabIndex={isMutationLoading ? undefined : 0}
+              onKeyDown={(e) => !isMutationLoading && e.key === 'Enter' && handleEditStart()}
             >
               {modalOpen ? pendingName.trim() : name}
-              {isPropagating && (
+              {isMutationLoading && (
                 <InlineLoaderWrapper>
                   <Loader size="smaller" />
                 </InlineLoaderWrapper>
@@ -190,6 +256,11 @@ export function EditableDeploymentName({
         }
       >
         <Stack direction="vertical" gap="r24" style={{ width: '500px' }}>
+          {setInstanceNameErrorMessage && (
+            <Banner variant="danger" title="Error renaming deployment">
+              {setInstanceNameErrorMessage}
+            </Banner>
+          )}
           <InfoMessage
             title="About deployment names"
             content="The deployment name is a label for this instance, visible in the UI. It is auto-generated at installation. Renaming it early helps distinguish this deployment from others in multi-deployment environments."

--- a/shell-ui/src/navbar/EditableDeploymentName.tsx
+++ b/shell-ui/src/navbar/EditableDeploymentName.tsx
@@ -192,7 +192,7 @@ export function EditableDeploymentName({
         <Stack direction="vertical" gap="r24" style={{ width: '500px' }}>
           <InfoMessage
             title="About deployment names"
-            content="The deployment name is a label for this instance, visible in the UI and potentially shared with external systems. It is auto-generated at installation. Renaming it early helps distinguish this deployment from others when several are running in parallel."
+            content="The deployment name is a label for this instance, visible in the UI. It is auto-generated at installation. Renaming it early helps distinguish this deployment from others in multi-deployment environments."
           />
           <Text>Are you sure you want to rename this deployment?</Text>
           <KeyValueGrid>

--- a/shell-ui/src/navbar/EditableDeploymentName.tsx
+++ b/shell-ui/src/navbar/EditableDeploymentName.tsx
@@ -15,6 +15,13 @@ import { Banner } from '@scality/core-ui/dist/components/banner/Banner.component
 import { type InstanceNameAdapter, INSTANCE_NAME_QUERY_KEY } from './InstanceName';
 import { useMutation, useQueryClient } from 'react-query';
 
+function renameMutationErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return 'An error occurred while updating the deployment name';
+}
+
 const ModalDivider = styled.hr`
   border: none;
   border-top: 1px solid ${(props) => props.theme.backgroundLevel3};
@@ -127,8 +134,6 @@ export function EditableDeploymentName({
   const inputRef = useRef<HTMLInputElement>(null);
   const [inputValidationError, setInputValidationError] = useState<string | undefined>(undefined);
 
-  const [setInstanceNameErrorMessage, setSetInstanceNameErrorMessage] = useState<string | undefined>(undefined);
-
   useEffect(() => {
     if (isEditing) {
       setPendingName(name);
@@ -142,15 +147,7 @@ export function EditableDeploymentName({
       return setInstanceName(value);
     },
     onSuccess: () => {
-      setSetInstanceNameErrorMessage(undefined);
       setModalOpen(false);
-    },
-    onError: (error) => {
-      let errorMessage = 'An error occurred while updating the deployment name';
-      if (error instanceof Error) {
-        errorMessage = error.message;
-      }
-      setSetInstanceNameErrorMessage(errorMessage);
     },
     onSettled: () => {
       queryClient.invalidateQueries([INSTANCE_NAME_QUERY_KEY]);
@@ -199,8 +196,10 @@ export function EditableDeploymentName({
 
   const handleModalCancel = () => {
     setModalOpen(false);
-    setSetInstanceNameErrorMessage(undefined);
     setInputValidationError(undefined);
+    if (!mutation.isLoading) {
+      mutation.reset();
+    }
   };
 
   return (
@@ -264,9 +263,9 @@ export function EditableDeploymentName({
         }
       >
         <Stack direction="vertical" gap="r24" style={{ width: '500px' }}>
-          {setInstanceNameErrorMessage && (
+          {mutation.isError && mutation.error != null && (
             <Banner variant="danger" title="Error renaming deployment">
-              {setInstanceNameErrorMessage}
+              {renameMutationErrorMessage(mutation.error)}
             </Banner>
           )}
           <InfoMessage

--- a/shell-ui/src/navbar/EditableDeploymentName.tsx
+++ b/shell-ui/src/navbar/EditableDeploymentName.tsx
@@ -12,7 +12,7 @@ import { Box } from '@scality/core-ui/dist/components/box/Box';
 
 import { spacing } from '@scality/core-ui/dist/spacing';
 import { Banner } from '@scality/core-ui/dist/components/banner/Banner.component';
-import type { InstanceNameAdapter } from './InstanceName';
+import { type InstanceNameAdapter, INSTANCE_NAME_QUERY_KEY } from './InstanceName';
 import { useMutation, useQueryClient } from 'react-query';
 
 const ModalDivider = styled.hr`
@@ -143,16 +143,17 @@ export function EditableDeploymentName({
     },
     onSuccess: () => {
       setSetInstanceNameErrorMessage(undefined);
+      setModalOpen(false);
     },
     onError: (error) => {
       let errorMessage = 'An error occurred while updating the deployment name';
       if (error instanceof Error) {
         errorMessage = error.message;
-        setSetInstanceNameErrorMessage(errorMessage);
       }
+      setSetInstanceNameErrorMessage(errorMessage);
     },
     onSettled: () => {
-      queryClient.invalidateQueries(['instanceName']);
+      queryClient.invalidateQueries([INSTANCE_NAME_QUERY_KEY]);
     },
   });
 
@@ -194,11 +195,12 @@ export function EditableDeploymentName({
 
   const handleConfirm = () => {
     mutation.mutate({ value: pendingName.trim() });
-    setModalOpen(false);
   };
 
   const handleModalCancel = () => {
     setModalOpen(false);
+    setSetInstanceNameErrorMessage(undefined);
+    setInputValidationError(undefined);
   };
 
   return (
@@ -251,7 +253,13 @@ export function EditableDeploymentName({
         footer={
           <Stack gap="r8" direction="horizontal" style={{ justifyContent: 'flex-end' }}>
             <Button variant="outline" label="Cancel" onClick={handleModalCancel} />
-            <Button variant="primary" label="Rename" onClick={handleConfirm} />
+            <Button
+              variant="primary"
+              label="Rename"
+              onClick={handleConfirm}
+              isLoading={isMutationLoading}
+              disabled={isMutationLoading}
+            />
           </Stack>
         }
       >

--- a/shell-ui/src/navbar/InstanceName.spec.tsx
+++ b/shell-ui/src/navbar/InstanceName.spec.tsx
@@ -1,5 +1,5 @@
 import type { PropsWithChildren } from 'react';
-import { InstanceNameProvider, _InternalInstanceName } from './InstanceName';
+import { _InternalInstanceName } from './InstanceName';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import { jest } from '@jest/globals';
 import userEvent from '@testing-library/user-event';
@@ -55,21 +55,19 @@ jest.mock('../auth/AuthProvider', () => ({
 const Wrapper = ({ children }: PropsWithChildren) => (
   <CoreUiThemeProvider theme={coreUIAvailableThemes.darkRebrand}>
     <ToastProvider>
-      <InstanceNameProvider>
-        <QueryClientProvider
-          client={
-            new QueryClient({
-              defaultOptions: {
-                queries: {
-                  retry: false,
-                },
+      <QueryClientProvider
+        client={
+          new QueryClient({
+            defaultOptions: {
+              queries: {
+                retry: false,
               },
-            })
-          }
-        >
-          {children}
-        </QueryClientProvider>
-      </InstanceNameProvider>
+            },
+          })
+        }
+      >
+        {children}
+      </QueryClientProvider>
     </ToastProvider>
   </CoreUiThemeProvider>
 );

--- a/shell-ui/src/navbar/InstanceName.spec.tsx
+++ b/shell-ui/src/navbar/InstanceName.spec.tsx
@@ -1,28 +1,36 @@
-import React, { PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 import { InstanceNameProvider, _InternalInstanceName } from './InstanceName';
-import {
-  render,
-  screen,
-  waitFor,
-  waitForElementToBeRemoved,
-  within,
-} from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import { jest } from '@jest/globals';
 import userEvent from '@testing-library/user-event';
 import { QueryClient } from 'react-query';
+import { CoreUiThemeProvider } from '@scality/core-ui/dist/components/coreuithemeprovider/CoreUiThemeProvider';
 import { ToastProvider } from '@scality/core-ui/dist/components/toast/ToastProvider';
-import { UserData } from '../auth/AuthProvider';
+import { coreUIAvailableThemes } from '@scality/core-ui/dist/style/theme';
+import type { UserData } from '../auth/AuthProvider';
+import type { RuntimeWebFinger } from '../initFederation/ConfigurationProviders';
 import { QueryClientProvider } from '../QueryClientProvider';
 
 jest.mock('../initFederation/ConfigurationProviders', () => ({
   useConfigRetriever: () => ({
-    retrieveConfiguration: () => ({
-      spec: {
-        instanceNameAdapter: {
-          module: './instanceNameAdapter',
-        },
-      },
-    }),
+    retrieveConfiguration: (config: { configType: 'build'; name: string }) => {
+      if (config.configType === 'build') {
+        return {
+          spec: {
+            instanceNameAdapter: {
+              module: './instanceNameAdapter',
+            },
+          },
+        };
+      } else if (config.configType === 'run') {
+        return {
+          spec: {
+            apiUrl: 'http://localhost:3000/api/v1',
+          },
+        };
+      }
+      return null;
+    },
   }),
 }));
 
@@ -39,38 +47,50 @@ jest.mock('../initFederation/UIListProvider', () => ({
 jest.mock('../auth/AuthProvider', () => ({
   useAuth: () => ({
     userData: {
-      token: 'test',
+      token: 'test-token',
     },
   }),
 }));
 
-const Wrapper = ({ children }: PropsWithChildren<{}>) => (
-  <ToastProvider>
-    <InstanceNameProvider>
-      <QueryClientProvider
-        client={
-          new QueryClient({
-            defaultOptions: {
-              queries: {
-                retry: false,
+const Wrapper = ({ children }: PropsWithChildren) => (
+  <CoreUiThemeProvider theme={coreUIAvailableThemes.darkRebrand}>
+    <ToastProvider>
+      <InstanceNameProvider>
+        <QueryClientProvider
+          client={
+            new QueryClient({
+              defaultOptions: {
+                queries: {
+                  retry: false,
+                },
               },
-            },
-          })
-        }
-      >
-        {children}
-      </QueryClientProvider>
-    </InstanceNameProvider>
-  </ToastProvider>
+            })
+          }
+        >
+          {children}
+        </QueryClientProvider>
+      </InstanceNameProvider>
+    </ToastProvider>
+  </CoreUiThemeProvider>
 );
 
 describe('InstanceName', () => {
-  it('should display the instance name input when it resolved its configuration', async () => {
-    //S
+  it('shows Loader in Tooltip while deployment name query is loading', async () => {
     const getInstanceName = jest
-      .fn<(userData: UserData) => Promise<string>>()
-      .mockResolvedValue('default');
-    const setInstanceName = jest.fn<(userData: UserData) => Promise<void>>();
+      .fn<
+        (userData: UserData | undefined, configuration: RuntimeWebFinger<Record<string, unknown>>) => Promise<string>
+      >()
+      .mockImplementation(() => new Promise(() => {}));
+    const setInstanceName = jest
+      .fn<
+        (
+          userData: UserData | undefined,
+          name: string,
+          configuration: RuntimeWebFinger<Record<string, unknown>>,
+        ) => Promise<void>
+      >()
+      .mockResolvedValue(undefined);
+
     render(
       <_InternalInstanceName
         moduleExports={{
@@ -82,25 +102,124 @@ describe('InstanceName', () => {
       />,
       { wrapper: Wrapper },
     );
-    //E
-    await waitForElementToBeRemoved(() => screen.getByText(/loading/i));
-    await userEvent.tab();
-    await waitFor(() => expect(screen.getByRole('button')).toBeInTheDocument());
-    await userEvent.click(screen.getByRole('button'));
-    await userEvent.type(screen.getByRole('textbox'), 'test');
-    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
-    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+
+    await waitFor(() => {
+      expect(document.querySelector('.sc-loader')).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: 'sweet-cluster' })).not.toBeInTheDocument();
+    expect(setInstanceName).not.toHaveBeenCalled();
+  });
+
+  it('shows warning Icon in Tooltip when loading deployment name fails', async () => {
+    const getInstanceName = jest
+      .fn<
+        (userData: UserData | undefined, configuration: RuntimeWebFinger<Record<string, unknown>>) => Promise<string>
+      >()
+      .mockRejectedValue(new Error('boom'));
+    const setInstanceName = jest
+      .fn<
+        (
+          userData: UserData | undefined,
+          name: string,
+          configuration: RuntimeWebFinger<Record<string, unknown>>,
+        ) => Promise<void>
+      >()
+      .mockResolvedValue(undefined);
+
+    render(
+      <_InternalInstanceName
+        moduleExports={{
+          './instanceNameAdapter': {
+            getInstanceName,
+            setInstanceName,
+          },
+        }}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    await waitFor(() => {
+      expect(document.querySelector('.sc-loader')).not.toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      const icon = document.querySelector('[data-icon="circle-exclamation"]');
+      expect(icon).toBeInTheDocument();
+      expect(icon).toHaveAttribute('color', 'statusWarning');
+    });
+
+    expect(setInstanceName).not.toHaveBeenCalled();
+    expect(getInstanceName).toHaveBeenCalled();
+  });
+
+  it('loads deployment name then renames via EditableDeploymentName and calls setInstanceName', async () => {
+    const getInstanceName = jest
+      .fn<
+        (userData: UserData | undefined, configuration: RuntimeWebFinger<Record<string, unknown>>) => Promise<string>
+      >()
+      .mockResolvedValue('sweet-cluster');
+    const setInstanceName = jest
+      .fn<
+        (
+          userData: UserData | undefined,
+          name: string,
+          configuration: RuntimeWebFinger<Record<string, unknown>>,
+        ) => Promise<void>
+      >()
+      .mockResolvedValue(undefined);
+
+    render(
+      <_InternalInstanceName
+        moduleExports={{
+          './instanceNameAdapter': {
+            getInstanceName,
+            setInstanceName,
+          },
+        }}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'sweet-cluster' })).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: 'sweet-cluster' }));
+    const input = screen.getByRole('textbox', { name: 'Deployment name' });
+    await userEvent.type(input, 'test');
+    await userEvent.keyboard('{Enter}');
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog', { name: 'Rename deployment?' })).toBeInTheDocument();
+    });
+
     await userEvent.click(
-      within(screen.getByRole('dialog')).getByRole('button', {
-        name: 'Confirm',
+      within(screen.getByRole('dialog', { name: 'Rename deployment?' })).getByRole('button', {
+        name: 'Rename',
       }),
     );
+
     await waitFor(() => expect(setInstanceName).toHaveBeenCalledTimes(1));
-    //V
-    expect(getInstanceName).toHaveBeenCalledTimes(1);
-    expect(setInstanceName).toHaveBeenCalledWith(
-      { token: 'test' },
-      'defaulttest',
+    await waitFor(() => expect(getInstanceName).toHaveBeenCalledTimes(2));
+
+    expect(getInstanceName).toHaveBeenNthCalledWith(
+      1,
+      { token: 'test-token' },
+      expect.objectContaining({ spec: { apiUrl: 'http://localhost:3000/api/v1' } }),
     );
+    expect(getInstanceName).toHaveBeenNthCalledWith(
+      2,
+      { token: 'test-token' },
+      expect.objectContaining({
+        spec: { apiUrl: 'http://localhost:3000/api/v1' },
+      }),
+    );
+    expect(setInstanceName).toHaveBeenCalledWith(
+      { token: 'test-token' },
+      'test',
+      expect.objectContaining({
+        spec: { apiUrl: 'http://localhost:3000/api/v1' },
+      }),
+    );
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'sweet-cluster' })).toBeInTheDocument());
   });
 });

--- a/shell-ui/src/navbar/InstanceName.tsx
+++ b/shell-ui/src/navbar/InstanceName.tsx
@@ -1,15 +1,15 @@
 import { ErrorPage500 } from '@scality/core-ui/dist/components/error-pages/ErrorPage500.component';
+import { Icon } from '@scality/core-ui/dist/components/icon/Icon.component';
+import { Loader } from '@scality/core-ui/dist/components/loader/Loader.component';
+import { Tooltip } from '@scality/core-ui/dist/components/tooltip/Tooltip.component';
 import { ComponentWithFederatedImports } from '@scality/module-federation';
 import { createContext, useContext, useState, type PropsWithChildren } from 'react';
-import { useMutation, useQuery, useQueryClient } from 'react-query';
+import { useQuery } from 'react-query';
 import { useAuth, type UserData } from '../auth/AuthProvider';
 import { useConfigRetriever, type RuntimeWebFinger } from '../initFederation/ConfigurationProviders';
 import { useShellConfig } from '../initFederation/ShellConfigProvider';
 import { useDeployedApps } from '../initFederation/UIListProvider';
 import { EditableDeploymentName } from './EditableDeploymentName';
-import { Icon } from '@scality/core-ui/dist/components/icon/Icon.component';
-import { Loader } from '@scality/core-ui/dist/components/loader/Loader.component';
-import { Tooltip } from '@scality/core-ui/dist/components/tooltip/Tooltip.component';
 
 const InstanceNameContext = createContext<{
   instanceName: string;
@@ -87,6 +87,8 @@ export const useInstanceNameConfiguration = () => {
   };
 };
 
+export const INSTANCE_NAME_QUERY_KEY = 'instanceName';
+
 export type InstanceNameAdapter = {
   getInstanceName: (
     userData: UserData | undefined,
@@ -118,7 +120,7 @@ export const _InternalInstanceName = ({
   const setInstanceName = useSetInstanceName();
   const { userData } = useAuth();
   const { data, status } = useQuery({
-    queryKey: ['instanceName'],
+    queryKey: [INSTANCE_NAME_QUERY_KEY],
     queryFn: async () =>
       moduleExports[instanceNameAdapter?.module ?? ''].getInstanceName(userData, runtimeAppConfiguration),
     onSuccess: (data) => {

--- a/shell-ui/src/navbar/InstanceName.tsx
+++ b/shell-ui/src/navbar/InstanceName.tsx
@@ -12,12 +12,13 @@ import { EditableDeploymentName } from './EditableDeploymentName';
 
 export const INSTANCE_NAME_QUERY_KEY = 'instanceName';
 
-export const useInstanceName = (): string => {
-  const { data } = useQuery({
+export const useInstanceName = (): string | undefined => {
+  const { data } = useQuery<string>({
     queryKey: [INSTANCE_NAME_QUERY_KEY],
     enabled: false, // Don't refetch, just read from cache
   });
-  return (data as string) ?? '';
+
+  return data;
 };
 
 export const useInstanceNameAdapter = () => {

--- a/shell-ui/src/navbar/InstanceName.tsx
+++ b/shell-ui/src/navbar/InstanceName.tsx
@@ -3,7 +3,6 @@ import { Icon } from '@scality/core-ui/dist/components/icon/Icon.component';
 import { Loader } from '@scality/core-ui/dist/components/loader/Loader.component';
 import { Tooltip } from '@scality/core-ui/dist/components/tooltip/Tooltip.component';
 import { ComponentWithFederatedImports } from '@scality/module-federation';
-import { createContext, useContext, useState, type PropsWithChildren } from 'react';
 import { useQuery } from 'react-query';
 import { useAuth, type UserData } from '../auth/AuthProvider';
 import { useConfigRetriever, type RuntimeWebFinger } from '../initFederation/ConfigurationProviders';
@@ -12,17 +11,6 @@ import { useDeployedApps } from '../initFederation/UIListProvider';
 import { EditableDeploymentName } from './EditableDeploymentName';
 
 export const INSTANCE_NAME_QUERY_KEY = 'instanceName';
-
-const InstanceNameContext = createContext<{
-  instanceName: string;
-  setInstanceName: (name: string) => void;
-} | null>(null);
-export const InstanceNameProvider = ({ children }: PropsWithChildren<{}>) => {
-  const [instanceName, setInstanceName] = useState('');
-  return (
-    <InstanceNameContext.Provider value={{ instanceName, setInstanceName }}>{children}</InstanceNameContext.Provider>
-  );
-};
 
 export const useInstanceName = (): string => {
   const { data } = useQuery({

--- a/shell-ui/src/navbar/InstanceName.tsx
+++ b/shell-ui/src/navbar/InstanceName.tsx
@@ -24,20 +24,12 @@ export const InstanceNameProvider = ({ children }: PropsWithChildren<{}>) => {
   );
 };
 
-export const useInstanceName = () => {
-  const context = useContext(InstanceNameContext);
-  if (!context) {
-    throw new Error('useInstanceName must be used within a InstanceNameProvider');
-  }
-  return context.instanceName;
-};
-
-const useSetInstanceName = () => {
-  const context = useContext(InstanceNameContext);
-  if (!context) {
-    throw new Error('useSetInstanceName must be used within a InstanceNameProvider');
-  }
-  return context.setInstanceName;
+export const useInstanceName = (): string => {
+  const { data } = useQuery({
+    queryKey: [INSTANCE_NAME_QUERY_KEY],
+    enabled: false, // Don't refetch, just read from cache
+  });
+  return (data as string) ?? '';
 };
 
 export const useInstanceNameAdapter = () => {

--- a/shell-ui/src/navbar/InstanceName.tsx
+++ b/shell-ui/src/navbar/InstanceName.tsx
@@ -10,7 +10,6 @@ import { EditableDeploymentName } from './EditableDeploymentName';
 import { Icon } from '@scality/core-ui/dist/components/icon/Icon.component';
 import { Loader } from '@scality/core-ui/dist/components/loader/Loader.component';
 import { Tooltip } from '@scality/core-ui/dist/components/tooltip/Tooltip.component';
-import { useToast } from '@scality/core-ui/dist/components/toast/ToastProvider';
 
 const InstanceNameContext = createContext<{
   instanceName: string;
@@ -88,26 +87,31 @@ export const useInstanceNameConfiguration = () => {
   };
 };
 
+export type InstanceNameAdapter = {
+  getInstanceName: (
+    userData: UserData | undefined,
+    configuration: RuntimeWebFinger<Record<string, unknown>>,
+  ) => Promise<string>;
+  setInstanceName: (
+    userData: UserData | undefined,
+    name: string,
+    configuration: RuntimeWebFinger<Record<string, unknown>>,
+  ) => Promise<void>;
+  checkInstanceName: (name: string) => { hasError: true; message: string } | { hasError: false };
+};
+
 //Do not use directly - exported for testing purposes
 export const _InternalInstanceName = ({
   moduleExports,
 }: {
   moduleExports: {
     [moduleName: string]: {
-      getInstanceName: (
-        userData: UserData | undefined,
-        configuration: RuntimeWebFinger<Record<string, unknown>>,
-      ) => Promise<string>;
-      setInstanceName: (
-        userData: UserData | undefined,
-        name: string,
-        configuration: RuntimeWebFinger<Record<string, unknown>>,
-      ) => Promise<void>;
+      getInstanceName: InstanceNameAdapter['getInstanceName'];
+      setInstanceName: InstanceNameAdapter['setInstanceName'];
+      checkInstanceName?: InstanceNameAdapter['checkInstanceName'];
     };
   };
 }) => {
-  const queryClient = useQueryClient();
-  const { showToast } = useToast();
   const instanceNameAdapter = useInstanceNameAdapter();
   const instanceNameConfiguration = useInstanceNameConfiguration();
   const runtimeAppConfiguration = instanceNameConfiguration?.runtimeAppConfiguration;
@@ -120,40 +124,7 @@ export const _InternalInstanceName = ({
     onSuccess: (data) => {
       setInstanceName(data);
     },
-    onError: (error) => {
-      let errorMessage = 'An error occurred while loading the deployment name';
-      if (error instanceof Error) {
-        errorMessage = error.message;
-      }
-      showToast({
-        open: true,
-        status: 'error',
-        message: errorMessage,
-      });
-    },
     enabled: !!runtimeAppConfiguration,
-  });
-
-  const mutation = useMutation({
-    mutationFn: async ({ value }: { value: string }) => {
-      return moduleExports[instanceNameAdapter?.module ?? ''].setInstanceName(userData, value, runtimeAppConfiguration);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries(['instanceName']);
-    },
-    onError: (error) => {
-      let errorMessage = 'An error occurred while updating the deployment name';
-      if (error instanceof Error) {
-        errorMessage = error.message;
-      }
-
-      queryClient.invalidateQueries(['instanceName']);
-      showToast({
-        open: true,
-        status: 'error',
-        message: errorMessage,
-      });
-    },
   });
 
   if (status === 'loading' || status === 'idle') {
@@ -175,9 +146,13 @@ export const _InternalInstanceName = ({
   return (
     <EditableDeploymentName
       name={data}
-      isPropagating={mutation.isLoading}
-      onChange={(value) => {
-        mutation.mutate({ value });
+      checkInstanceName={moduleExports[instanceNameAdapter?.module ?? ''].checkInstanceName}
+      setInstanceName={(name) => {
+        return moduleExports[instanceNameAdapter?.module ?? ''].setInstanceName(
+          userData,
+          name,
+          runtimeAppConfiguration,
+        );
       }}
     />
   );

--- a/shell-ui/src/navbar/InstanceName.tsx
+++ b/shell-ui/src/navbar/InstanceName.tsx
@@ -11,6 +11,8 @@ import { useShellConfig } from '../initFederation/ShellConfigProvider';
 import { useDeployedApps } from '../initFederation/UIListProvider';
 import { EditableDeploymentName } from './EditableDeploymentName';
 
+export const INSTANCE_NAME_QUERY_KEY = 'instanceName';
+
 const InstanceNameContext = createContext<{
   instanceName: string;
   setInstanceName: (name: string) => void;
@@ -87,8 +89,6 @@ export const useInstanceNameConfiguration = () => {
   };
 };
 
-export const INSTANCE_NAME_QUERY_KEY = 'instanceName';
-
 export type InstanceNameAdapter = {
   getInstanceName: (
     userData: UserData | undefined,
@@ -117,15 +117,11 @@ export const _InternalInstanceName = ({
   const instanceNameAdapter = useInstanceNameAdapter();
   const instanceNameConfiguration = useInstanceNameConfiguration();
   const runtimeAppConfiguration = instanceNameConfiguration?.runtimeAppConfiguration;
-  const setInstanceName = useSetInstanceName();
   const { userData } = useAuth();
   const { data, status } = useQuery({
     queryKey: [INSTANCE_NAME_QUERY_KEY],
     queryFn: async () =>
       moduleExports[instanceNameAdapter?.module ?? ''].getInstanceName(userData, runtimeAppConfiguration),
-    onSuccess: (data) => {
-      setInstanceName(data);
-    },
     enabled: !!runtimeAppConfiguration,
   });
 

--- a/shell-ui/src/navbar/InstanceName.tsx
+++ b/shell-ui/src/navbar/InstanceName.tsx
@@ -1,18 +1,16 @@
-import React, {
-  PropsWithChildren,
-  createContext,
-  useContext,
-  useState,
-} from 'react';
-import { useShellConfig } from '../initFederation/ShellConfigProvider';
-import { InlineInput } from '@scality/core-ui/dist/components/inlineinput/InlineInput';
-import { useMutation, useQuery } from 'react-query';
-import { useDeployedApps } from '../initFederation/UIListProvider';
-import { useConfigRetriever } from '../initFederation/ConfigurationProviders';
-import { ComponentWithFederatedImports } from '@scality/module-federation';
 import { ErrorPage500 } from '@scality/core-ui/dist/components/error-pages/ErrorPage500.component';
-import { Text } from '@scality/core-ui/dist/components/text/Text.component';
-import { UserData, useAuth } from '../auth/AuthProvider';
+import { ComponentWithFederatedImports } from '@scality/module-federation';
+import { createContext, useContext, useState, type PropsWithChildren } from 'react';
+import { useMutation, useQuery, useQueryClient } from 'react-query';
+import { useAuth, type UserData } from '../auth/AuthProvider';
+import { useConfigRetriever, type RuntimeWebFinger } from '../initFederation/ConfigurationProviders';
+import { useShellConfig } from '../initFederation/ShellConfigProvider';
+import { useDeployedApps } from '../initFederation/UIListProvider';
+import { EditableDeploymentName } from './EditableDeploymentName';
+import { Icon } from '@scality/core-ui/dist/components/icon/Icon.component';
+import { Loader } from '@scality/core-ui/dist/components/loader/Loader.component';
+import { Tooltip } from '@scality/core-ui/dist/components/tooltip/Tooltip.component';
+import { useToast } from '@scality/core-ui/dist/components/toast/ToastProvider';
 
 const InstanceNameContext = createContext<{
   instanceName: string;
@@ -21,18 +19,14 @@ const InstanceNameContext = createContext<{
 export const InstanceNameProvider = ({ children }: PropsWithChildren<{}>) => {
   const [instanceName, setInstanceName] = useState('');
   return (
-    <InstanceNameContext.Provider value={{ instanceName, setInstanceName }}>
-      {children}
-    </InstanceNameContext.Provider>
+    <InstanceNameContext.Provider value={{ instanceName, setInstanceName }}>{children}</InstanceNameContext.Provider>
   );
 };
 
 export const useInstanceName = () => {
   const context = useContext(InstanceNameContext);
   if (!context) {
-    throw new Error(
-      'useInstanceName must be used within a InstanceNameProvider',
-    );
+    throw new Error('useInstanceName must be used within a InstanceNameProvider');
   }
   return context.instanceName;
 };
@@ -40,9 +34,7 @@ export const useInstanceName = () => {
 const useSetInstanceName = () => {
   const context = useContext(InstanceNameContext);
   if (!context) {
-    throw new Error(
-      'useSetInstanceName must be used within a InstanceNameProvider',
-    );
+    throw new Error('useSetInstanceName must be used within a InstanceNameProvider');
   }
   return context.setInstanceName;
 };
@@ -69,54 +61,123 @@ export const useInstanceNameAdapter = () => {
   };
 };
 
+export const useInstanceNameConfiguration = () => {
+  const deployedUIApps = useDeployedApps();
+  const { retrieveConfiguration } = useConfigRetriever();
+  const mainApp = deployedUIApps.find((app) => app.appHistoryBasePath === '');
+  if (!mainApp) {
+    return null;
+  }
+  const mainAppConfiguration = retrieveConfiguration<'build'>({
+    configType: 'build',
+    name: mainApp.name,
+  });
+
+  const mainAppRuntimeConfiguration = retrieveConfiguration<Record<string, unknown>>({
+    configType: 'run',
+    name: mainApp.name,
+  });
+
+  if (!mainAppConfiguration || !mainAppRuntimeConfiguration) {
+    return null;
+  }
+
+  return {
+    microAppConfiguration: mainAppConfiguration,
+    runtimeAppConfiguration: mainAppRuntimeConfiguration,
+  };
+};
+
 //Do not use directly - exported for testing purposes
 export const _InternalInstanceName = ({
   moduleExports,
 }: {
   moduleExports: {
     [moduleName: string]: {
-      getInstanceName: (userData: UserData | undefined) => Promise<string>;
+      getInstanceName: (
+        userData: UserData | undefined,
+        configuration: RuntimeWebFinger<Record<string, unknown>>,
+      ) => Promise<string>;
       setInstanceName: (
         userData: UserData | undefined,
         name: string,
+        configuration: RuntimeWebFinger<Record<string, unknown>>,
       ) => Promise<void>;
     };
   };
 }) => {
+  const queryClient = useQueryClient();
+  const { showToast } = useToast();
   const instanceNameAdapter = useInstanceNameAdapter();
-
+  const instanceNameConfiguration = useInstanceNameConfiguration();
+  const runtimeAppConfiguration = instanceNameConfiguration?.runtimeAppConfiguration;
   const setInstanceName = useSetInstanceName();
   const { userData } = useAuth();
   const { data, status } = useQuery({
     queryKey: ['instanceName'],
-    queryFn: () =>
-      moduleExports[instanceNameAdapter?.module ?? ''].getInstanceName(
-        userData,
-      ),
+    queryFn: async () =>
+      moduleExports[instanceNameAdapter?.module ?? ''].getInstanceName(userData, runtimeAppConfiguration),
     onSuccess: (data) => {
       setInstanceName(data);
     },
+    onError: (error) => {
+      let errorMessage = 'An error occurred while loading the deployment name';
+      if (error instanceof Error) {
+        errorMessage = error.message;
+      }
+      showToast({
+        open: true,
+        status: 'error',
+        message: errorMessage,
+      });
+    },
+    enabled: !!runtimeAppConfiguration,
   });
 
   const mutation = useMutation({
-    mutationFn: ({ value }: { value: string }) => {
-      return moduleExports[instanceNameAdapter?.module ?? ''].setInstanceName(
-        userData,
-        value,
-      );
+    mutationFn: async ({ value }: { value: string }) => {
+      return moduleExports[instanceNameAdapter?.module ?? ''].setInstanceName(userData, value, runtimeAppConfiguration);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries(['instanceName']);
+    },
+    onError: (error) => {
+      let errorMessage = 'An error occurred while updating the deployment name';
+      if (error instanceof Error) {
+        errorMessage = error.message;
+      }
+
+      queryClient.invalidateQueries(['instanceName']);
+      showToast({
+        open: true,
+        status: 'error',
+        message: errorMessage,
+      });
     },
   });
 
-  return status === 'loading' ? (
-    <Text>Loading...</Text>
-  ) : (
-    <InlineInput
-      id="instanceName"
-      changeMutation={mutation}
-      defaultValue={data}
-      confirmationModal={{
-        title: <>Change instance name</>,
-        body: <>Are you sure you want to change the instance name?</>,
+  if (status === 'loading' || status === 'idle') {
+    return (
+      <Tooltip overlay="Loading deployment name" placement="bottom">
+        <Loader size="smaller" />
+      </Tooltip>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <Tooltip overlay="Error loading deployment name" placement="bottom">
+        <Icon color="statusWarning" name="Exclamation-circle" />
+      </Tooltip>
+    );
+  }
+
+  return (
+    <EditableDeploymentName
+      name={data}
+      isPropagating={mutation.isLoading}
+      onChange={(value) => {
+        mutation.mutate({ value });
       }}
     />
   );

--- a/shell-ui/src/navbar/index.tsx
+++ b/shell-ui/src/navbar/index.tsx
@@ -6,7 +6,6 @@ import { NavbarConfigProvider } from './NavbarConfigProvider';
 import { NavbarUpdaterComponents } from './NavbarUpdaterComponents';
 import { useFavicon } from './favicon';
 import './library';
-import { InstanceNameProvider } from './InstanceName';
 export type SolutionsNavbarProps = {
   children?: React.ReactNode;
 };
@@ -17,14 +16,12 @@ export const SolutionsNavbar = ({ children }: SolutionsNavbarProps) => {
   useFavicon(config?.favicon || '/brand/favicon-metalk8s.svg');
   return (
     <NavbarConfigProvider>
-      <InstanceNameProvider>
-        <>
-          <Navbar logo={assets.logoPath} canChangeTheme={config.canChangeTheme}>
-            {children}
-          </Navbar>
-          <NavbarUpdaterComponents />
-        </>
-      </InstanceNameProvider>
+      <>
+        <Navbar logo={assets.logoPath} canChangeTheme={config.canChangeTheme}>
+          {children}
+        </Navbar>
+        <NavbarUpdaterComponents />
+      </>
     </NavbarConfigProvider>
   );
 };

--- a/ui/@mf-types/shell/compiled-types/src/navbar/InstanceName.d.ts
+++ b/ui/@mf-types/shell/compiled-types/src/navbar/InstanceName.d.ts
@@ -1,7 +1,6 @@
-import { type PropsWithChildren } from 'react';
 import { type UserData } from '../auth/AuthProvider';
 import { type RuntimeWebFinger } from '../initFederation/ConfigurationProviders';
-export declare const InstanceNameProvider: ({ children }: PropsWithChildren<{}>) => import("react/jsx-runtime").JSX.Element;
+export declare const INSTANCE_NAME_QUERY_KEY = "instanceName";
 export declare const useInstanceName: () => string;
 export declare const useInstanceNameAdapter: () => {
     remoteEntryUrl: string;
@@ -12,7 +11,6 @@ export declare const useInstanceNameConfiguration: () => {
     microAppConfiguration: import("../initFederation/ConfigurationProviders").EnrichedBuildtimeWebFinger;
     runtimeAppConfiguration: RuntimeWebFinger<Record<string, unknown>>;
 };
-export declare const INSTANCE_NAME_QUERY_KEY = "instanceName";
 export type InstanceNameAdapter = {
     getInstanceName: (userData: UserData | undefined, configuration: RuntimeWebFinger<Record<string, unknown>>) => Promise<string>;
     setInstanceName: (userData: UserData | undefined, name: string, configuration: RuntimeWebFinger<Record<string, unknown>>) => Promise<void>;

--- a/ui/@mf-types/shell/compiled-types/src/navbar/InstanceName.d.ts
+++ b/ui/@mf-types/shell/compiled-types/src/navbar/InstanceName.d.ts
@@ -1,5 +1,6 @@
-import { PropsWithChildren } from 'react';
-import { UserData } from '../auth/AuthProvider';
+import { type PropsWithChildren } from 'react';
+import { type UserData } from '../auth/AuthProvider';
+import { type RuntimeWebFinger } from '../initFederation/ConfigurationProviders';
 export declare const InstanceNameProvider: ({ children }: PropsWithChildren<{}>) => import("react/jsx-runtime").JSX.Element;
 export declare const useInstanceName: () => string;
 export declare const useInstanceNameAdapter: () => {
@@ -7,11 +8,26 @@ export declare const useInstanceNameAdapter: () => {
     module: string;
     scope: string;
 };
+export declare const useInstanceNameConfiguration: () => {
+    microAppConfiguration: import("../initFederation/ConfigurationProviders").EnrichedBuildtimeWebFinger;
+    runtimeAppConfiguration: RuntimeWebFinger<Record<string, unknown>>;
+};
+export type InstanceNameAdapter = {
+    getInstanceName: (userData: UserData | undefined, configuration: RuntimeWebFinger<Record<string, unknown>>) => Promise<string>;
+    setInstanceName: (userData: UserData | undefined, name: string, configuration: RuntimeWebFinger<Record<string, unknown>>) => Promise<void>;
+    checkInstanceName: (name: string) => {
+        hasError: true;
+        message: string;
+    } | {
+        hasError: false;
+    };
+};
 export declare const _InternalInstanceName: ({ moduleExports, }: {
     moduleExports: {
         [moduleName: string]: {
-            getInstanceName: (userData: UserData | undefined) => Promise<string>;
-            setInstanceName: (userData: UserData | undefined, name: string) => Promise<void>;
+            getInstanceName: InstanceNameAdapter["getInstanceName"];
+            setInstanceName: InstanceNameAdapter["setInstanceName"];
+            checkInstanceName: InstanceNameAdapter["checkInstanceName"];
         };
     };
 }) => import("react/jsx-runtime").JSX.Element;

--- a/ui/@mf-types/shell/compiled-types/src/navbar/InstanceName.d.ts
+++ b/ui/@mf-types/shell/compiled-types/src/navbar/InstanceName.d.ts
@@ -12,6 +12,7 @@ export declare const useInstanceNameConfiguration: () => {
     microAppConfiguration: import("../initFederation/ConfigurationProviders").EnrichedBuildtimeWebFinger;
     runtimeAppConfiguration: RuntimeWebFinger<Record<string, unknown>>;
 };
+export declare const INSTANCE_NAME_QUERY_KEY = "instanceName";
 export type InstanceNameAdapter = {
     getInstanceName: (userData: UserData | undefined, configuration: RuntimeWebFinger<Record<string, unknown>>) => Promise<string>;
     setInstanceName: (userData: UserData | undefined, name: string, configuration: RuntimeWebFinger<Record<string, unknown>>) => Promise<void>;
@@ -27,7 +28,7 @@ export declare const _InternalInstanceName: ({ moduleExports, }: {
         [moduleName: string]: {
             getInstanceName: InstanceNameAdapter["getInstanceName"];
             setInstanceName: InstanceNameAdapter["setInstanceName"];
-            checkInstanceName: InstanceNameAdapter["checkInstanceName"];
+            checkInstanceName?: InstanceNameAdapter["checkInstanceName"];
         };
     };
 }) => import("react/jsx-runtime").JSX.Element;


### PR DESCRIPTION
## Context / Intent
Follow-up of this PR : https://github.com/scality/artesca/pull/4945

This PR is about the integration of the instance name edit in the UI.
The user should be able to : 
- see the instance name's name.
- edit the instance name.

This first iteration consider that everything is synchronous, we will manage the async part in a futur PR  

## Change since last review 

- ux: change the input error behavior (remove toast, inline error and banner for api error)
- refactor: move the mutation directly in `EditableDeploymentName`
- pr: link to this PR https://github.com/scality/artesca/pull/4953

Happy Path : 

https://github.com/user-attachments/assets/6b6e3eb0-3edb-42ff-8c8d-387bc04b42d3

`main` instancename CR is not availaible : 
<img width="382" height="111" alt="not main available" src="https://github.com/user-attachments/assets/0a283ace-674a-4f95-bc8c-0568b4878794" />

Error input management : 

https://github.com/user-attachments/assets/f330d7e7-b981-4270-94dd-15efa834a88d

API error management : 

https://github.com/user-attachments/assets/9726d1ff-4e60-4093-92fd-7b4a7fd46a43


## How to test ?

The easiest way to to test it will the latest version of artesca (dev/4)
And use the launcher with the command : 
```
npm run v2 -- artesca metalk8s
```

## Next ?
artesca: activate `canChangeInstanceName` to true in artesca (when this is ready)

ref: https://docs.google.com/document/d/1tuDBOIulVYzQQqElrqouh9s-BDS7_6eSSCjfFGVo_mg/edit?tab=t.clq3575svngm#heading=h.g1vuioutall
core-ui spec: https://github.com/scality/core-ui/pull/1052