### PR TITLE
fix(ui): disable Save & test-email buttons until the SMTP config is valid

### DIFF
--- a/ui/src/alert-configuration/ConfigureAlerting.test.tsx
+++ b/ui/src/alert-configuration/ConfigureAlerting.test.tsx
@@ -221,7 +221,7 @@ describe('<ConfigureAlerting />', () => {
     expect(selectors.recipient()).toHaveValue('');
     expect(selectors.receiveResolved()).not.toBeChecked();
 
-    expect(selectors.sendTestingEmailButton()).toBeEnabled();
+    expect(selectors.sendTestingEmailButton()).toBeDisabled();
     expect(selectors.cancelButton()).toBeEnabled();
     expect(selectors.saveButton()).toBeDisabled();
 
@@ -342,7 +342,7 @@ describe('<ConfigureAlerting />', () => {
     expect(selectors.receiveResolved()).toBeChecked();
   });
 
-  it('show errors on submit with not all required field', async () => {
+  it('surfaces required-field errors and keeps Save disabled when the config is enabled but incomplete', async () => {
     await commonSetup();
 
     await waitFor(() => {
@@ -352,23 +352,19 @@ describe('<ConfigureAlerting />', () => {
       await userEvent.click(selectors.enableConfiguration());
     });
 
-    await waitFor(() => {
-      expect(selectors.saveButton()).toBeInTheDocument();
-    });
-
-    await act(async () => {
-      await userEvent.click(selectors.saveButton());
-    });
-
     const errors = [
       /"smtp host" is not allowed to be empty/i,
       /"Sender Email Address" is not allowed to be empty/i,
       /"Recipient Email Addresses" is not allowed to be empty/i,
     ];
 
-    errors.forEach((error) => {
-      expect(screen.getByText(error)).toBeInTheDocument();
+    await waitFor(() => {
+      errors.forEach((error) => {
+        expect(screen.getByText(error)).toBeInTheDocument();
+      });
     });
+
+    expect(selectors.saveButton()).toBeDisabled();
   });
 
   it('should redirect to alerts page when you click on cancel button', async () => {
@@ -789,9 +785,9 @@ spec:
       await userEvent.type(selectors.sender(), 'renard.admin@scality.com');
 
       await userEvent.type(selectors.recipient(), 'user1@test.com, user2@test.com');
-
-      await userEvent.click(selectors.sendTestingEmailButton());
     });
+
+    await userEvent.click(selectors.sendTestingEmailButton());
 
     expect(selectors.sendTestingEmailButton()).toBeDisabled();
 
@@ -982,20 +978,21 @@ spec:
       await userEvent.type(selectors.sender(), 'renard.admin@scality.com');
 
       await userEvent.type(selectors.recipient(), 'user1@test.com, user2@test.com');
-      server.use(
-        rest.get(
-          `http://localhost/api/kubernetes/api/v1/namespaces/metalk8s-monitoring/pods/alertmanager-prometheus-operator-alertmanager-0/log`,
-          (req, res, ctx) => {
-            const logs = `
+    });
+    server.use(
+      rest.get(
+        `http://localhost/api/kubernetes/api/v1/namespaces/metalk8s-monitoring/pods/alertmanager-prometheus-operator-alertmanager-0/log`,
+        (req, res, ctx) => {
+          const logs = `
     ts=2023-06-27T12:00:00.000Z caller=dispatch.go:352 level=error component=dispatcher msg="Notify for alerts failed" num_alerts=1 err="test-receiver-config-from-ui/email[0]: notify retry canceled after 7 attempts: establish connection to server: dial tcp: lookup smtp4dev.default.svc.cluster.local1 on 10.0.0.0: no such host"
     ts=2023-06-27T12:00:00.000Z caller=notify.go:732 level=warn component=dispatcher receiver=test-receiver-config-from-ui integration=email[0] msg="Notify attempt failed, will retry later" attempts=1 err="establish connection to server: dial tcp: lookup smtp4dev.default.svc.cluster.local1 on 10.0.0.0: no such host"
             `;
-            return res(ctx.text(logs));
-          },
-        ),
-      );
-      await userEvent.click(selectors.sendTestingEmailButton());
-    });
+          return res(ctx.text(logs));
+        },
+      ),
+    );
+    await userEvent.click(selectors.sendTestingEmailButton());
+
     expect(selectors.sendTestingEmailButton()).toBeDisabled();
     await waitForElementToBeRemoved(() => {
       return screen.getByText(/Sending.../);
@@ -1055,5 +1052,31 @@ spec:
     });
     expect(screen.getByText(/The email address is invalid/i)).toBeInTheDocument();
     expect(screen.getByText(/The email addresses are invalid/i)).toBeInTheDocument();
+  });
+
+  it('keeps "Send a test email" disabled until all required SMTP fields are valid', async () => {
+    await commonSetup();
+
+    await waitFor(() => {
+      expect(selectors.sendTestingEmailButton()).toBeDisabled();
+    });
+
+    await act(async () => {
+      await userEvent.type(selectors.recipient(), 'user@example.com');
+    });
+    expect(selectors.sendTestingEmailButton()).toBeDisabled();
+
+    await act(async () => {
+      await userEvent.type(selectors.sender(), 'admin@example.com');
+    });
+    expect(selectors.sendTestingEmailButton()).toBeDisabled();
+
+    await act(async () => {
+      await userEvent.type(selectors.host(), 'smtp.example.com');
+    });
+
+    await waitFor(() => {
+      expect(selectors.sendTestingEmailButton()).toBeEnabled();
+    });
   });
 });

--- a/ui/src/alert-configuration/ConfigureAlerting.tsx
+++ b/ui/src/alert-configuration/ConfigureAlerting.tsx
@@ -106,11 +106,12 @@ export default function ConfigureAlerting() {
   const theme = useTheme();
   const navigate = useBasenameRelativeNavigate();
   const dispatch = useDispatch();
-  const { register, reset, handleSubmit, control, watch, getValues, formState } = useForm<AlertConfiguration>({
+  const { register, reset, handleSubmit, control, watch, trigger, getValues, formState } = useForm<AlertConfiguration>({
     mode: 'onChange',
     resolver: joiResolver(schema),
   });
   const credsType = watch('type');
+  const isEmailNotificationEnabled = watch('enabled');
 
   const { url: kubernetesApiUrl, url_salt: saltApiUrl, url_alertmanager: alertManagerUrl } = useConfig();
 
@@ -151,6 +152,12 @@ export default function ConfigureAlerting() {
     }
   }, [alertConfiguration.status]);
 
+  useEffect(() => {
+    if (isEmailNotificationEnabled) {
+      trigger();
+    }
+  }, [isEmailNotificationEnabled, trigger]);
+
   const { sendTestAlertMutation, logs: testAlertlogs } = useTestAlertConfiguration({
     alertConfigurationStore,
   });
@@ -168,7 +175,8 @@ export default function ConfigureAlerting() {
 
   const labelWidth = 270;
 
-  const disableFormButton = editAlertMutation.isLoading || sendTestAlertMutation.isLoading || !formState.isDirty;
+  const disableFormButton =
+    editAlertMutation.isLoading || sendTestAlertMutation.isLoading || !formState.isDirty || !formState.isValid;
 
   if (alertConfiguration.status === 'loading') {
     return <div>Loading...</div>;
@@ -204,7 +212,7 @@ export default function ConfigureAlerting() {
                         }
                       : undefined
                   }
-                  disabled={sendTestAlertMutation.isLoading || editAlertMutation.isLoading}
+                  disabled={sendTestAlertMutation.isLoading || editAlertMutation.isLoading || !formState.isValid}
                   label={
                     sendTestAlertMutation.isLoading ? (
                       <Text


### PR DESCRIPTION
**TL;DR** — Disables the Save and Send-test-email buttons on the alert config page until the SMTP form is actually valid; previously an incomplete config could trigger a real `PrometheusOperatorSyncFailed` alert in production.

### Context / Why
Repro from [ARTESCA-17689](https://scality.atlassian.net/browse/ARTESCA-17689): open Email notification configuration with no recipient set, click **Send a test email** — this triggers `PrometheusOperatorSyncFailed` ("Controller alertmanager in metalk8s-monitoring namespace fails to reconcile 1 objects", with the alertmanager logs showing "missing to address in email config"). Both buttons submit the whole form as the Alertmanager config, so any invalid required field (recipient, sender, SMTP host, or the conditional auth fields) was reaching production config. Gating both buttons on `formState.isValid` blocks that at the source.

Disabling Save also removes the old "click Save to see what's missing" discovery path, so enabling notifications now runs full-form validation immediately — required-field errors surface inline instead of only on submit.

### 🔍 Review focus
- 🟡 **Moderate** — `ConfigureAlerting.tsx` — worth confirming `formState.isValid` reflects the just-loaded config correctly (after `reset()` populates existing values), not a stale/default form state — otherwise an already-valid *saved* configuration could show Save/Send as disabled on first page load.
- ⚪ **Minor** — same file — the new `useEffect` calls `trigger()` whenever email notifications get toggled on, to force the inline-errors-on-enable behavior described above; low risk, and both buttons' "disabled until valid" behavior has direct test coverage.

### 📷 Screenshots
<!-- 📷 Before: /configure-alerts, email notifications enabled with an empty/invalid recipient — Save and Send-a-test-email are clickable (checkout main to reproduce the old behavior) -->
<!-- 📷 After: /configure-alerts, same invalid state — both buttons disabled, required-field errors shown inline -->

### 🧪 How to test
1. Navigate to **Configure Alerts** (`/configure-alerts`).
2. Enable email notifications without filling in a recipient (or with an invalid SMTP host).
3. Confirm both **Save** and **Send a test email** are disabled, and required-field errors appear inline immediately — not only after clicking Save.
4. Fill in all required fields validly — confirm both buttons become enabled.
5. Confirm the invalid-config path is no longer reachable at all (buttons unclickable), so it can't trigger `PrometheusOperatorSyncFailed` in Alertmanager.

### 🔗 References
- [ARTESCA-17689](https://scality.atlassian.net/browse/ARTESCA-17689) — "[RD] Alertmanager: \"Send a test email\" button triggers a PrometheusOperatorSyncFailed alert when no recipient email is configured" (Bug, status: Waiting for Release)

<details><summary>What changed</summary>

`ConfigureAlerting.test.tsx` — 19/19 pass, including new coverage for "disabled until valid" on both buttons.

</details>

[ARTESCA-17689]: https://scality.atlassian.net/browse/ARTESCA-17689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ARTESCA-17689]: https://scality.atlassian.net/browse/ARTESCA-17689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ