### PR TITLE
enhancement(upgrade): wait for kube-apiserver readiness before upgrade_apiservers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Release 133.0.10 (in development)
 
+### Enhancements
+
+- Wait for the kube-apiserver to be ready before upgrading the apiservers, to
+  avoid a transient upgrade failure when etcd has just been restarted
+  (PR[#4974](https://github.com/scality/metalk8s/pull/4974))
+
 ## Release 133.0.9
 
 ## Release 133.0.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
   avoid a transient upgrade failure when etcd has just been restarted
   (PR[#4974](https://github.com/scality/metalk8s/pull/4974))
 
+### Bug Fixes
+
+- upgrade script now waits for all minions to reconnect to new salt master before
+  flushing the mine
+  (PR[#4972](https://github.com/scality/metalk8s/pull/4972))
+
 ## Release 133.0.9
 
 ## Release 133.0.8

--- a/scripts/upgrade.sh.in
+++ b/scripts/upgrade.sh.in
@@ -90,6 +90,13 @@ upgrade_bootstrap () {
     "$SALT_CALL" --local saltutil.refresh_grains
     "$SALT_CALL" --local --retcode-passthrough state.sls \
         metalk8s.salt.master.installed saltenv="$SALTENV"
+
+    # After the salt-master container restarts, wait for all minions to
+    # reconnect before proceeding. Without this, the subsequent mine.flush
+    # + mine.update may fire before minions have re-established their ZeroMQ
+    # connection, causing "Minion did not return. [No response]" errors.
+    SALT_MASTER_CALL=("${EXEC_CONTAINER_COMMAND[@]}" "$(get_salt_container)")
+    retry 10 10 "${SALT_MASTER_CALL[@]}" salt '*' test.ping
 }
 
 flush_and_refresh_mine() {

--- a/scripts/upgrade.sh.in
+++ b/scripts/upgrade.sh.in
@@ -139,6 +139,16 @@ upgrade_etcd () {
 }
 
 upgrade_apiservers () {
+    # The etcd upgrade above restarts etcd, which can make the kube-apiserver
+    # briefly unavailable (especially on a single-node cluster). Wait for the
+    # apiserver to be ready before running the orchestrate: rendering it
+    # requires the salt-master to compile the `metalk8s_nodes` ext_pillar
+    # against the apiserver, and if it is still down the pillar compilation
+    # fails and aborts the whole upgrade.
+    "${SALT_CALL}" --local --retcode-passthrough http.wait_for_successful_query \
+        https://127.0.0.1:7443/healthz \
+        verify_ssl=False status=200 match="ok" wait_for=300 request_interval=5
+
     SALT_MASTER_CALL=("${EXEC_CONTAINER_COMMAND[@]}" "$(get_salt_container)")
     "${SALT_MASTER_CALL[@]}" salt-run state.orchestrate \
         metalk8s.orchestrate.apiserver saltenv="$SALTENV"


### PR DESCRIPTION
## Problem

On a single-node upgrade, the upgrade may fails at **"Upgrading all kube-api-server instances"**, leaving the node cordoned and all pods `Pending` until manually uncordoned.

The step order in `scripts/upgrade.sh.in` is:

```
upgrade_etcd          # restarts etcd (single node)
upgrade_apiservers    # <-- fails here, no readiness gate
upgrade_local_engines # already waits for https://127.0.0.1:7443/healthz
```

Restarting etcd makes the single kube-apiserver briefly unavailable. `upgrade_apiservers` immediately runs `salt-run state.orchestrate metalk8s.orchestrate.apiserver`, whose **render** requires the salt-master to compile the `metalk8s_nodes` ext_pillar against `https://127.0.0.1:7443`. With the apiserver still down the query could fail (`ProtocolError('Connection aborted.', OSError(0, 'Error'))`); the kubernetes client does only 3 immediate retries and `ext_pillar()` has none of its own, so pillar compilation aborts and the orchestrate fails **at render time** (`Total states run: 0`, retcode 1).

Evidence (sosreport `dedc312obj1`): etcd done `15:48:44`, ext_pillar SSL errors on the first line of `upgrade_apiservers`, failure `15:49:13`.

## Improvement

Gate `upgrade_apiservers` on apiserver readiness before invoking the orchestrate, reusing the exact `http.wait_for_successful_query .../healthz` idiom already used by `upgrade_local_engines`, with an explicit 5-minute budget and a 5s poll interval:

```sh
"${SALT_CALL}" --local --retcode-passthrough http.wait_for_successful_query \
    https://127.0.0.1:7443/healthz \
    verify_ssl=False status=200 match="ok" wait_for=300 request_interval=5
```

On timeout it re-raises and the step fails cleanly (no hang); 300s is far longer than the observed restart window.

## Notes

- Related: #4972 / MK8S-324 (same upgrade-readiness-gate pattern, for salt-master reconnect after `upgrade_bootstrap`).

Issue: MK8S-326