### PR TITLE
salt: bump kube-apiserver AuthenticationConfiguration to v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,10 @@
   `k8s.io/{api,apimachinery,client-go}` dependencies to v0.33.13
   (PR[#5000](https://github.com/scality/metalk8s/pull/5000))
 
+- Bump `kube-apiserver` `AuthenticationConfiguration` apiVersion to
+  `apiserver.config.k8s.io/v1` (GA in Kubernetes 1.34)
+  (PR[#5001](https://github.com/scality/metalk8s/pull/5001))
+
 ## Release 133.0.12 (in development)
 
 ## Release 133.0.11

--- a/salt/metalk8s/kubernetes/apiserver/authnconfig.sls
+++ b/salt/metalk8s/kubernetes/apiserver/authnconfig.sls
@@ -63,11 +63,7 @@ Create kube-apiserver authentication configuration:
     - group: root
     - makedirs: True
     - dataset:
-        {#- TODO(MK8S-258): bump apiVersion to apiserver.config.k8s.io/v1 once metalk8s
-        pins Kubernetes >= 1.34. AuthenticationConfiguration is registered in
-        v1beta1 in 1.32/1.33 and promotes to v1 (GA) in 1.34.
-        it will also continue to be supported in v1beta1 until 1.36 #}
-        apiVersion: apiserver.config.k8s.io/v1beta1
+        apiVersion: apiserver.config.k8s.io/v1
         kind: AuthenticationConfiguration
         anonymous:
           enabled: true


### PR DESCRIPTION
**Component**: salt, kubernetes

**Context**:
Tracks [MK8S-258](https://scality.atlassian.net/browse/MK8S-258).

Kubernetes 1.34 promotes `apiserver.config.k8s.io/AuthenticationConfiguration` from v1beta1 to GA (v1). Since metalk8s now pins K8s 1.34.7, the file emitted by `salt/metalk8s/kubernetes/apiserver/authnconfig.sls` and consumed by kube-apiserver via `--authentication-config` can move off the beta apiVersion.

**Summary**:
- Switch `apiVersion: apiserver.config.k8s.io/v1beta1` -> `v1` in `authnconfig.sls`.
- Drop the TODO referencing this ticket.

**Acceptance criteria**:
- [x] `apiVersion: apiserver.config.k8s.io/v1` in `authnconfig.sls`.
- [x] TODO comment referencing MK8S-258 removed.
- [x] Single-node and multi-node e2e green (CI).
- [ ] No regression in post-install authentication scenarios (anonymous /livez,/readyz,/healthz return 200; authenticated paths still 200; /version still 401).

[MK8S-258]: https://scality.atlassian.net/browse/MK8S-258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ