### PR TITLE
fix(ui): separate Prometheus init from auth header update in federate…

### DIFF
--- a/ui/src/components/PlatformGlobalHealthBarFederated.tsx
+++ b/ui/src/components/PlatformGlobalHealthBarFederated.tsx
@@ -34,8 +34,13 @@ export default function PlatformGlobalHealthBarFederated({
    * The prometheus client could not be initialized in the parent component rendering it.
    */
   useLayoutEffect(() => {
-    if (token) {
+    if (prometheusUrl) {
       initializePrometheus(prometheusUrl);
+    }
+  }, [prometheusUrl]);
+
+  useLayoutEffect(() => {
+    if (token) {
       setHeaders({ Authorization: `Bearer ${token}` });
     }
   }, [prometheusUrl, token]);


### PR DESCRIPTION
…d health bar

Token refreshes were re-initializing the shared Prometheus API client, overwriting the correct baseURL set by the Platform UI saga. When navigating back to Platform UI, requests went to /api/v1/query_range instead of /api/prometheus/api/v1/query_range, returning HTML instead of JSON and crashing the UI with a TypeError on resultType.

Split the single useLayoutEffect into two: one for client initialization (keyed on prometheusUrl) and one for auth header updates (keyed on token).

Ref: ARTESCA-17585

**Component**:

<!-- E.g. 'salt', 'containers', 'kubernetes', 'build', 'tests'... -->

**Context**: 

**Summary**:

**Acceptance criteria**: 


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
