### PR TITLE
Share GlobalHealthBar via Module Federation

### DIFF
--- a/ui/rspack.config.ts
+++ b/ui/rspack.config.ts
@@ -123,6 +123,7 @@ const config: Configuration = {
         './platformLibrary': './src/services/platformlibrary/k8s.ts',
         './AlertsNavbarUpdater': './src/components/AlertNavbarUpdaterComponent.tsx',
         './Metalk8sLocalVolumeProvider': './src/services/k8s/Metalk8sLocalVolumeProvider.ts',
+        './PlatformGlobalHealthBarFederated': './src/components/PlatformGlobalHealthBarFederated.tsx',
       },
       remotes: !isProduction
         ? {

--- a/ui/src/components/DashboardGlobalHealth.tsx
+++ b/ui/src/components/DashboardGlobalHealth.tsx
@@ -1,59 +1,32 @@
 import styled from 'styled-components';
-import DashboardAlerts from './DashboardAlerts';
-import { Box, useMetricsTimeSpan } from '@scality/core-ui/dist/next';
-import {
-  EmphaseText,
-  LargerText,
-  SmallerText,
-  StatusWrapper,
-  Loader,
-  AppContainer,
-  spacing,
-  Stack,
-  IconHelp,
-} from '@scality/core-ui';
-import { Alert, GlobalHealthBar as GlobalHealthBarRecharts } from '@scality/core-ui/dist/next';
+import { AppContainer, LargerText, Stack, StatusWrapper } from '@scality/core-ui';
+import { Box } from '@scality/core-ui/dist/next';
 import { highestAlertToStatus, useAlertLibrary, useHighestSeverityAlerts } from '../containers/AlertProvider';
 import { useIntl } from 'react-intl';
-import { useStartingTimeStamp } from '../containers/StartTimeProvider';
-import CircleStatus from './CircleStatus';
+import DashboardAlerts from './DashboardAlerts';
+import PlatformGlobalHealthBar from './PlatformGlobalHealthBar';
 import StatusIcon from './StatusIcon';
-import { getClusterAlertSegmentQuery } from '../services/platformlibrary/metrics';
 
-import { useQuery } from 'react-query';
-
-const HealthBarContainer = styled.div`
-  flex-direction: column;
-  width: 90%;
-  margin: 0 auto;
-`;
 const PlatformStatusIcon = styled.div`
   margin: 0 1rem;
   font-size: 2rem;
 `;
 
-const StyledEmphaseText = styled(EmphaseText)`
-  letter-spacing: ${spacing.r2};
-`;
-
 const DashboardGlobalHealth = () => {
   const intl = useIntl();
-  const { startingTimeISO, currentTimeISO } = useStartingTimeStamp();
   const alertsLibrary = useAlertLibrary();
-  const { duration } = useMetricsTimeSpan();
-  const { data: alerts, status: historyAlertStatus } = useQuery(getClusterAlertSegmentQuery(duration));
   const platformHighestSeverityAlert = useHighestSeverityAlerts(alertsLibrary.getPlatformAlertSelectors());
   const platformStatus = highestAlertToStatus(platformHighestSeverityAlert);
+
   return (
     <AppContainer.OverallSummary>
       <Stack style={{ alignItems: 'center' }}>
         <Box flex="1" display="flex">
           <PlatformStatusIcon>
             <StatusWrapper status={platformStatus}>
-              <StatusIcon status={platformStatus} name="Datacenter" entity='Platform' />
+              <StatusIcon status={platformStatus} name="Datacenter" entity="Platform" />
             </StatusWrapper>
           </PlatformStatusIcon>
-
           <LargerText>
             {intl.formatMessage({
               id: 'platform',
@@ -61,58 +34,7 @@ const DashboardGlobalHealth = () => {
           </LargerText>
         </Box>
         <Box flex="2">
-          <HealthBarContainer>
-            <Stack
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-              }}
-              gap="r20"
-            >
-              <StyledEmphaseText>Global Health</StyledEmphaseText>
-
-              <IconHelp
-                placement="bottom"
-                tooltipMessage={
-                  <Stack direction="vertical" gap="r4">
-                    {intl
-                      .formatMessage({
-                        id: 'global_health_explanation',
-                      })
-                      .split('\n')
-                      .map((line, key) => (
-                        <SmallerText key={`globalheathexplanation-${key}`}>{line}</SmallerText>
-                      ))}
-                  </Stack>
-                }
-              />
-              <CircleStatus status={platformStatus} />
-            </Stack>
-
-            {historyAlertStatus === 'loading' ? (
-              <Box ml={8} height={50}>
-                <Loader size={'larger'} />
-              </Box>
-            ) : (
-              <GlobalHealthBarRecharts
-                id={'platform_globalhealth'}
-                alerts={
-                  historyAlertStatus === 'error'
-                    ? ([
-                        {
-                          startsAt: startingTimeISO,
-                          endsAt: currentTimeISO,
-                          severity: 'unavailable',
-                          description: 'Failed to load alert history for the selected period',
-                        },
-                      ] as Alert[])
-                    : alerts || []
-                }
-                start={new Date(startingTimeISO)}
-                end={new Date(currentTimeISO)}
-              />
-            )}
-          </HealthBarContainer>
+          <PlatformGlobalHealthBar />
         </Box>
         <Box flex="2" ml={24}>
           <DashboardAlerts />

--- a/ui/src/components/PlatformGlobalHealthBar.tsx
+++ b/ui/src/components/PlatformGlobalHealthBar.tsx
@@ -9,8 +9,8 @@ import { getClusterAlertSegmentQuery } from '../services/platformlibrary/metrics
 import CircleStatus from './CircleStatus';
 
 const HealthBarContainer = styled.div`
+  display: flex;
   flex-direction: column;
-  margin: 0 auto;
 `;
 
 const PlatformGlobalHealthBar = ({ title = 'Global Health' }: { title?: string }) => {

--- a/ui/src/components/PlatformGlobalHealthBar.tsx
+++ b/ui/src/components/PlatformGlobalHealthBar.tsx
@@ -1,0 +1,85 @@
+import { IconHelp, Loader, SmallerText, Stack, Text } from '@scality/core-ui';
+import { Alert, Box, GlobalHealthBar as GlobalHealthBarRecharts, useMetricsTimeSpan } from '@scality/core-ui/dist/next';
+import { useIntl } from 'react-intl';
+import { useQuery } from 'react-query';
+import styled from 'styled-components';
+import { highestAlertToStatus, useAlertLibrary, useHighestSeverityAlerts } from '../containers/AlertProvider';
+import { useStartingTimeStamp } from '../containers/StartTimeProvider';
+import { getClusterAlertSegmentQuery } from '../services/platformlibrary/metrics';
+import CircleStatus from './CircleStatus';
+
+const HealthBarContainer = styled.div`
+  flex-direction: column;
+  margin: 0 auto;
+`;
+
+const PlatformGlobalHealthBar = ({ title = 'Global Health' }: { title?: string }) => {
+  const intl = useIntl();
+  const { startingTimeISO, currentTimeISO } = useStartingTimeStamp();
+  const alertsLibrary = useAlertLibrary();
+  const { duration } = useMetricsTimeSpan();
+  const { data: alerts, status: historyAlertStatus } = useQuery({
+    ...getClusterAlertSegmentQuery(duration),
+    keepPreviousData: true,
+  });
+  const platformHighestSeverityAlert = useHighestSeverityAlerts(alertsLibrary.getPlatformAlertSelectors());
+  const platformStatus = highestAlertToStatus(platformHighestSeverityAlert);
+
+  return (
+    <HealthBarContainer>
+      <Stack
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+        }}
+        gap="r8"
+      >
+        <CircleStatus status={platformStatus} />
+        <Text variant="Large" isEmphazed>
+          {title}
+        </Text>
+        <IconHelp
+          placement="bottom"
+          tooltipMessage={
+            <Stack direction="vertical" gap="r4">
+              {intl
+                .formatMessage({
+                  id: 'global_health_explanation',
+                })
+                .split('\n')
+                .map((line, key) => (
+                  <SmallerText key={`globalheathexplanation-${key}`}>{line}</SmallerText>
+                ))}
+            </Stack>
+          }
+        />
+      </Stack>
+
+      {historyAlertStatus === 'loading' ? (
+        <Box ml={8} height={50}>
+          <Loader size={'larger'} />
+        </Box>
+      ) : (
+        <GlobalHealthBarRecharts
+          id={'platform_globalhealth'}
+          alerts={
+            historyAlertStatus === 'error'
+              ? ([
+                  {
+                    startsAt: startingTimeISO,
+                    endsAt: currentTimeISO,
+                    severity: 'unavailable',
+                    description: 'Failed to load alert history for the selected period',
+                  },
+                ] as Alert[])
+              : alerts || []
+          }
+          start={new Date(startingTimeISO)}
+          end={new Date(currentTimeISO)}
+        />
+      )}
+    </HealthBarContainer>
+  );
+};
+
+export default PlatformGlobalHealthBar;

--- a/ui/src/components/PlatformGlobalHealthBar.tsx
+++ b/ui/src/components/PlatformGlobalHealthBar.tsx
@@ -35,9 +35,7 @@ const PlatformGlobalHealthBar = ({ title = 'Global Health' }: { title?: string }
         gap="r8"
       >
         <CircleStatus status={platformStatus} />
-        <Text variant="Large" isEmphazed>
-          {title}
-        </Text>
+        <Text isEmphazed>{title}</Text>
         <IconHelp
           placement="bottom"
           tooltipMessage={

--- a/ui/src/components/PlatformGlobalHealthBar.tsx
+++ b/ui/src/components/PlatformGlobalHealthBar.tsx
@@ -63,13 +63,13 @@ const PlatformGlobalHealthBar = ({ title = 'Global Health' }: { title?: string }
           alerts={
             historyAlertStatus === 'error'
               ? ([
-                  {
-                    startsAt: startingTimeISO,
-                    endsAt: currentTimeISO,
-                    severity: 'unavailable',
-                    description: 'Failed to load alert history for the selected period',
-                  },
-                ] as Alert[])
+                {
+                  startsAt: startingTimeISO,
+                  endsAt: currentTimeISO,
+                  severity: 'unavailable',
+                  description: 'Failed to load alert history for the selected period',
+                },
+              ] as Alert[])
               : alerts || []
           }
           start={new Date(startingTimeISO)}

--- a/ui/src/components/PlatformGlobalHealthBarFederated.tsx
+++ b/ui/src/components/PlatformGlobalHealthBarFederated.tsx
@@ -30,7 +30,7 @@ export default function PlatformGlobalHealthBarFederated({
 
   /**
    * Initialize the Prometheus client and set the authorization header if the token is available
-   * The initialization of Prometheus client is neeeded here as it is shared with Module Federation to another ui
+   * The initialization of Prometheus client is needed here as it is shared with Module Federation to another ui
    * The prometheus client could not be initialized in the parent component rendering it.
    */
   useLayoutEffect(() => {

--- a/ui/src/components/PlatformGlobalHealthBarFederated.tsx
+++ b/ui/src/components/PlatformGlobalHealthBarFederated.tsx
@@ -1,6 +1,6 @@
 import { MetricsTimeSpanContext } from '@scality/core-ui/dist/components/charts/MetricsTimeSpanProvider';
 import { useShellHooks } from '@scality/module-federation';
-import { useLayoutEffect, useMemo } from 'react';
+import { useEffect, useLayoutEffect, useMemo } from 'react';
 import FederatedIntlProvider from '../containers/IntlProvider';
 import StartTimeProvider from '../containers/StartTimeProvider';
 import { initialize as initializePrometheus, setHeaders } from '../services/prometheus/api';
@@ -27,7 +27,13 @@ export default function PlatformGlobalHealthBarFederated({
   const { userData } = useAuth();
   const token = userData?.token;
 
-  useLayoutEffect(() => {
+
+  /**
+   * Initialize the Prometheus client and set the authorization header if the token is available
+   * The initialization of Prometheus client is neeeded here as it is shared with Module Federation to another ui
+   * The prometheus client could not be initialized in the parent component rendering it.
+   */
+  useEffect(() => {
     if (token) {
       initializePrometheus(prometheusUrl);
       setHeaders({ Authorization: `Bearer ${token}` });

--- a/ui/src/components/PlatformGlobalHealthBarFederated.tsx
+++ b/ui/src/components/PlatformGlobalHealthBarFederated.tsx
@@ -1,0 +1,56 @@
+import { MetricsTimeSpanContext } from '@scality/core-ui/dist/components/charts/MetricsTimeSpanProvider';
+import { useShellHooks } from '@scality/module-federation';
+import { useLayoutEffect } from 'react';
+import FederatedIntlProvider from '../containers/IntlProvider';
+import StartTimeProvider from '../containers/StartTimeProvider';
+import { initialize as initializePrometheus, setHeaders } from '../services/prometheus/api';
+import PlatformGlobalHealthBar from './PlatformGlobalHealthBar';
+
+// 7-day defaults — same constants as core-ui's SAMPLE_DURATION/FREQUENCY_LAST_SEVEN_DAYS
+const DEFAULT_DURATION_SECONDS = 7 * 24 * 60 * 60;
+const DEFAULT_FREQUENCY_SECONDS = 60 * 60;
+
+type Props = {
+  prometheusUrl: string;
+  title?: string;
+  durationSeconds?: number;
+  frequencySeconds?: number;
+};
+
+export default function PlatformGlobalHealthBarFederated({
+  prometheusUrl,
+  title,
+  durationSeconds = DEFAULT_DURATION_SECONDS,
+  frequencySeconds = DEFAULT_FREQUENCY_SECONDS,
+}: Props) {
+  const { useAuth } = useShellHooks();
+  const { userData } = useAuth();
+  const token = userData?.token;
+
+  useLayoutEffect(() => {
+    if (token) {
+      initializePrometheus(prometheusUrl);
+      setHeaders({ Authorization: `Bearer ${token}` });
+    }
+  }, [prometheusUrl, token]);
+
+  if (!token) return null;
+
+  const timeSpan = {
+    query: '',
+    label: '',
+    duration: durationSeconds,
+    interval: frequencySeconds,
+    frequency: frequencySeconds, // StartTimeProvider reads this deprecated field
+  };
+
+  return (
+    <MetricsTimeSpanContext.Provider value={timeSpan}>
+      <StartTimeProvider>
+        <FederatedIntlProvider>
+          <PlatformGlobalHealthBar title={title} />
+        </FederatedIntlProvider>
+      </StartTimeProvider>
+    </MetricsTimeSpanContext.Provider>
+  );
+}

--- a/ui/src/components/PlatformGlobalHealthBarFederated.tsx
+++ b/ui/src/components/PlatformGlobalHealthBarFederated.tsx
@@ -1,6 +1,6 @@
 import { MetricsTimeSpanContext } from '@scality/core-ui/dist/components/charts/MetricsTimeSpanProvider';
 import { useShellHooks } from '@scality/module-federation';
-import { useEffect, useLayoutEffect, useMemo } from 'react';
+import { useLayoutEffect, useMemo } from 'react';
 import FederatedIntlProvider from '../containers/IntlProvider';
 import StartTimeProvider from '../containers/StartTimeProvider';
 import { initialize as initializePrometheus, setHeaders } from '../services/prometheus/api';
@@ -33,7 +33,7 @@ export default function PlatformGlobalHealthBarFederated({
    * The initialization of Prometheus client is neeeded here as it is shared with Module Federation to another ui
    * The prometheus client could not be initialized in the parent component rendering it.
    */
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (token) {
       initializePrometheus(prometheusUrl);
       setHeaders({ Authorization: `Bearer ${token}` });

--- a/ui/src/components/PlatformGlobalHealthBarFederated.tsx
+++ b/ui/src/components/PlatformGlobalHealthBarFederated.tsx
@@ -1,6 +1,6 @@
 import { MetricsTimeSpanContext } from '@scality/core-ui/dist/components/charts/MetricsTimeSpanProvider';
 import { useShellHooks } from '@scality/module-federation';
-import { useLayoutEffect } from 'react';
+import { useLayoutEffect, useMemo } from 'react';
 import FederatedIntlProvider from '../containers/IntlProvider';
 import StartTimeProvider from '../containers/StartTimeProvider';
 import { initialize as initializePrometheus, setHeaders } from '../services/prometheus/api';
@@ -34,15 +34,19 @@ export default function PlatformGlobalHealthBarFederated({
     }
   }, [prometheusUrl, token]);
 
-  if (!token) return null;
+  const timeSpan = useMemo(
+    () => ({
+      query: '',
+      label: '',
+      duration: durationSeconds,
+      interval: frequencySeconds,
+      //TODO: remove this field when QueryTimeSpan type is updated
+      frequency: frequencySeconds, // required by QueryTimeSpan type (deprecated but not optional)
+    }),
+    [durationSeconds, frequencySeconds],
+  );
 
-  const timeSpan = {
-    query: '',
-    label: '',
-    duration: durationSeconds,
-    interval: frequencySeconds,
-    frequency: frequencySeconds, // StartTimeProvider reads this deprecated field
-  };
+  if (!token) return null;
 
   return (
     <MetricsTimeSpanContext.Provider value={timeSpan}>

--- a/ui/src/containers/StartTimeProvider.tsx
+++ b/ui/src/containers/StartTimeProvider.tsx
@@ -1,8 +1,8 @@
-import React, { createContext, useContext, useCallback, useState } from 'react';
 import { useMetricsTimeSpan } from '@scality/core-ui/dist/next';
+import type React from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { REFRESH_METRICS_GRAPH } from '../constants';
-import { useEffect } from 'react';
-import { useMemo } from 'react';
+
 type StartTimeContextType = {
   startingTimeISO: string;
   currentTimeISO: string;
@@ -22,23 +22,23 @@ export const useStartingTimeStamp = (): {
 };
 
 const StartTimeProvider = ({ children }: { children: React.ReactNode }) => {
-  const { duration, frequency } = useMetricsTimeSpan();
+  const { duration, interval } = useMetricsTimeSpan();
   const [currentTime, setCurrentTime] = useState(() => {
-    const newCurrentDate = new Date().getTime();
-    return newCurrentDate - (newCurrentDate % (frequency * 1000));
+    const newCurrentDate = Date.now();
+    return newCurrentDate - (newCurrentDate % (interval * 1000));
   });
   const [startingTimeISO, setStartingTimeISO] = useState(
     new Date((currentTime / 1000 - duration) * 1000).toISOString(),
   );
   const updateCurrentTime = useCallback(() => {
-    const newCurrentDate = new Date().getTime();
+    const newCurrentDate = Date.now();
     //In order to always display the same data on the charts over refresh and new entroes comming
     //we round start and end time to frequency factors. Hence for example for a 30 seconds fequency
     //we will rount current time and start time to the previous 30 seconds factor (00, or 30 seconds for each minute)
-    const newCurrentTime = newCurrentDate - (newCurrentDate % (frequency * 1000));
+    const newCurrentTime = newCurrentDate - (newCurrentDate % (interval * 1000));
     setCurrentTime(newCurrentTime);
     setStartingTimeISO(new Date((newCurrentTime / 1000 - duration) * 1000).toISOString());
-  }, [duration, frequency]);
+  }, [duration, interval]);
   useMemo(() => {
     updateCurrentTime();
   }, [updateCurrentTime]);


### PR DESCRIPTION
## Context
The new overview page in artesca has a Platform status section showing the global health bar

## Summary
Extract the global health bar from the dashboard and move it in its own component
Use the new component in dashboard
Wrap the new component with its providers before sharing it via module federation 