### PR TITLE
Add tool annotation during tool registration

### DIFF
--- a/shell-ui/src/mcp/MCPRegistrar.test.tsx
+++ b/shell-ui/src/mcp/MCPRegistrar.test.tsx
@@ -1,4 +1,4 @@
-import type { ToolDescriptor } from '@mcp-b/webmcp-types';
+import type { ToolAnnotations, ToolDescriptor } from '@mcp-b/webmcp-types';
 import { render } from '@testing-library/react';
 import type { FederatedModuleInfo } from '../initFederation/ConfigurationProviders';
 import { _InternalMCPRegistrar } from './MCPRegistrar';
@@ -28,6 +28,7 @@ type RegisteredTool = {
   name: string;
   description: string;
   inputSchema: Record<string, unknown>;
+  annotations?: ToolAnnotations;
   execute: (params: unknown, client: unknown) => Promise<unknown>;
 };
 
@@ -41,10 +42,11 @@ const mockModelContext = {
     delete registeredTools[name];
   }),
   listTools: jest.fn(() =>
-    Object.values(registeredTools).map(({ name, description, inputSchema }) => ({
+    Object.values(registeredTools).map(({ name, description, inputSchema, annotations }) => ({
       name,
       description,
       inputSchema,
+      ...(annotations && { annotations }),
     })),
   ),
 };
@@ -158,6 +160,32 @@ describe('_InternalMCPRegistrar', () => {
       // Simulate token refresh — the ref must pick up the new implementation
       mockGetToken.mockResolvedValueOnce('refreshed-token');
       await expect(capturedContext!.getToken()).resolves.toBe('refreshed-token');
+    });
+
+    it('forwards annotations including readOnlyHint to registerTool', () => {
+      const tool = makeTool({
+        annotations: { readOnlyHint: true, openWorldHint: true },
+      });
+      const moduleExports = {
+        [MODULE_KEY]: { createTools: () => [tool] },
+      };
+
+      render(
+        <_InternalMCPRegistrar
+          moduleExports={moduleExports}
+          mcpToolsModuleInfo={mcpToolsModuleInfo}
+          selfConfiguration={selfConfiguration}
+          navigate={mockNavigate}
+        />,
+      );
+
+      expect(mockModelContext.registerTool).toHaveBeenCalledWith(
+        expect.objectContaining({
+          annotations: { readOnlyHint: true, openWorldHint: true },
+        }),
+      );
+      const listed = mockModelContext.listTools();
+      expect(listed[0].annotations).toEqual({ readOnlyHint: true, openWorldHint: true });
     });
 
     it('registers multiple tools', () => {

--- a/shell-ui/src/mcp/MCPRegistrar.tsx
+++ b/shell-ui/src/mcp/MCPRegistrar.tsx
@@ -75,6 +75,7 @@ export const _InternalMCPRegistrar = ({
         description: tool.description,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         inputSchema: tool.inputSchema,
+        ...(tool.annotations && { annotations: tool.annotations }),
         execute: async (params: unknown, client: ModelContextClient) => {
           // For createTools-based modules, context is already baked into the
           // tool's execute closure. For legacy tools, inject context here.


### PR DESCRIPTION
Allow the tools to pass their register their standard annotations property that contains the readOnlyHint flag used to skip the allow tool prompt in guardian.