### PR TITLE
test: increase retry budgets for monitoring and CR waits (MK8S-261)

### DIFF
--- a/tests/kube_utils.py
+++ b/tests/kube_utils.py
@@ -258,8 +258,8 @@ class Client(abc.ABC):
 
         return utils.retry(
             _wait_for_status,
-            times=24,
-            wait=5,  # wait for 2mn
+            times=48,
+            wait=5,  # wait for 4mn
             name=f"waiting for {self._kind} {name} to become {status}",
         )
 

--- a/tests/post/steps/test_monitoring.py
+++ b/tests/post/steps/test_monitoring.py
@@ -368,7 +368,7 @@ def check_job_health(prometheus_api, job, namespace, health):
     # e.g. kube-state-metrics
     utils.retry(
         _wait_job_status,
-        times=30,
+        times=60,
         wait=3,
         name="wait for job '{}' in namespace '{}' being '{}'".format(
             job, namespace, health


### PR DESCRIPTION
## Summary

Bump retry budgets on two e2e waits that have been hitting their timeouts
without any real product regression — the resources do become healthy,
just past the existing budget on slower CI runners.

- `tests/post/steps/test_monitoring.py`: 30 → 60 retries (90s → 180s) for the
  Prometheus job-up wait (the comment above the call already flags
  kube-state-metrics as slow to start).
- `tests/kube_utils.py`: 24 → 48 retries (120s → 240s) for the generic
  `wait_for_status` used by Volume and other CR tests; inline comment
  realigned to `# wait for 4mn`.

Jira: [MK8S-261](https://scality.atlassian.net/browse/MK8S-261)

## Observed failures motivating this change

From [run 26082753540](https://github.com/scality/metalk8s/actions/runs/26082753540):

- **Single-node**: `test_monitored_components` failed after 90s waiting on
  `kube-state-metrics` to be `up` (`connect: connection refused`). The
  parallel multi-node job's monitoring tests passed.
- **Multi-node**: `test_volume_creation_loop` failed after 120s waiting on
  a Volume to reach `Available` (stuck at `Pending`). The parallel
  single-node job's volume tests passed.

Two different subsystems timing out in two different jobs is the classic
flake signature — not a regression we can fix on the product side.

## Tradeoff

A real hang on one of these resources will take ~2× longer to surface,
but e2e jobs already run ~2h so the extra 1–2 minutes is negligible
compared to the cost of repeated false-positive failures and reruns.

## Test plan

- [ ] Pre-merge e2e jobs pass on this branch.
- [ ] No noticeable increase in green-run duration (the new budgets only
      kick in on failure paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MK8S-261]: https://scality.atlassian.net/browse/MK8S-261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ