### PR TITLE
nginx-ingress: strip inbound OpenTelemetry traceparent/tracestate headers

### DIFF
--- a/salt/metalk8s/addons/nginx-ingress-control-plane/config/ingress-controller.yaml.j2
+++ b/salt/metalk8s/addons/nginx-ingress-control-plane/config/ingress-controller.yaml.j2
@@ -10,3 +10,6 @@ spec:
     hide-headers: 'Server,X-Powered-By'
     ssl-ciphers: 'EECDH+AESGCM:EDH+AESGCM'
     ssl-protocols: 'TLSv1.2 TLSv1.3'
+    location-snippet: |
+      proxy_set_header traceparent "";
+      proxy_set_header tracestate "";

--- a/salt/metalk8s/addons/nginx-ingress/config/ingress-controller.yaml.j2
+++ b/salt/metalk8s/addons/nginx-ingress/config/ingress-controller.yaml.j2
@@ -10,3 +10,6 @@ spec:
     hide-headers: 'Server,X-Powered-By'
     ssl-ciphers: 'EECDH+AESGCM:EDH+AESGCM'
     ssl-protocols: 'TLSv1.2 TLSv1.3'
+    location-snippet: |
+      proxy_set_header traceparent "";
+      proxy_set_header tracestate "";


### PR DESCRIPTION
## Summary

Both MetalK8s nginx ingress controllers (`nginx-ingress` and `nginx-ingress-control-plane`) sit at the trust boundary between the customer/internet side and internal cluster services. Prior to this change, attacker-supplied W3C OpenTelemetry trace-context headers (`traceparent` / `tracestate`) were forwarded as-is to OTEL-instrumented backends (cloudserver, vault, backbeat, pensieve-api, scuba, ...).

## Why

Forwarding those headers lets a hostile caller:
- spoof trace IDs to pollute our observability data
- force `sampled=1` on every request and DoS-amplify the tracing backend
- correlate user requests with our internal span structure

## What

Add a `location-snippet` under `spec.config` on both controllers that unsets the two headers before proxying upstream:

```yaml
location-snippet: |
  proxy_set_header traceparent "";
  proxy_set_header tracestate "";
```

Internal pod-to-pod traffic uses `.svc.cluster.local` and bypasses nginx entirely, so legitimate internal trace propagation is unaffected.

## Scope

- `salt/metalk8s/addons/nginx-ingress/config/ingress-controller.yaml.j2`
- `salt/metalk8s/addons/nginx-ingress-control-plane/config/ingress-controller.yaml.j2`

6 lines total.

## Notes

Verified on `artesca-1`: 70+ requests carrying a crafted `traceparent: 00-deadbeef…-01` through both ingresses produced no spans with the attacker trace ID in Jaeger, while cloudserver continued generating its own traces normally. The override ConfigMaps in the running cluster were also patched with the same snippet so the current environment already reflects the change; nginx reloaded cleanly.

Context: this is Part A of a cross-repo OTEL trust-boundary plan. Backend services still implement their own egress policy separately.

Issue: MK8S-239