### PR TITLE
`disk-management-agent`: Bump to version 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,10 @@
   `apiserver.config.k8s.io/v1` (GA in Kubernetes 1.34)
   (PR[#5001](https://github.com/scality/metalk8s/pull/5001))
 
+- Bump [disk-management-agent](https://github.com/scality/disk-management-agent) to version
+  [v0.1.0](https://github.com/scality/disk-management-agent/releases/tag/v0.1.0)
+  (PR[#5024](https://github.com/scality/metalk8s/pull/5024))
+
 ## Release 133.0.12 (in development)
 
 ## Release 133.0.11

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -311,8 +311,8 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
     ),
     Image(
         name="disk-management-agent",
-        version="v0.0.1-beta.2",
-        digest="sha256:8a98623a20f30af4a8b0eb8abe284b15ed8603bd66e13905d32f50e37e6155ed",
+        version="v0.1.0",
+        digest="sha256:d63d4e20a089dcd3ac33f58d2210a66e48a1f9f08120494352b22cca94747769",
     ),
 )
 

--- a/kustomizes/disk-management-agent/kustomization.yaml
+++ b/kustomizes/disk-management-agent/kustomization.yaml
@@ -1,12 +1,12 @@
 namespace: metalk8s-storage-management
 
 resources:
-  - github.com/scality/disk-management-agent.git/config/default?ref=v0.0.1-beta.2
+  - github.com/scality/disk-management-agent.git/config/default?ref=v0.1.0
 
 images:
   - name: controller
     newName: '{% endraw -%}{{ build_image_name("disk-management-agent", False) }}{%- raw %}'
-    newTag: v0.0.1-beta.2
+    newTag: v0.1.0
 
 patches:
   - path: deploy_patch.yaml

--- a/salt/metalk8s/addons/disk-management-agent/deployed/chart.sls
+++ b/salt/metalk8s/addons/disk-management-agent/deployed/chart.sls
@@ -416,10 +416,14 @@ spec:
           value: /host/libexec/MegaRAID/storcli/storcli64
         - name: PERCCLI_PATH
           value: /host/libexec/MegaRAID/perccli/perccli64
+        - name: STORCLI2_PATH
+          value: /host/libexec/MegaRAID/storcli2/storcli2
+        - name: PERCCLI2_PATH
+          value: /host/libexec/MegaRAID/perccli2/perccli2
         - name: SSACLI_PATH
           value: /host/libexec/ssacli
         image: '{% endraw -%}{{ build_image_name("disk-management-agent", False) }}{%-
-          raw %}:v0.0.1-beta.2'
+          raw %}:v0.1.0'
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
**Component**: containers, salt, build

**Context**:

[disk-management-agent v0.1.0](https://github.com/scality/disk-management-agent/releases/tag/v0.1.0) (first GA) embeds [raidmgmt v0.16.0](https://github.com/scality/raidmgmt/releases/tag/v0.16.0).

**Summary**:

- Bump the `disk-management-agent` image to v0.1.0 in `versions.py` (version + digest) and `kustomizes/disk-management-agent/kustomization.yaml`
- Regenerate `salt/metalk8s/addons/disk-management-agent/deployed/chart.sls` via `./doit.sh codegen` (picks up the new `STORCLI2_PATH`/`PERCCLI2_PATH` env vars from the dma kustomize config)
- CHANGELOG entry

**Acceptance criteria**:

- CI passes (lint enforces codegen freshness)