### PR TITLE
buildchain,charts,salt: bump fluent-bit chart to 0.57.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 - Bump dex chart to [0.24.1](https://github.com/dexidp/helm-charts/releases/tag/dex-0.24.1)
   (PR[#4977](https://github.com/scality/metalk8s/pull/4977))
 
+- Bump fluent-bit chart to [0.57.7](https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.57.7)
+  and Fluent Bit image to [v5.0.7](https://github.com/fluent/fluent-bit/releases/tag/v5.0.7)
+  (PR[#4978](https://github.com/scality/metalk8s/pull/4978))
+
 ## Release 133.0.11 (in development)
 
 ### Bug Fixes

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -285,8 +285,8 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     ),
     Image(
         name="fluent-bit",
-        version="4.2.3",
-        digest="sha256:a5761fa961cb22dd0875883a4d446b1acd99d4935d77358aa9f50ee177e44fe2",
+        version="5.0.7",
+        digest="sha256:c96ee743cba9b1d5a38654931f411700af80bb7652697afbe67daad46cae237b",
     ),
     Image(
         name="cert-manager-controller",

--- a/charts/fluent-bit/CHANGELOG.md
+++ b/charts/fluent-bit/CHANGELOG.md
@@ -14,6 +14,54 @@
 
 ## [UNRELEASED]
 
+## [v0.57.7] - 2026-06-08
+
+### Changed
+
+- Update _Fluent Bit_ OCI image to [v5.0.7](https://github.com/fluent/fluent-bit/releases/tag/v5.0.7). ([#729](https://github.com/fluent/helm-charts/pull/729)) _@stevehipwell_
+
+## [v0.57.6] - 2026-05-22
+
+### Changed
+
+- Update _Fluent Bit_ OCI image to [v5.0.6](https://github.com/fluent/fluent-bit/releases/tag/v5.0.6). ([#724](https://github.com/fluent/helm-charts/pull/724)) _@stevehipwell_
+
+## [v0.57.5] - 2026-05-12
+
+### Changed
+
+- Update _Fluent Bit_ OCI image to [v5.0.5](https://github.com/fluent/fluent-bit/releases/tag/v5.0.5). ([#721](https://github.com/fluent/helm-charts/pull/721)) _@stevehipwell_
+
+## [v0.57.4] - 2026-05-12
+
+### Changed
+
+- Update _Fluent Bit_ OCI image to [v5.0.4](https://github.com/fluent/fluent-bit/releases/tag/v5.0.4). ([#719](https://github.com/fluent/helm-charts/pull/719)) _@stevehipwell_
+
+## [v0.57.3] - 2026-04-17
+
+### Changed
+
+- Update _Fluent Bit_ OCI image to [v5.0.3](https://github.com/fluent/fluent-bit/releases/tag/v5.0.3). ([#710](https://github.com/fluent/helm-charts/pull/710)) _@stevehipwell_
+
+## [v0.57.2] - 2026-04-02
+
+### Changed
+
+- Update _Fluent Bit_ OCI image to [v5.0.2](https://github.com/fluent/fluent-bit/releases/tag/v5.0.2). ([#705](https://github.com/fluent/helm-charts/pull/705)) _@stevehipwell_
+
+## [v0.57.1] - 2026-04-02
+
+### Changed
+
+- Update _Fluent Bit_ OCI image to [v5.0.1](https://github.com/fluent/fluent-bit/releases/tag/v5.0.1). ([#704](https://github.com/fluent/helm-charts/pull/704)) _@stevehipwell_
+
+## [v0.57.0] - 2026-03-23
+
+### Changed
+
+- Update _Fluent Bit_ OCI image to [v5.0.0](https://github.com/fluent/fluent-bit/releases/tag/v5.0.0). ([#700](https://github.com/fluent/helm-charts/pull/700)) _@stevehipwell_
+
 ## [v0.56.0] - 2026-02-27
 
 ### Added
@@ -49,6 +97,14 @@ RELEASE LINKS
 -->
 
 [UNRELEASED]: https://github.com/fluent/helm-charts/tree/main/charts/fluent-bit
+[v0.57.7]: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.57.7
+[v0.57.6]: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.57.6
+[v0.57.5]: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.57.5
+[v0.57.4]: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.57.4
+[v0.57.3]: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.57.3
+[v0.57.2]: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.57.2
+[v0.57.1]: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.57.1
+[v0.57.0]: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.57.0
 [v0.56.0]: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.56.0
 [v0.55.1]: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.55.1
 [v0.55.0]: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.55.0

--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -1,9 +1,9 @@
 annotations:
   artifacthub.io/changes: |-
-    - kind: added
-      description: "VPA recommender may be specified with .autoscaling.vpa."
+    - kind: changed
+      description: "Update Fluent Bit OCI image to v5.0.7."
 apiVersion: v1
-appVersion: 4.2.3
+appVersion: 5.0.7
 description: Fast and lightweight log processor and forwarder for Linux, OSX and BSD
   family operating systems.
 home: https://fluentbit.io/
@@ -24,4 +24,4 @@ maintainers:
 name: fluent-bit
 sources:
 - https://github.com/fluent/fluent-bit/
-version: 0.56.0
+version: 0.57.7

--- a/charts/fluent-bit/README.md
+++ b/charts/fluent-bit/README.md
@@ -1,6 +1,6 @@
 # fluent-bit
 
-![Version: 0.56.0](https://img.shields.io/badge/Version-0.56.0-informational?style=flat-square) ![AppVersion: 4.2.3](https://img.shields.io/badge/AppVersion-4.2.3-informational?style=flat-square)
+![Version: 0.57.7](https://img.shields.io/badge/Version-0.57.7-informational?style=flat-square) ![AppVersion: 5.0.7](https://img.shields.io/badge/AppVersion-5.0.7-informational?style=flat-square)
 
 Fast and lightweight log processor and forwarder for Linux, OSX and BSD family operating systems.
 
@@ -26,7 +26,7 @@ Fast and lightweight log processor and forwarder for Linux, OSX and BSD family o
 To install the chart using the recommended OCI method you can use the following command.
 
 ```shell
-helm upgrade --install fluent-bit oci://ghcr.io/fluent/helm-charts/fluent-bit --version 0.56.0
+helm upgrade --install fluent-bit oci://ghcr.io/fluent/helm-charts/fluent-bit --version 0.57.7
 ```
 
 #### Verification
@@ -34,7 +34,7 @@ helm upgrade --install fluent-bit oci://ghcr.io/fluent/helm-charts/fluent-bit --
 As the OCI chart release is signed by [Cosign](https://github.com/sigstore/cosign) you can verify the chart before installing it by running the following command.
 
 ```shell
-cosign verify --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp 'https://github\.com/action-stars/helm-workflows/\.github/workflows/release\.yaml@.+' --certificate-github-workflow-repository fluent/helm-charts --certificate-github-workflow-name Release ghcr.io/fluent/helm-charts/fluent-bit:0.56.0
+cosign verify --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp 'https://github\.com/action-stars/helm-workflows/\.github/workflows/release\.yaml@.+' --certificate-github-workflow-repository fluent/helm-charts --certificate-github-workflow-name Release ghcr.io/fluent/helm-charts/fluent-bit:0.57.7
 ```
 
 ### Non-OCI Repository
@@ -43,7 +43,7 @@ Alternatively you can use the legacy non-OCI method via the following commands.
 
 ```shell
 helm repo add fluent https://fluent.github.io/helm-charts/
-helm upgrade --install fluent-bit fluent/fluent-bit --version 0.56.0
+helm upgrade --install fluent-bit fluent/fluent-bit --version 0.57.7
 ```
 
 ## Values
@@ -171,7 +171,7 @@ helm upgrade --install fluent-bit fluent/fluent-bit --version 0.56.0
 | rbac.create | bool | `true` |  |
 | rbac.eventsAccess | bool | `false` |  |
 | rbac.nodeAccess | bool | `false` |  |
-| readinessProbe.httpGet.path | string | `"/api/v1/health"` |  |
+| readinessProbe.httpGet.path | string | `"/api/v2/health"` |  |
 | readinessProbe.httpGet.port | string | `"http"` |  |
 | replicaCount | int | `1` | Only applicable if kind=Deployment |
 | resources | object | `{}` |  |

--- a/charts/fluent-bit/RELEASE.md
+++ b/charts/fluent-bit/RELEASE.md
@@ -1,3 +1,3 @@
-### Added
+### Changed
 
-- VPA recommender may be specified with `.autoscaling.vpa.recommender`
+- Update _Fluent Bit_ OCI image to [v5.0.7](https://github.com/fluent/fluent-bit/releases/tag/v5.0.7). ([#729](https://github.com/fluent/helm-charts/pull/729)) _@stevehipwell_

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -109,7 +109,7 @@ service:
   # nodePort: 30020
   # clusterIP: 172.16.10.1
   annotations: {}
-  #   prometheus.io/path: "/api/v1/metrics/prometheus"
+  #   prometheus.io/path: "/api/v2/metrics/prometheus"
   #   prometheus.io/port: "2020"
   #   prometheus.io/scrape: "true"
   externalIPs: []
@@ -206,7 +206,7 @@ livenessProbe:
 
 readinessProbe:
   httpGet:
-    path: /api/v1/health
+    path: /api/v2/health
     port: http
 
 resources: {}

--- a/salt/metalk8s/addons/logging/fluent-bit/deployed/chart.sls
+++ b/salt/metalk8s/addons/logging/fluent-bit/deployed/chart.sls
@@ -15,8 +15,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: fluent-bit
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 4.2.3
-    helm.sh/chart: fluent-bit-0.56.0
+    app.kubernetes.io/version: 5.0.7
+    helm.sh/chart: fluent-bit-0.57.7
     heritage: metalk8s
   name: fluent-bit
   namespace: metalk8s-logging
@@ -1596,9 +1596,9 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: fluent-bit
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 4.2.3
+    app.kubernetes.io/version: 5.0.7
     grafana_dashboard: '1'
-    helm.sh/chart: fluent-bit-0.56.0
+    helm.sh/chart: fluent-bit-0.57.7
     heritage: metalk8s
   name: fluent-bit-dashboard-fluent-bit
   namespace: metalk8s-logging
@@ -1611,8 +1611,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: fluent-bit
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 4.2.3
-    helm.sh/chart: fluent-bit-0.56.0
+    app.kubernetes.io/version: 5.0.7
+    helm.sh/chart: fluent-bit-0.57.7
     heritage: metalk8s
   name: fluent-bit
   namespace: metalk8s-logging
@@ -1635,8 +1635,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: fluent-bit
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 4.2.3
-    helm.sh/chart: fluent-bit-0.56.0
+    app.kubernetes.io/version: 5.0.7
+    helm.sh/chart: fluent-bit-0.57.7
     heritage: metalk8s
   name: fluent-bit
   namespace: metalk8s-logging
@@ -1657,8 +1657,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: fluent-bit
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 4.2.3
-    helm.sh/chart: fluent-bit-0.56.0
+    app.kubernetes.io/version: 5.0.7
+    helm.sh/chart: fluent-bit-0.57.7
     heritage: metalk8s
   name: fluent-bit
   namespace: metalk8s-logging
@@ -1681,8 +1681,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: fluent-bit
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 4.2.3
-    helm.sh/chart: fluent-bit-0.56.0
+    app.kubernetes.io/version: 5.0.7
+    helm.sh/chart: fluent-bit-0.57.7
     heritage: metalk8s
   name: fluent-bit
   namespace: metalk8s-logging
@@ -1714,7 +1714,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: {% endraw -%}{{ build_image_name("fluent-bit", False) }}{%- raw %}:4.2.3
+        image: {% endraw -%}{{ build_image_name("fluent-bit", False) }}{%- raw %}:5.0.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -1727,7 +1727,7 @@ spec:
           protocol: TCP
         readinessProbe:
           httpGet:
-            path: /api/v1/health
+            path: /api/v2/health
             port: http
         resources: {% endraw -%}{{ fluent_bit.spec.deployment.resources }}{%- raw %}
         volumeMounts:
@@ -1785,8 +1785,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: fluent-bit
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 4.2.3
-    helm.sh/chart: fluent-bit-0.56.0
+    app.kubernetes.io/version: 5.0.7
+    helm.sh/chart: fluent-bit-0.57.7
     heritage: metalk8s
     metalk8s.scality.com/monitor: ''
   name: fluent-bit
@@ -1823,8 +1823,8 @@ metadata:
     app.kubernetes.io/managed-by: salt
     app.kubernetes.io/name: fluent-bit
     app.kubernetes.io/part-of: metalk8s
-    app.kubernetes.io/version: 4.2.3
-    helm.sh/chart: fluent-bit-0.56.0
+    app.kubernetes.io/version: 5.0.7
+    helm.sh/chart: fluent-bit-0.57.7
     heritage: metalk8s
     metalk8s.scality.com/monitor: ''
   name: fluent-bit


### PR DESCRIPTION
Fluent Bit itself has been bumped to v5.0.7 accordingly.

Also updated the Salt file to use the new chart version.

Although this is a major version bump (v4 -> v5), the v5.0 breaking changes have been reviewed and none of them affect our configuration:
- Shared HTTP listener settings: we only use tail inputs, not HTTP-based inputs
- Forward output `retain_metadata_in_forward_mode`: we use Loki output, not forward
- Emitter backpressure with filesystem storage: we do not use `rewrite_tag` or filesystem storage
- `fluentbit_hot_reloaded_times` metric type change: not referenced in our alert rules
- HTTP API paths `/api/v1` → `/api/v2`: already reflected in the regenerated chart.sls

Ref: MK8S-227