### PR TITLE
MK8S-140 - Bug fix when deploy oidc proxy

### DIFF
--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-alertmanager.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-alertmanager.sls
@@ -16,8 +16,8 @@
 {%- set alertmanager_oidc = alertmanager.spec.get('config', {}).get('oidc', {}) %}
 
 {%- set alertmanager_oidc_ca = alertmanager_oidc.get('caSecret', {}) %}
-{%- set ca_namespace = alertmanager_oidc_ca.get('namespace') or 'metalk8s-ingress' %}
-{%- set ca_name = alertmanager_oidc_ca.get('name') or 'ingress-control-plane-default-certificate' %}
+{%- set ca_namespace = alertmanager_oidc_ca.get('namespace', '') or 'metalk8s-ingress' %}
+{%- set ca_name = alertmanager_oidc_ca.get('name', '') or 'ingress-control-plane-default-certificate' %}
 
 {%- set ca_file = 'namespace_' ~ ca_namespace ~ '.secret_' ~ ca_name ~ '.tls.crt' %}
 

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-alertmanager.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-alertmanager.sls
@@ -16,8 +16,8 @@
 {%- set alertmanager_oidc = alertmanager.spec.get('config', {}).get('oidc', {}) %}
 
 {%- set alertmanager_oidc_ca = alertmanager_oidc.get('caSecret', {}) %}
-{%- set ca_namespace = alertmanager_oidc_ca.get('namespace', 'metalk8s-ingress') %}
-{%- set ca_name = alertmanager_oidc_ca.get('name', 'ingress-control-plane-default-certificate') %}
+{%- set ca_namespace = alertmanager_oidc_ca.get('namespace') or 'metalk8s-ingress' %}
+{%- set ca_name = alertmanager_oidc_ca.get('name') or 'ingress-control-plane-default-certificate' %}
 
 {%- set ca_file = 'namespace_' ~ ca_namespace ~ '.secret_' ~ ca_name ~ '.tls.crt' %}
 
@@ -109,7 +109,7 @@ Create oauth2-proxy-alertmanager Deployment:
               - name: restart-script
                 configMap:
                   name: oidc-proxy-restart-script
-                  defaultMode: "0555"
+                  defaultMode: 365
 
 Create oauth2-proxy-alertmanager Service:
   metalk8s_kubernetes.object_present:

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-prometheus.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-prometheus.sls
@@ -16,8 +16,8 @@
 {%- set prometheus_oidc = prometheus.spec.get('config', {}).get('oidc', {}) %}
 
 {%- set prometheus_oidc_ca = prometheus_oidc.get('caSecret', {}) %}
-{%- set ca_namespace = prometheus_oidc_ca.get('namespace') or 'metalk8s-ingress' %}
-{%- set ca_name = prometheus_oidc_ca.get('name') or 'ingress-control-plane-default-certificate' %}
+{%- set ca_namespace = prometheus_oidc_ca.get('namespace', '') or 'metalk8s-ingress' %}
+{%- set ca_name = prometheus_oidc_ca.get('name', '') or 'ingress-control-plane-default-certificate' %}
 {%- set ca_file = 'namespace_' ~ ca_namespace ~ '.secret_' ~ ca_name ~ '.tls.crt' %}
 
 {%- if prometheus_oidc_enabled %}

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-prometheus.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-prometheus.sls
@@ -16,8 +16,8 @@
 {%- set prometheus_oidc = prometheus.spec.get('config', {}).get('oidc', {}) %}
 
 {%- set prometheus_oidc_ca = prometheus_oidc.get('caSecret', {}) %}
-{%- set ca_namespace = prometheus_oidc_ca.get('namespace', 'metalk8s-ingress') %}
-{%- set ca_name = prometheus_oidc_ca.get('name', 'ingress-control-plane-default-certificate') %}
+{%- set ca_namespace = prometheus_oidc_ca.get('namespace') or 'metalk8s-ingress' %}
+{%- set ca_name = prometheus_oidc_ca.get('name') or 'ingress-control-plane-default-certificate' %}
 {%- set ca_file = 'namespace_' ~ ca_namespace ~ '.secret_' ~ ca_name ~ '.tls.crt' %}
 
 {%- if prometheus_oidc_enabled %}
@@ -108,7 +108,7 @@ Create oauth2-proxy-prometheus Deployment:
               - name: restart-script
                 configMap:
                   name: oidc-proxy-restart-script
-                  defaultMode: "0555"
+                  defaultMode: 365
 
 Create oauth2-proxy-prometheus Service:
   metalk8s_kubernetes.object_present:

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-rbac.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-rbac.sls
@@ -23,8 +23,8 @@
 {%- set prometheus_oidc_enabled = prometheus.spec.get('config', {}).get('enable_oidc_authentication', False) %}
 {%- set alertmanager_oidc_enabled = alertmanager.spec.get('config', {}).get('enable_oidc_authentication', False) %}
 
-{%- set prometheus_ca_namespace = prometheus.spec.get('config', {}).get('oidc', {}).get('caSecret', {}).get('namespace', 'metalk8s-ingress') %}
-{%- set alertmanager_ca_namespace = alertmanager.spec.get('config', {}).get('oidc', {}).get('caSecret', {}).get('namespace', 'metalk8s-ingress') %}
+{%- set prometheus_ca_namespace = prometheus.spec.get('config', {}).get('oidc', {}).get('caSecret', {}).get('namespace') or 'metalk8s-ingress' %}
+{%- set alertmanager_ca_namespace = alertmanager.spec.get('config', {}).get('oidc', {}).get('caSecret', {}).get('namespace') or 'metalk8s-ingress' %}
 
 {%- if prometheus_oidc_enabled %}
 

--- a/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-rbac.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/oidc-proxy-rbac.sls
@@ -23,8 +23,8 @@
 {%- set prometheus_oidc_enabled = prometheus.spec.get('config', {}).get('enable_oidc_authentication', False) %}
 {%- set alertmanager_oidc_enabled = alertmanager.spec.get('config', {}).get('enable_oidc_authentication', False) %}
 
-{%- set prometheus_ca_namespace = prometheus.spec.get('config', {}).get('oidc', {}).get('caSecret', {}).get('namespace') or 'metalk8s-ingress' %}
-{%- set alertmanager_ca_namespace = alertmanager.spec.get('config', {}).get('oidc', {}).get('caSecret', {}).get('namespace') or 'metalk8s-ingress' %}
+{%- set prometheus_ca_namespace = prometheus.spec.get('config', {}).get('oidc', {}).get('caSecret', {}).get('namespace', '') or 'metalk8s-ingress' %}
+{%- set alertmanager_ca_namespace = alertmanager.spec.get('config', {}).get('oidc', {}).get('caSecret', {}).get('namespace', '') or 'metalk8s-ingress' %}
 
 {%- if prometheus_oidc_enabled %}
 


### PR DESCRIPTION
**Component**: Salt

**Context**: 
In Artesca-installer, we patch the config metalk8s-prometheus-config, but we dont' want to provide the caSecret. 
```
Patch Prometheus OIDC proxy configuration:
  metalk8s.service_config_updated:
    - name: metalk8s-prometheus-config
    - namespace: metalk8s-monitoring
    - patch:
        spec:
          config:
            enable_oidc_authentication: true
            oidc:
              issuer: {{ oidc_proxy_issuer }}
              audience: {{ k8s_oidc_client_id }}
              groupsClaim: roles
              authorizedGroups: {{ oidc_authorized_groups }}
    - onchanges_in:
      - module: Apply monitoring services configuration changes
    - require:
      - module: Apply Artesca Monitoring manifest
 ```

**Summary**:
 **Bug 1: caSecret.namespace empty string fallback**

  The MetalK8s default config defines caSecret.namespace: "". When Artesca patches the service config without providing caSecret, the empty string is preserved after merge. The Jinja .get('namespace', 'metalk8s-ingress') fallback doesn't trigger because the key exists — it's just empty. This results in:
  - Role/RoleBinding created with no namespace → ValueError: Namespace is required
  - CA file path resolves to namespace_.secret_.tls.crt → file not found

  Fix: Changed .get('namespace', 'metalk8s-ingress') to .get('namespace') or 'metalk8s-ingress' (same for name) in all 3 files.

  **Bug 2: defaultMode sent as string instead of int32**

  defaultMode: "0555" in YAML is a string due to the quotes. The Kubernetes API requires defaultMode to be an int32 and rejects the request with 400 Bad Request.

  Fix: Changed "0555" to 365 (the decimal equivalent of octal 0555) in both deployment files.

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
