### PR TITLE
buildchain,charts,salt: bump loki chart to 7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
   and Fluent Bit image to [v5.0.7](https://github.com/fluent/fluent-bit/releases/tag/v5.0.7)
   (PR[#4978](https://github.com/scality/metalk8s/pull/4978))
 
+- Bump loki chart to [7.0.0](https://github.com/grafana/helm-charts/releases/tag/helm-loki-7.0.0)
+  and Loki image to [v3.6.7](https://github.com/grafana/loki/releases/tag/v3.6.7)
+  (PR[#4979](https://github.com/scality/metalk8s/pull/4979))
+
 ## Release 133.0.11 (in development)
 
 ### Bug Fixes

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -280,8 +280,8 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     ),
     Image(
         name="loki",
-        version="3.6.5",
-        digest="sha256:847c287ada0e12603910589f42038c5cdaaad04e248bd1dc6c6e0920a235f427",
+        version="3.6.7",
+        digest="sha256:3c8fd3570dd9219951a60d3f919c7f31923d10baee578b77bc26c4a0b32d092d",
     ),
     Image(
         name="fluent-bit",

--- a/charts/loki/CONTRIBUTING.md
+++ b/charts/loki/CONTRIBUTING.md
@@ -4,6 +4,8 @@ Thank you for your interest in contributing to the Loki Helm Chart! This documen
 
 For general Loki project contributions, please also see the main [Contributing Guide](../../../CONTRIBUTING.md).
 
+**IMPORTANT** As of March 16, 2026, the open source Loki Helm Chart for is being maintained by Grafana Champions and the Grafana Community in the [Grafana-community/helm-charts repository](https://github.com/grafana-community/helm-charts). Please open issues and pull requests for the Loki Helm chart against the Grafana-community repo.  The chart in this repo is being maintained for Grafana Enterprise Logs (GEL) customers only.
+
 ## Contribution Guidelines
 
 ### What We Welcome

--- a/charts/loki/Chart.lock
+++ b/charts/loki/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 0.5.2
 - name: rollout-operator
   repository: https://grafana.github.io/helm-charts
-  version: 0.41.0
-digest: sha256:8c45cdff45c47ed4f15c529703475d7921e2720062f31e35f9e3052b7abd0ca1
-generated: "2026-02-10T14:08:17.625986897Z"
+  version: 0.47.0
+digest: sha256:428f3ca4c31466a0bed600702e1636e2888b62923be84de94503e6c7edd335c1
+generated: "2026-04-04T19:04:22.962853092Z"

--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 3.6.5
+appVersion: 3.6.7
 dependencies:
 - alias: minio
   condition: minio.enabled
@@ -15,7 +15,7 @@ dependencies:
   condition: rollout_operator.enabled
   name: rollout-operator
   repository: https://grafana.github.io/helm-charts
-  version: 0.41.0
+  version: 0.47.0
 description: Helm chart for Grafana Loki and Grafana Enterprise Logs supporting monolithic,
   simple scalable, and microservices modes.
 home: https://grafana.github.io/helm-charts
@@ -29,4 +29,4 @@ sources:
 - https://grafana.com/oss/loki/
 - https://grafana.com/docs/loki/latest/
 type: application
-version: 6.53.0
+version: 7.0.0

--- a/charts/loki/README.md
+++ b/charts/loki/README.md
@@ -1,11 +1,11 @@
 # loki
 
-![Version: 6.53.0](https://img.shields.io/badge/Version-6.53.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.6.5](https://img.shields.io/badge/AppVersion-3.6.5-informational?style=flat-square)
+![Version: 7.0.0](https://img.shields.io/badge/Version-7.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.6.7](https://img.shields.io/badge/AppVersion-3.6.7-informational?style=flat-square)
 
 Helm chart for Grafana Loki and Grafana Enterprise Logs supporting monolithic, simple scalable, and microservices modes.
 
 ## ⚠️ Helm Chart Migration
-Effective March 16, 2026, the Grafana Loki Helm chart will be forked to a new repository [grafana-community/helm-charts](https://github.com/grafana-community/helm-charts).  The chart in the Loki repository will continue to be maintained for GEL users only.  See [#20705](https://github.com/grafana/loki/issues/20705) for details.
+As of March 16, 2026, the Grafana Loki Helm chart for OSS users has moved to [grafana-community/helm-charts](https://github.com/grafana-community/helm-charts) (forked at chart version 6.55.0). OSS users are encouraged to migrate to the community-maintained chart. The chart in this repository is now maintained for Grafana Enterprise Logs (GEL) users only. See [#20705](https://github.com/grafana/loki/issues/20705) for details.
 
 ## Source Code
 
@@ -19,7 +19,7 @@ Effective March 16, 2026, the Grafana Loki Helm chart will be forked to a new re
 |------------|------|---------|
 | https://charts.min.io/ | minio(minio) | 5.4.0 |
 | https://grafana.github.io/helm-charts | grafana-agent-operator(grafana-agent-operator) | 0.5.2 |
-| https://grafana.github.io/helm-charts | rollout_operator(rollout-operator) | 0.40.0 |
+| https://grafana.github.io/helm-charts | rollout_operator(rollout-operator) | 0.47.0 |
 
 Find more information in the Loki Helm Chart [documentation](https://grafana.com/docs/loki/latest/setup/install/helm/).
 

--- a/charts/loki/charts/rollout-operator/Chart.yaml
+++ b/charts/loki/charts/rollout-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v0.34.0
+appVersion: v0.36.1
 description: Grafana rollout-operator
 home: https://github.com/grafana/rollout-operator
 kubeVersion: ^1.10.0-0
 name: rollout-operator
 type: application
-version: 0.41.0
+version: 0.47.0

--- a/charts/loki/charts/rollout-operator/README.md
+++ b/charts/loki/charts/rollout-operator/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana rollout-operator](https://github.com/grafana/r
 
 # rollout-operator
 
-![Version: 0.41.0](https://img.shields.io/badge/Version-0.41.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.34.0](https://img.shields.io/badge/AppVersion-v0.34.0-informational?style=flat-square)
+![Version: 0.47.0](https://img.shields.io/badge/Version-0.47.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.36.1](https://img.shields.io/badge/AppVersion-v0.36.1-informational?style=flat-square)
 
 Grafana rollout-operator
 
@@ -62,6 +62,7 @@ Manually applying these CRDs is only required if upgrading from a chart <= v0.32
 | imagePullSecrets | list | `[]` |  |
 | minReadySeconds | int | `10` |  |
 | nameOverride | string | `""` |  |
+| namespaceSelector | object | `{"matchExpressions":[]}` | Namespace selector applied to all webhooks. Defaults to restricting to the release namespace. See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` | Pod Annotations |
 | podLabels | object | `{}` | Pod (extra) Labels |
@@ -88,3 +89,4 @@ Manually applying these CRDs is only required if upgrading from a chart <= v0.32
 | webhooks.failurePolicy | string | `"Fail"` | Validating and mutating webhook failure policy. `Ignore` or `Fail`. |
 | webhooks.objectSelector | object | `{}` | objectSelector to filter which objects the webhooks apply to. |
 | webhooks.selfSignedCertSecretName | string | `"certificate"` | Secret resource name for the TLS certificate to be used with the webhooks |
+| webhooks.timeoutSeconds | int | `10` | Timeout in seconds for the prepare-downscale mutating webhook. Must be between 1 and 30. |

--- a/charts/loki/charts/rollout-operator/templates/no-downscale-webhook.yaml
+++ b/charts/loki/charts/rollout-operator/templates/no-downscale-webhook.yaml
@@ -28,9 +28,24 @@ webhooks:
         scope: Namespaced
     admissionReviewVersions:
       - v1
+    {{- if not (kindIs "invalid" .Values.namespaceSelector) }}
     namespaceSelector:
+      {{- if .Values.namespaceSelector.matchLabels }}
+      matchLabels:
+        {{- toYaml .Values.namespaceSelector.matchLabels | nindent 8 }}
+      {{- with .Values.namespaceSelector.matchExpressions }}
+      matchExpressions:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- else }}
       matchLabels:
         kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
+      {{- with .Values.namespaceSelector.matchExpressions }}
+      matchExpressions:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
+    {{- end }}
     {{- with .Values.webhooks.objectSelector }}
     objectSelector:
       {{- toYaml . | nindent 6 }}

--- a/charts/loki/charts/rollout-operator/templates/pod-eviction-webhook.yaml
+++ b/charts/loki/charts/rollout-operator/templates/pod-eviction-webhook.yaml
@@ -27,13 +27,25 @@ webhooks:
         scope: Namespaced
     admissionReviewVersions:
       - v1
+    {{- if not (kindIs "invalid" .Values.namespaceSelector) }}
     namespaceSelector:
+      {{- if .Values.namespaceSelector.matchLabels }}
+      matchLabels:
+        {{- toYaml .Values.namespaceSelector.matchLabels | nindent 8 }}
+      {{- else }}
       matchLabels:
         kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
+      {{- end }}
+      {{- with .Values.namespaceSelector.matchExpressions }}
+      matchExpressions:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
     {{- with .Values.webhooks.objectSelector }}
     objectSelector:
       {{- toYaml . | nindent 6 }}
     {{- end }}
     sideEffects: None
+    timeoutSeconds: {{.Values.webhooks.timeoutSeconds}}
     failurePolicy: {{.Values.webhooks.failurePolicy}}
 {{- end -}}

--- a/charts/loki/charts/rollout-operator/templates/prepare-downscale-webhook.yaml
+++ b/charts/loki/charts/rollout-operator/templates/prepare-downscale-webhook.yaml
@@ -28,15 +28,26 @@ webhooks:
         scope: Namespaced
     admissionReviewVersions:
       - v1
+    {{- if not (kindIs "invalid" .Values.namespaceSelector) }}
     namespaceSelector:
+      {{- if .Values.namespaceSelector.matchLabels }}
+      matchLabels:
+        {{- toYaml .Values.namespaceSelector.matchLabels | nindent 8 }}
+      {{- else }}
       matchLabels:
         kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
+      {{- end }}
+      {{- with .Values.namespaceSelector.matchExpressions }}
+      matchExpressions:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
     {{- with .Values.webhooks.objectSelector }}
     objectSelector:
       {{- toYaml . | nindent 6 }}
     {{- end }}
     sideEffects: NoneOnDryRun
     matchPolicy: Equivalent
-    timeoutSeconds: 10
+    timeoutSeconds: {{.Values.webhooks.timeoutSeconds}}
     failurePolicy: {{.Values.webhooks.failurePolicy}}
 {{- end -}}

--- a/charts/loki/charts/rollout-operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/charts/loki/charts/rollout-operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -27,13 +27,25 @@ webhooks:
           - zoneawarepoddisruptionbudgets
         scope: Namespaced
     admissionReviewVersions: ["v1"]
+    {{- if not (kindIs "invalid" .Values.namespaceSelector) }}
     namespaceSelector:
+      {{- if .Values.namespaceSelector.matchLabels }}
+      matchLabels:
+        {{- toYaml .Values.namespaceSelector.matchLabels | nindent 8 }}
+      {{- else }}
       matchLabels:
         kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
+      {{- end }}
+      {{- with .Values.namespaceSelector.matchExpressions }}
+      matchExpressions:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
     {{- with .Values.webhooks.objectSelector }}
     objectSelector:
       {{- toYaml . | nindent 6 }}
     {{- end }}
     sideEffects: None
+    timeoutSeconds: {{.Values.webhooks.timeoutSeconds}}
     failurePolicy: {{.Values.webhooks.failurePolicy}}
 {{- end -}}

--- a/charts/loki/charts/rollout-operator/values.yaml
+++ b/charts/loki/charts/rollout-operator/values.yaml
@@ -108,6 +108,8 @@ webhooks:
   # -- Enable the rollout-operator webhooks. See https://github.com/grafana/rollout-operator/#webhooks.
   # Note that the webhooks require custom resource definitions. If upgrading, manually apply the files in the `crds` directory.
   enabled: true
+  # -- Timeout in seconds for the prepare-downscale mutating webhook. Must be between 1 and 30.
+  timeoutSeconds: 10
   # -- Validating and mutating webhook failure policy. `Ignore` or `Fail`.
   failurePolicy: "Fail"
   # -- Secret resource name for the TLS certificate to be used with the webhooks
@@ -124,3 +126,37 @@ webhooks:
   #         operator: In
   #         values:
   #           - production
+
+# -- Namespace selector applied to all webhooks. Defaults to restricting to the release namespace.
+# See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector
+namespaceSelector:
+  # Example 1 - matchExpressions only: merged with the default release namespace matchLabels.
+  #   values.yaml:
+  #     matchExpressions:
+  #       - key: team
+  #         operator: NotIn
+  #         values: [team-a]
+  #   renders:
+  #     namespaceSelector:
+  #       matchLabels:
+  #         kubernetes.io/metadata.name: <release-namespace>
+  #       matchExpressions:
+  #         - key: team
+  #           operator: NotIn
+  #           values: [team-a]
+  #
+  # Example 2 - matchLabels set: full selector is user-controlled (matchExpressions also supported).
+  #   values.yaml:
+  #     matchLabels:
+  #       kubernetes.io/metadata.name: logging
+  #   renders:
+  #     namespaceSelector:
+  #       matchLabels:
+  #         kubernetes.io/metadata.name: logging
+  #
+  # Example 3 - set to null: omits namespaceSelector entirely (e.g. when objectSelector alone is sufficient).
+  #   values.yaml:
+  #     namespaceSelector: null
+  #   renders:
+  #     (nothing)
+  matchExpressions: []

--- a/charts/loki/distributed-values.yaml
+++ b/charts/loki/distributed-values.yaml
@@ -1,4 +1,7 @@
 ---
+commonLabels:
+  labelA: valueA
+  labelA: valueB
 loki:
   schemaConfig:
     configs:

--- a/charts/loki/reference.md.gotmpl
+++ b/charts/loki/reference.md.gotmpl
@@ -17,6 +17,21 @@ keywords: []
 
 This is the generated reference for the Loki Helm Chart values.
 
+Because the Loki Helm chart exposes a large number of configuration options, this reference is intentionally exhaustive and can be quite long.
+
+Configuration keys are grouped by prefix. For example:
+
+- `adminApi.*` — configuration for the admin API component
+- `backend.*` — configuration for backend pods
+- `backend.persistence.*` — storage configuration for backend pods
+- `backend.autoscaling.*` — autoscaling configuration for backend pods
+
+To navigate it more easily:
+
+- Use your browser search (`Ctrl+F`) to locate specific configuration keys.
+- Search by prefix (for example `backend.` or `ingester.`) to jump between related settings.
+- For installation examples and setup instructions, refer to the Helm installation guide rather than this reference page.
+
 > **Note:** This reference is for the Loki Helm chart version 3.0 or greater.
 > If you are using the `grafana/loki-stack` Helm chart from the community repo,
 > please refer to the `values.yaml` of the respective Github repository

--- a/charts/loki/simple-scalable-values.yaml
+++ b/charts/loki/simple-scalable-values.yaml
@@ -1,4 +1,7 @@
 ---
+commonLabels:
+  labelA: valueA
+  labelA: valueB
 loki:
   schemaConfig:
     configs:

--- a/charts/loki/single-binary-values.yaml
+++ b/charts/loki/single-binary-values.yaml
@@ -1,4 +1,7 @@
 ---
+commonLabels:
+  labelA: valueA
+  labelA: valueB
 loki:
   commonConfig:
     replication_factor: 1

--- a/charts/loki/src/helm-test/Dockerfile
+++ b/charts/loki/src/helm-test/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.26
 FROM golang:${GO_VERSION} as build
 
 # build via Makefile target helm-test-image in root

--- a/charts/loki/src/helm-test/canary_test.go
+++ b/charts/loki/src/helm-test/canary_test.go
@@ -129,7 +129,7 @@ func testResultCanary(t *testing.T, ctx context.Context, metric string, test fun
 	body, err := io.ReadAll(rsp.Body)
 	require.NoError(t, err, "Failed to read response body")
 
-	p, err := textparse.New(body, rsp.Header.Get("Content-Type"), "", true, false, true, labels.NewSymbolTable())
+	p, err := textparse.New(body, rsp.Header.Get("Content-Type"), labels.NewSymbolTable(), textparse.ParserOptions{})
 	require.NoError(t, err, "Failed to create Prometheus parser")
 
 	for {

--- a/charts/loki/templates/_helpers.tpl
+++ b/charts/loki/templates/_helpers.tpl
@@ -138,6 +138,9 @@ helm.sh/chart: {{ include "loki.chart" . }}
 {{- if or (.Chart.AppVersion) (.Values.loki.image.tag) }}
 app.kubernetes.io/version: {{ include "loki.validLabelValue" (.Values.loki.image.tag | default .Chart.AppVersion) | quote }}
 {{- end }}
+{{- if .Values.commonLabels }}
+{{ .Values.commonLabels | toYaml }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -175,7 +178,8 @@ It also respects `.digest` as well as `.sha` (deprecated).
 {{- $ref := ternary (printf ":%s" (.service.tag | default .defaultVersion | toString)) ($digest) (empty $digest) -}}
 
 {{- $prefix := "" -}}
-{{- if and $registry (not (contains "." $repository)) -}}
+{{- $firstSegment := (split "/" $repository)._0 -}}
+{{- if and $registry (not (contains "." $firstSegment)) -}}
 {{- $prefix = printf "%s/" $registry -}}
 {{- end -}}
 

--- a/charts/loki/templates/backend/poddisruptionbudget-backend.yaml
+++ b/charts/loki/templates/backend/poddisruptionbudget-backend.yaml
@@ -11,5 +11,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.backendSelectorLabels" . | nindent 6 }}
-  maxUnavailable: 1
+  {{- with .Values.backend.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/loki/templates/backend/statefulset-backend.yaml
+++ b/charts/loki/templates/backend/statefulset-backend.yaml
@@ -175,6 +175,10 @@ spec:
             - name: SKIP_TLS_VERIFY
               value: "{{ .Values.sidecar.skipTlsVerify }}"
             {{- end }}
+            {{- if .Values.sidecar.disableX509StrictVerification }}
+            - name: DISABLE_X509_STRICT_VERIFICATION
+              value: "{{ .Values.sidecar.disableX509StrictVerification }}"
+            {{- end }}
             {{- if .Values.sidecar.rules.script }}
             - name: SCRIPT
               value: "{{ .Values.sidecar.rules.script }}"
@@ -212,6 +216,8 @@ spec:
           {{- toYaml .Values.sidecar.securityContext | nindent 12 }}
           {{- end }}
           volumeMounts:
+            - name: tmp
+              mountPath: /tmp
             - name: sc-rules-volume
               mountPath: {{ .Values.sidecar.rules.folder | quote }}
         {{- end}}

--- a/charts/loki/templates/ciliumnetworkpolicy.yaml
+++ b/charts/loki/templates/ciliumnetworkpolicy.yaml
@@ -36,7 +36,7 @@ spec:
       - port: "53"
         protocol: TCP
     toEndpoints:
-    - namespaceSelector: {}
+    - {}
 
 ---
 apiVersion: cilium.io/v2

--- a/charts/loki/templates/memcached/_memcached-statefulset.tpl
+++ b/charts/loki/templates/memcached/_memcached-statefulset.tpl
@@ -101,7 +101,7 @@ spec:
             limits:
               memory: {{ $requestMemory }}Mi
             requests:
-              cpu: 500m
+              cpu: {{ .allocatedCPU }}
               memory: {{ $requestMemory }}Mi
           {{- end }}
           ports:

--- a/charts/loki/templates/read/poddisruptionbudget-read.yaml
+++ b/charts/loki/templates/read/poddisruptionbudget-read.yaml
@@ -11,5 +11,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.readSelectorLabels" . | nindent 6 }}
-  maxUnavailable: 1
+  {{- with .Values.read.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/loki/templates/ruler/statefulset-ruler.yaml
+++ b/charts/loki/templates/ruler/statefulset-ruler.yaml
@@ -161,6 +161,10 @@ spec:
             - name: SKIP_TLS_VERIFY
               value: "{{ .Values.sidecar.skipTlsVerify }}"
             {{- end }}
+            {{- if .Values.sidecar.disableX509StrictVerification }}
+            - name: DISABLE_X509_STRICT_VERIFICATION
+              value: "{{ .Values.sidecar.disableX509StrictVerification }}"
+            {{- end }}
             {{- if .Values.sidecar.rules.script }}
             - name: SCRIPT
               value: "{{ .Values.sidecar.rules.script }}"
@@ -194,6 +198,8 @@ spec:
           {{- toYaml .Values.sidecar.securityContext | nindent 12 }}
           {{- end }}
           volumeMounts:
+            - name: tmp
+              mountPath: /tmp
             - name: sc-rules-volume
               mountPath: {{ .Values.sidecar.rules.folder | quote }}
         {{- end}}

--- a/charts/loki/templates/single-binary/service.yaml
+++ b/charts/loki/templates/single-binary/service.yaml
@@ -37,4 +37,7 @@ spec:
     {{- with .Values.singleBinary.selectorLabels }}
       {{- tpl (toYaml .) $ | nindent 4 }}
     {{- end }}
+{{- with .Values.singleBinary.service.trafficDistribution | default .Values.loki.service.trafficDistribution }}
+  trafficDistribution: {{ . }}
+{{- end }}
 {{- end }}

--- a/charts/loki/templates/single-binary/statefulset-recreate-job.yaml
+++ b/charts/loki/templates/single-binary/statefulset-recreate-job.yaml
@@ -53,7 +53,7 @@ spec:
       containers:
         - name: recreate-statefulset
           image: {{ include "loki.baseImage" (dict "service" (dict "registry" "docker.io" "repository" "rancher/kubectl" "tag" (.Capabilities.KubeVersion.Version | default "v1.33.0")) "global" .Values.global) }}
-          command:
+          args:
             - delete
             - statefulset
             - --namespace={{ $newStatefulSet.metadata.namespace }}
@@ -63,7 +63,7 @@ spec:
           {{- range $template, $size := $templates }}
         - name: patch-pvc-{{ $template }}-{{ $index }}
           image: {{ include "loki.baseImage" (dict "service" (dict "registry" "docker.io" "repository" "rancher/kubectl" "tag" ($.Capabilities.KubeVersion.Version | default "v1.33.0")) "global" $.Values.global) }}
-          command:
+          args:
             - patch
             - pvc
             - --namespace={{ $newStatefulSet.metadata.namespace }}

--- a/charts/loki/templates/single-binary/statefulset.yaml
+++ b/charts/loki/templates/single-binary/statefulset.yaml
@@ -185,6 +185,10 @@ spec:
             - name: SKIP_TLS_VERIFY
               value: "{{ .Values.sidecar.skipTlsVerify }}"
             {{- end }}
+            {{- if .Values.sidecar.disableX509StrictVerification }}
+            - name: DISABLE_X509_STRICT_VERIFICATION
+              value: "{{ .Values.sidecar.disableX509StrictVerification }}"
+            {{- end }}
             {{- if .Values.sidecar.rules.script }}
             - name: SCRIPT
               value: "{{ .Values.sidecar.rules.script }}"
@@ -222,6 +226,8 @@ spec:
           {{- toYaml .Values.sidecar.securityContext | nindent 12 }}
           {{- end }}
           volumeMounts:
+            - name: tmp
+              mountPath: /tmp
             - name: sc-rules-volume
               mountPath: {{ .Values.sidecar.rules.folder | quote }}
         {{- end}}

--- a/charts/loki/templates/write/poddisruptionbudget-write.yaml
+++ b/charts/loki/templates/write/poddisruptionbudget-write.yaml
@@ -11,5 +11,7 @@ spec:
   selector:
     matchLabels:
       {{- include "loki.writeSelectorLabels" . | nindent 6 }}
-  maxUnavailable: 1
+  {{- with .Values.write.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/loki/test/integration/distributed-advanced/log-generator.yaml
+++ b/charts/loki/test/integration/distributed-advanced/log-generator.yaml
@@ -18,6 +18,7 @@ spec:
   chart:
     spec:
       chart: alloy
+      version: 1.7.0
       sourceRef:
         kind: HelmRepository
         name: grafana

--- a/charts/loki/test/integration/single-binary/log-generator.yaml
+++ b/charts/loki/test/integration/single-binary/log-generator.yaml
@@ -18,6 +18,7 @@ spec:
   chart:
     spec:
       chart: alloy
+      version: 1.7.0
       sourceRef:
         kind: HelmRepository
         name: grafana

--- a/charts/loki/test/integration/ssd/log-generator.yaml
+++ b/charts/loki/test/integration/ssd/log-generator.yaml
@@ -18,6 +18,7 @@ spec:
   chart:
     spec:
       chart: alloy
+      version: 1.7.0
       sourceRef:
         kind: HelmRepository
         name: grafana

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -57,6 +57,8 @@ imagePullSecrets: []
 # - SimpleScalable<->Distributed: Migrate from SimpleScalable to Distributed (or vice versa)
 # Note: SimpleScalable and Distributed REQUIRE the use of object storage.
 deploymentMode: SimpleScalable
+# -- Labels to be added to resources
+commonLabels: {}
 ######################################################################################################################
 #
 # Base Loki Configs including kubernetes configurations and configurations for Loki itself,
@@ -86,7 +88,7 @@ loki:
     # -- Docker image repository
     repository: grafana/loki
     # -- Overrides the image tag whose default is the chart's appVersion
-    tag: 3.6.5
+    tag: 3.6.7
     # -- Overrides the image tag with an image digest
     digest: null
     # -- Docker image pull policy
@@ -627,10 +629,12 @@ loki:
 
 # -- Configuration for running Enterprise Loki
 enterprise:
-  # Enable enterprise features, license must be provided
+  # Enterprise features are disabled by default.
+  # Set to `true` to deploy Grafana Enterprise Logs (GEL) with a valid license via
+  # `enterprise.license.contents` or `enterprise.useExternalLicense`/`enterprise.externalLicenseName`.
   enabled: false
   # Default version of GEL to deploy
-  version: 3.6.3
+  version: 3.6.6
   # -- Optional name of the GEL cluster, otherwise will use .Release.Name
   # The cluster name must match what is in your GEL license
   cluster_name: null
@@ -672,7 +676,7 @@ enterprise:
     # -- Docker image repository
     repository: grafana/enterprise-logs
     # -- Docker image tag
-    tag: 3.6.5
+    tag: 3.6.6
     # -- Overrides the image tag with an image digest
     digest: null
     # -- Docker image pull policy
@@ -685,9 +689,13 @@ enterprise:
   canarySecret: null
   # -- Configuration for `provisioner` target
   # Note: Uses enterprise.adminToken.secret value to mount the admin token used to call the admin api.
+  # The provisioner is disabled by default because it requires an out-of-band admin token secret
+  # (created via GEL `tokengen`) referenced by `enterprise.adminToken.secret`. After creating that
+  # secret, set both `enterprise.adminToken.secret` and `enterprise.provisioner.enabled: true`.
+  # See production/helm/loki/docs/examples/enterprise/README.md for the full procedure.
   provisioner:
     # -- Whether the job should be part of the deployment
-    enabled: true
+    enabled: false
     # -- Name of the secret to store provisioned tokens in
     provisionedSecretPrefix: null
     # -- Hook type(s) to customize when the job runs.  defaults to post-install
@@ -1672,6 +1680,8 @@ write:
           topologyKey: kubernetes.io/hostname
   # -- DNS config for write pods
   dnsConfig: {}
+  # -- Pod Disruption Budget maxUnavailable
+  maxUnavailable: 1
   # -- Node selector for write pods
   nodeSelector: {}
   # -- Topology Spread Constraints for write pods
@@ -1811,6 +1821,8 @@ read:
           topologyKey: kubernetes.io/hostname
   # -- DNS config for read pods
   dnsConfig: {}
+  # -- Pod Disruption Budget maxUnavailable
+  maxUnavailable: 1
   # -- Node selector for read pods
   nodeSelector: {}
   # -- Topology Spread Constraints for read pods
@@ -1938,6 +1950,8 @@ backend:
           topologyKey: kubernetes.io/hostname
   # -- DNS config for backend pods
   dnsConfig: {}
+  # -- Pod Disruption Budget maxUnavailable
+  maxUnavailable: 1
   # -- Node selector for backend pods
   nodeSelector: {}
   # -- Topology Spread Constraints for backend pods
@@ -3662,6 +3676,8 @@ resultsCache:
   port: 11211
   # -- Amount of memory allocated to results-cache for object storage (in MB).
   allocatedMemory: 1024
+  # -- Amount of cpu allocated to results-cache for object storage (in integer or millicores).
+  allocatedCPU: 500m
   # -- Maximum item results-cache for memcached (in MB).
   maxItemMemory: 5
   # -- Maximum number of connections allowed
@@ -3777,6 +3793,8 @@ chunksCache:
   port: 11211
   # -- Amount of memory allocated to chunks-cache for object storage (in MB).
   allocatedMemory: 8192
+  # -- Amount of cpu allocated to chunks-cache for object storage (in integer or millicores).
+  allocatedCPU: 500m
   # -- Maximum item memory for chunks-cache (in MB).
   maxItemMemory: 5
   # -- Maximum number of connections allowed
@@ -3895,6 +3913,8 @@ chunksCache:
     port: 11211
     # -- Amount of memory allocated to chunks-cache-l2 for object storage (in MB).
     allocatedMemory: 8192
+    # -- Amount of cpu allocated to chunks-cache-l2 for object storage (in integer or millicores).
+    allocatedCPU: 500m
     # -- Maximum item memory for chunks-cache-l2 (in MB).
     maxItemMemory: 5
     # -- Maximum number of connections allowed
@@ -4020,6 +4040,17 @@ rollout_operator:
 # -- Configuration for the minio subchart
 minio:
   enabled: false
+  # Override the upstream MinIO, Inc. images with the Pigsty (pgsty) community
+  # fork to mitigate the unresolved CVE in the abandoned MinIO images.
+  # See https://github.com/pgsty/minio for details.
+  image:
+    repository: docker.io/pgsty/minio
+    tag: RELEASE.2026-03-14T12-00-00Z
+    pullPolicy: IfNotPresent
+  mcImage:
+    repository: docker.io/pgsty/mc
+    tag: RELEASE.2026-03-13T08-57-32Z
+    pullPolicy: IfNotPresent
   replicas: 1
   # Minio requires 2 to 16 drives for erasure code (drivesPerNode * replicas)
   # https://docs.min.io/docs/minio-erasure-code-quickstart-guide
@@ -4094,7 +4125,7 @@ sidecar:
     # -- The Docker registry and image for the k8s sidecar
     repository: kiwigrid/k8s-sidecar
     # -- Docker image tag
-    tag: 1.30.9
+    tag: 2.5.0
     # -- Docker image sha. If empty, no sha will be used
     sha: ""
     # -- Docker image pull policy
@@ -4116,6 +4147,8 @@ sidecar:
     allowPrivilegeEscalation: false
   # -- Set to true to skip tls verification for kube api calls.
   skipTlsVerify: false
+  # -- Set to true to disable strict x509 verification for kube api calls.
+  disableX509StrictVerification: false
   # -- Ensure that rule files aren't conflicting and being overwritten by prefixing their name with the namespace they are defined in.
   enableUniqueFilenames: false
   # -- Readiness probe definition. Probe is disabled on the sidecar by default.

--- a/salt/metalk8s/addons/logging/loki/deployed/chart.sls
+++ b/salt/metalk8s/addons/logging/loki/deployed/chart.sls
@@ -14,8 +14,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: loki
     app.kubernetes.io/name: loki
-    app.kubernetes.io/version: 3.6.5
-    helm.sh/chart: loki-6.53.0
+    app.kubernetes.io/version: 3.6.7
+    helm.sh/chart: loki-7.0.0
   name: loki
   namespace: metalk8s-logging
 ---
@@ -28,8 +28,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: loki
     app.kubernetes.io/name: loki
-    app.kubernetes.io/version: 3.6.5
-    helm.sh/chart: loki-6.53.0
+    app.kubernetes.io/version: 3.6.7
+    helm.sh/chart: loki-7.0.0
   name: loki-runtime
   namespace: metalk8s-logging
 ---
@@ -39,8 +39,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: loki
     app.kubernetes.io/name: loki
-    app.kubernetes.io/version: 3.6.5
-    helm.sh/chart: loki-6.53.0
+    app.kubernetes.io/version: 3.6.7
+    helm.sh/chart: loki-7.0.0
   name: loki-clusterrole
   namespace: metalk8s-logging
 rules:
@@ -60,8 +60,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: loki
     app.kubernetes.io/name: loki
-    app.kubernetes.io/version: 3.6.5
-    helm.sh/chart: loki-6.53.0
+    app.kubernetes.io/version: 3.6.7
+    helm.sh/chart: loki-7.0.0
   name: loki-clusterrolebinding
   namespace: metalk8s-logging
 roleRef:
@@ -80,8 +80,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: loki
     app.kubernetes.io/name: loki
-    app.kubernetes.io/version: 3.6.5
-    helm.sh/chart: loki-6.53.0
+    app.kubernetes.io/version: 3.6.7
+    helm.sh/chart: loki-7.0.0
   name: loki-memberlist
   namespace: metalk8s-logging
 spec:
@@ -104,8 +104,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: loki
     app.kubernetes.io/name: loki
-    app.kubernetes.io/version: 3.6.5
-    helm.sh/chart: loki-6.53.0
+    app.kubernetes.io/version: 3.6.7
+    helm.sh/chart: loki-7.0.0
     prometheus.io/service-monitor: 'false'
     variant: headless
   name: loki-headless
@@ -128,8 +128,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: loki
     app.kubernetes.io/name: loki
-    app.kubernetes.io/version: 3.6.5
-    helm.sh/chart: loki-6.53.0
+    app.kubernetes.io/version: 3.6.7
+    helm.sh/chart: loki-7.0.0
   name: loki
   namespace: metalk8s-logging
 spec:
@@ -156,8 +156,8 @@ metadata:
     app.kubernetes.io/instance: loki
     app.kubernetes.io/name: loki
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: 3.6.5
-    helm.sh/chart: loki-6.53.0
+    app.kubernetes.io/version: 3.6.7
+    helm.sh/chart: loki-7.0.0
   name: loki
   namespace: metalk8s-logging
 spec:
@@ -197,7 +197,7 @@ spec:
       - args:
         - -config.file=/etc/loki/config/config.yaml
         - -target=all,table-manager
-        image: {% endraw -%}{{ build_image_name("loki", False) }}{%- raw %}:3.6.5
+        image: {% endraw -%}{{ build_image_name("loki", False) }}{%- raw %}:3.6.7
         imagePullPolicy: IfNotPresent
         name: loki
         ports:
@@ -262,6 +262,8 @@ spec:
             - ALL
           readOnlyRootFilesystem: true
         volumeMounts:
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /rules
           name: sc-rules-volume
       enableServiceLinks: true
@@ -316,8 +318,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: loki
     app.kubernetes.io/name: loki
-    app.kubernetes.io/version: 3.6.5
-    helm.sh/chart: loki-6.53.0
+    app.kubernetes.io/version: 3.6.7
+    helm.sh/chart: loki-7.0.0
     metalk8s.scality.com/monitor: ''
   name: loki
   namespace: metalk8s-logging


### PR DESCRIPTION
Loki itself has been bumped to v3.6.7 accordingly.

Also updated the Salt file to use the new chart version.

Although this is a major chart version bump (6.x -> 7.0.0), the changes have been reviewed and are non-breaking for our configuration:
- `deploymentMode` default changed to `SimpleScalable`: we override with `SingleBinary`
- Enterprise `provisioner.enabled` default changed to `false`: we do not use enterprise
- MinIO image switched to pgsty fork: we do not use MinIO (`minio.enabled: false`)
- sidecar tag bumped to 2.5.0: we already pin 2.5.0 in our values

Ref: MK8S-228