### PR TITLE
build: bump rockylinux9 base image to 9.8-minimal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@
 - Bump Alpine base image version to [3.24.1](https://github.com/alpinelinux/aports/releases/tag/v3.24.1)
   (PR[#4993](https://github.com/scality/metalk8s/pull/4993))
 
+- Bump the rocky base image used by `metalk8s-utils` image to
+  `rockylinux:9.8-minimal`
+  (PR[#4994](https://github.com/scality/metalk8s/pull/4994))
+
 ## Release 133.0.12 (in development)
 
 ## Release 133.0.11

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -75,8 +75,8 @@ ROCKY_BASE_IMAGE_8_SHA256: str = (
     "6d2ede107b4f005a638728711dae05d5fbbfd8abd521cecf5ab61196b361c965"
 )
 ROCKY_BASE_IMAGE_9_SHA256: str = (
-    # rockylinux:9.7-minimal
-    "c26c789bd9b2c9fd092109688dbac8bdab27e51651d8130d7e10220f8e07614a"
+    # rockylinux:9.8-minimal
+    "e1d0a9f5ed99d52e7faf03afe7ee32e48b231c4dd9586808b3d1aedf894dff04"
 )
 
 ETCD_VERSION: str = "3.6.11"


### PR DESCRIPTION
minor bump for rocky9
there was no new versions for rocky8
Ref: [MK8S-236](https://scality.atlassian.net/browse/MK8S-236)



[MK8S-236]: https://scality.atlassian.net/browse/MK8S-236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ