### PR TITLE
feat(MK8S-196): expose shared QueryClient to MCP tools via ToolContext

### DIFF
--- a/shell-ui/src/mcp/MCPRegistrar.test.tsx
+++ b/shell-ui/src/mcp/MCPRegistrar.test.tsx
@@ -1,8 +1,18 @@
 import type { ToolAnnotations, ToolDescriptor } from '@mcp-b/webmcp-types';
 import { render } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { QueryClient } from 'react-query';
+import { QueryClientProvider } from '../QueryClientProvider';
 import type { FederatedModuleInfo } from '../initFederation/ConfigurationProviders';
 import { _InternalMCPRegistrar } from './MCPRegistrar';
 import type { ToolContext } from './types';
+
+const renderWithQueryClient = (ui: ReactElement) => {
+  const queryClient = new QueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+};
 
 // ─── Auth mock ────────────────────────────────────────────────────────────────
 
@@ -91,7 +101,7 @@ describe('_InternalMCPRegistrar', () => {
         [MODULE_KEY]: { createTools: () => [tool] },
       };
 
-      render(
+      renderWithQueryClient(
         <_InternalMCPRegistrar
           moduleExports={moduleExports}
           mcpToolsModuleInfo={mcpToolsModuleInfo}
@@ -120,7 +130,7 @@ describe('_InternalMCPRegistrar', () => {
         },
       };
 
-      render(
+      renderWithQueryClient(
         <_InternalMCPRegistrar
           moduleExports={moduleExports}
           mcpToolsModuleInfo={mcpToolsModuleInfo}
@@ -131,6 +141,7 @@ describe('_InternalMCPRegistrar', () => {
 
       expect(capturedContext?.selfConfiguration).toEqual(selfConfiguration);
       expect(capturedNavigate).toBe(mockNavigate);
+      expect(capturedContext?.queryClient).toBeDefined();
     });
 
     it('context.getToken always returns the latest token via ref', async () => {
@@ -145,7 +156,7 @@ describe('_InternalMCPRegistrar', () => {
         },
       };
 
-      render(
+      renderWithQueryClient(
         <_InternalMCPRegistrar
           moduleExports={moduleExports}
           mcpToolsModuleInfo={mcpToolsModuleInfo}
@@ -170,7 +181,7 @@ describe('_InternalMCPRegistrar', () => {
         [MODULE_KEY]: { createTools: () => [tool] },
       };
 
-      render(
+      renderWithQueryClient(
         <_InternalMCPRegistrar
           moduleExports={moduleExports}
           mcpToolsModuleInfo={mcpToolsModuleInfo}
@@ -195,7 +206,7 @@ describe('_InternalMCPRegistrar', () => {
         [MODULE_KEY]: { createTools: () => [tool1, tool2] },
       };
 
-      render(
+      renderWithQueryClient(
         <_InternalMCPRegistrar
           moduleExports={moduleExports}
           mcpToolsModuleInfo={mcpToolsModuleInfo}
@@ -216,7 +227,7 @@ describe('_InternalMCPRegistrar', () => {
         [MODULE_KEY]: { tools: [tool] },
       };
 
-      render(
+      renderWithQueryClient(
         <_InternalMCPRegistrar
           moduleExports={moduleExports}
           mcpToolsModuleInfo={mcpToolsModuleInfo}
@@ -238,7 +249,7 @@ describe('_InternalMCPRegistrar', () => {
         },
       };
 
-      render(
+      renderWithQueryClient(
         <_InternalMCPRegistrar
           moduleExports={moduleExports}
           mcpToolsModuleInfo={mcpToolsModuleInfo}
@@ -269,7 +280,7 @@ describe('_InternalMCPRegistrar', () => {
         },
       };
 
-      const { unmount } = render(
+      const { unmount } = renderWithQueryClient(
         <_InternalMCPRegistrar
           moduleExports={moduleExports}
           mcpToolsModuleInfo={mcpToolsModuleInfo}
@@ -298,7 +309,7 @@ describe('_InternalMCPRegistrar', () => {
       };
 
       expect(() =>
-        render(
+        renderWithQueryClient(
           <_InternalMCPRegistrar
             moduleExports={moduleExports}
             mcpToolsModuleInfo={mcpToolsModuleInfo}
@@ -313,7 +324,7 @@ describe('_InternalMCPRegistrar', () => {
 
     it('registers no tools when module export is missing', () => {
       // moduleExports doesn't have the expected module key
-      render(
+      renderWithQueryClient(
         <_InternalMCPRegistrar
           moduleExports={{}}
           mcpToolsModuleInfo={mcpToolsModuleInfo}

--- a/shell-ui/src/mcp/MCPRegistrar.tsx
+++ b/shell-ui/src/mcp/MCPRegistrar.tsx
@@ -3,6 +3,7 @@ import type { ModelContextClient, ToolDescriptor } from '@mcp-b/webmcp-types';
 import { ComponentWithFederatedImports } from '@scality/module-federation';
 import { useEffect, useMemo, useRef } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
+import { useQueryClient } from 'react-query';
 import { useNavigate } from 'react-router';
 import { useAuth } from '../auth/AuthProvider';
 import {
@@ -43,6 +44,7 @@ export const _InternalMCPRegistrar = ({
   navigate: (path: string) => void;
 }) => {
   const { getToken, userData } = useAuth();
+  const queryClient = useQueryClient();
 
   // Keep auth refs current so tool execute() always reads fresh credentials
   // without causing the registration effect to re-run on every render.
@@ -61,6 +63,7 @@ export const _InternalMCPRegistrar = ({
       get getToken() { return getTokenRef.current; },
       get userData() { return userDataRef.current; },
       selfConfiguration,
+      queryClient,
     };
     // Prefer the new createTools factory (supports navigate + dynamic context);
     // fall back to the legacy static tools array for modules not yet migrated.
@@ -99,7 +102,7 @@ export const _InternalMCPRegistrar = ({
         navigator.modelContext?.unregisterTool?.(name),
       );
     };
-  }, [moduleExports, mcpToolsModuleInfo, selfConfiguration, navigate]);
+  }, [moduleExports, mcpToolsModuleInfo, selfConfiguration, navigate, queryClient]);
 
   return null;
 };

--- a/shell-ui/src/mcp/types.ts
+++ b/shell-ui/src/mcp/types.ts
@@ -4,6 +4,7 @@
  * It contains only what shell-ui itself owns. Micro-frontends extend it with their own
  * app-specific context derived from selfConfiguration.
  */
+import type { QueryClient } from 'react-query';
 import type { UserData } from '../auth/AuthProvider';
 export type { UserData };
 
@@ -21,4 +22,12 @@ export type ToolContext = {
    * Micro-frontends cast this to their own known config shape to extract endpoints etc.
    */
   selfConfiguration: Record<string, unknown>;
+  /**
+   * The shell-ui–owned QueryClient, shared across every federated app via
+   * <QueryClientProvider contextSharing> (see FederatedApp.tsx). Tools use
+   * this to keep the chat-side UI panels in sync with their mutations —
+   * `invalidateQueries`, `setQueryData` for optimistic updates, or
+   * `refetchQueries` — picking the strategy that fits the operation.
+   */
+  queryClient: QueryClient;
 };


### PR DESCRIPTION
## Summary

- Add `queryClient: QueryClient` to `ToolContext` so federated apps' MCP tools can keep chat-side panels in sync after mutations.
- Populate it in `MCPRegistrar` from the shell-ui-owned `queryClient` exported by `FederatedApp.tsx`.

Follow-up to merged PR #4820 (branch was kept alive). Pairs with:
- scality/data-browser#367 — per-tool cache-sync via injected QueryClient
- scality/zenko-ui#1185 — targeted invalidation in zenko's MCP tools

## Why

The previous wrapper-side approach (zenko-ui's `withQueryCacheInvalidation`) called `invalidateQueries()` with no arguments after every non-readonly tool, blowing the entire cache — including auth queries — and leaving the UI empty. Injecting the QueryClient lets each tool target only the keys it actually affects.

## Test plan

- [ ] Type-check passes (\`npm run check-types\`).
- [ ] Manual E2E on the ARTESCA test cluster: agent-driven \`createBucket\` refreshes the bucket panel without empty-UI regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)