### PR TITLE
ci: update GitHub Actions to Node 24 runtime (Node 20 deprecation)

### DIFF
--- a/.github/workflows/build-devcontainer.yaml
+++ b/.github/workflows/build-devcontainer.yaml
@@ -19,9 +19,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to the registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -30,7 +30,7 @@ jobs:
         # NOTE: We only skip this and not the full Job
         # otherwise step that "need" it will not be started
         if: ${{ ! inputs.skip }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .devcontainer/
           push: true

--- a/.github/workflows/build-shell-ui.yaml
+++ b/.github/workflows/build-shell-ui.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Compute shell-ui version
         run: |
           source VERSION

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,7 +70,7 @@ jobs:
       artifact-link: ${{ steps.upload.outputs.link }}
     steps:
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_LOGIN }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -396,7 +396,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Install node
         uses: actions/setup-node@v6
         with:
@@ -446,13 +446,13 @@ jobs:
           ADD service /usr/share/nginx/html
           EOF
       - name: Login to Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           push: true
           file: Dockerfile

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,7 +37,7 @@ jobs:
           # See: https://github.com/actions/checkout/issues/882
           ref: ${{ github.ref }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Retrieve Shell UI image from the build, load it and compute version
       - name: Retrieve artifacts url
@@ -125,7 +125,7 @@ jobs:
 
       # Push image to the registry
       - name: Login to the registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY_HOST }}
           username: ${{ github.repository_owner }}
@@ -143,7 +143,7 @@ jobs:
           git tag -l --format='%(contents)' "${{ env.SHELL_UI_VERSION }}" | tail -n +4 | tee -a $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v3
         if: inputs.is_production
         with:
           name: Metalk8s ${{ env.SHELL_UI_VERSION }}


### PR DESCRIPTION
## Summary
Update GitHub Actions workflow files to use action versions running on Node 24.

## Context
GitHub deprecated Node 20 in GitHub Actions runners:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
- June 2, 2026: Runners default to Node 24
- Fall 2026: Node 20 completely removed

## Changes
Updated: actions/checkout@v4→@v6, docker/build-push-action@v5/v6→@v7, docker/metadata-action@v5→@v6, github/codeql-action@v3→@v4, etc.