### PR TITLE
Always create fluent-bit-certs secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Release 133.0.1 (in development)
 
+### Enhancements
+
+- Ensure fluent-bit-certs secret is always created regardless of fluent-bit's state
+  (PR[#4876](https://github.com/scality/metalk8s/pull/4876))
+
 ## Release 133.0.0
 
 ### Breaking changes

--- a/salt/metalk8s/addons/logging/fluent-bit/deployed/init.sls
+++ b/salt/metalk8s/addons/logging/fluent-bit/deployed/init.sls
@@ -3,7 +3,6 @@
 include:
   - .configmap
   - .service-configuration
-  - .secret
   - .chart
 
 {%- else %}

--- a/salt/metalk8s/addons/logging/fluent-bit/deployed/service-configuration.sls
+++ b/salt/metalk8s/addons/logging/fluent-bit/deployed/service-configuration.sls
@@ -1,5 +1,6 @@
 include:
   - ...deployed.namespace
+  - .secret
 
 {%- set fluent_bit_config = salt.metalk8s_kubernetes.get_object(
         kind='ConfigMap',


### PR DESCRIPTION
Include fluent-bit-certs secret creation in service-configuration state so it is created regardless of fluent-bit's state

part of ARTESCA-15756 related to ARTESCA-17176


