### PR TITLE
fix(upgrade): wait for minions to reconnect after salt-master restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Release 133.0.10 (in development)
 
+### Bug Fixes
+
+- upgrade script now waits for all minions to reconnect to new salt master before
+  flushing the mine
+  (PR[#4972](https://github.com/scality/metalk8s/pull/4972))
+
 ## Release 133.0.9
 
 ## Release 133.0.8

--- a/scripts/upgrade.sh.in
+++ b/scripts/upgrade.sh.in
@@ -90,6 +90,13 @@ upgrade_bootstrap () {
     "$SALT_CALL" --local saltutil.refresh_grains
     "$SALT_CALL" --local --retcode-passthrough state.sls \
         metalk8s.salt.master.installed saltenv="$SALTENV"
+
+    # After the salt-master container restarts, wait for all minions to
+    # reconnect before proceeding. Without this, the subsequent mine.flush
+    # + mine.update may fire before minions have re-established their ZeroMQ
+    # connection, causing "Minion did not return. [No response]" errors.
+    SALT_MASTER_CALL=("${EXEC_CONTAINER_COMMAND[@]}" "$(get_salt_container)")
+    retry 10 10 "${SALT_MASTER_CALL[@]}" salt '*' test.ping
 }
 
 flush_and_refresh_mine() {


### PR DESCRIPTION
After upgrading salt-master (`metalk8s.salt.master.installed`), the container restarts with a new ID. The subsequent `mine.flush` + `mine.update` step (`flush_and_refresh_mine`) was firing before minions had re-established their ZeroMQ connection to the new master, causing:

```
ERROR: Minions returned with non-zero exit code
bootstrap:
    Minion did not return. [No response]
```

Add a retry loop (10 attempts, 10s apart) using `salt '*' test.ping` at the end of `upgrade_bootstrap` to ensure all minions are reachable before proceeding.

Closes MK8S-324