### PR TITLE
buildchain,changelog: bump Alpine base image from 3.21.3 to 3.23.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,9 @@
   `rockylinux:9.7-minimal`
   (PR[#4851](https://github.com/scality/metalk8s/pull/4851))
 
+- Bump Alpine base image version to [3.23.3](https://github.com/alpinelinux/aports/releases/tag/v3.23.3)
+  (PR[#4858](https://github.com/scality/metalk8s/pull/4858))
+
 ### Bug Fixes
 
 - Fix a bug where part of the upgrade process would silently be skipped

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -105,8 +105,8 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     # Remote images
     Image(
         name="alpine",
-        version="3.21.3",
-        digest="sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c",
+        version="3.23.3",
+        digest="sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659",
     ),
     Image(
         name="alertmanager",


### PR DESCRIPTION
Closes: MK8S-108
