### PR TITLE
improvement(shell-ui): upgrade WebMCP to 3.0 and harden tool registration

### DIFF
--- a/shell-ui/package-lock.json
+++ b/shell-ui/package-lock.json
@@ -8,9 +8,9 @@
       "name": "shell-ui",
       "version": "1.0.0",
       "dependencies": {
-        "@mcp-b/global": "^2.2.0",
-        "@mcp-b/webmcp-local-relay": "^2.2.0",
-        "@mcp-b/webmcp-types": "^2.2.0",
+        "@mcp-b/global": "^3.0.0",
+        "@mcp-b/webmcp-local-relay": "^3.0.0",
+        "@mcp-b/webmcp-types": "^3.0.0",
         "@scality/core-ui": "0.219.0",
         "@scality/module-federation": "1.6.1",
         "downshift": "^8.0.0",
@@ -3803,27 +3803,27 @@
       "license": "MIT"
     },
     "node_modules/@mcp-b/global": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@mcp-b/global/-/global-2.2.0.tgz",
-      "integrity": "sha512-3+FNuVXPGyhzYsVPL5UItMkTF+GD6E3iHEmuJY0yydjjpWtlqrUw7b7PLhyuymKcc1+jTMunyrr3Zps0uPEfiw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mcp-b/global/-/global-3.0.0.tgz",
+      "integrity": "sha512-HZWlR2Gb5v/ROtg0noiiHfrnHVPYxxhOPPaeYlXvCd6UB/u82Q3lwtCdWQLw66N25Zp9VSMGRR1Eq72yDFqcNQ==",
       "license": "MIT",
       "dependencies": {
-        "@mcp-b/transports": "2.2.0",
-        "@mcp-b/webmcp-polyfill": "2.2.0",
-        "@mcp-b/webmcp-ts-sdk": "2.2.0",
-        "@mcp-b/webmcp-types": "2.2.0"
+        "@mcp-b/transports": "3.0.0",
+        "@mcp-b/webmcp-polyfill": "3.0.0",
+        "@mcp-b/webmcp-ts-sdk": "3.0.0",
+        "@mcp-b/webmcp-types": "3.0.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@mcp-b/transports": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@mcp-b/transports/-/transports-2.2.0.tgz",
-      "integrity": "sha512-zSqYekrmou72z67GF5jXaDnQdhT84Hlmi4meshm0zMn71GlaYmHhXfb3UsgW3xQ7Y5CexQ4U9L9IrdG6/+MTfA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mcp-b/transports/-/transports-3.0.0.tgz",
+      "integrity": "sha512-WMgeb0P9Bhu+0mN07qkvCo+W9Fucdk9+iyp7wPZYAtQ4ZTcbNuu8Zl1qdNM8oWxXgMbA749w4nUcPsbPaMvSvA==",
       "license": "MIT",
       "dependencies": {
-        "@mcp-b/webmcp-ts-sdk": "2.2.0",
+        "@mcp-b/webmcp-ts-sdk": "3.0.0",
         "zod": "3.25.76"
       }
     },
@@ -3837,9 +3837,9 @@
       }
     },
     "node_modules/@mcp-b/webmcp-local-relay": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@mcp-b/webmcp-local-relay/-/webmcp-local-relay-2.2.0.tgz",
-      "integrity": "sha512-JYNAp5jjNto+0yW+ONjKZEpUE8SdOBUYsgF88lv1i4DVg2Smzn+q6+WN5glJ0HZ1KBtkXJtOWAHWLRLFfxwOpw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mcp-b/webmcp-local-relay/-/webmcp-local-relay-3.0.0.tgz",
+      "integrity": "sha512-p8Yp4ecitHt9YvSrTGRaENA9s2fCa+YUo0qyIMs27mI1rAoWV3qtVSVrbc7jvLfll+hdAuPB+Qv0+tC+rST4ng==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.26.0",
@@ -3847,7 +3847,7 @@
         "zod": "3.25.76"
       },
       "bin": {
-        "webmcp-local-relay": "dist/cli.js"
+        "webmcp-local-relay": "dist/cli.mjs"
       },
       "engines": {
         "node": ">=22"
@@ -3884,13 +3884,13 @@
       }
     },
     "node_modules/@mcp-b/webmcp-polyfill": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@mcp-b/webmcp-polyfill/-/webmcp-polyfill-2.2.0.tgz",
-      "integrity": "sha512-as49JP4MHXVMMVNzD8938EsiU2tEzWNk7Un6c6C/xK5rstkIrQZQsVLbH7NFtmgMb6bbryzSqg9JWSFIxkU27Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mcp-b/webmcp-polyfill/-/webmcp-polyfill-3.0.0.tgz",
+      "integrity": "sha512-TCrCOZCTfRWrTp8MpWU8EO4U7r7IvDDaIYW9Ej0aBD2KVR2hvwr4t3T7kPkSYssGhpIZJrq19owSzN1vZabW+A==",
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.1.1",
-        "@mcp-b/webmcp-types": "2.2.0",
+        "@mcp-b/webmcp-types": "3.0.0",
         "@standard-schema/spec": "^1.1.0"
       },
       "engines": {
@@ -3898,13 +3898,13 @@
       }
     },
     "node_modules/@mcp-b/webmcp-ts-sdk": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@mcp-b/webmcp-ts-sdk/-/webmcp-ts-sdk-2.2.0.tgz",
-      "integrity": "sha512-IzjwqrpbbASbAJxpr5k5m1ryiELGdnohDXzpLuB7UK2VI1rsAwQ04j59uRkMvaqZ4iwvxHTzKk+AajRB57OcPw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mcp-b/webmcp-ts-sdk/-/webmcp-ts-sdk-3.0.0.tgz",
+      "integrity": "sha512-Lbn7ODKWMYd6xqpcl+OmXseKbjwB+Q3F9CUm9vDFpZgviWc3/5CuG3IDylHg/toVMeZz6v5+E8AmBnv8zj5G5w==",
       "license": "MIT",
       "dependencies": {
-        "@mcp-b/webmcp-polyfill": "2.2.0",
-        "@mcp-b/webmcp-types": "2.2.0"
+        "@mcp-b/webmcp-polyfill": "3.0.0",
+        "@mcp-b/webmcp-types": "3.0.0"
       },
       "engines": {
         "node": ">=18"
@@ -3923,9 +3923,9 @@
       }
     },
     "node_modules/@mcp-b/webmcp-types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@mcp-b/webmcp-types/-/webmcp-types-2.2.0.tgz",
-      "integrity": "sha512-1/UYAwQKBkqRgK18GkbGR4m6Cn9vz6Qy6pTL5LIIinUOhR5dMLaNl/blH/tJT+nJleMmgDoFZWGAmmr+fAz2PQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mcp-b/webmcp-types/-/webmcp-types-3.0.0.tgz",
+      "integrity": "sha512-MmKHNAtlyZoK5khz5GnmgEj/ehk5esoUbgOaFndrlZvpjq3ppmIY3BDrwCv6xaihuuIMOoLLDlf0E65wUd4q7A==",
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {

--- a/shell-ui/package.json
+++ b/shell-ui/package.json
@@ -46,9 +46,9 @@
     "ts-node": "^10.9.2"
   },
   "dependencies": {
-    "@mcp-b/global": "^2.2.0",
-    "@mcp-b/webmcp-local-relay": "^2.2.0",
-    "@mcp-b/webmcp-types": "^2.2.0",
+    "@mcp-b/global": "^3.0.0",
+    "@mcp-b/webmcp-local-relay": "^3.0.0",
+    "@mcp-b/webmcp-types": "^3.0.0",
     "@scality/core-ui": "0.219.0",
     "@scality/module-federation": "1.6.1",
     "downshift": "^8.0.0",

--- a/shell-ui/src/guardian/guardianPostMessageHooks.ts
+++ b/shell-ui/src/guardian/guardianPostMessageHooks.ts
@@ -11,7 +11,10 @@ const DISCOVERY_INTERVAL_MS = 3000;
 export const useDiscoveryEmitter = (iframeRef: React.RefObject<HTMLIFrameElement>, origin: string) => {
   // biome-ignore lint/correctness/useExhaustiveDependencies: useRef dependency
   const sendDiscovery = useCallback(() => {
-    const tools = (navigator.modelContext as ModelContextWithExtensions)?.listTools?.() ?? [];
+    // Chrome 150 moved modelContext from navigator to document; navigator is a
+    // deprecated alias. https://github.com/webmachinelearning/webmcp/pull/184
+    const modelContext = document.modelContext || navigator.modelContext;
+    const tools = (modelContext as ModelContextWithExtensions)?.listTools?.() ?? [];
     iframeRef.current?.contentWindow?.postMessage?.({ type: 'MCP_DISCOVERY', tools }, origin);
   }, [origin]);
 
@@ -60,7 +63,8 @@ export const useMcpCallHandler = (iframeRef: React.RefObject<HTMLIFrameElement>,
       iframeRef.current?.contentWindow?.postMessage({ type: 'MCP_ACK', id }, origin);
 
       try {
-        const result = await (navigator.modelContext as ModelContextWithExtensions)?.callTool?.(params);
+        const modelContext = document.modelContext || navigator.modelContext;
+        const result = await (modelContext as ModelContextWithExtensions)?.callTool?.(params);
         postResponse(id, result);
       } catch (err) {
         console.error('[GuardianBubble] Tool execution failed:', err);

--- a/shell-ui/src/mcp/MCPRegistrar.test.tsx
+++ b/shell-ui/src/mcp/MCPRegistrar.test.tsx
@@ -44,9 +44,21 @@ type RegisteredTool = {
 
 const registeredTools: Record<string, RegisteredTool> = {};
 
+// Mirror the WebMCP v3 runtime semantics: registerTool throws on a duplicate name
+// (https://github.com/WebMCP-org/npm-packages/issues/231) and an aborted
+// options.signal unregisters the tool (the spec-blessed cleanup path that
+// replaced the now-removed unregisterTool).
+type RegisterToolOptions = { signal?: AbortSignal };
+
 const mockModelContext = {
-  registerTool: jest.fn((tool: RegisteredTool) => {
+  registerTool: jest.fn((tool: RegisteredTool, options?: RegisterToolOptions) => {
+    if (registeredTools[tool.name]) {
+      throw new Error(`Tool already registered: ${tool.name}`);
+    }
     registeredTools[tool.name] = tool;
+    options?.signal?.addEventListener('abort', () => {
+      delete registeredTools[tool.name];
+    });
   }),
   unregisterTool: jest.fn((name: string) => {
     delete registeredTools[name];
@@ -65,11 +77,15 @@ beforeEach(() => {
   Object.keys(registeredTools).forEach((k) => delete registeredTools[k]);
   jest.clearAllMocks();
   mockGetToken.mockResolvedValue('test-token');
+  // Chrome 150+ exposes modelContext on document; navigator is a deprecated alias.
+  // Default tests onto document; feature-detection tests override per case.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (navigator as any).modelContext = mockModelContext;
+  (document as any).modelContext = mockModelContext;
 });
 
 afterEach(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (document as any).modelContext;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   delete (navigator as any).modelContext;
 });
@@ -194,6 +210,7 @@ describe('_InternalMCPRegistrar', () => {
         expect.objectContaining({
           annotations: { readOnlyHint: true, openWorldHint: true },
         }),
+        expect.anything(),
       );
       const listed = mockModelContext.listTools();
       expect(listed[0].annotations).toEqual({ readOnlyHint: true, openWorldHint: true });
@@ -273,7 +290,7 @@ describe('_InternalMCPRegistrar', () => {
   });
 
   describe('cleanup', () => {
-    it('unregisters all tools on unmount', () => {
+    it('registers each tool with an AbortSignal and unregisters all on unmount', () => {
       const moduleExports = {
         [MODULE_KEY]: {
           createTools: () => [makeTool({ name: 'tool1' }), makeTool({ name: 'tool2' })],
@@ -290,17 +307,120 @@ describe('_InternalMCPRegistrar', () => {
       );
 
       expect(mockModelContext.listTools()).toHaveLength(2);
+      // Cleanup must go through the spec-blessed AbortSignal path, not the
+      // removed unregisterTool API.
+      expect(mockModelContext.registerTool).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+      expect(mockModelContext.unregisterTool).not.toHaveBeenCalled();
 
       unmount();
 
       expect(mockModelContext.listTools()).toHaveLength(0);
-      expect(mockModelContext.unregisterTool).toHaveBeenCalledWith('tool1');
-      expect(mockModelContext.unregisterTool).toHaveBeenCalledWith('tool2');
+    });
+  });
+
+  describe('duplicate registration guard', () => {
+    it('does not re-register a tool whose name is already registered', () => {
+      // Simulate the name already being present (another app, a StrictMode/HMR
+      // remount, etc.). Re-registering would throw in WebMCP — see #231.
+      registeredTools['testTool'] = makeTool() as unknown as RegisteredTool;
+      const moduleExports = {
+        [MODULE_KEY]: { createTools: () => [makeTool()] },
+      };
+
+      expect(() =>
+        renderWithQueryClient(
+          <_InternalMCPRegistrar
+            moduleExports={moduleExports}
+            mcpToolsModuleInfo={mcpToolsModuleInfo}
+            selfConfiguration={selfConfiguration}
+            navigate={mockNavigate}
+          />,
+        ),
+      ).not.toThrow();
+
+      expect(mockModelContext.registerTool).not.toHaveBeenCalled();
+      expect(mockModelContext.listTools()).toHaveLength(1);
+    });
+
+    it('registers only the not-yet-registered tools from a mixed list', () => {
+      registeredTools['existing'] = makeTool({ name: 'existing' }) as unknown as RegisteredTool;
+      const moduleExports = {
+        [MODULE_KEY]: {
+          createTools: () => [makeTool({ name: 'existing' }), makeTool({ name: 'fresh' })],
+        },
+      };
+
+      renderWithQueryClient(
+        <_InternalMCPRegistrar
+          moduleExports={moduleExports}
+          mcpToolsModuleInfo={mcpToolsModuleInfo}
+          selfConfiguration={selfConfiguration}
+          navigate={mockNavigate}
+        />,
+      );
+
+      expect(mockModelContext.registerTool).toHaveBeenCalledTimes(1);
+      expect(mockModelContext.registerTool).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'fresh' }),
+        expect.anything(),
+      );
+      expect(mockModelContext.listTools().map((t) => t.name).sort()).toEqual([
+        'existing',
+        'fresh',
+      ]);
+    });
+  });
+
+  describe('modelContext feature detection (Chrome 150 document-first API)', () => {
+    it('registers via document.modelContext when present', () => {
+      const moduleExports = {
+        [MODULE_KEY]: { createTools: () => [makeTool()] },
+      };
+
+      renderWithQueryClient(
+        <_InternalMCPRegistrar
+          moduleExports={moduleExports}
+          mcpToolsModuleInfo={mcpToolsModuleInfo}
+          selfConfiguration={selfConfiguration}
+          navigate={mockNavigate}
+        />,
+      );
+
+      expect(mockModelContext.registerTool).toHaveBeenCalled();
+      expect(mockModelContext.listTools()).toHaveLength(1);
+    });
+
+    it('falls back to navigator.modelContext when document.modelContext is absent', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (document as any).modelContext;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (navigator as any).modelContext = mockModelContext;
+
+      const moduleExports = {
+        [MODULE_KEY]: { createTools: () => [makeTool()] },
+      };
+
+      renderWithQueryClient(
+        <_InternalMCPRegistrar
+          moduleExports={moduleExports}
+          mcpToolsModuleInfo={mcpToolsModuleInfo}
+          selfConfiguration={selfConfiguration}
+          navigate={mockNavigate}
+        />,
+      );
+
+      expect(mockModelContext.registerTool).toHaveBeenCalled();
+      expect(mockModelContext.listTools()).toHaveLength(1);
     });
   });
 
   describe('edge cases', () => {
-    it('does nothing when navigator.modelContext is unavailable', () => {
+    it('does nothing when modelContext is unavailable on document and navigator', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (document as any).modelContext;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       delete (navigator as any).modelContext;
 

--- a/shell-ui/src/mcp/MCPRegistrar.tsx
+++ b/shell-ui/src/mcp/MCPRegistrar.tsx
@@ -1,5 +1,9 @@
 import '@mcp-b/global';
-import type { ModelContextClient, ToolDescriptor } from '@mcp-b/webmcp-types';
+import type {
+  ModelContextClient,
+  ModelContextWithExtensions,
+  ToolDescriptor,
+} from '@mcp-b/webmcp-types';
 import { ComponentWithFederatedImports } from '@scality/module-federation';
 import { useEffect, useMemo, useRef } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
@@ -54,7 +58,11 @@ export const _InternalMCPRegistrar = ({
   useEffect(() => { userDataRef.current = userData; }, [userData]);
 
   useEffect(() => {
-    if (!navigator.modelContext) return;
+    // Chrome 150 moved the modelContext getter from Navigator to Document
+    // (webmachinelearning/webmcp#173 / PR #184). document.modelContext is now
+    // canonical; navigator.modelContext is kept as a deprecated alias.
+    const modelContext = document.modelContext || navigator.modelContext;
+    if (!modelContext) return;
 
     const mod = moduleExports[mcpToolsModuleInfo.module] as MCPToolsModule | undefined;
     // Proxy getToken/userData through refs so execute() always uses the latest
@@ -70,38 +78,56 @@ export const _InternalMCPRegistrar = ({
     const tools = mod?.createTools
       ? mod.createTools(context, navigate)
       : (mod?.tools ?? []);
-    const registeredNames: string[] = [];
+
+    // Names already present in the context — registered by another federated app,
+    // or left over from a StrictMode/HMR remount. registerTool throws on a
+    // duplicate name, so we skip those rather than crash the registrar.
+    // https://github.com/WebMCP-org/npm-packages/issues/231
+    const existingNames = new Set(
+      (modelContext as ModelContextWithExtensions).listTools?.().map((t) => t.name) ?? [],
+    );
+
+    // AbortController is the spec-blessed cleanup path: registerTool(tool, { signal })
+    // unregisters the tool when the signal aborts. unregisterTool was removed from
+    // the WebMCP spec on 2026-04-23 and is a no-op on native Chrome.
+    const controller = new AbortController();
 
     for (const tool of tools) {
-      navigator.modelContext.registerTool({
-        name: tool.name,
-        description: tool.description,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        inputSchema: tool.inputSchema,
-        ...(tool.annotations && { annotations: tool.annotations }),
-        execute: async (params: unknown, client: ModelContextClient) => {
-          // For createTools-based modules, context is already baked into the
-          // tool's execute closure. For legacy tools, inject context here.
-          const injectedContext = mod?.createTools ? undefined : context;
+      if (existingNames.has(tool.name)) {
+        console.debug(`[MCP] Tool "${tool.name}" already registered — skipping`);
+        continue;
+      }
 
-          return tool.execute(
-            {
-              ...(params as Record<string, unknown>),
-              ...(injectedContext && { context: injectedContext }),
-            },
-            client,
-          );
+      modelContext.registerTool(
+        {
+          name: tool.name,
+          description: tool.description,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          inputSchema: tool.inputSchema,
+          ...(tool.annotations && { annotations: tool.annotations }),
+          execute: async (params: unknown, client: ModelContextClient) => {
+            // For createTools-based modules, context is already baked into the
+            // tool's execute closure. For legacy tools, inject context here.
+            const injectedContext = mod?.createTools ? undefined : context;
+
+            return tool.execute(
+              {
+                ...(params as Record<string, unknown>),
+                ...(injectedContext && { context: injectedContext }),
+              },
+              client,
+            );
+          },
         },
-      });
+        { signal: controller.signal },
+      );
 
-      registeredNames.push(tool.name);
+      // Track within this registration pass so the same name appearing twice in
+      // one tools array doesn't throw either.
+      existingNames.add(tool.name);
     }
 
-    return () => {
-      registeredNames.forEach((name) =>
-        navigator.modelContext?.unregisterTool?.(name),
-      );
-    };
+    return () => controller.abort();
   }, [moduleExports, mcpToolsModuleInfo, selfConfiguration, navigate, queryClient]);
 
   return null;


### PR DESCRIPTION
## Summary
Upgrades shell-ui's WebMCP integration to `@mcp-b/*` **3.0.0** (the document-first release) and hardens MCP tool registration against two issues.

> **Note on base branch:** this is stacked on `feature/guardian-origin-source-suffix` because the `guardianPostMessageHooks.ts` change depends on Guardian work not yet on `development/*`. Retarget to a development branch once Guardian merges.

## Changes
- **Bump** `@mcp-b/global`, `@mcp-b/webmcp-types`, `@mcp-b/webmcp-local-relay` `2.2.0 → 3.0.0`.
- **Feature-detect** the context surface as `document.modelContext || navigator.modelContext`. Chrome 150 moved the getter from `Navigator` to `Document`; `navigator.modelContext` is now a deprecated alias. Applied in `MCPRegistrar` and the Guardian postMessage hooks.
- **Duplicate-registration guard:** skip tools whose name is already present (via `listTools()`). `registerTool` throws on a duplicate name, which crashed the registrar on StrictMode/HMR remounts and cross-app name collisions — see [WebMCP-org/npm-packages#231](https://github.com/WebMCP-org/npm-packages/issues/231) (still unresolved upstream; 3.0 does **not** fix it).
- **Cleanup migration:** replace the removed `unregisterTool` with the spec-blessed `registerTool(tool, { signal })` + `AbortController.abort()`, which also works on native Chrome where `unregisterTool` is a no-op.

## Test plan
- `npm run check-types` — clean
- `npm test` (shell-ui) — 90/90 pass, incl. new tests for feature detection, the duplicate guard, and AbortSignal cleanup
- Relay `embed.js`/`widget.html` assets copy from the same `dist/browser` path → build-compatible, no config change

🤖 Generated with [Claude Code](https://claude.com/claude-code)