### PR TITLE
ARTESCA-17599: guard against alerts without a description annotation

### DIFF
--- a/shell-ui/src/alerts/services/alertUtils.ts
+++ b/shell-ui/src/alerts/services/alertUtils.ts
@@ -190,10 +190,10 @@ export const formatHistoryAlerts = (streamValues: StreamValue): Alert[] => {
         id: alert.fingerprint,
         summary: (alert.annotations && alert.annotations.summary) || '',
         description:
-        alert.annotations.description ||
-        alert.annotations.message ||
-        alert.annotations.summary ||
-        alert.labels.alertname,
+          alert.annotations.description ||
+          alert.annotations.message ||
+          alert.annotations.summary ||
+          alert.labels.alertname,
         startsAt: alert.startsAt,
         endsAt: alert.status === 'firing' ? new Date().toISOString() : alert.endsAt,
         severity: alert.labels.severity,

--- a/shell-ui/src/alerts/services/alertUtils.ts
+++ b/shell-ui/src/alerts/services/alertUtils.ts
@@ -83,7 +83,11 @@ export const formatActiveAlerts = (alerts: Array<PrometheusAlert>): Alert[] => {
     return {
       id: alert.fingerprint,
       summary: (alert.annotations && alert.annotations.summary) || '',
-      description: alert.annotations.description || alert.annotations.message,
+      description:
+        alert.annotations.description ||
+        alert.annotations.message ||
+        alert.annotations.summary ||
+        alert.labels.alertname,
       startsAt: alert.startsAt,
       endsAt: alert.endsAt || new Date().toISOString(),
       severity: alert.labels.severity,
@@ -185,7 +189,11 @@ export const formatHistoryAlerts = (streamValues: StreamValue): Alert[] => {
       [alert.fingerprint]: {
         id: alert.fingerprint,
         summary: (alert.annotations && alert.annotations.summary) || '',
-        description: alert.annotations.description || alert.annotations.message,
+        description:
+        alert.annotations.description ||
+        alert.annotations.message ||
+        alert.annotations.summary ||
+        alert.labels.alertname,
         startsAt: alert.startsAt,
         endsAt: alert.status === 'firing' ? new Date().toISOString() : alert.endsAt,
         severity: alert.labels.severity,

--- a/ui/src/services/alertUtils.ts
+++ b/ui/src/services/alertUtils.ts
@@ -72,7 +72,11 @@ export const formatActiveAlerts = (alerts: Array<PrometheusAlert>): Alert[] => {
     return {
       id: alert.fingerprint,
       summary: (alert.annotations && alert.annotations.summary) || '',
-      description: alert.annotations.description || alert.annotations.message,
+      description:
+        alert.annotations.description ||
+        alert.annotations.message ||
+        alert.annotations.summary ||
+        alert.labels.alertname,
       startsAt: alert.startsAt,
       endsAt: alert.endsAt || new Date().toISOString(),
       severity: alert.labels.severity,
@@ -175,7 +179,11 @@ export const formatHistoryAlerts = (streamValues: StreamValue): Alert[] => {
         [`${alert.fingerprint}-${alert.startsAt}`]: {
           id: alert.fingerprint,
           summary: (alert.annotations && alert.annotations.summary) || '',
-          description: alert.annotations.description || alert.annotations.message,
+          description:
+            alert.annotations.description ||
+            alert.annotations.message ||
+            alert.annotations.summary ||
+            alert.labels.alertname,
           startsAt: alert.startsAt,
           endsAt: alert.status === 'firing' ? null : alert.endsAt,
           severity: alert.labels.severity,


### PR DESCRIPTION
## Summary
- Extends the description fallback chain in `formatActiveAlerts` and `formatHistoryAlerts` (both `shell-ui` and the legacy `ui`) so an alert without `annotations.description` no longer renders as an empty row.
- Order now: `description` → `message` → `summary` → `alertname` label.

## Context
On a 4.3pw9 cluster, the new Overview page showed empty alert lines. Root cause: several upstream PrometheusRules only set `annotations.summary` (e.g. ARTESCA `UpgradeInProgress`/`UpgradeFailed`/`OSUpgrade*`, lib-alert-tree-derived `ClusterDegraded`/`CoreServicesDegraded`/`KubernetesControlPlaneDegraded`/`PlatformServicesDegraded`). The UI used `description: alert.annotations.description || alert.annotations.message` and rendered the result as text, so a missing description became an invisible row.

The companion fix for the ARTESCA upgrade rules ships in [bugfix/ARTESCA-17599-empty-alerts on scality/artesca](https://github.com/scality/artesca/tree/bugfix/ARTESCA-17599-empty-alerts). This PR is the defensive UI guard so future rules missing `description` never render blank.

Jira: https://scality.atlassian.net/browse/ARTESCA-17599

## Test plan
- [ ] Trigger an alert that only sets `annotations.summary` (e.g. `kubectl -n artesca-system create configmap upgrade-in-progress`) and verify the Overview row now shows the summary text instead of being blank
- [ ] Verify alerts that do have `annotations.description` still render exactly as before
- [ ] Verify the Alerts history view (Loki) renders the same fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)