### PR TITLE
tests: ensure ingress pods are ready before testing + dump cluster state on failure

### DIFF
--- a/tests/post/features/ingress.feature
+++ b/tests/post/features/ingress.feature
@@ -52,7 +52,8 @@ Feature: Ingress
         And we wait for the rollout of 'daemonset/calico-node' in namespace 'kube-system' to complete
         And we trigger a rollout restart of 'daemonset/ingress-nginx-controller' in namespace 'metalk8s-ingress'
         And we wait for the rollout of 'daemonset/ingress-nginx-controller' in namespace 'metalk8s-ingress' to complete
-        Then an HTTP request on port 80 on a workload-plane IP should not return
+        Then the DaemonSet 'ingress-nginx-controller' in the 'metalk8s-ingress' namespace has all desired Pods ready  
+        And an HTTP request on port 80 on a workload-plane IP should not return
         And an HTTP request on port 80 on a control-plane IP returns 200 'OK'
         And the server should respond with shell-ui index
 
@@ -64,7 +65,8 @@ Feature: Ingress
         And we wait for the ClusterConfig to be 'Ready'
         And we trigger a rollout restart of 'daemonset/ingress-nginx-controller' in namespace 'metalk8s-ingress'
         And we wait for the rollout of 'daemonset/ingress-nginx-controller' in namespace 'metalk8s-ingress' to complete
-        Then the '{wp_ingress_vips}' IPs are spread on nodes
+        Then the DaemonSet 'ingress-nginx-controller' in the 'metalk8s-ingress' namespace has all desired Pods ready
+        And the '{wp_ingress_vips}' IPs are spread on nodes
         And an HTTP request on port 80 on '{wp_ingress_vips}' IPs returns 200 'OK'
         And the server should respond with shell-ui index
 
@@ -76,9 +78,11 @@ Feature: Ingress
         And the '{wp_ingress_first_pool}' IPs are spread on nodes
         When we update the ClusterConfig to add 'test-vip-2' Workload Plane pool with IPs '{wp_ingress_second_pool}'
         And we wait for the ClusterConfig to be 'Ready'
+        And we wait for the rollout of 'daemonset/calico-node' in namespace 'kube-system' to complete
         And we trigger a rollout restart of 'daemonset/ingress-nginx-controller' in namespace 'metalk8s-ingress'
         And we wait for the rollout of 'daemonset/ingress-nginx-controller' in namespace 'metalk8s-ingress' to complete
-        Then the '{wp_ingress_second_pool}' IPs are spread on nodes
+        Then the DaemonSet 'ingress-nginx-controller' in the 'metalk8s-ingress' namespace has all desired Pods ready
+        And the '{wp_ingress_second_pool}' IPs are spread on nodes
         And an HTTP request on port 80 on '{wp_ingress_second_pool}' IPs returns 200 'OK'
         And the server should respond with shell-ui index
         And the '{wp_ingress_first_pool}' IPs are no longer available on nodes
@@ -94,7 +98,8 @@ Feature: Ingress
         And we wait for the ClusterConfig to be 'Ready'
         And we trigger a rollout restart of 'daemonset/ingress-nginx-controller' in namespace 'metalk8s-ingress'
         And we wait for the rollout of 'daemonset/ingress-nginx-controller' in namespace 'metalk8s-ingress' to complete
-        Then the '{wp_ingress_first_pool}' IPs are spread on nodes
+        Then the DaemonSet 'ingress-nginx-controller' in the 'metalk8s-ingress' namespace has all desired Pods ready
+        And the '{wp_ingress_first_pool}' IPs are spread on nodes
         And an HTTP request on port 80 on '{wp_ingress_first_pool}' IPs returns 200 'OK'
         And the server should respond with shell-ui index
         And the '{wp_ingress_second_pool}' IPs are spread on nodes

--- a/tests/post/steps/conftest.py
+++ b/tests/post/steps/conftest.py
@@ -2,12 +2,12 @@
 
 import json
 
-from kubernetes.client import CustomObjectsApi
-from kubernetes.client import StorageV1Api
+from kubernetes.client.rest import ApiException
 import pytest
 from pytest_bdd import given, parsers, then
 
 from tests import kube_utils, utils
+from tests.conftest import wait_rollout_status
 
 
 # Fixtures {{{
@@ -203,6 +203,77 @@ def then_check_pod_different_node(ssh_config, host, k8s_client, selector):
             pod.spec.nodeName not in nodes
         ), f"Node '{pod.spec.nodeName}' has several Pod with label '{selector}'"
         nodes.add(pod.spec.nodeName)
+
+
+@then("the DaemonSet <name> in the <namespace> namespace has all desired Pods ready")
+@then(
+    parsers.parse(
+        "the DaemonSet '{name}' in the '{namespace}' namespace has all desired "
+        "Pods ready"
+    )
+)
+def check_daemonset(host, k8s_client, name, namespace):
+    def _wait_for_daemon_set():
+        try:
+            daemon_set = k8s_client.resources.get(
+                api_version="apps/v1", kind="DaemonSet"
+            ).get(name=name, namespace=namespace)
+        except ApiException as exc:
+            if exc.status == 404:
+                pytest.fail(f"DaemonSet '{namespace}/{name}' does not exist")
+            raise
+
+        desired = daemon_set.status.desired_number_scheduled
+        scheduled = daemon_set.status.current_number_scheduled
+        assert (
+            desired == scheduled
+        ), f"DaemonSet is not ready yet (desired={desired}, scheduled={scheduled})"
+        available = daemon_set.status.number_available
+        assert (
+            desired == available
+        ), f"DaemonSet is not ready yet (desired={desired}, available={available})"
+
+        # The DaemonSet status counters do not account for pods being
+        # terminated: during a rolling update, the new pod is reported as
+        # available as soon as it is Ready, while the old one can still be
+        # in `Terminating` (long `terminationGracePeriodSeconds`, draining
+        # `preStop` hook, finalizers, ...).  Make sure no pod from a
+        # previous revision is still around before declaring the DaemonSet
+        # fully ready.
+        label_selector = ",".join(
+            f"{key}={value}"
+            for key, value in daemon_set.spec.selector.matchLabels.items()
+        )
+        pods = (
+            k8s_client.resources.get(api_version="v1", kind="Pod")
+            .get(namespace=namespace, label_selector=label_selector)
+            .items
+        )
+        terminating_pods = []
+        not_ready_pods = []
+        for pod in pods:
+            if pod.metadata.deletionTimestamp is not None:
+                terminating_pods.append(pod.metadata.name)
+            elif pod.status.conditions is not None:
+                for condition in pod.status.conditions:
+                    if condition.type == "Ready" and condition.status != "True":
+                        not_ready_pods.append(pod.metadata.name)
+
+        assert (
+            not terminating_pods
+        ), f"DaemonSet is not ready yet, some pods are still terminating: {', '.join(terminating_pods)}"
+        assert (
+            not not_ready_pods
+        ), f"DaemonSet is not ready yet, some pods are not ready: {', '.join(not_ready_pods)}"
+
+    utils.retry(
+        _wait_for_daemon_set,
+        times=60,
+        wait=3,
+        name=f"wait for DaemonSet '{namespace}/{name}'",
+    )
+
+    wait_rollout_status(host, f"daemonset/{name}", namespace)
 
 
 # }}}

--- a/tests/post/steps/test_ingress.py
+++ b/tests/post/steps/test_ingress.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import os
 import re
@@ -17,6 +18,61 @@ MAIN_CC_NAME = "main"
 
 OPERATOR_DEPLOYMENT = "metalk8s-operator-controller-manager"
 OPERATOR_NAMESPACE = "kube-system"
+
+
+def _ingress_debug(host):
+    """Collect live cluster-side ingress diagnostics.
+
+    The sosreport is collected after the whole step finishes and may miss the
+    transient state (a controller still rolling, missing endpoints, calico not
+    ready, ...) that caused a request to fail, so we dump the relevant cluster
+    state at failure time to complement it. Best-effort: never raises.
+    """
+    kubectl = "kubectl --kubeconfig=/etc/kubernetes/admin.conf"
+    commands = (
+        ("ingress-nginx pods", f"{kubectl} -n metalk8s-ingress get pods -o wide"),
+        (
+            "ingress-nginx daemonsets",
+            f"{kubectl} -n metalk8s-ingress get daemonset -o wide",
+        ),
+        ("ingress-nginx services", f"{kubectl} -n metalk8s-ingress get svc -o wide"),
+        ("ingress-nginx endpoints", f"{kubectl} -n metalk8s-ingress get endpoints"),
+        (
+            "calico-node daemonset",
+            f"{kubectl} -n kube-system get daemonset calico-node -o wide",
+        ),
+        (
+            "recent ingress events",
+            f"{kubectl} -n metalk8s-ingress get events --sort-by=.lastTimestamp",
+        ),
+    )
+    sections = []
+    try:
+        with host.sudo():
+            for title, cmd in commands:
+                result = host.run(cmd)
+                sections.append(
+                    "--- {} ---\n{}".format(
+                        title, (result.stdout or result.stderr).strip()
+                    )
+                )
+    except Exception as exc:  # pylint: disable=broad-except
+        sections.append(f"--- failed to collect ingress debug ---\n{exc}")
+    return "\n\n".join(sections)
+
+
+@contextlib.contextmanager
+def _ingress_debug_on_failure(host, label):
+    """Append live cluster ingress diagnostics to any assertion failure raised
+    inside the block, to complement the (later, possibly-stale) sosreport."""
+    try:
+        yield
+    except AssertionError as exc:
+        raise AssertionError(
+            f"{exc}\n\n"
+            f"=== Cluster ingress debug ({label}) ===\n"
+            f"{_ingress_debug(host)}"
+        ) from exc
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -609,10 +665,11 @@ def wait_cc_status(k8s_client, status):
     converters=dict(status_code=int),
 )
 def server_returns(host, context, status_code, reason):
-    response = context.get("response")
-    assert response is not None
-    assert response.status_code == int(status_code)
-    assert response.reason == reason
+    with _ingress_debug_on_failure(host, f"expecting {status_code} '{reason}'"):
+        response = context.get("response")
+        assert response is not None
+        assert response.status_code == int(status_code)
+        assert response.reason == reason
 
 
 @then("the server should respond with shell-ui index")
@@ -631,8 +688,9 @@ def shell_ui_not_returns(host, context):
 
 @then("the server should not respond")
 def server_does_not_respond(host, context):
-    assert "exception" in context
-    assert isinstance(context["exception"], requests.exceptions.ConnectionError)
+    with _ingress_debug_on_failure(host, "expecting no response"):
+        assert "exception" in context
+        assert isinstance(context["exception"], requests.exceptions.ConnectionError)
 
 
 @then(
@@ -674,7 +732,7 @@ def server_request_does_not_return(host, context, protocol, port, plane, path):
     converters=dict(status_code=int),
 )
 def server_request_returns_multiple_ips(
-    context, protocol, port, ips, path, status_code, reason
+    host, context, protocol, port, ips, path, status_code, reason
 ):
     ips = ips.format(**context).split(",")
 
@@ -684,15 +742,16 @@ def server_request_returns_multiple_ips(
         endpoint = "{proto}://{ip}:{port}/{path}".format(
             proto=protocol.lower(), ip=ip, port=port, path=path or ""
         )
-        try:
-            response = requests.get(endpoint, verify=False)
-            context["response"] = response
-        except Exception as exc:
-            raise AssertionError(f"Unable to reach ingress on '{endpoint}': {exc}")
+        with _ingress_debug_on_failure(host, f"request on '{endpoint}'"):
+            try:
+                response = requests.get(endpoint, verify=False)
+                context["response"] = response
+            except Exception as exc:
+                raise AssertionError(f"Unable to reach ingress on '{endpoint}': {exc}")
 
-        assert response is not None
-        assert response.status_code == status_code
-        assert response.reason == reason
+            assert response is not None
+            assert response.status_code == status_code
+            assert response.reason == reason
 
 
 @then(
@@ -701,7 +760,7 @@ def server_request_returns_multiple_ips(
         r"on port (?P<port>\d+) on '(?P<ips>.*)' IPs should not return"
     ),
 )
-def server_request_not_returns_multiple_ips(context, protocol, port, ips, path):
+def server_request_not_returns_multiple_ips(host, context, protocol, port, ips, path):
     ips = ips.format(**context).split(",")
 
     assert ips, "Error IPs list cannot be empty"
@@ -710,16 +769,17 @@ def server_request_not_returns_multiple_ips(context, protocol, port, ips, path):
         endpoint = "{proto}://{ip}:{port}/{path}".format(
             proto=protocol.lower(), ip=ip, port=port, path=path or ""
         )
-        try:
-            response = requests.get(endpoint, verify=False)
-        except requests.exceptions.ConnectionError as exc:
-            return
-        except Exception as exc:
-            raise AssertionError(
-                f"Error when trying to reach ingress on '{endpoint}': {exc}"
-            )
+        with _ingress_debug_on_failure(host, f"request on '{endpoint}'"):
+            try:
+                response = requests.get(endpoint, verify=False)
+            except requests.exceptions.ConnectionError:
+                return
+            except Exception as exc:
+                raise AssertionError(
+                    f"Error when trying to reach ingress on '{endpoint}': {exc}"
+                )
 
-        raise AssertionError(f"The server shouldn't answer but got '{response}'")
+            raise AssertionError(f"The server shouldn't answer but got '{response}'")
 
 
 @then(_SPREAD_IPS_PARSER)

--- a/tests/post/steps/test_ingress.py
+++ b/tests/post/steps/test_ingress.py
@@ -10,6 +10,7 @@ from pytest_bdd import given, parsers, scenario, then, when
 import testinfra
 
 from tests import utils
+from tests.conftest import wait_rollout_status
 
 
 MAIN_CC_NAME = "main"
@@ -164,6 +165,21 @@ def teardown(context, host, ssh_config, version, k8s_client):
     if context.get("reconfigure_portmap"):
         re_configure_portmap(host, version, ssh_config)
 
+    # Ensure all pods are ready
+    def _wait_for_pods_ready():
+        with host.sudo():
+            result = host.run(
+                "kubectl --kubeconfig=/etc/kubernetes/admin.conf wait --for=condition=Ready "
+                "pods --all -n metalk8s-ingress --timeout=30s"
+            )
+        assert result.succeeded, (
+            f"All pods in metalk8s-ingress namespace are not ready:\n"
+            f"    stdout: {result.stdout}\n"
+            f"    stderr: {result.stderr}"
+        )
+
+    utils.retry(_wait_for_pods_ready, times=10, wait=5)
+
 
 @given("a VIP for Control Plane Ingress is available")
 def we_have_a_vip(context):
@@ -242,6 +258,7 @@ def wp_ingress_vip_setup(
     update_cc_pool(host, context, ssh_config, version, k8s_client, pool_name, ips)
     wait_cc_status(k8s_client, "Ready")
     rollout_restart(host, "daemonset/ingress-nginx-controller", "metalk8s-ingress")
+    wait_rollout_status(host, "daemonset/ingress-nginx-controller", "metalk8s-ingress")
 
 
 _SPREAD_IPS_PARSER = parsers.parse("the '{ips}' IPs are spread on nodes")
@@ -495,8 +512,11 @@ def update_portmap_cidr(host, context, ssh_config, version, plane):
     )
 )
 def rollout_restart(host, resource, namespace):
+    # Make sure any previous rollout is completed
+    wait_rollout_status(host, resource, namespace)
+
     with host.sudo():
-        result = host.run(
+        host.run_test(
             "kubectl --kubeconfig=/etc/kubernetes/admin.conf "
             "rollout restart %s --namespace %s",
             resource,

--- a/tests/post/steps/test_sanity.py
+++ b/tests/post/steps/test_sanity.py
@@ -1,5 +1,4 @@
 import kubernetes.client
-from kubernetes.client import AppsV1Api
 from kubernetes.client.rest import ApiException
 import pytest
 from pytest_bdd import scenario, then, parsers
@@ -201,42 +200,6 @@ def check_deployment(k8s_client, name, namespace):
         times=10,
         wait=3,
         name="wait for Deployment '{}/{}'".format(namespace, name),
-    )
-
-
-@then("the DaemonSet <name> in the <namespace> namespace has all desired Pods ready")
-@then(
-    parsers.parse(
-        "the DaemonSet '{name}' in the '{namespace}' namespace has all desired "
-        "Pods ready"
-    )
-)
-def check_daemonset(k8s_client, name, namespace):
-    def _wait_for_daemon_set():
-        try:
-            daemon_set = k8s_client.resources.get(
-                api_version="apps/v1", kind="DaemonSet"
-            ).get(name=name, namespace=namespace)
-        except ApiException as exc:
-            if exc.status == 404:
-                pytest.fail("DaemonSet '{}/{}' does not exist".format(namespace, name))
-            raise
-
-        desired = daemon_set.status.desired_number_scheduled
-        scheduled = daemon_set.status.current_number_scheduled
-        assert desired == scheduled, (
-            "DaemonSet is not ready yet (desired={}, scheduled={})"
-        ).format(desired, scheduled)
-        available = daemon_set.status.number_available
-        assert desired == available, (
-            "DaemonSet is not ready yet (desired={}, available={})"
-        ).format(desired, available)
-
-    utils.retry(
-        _wait_for_daemon_set,
-        times=10,
-        wait=3,
-        name="wait for DaemonSet '{}/{}'".format(namespace, name),
     )
 
 


### PR DESCRIPTION
## Context

Addresses the ingress e2e flakiness tracked in **MK8S-331**.

## What changed

**1. Wait for the ingress to be genuinely ready before asserting** (cherry-picked from `1fae552`):
- Shared `check_daemonset` then-step (moved from `test_sanity.py` into `steps/conftest.py` so all suites reuse it). Beyond `desired == scheduled == available`, it now also verifies **no pod from a previous revision is still `Terminating`** — the DaemonSet status counters report the new pod available while the old one can still hold host-port :80/:443 during a rolling update, which is the actual source of the "connection refused / unexpected answer" flakes.
- `wait_rollout_status` before each `rollout restart` (don't restart while a previous rollout is still in flight) and after.
- `ingress.feature` scenarios gated on the DaemonSet being ready before the HTTP assertions; teardown waits for all `metalk8s-ingress` pods Ready.

**2. Dump live cluster ingress state on failure** (carried over from #4998):
- `_ingress_debug` + `_ingress_debug_on_failure` context manager append a snapshot (ingress-nginx pods/daemonsets/services/endpoints, calico-node daemonset, recent events) to any failing ingress request assertion — positive and negative, single- and multiple-IP. The sosreport is collected later and can miss the transient state, so this complements it.

The readiness gate prevents most flakes; when a request still fails, the dump explains why.

## Notes
- Cherry-pick conflict in `test_sanity.py` resolved by keeping the `133.0` scenario-outline (`<name>`/`<namespace>`) decorator variant — the moved `check_daemonset` in `conftest.py` carries it so `sanity.feature` still resolves.
- Tests need a live cluster to run; locally verified `py_compile` only.

Issue: MK8S-331

🤖 Generated with [Claude Code](https://claude.com/claude-code)