### PR TITLE
salt: Make deploy_node tolerant of slow salt-minion restart

### DIFF
--- a/salt/_runners/metalk8s_saltutil.py
+++ b/salt/_runners/metalk8s_saltutil.py
@@ -54,7 +54,7 @@ def wait_minions(tgt="*", retry=10):
         # Either `minions` is empty, or not all succeeded
         return False
 
-    for attempts in range(1, retry):
+    for attempts in range(1, retry + 1):
         try:
             minions = client.cmd(tgt, "test.ping", timeout=2)
         except Exception as exc:  # pylint: disable=broad-except

--- a/salt/metalk8s/orchestrate/deploy_node.sls
+++ b/salt/metalk8s/orchestrate/deploy_node.sls
@@ -93,6 +93,9 @@ Wait minion available ssh:
   salt.runner:
     - name: metalk8s_saltutil.wait_minions
     - tgt: {{ node_name }}
+    - retry:
+        attempts: 3
+        interval: 30
     - require:
       - salt: Accept key
     - require_in:
@@ -202,6 +205,13 @@ Wait minion available:
   salt.runner:
     - name: metalk8s_saltutil.wait_minions
     - tgt: {{ node_name }}
+    # After the restart the minion re-authenticates quickly but its
+    # subscription to the salt-master publish channel can take a few minutes
+    # to re-establish, during which it answers no jobs. Re-run the wait so a
+    # slow reconnect does not fail the whole deployment.
+    - retry:
+        attempts: 3
+        interval: 30
     - require:
       - test: Wait minion available
     - require_in:

--- a/salt/tests/unit/runners/files/test_metalk8s_saltutil.yaml
+++ b/salt/tests/unit/runners/files/test_metalk8s_saltutil.yaml
@@ -142,3 +142,21 @@ wait_minions:
     raises: True
     result: >-
       Minions still have running state after 10 retries: minion-2
+
+  # 13. Success: minion answers on the very last (10th) attempt
+  # Guards against an off-by-one in the retry loop: with the default
+  # `retry=10` all 10 ping attempts must be used, so a list of 9 failures
+  # followed by a success is fully consumed and the wait succeeds.
+  - ping_ret:
+      - False
+      - False
+      - False
+      - False
+      - False
+      - False
+      - False
+      - False
+      - False
+      - True
+    result: >-
+      All minions matching "*" responded and finished startup state: my-minion


### PR DESCRIPTION
## Symptom

The metalk8s `deploy_node` orchestrate fails with:

```
metalk8s_saltutil.wait_minions: Minion failed to respond after 10 retries: node-X
```

## Root cause

During `deploy_node`, `Reconfigure salt-minion` restarts the minion (via the Salt-recommended `salt-call service.restart salt-minion`, `bg: True`). Restarting a minion mid-orchestration is a known Salt limitation ([saltstack/salt#55201](https://github.com/saltstack/salt/issues/55201)): after the restart the minion re-authenticates on the return channel within seconds, but its **subscription to the salt-master publish channel can take a couple of minutes to re-establish**, during which it answers no jobs. The following `wait_minions` then times out (~110s) and fails the whole deploy — even though the minion recovers shortly after.

Evidence (sosreports + salt-master pod log): the master is healthy (`worker_threads: 24`, other minions answer instantly); the failing node is `Authentication accepted` early but returns nothing for ~4 min, then flushes all queued job returns at once — after `wait_minions` already gave up. No clock skew. Recovery time is variable (one node recovered in ~2 min and passed, another took ~4 min and failed), which is why it is flaky.

## Approach

Keep the Salt-recommended restart method (`service.restart` + `bg`, per the [Salt FAQ](https://docs.saltproject.io/en/latest/faq.html)) and instead make the wait tolerant of a slow reconnect.

## Changes

- **`salt/_runners/metalk8s_saltutil.py`** — `wait_minions`: fix the `range(1, retry)` off-by-one so it performs the full retry budget (10 attempts, not 9).
- **`salt/metalk8s/orchestrate/deploy_node.sls`** — add `- retry: {attempts: 3, interval: 30}` to both minion-availability `wait_minions` states so a slow reconnect is retried instead of failing the deploy.
- **`salt/tests/unit/runners/files/test_metalk8s_saltutil.yaml`** — new regression case: minion answers on the 10th attempt (fails before the off-by-one fix, passes after).

## Testing

Unit tests and pre-commit require python3.6 (not available locally) and run in CI. The new `wait_minions` case and existing cases were verified by simulation: failure-path messages still say "after 10 retries"; success list-cases break early; the new 10-attempt case is fully consumed only with the fixed loop bound.

Issue: MK8S-322