### PR TITLE
fix(ARTESCA-17681): unbreak System Load panel on wide time ranges

### DIFF
--- a/ui/src/services/platformlibrary/metrics.ts
+++ b/ui/src/services/platformlibrary/metrics.ts
@@ -147,7 +147,7 @@ export const getSystemLoadQuery = (instanceIP: string, timespanProps: TimeSpanPr
 };
 export const getNodesSystemLoadQuery = (timespanProps: TimeSpanProps) => {
   const { startingTimeISO, currentTimeISO, frequency } = timespanProps;
-  const systemLoadPrometheusQuery = `(avg(node_load1) by (instance) / ignoring(container,endpoint,job,namespace,pod,service,prometheus) count(node_cpu_seconds_total{mode="idle"}) without(cpu,mode)) * 100`;
+  const systemLoadPrometheusQuery = `(avg(node_load1) by (instance) / on(instance) count(count(node_cpu_seconds_total{mode="idle"}) by (instance, cpu)) by (instance)) * 100`;
   return {
     queryKey: ['SystemLoad', startingTimeISO],
     queryFn: () => {
@@ -159,7 +159,7 @@ export const getNodesSystemLoadQuery = (timespanProps: TimeSpanProps) => {
 };
 export const getNodesSystemLoadQuantileQuery = (timespanProps: TimeSpanProps, quantile: number) => {
   const queryName = 'SystemLoadQuantile';
-  const systemLoadQuantilePromQL = `quantile(${quantile}, (avg(node_load1) by (instance) / ignoring(container,endpoint,job,namespace,pod,service,prometheus) count(node_cpu_seconds_total{mode="idle"}) without(cpu,mode))) * 100`;
+  const systemLoadQuantilePromQL = `quantile(${quantile}, (avg(node_load1) by (instance) / on(instance) count(count(node_cpu_seconds_total{mode="idle"}) by (instance, cpu)) by (instance))) * 100`;
   const query = _getPromRangeMatrixQuery([queryName, `${quantile}`], systemLoadQuantilePromQL, timespanProps);
 
   return {
@@ -174,7 +174,7 @@ export const getNodesSystemLoadOutpassingThresholdQuery = (
   operator: '>' | '<',
   isOnHoverFetchingNeeded: boolean,
 ) => {
-  const nodesSystemLoadOutpassingThresholdPromQL = `(avg(node_load1) by (instance) / ignoring(container,endpoint,job,namespace,pod,service,prometheus) count(node_cpu_seconds_total{mode="idle"}) without(cpu,mode)) * 100 ${operator}= ${threshold}`;
+  const nodesSystemLoadOutpassingThresholdPromQL = `(avg(node_load1) by (instance) / on(instance) count(count(node_cpu_seconds_total{mode="idle"}) by (instance, cpu)) by (instance)) * 100 ${operator}= ${threshold}`;
   return {
     ..._getInstantValueQuery(
       // @ts-expect-error - FIXME when you are working on it


### PR DESCRIPTION
## Problem

On the Platform dashboard (`/platform/dashboard`), the **System Load** panel is empty on wide time ranges (e.g. *Last 7 days* / `?from=now-7d`) while it renders fine on *Last 24 hours* / *Last 1 hour*. Sibling panels (CPU, Memory, Disk, Bandwidth) are unaffected.

The panel is not returning empty data — the query fails with **HTTP 422 (execution error)**. The multi-node System Load queries divide two vectors with `ignoring(...,pod,...)` but aggregate the right-hand side with `count(node_cpu_seconds_total{mode="idle"}) without(cpu,mode)`, which *keeps* the `pod`/`namespace`/`prometheus` labels. When a node-exporter DaemonSet pod is recreated within the selected window, two pod-distinct series exist for the same `instance`; because the join ignores `pod`, the RHS collapses to duplicate series per instance and Thanos aborts the whole query:

```
found duplicate series for the match group {instance="10.160.122.207:9100"} on the
right hand-side of the operation:
 [{... pod="...-node-exporter-dqvl7", prometheus="metalk8s-monitoring/..."},
  {... pod="...-node-exporter-8lg82", prometheus="metalk8s-monitoring/..."}]
many-to-many matching not allowed: matching labels must be unique on one side
```

Narrow ranges only contain the current pod, so the RHS is unique and the query succeeds. The bug surfaces on any range spanning a node-exporter pod restart and self-heals once the old pod's samples age past retention.

## Fix

Aggregate the RHS by `(instance)` and join `on(instance)`, mirroring the already-correct per-node `getSystemLoadQuery` (which uses `count(count(...) by (cpu))` and is robust to duplicate pods):

```
(avg(node_load1) by (instance) / on(instance) count(count(node_cpu_seconds_total{mode="idle"}) by (instance, cpu)) by (instance)) * 100
```

This drops the offending labels from the RHS and dedupes the CPU count across overlapping node-exporter pods. Applied to all three affected functions in `ui/src/services/platformlibrary/metrics.ts`:
- `getNodesSystemLoadQuery` (the dashboard System Load panel)
- `getNodesSystemLoadQuantileQuery`
- `getNodesSystemLoadOutpassingThresholdQuery`

## Verification

Ran both queries through `thanos-query` (the live `/api/prometheus` path) on a cluster exhibiting the bug, over the failing 7d window:
- **Before** → `status: error … found duplicate series … many-to-many matching not allowed`
- **After** → `status: success`, full matrix of System Load values across the whole 7d window

Jira: ARTESCA-17681 (fixVersion 4.3.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)