### PR TITLE
fix(shell-ui): prevent long deployment name from breaking navbar layout

### DIFF
--- a/shell-ui/src/navbar/EditableDeploymentName.tsx
+++ b/shell-ui/src/navbar/EditableDeploymentName.tsx
@@ -61,6 +61,7 @@ const NameInput = styled.input`
   padding: ${spacing.r4} ${spacing.r8};
   outline: none;
   min-width: 180px;
+  max-width: 16rem;
 
   &:focus {
     border-color: ${(props) => props.theme.selectedActive};
@@ -75,7 +76,7 @@ const NameInput = styled.input`
 
 const KeyValueGrid = styled.dl`
   display: grid;
-  grid-template-columns: max-content 1fr;
+  grid-template-columns: max-content minmax(0, 1fr);
   gap: ${spacing.r8} ${spacing.r16};
   margin: 0;
 `;
@@ -88,6 +89,7 @@ const KeyLabel = styled.dt`
 const KeyValue = styled.dd`
   color: ${(props) => props.theme.textPrimary};
   margin: 0;
+  overflow-wrap: anywhere;
 `;
 
 const NameTrigger = styled.span`
@@ -101,7 +103,8 @@ const NameTrigger = styled.span`
   font-size: 1rem;
   font-family: 'Lato';
   color: ${(props) => props.theme.textPrimary};
-  white-space: nowrap;
+  max-width: 16rem;
+  min-width: 0;
   cursor: pointer;
   transition: border-color 0.15s ease, background 0.15s ease, opacity 0.15s ease;
 
@@ -113,6 +116,13 @@ const NameTrigger = styled.span`
     border-color: ${(props) => props.theme.infoPrimary};
     background: ${(props) => props.theme.highlight};
   }
+`;
+
+const NameTriggerLabel = styled.span`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 `;
 
 export function EditableDeploymentName({
@@ -223,7 +233,7 @@ export function EditableDeploymentName({
           </ValidationInputWrapper>
         ) : (
           <Tooltip
-            overlay={isMutationLoading ? 'Cannot edit while propagating' : 'Edit deployment name'}
+            overlay={isMutationLoading ? 'Cannot edit while propagating' : modalOpen ? pendingName.trim() : name}
             placement="bottom"
           >
             <NameTrigger
@@ -233,7 +243,7 @@ export function EditableDeploymentName({
               tabIndex={isMutationLoading ? undefined : 0}
               onKeyDown={(e) => !isMutationLoading && e.key === 'Enter' && handleEditStart()}
             >
-              {modalOpen ? pendingName.trim() : name}
+              <NameTriggerLabel>{modalOpen ? pendingName.trim() : name}</NameTriggerLabel>
               {isMutationLoading && (
                 <InlineLoaderWrapper>
                   <Loader size="smaller" />


### PR DESCRIPTION
## Summary
TLDR; Fix visual when the deployment name is long.

Before : 
<img width="1908" height="857" alt="Screenshot 2026-05-12 at 15 19 47" src="https://github.com/user-attachments/assets/33aa0007-eaea-4021-bae2-db3cd03c4b12" />
<img width="659" height="682" alt="Screenshot 2026-05-12 at 15 19 24" src="https://github.com/user-attachments/assets/479dcd62-69f7-46a7-b7ec-ec71dbc7fb15" />


After : 

<img width="1912" height="106" alt="Screenshot 2026-05-12 at 15 35 44" src="https://github.com/user-attachments/assets/41e22ba5-126a-4705-8bce-eda0a1ea5788" />
<img width="715" height="768" alt="Screenshot 2026-05-12 at 15 35 38" src="https://github.com/user-attachments/assets/7804f71e-b522-43a3-9521-5d6cc05636f9" />

- Cap the editable deployment-name pill and its edit input at `16rem` and truncate overflow with an ellipsis, so a 50-char name no longer pushes navbar items (Overview / Identity / Platform / …) off-screen.
- Surface the full deployment name in the hover tooltip (previously a static "Edit deployment name" hint), so truncated names remain readable.
- In the rename confirmation modal, switch the value column to `minmax(0, 1fr)` and add `overflow-wrap: anywhere` on the value cell, so long names wrap inside the 500px stack instead of overflowing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)