### PR TITLE
fix(prometheus-operator): stop resetting thanos-query-sd-files ConfigMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@
   `KernelDeadlock` and `ReadonlyFilesystem` conditions
   (PR[#5025](https://github.com/scality/metalk8s/pull/5025))
 
+### Bug Fixes
+
+- Stop resetting the `thanos-query-sd-files` ConfigMap every time the Prometheus
+  operator state is applied: its service discovery content, managed by MetalK8s
+  users, was wiped on each re-apply, leaving Thanos Query with no store to reach
+  (PR[#5027](https://github.com/scality/metalk8s/pull/5027))
+
 ## Release 133.0.11
 
 ### Bug Fixes

--- a/salt/metalk8s/addons/prometheus-operator/deployed/thanos-query-sd-files.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/thanos-query-sd-files.sls
@@ -1,14 +1,32 @@
-#!jinja | metalk8s_kubernetes
+include:
+  - .namespace
 
-{% raw %}
+{%- set thanos_query_sd_files = salt.metalk8s_kubernetes.get_object(
+        kind='ConfigMap',
+        apiVersion='v1',
+        namespace='metalk8s-monitoring',
+        name='thanos-query-sd-files',
+  )
+%}
 
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: thanos-query-sd-files
-  namespace: metalk8s-monitoring
-  labels:
-    app.kubernetes.io/component: query
-    app.kubernetes.io/instance: thanos
+{#- Never replace this ConfigMap: its content is managed by MetalK8s users and must survive re-apply. #}
+{%- if thanos_query_sd_files is none %}
 
-{% endraw %}
+Create thanos-query-sd-files ConfigMap:
+  metalk8s_kubernetes.object_present:
+    - manifest:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: thanos-query-sd-files
+          namespace: metalk8s-monitoring
+          labels:
+            app.kubernetes.io/component: query
+            app.kubernetes.io/instance: thanos
+
+{%- else %}
+
+thanos-query-sd-files ConfigMap already exists:
+  test.succeed_without_changes: []
+
+{%- endif %}

--- a/salt/tests/unit/formulas/config.yaml
+++ b/salt/tests/unit/formulas/config.yaml
@@ -121,6 +121,17 @@ metalk8s:
                         apiVersion: addons.metalk8s.scality.com
                         kind: PrometheusConfig
                         spec: {}
+        thanos-query-sd-files.sls:
+          _cases:
+            "ConfigMap does not exist (default)": {}
+            "ConfigMap already exists":
+              k8s_overrides:
+                add:
+                  - kind: ConfigMap
+                    apiVersion: v1
+                    metadata:
+                      name: thanos-query-sd-files
+                      namespace: metalk8s-monitoring
 
     solutions:
       deployed:


### PR DESCRIPTION
The thanos-query-sd-files ConfigMap was rendered through the metalk8s_kubernetes renderer, which replaces the whole object on every apply. As the manifest defines no `data`, each re-apply wiped the service discovery content managed by MetalK8s users, leaving Thanos Query with no store to reach.

Only create the ConfigMap when absent and leave it untouched otherwise, mirroring the sibling service-configuration state.

Issue: ARTESCA-17871