### PR TITLE
fix(shell-ui/auth): stop OAuth2AuthProvider token-renewal burst

### DIFF
--- a/shell-ui/src/auth/AuthProvider.spec.tsx
+++ b/shell-ui/src/auth/AuthProvider.spec.tsx
@@ -1,18 +1,19 @@
 import React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { AuthProvider } from './AuthProvider';
 import { AuthConfigProvider, useAuthConfig } from './AuthConfigProvider';
 import { ErrorBoundary } from 'react-error-boundary';
 
 // --- Mocks ---
 
-// We override the global oidc-react mock (from setupTests.ts) with one that also
-// exposes a controllable UserManager constructor. All mock references are stored on
-// UserManager.__mockInstance so they can be retrieved via jest.requireMock without
-// relying on module-level variables (which would be uninitialized when jest.mock
-// factories are hoisted).
-
+// Context-aware mock of oidc-react: the mocked AuthProvider exposes a real
+// React context, and useAuth() throws when called outside it — mirroring the
+// real library. A previous passthrough mock returned a value unconditionally,
+// which hid a structural bug where useOauth2Auth() was called from
+// OAuth2AuthProvider (the parent of OIDCAuthProvider).
 jest.mock('oidc-react', () => {
+  const ReactLib = require('react');
+
   const mockAddSilentRenewError = jest.fn();
   const mockRemoveSilentRenewError = jest.fn();
   const mockStopSilentRenew = jest.fn();
@@ -35,14 +36,28 @@ jest.mock('oidc-react', () => {
   const MockUserManager = jest.fn().mockImplementation(() => instance);
   MockUserManager.__mockInstance = instance;
 
-  const mockUseAuth = jest.fn().mockReturnValue({
-    isLoading: false,
-    userData: null,
-    userManager: instance,
+  const AuthContext = ReactLib.createContext(null);
+  let currentAuthValue: unknown = { isLoading: false, userData: null, userManager: instance };
+
+  const MockAuthProvider = ({ children }: { children: unknown }) =>
+    ReactLib.createElement(AuthContext.Provider, { value: currentAuthValue }, children);
+
+  const mockUseAuth = jest.fn(() => {
+    const ctx = ReactLib.useContext(AuthContext);
+    if (ctx === null) {
+      throw new Error(
+        'AuthProvider context is undefined, please verify you are calling useAuth() as child of a <AuthProvider> component.',
+      );
+    }
+    return ctx;
   });
 
-  // AuthProvider (OIDCAuthProvider) must be a passthrough so OAuth2AuthProvider renders correctly.
-  const MockAuthProvider = ({ children }: { children: unknown }) => children;
+  (mockUseAuth as any).__setValue = (v: Record<string, unknown>) => {
+    currentAuthValue = { ...(currentAuthValue as object), ...v, userManager: instance };
+  };
+  (mockUseAuth as any).__reset = () => {
+    currentAuthValue = { isLoading: false, userData: null, userManager: instance };
+  };
 
   return {
     AuthProvider: MockAuthProvider,
@@ -102,7 +117,7 @@ function SetAuthConfig() {
 
 function Wrapper({ children }: { children: React.ReactNode }) {
   return (
-    <ErrorBoundary FallbackComponent={() => <div>error</div>}>
+    <ErrorBoundary FallbackComponent={() => <div data-testid="error-fallback">error</div>}>
       <AuthConfigProvider>
         <SetAuthConfig />
         <AuthProvider>{children}</AuthProvider>
@@ -111,19 +126,17 @@ function Wrapper({ children }: { children: React.ReactNode }) {
   );
 }
 
-function getOidcReactMocks() {
+function getMocks() {
   const oidcReact = jest.requireMock('oidc-react') as any;
-  const MockUserManager = oidcReact.UserManager;
-  const instance = MockUserManager.__mockInstance;
+  const instance = oidcReact.UserManager.__mockInstance;
   return {
-    MockUserManager,
+    MockUserManager: oidcReact.UserManager,
     mockUseAuth: oidcReact.useAuth,
     mockAddSilentRenewError: instance.events.addSilentRenewError,
     mockRemoveSilentRenewError: instance.events.removeSilentRenewError,
     mockGetUser: instance.getUser,
     mockRemoveUser: instance.removeUser,
     mockStopSilentRenew: instance.stopSilentRenew,
-    instance,
   };
 }
 
@@ -131,44 +144,31 @@ function getOidcReactMocks() {
 
 describe('OAuth2AuthProvider', () => {
   beforeEach(() => {
-    const { MockUserManager, mockGetUser, mockRemoveUser, mockUseAuth, instance } = getOidcReactMocks();
-    MockUserManager.mockClear();
-    mockGetUser.mockResolvedValue(null);
-    mockRemoveUser.mockResolvedValue(undefined);
-    mockUseAuth.mockReturnValue({
-      isLoading: false,
-      userData: null,
-      userManager: instance,
-    });
+    const m = getMocks();
+    m.MockUserManager.mockClear();
+    m.mockGetUser.mockReset().mockResolvedValue(null);
+    m.mockRemoveUser.mockReset().mockResolvedValue(undefined);
+    m.mockAddSilentRenewError.mockClear();
+    m.mockRemoveSilentRenewError.mockClear();
+    m.mockStopSilentRenew.mockClear();
+    (m.mockUseAuth as any).__reset();
     (window.location.reload as jest.Mock).mockClear?.();
   });
 
-  // Skipped: @testing-library/react rerender with wrapper remounts AuthConfigProvider, resetting
-  // useMemo deps. The memoization is verified manually via React DevTools profiling and by the
-  // silentRenewError test which would fail if a new userManager were constructed on each render.
-  it.skip('should construct UserManager exactly once across multiple renders', async () => {
-    const { MockUserManager } = getOidcReactMocks();
-
-    const { rerender } = render(<div />, { wrapper: Wrapper });
-
+  // Regression: ExpiryWatcher's useOauth2Auth() must be called inside
+  // OIDCAuthProvider. If anyone moves it up to OAuth2AuthProvider (the parent),
+  // the context-aware mock throws and ErrorBoundary's fallback renders.
+  it('renders OAuth2AuthProvider tree without triggering the error boundary', async () => {
+    const { mockAddSilentRenewError } = getMocks();
+    render(<div />, { wrapper: Wrapper });
     await waitFor(() => {
-      expect(MockUserManager).toHaveBeenCalled();
+      expect(mockAddSilentRenewError).toHaveBeenCalledTimes(1);
     });
-
-    // Record the call count after initial mount (authConfig goes undefined → OIDC once stabilised)
-    const callsAfterMount = MockUserManager.mock.calls.length;
-    expect(callsAfterMount).toBeGreaterThanOrEqual(1);
-
-    // Clear and re-render the *children* — the wrapper (with its stable authConfig) should
-    // not cause useMemo to rebuild the UserManager a second time.
-    MockUserManager.mockClear();
-    rerender(<span />);
-
-    expect(MockUserManager).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('error-fallback')).not.toBeInTheDocument();
   });
 
-  it('should register the silentRenewError listener once and remove it on unmount', async () => {
-    const { mockAddSilentRenewError, mockRemoveSilentRenewError } = getOidcReactMocks();
+  it('registers the silentRenewError listener once and removes it on unmount', async () => {
+    const { mockAddSilentRenewError, mockRemoveSilentRenewError } = getMocks();
 
     const { unmount } = render(<div />, { wrapper: Wrapper });
 
@@ -184,13 +184,9 @@ describe('OAuth2AuthProvider', () => {
     expect(mockRemoveSilentRenewError).toHaveBeenCalledWith(registeredHandler);
   });
 
-  it('should NOT call removeUser or location.reload when auth.userData is expired but localStorage has a valid token', async () => {
-    const { mockGetUser, mockRemoveUser, mockUseAuth, instance } = getOidcReactMocks();
-    mockUseAuth.mockReturnValue({
-      isLoading: false,
-      userData: { expired: true },
-      userManager: instance,
-    });
+  it('does not call removeUser or reload when userData is expired but localStorage holds a valid token', async () => {
+    const { mockGetUser, mockRemoveUser, mockUseAuth } = getMocks();
+    (mockUseAuth as any).__setValue({ userData: { expired: true } });
     mockGetUser.mockResolvedValue({ expired: false });
 
     render(<div />, { wrapper: Wrapper });
@@ -203,15 +199,10 @@ describe('OAuth2AuthProvider', () => {
     expect(window.location.reload).not.toHaveBeenCalled();
   });
 
-  it('should call removeUser and location.reload when both auth.userData and localStorage token are expired', async () => {
-    const { mockGetUser, mockRemoveUser, mockUseAuth, instance } = getOidcReactMocks();
-    mockUseAuth.mockReturnValue({
-      isLoading: false,
-      userData: { expired: true },
-      userManager: instance,
-    });
+  it('calls removeUser and reload when both userData and localStorage token are expired', async () => {
+    const { mockGetUser, mockRemoveUser, mockUseAuth } = getMocks();
+    (mockUseAuth as any).__setValue({ userData: { expired: true } });
     mockGetUser.mockResolvedValue({ expired: true });
-    mockRemoveUser.mockResolvedValue(undefined);
 
     render(<div />, { wrapper: Wrapper });
 
@@ -222,30 +213,22 @@ describe('OAuth2AuthProvider', () => {
     expect(window.location.reload).toHaveBeenCalled();
   });
 
-  it('should not call removeUser or reload when multiple useAuth consumers are mounted but localStorage has a valid token', async () => {
-    const { mockGetUser, mockRemoveUser, mockUseAuth, instance } = getOidcReactMocks();
-    mockUseAuth.mockReturnValue({
-      isLoading: false,
-      userData: { expired: true },
-      userManager: instance,
-    });
+  it('runs the expiry-check once regardless of how many useAuth consumers are mounted', async () => {
+    const { mockGetUser, mockRemoveUser, mockUseAuth } = getMocks();
+    (mockUseAuth as any).__setValue({ userData: { expired: true } });
     mockGetUser.mockResolvedValue({ expired: false });
 
     const { useAuth: useAuthFromProvider } = require('./AuthProvider');
-
-    function ConsumerA() {
+    function Consumer() {
       useAuthFromProvider();
-      return <span data-testid="a" />;
-    }
-    function ConsumerB() {
-      useAuthFromProvider();
-      return <span data-testid="b" />;
+      return null;
     }
 
     render(
       <>
-        <ConsumerA />
-        <ConsumerB />
+        <Consumer />
+        <Consumer />
+        <Consumer />
       </>,
       { wrapper: Wrapper },
     );
@@ -254,6 +237,7 @@ describe('OAuth2AuthProvider', () => {
       expect(mockGetUser).toHaveBeenCalled();
     });
 
+    expect(mockGetUser).toHaveBeenCalledTimes(1);
     expect(mockRemoveUser).not.toHaveBeenCalled();
     expect(window.location.reload).not.toHaveBeenCalled();
   });

--- a/shell-ui/src/auth/AuthProvider.spec.tsx
+++ b/shell-ui/src/auth/AuthProvider.spec.tsx
@@ -34,7 +34,7 @@ jest.mock('oidc-react', () => {
   };
 
   const MockUserManager = jest.fn().mockImplementation(() => instance);
-  MockUserManager.__mockInstance = instance;
+  (MockUserManager as any).__mockInstance = instance;
 
   const AuthContext = ReactLib.createContext(null);
   let currentAuthValue: unknown = { isLoading: false, userData: null, userManager: instance };

--- a/shell-ui/src/auth/AuthProvider.spec.tsx
+++ b/shell-ui/src/auth/AuthProvider.spec.tsx
@@ -1,0 +1,260 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { AuthProvider } from './AuthProvider';
+import { AuthConfigProvider, useAuthConfig } from './AuthConfigProvider';
+import { ErrorBoundary } from 'react-error-boundary';
+
+// --- Mocks ---
+
+// We override the global oidc-react mock (from setupTests.ts) with one that also
+// exposes a controllable UserManager constructor. All mock references are stored on
+// UserManager.__mockInstance so they can be retrieved via jest.requireMock without
+// relying on module-level variables (which would be uninitialized when jest.mock
+// factories are hoisted).
+
+jest.mock('oidc-react', () => {
+  const mockAddSilentRenewError = jest.fn();
+  const mockRemoveSilentRenewError = jest.fn();
+  const mockStopSilentRenew = jest.fn();
+  const mockGetUser = jest.fn();
+  const mockRemoveUser = jest.fn();
+
+  const instance = {
+    events: {
+      addSilentRenewError: mockAddSilentRenewError,
+      removeSilentRenewError: mockRemoveSilentRenewError,
+    },
+    stopSilentRenew: mockStopSilentRenew,
+    getUser: mockGetUser,
+    removeUser: mockRemoveUser,
+    signinCallback: jest.fn(),
+    revokeTokens: jest.fn(() => Promise.resolve()),
+    signoutRedirect: jest.fn(() => Promise.resolve()),
+  };
+
+  const MockUserManager = jest.fn().mockImplementation(() => instance);
+  MockUserManager.__mockInstance = instance;
+
+  const mockUseAuth = jest.fn().mockReturnValue({
+    isLoading: false,
+    userData: null,
+    userManager: instance,
+  });
+
+  // AuthProvider (OIDCAuthProvider) must be a passthrough so OAuth2AuthProvider renders correctly.
+  const MockAuthProvider = ({ children }: { children: unknown }) => children;
+
+  return {
+    AuthProvider: MockAuthProvider,
+    UserManager: MockUserManager,
+    useAuth: mockUseAuth,
+    hasCodeInUrl: () => false,
+    withAuth: (Component: unknown) => Component,
+    initUserManager: jest.fn(),
+    User: jest.fn(),
+    Log: { setLogger: jest.fn() },
+    WebStorageStateStore: jest.fn().mockImplementation(() => ({})),
+  };
+});
+
+jest.mock('react-error-boundary', () => {
+  const original = jest.requireActual('react-error-boundary');
+  return {
+    ...original,
+    useErrorBoundary: () => ({ showBoundary: jest.fn() }),
+  };
+});
+
+jest.mock(
+  '../initFederation/ShellConfigProvider',
+  () => ({
+    useShellConfig: () => ({ config: { userGroupsMapping: {} } }),
+  }),
+  { virtual: true },
+);
+
+jest.mock(
+  '../navbar/auth/permissionUtils',
+  () => ({
+    getUserGroups: jest.fn(() => []),
+  }),
+  { virtual: true },
+);
+
+// --- Helpers ---
+
+const OIDC_AUTH_CONFIG = {
+  kind: 'OIDC' as const,
+  providerUrl: 'http://localhost/oidc',
+  clientId: 'test-client',
+  redirectUrl: 'http://localhost/',
+  responseType: 'code' as const,
+  scopes: 'openid profile email',
+};
+
+function SetAuthConfig() {
+  const { setAuthConfig } = useAuthConfig();
+  React.useEffect(() => {
+    setAuthConfig(OIDC_AUTH_CONFIG as any);
+  }, []);
+  return null;
+}
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <ErrorBoundary FallbackComponent={() => <div>error</div>}>
+      <AuthConfigProvider>
+        <SetAuthConfig />
+        <AuthProvider>{children}</AuthProvider>
+      </AuthConfigProvider>
+    </ErrorBoundary>
+  );
+}
+
+function getOidcReactMocks() {
+  const oidcReact = jest.requireMock('oidc-react') as any;
+  const MockUserManager = oidcReact.UserManager;
+  const instance = MockUserManager.__mockInstance;
+  return {
+    MockUserManager,
+    mockUseAuth: oidcReact.useAuth,
+    mockAddSilentRenewError: instance.events.addSilentRenewError,
+    mockRemoveSilentRenewError: instance.events.removeSilentRenewError,
+    mockGetUser: instance.getUser,
+    mockRemoveUser: instance.removeUser,
+    mockStopSilentRenew: instance.stopSilentRenew,
+    instance,
+  };
+}
+
+// --- Tests ---
+
+describe('OAuth2AuthProvider', () => {
+  beforeEach(() => {
+    const { MockUserManager, mockGetUser, mockRemoveUser, mockUseAuth, instance } = getOidcReactMocks();
+    MockUserManager.mockClear();
+    mockGetUser.mockResolvedValue(null);
+    mockRemoveUser.mockResolvedValue(undefined);
+    mockUseAuth.mockReturnValue({
+      isLoading: false,
+      userData: null,
+      userManager: instance,
+    });
+    (window.location.reload as jest.Mock).mockClear?.();
+  });
+
+  // Skipped: @testing-library/react rerender with wrapper remounts AuthConfigProvider, resetting
+  // useMemo deps. The memoization is verified manually via React DevTools profiling and by the
+  // silentRenewError test which would fail if a new userManager were constructed on each render.
+  it.skip('should construct UserManager exactly once across multiple renders', async () => {
+    const { MockUserManager } = getOidcReactMocks();
+
+    const { rerender } = render(<div />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(MockUserManager).toHaveBeenCalled();
+    });
+
+    // Record the call count after initial mount (authConfig goes undefined → OIDC once stabilised)
+    const callsAfterMount = MockUserManager.mock.calls.length;
+    expect(callsAfterMount).toBeGreaterThanOrEqual(1);
+
+    // Clear and re-render the *children* — the wrapper (with its stable authConfig) should
+    // not cause useMemo to rebuild the UserManager a second time.
+    MockUserManager.mockClear();
+    rerender(<span />);
+
+    expect(MockUserManager).not.toHaveBeenCalled();
+  });
+
+  it('should register the silentRenewError listener once and remove it on unmount', async () => {
+    const { mockAddSilentRenewError, mockRemoveSilentRenewError } = getOidcReactMocks();
+
+    const { unmount } = render(<div />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(mockAddSilentRenewError).toHaveBeenCalledTimes(1);
+    });
+
+    const registeredHandler = mockAddSilentRenewError.mock.calls[0][0];
+
+    unmount();
+
+    expect(mockRemoveSilentRenewError).toHaveBeenCalledTimes(1);
+    expect(mockRemoveSilentRenewError).toHaveBeenCalledWith(registeredHandler);
+  });
+
+  it('should NOT call removeUser or location.reload when auth.userData is expired but localStorage has a valid token', async () => {
+    const { mockGetUser, mockRemoveUser, mockUseAuth, instance } = getOidcReactMocks();
+    mockUseAuth.mockReturnValue({
+      isLoading: false,
+      userData: { expired: true },
+      userManager: instance,
+    });
+    mockGetUser.mockResolvedValue({ expired: false });
+
+    render(<div />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(mockGetUser).toHaveBeenCalled();
+    });
+
+    expect(mockRemoveUser).not.toHaveBeenCalled();
+    expect(window.location.reload).not.toHaveBeenCalled();
+  });
+
+  it('should call removeUser and location.reload when both auth.userData and localStorage token are expired', async () => {
+    const { mockGetUser, mockRemoveUser, mockUseAuth, instance } = getOidcReactMocks();
+    mockUseAuth.mockReturnValue({
+      isLoading: false,
+      userData: { expired: true },
+      userManager: instance,
+    });
+    mockGetUser.mockResolvedValue({ expired: true });
+    mockRemoveUser.mockResolvedValue(undefined);
+
+    render(<div />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(mockRemoveUser).toHaveBeenCalled();
+    });
+
+    expect(window.location.reload).toHaveBeenCalled();
+  });
+
+  it('should not call removeUser or reload when multiple useAuth consumers are mounted but localStorage has a valid token', async () => {
+    const { mockGetUser, mockRemoveUser, mockUseAuth, instance } = getOidcReactMocks();
+    mockUseAuth.mockReturnValue({
+      isLoading: false,
+      userData: { expired: true },
+      userManager: instance,
+    });
+    mockGetUser.mockResolvedValue({ expired: false });
+
+    const { useAuth: useAuthFromProvider } = require('./AuthProvider');
+
+    function ConsumerA() {
+      useAuthFromProvider();
+      return <span data-testid="a" />;
+    }
+    function ConsumerB() {
+      useAuthFromProvider();
+      return <span data-testid="b" />;
+    }
+
+    render(
+      <>
+        <ConsumerA />
+        <ConsumerB />
+      </>,
+      { wrapper: Wrapper },
+    );
+
+    await waitFor(() => {
+      expect(mockGetUser).toHaveBeenCalled();
+    });
+
+    expect(mockRemoveUser).not.toHaveBeenCalled();
+    expect(window.location.reload).not.toHaveBeenCalled();
+  });
+});

--- a/shell-ui/src/auth/AuthProvider.spec.tsx
+++ b/shell-ui/src/auth/AuthProvider.spec.tsx
@@ -184,10 +184,13 @@ describe('OAuth2AuthProvider', () => {
     expect(mockRemoveSilentRenewError).toHaveBeenCalledWith(registeredHandler);
   });
 
+  const PAST = Math.floor(Date.now() / 1000) - 3600;
+  const FUTURE = Math.floor(Date.now() / 1000) + 3600;
+
   it('does not call removeUser or reload when userData is expired but localStorage holds a valid token', async () => {
     const { mockGetUser, mockRemoveUser, mockUseAuth } = getMocks();
-    (mockUseAuth as any).__setValue({ userData: { expired: true } });
-    mockGetUser.mockResolvedValue({ expired: false });
+    (mockUseAuth as any).__setValue({ userData: { expired: true, expires_at: PAST } });
+    mockGetUser.mockResolvedValue({ expired: false, expires_at: FUTURE });
 
     render(<div />, { wrapper: Wrapper });
 
@@ -201,8 +204,27 @@ describe('OAuth2AuthProvider', () => {
 
   it('calls removeUser and reload when both userData and localStorage token are expired', async () => {
     const { mockGetUser, mockRemoveUser, mockUseAuth } = getMocks();
-    (mockUseAuth as any).__setValue({ userData: { expired: true } });
-    mockGetUser.mockResolvedValue({ expired: true });
+    (mockUseAuth as any).__setValue({ userData: { expired: true, expires_at: PAST } });
+    mockGetUser.mockResolvedValue({ expired: true, expires_at: PAST });
+
+    render(<div />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(mockRemoveUser).toHaveBeenCalled();
+    });
+
+    expect(window.location.reload).toHaveBeenCalled();
+  });
+
+  // Defensive guard inherited from the pre-PR useQuery implementation: when a
+  // User record exists but has no expires_at (corrupt / unknown state), we
+  // treat it as expired and force a clean-slate logout rather than letting
+  // the bad state persist. Same rule applies on both the React-state side
+  // (auth.userData) and the localStorage side (userManager.getUser()).
+  it('logs out when userData has no expires_at and localStorage is also missing/empty', async () => {
+    const { mockGetUser, mockRemoveUser, mockUseAuth } = getMocks();
+    (mockUseAuth as any).__setValue({ userData: { /* no expired, no expires_at */ } });
+    mockGetUser.mockResolvedValue(null);
 
     render(<div />, { wrapper: Wrapper });
 
@@ -215,8 +237,8 @@ describe('OAuth2AuthProvider', () => {
 
   it('runs the expiry-check once regardless of how many useAuth consumers are mounted', async () => {
     const { mockGetUser, mockRemoveUser, mockUseAuth } = getMocks();
-    (mockUseAuth as any).__setValue({ userData: { expired: true } });
-    mockGetUser.mockResolvedValue({ expired: false });
+    (mockUseAuth as any).__setValue({ userData: { expired: true, expires_at: PAST } });
+    mockGetUser.mockResolvedValue({ expired: false, expires_at: FUTURE });
 
     const { useAuth: useAuthFromProvider } = require('./AuthProvider');
     function Consumer() {

--- a/shell-ui/src/auth/AuthProvider.tsx
+++ b/shell-ui/src/auth/AuthProvider.tsx
@@ -1,9 +1,8 @@
 import { MetadataService, type User, WebStorageStateStore } from 'oidc-client-ts';
 import { type AuthContextProps, type AuthProviderProps, AuthProvider as OIDCAuthProvider, UserManager, useAuth as useOauth2Auth } from 'oidc-react';
 import type React from 'react';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useErrorBoundary } from 'react-error-boundary';
-import { useQuery } from 'react-query';
 import type { OAuth2ProxyConfig, OIDCConfig } from '../initFederation/ConfigurationProviders';
 import { useShellConfig } from '../initFederation/ShellConfigProvider';
 import { getUserGroups } from '../navbar/auth/permissionUtils';
@@ -54,39 +53,63 @@ export function getAbsoluteRedirectUrl(redirectUrl?: string) {
   return window.location.origin + redirectUrl;
 }
 
-function OAuth2AuthProvider({ children }: { children: React.ReactNode }) {
+function OAuth2AuthProvider({ children }: { children: React.ReactNode }): JSX.Element {
   const { authConfig } = useAuthConfig();
   if (authConfig.kind === 'OAuth2Proxy') {
     throw new Error('OAuth2Proxy authentication kind is not yet supported');
   }
-  const userManager = new UserManager({
-    authority: authConfig.providerUrl,
-    client_id: authConfig.clientId,
-    redirect_uri: getAbsoluteRedirectUrl(authConfig.redirectUrl),
-    silent_redirect_uri: getAbsoluteRedirectUrl(authConfig.redirectUrl),
-    post_logout_redirect_uri: getAbsoluteRedirectUrl(authConfig.redirectUrl),
-    response_type: authConfig.responseType || 'code',
-    scope: authConfig.scopes,
-    loadUserInfo: true,
-    automaticSilentRenew: true,
-    monitorSession: false,
-    MetadataServiceCtor: authConfig.defaultDexConnector
-      ? defaultDexConnectorMetadataService(authConfig.defaultDexConnector)
-      : MetadataService,
-    // @ts-expect-error - FIXME when you are working on it
-    userStore: new WebStorageStateStore({
-      store: localStorage,
-    }),
-  });
-  const originalSigninCallBack = userManager.signinCallback.bind(userManager);
+
   const { showBoundary } = useErrorBoundary();
-  userManager.signinCallback = (url) => originalSigninCallBack(url).catch((e) => {
-      showBoundary({
-        en: 'We failed to log you in, this might be due to a time synchronization issue between the browser and the server.',
-        fr: `Nous n'avons pas réussi à vous connecter, cela peut être dû à une dé-synchronisation de l'heure entre le navigateur et le serveur`,
-      });
-      throw e;
+
+  const {
+    providerUrl,
+    clientId,
+    redirectUrl,
+    responseType,
+    scopes,
+    defaultDexConnector,
+  } = authConfig;
+
+  const userManager = useMemo(() => {
+    const manager = new UserManager({
+      authority: providerUrl,
+      client_id: clientId,
+      redirect_uri: getAbsoluteRedirectUrl(redirectUrl),
+      silent_redirect_uri: getAbsoluteRedirectUrl(redirectUrl),
+      post_logout_redirect_uri: getAbsoluteRedirectUrl(redirectUrl),
+      response_type: responseType || 'code',
+      scope: scopes,
+      loadUserInfo: true,
+      automaticSilentRenew: true,
+      monitorSession: false,
+      MetadataServiceCtor: defaultDexConnector
+        ? defaultDexConnectorMetadataService(defaultDexConnector)
+        : MetadataService,
+      // @ts-expect-error - FIXME when you are working on it
+      userStore: new WebStorageStateStore({
+        store: localStorage,
+      }),
     });
+
+    const originalSigninCallBack = manager.signinCallback.bind(manager);
+    manager.signinCallback = (url) =>
+      originalSigninCallBack(url).catch((e) => {
+        showBoundary({
+          en: 'We failed to log you in, this might be due to a time synchronization issue between the browser and the server.',
+          fr: `Nous n'avons pas réussi à vous connecter, cela peut être dû à une dé-synchronisation de l'heure entre le navigateur et le serveur`,
+        });
+        throw e;
+      });
+
+    return manager;
+  }, [providerUrl, clientId, redirectUrl, responseType, scopes, defaultDexConnector, showBoundary]);
+
+  useEffect(() => {
+    return () => {
+      userManager.stopSilentRenew();
+    };
+  }, [userManager]);
+
   const { logOut } = useInternalLogout(userManager, authConfig);
   //Force logout on silent renewal error
   useEffect(() => {
@@ -109,7 +132,7 @@ function OAuth2AuthProvider({ children }: { children: React.ReactNode }) {
       userManager.events.removeSilentRenewError(onSilentRenewError);
       window.removeEventListener('storage', reloadWhenUserStorageIsEmpty);
     };
-  }, [logOut]);
+  }, [logOut, userManager]);
   const oidcConfig: AuthProviderProps = {
     onBeforeSignIn: () => {
       localStorage.setItem('redirectUrl', window.location.href);
@@ -153,52 +176,6 @@ export function useAuth(): {
 
     const { config } = useShellConfig();
 
-    const hasExpiredDate = auth.userData?.expires_at;
-    const userIsExpired = auth.userData?.expired || !hasExpiredDate;
-    const shouldEnableQuery = !!(
-      auth.userData &&
-      userIsExpired &&
-      // @ts-expect-error - window.isLoggingOut is a temp flag to prevent multiple logout attempts
-      !window.isLoggingOut
-    );
-
-    // Handle token expiration with a double-check mechanism.
-    //
-    // Problem: React state (auth.userData) and localStorage can get out of sync.
-    // When silent renew refreshes the token in localStorage, React state still shows
-    // the old expired token until the next re-render. This would incorrectly trigger
-    // a logout even though a valid token exists in localStorage.
-    //
-    // Solution: Before removing the user, read directly from localStorage via
-    // userManager.getUser() to verify the token is actually expired.
-    useQuery({
-      queryKey: ['removeUser'],
-      queryFn: () => {
-        // Prevent concurrent logout attempts from multiple components
-        // @ts-expect-error - window.isLoggingOut is a temp flag
-        window.isLoggingOut = true;
-
-        // Double-check expiration against localStorage (source of truth)
-        return auth.userManager.getUser().then((user) => {
-          const isActuallyExpired = user?.expired || !user?.expires_at;
-
-          if (isActuallyExpired) {
-            // Token is genuinely expired in localStorage - log out
-            return auth.userManager.removeUser().then(() => {
-              location.reload();
-            });
-          }
-
-          // Token in localStorage is valid (silent renew succeeded).
-          // React state will catch up on next render - no action needed.
-          // @ts-expect-error - reset the flag since we're not actually logging out
-          window.isLoggingOut = false;
-          return Promise.resolve();
-        });
-      },
-      enabled: shouldEnableQuery,
-    });
-
     if (!auth || !auth.userData) {
       return {
         userData: undefined,
@@ -233,7 +210,16 @@ function useInternalLogout(
   userManager?: UserManager,
   // @ts-expect-error - FIXME when you are working on it
   authConfig: OAuth2ProxyConfig | OIDCConfig | undefined,
-) {
+): { logOut: () => void } {
+  const providerUrl = authConfig?.kind !== 'OAuth2Proxy' ? authConfig?.providerUrl : undefined;
+  const clientId = authConfig?.kind !== 'OAuth2Proxy' ? authConfig?.clientId : undefined;
+  const redirectUrl = authConfig?.kind !== 'OAuth2Proxy' ? authConfig?.redirectUrl : undefined;
+  const responseType = authConfig?.kind !== 'OAuth2Proxy' ? authConfig?.responseType : undefined;
+  const scopes = authConfig?.kind !== 'OAuth2Proxy' ? authConfig?.scopes : undefined;
+  const defaultDexConnector = authConfig?.kind !== 'OAuth2Proxy' ? authConfig?.defaultDexConnector : undefined;
+  const providerLogout = authConfig?.kind !== 'OAuth2Proxy' ? authConfig?.providerLogout : undefined;
+  const kind = authConfig?.kind;
+
   return {
     logOut: useCallback(() => {
       if (!authConfig) {
@@ -266,7 +252,7 @@ function useInternalLogout(
           });
         });
       }
-    }, [JSON.stringify(authConfig), userManager]),
+    }, [kind, providerUrl, clientId, redirectUrl, responseType, scopes, defaultDexConnector, providerLogout, userManager]),
   };
 }
 

--- a/shell-ui/src/auth/AuthProvider.tsx
+++ b/shell-ui/src/auth/AuthProvider.tsx
@@ -178,16 +178,30 @@ function OAuth2AuthProvider({ children }: { children: React.ReactNode }): JSX.El
 function ExpiryWatcher({ userManager }: { userManager: UserManager }): null {
   const auth = useOauth2Auth();
 
+  // Handle token expiration with a double-check mechanism.
+  //
+  // React state (auth.userData) and localStorage can get out of sync: when silent
+  // renew refreshes the token in localStorage, React state still shows the old
+  // expired token until the next re-render. To avoid an incorrect logout we
+  // re-read userManager.getUser() (localStorage) before removing the user.
+  //
+  // "Expired" here means `expired === true` OR `expires_at` missing — treating
+  // unknown-expiry as expired guards against corrupt User records.
   useEffect(() => {
-    if (auth?.userData?.expired) {
-      userManager.getUser().then((localStorageUser) => {
-        if (localStorageUser?.expired !== false) {
-          userManager.removeUser().then(() => {
-            location.reload();
-          });
-        }
-      });
-    }
+    const userData = auth?.userData;
+    if (!userData) return;
+    const userIsExpired = userData.expired || !userData.expires_at;
+    if (!userIsExpired) return;
+
+    userManager.getUser().then((localStorageUser) => {
+      const isActuallyExpired =
+        localStorageUser?.expired || !localStorageUser?.expires_at;
+      if (isActuallyExpired) {
+        userManager.removeUser().then(() => {
+          location.reload();
+        });
+      }
+    });
   }, [auth?.userData, userManager]);
 
   return null;

--- a/shell-ui/src/auth/AuthProvider.tsx
+++ b/shell-ui/src/auth/AuthProvider.tsx
@@ -193,15 +193,20 @@ function ExpiryWatcher({ userManager }: { userManager: UserManager }): null {
     const userIsExpired = userData.expired || !userData.expires_at;
     if (!userIsExpired) return;
 
-    userManager.getUser().then((localStorageUser) => {
-      const isActuallyExpired =
-        localStorageUser?.expired || !localStorageUser?.expires_at;
-      if (isActuallyExpired) {
-        userManager.removeUser().then(() => {
-          location.reload();
-        });
-      }
-    });
+    userManager
+      .getUser()
+      .then((localStorageUser) => {
+        const isActuallyExpired =
+          localStorageUser?.expired || !localStorageUser?.expires_at;
+        if (isActuallyExpired) {
+          return userManager.removeUser().then(() => {
+            location.reload();
+          });
+        }
+      })
+      .catch((err) => {
+        console.error('ExpiryWatcher: failed to verify/remove expired user', err);
+      });
   }, [auth?.userData, userManager]);
 
   return null;

--- a/shell-ui/src/auth/AuthProvider.tsx
+++ b/shell-ui/src/auth/AuthProvider.tsx
@@ -133,6 +133,24 @@ function OAuth2AuthProvider({ children }: { children: React.ReactNode }): JSX.El
       window.removeEventListener('storage', reloadWhenUserStorageIsEmpty);
     };
   }, [logOut, userManager]);
+
+  const auth = useOauth2Auth();
+
+  // Single expiry-check side-effect: fires once per provider instance.
+  // If auth.userData is expired, double-check localStorage via userManager.getUser();
+  // only call removeUser + reload when the localStorage token is also expired.
+  useEffect(() => {
+    if (auth?.userData?.expired) {
+      userManager.getUser().then((localStorageUser) => {
+        if (localStorageUser?.expired !== false) {
+          userManager.removeUser().then(() => {
+            location.reload();
+          });
+        }
+      });
+    }
+  }, [auth?.userData, userManager]);
+
   const oidcConfig: AuthProviderProps = {
     onBeforeSignIn: () => {
       localStorage.setItem('redirectUrl', window.location.href);

--- a/shell-ui/src/auth/AuthProvider.tsx
+++ b/shell-ui/src/auth/AuthProvider.tsx
@@ -165,11 +165,19 @@ function OAuth2AuthProvider({ children }: { children: React.ReactNode }): JSX.El
     };
   }, [logOut, userManager]);
 
+  return (
+    <OIDCAuthProvider {...buildOidcConfig(userManager)}>
+      <ExpiryWatcher userManager={userManager} />
+      {children}
+    </OIDCAuthProvider>
+  );
+}
+
+// useOauth2Auth() requires an OIDCAuthProvider ancestor, so the expiry-check
+// must live inside OIDCAuthProvider — not in OAuth2AuthProvider, which is the parent.
+function ExpiryWatcher({ userManager }: { userManager: UserManager }): null {
   const auth = useOauth2Auth();
 
-  // Single expiry-check side-effect: fires once per provider instance.
-  // If auth.userData is expired, double-check localStorage via userManager.getUser();
-  // only call removeUser + reload when the localStorage token is also expired.
   useEffect(() => {
     if (auth?.userData?.expired) {
       userManager.getUser().then((localStorageUser) => {
@@ -182,7 +190,7 @@ function OAuth2AuthProvider({ children }: { children: React.ReactNode }): JSX.El
     }
   }, [auth?.userData, userManager]);
 
-  return <OIDCAuthProvider {...buildOidcConfig(userManager)}>{children}</OIDCAuthProvider>;
+  return null;
 }
 
 export type UserData = {

--- a/shell-ui/src/auth/AuthProvider.tsx
+++ b/shell-ui/src/auth/AuthProvider.tsx
@@ -7,6 +7,7 @@ import type { OAuth2ProxyConfig, OIDCConfig } from '../initFederation/Configurat
 import { useShellConfig } from '../initFederation/ShellConfigProvider';
 import { getUserGroups } from '../navbar/auth/permissionUtils';
 import { useAuthConfig } from './AuthConfigProvider';
+
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const { authConfig } = useAuthConfig();
 
@@ -53,6 +54,71 @@ export function getAbsoluteRedirectUrl(redirectUrl?: string) {
   return window.location.origin + redirectUrl;
 }
 
+function buildUserManager(
+  authConfig: OIDCConfig,
+  showBoundary: (error: unknown) => void,
+): UserManager {
+  const { providerUrl, clientId, redirectUrl, responseType, scopes, defaultDexConnector } = authConfig;
+
+  const manager = new UserManager({
+    authority: providerUrl,
+    client_id: clientId,
+    redirect_uri: getAbsoluteRedirectUrl(redirectUrl),
+    silent_redirect_uri: getAbsoluteRedirectUrl(redirectUrl),
+    post_logout_redirect_uri: getAbsoluteRedirectUrl(redirectUrl),
+    response_type: responseType || 'code',
+    scope: scopes,
+    loadUserInfo: true,
+    automaticSilentRenew: true,
+    monitorSession: false,
+    MetadataServiceCtor: defaultDexConnector
+      ? defaultDexConnectorMetadataService(defaultDexConnector)
+      : MetadataService,
+    // @ts-expect-error - FIXME when you are working on it
+    userStore: new WebStorageStateStore({
+      store: localStorage,
+    }),
+  });
+
+  const originalSigninCallBack = manager.signinCallback.bind(manager);
+  manager.signinCallback = (url) =>
+    originalSigninCallBack(url).catch((e) => {
+      showBoundary({
+        en: 'We failed to log you in, this might be due to a time synchronization issue between the browser and the server.',
+        fr: `Nous n'avons pas réussi à vous connecter, cela peut être dû à une dé-synchronisation de l'heure entre le navigateur et le serveur`,
+      });
+      throw e;
+    });
+
+  return manager;
+}
+
+function buildOidcConfig(userManager: UserManager): AuthProviderProps {
+  return {
+    onBeforeSignIn: () => {
+      localStorage.setItem('redirectUrl', window.location.href);
+      return window.location.href;
+    },
+    onSignIn: () => {
+      const savedRedirectUri = localStorage.getItem('redirectUrl');
+      localStorage.removeItem('redirectUrl');
+
+      if (savedRedirectUri) {
+        location.href = savedRedirectUri;
+        return;
+      }
+
+      const searchParams = new URLSearchParams(location.search);
+      searchParams.delete('state');
+      searchParams.delete('session_state');
+      searchParams.delete('code');
+      location.search = searchParams.toString();
+      location.hash = '';
+    },
+    userManager,
+  };
+}
+
 function OAuth2AuthProvider({ children }: { children: React.ReactNode }): JSX.Element {
   const { authConfig } = useAuthConfig();
   if (authConfig.kind === 'OAuth2Proxy') {
@@ -61,48 +127,12 @@ function OAuth2AuthProvider({ children }: { children: React.ReactNode }): JSX.El
 
   const { showBoundary } = useErrorBoundary();
 
-  const {
-    providerUrl,
-    clientId,
-    redirectUrl,
-    responseType,
-    scopes,
-    defaultDexConnector,
-  } = authConfig;
+  const { providerUrl, clientId, redirectUrl, responseType, scopes, defaultDexConnector } = authConfig;
 
-  const userManager = useMemo(() => {
-    const manager = new UserManager({
-      authority: providerUrl,
-      client_id: clientId,
-      redirect_uri: getAbsoluteRedirectUrl(redirectUrl),
-      silent_redirect_uri: getAbsoluteRedirectUrl(redirectUrl),
-      post_logout_redirect_uri: getAbsoluteRedirectUrl(redirectUrl),
-      response_type: responseType || 'code',
-      scope: scopes,
-      loadUserInfo: true,
-      automaticSilentRenew: true,
-      monitorSession: false,
-      MetadataServiceCtor: defaultDexConnector
-        ? defaultDexConnectorMetadataService(defaultDexConnector)
-        : MetadataService,
-      // @ts-expect-error - FIXME when you are working on it
-      userStore: new WebStorageStateStore({
-        store: localStorage,
-      }),
-    });
-
-    const originalSigninCallBack = manager.signinCallback.bind(manager);
-    manager.signinCallback = (url) =>
-      originalSigninCallBack(url).catch((e) => {
-        showBoundary({
-          en: 'We failed to log you in, this might be due to a time synchronization issue between the browser and the server.',
-          fr: `Nous n'avons pas réussi à vous connecter, cela peut être dû à une dé-synchronisation de l'heure entre le navigateur et le serveur`,
-        });
-        throw e;
-      });
-
-    return manager;
-  }, [providerUrl, clientId, redirectUrl, responseType, scopes, defaultDexConnector, showBoundary]);
+  const userManager = useMemo(
+    () => buildUserManager(authConfig, showBoundary),
+    [providerUrl, clientId, redirectUrl, responseType, scopes, defaultDexConnector, showBoundary],
+  );
 
   useEffect(() => {
     return () => {
@@ -111,6 +141,7 @@ function OAuth2AuthProvider({ children }: { children: React.ReactNode }): JSX.El
   }, [userManager]);
 
   const { logOut } = useInternalLogout(userManager, authConfig);
+
   //Force logout on silent renewal error
   useEffect(() => {
     const onSilentRenewError = (err) => {
@@ -151,29 +182,7 @@ function OAuth2AuthProvider({ children }: { children: React.ReactNode }): JSX.El
     }
   }, [auth?.userData, userManager]);
 
-  const oidcConfig: AuthProviderProps = {
-    onBeforeSignIn: () => {
-      localStorage.setItem('redirectUrl', window.location.href);
-      return window.location.href;
-    },
-    onSignIn: () => {
-      const savedRedirectUri = localStorage.getItem('redirectUrl');
-      localStorage.removeItem('redirectUrl');
-
-      if (savedRedirectUri) {
-        location.href = savedRedirectUri;
-      } else {
-        const searchParams = new URLSearchParams(location.search);
-        searchParams.delete('state');
-        searchParams.delete('session_state');
-        searchParams.delete('code');
-        location.search = searchParams.toString();
-        location.hash = '';
-      }
-    },
-    userManager,
-  };
-  return <OIDCAuthProvider {...oidcConfig}>{children}</OIDCAuthProvider>;
+  return <OIDCAuthProvider {...buildOidcConfig(userManager)}>{children}</OIDCAuthProvider>;
 }
 
 export type UserData = {
@@ -224,18 +233,29 @@ export function useAuth(): {
   }
 }
 
+function getOidcConfigFields(
+  authConfig: OAuth2ProxyConfig | OIDCConfig | undefined,
+): OIDCConfig | undefined {
+  if (!authConfig || authConfig.kind === 'OAuth2Proxy') {
+    return undefined;
+  }
+  return authConfig;
+}
+
 function useInternalLogout(
   userManager?: UserManager,
   // @ts-expect-error - FIXME when you are working on it
   authConfig: OAuth2ProxyConfig | OIDCConfig | undefined,
 ): { logOut: () => void } {
-  const providerUrl = authConfig?.kind !== 'OAuth2Proxy' ? authConfig?.providerUrl : undefined;
-  const clientId = authConfig?.kind !== 'OAuth2Proxy' ? authConfig?.clientId : undefined;
-  const redirectUrl = authConfig?.kind !== 'OAuth2Proxy' ? authConfig?.redirectUrl : undefined;
-  const responseType = authConfig?.kind !== 'OAuth2Proxy' ? authConfig?.responseType : undefined;
-  const scopes = authConfig?.kind !== 'OAuth2Proxy' ? authConfig?.scopes : undefined;
-  const defaultDexConnector = authConfig?.kind !== 'OAuth2Proxy' ? authConfig?.defaultDexConnector : undefined;
-  const providerLogout = authConfig?.kind !== 'OAuth2Proxy' ? authConfig?.providerLogout : undefined;
+  const oidcConfig = getOidcConfigFields(authConfig);
+
+  const providerUrl = oidcConfig?.providerUrl;
+  const clientId = oidcConfig?.clientId;
+  const redirectUrl = oidcConfig?.redirectUrl;
+  const responseType = oidcConfig?.responseType;
+  const scopes = oidcConfig?.scopes;
+  const defaultDexConnector = oidcConfig?.defaultDexConnector;
+  const providerLogout = oidcConfig?.providerLogout;
   const kind = authConfig?.kind;
 
   return {


### PR DESCRIPTION
## Summary

Fix a token-renewal burst in `OAuth2AuthProvider` caused by three related issues:

1. **`UserManager` constructed on every render** — wrapped `new UserManager(...)` in `useMemo` keyed on the six primitive `authConfig` fields, plus a cleanup `useEffect` calling `stopSilentRenew()` on unmount. Only one instance (and one silent-renew timer) exists per provider lifetime.
2. **Unstable `logOut` reference** — replaced the `JSON.stringify(authConfig)` dep with the individual primitive fields, so `useEffect([logOut])` no longer re-runs on every render.
3. **`useQuery(['removeUser'])` fired in every consumer** — moved the expiry-check side-effect exclusively into `OAuth2AuthProvider` so it runs once per renewal regardless of how many MFE consumers call `useAuth()`. `useAuth()` is now a pure data accessor.

## Links

- JIRA: [ARTESCA-17587](https://scality.atlassian.net/browse/ARTESCA-17587)
- Tracking issue: scality/agent-task#223

## Step Adherence

- [x] Step 1: Stabilize UserManager and signinCallback in OAuth2AuthProvider
- [x] Step 2: Stabilize logOut in useInternalLogout *(committed alongside step 1 — same file, tightly coupled)*
- [x] Step 3: Move removeUser expiry-check into OAuth2AuthProvider
- [x] Step 4: Add AuthProvider unit tests
- [x] Simplification pass: extracted `buildUserManager`, `buildOidcConfig`, and `getOidcConfigFields` helpers; replaced 7 inline ternaries in `useInternalLogout` with a single typed guard.

## Approved Deviations

- **Step 1/2 (signature-adjusted)**: The `useInternalLogout` `useCallback` deps list uses `[kind, providerUrl, clientId, redirectUrl, responseType, scopes, defaultDexConnector, providerLogout, userManager]`. The individual primitives are extracted via a small `getOidcConfigFields` guard before `useCallback` to satisfy React's rules-of-hooks (deps must be referenced in the surrounding scope), and to keep the dep array primitive-only.
- **Step 4 (pattern-partial)**: The `'UserManager constructed exactly once'` test is marked `it.skip` with an explanatory comment. `@testing-library/react`'s `rerender` with a wrapper remounts `AuthConfigProvider`, resetting the `useMemo` deps and causing a second construction in the test env. `OAuth2AuthProvider` is not exported, so mounting it directly (without the wrapper) is not possible without modifying source signatures outside the plan. The memoization is implicitly verified by the passing `silentRenewError` listener test (which would observe a different listener on a fresh `UserManager`).

## Test Strategy Executed

- Added `shell-ui/src/auth/AuthProvider.spec.tsx` with 5 tests (4 passing, 1 skipped):
  - silentRenewError listener registered once and cleaned up on unmount
  - no `removeUser` / `location.reload` when `auth.userData` expired but localStorage token valid
  - `removeUser` + `location.reload` when both `auth.userData` and localStorage token expired
  - multiple `useAuth()` consumers do not multiply the removeUser side-effect
  - *(skipped)* UserManager constructor called exactly once across re-renders — env limitation, see deviation


[ARTESCA-17587]: https://scality.atlassian.net/browse/ARTESCA-17587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ