### PR TITLE
charts,salt: bump dex chart to 0.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Bump etcd version to [3.6.11](https://github.com/etcd-io/etcd/releases/tag/v3.6.11)
   (PR[#4928](https://github.com/scality/metalk8s/pull/4928))
 
+- Bump dex chart to [0.24.1](https://github.com/dexidp/helm-charts/releases/tag/dex-0.24.1)
+  (PR[#4977](https://github.com/scality/metalk8s/pull/4977))
+
 ## Release 133.0.10 (in development)
 
 ### Enhancements

--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -26,4 +26,4 @@ sources:
 - https://github.com/dexidp/dex
 - https://github.com/dexidp/helm-charts/tree/master/charts/dex
 type: application
-version: 0.24.0
+version: 0.24.1

--- a/charts/dex/README.md
+++ b/charts/dex/README.md
@@ -1,6 +1,6 @@
 # dex
 
-![version: 0.24.0](https://img.shields.io/badge/version-0.24.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.44.0](https://img.shields.io/badge/app%20version-2.44.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
+![version: 0.24.1](https://img.shields.io/badge/version-0.24.1-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.44.0](https://img.shields.io/badge/app%20version-2.44.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
 
 OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
 
@@ -162,6 +162,11 @@ ingress:
 | ingress.annotations | object | `{}` | Annotations to be added to the ingress. |
 | ingress.hosts | list | See [values.yaml](values.yaml). | Ingress host configuration. |
 | ingress.tls | list | See [values.yaml](values.yaml). | Ingress TLS configuration. |
+| httpRoute.enabled | bool | `false` | Enable Gateway API HTTPRoute. Gateway API support is in EXPERIMENTAL status. Support depends on your Gateway controller implementation. See the [Gateway API documentation](https://gateway-api.sigs.k8s.io/) for details. |
+| httpRoute.annotations | object | `{}` | Annotations to be added to the HTTPRoute. |
+| httpRoute.parentRefs | list | `[]` | References to the Gateway(s) that this HTTPRoute is attached to. See the [API reference](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.ParentReference) for details. |
+| httpRoute.hostnames | list | `["chart-example.local"]` | Hostnames defines the hostnames for routing. See the [API reference](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.Hostname) for details. |
+| httpRoute.rules | list | `[{"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | HTTPRoute rules configuration. See the [API reference](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteRule) for details. |
 | serviceMonitor.enabled | bool | `false` | Enable Prometheus ServiceMonitor. See the [documentation](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/design.md#servicemonitor) and the [API reference](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor) for details. |
 | serviceMonitor.namespace | string | Release namespace. | Namespace where the ServiceMonitor resource should be deployed. |
 | serviceMonitor.interval | duration | `nil` | Prometheus scrape interval. |

--- a/charts/dex/templates/httproute.yaml
+++ b/charts/dex/templates/httproute.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- $fullName := include "dex.fullname" . -}}
+{{- $svcPort := .Values.service.ports.http.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ include "dex.namespace" . }}
+  labels:
+    {{- include "dex.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- with .Values.httpRoute.parentRefs }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.httpRoute.rules }}
+    {{- with .matches }}
+    - matches:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+      backendRefs:
+        - group: ''
+          kind: Service
+          name: {{ $fullName }}
+          port: {{ $svcPort }}
+          weight: 1
+    {{- end }}
+{{- end }}

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -220,6 +220,41 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+httpRoute:
+  # -- Enable Gateway API HTTPRoute.
+  # Gateway API support is in EXPERIMENTAL status. Support depends on your Gateway controller implementation.
+  # See the [Gateway API documentation](https://gateway-api.sigs.k8s.io/) for details.
+  enabled: false
+
+  # -- Annotations to be added to the HTTPRoute.
+  annotations: {}
+
+  # -- References to the Gateway(s) that this HTTPRoute is attached to.
+  # See the [API reference](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.ParentReference) for details.
+  parentRefs: []
+    # - name: gateway
+    # namespace: gateway-system
+    # sectionName: https
+    # port: 443
+
+  # -- Hostnames defines the hostnames for routing.
+  # See the [API reference](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.Hostname) for details.
+  hostnames:
+    - chart-example.local
+
+  # -- HTTPRoute rules configuration.
+  # See the [API reference](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteRule) for details.
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      # filters:
+      #   - type: RequestHeaderModifier
+      #     requestHeaderModifier:
+      #       add:
+      #         - name: X-Custom-Header
+      #           value: custom-value
 serviceMonitor:
   # -- Enable Prometheus ServiceMonitor.
   # See the [documentation](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/design.md#servicemonitor) and the [API reference](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor) for details.

--- a/salt/metalk8s/addons/dex/deployed/chart.sls
+++ b/salt/metalk8s/addons/dex/deployed/chart.sls
@@ -16,7 +16,7 @@ metadata:
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
     app.kubernetes.io/version: 2.44.0
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -30,7 +30,7 @@ metadata:
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
     app.kubernetes.io/version: 2.44.0
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -52,7 +52,7 @@ metadata:
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
     app.kubernetes.io/version: 2.44.0
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     heritage: metalk8s
   name: dex-cluster
   namespace: metalk8s-auth
@@ -74,7 +74,7 @@ metadata:
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
     app.kubernetes.io/version: 2.44.0
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -95,7 +95,7 @@ metadata:
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
     app.kubernetes.io/version: 2.44.0
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -117,7 +117,7 @@ metadata:
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
     app.kubernetes.io/version: 2.44.0
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -153,7 +153,7 @@ metadata:
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
     app.kubernetes.io/version: 2.44.0
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth
@@ -265,7 +265,7 @@ metadata:
     app.kubernetes.io/name: dex
     app.kubernetes.io/part-of: metalk8s
     app.kubernetes.io/version: 2.44.0
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     heritage: metalk8s
   name: dex
   namespace: metalk8s-auth


### PR DESCRIPTION
This is a chart-only patch release, app version remains v2.44.0.

Also updated the Salt file to reflect the new chart version.

Ref: MK8S-226