### PR TITLE
feat: make node monitoring and Pod eviction timeouts configurable (MK8S-318)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Enhancements
 
+- Make node monitoring and Pod eviction timeouts configurable through the
+  `BootstrapConfiguration`: `kube-apiserver`
+  `defaultNotReadyTolerationSeconds`/`defaultUnreachableTolerationSeconds`
+  (default `60`), `kube-controller-manager`
+  `nodeMonitorGracePeriod`/`nodeMonitorPeriod` (default `30s`/`5s`) and kubelet
+  `nodeStatusUpdateFrequency` (default `10s`)
+  (MK8S-318)
+
 - Bump Kubernetes version to [1.34.7](https://github.com/kubernetes/kubernetes/releases/tag/v1.34.7)
   (PR[#4928](https://github.com/scality/metalk8s/pull/4928))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
   `defaultNotReadyTolerationSeconds`/`defaultUnreachableTolerationSeconds`
   (default `60`), `kube-controller-manager`
   `nodeMonitorGracePeriod`/`nodeMonitorPeriod` (default `30s`/`5s`) and kubelet
-  `nodeStatusUpdateFrequency` (default `10s`)
-  (MK8S-318)
+  `nodeStatusUpdateFrequency` (default `10s`). 
+  (PR[#4966](https://github.com/scality/metalk8s/pull/4966))
 
 - Bump Kubernetes version to [1.34.7](https://github.com/kubernetes/kubernetes/releases/tag/v1.34.7)
   (PR[#4928](https://github.com/scality/metalk8s/pull/4928))

--- a/docs/installation/bootstrap.rst
+++ b/docs/installation/bootstrap.rst
@@ -280,7 +280,7 @@ defaults kubernetes configuration.
     network interruption, high CPU load delaying status reports) may trigger
     unnecessary evictions. The total time before eviction is roughly
     ``nodeStatusUpdateFrequency + nodeMonitorGracePeriod +
-    default*TolerationSeconds``.
+    default[NotReady/Unreachable]TolerationSeconds``.
 
 The ``salt`` field can be omitted if you do not have any specific salt settings
 to configure.

--- a/docs/installation/bootstrap.rst
+++ b/docs/installation/bootstrap.rst
@@ -80,9 +80,14 @@ Configuration
           oidc: {}
           featureGates:
             <feature_gate_name>: True
+          config:
+            defaultNotReadyTolerationSeconds: 60
+            defaultUnreachableTolerationSeconds: 60
         controllerManager:
           config:
             terminatedPodGCThreshold: 500
+            nodeMonitorGracePeriod: 30s
+            nodeMonitorPeriod: 5s
         coreDNS:
           hostForward: True
           replicas: 2
@@ -94,6 +99,7 @@ Configuration
         kubelet:
           config:
             maxPods: 110
+            nodeStatusUpdateFrequency: 10s
       salt:
         master:
           worker_threads: 12
@@ -245,13 +251,36 @@ defaults kubernetes configuration.
               hard:
                 - topologyKey: kubernetes.io/hostname
 
+  From ``apiServer`` section you can also tune how long ``kube-apiserver``
+  waits before evicting Pods running on a node that has been marked
+  ``NotReady`` or unreachable, through ``config.defaultNotReadyTolerationSeconds``
+  and ``config.defaultUnreachableTolerationSeconds`` (both default to ``60``
+  seconds).
+
   From ``controllerManager`` section you can override the number of terminated
   pods that can exist before the terminated pod garbage collector starts
   deleting them. If it's set to 0, the terminated pod garbage collector is
   disabled (default to ``500``)
 
+  You can also tune how the ``kube-controller-manager`` monitors nodes with
+  ``config.nodeMonitorGracePeriod``, the time a node can be unresponsive before
+  being marked ``NotReady`` (default to ``30s``), and ``config.nodeMonitorPeriod``,
+  the period of node status syncing (default to ``5s``).
+
   From ``kubelet`` section you can override the max number of pods that can
-  be scheduled on each nodes.
+  be scheduled on each nodes, and ``config.nodeStatusUpdateFrequency``, the
+  frequency at which the kubelet computes and reports node status (default to
+  ``10s``).
+
+  .. note::
+
+    These node monitoring and eviction settings control how fast Pods running
+    on a failed node get rescheduled elsewhere. Lowering them speeds up
+    recovery but, if set too low, transient issues (kubelet restart, brief
+    network interruption, high CPU load delaying status reports) may trigger
+    unnecessary evictions. The total time before eviction is roughly
+    ``nodeStatusUpdateFrequency + nodeMonitorGracePeriod +
+    default*TolerationSeconds``.
 
 The ``salt`` field can be omitted if you do not have any specific salt settings
 to configure.

--- a/salt/_pillar/metalk8s.py
+++ b/salt/_pillar/metalk8s.py
@@ -155,9 +155,31 @@ def _load_kubernetes(config_data):
     # Default CoreDNS host forwarding to True
     kubernetes_data["coreDNS"].setdefault("hostForward", True)
 
-    kubernetes_data.setdefault("controllerManager", {}).setdefault(
+    controller_manager_config = kubernetes_data.setdefault(
+        "controllerManager", {}
+    ).setdefault("config", {})
+    controller_manager_config.setdefault("terminatedPodGCThreshold", 500)
+    # Time a node can be unresponsive before being marked NotReady by the
+    # kube-controller-manager (`--node-monitor-grace-period`).
+    controller_manager_config.setdefault("nodeMonitorGracePeriod", "30s")
+    # Period of node status syncing performed by the kube-controller-manager
+    # (`--node-monitor-period`).
+    controller_manager_config.setdefault("nodeMonitorPeriod", "5s")
+
+    # Time the kube-apiserver waits before evicting Pods from a node marked
+    # NotReady / unreachable (`--default-not-ready-toleration-seconds` and
+    # `--default-unreachable-toleration-seconds`).
+    api_server_config = kubernetes_data.setdefault("apiServer", {}).setdefault(
         "config", {}
-    ).setdefault("terminatedPodGCThreshold", 500)
+    )
+    api_server_config.setdefault("defaultNotReadyTolerationSeconds", 60)
+    api_server_config.setdefault("defaultUnreachableTolerationSeconds", 60)
+
+    # Frequency at which the kubelet computes and reports node status
+    # (`nodeStatusUpdateFrequency`).
+    kubernetes_data.setdefault("kubelet", {}).setdefault("config", {}).setdefault(
+        "nodeStatusUpdateFrequency", "10s"
+    )
 
     return kubernetes_data
 

--- a/salt/metalk8s/kubernetes/apiserver/installed.sls
+++ b/salt/metalk8s/kubernetes/apiserver/installed.sls
@@ -107,6 +107,8 @@ Create kube-apiserver Pod manifest:
           - --bind-address={{ host }}
           - --encryption-provider-config={{ encryption_k8s_path }}
           - --cors-allowed-origins=^.*$
+          - --default-not-ready-toleration-seconds={{ pillar.kubernetes.apiServer.config.defaultNotReadyTolerationSeconds }}
+          - --default-unreachable-toleration-seconds={{ pillar.kubernetes.apiServer.config.defaultUnreachableTolerationSeconds }}
           - --v={{ 2 if metalk8s.debug else 0 }}
           - --authentication-config={{ authn_config_path }}
           {% if feature_gates %}

--- a/salt/metalk8s/kubernetes/controller-manager/installed.sls
+++ b/salt/metalk8s/kubernetes/controller-manager/installed.sls
@@ -43,6 +43,8 @@ Create kube-controller-manager Pod manifest:
           - --allocate-node-cidrs=true
           - --cluster-cidr={{ networks.pod }}
           - --node-cidr-mask-size=24
+          - --node-monitor-grace-period={{ pillar.kubernetes.controllerManager.config.nodeMonitorGracePeriod }}
+          - --node-monitor-period={{ pillar.kubernetes.controllerManager.config.nodeMonitorPeriod }}
           - --terminated-pod-gc-threshold={{ pillar.kubernetes.controllerManager.config.terminatedPodGCThreshold }}
           - --v={{ 2 if metalk8s.debug else 0 }}
         requested_cpu: 200m

--- a/salt/metalk8s/kubernetes/kubelet/standalone.sls
+++ b/salt/metalk8s/kubernetes/kubelet/standalone.sls
@@ -86,7 +86,7 @@ Create kubelet config file:
           verbosity: 0
         memorySwap: {}
         nodeStatusReportFrequency: 0s
-        nodeStatusUpdateFrequency: 0s
+        nodeStatusUpdateFrequency: {{ pillar.kubernetes.kubelet.config.nodeStatusUpdateFrequency }}
         # Disable rotate Certificates as we manage certificate rotation ourself
         # with salt
         # rotateCertificates: true

--- a/salt/tests/unit/formulas/data/base_pillar.yaml
+++ b/salt/tests/unit/formulas/data/base_pillar.yaml
@@ -180,9 +180,18 @@ certificates:
       workload-plane-ingress:
         watched: true
 kubernetes:
+  apiServer:
+    config:
+      defaultNotReadyTolerationSeconds: 60
+      defaultUnreachableTolerationSeconds: 60
   controllerManager:
     config:
       terminatedPodGCThreshold: 500
+      nodeMonitorGracePeriod: 30s
+      nodeMonitorPeriod: 5s
+  kubelet:
+    config:
+      nodeStatusUpdateFrequency: 10s
   coreDNS:
     hostForward: true
     replicas: 2


### PR DESCRIPTION
## Context

Jira: [MK8S-318](https://scality.atlassian.net/browse/MK8S-318)
When a node becomes `NotReady`/unreachable it takes ~6 min with the Kubernetes defaults before Pods running on it start being evicted/rescheduled (10s kubelet heartbeat + 50s monitor grace period + 300s API server toleration). During that window other nodes keep trying to reach the now-unavailable Pods.

This makes the relevant control-plane and kubelet settings configurable through the `BootstrapConfiguration`, so downstream products and operators can tune the recovery time for their environment.

## Changes

Newly configurable settings (with the values MetalK8s now defaults to):

| Component | Setting | BootstrapConfiguration key | Default |
|-----------|---------|----------------------------|---------|
| kube-apiserver | `--default-not-ready-toleration-seconds` | `kubernetes.apiServer.config.defaultNotReadyTolerationSeconds` | `60` |
| kube-apiserver | `--default-unreachable-toleration-seconds` | `kubernetes.apiServer.config.defaultUnreachableTolerationSeconds` | `60` |
| kube-controller-manager | `--node-monitor-grace-period` | `kubernetes.controllerManager.config.nodeMonitorGracePeriod` | `30s` |
| kube-controller-manager | `--node-monitor-period` | `kubernetes.controllerManager.config.nodeMonitorPeriod` | `5s` |
| kubelet | `nodeStatusUpdateFrequency` | `kubernetes.kubelet.config.nodeStatusUpdateFrequency` | `10s` |

Defaults follow the existing `terminatedPodGCThreshold` / `maxPods` pattern (set via `setdefault` in the `metalk8s` ext_pillar), so omitting the keys keeps the documented defaults and user overrides are preserved.

Example override:

```yaml
kubernetes:
  apiServer:
    config:
      defaultNotReadyTolerationSeconds: 20
      defaultUnreachableTolerationSeconds: 20
```

## Files

- `salt/_pillar/metalk8s.py` — defaults for the new keys
- `salt/metalk8s/kubernetes/apiserver/installed.sls` — render the two toleration flags
- `salt/metalk8s/kubernetes/controller-manager/installed.sls` — render the two node-monitor flags
- `salt/metalk8s/kubernetes/kubelet/standalone.sls` — source `nodeStatusUpdateFrequency` from pillar (was hardcoded `0s`)
- `salt/tests/unit/formulas/data/base_pillar.yaml` — test pillar data
- `docs/installation/bootstrap.rst`, `CHANGELOG.md` — docs

## Testing

- Formula render tests pass for apiserver / controller-manager / kubelet templates.
- Verified the ext_pillar merge applies defaults and honors overrides without clobbering existing `apiServer.featureGates` / `oidc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MK8S-318]: https://scality.atlassian.net/browse/MK8S-318