### PR TITLE
improvement(ARTESCA-17495): hide deployment-name pill on adapter 403

### DIFF
--- a/shell-ui/src/navbar/InstanceName.spec.tsx
+++ b/shell-ui/src/navbar/InstanceName.spec.tsx
@@ -1,15 +1,15 @@
-import type { PropsWithChildren } from 'react';
-import { _InternalInstanceName } from './InstanceName';
-import { render, screen, waitFor, within } from '@testing-library/react';
 import { jest } from '@jest/globals';
-import userEvent from '@testing-library/user-event';
-import { QueryClient } from 'react-query';
 import { CoreUiThemeProvider } from '@scality/core-ui/dist/components/coreuithemeprovider/CoreUiThemeProvider';
 import { ToastProvider } from '@scality/core-ui/dist/components/toast/ToastProvider';
 import { coreUIAvailableThemes } from '@scality/core-ui/dist/style/theme';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { PropsWithChildren } from 'react';
+import { QueryClient } from 'react-query';
 import type { UserData } from '../auth/AuthProvider';
 import type { RuntimeWebFinger } from '../initFederation/ConfigurationProviders';
 import { QueryClientProvider } from '../QueryClientProvider';
+import { _InternalInstanceName } from './InstanceName';
 
 jest.mock('../initFederation/ConfigurationProviders', () => ({
   useConfigRetriever: () => ({
@@ -61,6 +61,7 @@ const Wrapper = ({ children }: PropsWithChildren) => (
             defaultOptions: {
               queries: {
                 retry: false,
+                retryDelay: 0,
               },
             },
           })
@@ -190,6 +191,8 @@ describe('InstanceName', () => {
     expect(document.querySelector('[data-icon="circle-exclamation"]')).not.toBeInTheDocument();
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
     expect(setInstanceName).not.toHaveBeenCalled();
+    // No retry on 403: getInstanceName must be called exactly once.
+    expect(getInstanceName).toHaveBeenCalledTimes(1);
   });
 
   it('loads deployment name then renames via EditableDeploymentName and calls setInstanceName', async () => {

--- a/shell-ui/src/navbar/InstanceName.spec.tsx
+++ b/shell-ui/src/navbar/InstanceName.spec.tsx
@@ -150,6 +150,48 @@ describe('InstanceName', () => {
     expect(getInstanceName).toHaveBeenCalled();
   });
 
+  it('renders nothing when getInstanceName rejects with a 403 (forbidden) error — no pill, no warning icon', async () => {
+    const forbidden = Object.assign(new Error('Forbidden'), {
+      status: 403,
+      code: 'InstanceNameForbidden',
+    });
+    const getInstanceName = jest
+      .fn<
+        (userData: UserData | undefined, configuration: RuntimeWebFinger<Record<string, unknown>>) => Promise<string>
+      >()
+      .mockRejectedValue(forbidden);
+    const setInstanceName = jest
+      .fn<
+        (
+          userData: UserData | undefined,
+          name: string,
+          configuration: RuntimeWebFinger<Record<string, unknown>>,
+        ) => Promise<void>
+      >()
+      .mockResolvedValue(undefined);
+
+    render(
+      <_InternalInstanceName
+        moduleExports={{
+          './instanceNameAdapter': {
+            getInstanceName,
+            setInstanceName,
+          },
+        }}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    await waitFor(() => expect(getInstanceName).toHaveBeenCalled());
+    await waitFor(() => {
+      expect(document.querySelector('.sc-loader')).not.toBeInTheDocument();
+    });
+
+    expect(document.querySelector('[data-icon="circle-exclamation"]')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(setInstanceName).not.toHaveBeenCalled();
+  });
+
   it('loads deployment name then renames via EditableDeploymentName and calls setInstanceName', async () => {
     const getInstanceName = jest
       .fn<

--- a/shell-ui/src/navbar/InstanceName.tsx
+++ b/shell-ui/src/navbar/InstanceName.tsx
@@ -99,7 +99,7 @@ export const _InternalInstanceName = ({
   const instanceNameConfiguration = useInstanceNameConfiguration();
   const runtimeAppConfiguration = instanceNameConfiguration?.runtimeAppConfiguration;
   const { userData } = useAuth();
-  const { data, status } = useQuery({
+  const { data, error, status } = useQuery({
     queryKey: [INSTANCE_NAME_QUERY_KEY],
     queryFn: async () =>
       moduleExports[instanceNameAdapter?.module ?? ''].getInstanceName(userData, runtimeAppConfiguration),
@@ -115,6 +115,11 @@ export const _InternalInstanceName = ({
   }
 
   if (status === 'error') {
+    const err = error as (Error & { status?: number; code?: string }) | null | undefined;
+    if (err?.status === 403 || err?.code === 'InstanceNameForbidden') {
+      // User is not allowed to read the InstanceName — render nothing (no pill, no warning).
+      return null;
+    }
     return (
       <Tooltip overlay="Error loading deployment name" placement="bottom">
         <Icon color="statusWarning" name="Exclamation-circle" />

--- a/shell-ui/src/navbar/InstanceName.tsx
+++ b/shell-ui/src/navbar/InstanceName.tsx
@@ -4,8 +4,8 @@ import { Loader } from '@scality/core-ui/dist/components/loader/Loader.component
 import { Tooltip } from '@scality/core-ui/dist/components/tooltip/Tooltip.component';
 import { ComponentWithFederatedImports } from '@scality/module-federation';
 import { useQuery } from 'react-query';
-import { useAuth, type UserData } from '../auth/AuthProvider';
-import { useConfigRetriever, type RuntimeWebFinger } from '../initFederation/ConfigurationProviders';
+import { type UserData, useAuth } from '../auth/AuthProvider';
+import { type RuntimeWebFinger, useConfigRetriever } from '../initFederation/ConfigurationProviders';
 import { useShellConfig } from '../initFederation/ShellConfigProvider';
 import { useDeployedApps } from '../initFederation/UIListProvider';
 import { EditableDeploymentName } from './EditableDeploymentName';
@@ -104,6 +104,14 @@ export const _InternalInstanceName = ({
     queryFn: async () =>
       moduleExports[instanceNameAdapter?.module ?? ''].getInstanceName(userData, runtimeAppConfiguration),
     enabled: !!runtimeAppConfiguration,
+    retry: (failureCount, queryError) => {
+      // 403 (forbidden) won't resolve without user re-auth — don't burn retries on it.
+      const e = queryError as (Error & { status?: number; code?: string }) | null | undefined;
+      if (e?.status === 403 || e?.code === 'InstanceNameForbidden') {
+        return false;
+      }
+      return failureCount < 3;
+    },
   });
 
   if (status === 'loading' || status === 'idle') {


### PR DESCRIPTION
## Context / Intent

Pairs with the artesca-ui adapter change in [scality/artesca](https://github.com/scality/artesca) that throws a typed forbidden error on K8s 403 responses. When the navbar's `useQuery` for `getInstanceName` rejects with that error, render nothing — no pill, no warning icon. Non-403 errors keep the existing warning-icon behaviour.

The marker is matched on primitive fields (`status === 403` or `code === 'InstanceNameForbidden'`) rather than class identity, so the contract survives the Module Federation boundary in either direction. When neither field is present (old adapter), the existing warning-icon path is unchanged — no regression.

## How to test ?

`npm test -- InstanceName.spec` — all green; new test verifies that a rejection carrying `status: 403` and `code: 'InstanceNameForbidden'` renders neither the pill nor the warning icon.

The existing `EditableDeploymentName.spec.tsx` is untouched.

## Ref:

ARTESCA-17495
EPIC: ARTESCA-16776

Paired artesca PR: see body update post-creation.