### PR TITLE
tests: Make Prometheus alert-rules check addon-aware

### DIFF
--- a/tests/post/steps/test_monitoring.py
+++ b/tests/post/steps/test_monitoring.py
@@ -21,16 +21,6 @@ DASHBOARD_UIDS_FILE = LOCAL_DIR / "files/grafana_dashboard_uids.json"
 
 NODE_EXPORTER_PORT = 9100
 
-# Alert rules that are deployed only when a given addon is enabled. When the
-# addon is disabled the rule is absent from the cluster, so it must also be
-# dropped from the reference set (`alerting_rules.json`) before comparing,
-# otherwise the equality check fails on reduced-addon clusters (e.g. no-logging).
-# Mirrors the addon-aware dashboards check below.
-# Source: salt/metalk8s/addons/logging/*/deployed/chart.sls
-ADDON_ALERT_RULES = {
-    "fluent-bit": {"FluentBitBackPressure", "FluentBitOutputRetryLimit"},
-}
-
 # }}}
 # Scenarios {{{
 
@@ -532,18 +522,13 @@ def check_deployed_rules(host, prometheus_api):
     except json.JSONDecodeError as exc:
         pytest.fail(f"Failed to decode JSON from {ALERT_RULE_FILE}: {exc!s}")
 
-    # Drop alert rules whose addon is disabled on this cluster: they are not
-    # deployed, so they must not be expected in the reference set either.
-    disabled_alert_names = set()
-    for addon, alert_names in ADDON_ALERT_RULES.items():
-        if not utils.get_pillar(host, f"addons:{addon}:enabled"):
-            disabled_alert_names |= alert_names
-
-    if disabled_alert_names:
+    if not utils.get_pillar(host, "addons:fluent-bit:enabled"):
+        # Filter out FluentBit-specific alert rules if fluent-bit is disabled
         default_alert_rules = [
             rule
             for rule in default_alert_rules
-            if rule["name"] not in disabled_alert_names
+            if rule["name"]
+            not in ["FluentBitBackPressure", "FluentBitOutputRetryLimit"]
         ]
 
     default_sorted = sorted(

--- a/tests/post/steps/test_monitoring.py
+++ b/tests/post/steps/test_monitoring.py
@@ -564,9 +564,7 @@ def check_deployed_rules(host, prometheus_api):
         if extra:
             details.append(f"in deployed but not default: {extra}")
         if not details:
-            details.append(
-                "same alert names/severities but differing message or query"
-            )
+            details.append("same alert names/severities but differing message or query")
         pytest.fail(
             "Deployed Prometheus alert rules differ from the default alert "
             "rules (" + "; ".join(details) + ")."

--- a/tests/post/steps/test_monitoring.py
+++ b/tests/post/steps/test_monitoring.py
@@ -21,6 +21,16 @@ DASHBOARD_UIDS_FILE = LOCAL_DIR / "files/grafana_dashboard_uids.json"
 
 NODE_EXPORTER_PORT = 9100
 
+# Alert rules that are deployed only when a given addon is enabled. When the
+# addon is disabled the rule is absent from the cluster, so it must also be
+# dropped from the reference set (`alerting_rules.json`) before comparing,
+# otherwise the equality check fails on reduced-addon clusters (e.g. no-logging).
+# Mirrors the addon-aware dashboards check below.
+# Source: salt/metalk8s/addons/logging/*/deployed/chart.sls
+ADDON_ALERT_RULES = {
+    "fluent-bit": {"FluentBitBackPressure", "FluentBitOutputRetryLimit"},
+}
+
 # }}}
 # Scenarios {{{
 
@@ -522,11 +532,45 @@ def check_deployed_rules(host, prometheus_api):
     except json.JSONDecodeError as exc:
         pytest.fail(f"Failed to decode JSON from {ALERT_RULE_FILE}: {exc!s}")
 
-    assert sorted(
+    # Drop alert rules whose addon is disabled on this cluster: they are not
+    # deployed, so they must not be expected in the reference set either.
+    disabled_alert_names = set()
+    for addon, alert_names in ADDON_ALERT_RULES.items():
+        if not utils.get_pillar(host, f"addons:{addon}:enabled"):
+            disabled_alert_names |= alert_names
+
+    if disabled_alert_names:
+        default_alert_rules = [
+            rule
+            for rule in default_alert_rules
+            if rule["name"] not in disabled_alert_names
+        ]
+
+    default_sorted = sorted(
         default_alert_rules, key=operator.itemgetter("name", "severity")
-    ) == sorted(
+    )
+    deployed_sorted = sorted(
         deployed_alert_rules, key=operator.itemgetter("name", "severity")
-    ), "Expected default Prometheus rules to be equal to deployed rules."
+    )
+
+    if default_sorted != deployed_sorted:
+        default_keys = {(r["name"], r["severity"]) for r in default_alert_rules}
+        deployed_keys = {(r["name"], r["severity"]) for r in deployed_alert_rules}
+        missing = sorted(default_keys - deployed_keys)
+        extra = sorted(deployed_keys - default_keys)
+        details = []
+        if missing:
+            details.append(f"in default but not deployed: {missing}")
+        if extra:
+            details.append(f"in deployed but not default: {extra}")
+        if not details:
+            details.append(
+                "same alert names/severities but differing message or query"
+            )
+        pytest.fail(
+            "Deployed Prometheus alert rules differ from the default alert "
+            "rules (" + "; ".join(details) + ")."
+        )
 
 
 @then("the deployed dashboards match the expected ones")


### PR DESCRIPTION
## Problem

The post-install monitoring test fails deterministically on reduced-addon variants (seen on `single-node-rocky-8-no-idp-no-logging`):

```
tests/post/steps/test_monitoring.py: AssertionError
  Expected default Prometheus rules to be equal to deployed rules.
  At index 20 diff: {'name': 'FluentBitBackPressure', ...} != {'name': 'InfoInhibitor', ...}
```

`check_deployed_rules` compares the cluster's live alert rules against the **full-feature** reference `tools/rule_extractor/alerting_rules.json` with an exact-equality assertion. Fluent-bit add-on is disabled so we need to filter out the alerts if not enabled

## Fix (`tests/post/steps/test_monitoring.py`)

- Check if fluent bit is enabled (`if utils.get_pillar(host, "addons:fluent-bit:enabled")`).  Drop its alerts from the reference set before comparing if not enabled.
- Replace the opaque `assert ... == ...` with a failure message that lists which alert (name, severity) pairs are **missing** / **extra** (or notes a message/query-only difference), to make genuine alert-rule drift easy to diagnose.

## References

- Failing nightly: `scality/metalk8s` run 27829624212 (job `install (rocky-8, false, false) / single-node`)
- Reference file: `tools/rule_extractor/alerting_rules.json`

Issue: MK8S-330