### PR TITLE
Add Renovate workflow for Docker base image updates (UI scope)

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,44 @@
+name: Renovate
+on:
+  schedule:
+    - cron: "0 8 * * 1-5" # Weekdays at 8am UTC
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.ACTIONS_APP_ID }}
+          private-key: ${{ secrets.ACTIONS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@v46.1.9
+        with:
+          configurationFile: renovate.json
+          token: ${{ steps.app-token.outputs.token }}
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+
+      - name: Auto-approve Renovate PRs
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh pr list --repo ${{ github.repository }} --state open --json number,headRefName --jq '.[] | select(.headRefName | startswith("improvement/renovate-")) | .number' | while read -r pr; do
+            if ! gh pr view "$pr" --repo ${{ github.repository }} --json comments --jq '.comments[].body' | grep -q '^/approve$'; then
+              gh pr comment "$pr" --repo ${{ github.repository }} --body '/approve'
+              echo "Approved PR #$pr"
+            else
+              echo "PR #$pr already approved, skipping"
+            fi
+          done

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,10 @@
   "packageRules": [
     {
       "matchManagers": ["dockerfile"],
+      "groupName": "ui-base-images"
+    },
+    {
+      "matchManagers": ["dockerfile"],
       "matchUpdateTypes": ["minor", "patch"],
       "addLabels": ["dependencies", "docker", "renovate"]
     },

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "enabledManagers": ["dockerfile"],
+  "branchPrefix": "improvement/renovate-",
+  "includePaths": [
+    "shell-ui/Dockerfile",
+    "ui/Dockerfile",
+    "images/metalk8s-ui/Dockerfile"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["dockerfile"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "addLabels": ["dependencies", "docker", "renovate"]
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "matchUpdateTypes": ["major"],
+      "addLabels": ["dependencies", "docker", "major", "renovate"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add Renovate configuration to automatically update Docker base images
- Scoped to UI-related Dockerfiles only (`shell-ui/`, `ui/`, `images/metalk8s-ui/`)
- Runs on weekdays at 8am UTC with manual trigger option
- Auto-approves Renovate PRs via `/approve` comment
- Prevents CVE from outdated base layers

## Test plan
- [ ] Verify workflow runs successfully on manual trigger
- [ ] Verify Renovate detects Dockerfile base image updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)