### PR TITLE
fix(ARTESCA-17460): preserve original name in rename modal after failure

### DIFF
--- a/shell-ui/src/navbar/EditableDeploymentName.spec.tsx
+++ b/shell-ui/src/navbar/EditableDeploymentName.spec.tsx
@@ -117,6 +117,38 @@ describe('EditableDeploymentName', () => {
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
+  it('keeps original "Current name" in modal when name prop changes after a failed rename', async () => {
+    const setInstanceName = (jest.fn() as jest.MockedFunction<SetInstanceNameFn>).mockRejectedValue(
+      new Error('K8s not available'),
+    );
+    const queryClient = createTestQueryClient();
+    const Wrapper = ({ children }: PropsWithChildren) => (
+      <QueryClientProvider client={queryClient}>
+        <CoreUiThemeProvider theme={coreUIAvailableThemes.darkRebrand}>{children}</CoreUiThemeProvider>
+      </QueryClientProvider>
+    );
+    const { rerender } = render(
+      <EditableDeploymentName name="magenta-nature" setInstanceName={setInstanceName} />,
+      { wrapper: Wrapper },
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'magenta-nature' }));
+    const input = screen.getByRole('textbox', { name: 'Deployment name' });
+    await userEvent.clear(input);
+    await userEvent.type(input, 'magenta-nature-2');
+    await userEvent.keyboard('{Enter}');
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+    await userEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Rename' }));
+    const dialog = screen.getByRole('dialog');
+    await waitFor(() => {
+      expect(within(dialog).getByText('K8s not available')).toBeInTheDocument();
+    });
+    rerender(
+      <EditableDeploymentName name="magenta-nature-2" setInstanceName={setInstanceName} />,
+    );
+    expect(within(dialog).getByText('magenta-nature')).toBeInTheDocument();
+    expect(within(dialog).getByText('magenta-nature-2')).toBeInTheDocument();
+  });
+
   it('shows danger banner in modal when setInstanceName rejects with Error', async () => {
     const { setInstanceName } = renderEditable({
       setInstanceName: (jest.fn() as jest.MockedFunction<SetInstanceNameFn>).mockRejectedValue(

--- a/shell-ui/src/navbar/EditableDeploymentName.tsx
+++ b/shell-ui/src/navbar/EditableDeploymentName.tsx
@@ -1,19 +1,16 @@
-import { useEffect, useRef, useState } from 'react';
-import styled from 'styled-components';
-import { Modal } from '@scality/core-ui/dist/components/modal/Modal.component';
-import { Text } from '@scality/core-ui/dist/components/text/Text.component';
-import { Stack } from '@scality/core-ui/dist/spacing';
-import { Tooltip } from '@scality/core-ui/dist/components/tooltip/Tooltip.component';
-import { InfoMessage } from '@scality/core-ui/dist/components/infomessage/InfoMessage.component';
-import { SecondaryText } from '@scality/core-ui/dist/components/text/Text.component';
-import { Loader } from '@scality/core-ui/dist/components/loader/Loader.component';
-import { Button } from '@scality/core-ui/dist/components/buttonv2/Buttonv2.component';
-import { Box } from '@scality/core-ui/dist/components/box/Box';
-
-import { spacing } from '@scality/core-ui/dist/spacing';
 import { Banner } from '@scality/core-ui/dist/components/banner/Banner.component';
-import { type InstanceNameAdapter, INSTANCE_NAME_QUERY_KEY } from './InstanceName';
+import { Box } from '@scality/core-ui/dist/components/box/Box';
+import { Button } from '@scality/core-ui/dist/components/buttonv2/Buttonv2.component';
+import { InfoMessage } from '@scality/core-ui/dist/components/infomessage/InfoMessage.component';
+import { Loader } from '@scality/core-ui/dist/components/loader/Loader.component';
+import { Modal } from '@scality/core-ui/dist/components/modal/Modal.component';
+import { SecondaryText, Text } from '@scality/core-ui/dist/components/text/Text.component';
+import { Tooltip } from '@scality/core-ui/dist/components/tooltip/Tooltip.component';
+import { Stack, spacing } from '@scality/core-ui/dist/spacing';
+import { useEffect, useRef, useState } from 'react';
 import { useMutation, useQueryClient } from 'react-query';
+import styled from 'styled-components';
+import { INSTANCE_NAME_QUERY_KEY, type InstanceNameAdapter } from './InstanceName';
 
 function renameMutationErrorMessage(error: unknown): string {
   if (error instanceof Error) {
@@ -131,7 +128,7 @@ export function EditableDeploymentName({
   const [isEditing, setIsEditing] = useState(false);
   const [pendingName, setPendingName] = useState(name);
   const [modalOpen, setModalOpen] = useState(false);
-  const [confirmFromName, setConfirmFromName] = useState(name);
+  const [currentName, setCurrentName] = useState(name);
   const inputRef = useRef<HTMLInputElement>(null);
   const [inputValidationError, setInputValidationError] = useState<string | undefined>(undefined);
 
@@ -177,7 +174,7 @@ export function EditableDeploymentName({
 
     if (trimmed && trimmed !== name) {
       setIsEditing(false);
-      setConfirmFromName(name);
+      setCurrentName(name);
       setModalOpen(true);
     } else {
       setIsEditing(false);
@@ -277,7 +274,7 @@ export function EditableDeploymentName({
           <Text>Are you sure you want to rename this deployment?</Text>
           <KeyValueGrid>
             <KeyLabel>Current name</KeyLabel>
-            <KeyValue>{confirmFromName}</KeyValue>
+            <KeyValue>{currentName}</KeyValue>
             <KeyLabel>New name</KeyLabel>
             <KeyValue>{pendingName.trim()}</KeyValue>
           </KeyValueGrid>

--- a/shell-ui/src/navbar/EditableDeploymentName.tsx
+++ b/shell-ui/src/navbar/EditableDeploymentName.tsx
@@ -131,6 +131,7 @@ export function EditableDeploymentName({
   const [isEditing, setIsEditing] = useState(false);
   const [pendingName, setPendingName] = useState(name);
   const [modalOpen, setModalOpen] = useState(false);
+  const [confirmFromName, setConfirmFromName] = useState(name);
   const inputRef = useRef<HTMLInputElement>(null);
   const [inputValidationError, setInputValidationError] = useState<string | undefined>(undefined);
 
@@ -176,6 +177,7 @@ export function EditableDeploymentName({
 
     if (trimmed && trimmed !== name) {
       setIsEditing(false);
+      setConfirmFromName(name);
       setModalOpen(true);
     } else {
       setIsEditing(false);
@@ -275,7 +277,7 @@ export function EditableDeploymentName({
           <Text>Are you sure you want to rename this deployment?</Text>
           <KeyValueGrid>
             <KeyLabel>Current name</KeyLabel>
-            <KeyValue>{name}</KeyValue>
+            <KeyValue>{confirmFromName}</KeyValue>
             <KeyLabel>New name</KeyLabel>
             <KeyValue>{pendingName.trim()}</KeyValue>
           </KeyValueGrid>


### PR DESCRIPTION
## Context / Intent

Currently, when there is an error on Keycloak side. The value is mostly update on k8s side but not spread.
Since we invalidate the query, the value is update.
In order to avoid confusion for the user, we snapshot the value instead of showing the real value in the form.

Before : 
<img width="572" height="555" alt="Screenshot 2026-04-29 at 14 31 54" src="https://github.com/user-attachments/assets/c1223818-0c18-425a-9ff7-17fdc888d5cb" />

After :
<img width="603" height="572" alt="Screenshot 2026-04-30 at 14 50 19" src="https://github.com/user-attachments/assets/62fc6913-7757-449b-9b7f-2ae6f6dc70eb" />
