### PR TITLE
Make Thanos Querier resources configurable and switch Prometheus to EndpointSlice discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
   Querier also now runs with two replicas for high availability.
   (PR[#5008](https://github.com/scality/metalk8s/pull/5008))
 
+- Use the `EndpointSlice` service discovery role for Prometheus to stop the
+  deprecated `v1 Endpoints` API warnings logged on Kubernetes 1.33+
+  (PR[#5008](https://github.com/scality/metalk8s/pull/5008))
+
 ## Release 133.0.10
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Release 133.0.11 (in development)
 
+### Bug Fixes
+
+- Avoid the Thanos Querier being OOMKilled on heavy queries (such as the
+  `sosreport` metrics collection): its CPU/memory requests and limits are now
+  configurable through the `metalk8s-thanos-config` Cluster and Service
+  ConfigMap, and the default memory limit is raised from 192Mi to 2Gi. The
+  Querier also now runs with two replicas for high availability.
+  (PR[#5008](https://github.com/scality/metalk8s/pull/5008))
+
 ## Release 133.0.10
 
 ### Enhancements

--- a/buildchain/buildchain/codegen.py
+++ b/buildchain/buildchain/codegen.py
@@ -277,6 +277,9 @@ def codegen_chart_thanos() -> types.TaskDict:
     cmd = (
         f"{constants.CHART_RENDER_CMD} thanos {value_file} {chart_dir} "
         "--namespace metalk8s-monitoring "
+        "--service-config thanos metalk8s-thanos-config "
+        "metalk8s/addons/prometheus-operator/config/thanos.yaml "
+        "metalk8s-monitoring "
         f"--output {target_sls}"
     )
 

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -388,6 +388,7 @@ SALT_FILES: Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path("salt/metalk8s/addons/prometheus-operator/config/alertmanager.yaml"),
     Path("salt/metalk8s/addons/prometheus-operator/config/grafana.yaml.j2"),
     Path("salt/metalk8s/addons/prometheus-operator/config/prometheus.yaml"),
+    Path("salt/metalk8s/addons/prometheus-operator/config/thanos.yaml"),
     Path(
         "salt/metalk8s/addons/prometheus-operator/deployed/",
         "alertmanager-configuration-secret.sls",

--- a/charts/kube-prometheus-stack.yaml
+++ b/charts/kube-prometheus-stack.yaml
@@ -106,6 +106,10 @@ prometheus:
     enabled: true
 
   prometheusSpec:
+    # Enforce EndpointSlice usage since default "Endpoints" are deprecated
+    # and cause warning in the prometheus logs
+    serviceDiscoveryRole: EndpointSlice
+
     thanos:
       image: '__full_image__(thanos)'
       objectStorageConfig: {}

--- a/charts/thanos.yaml
+++ b/charts/thanos.yaml
@@ -84,3 +84,16 @@ query:
 
   nodeSelector:
     node-role.kubernetes.io/infra: ''
+
+  replicaCount: 2
+
+  # cpu/memory templated from CSC (metalk8s-thanos-config) so limits stay tunable
+  resources:
+    requests:
+      cpu: '__var__(thanos.spec.deployment.resources.requests.cpu)'
+      memory: '__var__(thanos.spec.deployment.resources.requests.memory)'
+      ephemeral-storage: 50Mi
+    limits:
+      cpu: '__var__(thanos.spec.deployment.resources.limits.cpu)'
+      memory: '__var__(thanos.spec.deployment.resources.limits.memory)'
+      ephemeral-storage: 2Gi

--- a/docs/operation/cluster_and_service_configuration.rst
+++ b/docs/operation/cluster_and_service_configuration.rst
@@ -73,6 +73,19 @@ The default configuration values for Prometheus are specified below:
    :lines: 3-
 
 
+Thanos Default Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Thanos provides a global, deduplicated query view over the (highly available)
+Prometheus instances.
+
+The default configuration values for Thanos are specified below:
+
+.. literalinclude:: ../../salt/metalk8s/addons/prometheus-operator/config/thanos.yaml
+   :language: yaml
+   :lines: 3-
+
+
 Loki Default Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -808,6 +821,61 @@ Applying configuration
 
 Any changes made to ``metalk8s-prometheus-config`` ConfigMap must then be
 applied with Salt.
+
+.. parsed-literal::
+
+   root\@bootstrap $ kubectl exec --kubeconfig /etc/kubernetes/admin.conf \\
+                      -n kube-system -c salt-master salt-master-bootstrap -- \\
+                      salt-run state.sls \\
+                      metalk8s.addons.prometheus-operator.deployed \\
+                      saltenv=metalk8s-|version|
+
+.. _csc-thanos-customization:
+
+Thanos Configuration Customization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default configuration for Thanos can be overridden by editing its
+Cluster and Service ConfigMap ``metalk8s-thanos-config`` in namespace
+``metalk8s-monitoring`` under the key ``data.config.yaml``:
+
+.. code-block:: shell
+
+   root@bootstrap $ kubectl --kubeconfig /etc/kubernetes/admin.conf \
+                      edit configmap -n metalk8s-monitoring \
+                      metalk8s-thanos-config
+
+Adjust the Thanos Querier resources
+"""""""""""""""""""""""""""""""""""
+
+The Thanos Querier holds query results in memory, so a heavy query (e.g. the
+metrics collection performed by ``sosreport``) can exceed the default memory
+limit and get the Pod ``OOMKilled``. The CPU and memory requests and limits
+can be tuned:
+
+.. code-block:: yaml
+
+   ---
+   apiVersion: v1
+   kind: ConfigMap
+   metadata:
+     name: metalk8s-thanos-config
+     namespace: metalk8s-monitoring
+   data:
+     config.yaml: |-
+       apiVersion: addons.metalk8s.scality.com
+       kind: ThanosConfig
+       spec:
+         deployment:
+           resources:
+             requests:
+               cpu: "500m"
+               memory: "512Mi"
+             limits:
+               cpu: "1"
+               memory: "4Gi"
+
+Then apply the configuration:
 
 .. parsed-literal::
 

--- a/salt/metalk8s/addons/prometheus-operator/config/thanos.yaml
+++ b/salt/metalk8s/addons/prometheus-operator/config/thanos.yaml
@@ -1,0 +1,15 @@
+#!yaml
+
+# Configuration of the Thanos service
+apiVersion: addons.metalk8s.scality.com
+kind: ThanosConfig
+spec:
+  # Configure the Thanos Querier Deployment
+  deployment:
+    resources:
+      requests:
+        cpu: "500m"
+        memory: "512Mi"
+      limits:
+        cpu: "1"
+        memory: "2Gi"

--- a/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
@@ -80448,6 +80448,7 @@ spec:
     seccompProfile:
       type: RuntimeDefault
   serviceAccountName: prometheus-operator-prometheus
+  serviceDiscoveryRole: EndpointSlice
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector:
     matchLabels:

--- a/salt/metalk8s/addons/prometheus-operator/deployed/service-configuration.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/service-configuration.sls
@@ -25,6 +25,14 @@ include:
   )
 %}
 
+{%- set thanos_config = salt.metalk8s_kubernetes.get_object(
+        kind='ConfigMap',
+        apiVersion='v1',
+        namespace='metalk8s-monitoring',
+        name='metalk8s-thanos-config',
+  )
+%}
+
 {%- if grafana_config is none %}
 
 Create grafana-config ConfigMap:
@@ -90,6 +98,29 @@ Create alertmanager-config ConfigMap:
 {%- else %}
 
 metalk8s-alertmanager-config ConfigMap already exists:
+  test.succeed_without_changes: []
+
+{%- endif %}
+
+{%- if thanos_config is none %}
+
+Create thanos-config ConfigMap:
+  metalk8s_kubernetes.object_present:
+    - manifest:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: metalk8s-thanos-config
+          namespace: metalk8s-monitoring
+        data:
+          config.yaml: |-
+            apiVersion: addons.metalk8s.scality.com
+            kind: ThanosConfig
+            spec: {}
+
+{%- else %}
+
+metalk8s-thanos-config ConfigMap already exists:
   test.succeed_without_changes: []
 
 {%- endif %}

--- a/salt/metalk8s/addons/prometheus-operator/deployed/thanos-chart.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/thanos-chart.sls
@@ -2,8 +2,8 @@
 
 {%- from "metalk8s/map.jinja" import repo with context %}
 {%- from "metalk8s/repo/macro.sls" import build_image_name with context %}
-
-
+{%- set thanos_defaults = salt.slsutil.renderer('salt://metalk8s/addons/prometheus-operator/config/thanos.yaml', saltenv=saltenv) %}
+{%- set thanos = salt.metalk8s_service_configuration.get_service_conf('metalk8s-monitoring', 'metalk8s-thanos-config', thanos_defaults) %}
 
 {% raw %}
 
@@ -124,7 +124,7 @@ metadata:
   name: thanos-query
   namespace: metalk8s-monitoring
 spec:
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -203,13 +203,13 @@ spec:
           timeoutSeconds: 30
         resources:
           limits:
-            cpu: 150m
+            cpu: {% endraw -%}{{ thanos.spec.deployment.resources.limits.cpu }}{%- raw %}
             ephemeral-storage: 2Gi
-            memory: 192Mi
+            memory: {% endraw -%}{{ thanos.spec.deployment.resources.limits.memory }}{%- raw %}
           requests:
-            cpu: 100m
+            cpu: {% endraw -%}{{ thanos.spec.deployment.resources.requests.cpu }}{%- raw %}
             ephemeral-storage: 50Mi
-            memory: 128Mi
+            memory: {% endraw -%}{{ thanos.spec.deployment.resources.requests.memory }}{%- raw %}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
## Summary

Two monitoring fixes, both surfacing on Kubernetes 1.33+.

### Thanos Querier OOMKilled on heavy queries

The Thanos Querier had a hardcoded 192Mi memory limit. Heavy queries -- e.g. the
per-metric subqueries run by the `sosreport` metrics collection -- load enough
series into the deduplicating Querier to blow past it, getting the Pod
`OOMKilled`.

- Querier CPU/memory **requests and limits are now configurable** through a new
  `metalk8s-thanos-config` Cluster and Service ConfigMap (`ThanosConfig`).
- Default memory limit raised **192Mi -> 2Gi**; requests default to `500m` / `512Mi`.
- The Querier now runs with **2 replicas** for high availability.

Raise the limit at runtime without a rebuild:

```yaml
# kubectl -n metalk8s-monitoring edit cm metalk8s-thanos-config
data:
  config.yaml: |-
    apiVersion: addons.metalk8s.scality.com
    kind: ThanosConfig
    spec:
      deployment:
        resources:
          limits:
            memory: "4Gi"
```

then `salt-run state.sls metalk8s.addons.prometheus-operator.deployed`.

> Note: more Querier replicas do **not** prevent the OOM (a single heavy query
> is handled by one Pod) -- the memory limit is the actual fix; replicas are for
> availability.

### Prometheus `v1 Endpoints` deprecation warnings

On Kubernetes 1.33+ the core `v1 Endpoints` API is deprecated; Prometheus
Kubernetes service discovery (`role: endpoints`) logs repeated deprecation
warnings. Set `serviceDiscoveryRole: EndpointSlice` so the operator generates
the scrape config with `role: endpointslice` instead.

Issue: ARTESCA-17766
