### PR TITLE
Add CI check for operator-sdk upgrade tooling

### DIFF
--- a/.github/changed-files.yaml
+++ b/.github/changed-files.yaml
@@ -25,11 +25,11 @@ unit-tests-shell-ui: &shell-ui
 unit-tests-crd-client-generator:
   - tools/crd-client-generator-js/**
 
-unit-tests-metalk8s-operator:
+unit-tests-metalk8s-operator: &metalk8s-operator
   - operator/**
   - .devcontainer/**
 
-unit-tests-storage-operator:
+unit-tests-storage-operator: &storage-operator
   - storage-operator/**
   - .devcontainer/**
 
@@ -41,6 +41,18 @@ unit-tests-salt:
 unit-tests-lib-alert-tree:
   - tools/lib-alert-tree/**
   - .devcontainer/**
+
+upgrade-operator-sdk-operator:
+  - *metalk8s-operator
+  - tools/upgrade-operator-sdk/*
+  - tools/upgrade-operator-sdk/operator/**
+  - .github/workflows/check-upgrade-operator-sdk.yaml
+
+upgrade-operator-sdk-storage-operator:
+  - *storage-operator
+  - tools/upgrade-operator-sdk/*
+  - tools/upgrade-operator-sdk/storage-operator/**
+  - .github/workflows/check-upgrade-operator-sdk.yaml
 
 integration-tests-ui:
   - *ui

--- a/.github/workflows/check-upgrade-operator-sdk.yaml
+++ b/.github/workflows/check-upgrade-operator-sdk.yaml
@@ -38,8 +38,8 @@ jobs:
         run: |
           python3 tools/upgrade-operator-sdk/upgrade.py \
             --operator-dir ${{ inputs.operator-dir }} \
-            --yes \
-            ${{ inputs.config-dir }}
+            --config-dir ${{ inputs.config-dir }} \
+            --yes
       - name: Verify no drift from upgrade tooling
         run: |
           if git diff --quiet ${{ inputs.operator-dir }}/; then

--- a/.github/workflows/check-upgrade-operator-sdk.yaml
+++ b/.github/workflows/check-upgrade-operator-sdk.yaml
@@ -37,20 +37,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python3 tools/upgrade-operator-sdk/upgrade.py \
-            --operator-dir ${{ inputs.operator-dir }} \
-            --config-dir ${{ inputs.config-dir }} \
+            --operator-dir "${{ inputs.operator-dir }}" \
+            --config-dir "${{ inputs.config-dir }}" \
             --yes
       - name: Verify no drift from upgrade tooling
         run: |
-          if git diff --quiet ${{ inputs.operator-dir }}/; then
-            echo "No drift detected in ${{ inputs.operator-dir }}/"
+          if git diff --quiet "${{ inputs.operator-dir }}"; then
+            echo "No drift detected in ${{ inputs.operator-dir }}"
           else
             echo "::error::${{ inputs.operator-dir }}/ differs from what the upgrade tool produces. Run the upgrade tool locally and commit the result, or update the upgrade config/patches."
             echo ""
             echo "=== Changed files ==="
-            git diff --stat ${{ inputs.operator-dir }}/
+            git diff --stat "${{ inputs.operator-dir }}"
             echo ""
             echo "=== Full diff ==="
-            git diff ${{ inputs.operator-dir }}/
+            git diff "${{ inputs.operator-dir }}"
             exit 1
           fi

--- a/.github/workflows/check-upgrade-operator-sdk.yaml
+++ b/.github/workflows/check-upgrade-operator-sdk.yaml
@@ -1,0 +1,56 @@
+name: Check upgrade operator-sdk
+
+on:
+  workflow_call:
+    inputs:
+      operator-dir:
+        type: string
+        required: true
+        description: "Path to the operator project directory (e.g. operator, storage-operator)"
+      config-dir:
+        type: string
+        required: true
+        description: "Path to the upgrade config directory (e.g. tools/upgrade-operator-sdk/operator)"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository }}/devcontainer:${{ github.sha }}
+      # We have to use `root` for the moment
+      # Sees: https://github.com/actions/checkout/issues/1575
+      # Could work with a user with 1001 id but not for docker
+      options: --user root
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Set safe directory (since container is root and not user 1001)
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+      - name: Run operator-sdk upgrade tooling
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 tools/upgrade-operator-sdk/upgrade.py \
+            --operator-dir ${{ inputs.operator-dir }} \
+            --yes \
+            ${{ inputs.config-dir }}
+      - name: Verify no drift from upgrade tooling
+        run: |
+          if git diff --quiet ${{ inputs.operator-dir }}/; then
+            echo "No drift detected in ${{ inputs.operator-dir }}/"
+          else
+            echo "::error::${{ inputs.operator-dir }}/ differs from what the upgrade tool produces. Run the upgrade tool locally and commit the result, or update the upgrade config/patches."
+            echo ""
+            echo "=== Changed files ==="
+            git diff --stat ${{ inputs.operator-dir }}/
+            echo ""
+            echo "=== Full diff ==="
+            git diff ${{ inputs.operator-dir }}/
+            exit 1
+          fi

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -38,6 +38,8 @@ jobs:
       unit-tests-salt: ${{ steps.diff.outputs.unit-tests-salt_any_modified == 'true' }}
       unit-tests-lib-alert-tree: ${{ steps.diff.outputs.unit-tests-lib-alert-tree_any_modified == 'true' }}
       integration-tests-ui: ${{ steps.diff.outputs.integration-tests-ui_any_modified == 'true' }}
+      upgrade-operator-sdk-operator: ${{ steps.diff.outputs.upgrade-operator-sdk-operator_any_modified == 'true' }}
+      upgrade-operator-sdk-storage-operator: ${{ steps.diff.outputs.upgrade-operator-sdk-storage-operator_any_modified == 'true' }}
       # If the workflow is triggered on a development branch let's always build
       build: ${{ startsWith(github.ref_name, 'development/') || steps.diff.outputs.build_any_modified == 'true' }}
     steps:
@@ -71,9 +73,11 @@ jobs:
           ALL_UNIT_TESTS_SALT_CHANGED_FILES: ${{ steps.diff.outputs.unit-tests-salt_all_changed_files }}
           ALL_UNIT_TESTS_LIB_ALERT_TREE_CHANGED_FILES: ${{ steps.diff.outputs.unit-tests-lib-alert-tree_all_changed_files }}
           ALL_INTEGRATION_TESTS_UI_CHANGED_FILES: ${{ steps.diff.outputs.integration-tests-ui_all_changed_files }}
+          ALL_UPGRADE_OPERATOR_SDK_OPERATOR_CHANGED_FILES: ${{ steps.diff.outputs.upgrade-operator-sdk-operator_all_changed_files }}
+          ALL_UPGRADE_OPERATOR_SDK_STORAGE_OPERATOR_CHANGED_FILES: ${{ steps.diff.outputs.upgrade-operator-sdk-storage-operator_all_changed_files }}
           ALL_BUILD_CHANGED_FILES: ${{ steps.diff.outputs.build_all_changed_files }}
         run: |
-          for type in docs shell-ui unit-tests-ui unit-tests-shell-ui unit-tests-crd-client-generator unit-tests-metalk8s-operator unit-tests-storage-operator unit-tests-salt unit-tests-lib-alert-tree integration-tests-ui build; do
+          for type in docs shell-ui unit-tests-ui unit-tests-shell-ui unit-tests-crd-client-generator unit-tests-metalk8s-operator unit-tests-storage-operator unit-tests-salt unit-tests-lib-alert-tree integration-tests-ui upgrade-operator-sdk-operator upgrade-operator-sdk-storage-operator build; do
             echo "All $type changed files:"
             changed_files_var=$(echo "ALL_${type^^}_CHANGED_FILES" | tr '-' '_')
             echo "${!changed_files_var}"
@@ -306,6 +310,28 @@ jobs:
       - name: Run all storage-operator unit and integration tests
         run: make test
 
+  check_upgrade_metalk8s_operator:
+    needs:
+      - build-devcontainer
+      - changed-files
+    if: needs.changed-files.outputs.upgrade-operator-sdk-operator == 'true'
+    uses: ./.github/workflows/check-upgrade-operator-sdk.yaml
+    with:
+      operator-dir: operator
+      config-dir: tools/upgrade-operator-sdk/operator
+    secrets: inherit
+
+  check_upgrade_storage_operator:
+    needs:
+      - build-devcontainer
+      - changed-files
+    if: needs.changed-files.outputs.upgrade-operator-sdk-storage-operator == 'true'
+    uses: ./.github/workflows/check-upgrade-operator-sdk.yaml
+    with:
+      operator-dir: storage-operator
+      config-dir: tools/upgrade-operator-sdk/storage-operator
+    secrets: inherit
+
   unit_tests_salt:
     runs-on: ubuntu-latest
     needs:
@@ -526,6 +552,8 @@ jobs:
       - unit_tests_crd_client_generator
       - unit_tests_metalk8s_operator
       - unit_tests_storage_operator
+      - check_upgrade_metalk8s_operator
+      - check_upgrade_storage_operator
       - unit_tests_salt
       - unit_tests_lib_alert_tree
       - integration_tests_ui

--- a/BUMPING.md
+++ b/BUMPING.md
@@ -137,7 +137,7 @@ This guide is applied for both `metalk8s-operator` and `storage-operator`.
 
 ### Updating the versions
 
-Target versions are pinned in `scripts/upgrade-operator-sdk/<name>/config.yaml`:
+Target versions are pinned in `tools/upgrade-operator-sdk/<name>/config.yaml`:
 
 ```yaml
 operator_sdk_version: v1.42.1    # target operator-sdk release
@@ -162,13 +162,13 @@ This is CI-friendly: zero interactive input during reconciliation.
 The script processes one operator at a time:
 
 ```bash
-python3 scripts/upgrade-operator-sdk/upgrade.py \
+python3 tools/upgrade-operator-sdk/upgrade.py \
     --operator-dir operator \
-    --config-dir scripts/upgrade-operator-sdk/operator
+    --config-dir tools/upgrade-operator-sdk/operator
 
-python3 scripts/upgrade-operator-sdk/upgrade.py \
+python3 tools/upgrade-operator-sdk/upgrade.py \
     --operator-dir storage-operator \
-    --config-dir scripts/upgrade-operator-sdk/storage-operator
+    --config-dir tools/upgrade-operator-sdk/storage-operator
 ```
 
 Options:
@@ -183,7 +183,7 @@ Options:
 
 ### YAML config files
 
-Each operator has a config directory at `scripts/upgrade-operator-sdk/<name>/` containing
+Each operator has a config directory at `tools/upgrade-operator-sdk/<name>/` containing
 `config.yaml` and a `patches/` subdirectory. The config fields are:
 
 - **Versions**: `operator_sdk_version`, `go_toolchain` (optional pin), `k8s_libs` (optional pin)

--- a/BUMPING.md
+++ b/BUMPING.md
@@ -164,17 +164,18 @@ The script processes one operator at a time:
 ```bash
 python3 scripts/upgrade-operator-sdk/upgrade.py \
     --operator-dir operator \
-    scripts/upgrade-operator-sdk/operator
+    --config-dir scripts/upgrade-operator-sdk/operator
 
 python3 scripts/upgrade-operator-sdk/upgrade.py \
     --operator-dir storage-operator \
-    scripts/upgrade-operator-sdk/storage-operator
+    --config-dir scripts/upgrade-operator-sdk/storage-operator
 ```
 
 Options:
 
 ```
 --operator-dir    Path to the operator project directory (required)
+--config-dir      Path to the upgrade config directory (required)
 --skip-backup     Reuse an existing .bak directory (no new backup)
 --clean-tools     Remove tool cache after upgrade
 --yes, -y         Skip the confirmation prompt

--- a/tools/upgrade-operator-sdk/upgrade.py
+++ b/tools/upgrade-operator-sdk/upgrade.py
@@ -6,13 +6,13 @@ versions, restores custom code from a backup, applies GNU patch files,
 and runs the build pipeline.
 
 Usage:
-    python3 scripts/upgrade-operator-sdk/upgrade.py \\
+    python3 tools/upgrade-operator-sdk/upgrade.py \\
         --operator-dir <path> --config-dir <path> [OPTIONS]
 
 Examples:
-    python3 scripts/upgrade-operator-sdk/upgrade.py \\
+    python3 tools/upgrade-operator-sdk/upgrade.py \\
         --operator-dir operator \\
-        --config-dir scripts/upgrade-operator-sdk/operator
+        --config-dir tools/upgrade-operator-sdk/operator
 
 Options:
     --operator-dir     Path to the operator project directory (required)

--- a/tools/upgrade-operator-sdk/upgrade.py
+++ b/tools/upgrade-operator-sdk/upgrade.py
@@ -7,15 +7,16 @@ and runs the build pipeline.
 
 Usage:
     python3 scripts/upgrade-operator-sdk/upgrade.py \\
-        --operator-dir <path> <config-dir> [OPTIONS]
+        --operator-dir <path> --config-dir <path> [OPTIONS]
 
 Examples:
     python3 scripts/upgrade-operator-sdk/upgrade.py \\
         --operator-dir operator \\
-        scripts/upgrade-operator-sdk/operator
+        --config-dir scripts/upgrade-operator-sdk/operator
 
 Options:
     --operator-dir     Path to the operator project directory (required)
+    --config-dir       Path to the config directory (required)
     --skip-backup      Skip the backup step (assumes .bak already exists)
     --clean-tools      Remove tool cache after the upgrade (forces re-download)
     --yes, -y          Skip the confirmation prompt
@@ -714,8 +715,9 @@ def main() -> None:
         "fresh and applying patches from a config directory.",
     )
     parser.add_argument(
-        "config_dir",
-        help="Path to config directory containing config.yaml " "and patches/",
+        "--config-dir",
+        required=True,
+        help="Path to config directory containing config.yaml and patches/",
     )
     parser.add_argument(
         "--operator-dir",


### PR DESCRIPTION
### Context

`tools/upgrade-operator-sdk/upgrade.py` automates the process of upgrading the `operator` and `storage-operator` projects to a new version of operator-sdk: it scaffolds a fresh project, restores custom code, applies patches, and runs the full build pipeline.

Without a CI gate, the config files and patches in `tools/upgrade-operator-sdk/` can silently drift from the committed operator code over time, making future upgrades fail unexpectedly.

### What this PR does

Adds a `check_upgrade_operator_sdk` job to the pre-merge workflow that:

1. Runs `upgrade.py --yes` for both `operator` and `storage-operator` in parallel (matrix strategy)
2. Asserts `git diff --exit-code <operator-dir>/` — if the regenerated tree differs from what is committed, the job fails with an actionable error message

This guarantees that the upgrade tooling (configs, patches, `raw_copy` entries) stays in sync with the committed operator code on every merge.

### Changes

- **`.github/changed-files.yaml`**: new `upgrade-operator-sdk` filter — triggers on `operator/**`, `storage-operator/**`, `tools/upgrade-operator-sdk/**`, `.devcontainer/**`, and the workflow/filter files themselves
- **`.github/workflows/pre-merge.yaml`**: new `check_upgrade_operator_sdk` job + wired into `changed-files` outputs and `write-final-status`

### Notes

- A newer operator-sdk version (`v1.42.2`) was detected during testing — the job will warn but continue using the pinned version in `config.yaml`. That bump can be handled in a separate PR using the upgrade tool.

### Test plan

- [x] CI passed with no drift (`operator` and `storage-operator` both green)
- [x] CI failed as expected when a spurious line was added to `operator/Makefile` (drift detection works)
- [ ] Remove `[TEMPORARY]` commits before merging

Closes: MK8S-216

--- 

Builds triggered:
- Passed: https://github.com/scality/metalk8s/actions/runs/24135099241/job/70433117963
- Failed: https://github.com/scality/metalk8s/actions/runs/24178886215/job/70566689548