### PR TITLE
feat(shell-ui): source Guardian origin from config + add source suffix

### DIFF
--- a/shell-ui/public/config.json
+++ b/shell-ui/public/config.json
@@ -16,6 +16,7 @@
   "productName": "MetalK8s",
   "canChangeTheme": true,
   "canUseGuardian": false,
+  "guardianOrigin": "http://localhost:8080",
   "themes": {
     "dark": {
       "type": "core-ui",

--- a/shell-ui/src/guardian/GuardianDrawer.tsx
+++ b/shell-ui/src/guardian/GuardianDrawer.tsx
@@ -21,7 +21,7 @@ export const GuardianDrawer = () => {
   // Bare origin (no query): used for postMessage targeting and origin checks.
   const guardianOrigin = config.guardianOrigin || GUARDIAN_ORIGIN_FALLBACK;
   // iframe src carries the source suffix; the origin passed to the hooks does not.
-  const iframeSrc = `${guardianOrigin}?source=${sourceForProduct(config.productName)}`;
+  const iframeSrc = `${guardianOrigin}?source=${encodeURIComponent(sourceForProduct(config.productName))}`;
 
   useDiscoveryEmitter(iframeRef, guardianOrigin);
   useMcpCallHandler(iframeRef, guardianOrigin);

--- a/shell-ui/src/guardian/GuardianDrawer.tsx
+++ b/shell-ui/src/guardian/GuardianDrawer.tsx
@@ -8,9 +8,10 @@ const DRAWER_WIDTH = 500;
 // Fallback Guardian origin for local development when shell config omits it.
 const GUARDIAN_ORIGIN_FALLBACK = 'http://localhost:8080';
 
-// Maps the shell product to the `source` value Guardian filters agents by.
-// RING reports `ring_ui`; every other console in the shell family is `artesca_ui`.
-const sourceForProduct = (productName: string): string => (productName === 'RING' ? 'ring_ui' : 'artesca_ui');
+// Maps the shell product to the `source` value Guardian filters agents by:
+// the lowercased product name with a `_ui` suffix (ARTESCA -> artesca_ui,
+// RING -> ring_ui).
+const sourceForProduct = (productName: string): string => `${productName.toLowerCase()}_ui`;
 
 export const GuardianDrawer = () => {
   const { isOpen } = useGuardianDrawer();

--- a/shell-ui/src/guardian/GuardianDrawer.tsx
+++ b/shell-ui/src/guardian/GuardianDrawer.tsx
@@ -1,15 +1,29 @@
 import { useRef } from 'react';
+import { useShellConfig } from '../initFederation/ShellConfigProvider';
 import { useGuardianDrawer } from './GuardianContext';
-import { GUARDIAN_ORIGIN, useDiscoveryEmitter, useMcpCallHandler } from './guardianPostMessageHooks';
+import { useDiscoveryEmitter, useMcpCallHandler } from './guardianPostMessageHooks';
 
 const DRAWER_WIDTH = 500;
 
+// Fallback Guardian origin for local development when shell config omits it.
+const GUARDIAN_ORIGIN_FALLBACK = 'http://localhost:8080';
+
+// Maps the shell product to the `source` value Guardian filters agents by.
+// RING reports `ring_ui`; every other console in the shell family is `artesca_ui`.
+const sourceForProduct = (productName: string): string => (productName === 'RING' ? 'ring_ui' : 'artesca_ui');
+
 export const GuardianDrawer = () => {
   const { isOpen } = useGuardianDrawer();
+  const { config } = useShellConfig();
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
 
-  useDiscoveryEmitter(iframeRef);
-  useMcpCallHandler(iframeRef);
+  // Bare origin (no query): used for postMessage targeting and origin checks.
+  const guardianOrigin = config.guardianOrigin || GUARDIAN_ORIGIN_FALLBACK;
+  // iframe src carries the source suffix; the origin passed to the hooks does not.
+  const iframeSrc = `${guardianOrigin}?source=${sourceForProduct(config.productName)}`;
+
+  useDiscoveryEmitter(iframeRef, guardianOrigin);
+  useMcpCallHandler(iframeRef, guardianOrigin);
 
   return (
     <div
@@ -25,7 +39,7 @@ export const GuardianDrawer = () => {
     >
       <iframe
         ref={iframeRef}
-        src={GUARDIAN_ORIGIN}
+        src={iframeSrc}
         title="Guardian AI Assistant"
         style={{ width: DRAWER_WIDTH, height: '100%', border: 'none', background: '#000' }}
         allow="clipboard-write"

--- a/shell-ui/src/guardian/guardianPostMessageHooks.ts
+++ b/shell-ui/src/guardian/guardianPostMessageHooks.ts
@@ -1,28 +1,27 @@
 import type { ModelContextWithExtensions } from '@mcp-b/webmcp-types';
-import { useCallback, useEffect } from "react";
-
-export const GUARDIAN_ORIGIN = process.env.GUARDIAN_ORIGIN || 'http://localhost:8080';
+import { useCallback, useEffect } from 'react';
 
 // How often to re-send MCP_DISCOVERY (Guardian's React app may mount after the iframe load event)
 const DISCOVERY_INTERVAL_MS = 3000;
 
-export const useDiscoveryEmitter = (iframeRef: React.RefObject<HTMLIFrameElement>) => {
+// Both hooks take the Guardian `origin` (scheme + host + port, no query string)
+// sourced from shell config. It is used as the postMessage target origin and to
+// validate inbound message origins, so it must stay query-string-free even when
+// the iframe src carries a `?source=` suffix.
+export const useDiscoveryEmitter = (iframeRef: React.RefObject<HTMLIFrameElement>, origin: string) => {
   // biome-ignore lint/correctness/useExhaustiveDependencies: useRef dependency
   const sendDiscovery = useCallback(() => {
     const tools = (navigator.modelContext as ModelContextWithExtensions)?.listTools?.() ?? [];
-    iframeRef.current?.contentWindow?.postMessage?.(
-      { type: 'MCP_DISCOVERY', tools },
-      GUARDIAN_ORIGIN,
-    );
-  }, []);
+    iframeRef.current?.contentWindow?.postMessage?.({ type: 'MCP_DISCOVERY', tools }, origin);
+  }, [origin]);
 
   useEffect(() => {
     const interval = setInterval(sendDiscovery, DISCOVERY_INTERVAL_MS);
     return () => clearInterval(interval);
   }, [sendDiscovery]);
-}
+};
 
-export const useMcpCallHandler = (iframeRef: React.RefObject<HTMLIFrameElement>) => {
+export const useMcpCallHandler = (iframeRef: React.RefObject<HTMLIFrameElement>, origin: string) => {
   const postResponse = (id: string, response: unknown, error?: { code: number; message: string }) => {
     // biome-ignore lint/suspicious/noExplicitAny: it's postMessage arg type
     const message: any = { type: 'MCP_RESPONSE', id };
@@ -33,13 +32,13 @@ export const useMcpCallHandler = (iframeRef: React.RefObject<HTMLIFrameElement>)
       console.debug('[GuardianBubble] MCP_RESPONSE sent:', response);
       message.result = response;
     }
-    iframeRef.current?.contentWindow?.postMessage(message, GUARDIAN_ORIGIN);
+    iframeRef.current?.contentWindow?.postMessage(message, origin);
   };
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: useRef dependency
   useEffect(() => {
     const handler = async (event: MessageEvent) => {
-      if (event.origin !== GUARDIAN_ORIGIN) return;
+      if (event.origin !== origin) return;
       if (event.data?.type !== 'MCP_CALL') return;
 
       const payload = event.data.payload;
@@ -58,10 +57,7 @@ export const useMcpCallHandler = (iframeRef: React.RefObject<HTMLIFrameElement>)
 
       // Immediately acknowledge reception
       console.debug('[GuardianBubble] MCP_ACK sent for id:', id);
-      iframeRef.current?.contentWindow?.postMessage(
-        { type: 'MCP_ACK', id },
-        GUARDIAN_ORIGIN,
-      );
+      iframeRef.current?.contentWindow?.postMessage({ type: 'MCP_ACK', id }, origin);
 
       try {
         const result = await (navigator.modelContext as ModelContextWithExtensions)?.callTool?.(params);
@@ -74,5 +70,5 @@ export const useMcpCallHandler = (iframeRef: React.RefObject<HTMLIFrameElement>)
 
     window.addEventListener('message', handler);
     return () => window.removeEventListener('message', handler);
-  }, []);
-}
+  }, [origin]);
+};

--- a/shell-ui/src/initFederation/ShellConfigProvider.tsx
+++ b/shell-ui/src/initFederation/ShellConfigProvider.tsx
@@ -48,6 +48,10 @@ export type ShellJSONFileConfig = {
   themes: Themes;
   favicon?: string;
 
+  // Origin of the embedded Guardian AI assistant (scheme + host + port, no path
+  // or query). Used as the iframe src and as the postMessage target origin.
+  guardianOrigin?: string;
+
   // for IDP that does not support user groups (ie: Dex)
   userGroupsMapping?: UserGroupsMapping;
 


### PR DESCRIPTION
## What

Lets the shell-ui tell the embedded Guardian AI assistant which console it is running in, via a `?source=` suffix on the iframe, and sources the Guardian origin from shell config instead of a build-time env var.

This pairs with [guardian-ui#275](https://github.com/scality/guardian-ui/pull/275) (which reads `?source=` and forwards it to the backend) and the `source` contract in [guardian-backend#306](https://github.com/scality/guardian-backend/pull/306).

## Changes

- **`ShellConfigProvider`** — add optional `guardianOrigin` to `ShellJSONFileConfig`.
- **`GuardianDrawer`** — read `guardianOrigin` + `productName` from `useShellConfig()`; set `iframe.src = ${origin}?source=<artesca_ui|ring_ui>` (`RING` → `ring_ui`, otherwise `artesca_ui`). `localhost:8080` dev fallback when `guardianOrigin` is unset.
- **`guardianPostMessageHooks`** — drop the `process.env.GUARDIAN_ORIGIN` constant; both hooks now take the **bare origin** (scheme + host + port, no query) as an argument, used for the `postMessage` target origin and the `event.origin` check. Keeping the origin query-string-free is why it's threaded separately from the iframe `src`.
- **`public/config.json`** — example `guardianOrigin`.

## Note on `ring_ui`

guardian-backend doesn't yet accept `ring_ui` (its `SourceType` is `portal | artesca_ui`), so the RING console's `?source=ring_ui` will 422 until a backend follow-up adds it. Sending it now is intentional.

## Base branch

Targets `development/133.0`, which already contains the Guardian/webmcp integration (`feature/MK8S-196-add-webmcp-protocol-support`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)