### PR TITLE
build: bump docker actions to Node.js 24 (MK8S-249)

### DIFF
--- a/.github/workflows/build-devcontainer.yaml
+++ b/.github/workflows/build-devcontainer.yaml
@@ -19,9 +19,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to the registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -30,7 +30,7 @@ jobs:
         # NOTE: We only skip this and not the full Job
         # otherwise step that "need" it will not be started
         if: ${{ ! inputs.skip }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .devcontainer/
           push: true

--- a/.github/workflows/build-shell-ui.yaml
+++ b/.github/workflows/build-shell-ui.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Compute shell-ui version
         run: |
           source VERSION

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,7 +70,7 @@ jobs:
       artifact-link: ${{ steps.upload.outputs.link }}
     steps:
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_LOGIN }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -396,7 +396,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Install node
         uses: actions/setup-node@v6
         with:
@@ -446,13 +446,13 @@ jobs:
           ADD service /usr/share/nginx/html
           EOF
       - name: Login to Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           push: true
           file: Dockerfile

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,7 +37,7 @@ jobs:
           # See: https://github.com/actions/checkout/issues/882
           ref: ${{ github.ref }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Retrieve Shell UI image from the build, load it and compute version
       - name: Retrieve artifacts url
@@ -125,7 +125,7 @@ jobs:
 
       # Push image to the registry
       - name: Login to the registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY_HOST }}
           username: ${{ github.repository_owner }}


### PR DESCRIPTION
Updates docker/setup-buildx-action v3→v4, docker/login-action v2/v3→v4, and docker/build-push-action v6→v7 across all workflows to resolve the Node.js 20 deprecation warning (Node.js 20 will be removed from GitHub Actions runners on September 16th, 2026).

**Component**: build

**Context**:  Node.js 20 will be removed from GitHub Actions runners on September 16th, 2026

**Summary**:

All Docker actions are now on Node 24-capable majors:
File | Change
-- | --
pre-merge.yaml | setup-buildx v3→v4, login v3→v4, build-push v6→v7
build-devcontainer.yaml | setup-buildx v3→v4, login v3→v4, build-push v6→v7
build.yaml | login v2→v4 (was already 2 majors behind)
build-shell-ui.yaml | setup-buildx v3→v4
publish.yaml | setup-buildx v3→v4, login v3→v4


Closes: #MK8S-249
