### PR TITLE
Workload Plane isolation detection and remediation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
   Workload Plane connectivity recovers
   (PR[#5031](https://github.com/scality/metalk8s/pull/5031))
 
+- Add Prometheus alerts for Workload Plane isolation: `NodeWorkloadPlaneUnavailable`
+  (a node reports `WorkloadPlaneNetworkUnavailable`), `NodeWorkloadPlaneRemediated`
+  (a node carries the Workload Plane isolation taint) and `WorkloadPlaneOutage` (the
+  majority of nodes are affected, remediation suppressed by the guard)
+  (PR[#5031](https://github.com/scality/metalk8s/pull/5031))
+
 ## Release 133.0.12
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Release 133.0.13 (in development)
 
+### Enhancements
+
+- Deploy [node-warden-operator](https://github.com/scality/node-warden-operator)
+  v1.0.0, a cluster-scoped operator that reacts to node conditions through
+  `NodeRemediationPolicy` custom resources. MetalK8s ships a default policy that,
+  when a Workload Plane node reports `WorkloadPlaneNetworkUnavailable`, applies a
+  reversible `node.scality.com/workload-plane-unreachable:NoExecute` taint to evict
+  its workloads and drop it from Service endpoints, and removes the taint once the
+  Workload Plane connectivity recovers
+  (PR[#5031](https://github.com/scality/metalk8s/pull/5031))
+
 ## Release 133.0.12
 
 ### Enhancements

--- a/buildchain/buildchain/codegen.py
+++ b/buildchain/buildchain/codegen.py
@@ -477,6 +477,73 @@ def codegen_kustomize_disk_management_agent() -> types.TaskDict:
     return tpl_task_dict
 
 
+def task_get_codegen_kustomize_node_warden_operator() -> types.TaskDict:
+    """Generate the kustomize manifests output for the Node Warden Operator."""
+    kustomize_dir = constants.ROOT / "kustomizes/node-warden-operator"
+
+    cmd = f"kustomize build {kustomize_dir}"
+
+    return {
+        "doc": task_get_codegen_kustomize_node_warden_operator.__doc__,
+        "actions": [doit.action.CmdAction(cmd, cwd=constants.ROOT, save_out="stdout")],
+        "file_dep": list(utils.git_ls(kustomize_dir)),
+        "task_dep": ["check_for:kustomize"],
+    }
+
+
+def task_transform_codegen_kustomize_node_warden_operator() -> types.TaskDict:
+    """Transform the kustomize manifests output for the Node Warden Operator."""
+
+    def _transform(stdout: str) -> Dict[str, str]:
+        """Transform the kustomize output."""
+        # Note: We have to replace the namespace 'node-warden-operator-system' by
+        # 'metalk8s-monitoring' and fill the metrics Certificate dnsNames placeholder
+        # as kustomize does not allow easily to patch every occurrence in "custom
+        # resources fields" like Certificate dnsNames.
+        return {
+            "output": stdout.strip().replace(
+                "node-warden-operator-system", "metalk8s-monitoring"
+            )
+        }
+
+    return {
+        "doc": task_transform_codegen_kustomize_node_warden_operator.__doc__,
+        "actions": [_transform],
+        "task_dep": ["get_codegen_kustomize_node_warden_operator"],
+        "getargs": {
+            "stdout": ("get_codegen_kustomize_node_warden_operator", "stdout"),
+        },
+    }
+
+
+def codegen_kustomize_node_warden_operator() -> types.TaskDict:
+    """Generate the SLS file for the Node Warden Operator."""
+    target_sls = (
+        constants.ROOT / "salt/metalk8s/addons/node-warden-operator/deployed/chart.sls"
+    )
+    template_file = constants.ROOT / "kustomizes/template.sls.in"
+
+    tpl_task = targets.TemplateFile(
+        task_name="kustomize_node-warden-operator",
+        source=template_file,
+        destination=target_sls,
+    )
+    tpl_task_dict = tpl_task.task
+    tpl_task_dict.update(
+        {
+            "title": utils.title_with_subtask_name("CODEGEN"),
+            "task_dep": ["transform_codegen_kustomize_node_warden_operator"],
+            "getargs": {
+                "Manifests": (
+                    "transform_codegen_kustomize_node_warden_operator",
+                    "output",
+                ),
+            },
+        }
+    )
+    return tpl_task_dict
+
+
 # List of available code generation tasks.
 CODEGEN: Tuple[Callable[[], types.TaskDict], ...] = (
     codegen_storage_operator,
@@ -492,6 +559,7 @@ CODEGEN: Tuple[Callable[[], types.TaskDict], ...] = (
     codegen_chart_cert_manager,
     codegen_kustomize_crl_operator,
     codegen_kustomize_disk_management_agent,
+    codegen_kustomize_node_warden_operator,
 )
 
 

--- a/buildchain/buildchain/image.py
+++ b/buildchain/buildchain/image.py
@@ -227,6 +227,7 @@ IMGS_PER_REPOSITORY: Dict[str, List[str]] = {
         "ui-operator",
         "crl-operator",
         "disk-management-agent",
+        "node-warden-operator",
     ],
 }
 

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -381,9 +381,17 @@ SALT_FILES: Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path("salt/metalk8s/addons/node-problem-detector/deployed/chart.sls"),
     Path("salt/metalk8s/addons/node-problem-detector/deployed/init.sls"),
     Path("salt/metalk8s/addons/node-problem-detector/deployed/wp-monitor.sls"),
+    Path(
+        "salt/metalk8s/addons/node-problem-detector/deployed/",
+        "workload-plane-alerts-rules.sls",
+    ),
     Path("salt/metalk8s/addons/node-warden-operator/deployed/chart.sls"),
     Path("salt/metalk8s/addons/node-warden-operator/deployed/init.sls"),
     Path("salt/metalk8s/addons/node-warden-operator/deployed/policy.sls"),
+    Path(
+        "salt/metalk8s/addons/node-warden-operator/deployed/",
+        "workload-plane-alerts-rules.sls",
+    ),
     Path("salt/metalk8s/addons/prometheus-adapter/deployed/chart.sls"),
     Path("salt/metalk8s/addons/prometheus-adapter/deployed/init.sls"),
     Path("salt/metalk8s/addons/prometheus-operator/macros.j2"),

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -383,6 +383,7 @@ SALT_FILES: Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path("salt/metalk8s/addons/node-problem-detector/deployed/wp-monitor.sls"),
     Path("salt/metalk8s/addons/node-warden-operator/deployed/chart.sls"),
     Path("salt/metalk8s/addons/node-warden-operator/deployed/init.sls"),
+    Path("salt/metalk8s/addons/node-warden-operator/deployed/policy.sls"),
     Path("salt/metalk8s/addons/prometheus-adapter/deployed/chart.sls"),
     Path("salt/metalk8s/addons/prometheus-adapter/deployed/init.sls"),
     Path("salt/metalk8s/addons/prometheus-operator/macros.j2"),

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -381,6 +381,8 @@ SALT_FILES: Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path("salt/metalk8s/addons/node-problem-detector/deployed/chart.sls"),
     Path("salt/metalk8s/addons/node-problem-detector/deployed/init.sls"),
     Path("salt/metalk8s/addons/node-problem-detector/deployed/wp-monitor.sls"),
+    Path("salt/metalk8s/addons/node-warden-operator/deployed/chart.sls"),
+    Path("salt/metalk8s/addons/node-warden-operator/deployed/init.sls"),
     Path("salt/metalk8s/addons/prometheus-adapter/deployed/chart.sls"),
     Path("salt/metalk8s/addons/prometheus-adapter/deployed/init.sls"),
     Path("salt/metalk8s/addons/prometheus-operator/macros.j2"),

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -323,6 +323,11 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
         version="v0.0.1-beta.2",
         digest="sha256:8a98623a20f30af4a8b0eb8abe284b15ed8603bd66e13905d32f50e37e6155ed",
     ),
+    Image(
+        name="node-warden-operator",
+        version="v1.0.0",
+        digest="sha256:9fafa55c92f07f1d48a9fd69b4a9e78b7918939a56fc3449d10f121c7cba633f",
+    ),
 )
 
 CONTAINER_IMAGES_MAP = {image.name: image for image in CONTAINER_IMAGES}

--- a/charts/fluent-bit.yaml
+++ b/charts/fluent-bit.yaml
@@ -23,6 +23,10 @@ tolerations:
 - key: node-role.kubernetes.io/master
   effect: NoSchedule
   operator: Exists
+# Keep shipping logs from WP-isolated nodes tainted by node-warden
+- key: node.scality.com/workload-plane-unreachable
+  effect: NoExecute
+  operator: Exists
 
 # Extra volumes to scrape logs from
 daemonSetVolumes:

--- a/charts/kube-prometheus-stack.yaml
+++ b/charts/kube-prometheus-stack.yaml
@@ -288,6 +288,14 @@ prometheus-node-exporter:
     - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+|var/lib/containerd/.+)($|/)
     - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$
 
+  # NoSchedule/Exists is the subchart default, re-declared here because Helm replaces the list; we only add the node-warden WP-isolation NoExecute taint
+  tolerations:
+    - effect: NoSchedule
+      operator: Exists
+    - key: node.scality.com/workload-plane-unreachable
+      effect: NoExecute
+      operator: Exists
+
 kubeEtcd:
   service:
     port: 2381

--- a/kustomizes/node-warden-operator/delete_ns.yaml
+++ b/kustomizes/node-warden-operator/delete_ns.yaml
@@ -1,0 +1,5 @@
+$patch: delete
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: system

--- a/kustomizes/node-warden-operator/deploy_patch.yaml
+++ b/kustomizes/node-warden-operator/deploy_patch.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: not-important
+spec:
+  template:
+    nodeSelector:
+      node-role.kubernetes.io/master: ""
+    spec:
+      tolerations:
+      - key: "node-role.kubernetes.io/bootstrap"
+        operator: "Exists"
+        effect: "NoSchedule"
+      - key: "node-role.kubernetes.io/infra"
+        operator: "Exists"
+        effect: "NoSchedule"
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"

--- a/kustomizes/node-warden-operator/kustomization.yaml
+++ b/kustomizes/node-warden-operator/kustomization.yaml
@@ -1,0 +1,18 @@
+namespace: metalk8s-monitoring
+
+resources:
+  - github.com/scality/node-warden-operator.git/config/default?ref=v1.0.0
+
+images:
+  - name: controller
+    newName: '{% endraw -%}{{ build_image_name("node-warden-operator", False) }}{%- raw %}'
+    newTag: v1.0.0
+
+patches:
+  - path: servicemonitor_patch.yaml
+    target:
+      kind: ServiceMonitor
+  - path: deploy_patch.yaml
+    target:
+      kind: Deployment
+  - path: delete_ns.yaml

--- a/kustomizes/node-warden-operator/servicemonitor_patch.yaml
+++ b/kustomizes/node-warden-operator/servicemonitor_patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: not-important
+  labels:
+    metalk8s.scality.com/monitor: ""

--- a/salt/metalk8s/addons/logging/fluent-bit/deployed/chart.sls
+++ b/salt/metalk8s/addons/logging/fluent-bit/deployed/chart.sls
@@ -1760,6 +1760,9 @@ spec:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
         operator: Exists
+      - effect: NoExecute
+        key: node.scality.com/workload-plane-unreachable
+        operator: Exists
       volumes:
       - configMap:
           name: fluent-bit

--- a/salt/metalk8s/addons/node-problem-detector/deployed/init.sls
+++ b/salt/metalk8s/addons/node-problem-detector/deployed/init.sls
@@ -2,3 +2,4 @@ include:
   - metalk8s.addons.prometheus-operator.deployed.namespace
   - .wp-monitor
   - .chart
+  - .workload-plane-alerts-rules

--- a/salt/metalk8s/addons/node-problem-detector/deployed/workload-plane-alerts-rules.sls
+++ b/salt/metalk8s/addons/node-problem-detector/deployed/workload-plane-alerts-rules.sls
@@ -1,0 +1,27 @@
+#!jinja | metalk8s_kubernetes
+
+{%- raw %}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/part-of: metalk8s
+    metalk8s.scality.com/monitor: ''
+  name: metalk8s-workload-plane-detection.rules
+  namespace: metalk8s-monitoring
+spec:
+  groups:
+  - name: workload-plane-detection
+    rules:
+    - alert: NodeWorkloadPlaneUnavailable
+      annotations:
+        summary: Node has lost Workload Plane connectivity
+        description: Node {{ $labels.node }} reports WorkloadPlaneNetworkUnavailable=True,
+          it cannot reach the majority of its peers over the Workload Plane network.
+          If the condition persists, node-warden taints the node NoExecute to drain
+          its workloads. Check the Workload Plane network on this node.
+      expr: kube_node_status_condition{condition="WorkloadPlaneNetworkUnavailable",status="true"} == 1
+      for: 2m
+      labels:
+        severity: warning
+{%- endraw %}

--- a/salt/metalk8s/addons/node-warden-operator/deployed/chart.sls
+++ b/salt/metalk8s/addons/node-warden-operator/deployed/chart.sls
@@ -1,0 +1,871 @@
+#!jinja | metalk8s_kubernetes
+{%- from "metalk8s/repo/macro.sls" import build_image_name with context %}
+
+{%- raw %}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.21.0
+  name: noderemediationpolicies.warden.scality.com
+spec:
+  group: warden.scality.com
+  names:
+    kind: NodeRemediationPolicy
+    listKind: NodeRemediationPolicyList
+    plural: noderemediationpolicies
+    shortNames:
+    - nrp
+    singular: noderemediationpolicy
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.condition.type
+      name: Condition
+      type: string
+    - jsonPath: .status.matchedCount
+      name: Matched
+      type: integer
+    - jsonPath: .status.remediatedCount
+      name: Remediated
+      type: integer
+    - jsonPath: .status.unknownCount
+      name: Unknown
+      type: integer
+    - jsonPath: .status.selectedCount
+      name: Selected
+      priority: 1
+      type: integer
+    - jsonPath: .status.pendingCount
+      name: Pending
+      priority: 1
+      type: integer
+    - jsonPath: .status.heldCount
+      name: Held
+      priority: 1
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NodeRemediationPolicy is the Schema for the noderemediationpolicies
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of NodeRemediationPolicy
+            properties:
+              condition:
+                description: condition is the node condition that triggers remediation.
+                properties:
+                  status:
+                    default: "True"
+                    description: status is the condition status that triggers remediation.
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
+                    type: string
+                  type:
+                    description: type is the node condition type to watch (for example,
+                      one set by a node problem detector).
+                    minLength: 1
+                    type: string
+                required:
+                - type
+                type: object
+              debounce:
+                description: debounce sets how long the condition must be stable before
+                  applying or removing the remediation.
+                properties:
+                  enter:
+                    default: 60s
+                    description: enter is how long the condition must hold before
+                      the remediation is applied.
+                    type: string
+                  exit:
+                    default: 30s
+                    description: exit is how long the condition must be clear before
+                      the remediation is removed.
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: debounce.enter and debounce.exit must be a non-negative
+                    Go duration (e.g. 60s, 1h30m, 500ms)
+                  rule: (!has(self.enter) || self.enter.matches('^(([0-9]{1,6}([.][0-9]+)?|[.][0-9]+)(ns|us|µs|ms|s|m|h))+$'))
+                    && (!has(self.exit) || self.exit.matches('^(([0-9]{1,6}([.][0-9]+)?|[.][0-9]+)(ns|us|µs|ms|s|m|h))+$'))
+              guard:
+                description: guard limits how many nodes a single policy may remediate
+                  at once.
+                properties:
+                  maxAffectedPercent:
+                    default: 100
+                    description: |-
+                      maxAffectedPercent is evaluated over the selected nodes that report a determinate condition
+                      (Unknown or unreported nodes are excluded); if the percentage of matched nodes exceeds it, no
+                      node is remediated. Defaults to 100 (guard off).
+                    format: int32
+                    maximum: 100
+                    minimum: 0
+                    type: integer
+                type: object
+              nodeSelector:
+                description: nodeSelector scopes the policy to a subset of nodes (empty
+                  = all nodes).
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              remediations:
+                description: remediations lists the remediations to apply to a matched
+                  node; v1 supports taint.
+                properties:
+                  taint:
+                    description: |-
+                      taint applied to matched nodes; effect must be a real Kubernetes taint effect. NoExecute
+                      also evicts non-tolerating pods and drops the node from Service endpoints; NoSchedule and
+                      PreferNoSchedule only keep new pods off the node. The taint is reversible and removed when
+                      the condition clears.
+                      key is a valid Kubernetes qualified name: a name of at most 63 characters, optionally prefixed
+                      with a DNS subdomain and a slash (for example, node.example.com/unreachable).
+                      value, when set, is a valid Kubernetes label value (at most 63 characters).
+                      The taint is immutable once set; delete and recreate the policy to change it.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                      timeAdded:
+                        description: TimeAdded represents the time at which the taint
+                          was added.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                    required:
+                    - effect
+                    - key
+                    type: object
+                    x-kubernetes-validations:
+                    - message: taint.effect must be one of NoSchedule, PreferNoSchedule,
+                        NoExecute
+                      rule: self.effect in ['NoSchedule','PreferNoSchedule','NoExecute']
+                    - message: taint.key must be a valid Kubernetes qualified name
+                        (name <=63 chars, optional DNS-subdomain prefix)
+                      rule: self.key.matches('^([a-z0-9]([-a-z0-9]*[a-z0-9])?([.][a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?[A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?$')
+                        && self.key.size() <= 317
+                    - message: taint.value must be empty or a valid Kubernetes label
+                        value (<=63 chars)
+                      rule: '!has(self.value) || self.value.matches(''^([A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?)?$'')'
+                    - message: taint is immutable; delete and recreate the policy
+                        to change it
+                      rule: self == oldSelf
+                type: object
+                x-kubernetes-validations:
+                - message: at least one remediation must be set (v1 supports 'taint')
+                  rule: has(self.taint)
+            required:
+            - condition
+            - remediations
+            type: object
+          status:
+            description: status defines the observed state of NodeRemediationPolicy
+            properties:
+              conditions:
+                description: conditions represents the observations of the policy
+                  state (e.g. the Remediating condition).
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              heldCount:
+                description: heldCount is the number of matched nodes held for a missing
+                  lastTransitionTime.
+                format: int32
+                type: integer
+              heldNodes:
+                description: |-
+                  heldNodes are the matched nodes held because their condition carries no lastTransitionTime,
+                  so the debounce cannot be evaluated; they stay stuck until a timestamp appears.
+                items:
+                  type: string
+                type: array
+              matchedCount:
+                description: matchedCount is the number of nodes currently matching
+                  the policy condition.
+                format: int32
+                type: integer
+              matchedNodes:
+                description: matchedNodes are the selected nodes whose condition currently
+                  matches.
+                items:
+                  type: string
+                type: array
+              pendingCount:
+                description: pendingCount is the number of matched nodes not yet remediated.
+                format: int32
+                type: integer
+              pendingNodes:
+                description: |-
+                  pendingNodes are the matched nodes not yet remediated (awaiting the debounce window,
+                  blocked by the guard, or being applied).
+                items:
+                  type: string
+                type: array
+              remediatedCount:
+                description: remediatedCount is the number of nodes currently carrying
+                  the remediation.
+                format: int32
+                type: integer
+              remediatedNodes:
+                description: remediatedNodes are the selected nodes that currently
+                  carry the remediation taint.
+                items:
+                  type: string
+                type: array
+              selectedCount:
+                description: selectedCount is the number of nodes in scope of the
+                  policy.
+                format: int32
+                type: integer
+              selectedNodes:
+                description: selectedNodes are the nodes in scope, matching spec.nodeSelector
+                  (empty selector = all nodes).
+                items:
+                  type: string
+                type: array
+              unknownCount:
+                description: unknownCount is the number of selected nodes whose condition
+                  is Unknown or unreported.
+                format: int32
+                type: integer
+              unknownNodes:
+                description: |-
+                  unknownNodes are the selected nodes whose condition is Unknown or unreported (held:
+                  neither remediated nor cleared).
+                items:
+                  type: string
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: node-warden-operator
+  name: node-warden-operator-controller-manager
+  namespace: metalk8s-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: node-warden-operator
+  name: node-warden-operator-leader-election-role
+  namespace: metalk8s-monitoring
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: node-warden-operator-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - warden.scality.com
+  resources:
+  - noderemediationpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - warden.scality.com
+  resources:
+  - noderemediationpolicies/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - warden.scality.com
+  resources:
+  - noderemediationpolicies/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: node-warden-operator-metrics-auth-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: node-warden-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: node-warden-operator
+  name: node-warden-operator-noderemediationpolicy-admin-role
+rules:
+- apiGroups:
+  - warden.scality.com
+  resources:
+  - noderemediationpolicies
+  verbs:
+  - '*'
+- apiGroups:
+  - warden.scality.com
+  resources:
+  - noderemediationpolicies/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: node-warden-operator
+  name: node-warden-operator-noderemediationpolicy-editor-role
+rules:
+- apiGroups:
+  - warden.scality.com
+  resources:
+  - noderemediationpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - warden.scality.com
+  resources:
+  - noderemediationpolicies/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: node-warden-operator
+  name: node-warden-operator-noderemediationpolicy-viewer-role
+rules:
+- apiGroups:
+  - warden.scality.com
+  resources:
+  - noderemediationpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - warden.scality.com
+  resources:
+  - noderemediationpolicies/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: node-warden-operator
+  name: node-warden-operator-leader-election-rolebinding
+  namespace: metalk8s-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: node-warden-operator-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: node-warden-operator-controller-manager
+  namespace: metalk8s-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: node-warden-operator
+  name: node-warden-operator-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: node-warden-operator-manager-role
+subjects:
+- kind: ServiceAccount
+  name: node-warden-operator-controller-manager
+  namespace: metalk8s-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: node-warden-operator-metrics-auth-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: node-warden-operator-metrics-auth-role
+subjects:
+- kind: ServiceAccount
+  name: node-warden-operator-controller-manager
+  namespace: metalk8s-monitoring
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: node-warden-operator
+    control-plane: controller-manager
+  name: node-warden-operator-controller-manager-metrics-service
+  namespace: metalk8s-monitoring
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/name: node-warden-operator
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: node-warden-operator
+  name: node-warden-operator-webhook-service
+  namespace: metalk8s-monitoring
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app.kubernetes.io/name: node-warden-operator
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: node-warden-operator
+    control-plane: controller-manager
+  name: node-warden-operator-controller-manager
+  namespace: metalk8s-monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: node-warden-operator
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app.kubernetes.io/name: node-warden-operator
+        control-plane: controller-manager
+    nodeSelector:
+      node-role.kubernetes.io/master: ""
+    spec:
+      containers:
+      - args:
+        - --metrics-bind-address=:8443
+        - --leader-elect
+        - --health-probe-bind-address=:8081
+        - --metrics-cert-path=/tmp/k8s-metrics-server/metrics-certs
+        - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
+        command:
+        - /manager
+        image: '{% endraw -%}{{ build_image_name("node-warden-operator", False) }}{%-
+          raw %}:v1.0.0'
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 8081
+          name: health
+          protocol: TCP
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /tmp/k8s-metrics-server/metrics-certs
+          name: metrics-certs
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: webhook-certs
+          readOnly: true
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: node-warden-operator-controller-manager
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/bootstrap
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      volumes:
+      - name: metrics-certs
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          - key: tls.crt
+            path: tls.crt
+          - key: tls.key
+            path: tls.key
+          optional: false
+          secretName: metrics-server-cert
+      - name: webhook-certs
+        secret:
+          secretName: webhook-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: node-warden-operator
+  name: node-warden-operator-metrics-certs
+  namespace: metalk8s-monitoring
+spec:
+  dnsNames:
+  - node-warden-operator-controller-manager-metrics-service.metalk8s-monitoring.svc
+  - node-warden-operator-controller-manager-metrics-service.metalk8s-monitoring.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: node-warden-operator-selfsigned-issuer
+  secretName: metrics-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: node-warden-operator
+  name: node-warden-operator-serving-cert
+  namespace: metalk8s-monitoring
+spec:
+  dnsNames:
+  - node-warden-operator-webhook-service.metalk8s-monitoring.svc
+  - node-warden-operator-webhook-service.metalk8s-monitoring.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: node-warden-operator-selfsigned-issuer
+  secretName: webhook-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: node-warden-operator
+  name: node-warden-operator-selfsigned-issuer
+  namespace: metalk8s-monitoring
+spec:
+  selfSigned: {}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: node-warden-operator
+    control-plane: controller-manager
+    metalk8s.scality.com/monitor: ""
+  name: node-warden-operator-controller-manager-metrics-monitor
+  namespace: metalk8s-monitoring
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    path: /metrics
+    port: https
+    scheme: https
+    tlsConfig:
+      ca:
+        secret:
+          key: ca.crt
+          name: metrics-server-cert
+      cert:
+        secret:
+          key: tls.crt
+          name: metrics-server-cert
+      insecureSkipVerify: false
+      keySecret:
+        key: tls.key
+        name: metrics-server-cert
+      serverName: node-warden-operator-controller-manager-metrics-service.metalk8s-monitoring.svc
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: node-warden-operator
+      control-plane: controller-manager
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: metalk8s-monitoring/node-warden-operator-serving-cert
+  name: node-warden-operator-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: node-warden-operator-webhook-service
+      namespace: metalk8s-monitoring
+      path: /validate-warden-scality-com-v1alpha1-noderemediationpolicy
+  failurePolicy: Fail
+  name: vnoderemediationpolicy-v1alpha1.kb.io
+  rules:
+  - apiGroups:
+    - warden.scality.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - noderemediationpolicies
+  sideEffects: None
+{%- endraw %}

--- a/salt/metalk8s/addons/node-warden-operator/deployed/init.sls
+++ b/salt/metalk8s/addons/node-warden-operator/deployed/init.sls
@@ -1,0 +1,10 @@
+include:
+  - metalk8s.addons.prometheus-operator.deployed.namespace
+  - .chart
+
+Ensure namespace is created before deploying node-warden-operator:
+  test.succeed_without_changes:
+    - require:
+      - sls: metalk8s.addons.prometheus-operator.deployed.namespace
+    - require_in:
+      - sls: metalk8s.addons.node-warden-operator.deployed.chart

--- a/salt/metalk8s/addons/node-warden-operator/deployed/init.sls
+++ b/salt/metalk8s/addons/node-warden-operator/deployed/init.sls
@@ -1,6 +1,7 @@
 include:
   - metalk8s.addons.prometheus-operator.deployed.namespace
   - .chart
+  - .policy
 
 Ensure namespace is created before deploying node-warden-operator:
   test.succeed_without_changes:
@@ -8,3 +9,17 @@ Ensure namespace is created before deploying node-warden-operator:
       - sls: metalk8s.addons.prometheus-operator.deployed.namespace
     - require_in:
       - sls: metalk8s.addons.node-warden-operator.deployed.chart
+
+Wait for the node-warden-operator to be Ready:
+  test.configurable_test_state:
+    - changes: False
+    - result: __slot__:salt:metalk8s_kubernetes.check_object_ready(
+        apiVersion=apps/v1, kind=Deployment,
+        name=node-warden-operator-controller-manager, namespace=metalk8s-monitoring)
+    - comment: Wait for the node-warden-operator to be Ready
+    - retry:
+        attempts: 30
+    - require:
+      - sls: metalk8s.addons.node-warden-operator.deployed.chart
+    - require_in:
+      - sls: metalk8s.addons.node-warden-operator.deployed.policy

--- a/salt/metalk8s/addons/node-warden-operator/deployed/init.sls
+++ b/salt/metalk8s/addons/node-warden-operator/deployed/init.sls
@@ -2,6 +2,7 @@ include:
   - metalk8s.addons.prometheus-operator.deployed.namespace
   - .chart
   - .policy
+  - .workload-plane-alerts-rules
 
 Ensure namespace is created before deploying node-warden-operator:
   test.succeed_without_changes:

--- a/salt/metalk8s/addons/node-warden-operator/deployed/policy.sls
+++ b/salt/metalk8s/addons/node-warden-operator/deployed/policy.sls
@@ -1,0 +1,19 @@
+#!jinja | metalk8s_kubernetes
+
+apiVersion: warden.scality.com/v1alpha1
+kind: NodeRemediationPolicy
+metadata:
+  name: workload-plane-isolation
+spec:
+  condition:
+    type: WorkloadPlaneNetworkUnavailable
+    status: "True"
+  remediations:
+    taint:
+      key: node.scality.com/workload-plane-unreachable
+      effect: NoExecute
+  debounce:
+    enter: 60s
+    exit: 30s
+  guard:
+    maxAffectedPercent: 50

--- a/salt/metalk8s/addons/node-warden-operator/deployed/workload-plane-alerts-rules.sls
+++ b/salt/metalk8s/addons/node-warden-operator/deployed/workload-plane-alerts-rules.sls
@@ -1,0 +1,42 @@
+#!jinja | metalk8s_kubernetes
+
+{%- raw %}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/part-of: metalk8s
+    metalk8s.scality.com/monitor: ''
+  name: metalk8s-workload-plane-remediation.rules
+  namespace: metalk8s-monitoring
+spec:
+  groups:
+  - name: workload-plane-remediation
+    rules:
+    - alert: NodeWorkloadPlaneRemediated
+      annotations:
+        summary: Node drained after Workload Plane isolation
+        description: Node {{ $labels.node }} carries the
+          node.scality.com/workload-plane-unreachable:NoExecute taint applied by node-warden;
+          its non-tolerating workloads have been evicted and it no longer serves Service
+          traffic. The taint is removed automatically once Workload Plane connectivity
+          recovers.
+      expr: kube_node_spec_taint{key="node.scality.com/workload-plane-unreachable"} == 1
+      for: 1m
+      labels:
+        severity: warning
+    - alert: WorkloadPlaneOutage
+      annotations:
+        summary: Workload Plane outage affecting the majority of nodes
+        description: More than half of the nodes report WorkloadPlaneNetworkUnavailable=True.
+          node-warden's guard suppresses remediation in this case (a cluster-wide Workload
+          Plane failure rather than a single-node fault), so no node is tainted. Investigate
+          the Workload Plane network fabric.
+      expr: |-
+        count(kube_node_status_condition{condition="WorkloadPlaneNetworkUnavailable",status="true"} == 1)
+          /
+        count(kube_node_status_condition{condition="WorkloadPlaneNetworkUnavailable",status="true"}) > 0.5
+      for: 1m
+      labels:
+        severity: critical
+{%- endraw %}

--- a/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
+++ b/salt/metalk8s/addons/prometheus-operator/deployed/chart.sls
@@ -79803,6 +79803,9 @@ spec:
       tolerations:
       - effect: NoSchedule
         operator: Exists
+      - effect: NoExecute
+        key: node.scality.com/workload-plane-unreachable
+        operator: Exists
       volumes:
       - hostPath:
           path: /proc

--- a/salt/metalk8s/deployed/init.sls
+++ b/salt/metalk8s/deployed/init.sls
@@ -13,6 +13,7 @@ include:
   - metalk8s.addons.dex.deployed
   - metalk8s.addons.prometheus-adapter.deployed
   - metalk8s.addons.node-problem-detector.deployed
+  - metalk8s.addons.node-warden-operator.deployed
   - metalk8s.addons.logging.deployed
   - metalk8s.addons.alert-tree.deployed
   - metalk8s.addons.crl-operator.deployed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -368,6 +368,24 @@ def wait_rollout_status(host, resource, namespace):
     )
 
 
+@when(
+    parsers.parse(
+        "we trigger a rollout restart of '{resource}' in namespace '{namespace}'"
+    )
+)
+def rollout_restart(host, resource, namespace):
+    # Make sure any previous rollout is completed
+    wait_rollout_status(host, resource, namespace)
+
+    with host.sudo():
+        host.run_test(
+            "kubectl --kubeconfig=/etc/kubernetes/admin.conf "
+            "rollout restart %s --namespace %s",
+            resource,
+            namespace,
+        )
+
+
 @when(parsers.parse("we wait {seconds} seconds for the {job} job to complete"))
 def wait_for_job(host, seconds, job):
     with host.sudo():

--- a/tests/post/features/sanity.feature
+++ b/tests/post/features/sanity.feature
@@ -41,6 +41,7 @@ Feature: Cluster Sanity Checks
         | metalk8s-monitoring | prometheus-operator-kube-state-metrics |
         | metalk8s-monitoring | prometheus-operator-operator           |
         | metalk8s-monitoring | thanos-query                           |
+        | metalk8s-monitoring | node-warden-operator-controller-manager |
         | metalk8s-ui         | metalk8s-ui                            |
         | metalk8s-certs      | cert-manager                           |
         | metalk8s-certs      | cert-manager-cainjector                |

--- a/tests/post/features/workload_plane_isolation.feature
+++ b/tests/post/features/workload_plane_isolation.feature
@@ -1,0 +1,52 @@
+@post @ci @local @workloadplane
+Feature: Workload Plane isolation detection and remediation
+    A node that loses Workload Plane connectivity must be detected through the
+    WorkloadPlaneNetworkUnavailable condition, drained via a reversible
+    NoExecute taint, and restored once connectivity recovers -- without
+    over-reacting to a transient event or to a cluster-wide outage.
+
+    Background:
+        Given the Kubernetes API is available
+        And the Prometheus API is available
+        And the node-warden 'workload-plane-isolation' policy is deployed
+
+    Scenario Outline: An isolated node is drained and recovers (<mode>)
+        Given we are on a cluster with at least 3 workload-plane nodes
+        And a test workload is running on every workload-plane node
+        When we cut the Workload Plane network on a workload-plane node using '<mode>'
+        Then the isolated node reports 'WorkloadPlaneNetworkUnavailable' as 'True'
+        And no other node reports 'WorkloadPlaneNetworkUnavailable' as 'True'
+        And the 'NodeWorkloadPlaneUnavailable' alert is firing
+        And the isolated node gets the 'node.scality.com/workload-plane-unreachable' taint
+        And the 'NodeWorkloadPlaneRemediated' alert is firing
+        And the test workload has no endpoint on the isolated node
+        When we restore the Workload Plane network on the isolated node
+        Then the isolated node no longer reports 'WorkloadPlaneNetworkUnavailable' as 'True'
+        And the 'node.scality.com/workload-plane-unreachable' taint is removed from the isolated node
+        And the 'NodeWorkloadPlaneUnavailable' alert clears
+        And the 'NodeWorkloadPlaneRemediated' alert clears
+        And the test workload has an endpoint on every workload-plane node
+
+        Examples:
+        | mode      |
+        | link-down |
+        | blocked   |
+
+    Scenario: A Calico rolling restart does not trigger remediation
+        When we trigger a rollout restart of 'daemonset/calico-node' in namespace 'kube-system'
+        Then no node is tainted and alerts 'NodeWorkloadPlaneRemediated' do not fire within 90 seconds
+
+    Scenario: A short Workload Plane blip does not trigger remediation
+        Given the node control-plane IP is not equal to its workload-plane IP
+        When we cut then restore the Workload Plane network on a workload-plane node within 20 seconds
+        Then no node is tainted and alerts 'NodeWorkloadPlaneUnavailable,NodeWorkloadPlaneRemediated' do not fire within 90 seconds
+
+    Scenario: A majority Workload Plane outage is not remediated but alerts
+        Given we are on a multi node cluster
+        When we cut the Workload Plane network on the majority of workload-plane nodes using 'blocked'
+        Then no node is tainted and alerts 'NodeWorkloadPlaneRemediated' do not fire within 120 seconds
+        And the 'NodeWorkloadPlaneUnavailable' alert is firing
+        And the 'WorkloadPlaneOutage' alert is firing
+        When we restore the Workload Plane network on all isolated nodes
+        Then no node reports 'WorkloadPlaneNetworkUnavailable' as 'True'
+        And the 'WorkloadPlaneOutage' alert clears

--- a/tests/post/steps/test_ingress.py
+++ b/tests/post/steps/test_ingress.py
@@ -11,7 +11,7 @@ from pytest_bdd import given, parsers, scenario, then, when
 import testinfra
 
 from tests import utils
-from tests.conftest import wait_rollout_status
+from tests.conftest import rollout_restart, wait_rollout_status
 
 
 MAIN_CC_NAME = "main"
@@ -560,24 +560,6 @@ def update_portmap_cidr(host, context, ssh_config, version, plane):
 
     utils.patch_bootstrap_config(context, host, bootstrap_patch)
     re_configure_portmap(host, version, ssh_config, context=context)
-
-
-@when(
-    parsers.parse(
-        "we trigger a rollout restart of '{resource}' in namespace '{namespace}'"
-    )
-)
-def rollout_restart(host, resource, namespace):
-    # Make sure any previous rollout is completed
-    wait_rollout_status(host, resource, namespace)
-
-    with host.sudo():
-        host.run_test(
-            "kubectl --kubeconfig=/etc/kubernetes/admin.conf "
-            "rollout restart %s --namespace %s",
-            resource,
-            namespace,
-        )
 
 
 @when(

--- a/tests/post/steps/test_workload_plane_isolation.py
+++ b/tests/post/steps/test_workload_plane_isolation.py
@@ -1,0 +1,657 @@
+# coding: utf-8
+"""End-to-end validation of the Workload Plane isolation flow.
+
+Detection (node-problem-detector sets the WorkloadPlaneNetworkUnavailable
+condition) -> remediation (node-warden taints the node NoExecute) -> traffic
+drained (pods evicted, node out of the Service endpoints) -> recovery on
+restore, plus the false-positive and guard-suppression safeguards.
+
+These scenarios require a segregated-network cluster (separate control plane
+and workload plane) with at least 3 nodes, so the majority quorum can tell a
+single-node isolation apart from a global outage.
+"""
+
+import json
+import time
+
+import kubernetes.client
+import pytest
+import testinfra
+from pytest_bdd import parsers, scenario, given, when, then
+
+from tests import utils
+
+WORKLOAD_NAMESPACE = "wp-test"
+
+
+# Scenarios {{{
+
+
+@scenario(
+    "../features/workload_plane_isolation.feature",
+    "An isolated node is drained and recovers (<mode>)",
+    example_converters={"mode": str},
+)
+def test_isolated_node_drained_and_recovers(host, teardown):
+    pass
+
+
+@scenario(
+    "../features/workload_plane_isolation.feature",
+    "A Calico rolling restart does not trigger remediation",
+)
+def test_calico_restart_no_remediation(host, teardown):
+    pass
+
+
+@scenario(
+    "../features/workload_plane_isolation.feature",
+    "A short Workload Plane blip does not trigger remediation",
+)
+def test_wp_blip_no_remediation(host, teardown):
+    pass
+
+
+@scenario(
+    "../features/workload_plane_isolation.feature",
+    "A majority Workload Plane outage is not remediated but alerts",
+)
+def test_majority_outage_alerts(host, teardown):
+    pass
+
+
+# }}}
+# Fixtures {{{
+
+
+@pytest.fixture
+def context():
+    return {"cut": []}
+
+
+@pytest.fixture
+def teardown(host, context, k8s_client, ssh_config):
+    yield
+
+    # Restore Workload Plane connectivity on every node we cut, even on failure.
+    for node_name, mode, iface in context["cut"]:
+        try:
+            _restore_wp(_node_host(node_name, ssh_config), mode, iface)
+        except Exception as exc:  # noqa: BLE001 - best-effort cleanup
+            utils.LOGGER.warning("Failed to restore WP on %s: %s", node_name, exc)
+
+    # Uncordon any node cordoned to relocate kube-state-metrics.
+    for node_name in context.get("cordoned", []):
+        try:
+            _uncordon(host, node_name)
+        except Exception as exc:  # noqa: BLE001 - best-effort cleanup
+            utils.LOGGER.warning("Failed to uncordon %s: %s", node_name, exc)
+
+    # Remove the test workload and wait for the namespace to be fully gone, so
+    # the next scenario can recreate it (a still-terminating namespace rejects
+    # new objects).
+    if context.get("workload"):
+        ns_client = k8s_client.resources.get(api_version="v1", kind="Namespace")
+        try:
+            ns_client.delete(
+                name=WORKLOAD_NAMESPACE,
+                body=kubernetes.client.V1DeleteOptions(propagation_policy="Foreground"),
+            )
+        except kubernetes.client.rest.ApiException:
+            pass
+
+        def _gone():
+            try:
+                ns_client.get(name=WORKLOAD_NAMESPACE)
+            except kubernetes.client.rest.ApiException as exc:
+                if exc.status == 404:
+                    return
+                raise
+            raise AssertionError(f"namespace {WORKLOAD_NAMESPACE} still terminating")
+
+        utils.retry(_gone, times=30, wait=5, name=f"delete {WORKLOAD_NAMESPACE}")
+
+
+# }}}
+# Given {{{
+
+
+@given("we are on a cluster with at least 3 workload-plane nodes")
+def at_least_three_nodes(k8s_client):
+    nodes = _all_nodes(k8s_client)
+    if len(nodes) < 3:
+        pytest.skip(
+            "Workload Plane isolation tests need at least 3 workload-plane nodes "
+            f"(found {len(nodes)})"
+        )
+
+
+@given(parsers.parse("the node-warden '{name}' policy is deployed"))
+def policy_is_deployed(k8s_client, name):
+    policies = k8s_client.resources.get(
+        api_version="warden.scality.com/v1alpha1", kind="NodeRemediationPolicy"
+    )
+
+    def _check():
+        try:
+            policies.get(name=name)
+        except kubernetes.client.rest.ApiException as exc:
+            if exc.status == 404:
+                raise AssertionError(f"NodeRemediationPolicy '{name}' not found")
+            raise
+
+    utils.retry(_check, times=10, wait=3, name=f"wait for policy '{name}'")
+
+
+@given("a test workload is running on every workload-plane node")
+def deploy_test_workload(context, k8s_client, utils_image):
+    node_names = [node.metadata.name for node in _all_nodes(k8s_client)]
+
+    _create_namespace(k8s_client, WORKLOAD_NAMESPACE)
+    context["workload"] = True
+
+    deployment = _workload_deployment(utils_image, replicas=len(node_names))
+    k8s_client.resources.get(api_version="apps/v1", kind="Deployment").create(
+        body=deployment, namespace=WORKLOAD_NAMESPACE
+    )
+    k8s_client.resources.get(api_version="v1", kind="Service").create(
+        body=_workload_service(), namespace=WORKLOAD_NAMESPACE
+    )
+
+    _wait_endpoints_on_nodes(k8s_client, set(node_names))
+
+
+# }}}
+# When {{{
+
+
+@when("we cut the Workload Plane network on a workload-plane node using '<mode>'")
+def cut_wp_single(host, context, k8s_client, ssh_config, mode):
+    node_name = _pick_wp_node(k8s_client, ssh_config)
+    context["isolated"] = node_name
+    # Move kube-state-metrics off the node we isolate so Prometheus keeps
+    # scraping it and can compute the alerts.
+    _relocate_ksm(host, k8s_client, [node_name], context)
+    _cut_wp(context, ssh_config, node_name, mode)
+
+
+@when(
+    parsers.parse(
+        "we cut the Workload Plane network on the majority of workload-plane nodes "
+        "using '{mode}'"
+    )
+)
+def cut_wp_majority(host, context, k8s_client, ssh_config, mode):
+    node_names = [node.metadata.name for node in _all_nodes(k8s_client)]
+    prometheus = _prometheus_nodes(k8s_client)
+    # Keep one Prometheus node uncut -- a single replica is enough for the alerts
+    # to stay computable and queryable while the rest of the plane is isolated.
+    keep = next((name for name in node_names if name in prometheus), None)
+    assert keep, "No Prometheus node to preserve"
+    majority = len(node_names) // 2 + 1
+    to_cut = [name for name in node_names if name != keep][:majority]
+    # kube-state-metrics must stay reachable from Prometheus: force it onto an
+    # uncut node before isolating the majority.
+    _relocate_ksm(host, k8s_client, to_cut, context)
+    for node_name in to_cut:
+        _cut_wp(context, ssh_config, node_name, mode)
+
+
+@when("we restore the Workload Plane network on the isolated node")
+@when("we restore the Workload Plane network on all isolated nodes")
+def restore_wp(context, ssh_config):
+    for node_name, mode, iface in context["cut"]:
+        _restore_wp(_node_host(node_name, ssh_config), mode, iface)
+    context["cut"] = []
+
+
+@when(
+    parsers.parse(
+        "we cut then restore the Workload Plane network on a workload-plane node "
+        "within {seconds:d} seconds"
+    )
+)
+def wp_blip(context, k8s_client, ssh_config, seconds):
+    node_name = _pick_wp_node(k8s_client, ssh_config, keep_prometheus=False)
+    _cut_wp(context, ssh_config, node_name, "blocked")
+    time.sleep(seconds)
+    for node_name, mode, iface in context["cut"]:
+        _restore_wp(_node_host(node_name, ssh_config), mode, iface)
+    context["cut"] = []
+
+
+# }}}
+# Then {{{
+
+
+@then(parsers.parse("the isolated node reports '{condition}' as '{status}'"))
+def isolated_reports_condition(context, k8s_client, condition, status):
+    node_name = context["isolated"]
+
+    def _check():
+        assert (
+            _node_condition(k8s_client, node_name, condition) == status
+        ), f"Node {node_name} condition {condition} is not {status}"
+
+    utils.retry(_check, times=18, wait=10, name=f"wait for {condition} on {node_name}")
+
+
+@then(parsers.parse("no other node reports '{condition}' as '{status}'"))
+def no_other_node_condition(context, k8s_client, condition, status):
+    isolated = context["isolated"]
+    for node in _all_nodes(k8s_client):
+        if node.metadata.name == isolated:
+            continue
+        assert (
+            _node_condition(k8s_client, node.metadata.name, condition) != status
+        ), f"Unexpected {condition}={status} on node {node.metadata.name}"
+
+
+@then(parsers.parse("the isolated node gets the '{key}' taint"))
+def isolated_gets_taint(context, k8s_client, key):
+    node_name = context["isolated"]
+
+    def _check():
+        assert _has_taint(
+            k8s_client, node_name, key
+        ), f"Node {node_name} is not tainted {key}"
+
+    utils.retry(_check, times=18, wait=10, name=f"wait for taint {key} on {node_name}")
+
+
+@then("the test workload has no endpoint on the isolated node")
+def no_endpoint_on_isolated(context, k8s_client):
+    node_name = context["isolated"]
+
+    def _check():
+        assert node_name not in _endpoint_nodes(
+            k8s_client
+        ), f"Node {node_name} still serves the test workload"
+
+    utils.retry(
+        _check, times=18, wait=10, name=f"wait for {node_name} to leave endpoints"
+    )
+
+
+@then(parsers.parse("the isolated node no longer reports '{condition}' as '{status}'"))
+def isolated_condition_cleared(context, k8s_client, condition, status):
+    node_name = context["isolated"]
+
+    def _check():
+        assert (
+            _node_condition(k8s_client, node_name, condition) != status
+        ), f"Node {node_name} still reports {condition}={status}"
+
+    utils.retry(
+        _check, times=18, wait=10, name=f"wait for {condition} to clear on {node_name}"
+    )
+
+
+@then(parsers.parse("the '{key}' taint is removed from the isolated node"))
+def taint_removed(context, k8s_client, key):
+    node_name = context["isolated"]
+
+    def _check():
+        assert not _has_taint(
+            k8s_client, node_name, key
+        ), f"Node {node_name} still tainted {key}"
+
+    utils.retry(
+        _check, times=18, wait=10, name=f"wait for taint {key} removal on {node_name}"
+    )
+
+
+@then("the test workload has an endpoint on every workload-plane node")
+def endpoint_on_every_node(k8s_client):
+    node_names = {node.metadata.name for node in _all_nodes(k8s_client)}
+    _wait_endpoints_on_nodes(k8s_client, node_names)
+
+
+@then(
+    parsers.parse(
+        "no node is tainted and alerts '{alert_names}' do not fire "
+        "within {seconds:d} seconds"
+    )
+)
+def no_taint_no_alerts_within(k8s_client, ssh_config, context, alert_names, seconds):
+    # One window checking the taint and every listed alert at once, instead of
+    # polling each signal for a full window in sequence.
+    avoid = {name for name, _, _ in context["cut"]}
+    key = "node.scality.com/workload-plane-unreachable"
+    names = {name.strip() for name in alert_names.split(",")}
+    remaining = seconds
+    while remaining > 0:
+        tainted = [
+            node.metadata.name
+            for node in _all_nodes(k8s_client)
+            if _has_taint(k8s_client, node.metadata.name, key)
+        ]
+        assert not tainted, f"Unexpected taint {key} on nodes {tainted}"
+        firing = names & _firing_alerts(k8s_client, ssh_config, avoid)
+        assert not firing, f"Alerts fired unexpectedly: {sorted(firing)}"
+        time.sleep(10)
+        remaining -= 10
+
+
+@then(parsers.parse("the '{alert_name}' alert is firing"))
+def alert_is_firing(k8s_client, ssh_config, context, alert_name):
+    avoid = {name for name, _, _ in context["cut"]}
+
+    def _check():
+        assert alert_name in _firing_alerts(
+            k8s_client, ssh_config, avoid
+        ), f"Alert {alert_name} is not firing"
+
+    # Firing needs the condition/taint set, a kube-state-metrics scrape and the
+    # rule `for` window, so allow a generous budget.
+    utils.retry(_check, times=30, wait=10, name=f"wait for alert {alert_name}")
+
+
+@then(parsers.parse("the '{alert_name}' alert clears"))
+def alert_clears(k8s_client, ssh_config, context, alert_name):
+    avoid = {name for name, _, _ in context["cut"]}
+
+    def _check():
+        assert alert_name not in _firing_alerts(
+            k8s_client, ssh_config, avoid
+        ), f"Alert {alert_name} is still firing"
+
+    utils.retry(_check, times=30, wait=10, name=f"wait for alert {alert_name} to clear")
+
+
+@then(parsers.parse("no node reports '{condition}' as '{status}'"))
+def no_node_condition(k8s_client, condition, status):
+    def _check():
+        offenders = [
+            node.metadata.name
+            for node in _all_nodes(k8s_client)
+            if _node_condition(k8s_client, node.metadata.name, condition) == status
+        ]
+        assert not offenders, f"Nodes still report {condition}={status}: {offenders}"
+
+    utils.retry(
+        _check, times=18, wait=10, name=f"wait for {condition} to clear everywhere"
+    )
+
+
+# }}}
+# Helpers {{{
+
+
+def _all_nodes(k8s_client):
+    return k8s_client.resources.get(api_version="v1", kind="Node").get().items
+
+
+def _pick_wp_node(k8s_client, ssh_config, keep_prometheus=True):
+    """Pick a workload-plane node to cut, preferring a non-bootstrap one.
+
+    keep_prometheus leaves a Prometheus replica uncut (the isolation flow taints
+    the node, which would evict Prometheus); a blip never taints, so it can cut
+    any node -- which is what lets the single-node case work.
+    """
+    bootstrap = utils.get_node_name("bootstrap", ssh_config)
+    node_names = [node.metadata.name for node in _all_nodes(k8s_client)]
+    if keep_prometheus:
+        prometheus = _prometheus_nodes(k8s_client)
+        non_prometheus = [name for name in node_names if name not in prometheus]
+        if non_prometheus:
+            candidates = non_prometheus
+        else:
+            keep = sorted(prometheus)[0]
+            candidates = [name for name in node_names if name != keep]
+    else:
+        candidates = node_names
+    assert candidates, "No workload-plane node available to cut"
+    for name in candidates:
+        if name != bootstrap:
+            return name
+    return candidates[0]
+
+
+def _pod_nodes(k8s_client, label):
+    pods = k8s_client.resources.get(api_version="v1", kind="Pod").get(
+        namespace="metalk8s-monitoring", label_selector=label
+    )
+    return {pod.spec.nodeName for pod in pods.items if pod.spec.nodeName}
+
+
+def _prometheus_nodes(k8s_client):
+    return _pod_nodes(k8s_client, "app.kubernetes.io/name=prometheus")
+
+
+def _ksm_nodes(k8s_client):
+    return _pod_nodes(k8s_client, "app.kubernetes.io/name=kube-state-metrics")
+
+
+def _node_host(node_name, ssh_config):
+    assert ssh_config is not None, "This test requires SSH access to the nodes"
+    return testinfra.get_host(node_name, ssh_config=ssh_config)
+
+
+def _node_condition(k8s_client, node_name, condition):
+    node = k8s_client.resources.get(api_version="v1", kind="Node").get(name=node_name)
+    for cond in node.status.conditions or []:
+        if cond.type == condition:
+            return cond.status
+    return None
+
+
+def _has_taint(k8s_client, node_name, key):
+    node = k8s_client.resources.get(api_version="v1", kind="Node").get(name=node_name)
+    return any((taint.key == key) for taint in (node.spec.taints or []))
+
+
+def _endpoint_nodes(k8s_client):
+    """Return the set of node names with a ready endpoint for the test workload."""
+    slices = k8s_client.resources.get(
+        api_version="discovery.k8s.io/v1", kind="EndpointSlice"
+    ).get(
+        namespace=WORKLOAD_NAMESPACE,
+        label_selector="kubernetes.io/service-name=wp-test-workload",
+    )
+    nodes = set()
+    for endpoint_slice in slices.items:
+        for endpoint in endpoint_slice.endpoints or []:
+            ready = endpoint.conditions and endpoint.conditions.ready
+            if ready and endpoint.nodeName:
+                nodes.add(endpoint.nodeName)
+    return nodes
+
+
+def _wait_endpoints_on_nodes(k8s_client, expected_nodes):
+    def _check():
+        current = _endpoint_nodes(k8s_client)
+        assert (
+            current == expected_nodes
+        ), f"Endpoints {current} do not cover every node {expected_nodes}"
+
+    utils.retry(
+        _check, times=30, wait=10, name="wait for workload endpoints on every node"
+    )
+
+
+def _prometheus_endpoint(k8s_client, avoid_nodes):
+    """Return (node, pod_ip) for a Prometheus pod on an uncut node: it has been
+    able to scrape kube-state-metrics, and its own node can reach the pod IP
+    locally without crossing the (possibly cut) Workload Plane."""
+    pods = k8s_client.resources.get(api_version="v1", kind="Pod").get(
+        namespace="metalk8s-monitoring",
+        label_selector="app.kubernetes.io/name=prometheus",
+    )
+    for pod in pods.items:
+        if pod.spec.nodeName not in avoid_nodes and pod.status.podIP:
+            return pod.spec.nodeName, pod.status.podIP
+    raise AssertionError("No Prometheus pod outside the isolated nodes")
+
+
+def _firing_alerts(k8s_client, ssh_config, avoid_nodes):
+    # Query Prometheus from its own node against the pod IP: node-to-local-pod
+    # traffic is not routed over the (possibly cut) Workload Plane, and it needs
+    # no shell inside the (distroless) Prometheus pod.
+    node_name, pod_ip = _prometheus_endpoint(k8s_client, avoid_nodes)
+    node = _node_host(node_name, ssh_config)
+    url = f"http://{pod_ip}:9090/api/v1/alerts"
+    # Prometheus can briefly answer 503 (starting up, reloading rules); ride it out.
+    data = None
+    for _ in range(6):
+        res = node.run(f"curl -sf --max-time 15 {url}")
+        if res.rc == 0:
+            try:
+                data = json.loads(res.stdout)
+                break
+            except ValueError:
+                pass
+        time.sleep(5)
+    assert data is not None, f"Prometheus at {pod_ip} did not answer /api/v1/alerts"
+    return {
+        alert["labels"].get("alertname")
+        for alert in data.get("data", {}).get("alerts", [])
+        if alert.get("state") == "firing"
+    }
+
+
+def _kubectl(host, args):
+    with host.sudo():
+        return host.check_output(
+            f"kubectl --kubeconfig=/etc/kubernetes/admin.conf {args}"
+        )
+
+
+def _cordon(host, node_name):
+    _kubectl(host, f"cordon {node_name}")
+
+
+def _uncordon(host, node_name):
+    _kubectl(host, f"uncordon {node_name}")
+
+
+def _relocate_ksm(host, k8s_client, cut_nodes, context):
+    """Ensure kube-state-metrics runs on a node that stays up, so Prometheus can
+    keep scraping it: cordon the nodes about to be cut, delete the pod so it
+    reschedules onto an uncut node, then uncordon."""
+    cut = set(cut_nodes)
+    if _ksm_nodes(k8s_client) - cut:
+        return  # already on an uncut node
+    for node_name in cut_nodes:
+        _cordon(host, node_name)
+    context["cordoned"] = list(cut_nodes)
+    pods = k8s_client.resources.get(api_version="v1", kind="Pod").get(
+        namespace="metalk8s-monitoring",
+        label_selector="app.kubernetes.io/name=kube-state-metrics",
+    )
+    for pod in pods.items:
+        _kubectl(host, f"-n metalk8s-monitoring delete pod {pod.metadata.name}")
+
+    def _off_cut():
+        assert _ksm_nodes(k8s_client) - cut, "kube-state-metrics still on a cut node"
+
+    utils.retry(_off_cut, times=30, wait=5, name="relocate kube-state-metrics")
+    for node_name in cut_nodes:
+        _uncordon(host, node_name)
+    context["cordoned"] = []
+
+
+def _wp_iface(node):
+    wp_ip = utils.get_grain(node, "metalk8s:workload_plane_ip")
+    for iface, ips in utils.get_grain(node, "ip4_interfaces").items():
+        if wp_ip in ips:
+            return iface
+    raise AssertionError(f"Could not find the Workload Plane interface for IP {wp_ip}")
+
+
+def _cut_wp(context, ssh_config, node_name, mode):
+    node = _node_host(node_name, ssh_config)
+    iface = _wp_iface(node)
+    with node.sudo():
+        if mode == "link-down":
+            node.check_output(f"ip link set {iface} down")
+        elif mode == "blocked":
+            # filter-table drops are bypassed by Calico's cali-FORWARD chain, so
+            # drop on the raw table to simulate a link-up-but-blocked failure.
+            node.check_output(f"iptables -t raw -I PREROUTING -i {iface} -j DROP")
+            node.check_output(f"iptables -t raw -I OUTPUT -o {iface} -j DROP")
+        else:
+            raise ValueError(f"Unknown cut mode '{mode}'")
+    context["cut"].append((node_name, mode, iface))
+
+
+def _restore_wp(node, mode, iface):
+    with node.sudo():
+        if mode == "link-down":
+            node.check_output(f"ip link set {iface} up")
+        elif mode == "blocked":
+            node.check_output(f"iptables -t raw -D PREROUTING -i {iface} -j DROP")
+            node.check_output(f"iptables -t raw -D OUTPUT -o {iface} -j DROP")
+
+
+def _create_namespace(k8s_client, name):
+    ns_client = k8s_client.resources.get(api_version="v1", kind="Namespace")
+    try:
+        ns_client.get(name=name)
+    except kubernetes.client.rest.ApiException as exc:
+        if exc.status != 404:
+            raise
+        ns_client.create(
+            body={"apiVersion": "v1", "kind": "Namespace", "metadata": {"name": name}}
+        )
+
+
+def _workload_deployment(image, replicas):
+    labels = {"app": "wp-test-workload"}
+    return {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {"name": "wp-test-workload", "labels": labels},
+        "spec": {
+            "replicas": replicas,
+            "selector": {"matchLabels": labels},
+            "template": {
+                "metadata": {"labels": labels},
+                "spec": {
+                    # One pod per node so isolating a node empties exactly one pod.
+                    "affinity": {
+                        "podAntiAffinity": {
+                            "requiredDuringSchedulingIgnoredDuringExecution": [
+                                {
+                                    "labelSelector": {"matchLabels": labels},
+                                    "topologyKey": "kubernetes.io/hostname",
+                                }
+                            ]
+                        }
+                    },
+                    # Tolerate control-plane taints so the workload lands on every node.
+                    "tolerations": [
+                        {
+                            "key": f"node-role.kubernetes.io/{role}",
+                            "operator": "Exists",
+                            "effect": "NoSchedule",
+                        }
+                        for role in ("bootstrap", "etcd", "infra", "master")
+                    ],
+                    "containers": [
+                        {
+                            "name": "workload",
+                            "image": image,
+                            "command": ["sleep", "infinity"],
+                            "ports": [{"containerPort": 8080, "name": "http"}],
+                        }
+                    ],
+                },
+            },
+        },
+    }
+
+
+def _workload_service():
+    return {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {"name": "wp-test-workload"},
+        "spec": {
+            "selector": {"app": "wp-test-workload"},
+            "ports": [{"name": "http", "port": 8080, "targetPort": "http"}],
+        },
+    }
+
+
+# }}}

--- a/tools/lib-alert-tree/metalk8s/__init__.py
+++ b/tools/lib-alert-tree/metalk8s/__init__.py
@@ -3,7 +3,7 @@
 from lib_alert_tree.models import Relationship, severity_pair
 from lib_alert_tree.prometheus import PrometheusRule
 
-from .network import NETWORK_WARNING
+from .network import NETWORK_WARNING, NETWORK_CRITICAL
 from .nodes import NODE_WARNING, NODE_CRITICAL
 from .platform import PLATFORM_WARNING, PLATFORM_CRITICAL
 from .volumes import VOLUME_WARNING, VOLUME_CRITICAL
@@ -13,6 +13,11 @@ CLUSTER_WARNING, CLUSTER_CRITICAL = severity_pair(
     summary_name="The cluster",
     relationship=Relationship.ANY,
     warning_children=[NETWORK_WARNING, NODE_WARNING, PLATFORM_WARNING, VOLUME_WARNING],
-    critical_children=[NODE_CRITICAL, PLATFORM_CRITICAL, VOLUME_CRITICAL],
+    critical_children=[
+        NETWORK_CRITICAL,
+        NODE_CRITICAL,
+        PLATFORM_CRITICAL,
+        VOLUME_CRITICAL,
+    ],
     duration="1m",
 )

--- a/tools/lib-alert-tree/metalk8s/network.py
+++ b/tools/lib-alert-tree/metalk8s/network.py
@@ -18,3 +18,13 @@ NETWORK_WARNING = Derived.warning(
     summary="The network is degraded.",
     duration="1m",
 )
+
+NETWORK_CRITICAL = Derived.critical(
+    name="NetworkOutage",
+    relationship=Relationship.ANY,
+    children=[
+        Existing.critical("WorkloadPlaneOutage"),
+    ],
+    summary="The network has a critical outage.",
+    duration="1m",
+)

--- a/tools/lib-alert-tree/metalk8s/nodes.py
+++ b/tools/lib-alert-tree/metalk8s/nodes.py
@@ -44,6 +44,8 @@ NODE_WARNING, NODE_CRITICAL = severity_pair(
         Existing.warning("NodeClockSkewDetected"),
         Existing.warning("NodeRAIDDiskFailure"),
         Existing.warning("NodeTextFileCollectorScrapeError"),
+        Existing.warning("NodeWorkloadPlaneUnavailable"),
+        Existing.warning("NodeWorkloadPlaneRemediated"),
         SYSTEM_PARTITION_WARNING,
     ],
     critical_children=[

--- a/tools/rule_extractor/alerting_rules.json
+++ b/tools/rule_extractor/alerting_rules.json
@@ -1,5 +1,17 @@
 [
     {
+        "message": "Fluent Bit pod {{ $labels.pod }} input {{ $labels.name }} has been paused due to back pressure for more than 5 minutes. Log ingestion is halted until the output pipeline catches up.",
+        "name": "FluentBitBackPressure",
+        "query": "fluentbit_input_ingestion_paused == 1 or fluentbit_input_storage_overlimit == 1",
+        "severity": "warning"
+    },
+    {
+        "message": "Fluent Bit pod {{ $labels.pod }} output {{ $labels.name }} has been failing retries and dropping log records for more than 15 minutes. Check the destination and network connectivity.",
+        "name": "FluentBitOutputRetryLimit",
+        "query": "rate(fluentbit_output_retries_failed_total[5m]) > 0",
+        "severity": "critical"
+    },
+    {
         "message": "The alerting service is at risk.",
         "name": "AlertingServiceAtRisk",
         "query": "sum(ALERTS{alertname=\"AlertmanagerClusterCrashlooping\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"AlertmanagerClusterDown\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"AlertmanagerClusterFailedToSendAlerts\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"AlertmanagerConfigInconsistent\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"AlertmanagerMembersInconsistent\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"AlertmanagerFailedReload\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
@@ -8,7 +20,7 @@
     {
         "message": "The cluster is at risk.",
         "name": "ClusterAtRisk",
-        "query": "sum(ALERTS{alertname=\"NodeAtRisk\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"PlatformServicesAtRisk\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"VolumeAtRisk\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
+        "query": "sum(ALERTS{alertname=\"NetworkOutage\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"NodeAtRisk\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"PlatformServicesAtRisk\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"VolumeAtRisk\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
         "severity": "critical"
     },
     {
@@ -24,9 +36,21 @@
         "severity": "critical"
     },
     {
+        "message": "The logging service is at risk.",
+        "name": "LoggingServiceAtRisk",
+        "query": "sum(ALERTS{alertname=\"FluentBitOutputRetryLimit\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
+        "severity": "critical"
+    },
+    {
         "message": "The monitoring service is at risk.",
         "name": "MonitoringServiceAtRisk",
         "query": "sum(ALERTS{alertname=\"KubeStateMetricsShardingMismatch\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"KubeStateMetricsShardsMissing\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"PrometheusRuleFailures\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"PrometheusRemoteWriteBehind\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"PrometheusRemoteStorageFailures\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"PrometheusErrorSendingAlertsToAnyAlertmanager\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"PrometheusBadConfig\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"PrometheusTargetSyncFailure\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
+        "severity": "critical"
+    },
+    {
+        "message": "The network has a critical outage.",
+        "name": "NetworkOutage",
+        "query": "sum(ALERTS{alertname=\"WorkloadPlaneOutage\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
         "severity": "critical"
     },
     {
@@ -134,7 +158,7 @@
     {
         "message": "The node {{ $labels.instance }} is degraded.",
         "name": "NodeDegraded",
-        "query": "sum by (instance) (ALERTS{alertname=\"KubeNodeNotReady\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeNodeReadinessFlapping\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeNodeUnreachable\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletClientCertificateExpiration\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletClientCertificateRenewalErrors\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletPlegDurationHigh\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletPodStartUpLatencyHigh\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletServerCertificateExpiration\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletServerCertificateRenewalErrors\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeClockNotSynchronising\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeClockSkewDetected\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeRAIDDiskFailure\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeTextFileCollectorScrapeError\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"SystemPartitionDegraded\",alertstate=\"firing\",severity=\"warning\"}) >= 1",
+        "query": "sum by (instance) (ALERTS{alertname=\"KubeNodeNotReady\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeNodeReadinessFlapping\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeNodeUnreachable\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletClientCertificateExpiration\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletClientCertificateRenewalErrors\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletPlegDurationHigh\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletPodStartUpLatencyHigh\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletServerCertificateExpiration\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletServerCertificateRenewalErrors\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeClockNotSynchronising\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeClockSkewDetected\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeRAIDDiskFailure\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeTextFileCollectorScrapeError\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeWorkloadPlaneUnavailable\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeWorkloadPlaneRemediated\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"SystemPartitionDegraded\",alertstate=\"firing\",severity=\"warning\"}) >= 1",
         "severity": "warning"
     },
     {
@@ -286,6 +310,24 @@
         "name": "NodeTextFileCollectorScrapeError",
         "query": "node_textfile_scrape_error{job=\"node-exporter\"} == 1",
         "severity": "warning"
+    },
+    {
+        "message": "Node has lost Workload Plane connectivity",
+        "name": "NodeWorkloadPlaneUnavailable",
+        "query": "kube_node_status_condition{condition=\"WorkloadPlaneNetworkUnavailable\",status=\"true\"} == 1",
+        "severity": "warning"
+    },
+    {
+        "message": "Node drained after Workload Plane isolation",
+        "name": "NodeWorkloadPlaneRemediated",
+        "query": "kube_node_spec_taint{key=\"node.scality.com/workload-plane-unreachable\"} == 1",
+        "severity": "warning"
+    },
+    {
+        "message": "Workload Plane outage affecting the majority of nodes",
+        "name": "WorkloadPlaneOutage",
+        "query": "count(kube_node_status_condition{condition=\"WorkloadPlaneNetworkUnavailable\",status=\"true\"} == 1) / count(kube_node_status_condition{condition=\"WorkloadPlaneNetworkUnavailable\",status=\"true\"}) > 0.5",
+        "severity": "critical"
     },
     {
         "message": "Half or more of the Alertmanager instances within the same cluster are crashlooping.",
@@ -660,18 +702,6 @@
         "severity": "warning"
     },
     {
-        "message": "Kubernetes API server client is experiencing errors.",
-        "name": "KubeClientErrors",
-        "query": "(sum by (cluster, instance, job, namespace) (rate(rest_client_requests_total{code=~\"5..\",job=\"apiserver\"}[5m])) / sum by (cluster, instance, job, namespace) (rate(rest_client_requests_total{job=\"apiserver\"}[5m]))) > 0.01",
-        "severity": "warning"
-    },
-    {
-        "message": "Different semantic versions of Kubernetes components running.",
-        "name": "KubeVersionMismatch",
-        "query": "count by (cluster) (count by (git_version, cluster) (label_replace(kubernetes_build_info{job!~\"kube-dns|coredns\"}, \"git_version\", \"$1\", \"git_version\", \"(v[0-9]*.[0-9]*).*\"))) > 1",
-        "severity": "warning"
-    },
-    {
         "message": "Target disappeared from Prometheus target discovery.",
         "name": "KubeAPIDown",
         "query": "absent(up{job=\"apiserver\"})",
@@ -712,6 +742,18 @@
         "name": "KubeControllerManagerDown",
         "query": "absent(up{job=\"kube-controller-manager\"})",
         "severity": "critical"
+    },
+    {
+        "message": "Kubernetes API server client is experiencing errors.",
+        "name": "KubeClientErrors",
+        "query": "(sum by (cluster, instance, job, namespace) (rate(rest_client_requests_total{code=~\"5..\",job=\"apiserver\"}[5m])) / sum by (cluster, instance, job, namespace) (rate(rest_client_requests_total{job=\"apiserver\"}[5m]))) > 0.01",
+        "severity": "warning"
+    },
+    {
+        "message": "Different semantic versions of Kubernetes components running.",
+        "name": "KubeVersionMismatch",
+        "query": "count by (cluster) (count by (git_version, cluster) (label_replace(kubernetes_build_info{job!~\"kube-dns|coredns\"}, \"git_version\", \"$1\", \"git_version\", \"(v[0-9]*.[0-9]*).*\"))) > 1",
+        "severity": "warning"
     },
     {
         "message": "Target disappeared from Prometheus target discovery.",
@@ -1054,23 +1096,5 @@
         "name": "PrometheusOperatorWatchErrors",
         "query": "(sum by (cluster, controller, namespace) (rate(prometheus_operator_watch_operations_failed_total{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"}[5m])) / sum by (cluster, controller, namespace) (rate(prometheus_operator_watch_operations_total{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"}[5m]))) > 0.4",
         "severity": "warning"
-    },
-    {
-        "message": "Fluent Bit pod {{ $labels.pod }} input {{ $labels.name }} has been paused due to back pressure for more than 5 minutes. Log ingestion is halted until the output pipeline catches up.",
-        "name": "FluentBitBackPressure",
-        "query": "fluentbit_input_ingestion_paused == 1 or fluentbit_input_storage_overlimit == 1",
-        "severity": "warning"
-    },
-    {
-        "message": "Fluent Bit pod {{ $labels.pod }} output {{ $labels.name }} has been failing retries and dropping log records for more than 15 minutes. Check the destination and network connectivity.",
-        "name": "FluentBitOutputRetryLimit",
-        "query": "rate(fluentbit_output_retries_failed_total[5m]) > 0",
-        "severity": "critical"
-    },
-    {
-        "message": "The logging service is at risk.",
-        "name": "LoggingServiceAtRisk",
-        "query": "sum(ALERTS{alertname=\"FluentBitOutputRetryLimit\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
-        "severity": "critical"
     }
 ]

--- a/tools/rule_extractor/rules.json
+++ b/tools/rule_extractor/rules.json
@@ -2,10 +2,61 @@
     "data": {
         "groups": [
             {
-                "evaluationTime": 0.001967181,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-alert-tree.rules-2476d84f-4df8-440f-af6f-b3b40a22698b.yaml",
+                "evaluationTime": 0.000351937,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-logging-fluent-bit-3e5bc5aa-6877-4c77-9b60-7d6d7c870fbc.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:01:55.291162902Z",
+                "lastEvaluation": "2026-07-16T17:16:04.61778368Z",
+                "limit": 0,
+                "name": "fluent-bit",
+                "partialResponseStrategy": "ABORT",
+                "rules": [
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "Fluent Bit pod {{ $labels.pod }} input {{ $labels.name }} has been paused due to back pressure for more than 5 minutes. Log ingestion is halted until the output pipeline catches up.",
+                            "summary": "Fluent Bit input is experiencing back pressure."
+                        },
+                        "duration": 300,
+                        "evaluationTime": 0.000232807,
+                        "health": "ok",
+                        "keepFiringFor": 0,
+                        "labels": {
+                            "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
+                            "severity": "warning"
+                        },
+                        "lastEvaluation": "2026-07-16T17:16:04.617803199Z",
+                        "name": "FluentBitBackPressure",
+                        "query": "fluentbit_input_ingestion_paused == 1 or fluentbit_input_storage_overlimit == 1",
+                        "state": "inactive",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "message": "Fluent Bit pod {{ $labels.pod }} output {{ $labels.name }} has been failing retries and dropping log records for more than 15 minutes. Check the destination and network connectivity.",
+                            "summary": "Fluent Bit output is dropping logs after exhausting retries."
+                        },
+                        "duration": 900,
+                        "evaluationTime": 9.0492e-05,
+                        "health": "ok",
+                        "keepFiringFor": 0,
+                        "labels": {
+                            "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
+                            "severity": "critical"
+                        },
+                        "lastEvaluation": "2026-07-16T17:16:04.618041258Z",
+                        "name": "FluentBitOutputRetryLimit",
+                        "query": "rate(fluentbit_output_retries_failed_total[5m]) > 0",
+                        "state": "inactive",
+                        "type": "alerting"
+                    }
+                ]
+            },
+            {
+                "evaluationTime": 0.001899998,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-alert-tree.rules-b47131ce-7134-4bea-86eb-ab7ba74a80e7.yaml",
+                "interval": 30,
+                "lastEvaluation": "2026-07-16T17:15:55.203884357Z",
                 "limit": 0,
                 "name": "cluster-at-risk.rules",
                 "partialResponseStrategy": "ABORT",
@@ -18,14 +69,14 @@
                             "summary": "The alerting service is at risk."
                         },
                         "duration": 60,
-                        "evaluationTime": 0.000179548,
+                        "evaluationTime": 0.000162265,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.292847345Z",
+                        "lastEvaluation": "2026-07-16T17:15:55.20546776Z",
                         "name": "AlertingServiceAtRisk",
                         "query": "sum(ALERTS{alertname=\"AlertmanagerClusterCrashlooping\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"AlertmanagerClusterDown\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"AlertmanagerClusterFailedToSendAlerts\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"AlertmanagerConfigInconsistent\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"AlertmanagerMembersInconsistent\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"AlertmanagerFailedReload\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
                         "state": "inactive",
@@ -34,21 +85,21 @@
                     {
                         "alerts": [],
                         "annotations": {
-                            "children": "NodeAtRisk{severity='critical'}, PlatformServicesAtRisk{severity='critical'}, VolumeAtRisk{severity='critical'}",
-                            "childrenJsonPath": "$[?((@.labels.alertname === 'NodeAtRisk' && @.labels.severity === 'critical') || (@.labels.alertname === 'PlatformServicesAtRisk' && @.labels.severity === 'critical') || (@.labels.alertname === 'VolumeAtRisk' && @.labels.severity === 'critical'))]",
+                            "children": "NetworkOutage{severity='critical'}, NodeAtRisk{severity='critical'}, PlatformServicesAtRisk{severity='critical'}, VolumeAtRisk{severity='critical'}",
+                            "childrenJsonPath": "$[?((@.labels.alertname === 'NetworkOutage' && @.labels.severity === 'critical') || (@.labels.alertname === 'NodeAtRisk' && @.labels.severity === 'critical') || (@.labels.alertname === 'PlatformServicesAtRisk' && @.labels.severity === 'critical') || (@.labels.alertname === 'VolumeAtRisk' && @.labels.severity === 'critical'))]",
                             "summary": "The cluster is at risk."
                         },
                         "duration": 60,
-                        "evaluationTime": 0.000278719,
+                        "evaluationTime": 0.000251526,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.29120213Z",
+                        "lastEvaluation": "2026-07-16T17:15:55.203916241Z",
                         "name": "ClusterAtRisk",
-                        "query": "sum(ALERTS{alertname=\"NodeAtRisk\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"PlatformServicesAtRisk\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"VolumeAtRisk\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
+                        "query": "sum(ALERTS{alertname=\"NetworkOutage\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"NodeAtRisk\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"PlatformServicesAtRisk\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"VolumeAtRisk\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
                         "state": "inactive",
                         "type": "alerting"
                     },
@@ -60,14 +111,14 @@
                             "summary": "The Core services are at risk."
                         },
                         "duration": 60,
-                        "evaluationTime": 8.6646e-05,
+                        "evaluationTime": 5.9339e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.291983612Z",
+                        "lastEvaluation": "2026-07-16T17:15:55.204662842Z",
                         "name": "CoreServicesAtRisk",
                         "query": "sum(ALERTS{alertname=\"KubernetesControlPlaneAtRisk\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
                         "state": "inactive",
@@ -81,16 +132,37 @@
                             "summary": "The Kubernetes control plane is at risk."
                         },
                         "duration": 60,
-                        "evaluationTime": 0.000448916,
+                        "evaluationTime": 0.000418731,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.292083017Z",
+                        "lastEvaluation": "2026-07-16T17:15:55.204726038Z",
                         "name": "KubernetesControlPlaneAtRisk",
                         "query": "sum(ALERTS{alertname=\"KubeAPIErrorBudgetBurn\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"etcdHighNumberOfFailedGRPCRequests\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"etcdGRPCRequestsSlow\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"etcdInsufficientMembers\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"etcdNoLeader\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"etcdDatabaseQuotaLowSpace\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"etcdHighFsyncDurations\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"KubeStateMetricsListErrors\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"KubeStateMetricsWatchErrors\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"KubeAPIDown\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"KubeClientCertificateExpiration\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"KubeControllerManagerDown\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"KubeletDown\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"KubeSchedulerDown\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
+                        "state": "inactive",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "children": "FluentBitOutputRetryLimit{severity='critical'}",
+                            "childrenJsonPath": "$[?((@.labels.alertname === 'FluentBitOutputRetryLimit' && @.labels.severity === 'critical'))]",
+                            "summary": "The logging service is at risk."
+                        },
+                        "duration": 60,
+                        "evaluationTime": 6.0633e-05,
+                        "health": "ok",
+                        "keepFiringFor": 0,
+                        "labels": {
+                            "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
+                            "severity": "critical"
+                        },
+                        "lastEvaluation": "2026-07-16T17:15:55.205634535Z",
+                        "name": "LoggingServiceAtRisk",
+                        "query": "sum(ALERTS{alertname=\"FluentBitOutputRetryLimit\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
                         "state": "inactive",
                         "type": "alerting"
                     },
@@ -102,16 +174,37 @@
                             "summary": "The monitoring service is at risk."
                         },
                         "duration": 60,
-                        "evaluationTime": 0.000221049,
+                        "evaluationTime": 0.000199651,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.292621362Z",
+                        "lastEvaluation": "2026-07-16T17:15:55.205262517Z",
                         "name": "MonitoringServiceAtRisk",
                         "query": "sum(ALERTS{alertname=\"KubeStateMetricsShardingMismatch\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"KubeStateMetricsShardsMissing\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"PrometheusRuleFailures\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"PrometheusRemoteWriteBehind\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"PrometheusRemoteStorageFailures\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"PrometheusErrorSendingAlertsToAnyAlertmanager\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"PrometheusBadConfig\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"PrometheusTargetSyncFailure\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
+                        "state": "inactive",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "children": "WorkloadPlaneOutage{severity='critical'}",
+                            "childrenJsonPath": "$[?((@.labels.alertname === 'WorkloadPlaneOutage' && @.labels.severity === 'critical'))]",
+                            "summary": "The network has a critical outage."
+                        },
+                        "duration": 60,
+                        "evaluationTime": 7.2666e-05,
+                        "health": "ok",
+                        "keepFiringFor": 0,
+                        "labels": {
+                            "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
+                            "severity": "critical"
+                        },
+                        "lastEvaluation": "2026-07-16T17:15:55.20417458Z",
+                        "name": "NetworkOutage",
+                        "query": "sum(ALERTS{alertname=\"WorkloadPlaneOutage\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
                         "state": "inactive",
                         "type": "alerting"
                     },
@@ -123,14 +216,14 @@
                             "summary": "The node {{ $labels.instance }} is at risk."
                         },
                         "duration": 60,
-                        "evaluationTime": 0.000170668,
+                        "evaluationTime": 0.000144911,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.291502166Z",
+                        "lastEvaluation": "2026-07-16T17:15:55.204253309Z",
                         "name": "NodeAtRisk",
                         "query": "sum by (instance) (ALERTS{alertname=\"KubeletClientCertificateExpiration\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"NodeRAIDDegraded\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"SystemPartitionAtRisk\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
                         "state": "inactive",
@@ -139,21 +232,21 @@
                     {
                         "alerts": [],
                         "annotations": {
-                            "children": "MonitoringServiceAtRisk{severity='critical'}, AlertingServiceAtRisk{severity='critical'}",
-                            "childrenJsonPath": "$[?((@.labels.alertname === 'MonitoringServiceAtRisk' && @.labels.severity === 'critical') || (@.labels.alertname === 'AlertingServiceAtRisk' && @.labels.severity === 'critical'))]",
+                            "children": "MonitoringServiceAtRisk{severity='critical'}, AlertingServiceAtRisk{severity='critical'}, LoggingServiceAtRisk{severity='critical'}",
+                            "childrenJsonPath": "$[?((@.labels.alertname === 'MonitoringServiceAtRisk' && @.labels.severity === 'critical') || (@.labels.alertname === 'AlertingServiceAtRisk' && @.labels.severity === 'critical') || (@.labels.alertname === 'LoggingServiceAtRisk' && @.labels.severity === 'critical'))]",
                             "summary": "The observability services are at risk."
                         },
                         "duration": 60,
-                        "evaluationTime": 7.813e-05,
+                        "evaluationTime": 0.000107326,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.292538675Z",
+                        "lastEvaluation": "2026-07-16T17:15:55.205150643Z",
                         "name": "ObservabilityServicesAtRisk",
-                        "query": "sum(ALERTS{alertname=\"MonitoringServiceAtRisk\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"AlertingServiceAtRisk\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
+                        "query": "sum(ALERTS{alertname=\"MonitoringServiceAtRisk\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"AlertingServiceAtRisk\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"LoggingServiceAtRisk\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
                         "state": "inactive",
                         "type": "alerting"
                     },
@@ -165,14 +258,14 @@
                             "summary": "The Platform services are at risk."
                         },
                         "duration": 60,
-                        "evaluationTime": 0.000130865,
+                        "evaluationTime": 8.5983e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.291845613Z",
+                        "lastEvaluation": "2026-07-16T17:15:55.204571819Z",
                         "name": "PlatformServicesAtRisk",
                         "query": "sum(ALERTS{alertname=\"CoreServicesAtRisk\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"ObservabilityServicesAtRisk\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
                         "state": "inactive",
@@ -186,14 +279,14 @@
                             "summary": "The system partition {{ $labels.mountpoint }} on node {{ $labels.instance }} is at risk."
                         },
                         "duration": 60,
-                        "evaluationTime": 0.000160954,
+                        "evaluationTime": 0.000163629,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.291677921Z",
+                        "lastEvaluation": "2026-07-16T17:15:55.20440317Z",
                         "name": "SystemPartitionAtRisk",
                         "query": "sum by (mountpoint, instance) (ALERTS{alertname=\"NodeFileDescriptorLimit\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"NodeFilesystemAlmostOutOfSpace\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"NodeFilesystemAlmostOutOfFiles\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"NodeFilesystemFilesFillingUp\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"NodeFilesystemSpaceFillingUp\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
                         "state": "inactive",
@@ -207,14 +300,14 @@
                             "summary": "The volume {{ $labels.persistentvolumeclaim }} in namespace {{ $labels.namespace }} on node {{ $labels.instance }} is at risk."
                         },
                         "duration": 60,
-                        "evaluationTime": 9.551e-05,
+                        "evaluationTime": 8.2325e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.293031654Z",
+                        "lastEvaluation": "2026-07-16T17:15:55.205699115Z",
                         "name": "VolumeAtRisk",
                         "query": "sum by (persistentvolumeclaim, namespace, instance) (ALERTS{alertname=\"KubePersistentVolumeFillingUp\",alertstate=\"firing\",severity=\"critical\"} or ALERTS{alertname=\"KubePersistentVolumeErrors\",alertstate=\"firing\",severity=\"critical\"}) >= 1",
                         "state": "inactive",
@@ -223,10 +316,10 @@
                 ]
             },
             {
-                "evaluationTime": 0.00473145,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-alert-tree.rules-2476d84f-4df8-440f-af6f-b3b40a22698b.yaml",
+                "evaluationTime": 0.002344993,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-alert-tree.rules-b47131ce-7134-4bea-86eb-ab7ba74a80e7.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:01:55.785917431Z",
+                "lastEvaluation": "2026-07-16T17:15:57.90389469Z",
                 "limit": 0,
                 "name": "cluster-degraded.rules",
                 "partialResponseStrategy": "ABORT",
@@ -239,14 +332,14 @@
                             "summary": "The Access services are degraded."
                         },
                         "duration": 60,
-                        "evaluationTime": 9.4787e-05,
+                        "evaluationTime": 4.52e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.787043809Z",
+                        "lastEvaluation": "2026-07-16T17:15:57.904504065Z",
                         "name": "AccessServicesDegraded",
                         "query": "sum(ALERTS{alertname=\"AuthenticationServiceDegraded\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"IngressControllerServicesDegraded\",alertstate=\"firing\",severity=\"warning\"}) >= 1",
                         "state": "inactive",
@@ -260,14 +353,14 @@
                             "summary": "The alerting service is degraded."
                         },
                         "duration": 60,
-                        "evaluationTime": 0.000173494,
+                        "evaluationTime": 9.0913e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.789999144Z",
+                        "lastEvaluation": "2026-07-16T17:15:57.905948027Z",
                         "name": "AlertingServiceDegraded",
                         "query": "sum(ALERTS{alertname=\"AlertmanagerClusterFailedToSendAlerts\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"AlertmanagerFailedToSendAlerts\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeStatefulSetReplicasMismatch\",alertstate=\"firing\",namespace=~\"metalk8s-monitoring\",severity=\"warning\",statefulset=~\"alertmanager-prometheus-operator-alertmanager\"} or ALERTS{alertname=\"KubeStatefulSetGenerationMismatch\",alertstate=\"firing\",namespace=~\"metalk8s-monitoring\",severity=\"warning\",statefulset=~\"alertmanager-prometheus-operator-alertmanager\"} or ALERTS{alertname=\"KubeStatefulSetUpdateNotRolledOut\",alertstate=\"firing\",namespace=~\"metalk8s-monitoring\",severity=\"warning\",statefulset=~\"alertmanager-prometheus-operator-alertmanager\"}) >= 1",
                         "state": "inactive",
@@ -281,14 +374,14 @@
                             "summary": "The Authentication service for K8S API is degraded."
                         },
                         "duration": 60,
-                        "evaluationTime": 9.8372e-05,
+                        "evaluationTime": 5.8677e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.787149583Z",
+                        "lastEvaluation": "2026-07-16T17:15:57.904551841Z",
                         "name": "AuthenticationServiceDegraded",
                         "query": "sum(ALERTS{alertname=\"KubeDeploymentReplicasMismatch\",alertstate=\"firing\",deployment=~\"dex\",namespace=~\"metalk8s-auth\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentGenerationMismatch\",alertstate=\"firing\",deployment=~\"dex\",namespace=~\"metalk8s-auth\",severity=\"warning\"}) >= 1",
                         "state": "inactive",
@@ -302,14 +395,14 @@
                             "summary": "The MetalK8s Bootstrap services are degraded."
                         },
                         "duration": 60,
-                        "evaluationTime": 0.0004074,
+                        "evaluationTime": 0.000206245,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.788648177Z",
+                        "lastEvaluation": "2026-07-16T17:15:57.905269162Z",
                         "name": "BootstrapServicesDegraded",
                         "query": "sum(ALERTS{alertname=\"KubePodNotReady\",alertstate=\"firing\",namespace=~\"kube-system\",pod=~\"repositories-.*\",severity=\"warning\"} or ALERTS{alertname=\"KubePodCrashLooping\",alertstate=\"firing\",namespace=~\"kube-system\",pod=~\"repositories-.*\",severity=\"warning\"} or ALERTS{alertname=\"KubePodNotReady\",alertstate=\"firing\",namespace=~\"kube-system\",pod=~\"salt-master-.*\",severity=\"warning\"} or ALERTS{alertname=\"KubePodCrashLooping\",alertstate=\"firing\",namespace=~\"kube-system\",pod=~\"salt-master-.*\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentReplicasMismatch\",alertstate=\"firing\",deployment=~\"storage-operator\",namespace=~\"kube-system\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentGenerationMismatch\",alertstate=\"firing\",deployment=~\"storage-operator\",namespace=~\"kube-system\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentReplicasMismatch\",alertstate=\"firing\",deployment=~\"metalk8s-ui\",namespace=~\"metalk8s-ui\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentGenerationMismatch\",alertstate=\"firing\",deployment=~\"metalk8s-ui\",namespace=~\"metalk8s-ui\",severity=\"warning\"}) >= 1",
                         "state": "inactive",
@@ -323,14 +416,14 @@
                             "summary": "The cluster is degraded."
                         },
                         "duration": 60,
-                        "evaluationTime": 0.000192092,
+                        "evaluationTime": 0.000137436,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.785940745Z",
+                        "lastEvaluation": "2026-07-16T17:15:57.903908017Z",
                         "name": "ClusterDegraded",
                         "query": "sum(ALERTS{alertname=\"NetworkDegraded\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeDegraded\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PlatformServicesDegraded\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"VolumeDegraded\",alertstate=\"firing\",severity=\"warning\"}) >= 1",
                         "state": "inactive",
@@ -344,14 +437,14 @@
                             "summary": "The Core services are degraded."
                         },
                         "duration": 60,
-                        "evaluationTime": 9.4135e-05,
+                        "evaluationTime": 6.6534e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.787654682Z",
+                        "lastEvaluation": "2026-07-16T17:15:57.904785791Z",
                         "name": "CoreServicesDegraded",
                         "query": "sum(ALERTS{alertname=\"KubernetesControlPlaneDegraded\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"BootstrapServicesDegraded\",alertstate=\"firing\",severity=\"warning\"}) >= 1",
                         "state": "inactive",
@@ -365,14 +458,14 @@
                             "summary": "The dashboarding service is degraded."
                         },
                         "duration": 60,
-                        "evaluationTime": 0.000139194,
+                        "evaluationTime": 5.0742e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.790416746Z",
+                        "lastEvaluation": "2026-07-16T17:15:57.906151606Z",
                         "name": "DashboardingServiceDegraded",
                         "query": "sum(ALERTS{alertname=\"KubeDeploymentReplicasMismatch\",alertstate=\"firing\",deployment=~\"prometheus-operator-grafana\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentGenerationMismatch\",alertstate=\"firing\",deployment=~\"prometheus-operator-grafana\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"}) >= 1",
                         "state": "inactive",
@@ -386,14 +479,14 @@
                             "summary": "The Ingress Controllers for control plane and workload plane are degraded."
                         },
                         "duration": 60,
-                        "evaluationTime": 0.000389339,
+                        "evaluationTime": 0.000171033,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.787253226Z",
+                        "lastEvaluation": "2026-07-16T17:15:57.904612634Z",
                         "name": "IngressControllerServicesDegraded",
                         "query": "sum(ALERTS{alertname=\"KubeDeploymentReplicasMismatch\",alertstate=\"firing\",deployment=~\"ingress-nginx-defaultbackend\",namespace=~\"metalk8s-ingress\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentGenerationMismatch\",alertstate=\"firing\",deployment=~\"ingress-nginx-defaultbackend\",namespace=~\"metalk8s-ingress\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetNotScheduled\",alertstate=\"firing\",daemonset=~\"ingress-nginx-controller\",namespace=~\"metalk8s-ingress\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetMisScheduled\",alertstate=\"firing\",daemonset=~\"ingress-nginx-controller\",namespace=~\"metalk8s-ingress\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetRolloutStuck\",alertstate=\"firing\",daemonset=~\"ingress-nginx-controller\",namespace=~\"metalk8s-ingress\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetNotScheduled\",alertstate=\"firing\",daemonset=~\"ingress-nginx-control-plane-controller\",namespace=~\"metalk8s-ingress\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetMisScheduled\",alertstate=\"firing\",daemonset=~\"ingress-nginx-control-plane-controller\",namespace=~\"metalk8s-ingress\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetRolloutStuck\",alertstate=\"firing\",daemonset=~\"ingress-nginx-control-plane-controller\",namespace=~\"metalk8s-ingress\",severity=\"warning\"}) >= 1",
                         "state": "inactive",
@@ -407,14 +500,14 @@
                             "summary": "The Kubernetes control plane is degraded."
                         },
                         "duration": 60,
-                        "evaluationTime": 0.000888305,
+                        "evaluationTime": 0.000410646,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.787753044Z",
+                        "lastEvaluation": "2026-07-16T17:15:57.904854989Z",
                         "name": "KubernetesControlPlaneDegraded",
                         "query": "sum(ALERTS{alertname=\"KubeAPIErrorBudgetBurn\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeAPITerminatedRequests\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"etcdHighNumberOfFailedGRPCRequests\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"etcdHighCommitDurations\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"etcdHighFsyncDurations\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"etcdHighNumberOfFailedProposals\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"etcdHighNumberOfLeaderChanges\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"etcdMemberCommunicationSlow\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"etcdMembersDown\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"etcdExcessiveDatabaseGrowth\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeCPUOvercommit\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeCPUQuotaOvercommit\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeMemoryOvercommit\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeMemoryQuotaOvercommit\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeClientCertificateExpiration\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeClientErrors\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeVersionMismatch\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentReplicasMismatch\",alertstate=\"firing\",deployment=~\"coredns\",namespace=~\"kube-system\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentGenerationMismatch\",alertstate=\"firing\",deployment=~\"coredns\",namespace=~\"kube-system\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentReplicasMismatch\",alertstate=\"firing\",deployment=~\"prometheus-adapter\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentGenerationMismatch\",alertstate=\"firing\",deployment=~\"prometheus-adapter\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentReplicasMismatch\",alertstate=\"firing\",deployment=~\"prometheus-operator-kube-state-metrics\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentGenerationMismatch\",alertstate=\"firing\",deployment=~\"prometheus-operator-kube-state-metrics\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"}) >= 1",
                         "state": "inactive",
@@ -423,21 +516,21 @@
                     {
                         "alerts": [],
                         "annotations": {
-                            "children": "KubeStatefulSetReplicasMismatch{namespace=~'metalk8s-logging', severity='warning', statefulset=~'loki'}, KubeStatefulSetGenerationMismatch{namespace=~'metalk8s-logging', severity='warning', statefulset=~'loki'}, KubeStatefulSetUpdateNotRolledOut{namespace=~'metalk8s-logging', severity='warning', statefulset=~'loki'}, KubeDaemonSetNotScheduled{daemonset=~'fluentbit', namespace=~'metalk8s-logging', severity='warning'}, KubeDaemonSetMisScheduled{daemonset=~'fluentbit', namespace=~'metalk8s-logging', severity='warning'}, KubeDaemonSetRolloutStuck{daemonset=~'fluentbit', namespace=~'metalk8s-logging', severity='warning'}",
-                            "childrenJsonPath": "$[?((@.labels.alertname === 'KubeStatefulSetReplicasMismatch' && @.labels.namespace.match(new RegExp('^(?:metalk8s-logging)$')) && @.labels.severity === 'warning' && @.labels.statefulset.match(new RegExp('^(?:loki)$'))) || (@.labels.alertname === 'KubeStatefulSetGenerationMismatch' && @.labels.namespace.match(new RegExp('^(?:metalk8s-logging)$')) && @.labels.severity === 'warning' && @.labels.statefulset.match(new RegExp('^(?:loki)$'))) || (@.labels.alertname === 'KubeStatefulSetUpdateNotRolledOut' && @.labels.namespace.match(new RegExp('^(?:metalk8s-logging)$')) && @.labels.severity === 'warning' && @.labels.statefulset.match(new RegExp('^(?:loki)$'))) || (@.labels.alertname === 'KubeDaemonSetNotScheduled' && @.labels.daemonset.match(new RegExp('^(?:fluentbit)$')) && @.labels.namespace.match(new RegExp('^(?:metalk8s-logging)$')) && @.labels.severity === 'warning') || (@.labels.alertname === 'KubeDaemonSetMisScheduled' && @.labels.daemonset.match(new RegExp('^(?:fluentbit)$')) && @.labels.namespace.match(new RegExp('^(?:metalk8s-logging)$')) && @.labels.severity === 'warning') || (@.labels.alertname === 'KubeDaemonSetRolloutStuck' && @.labels.daemonset.match(new RegExp('^(?:fluentbit)$')) && @.labels.namespace.match(new RegExp('^(?:metalk8s-logging)$')) && @.labels.severity === 'warning'))]",
+                            "children": "KubeStatefulSetReplicasMismatch{namespace=~'metalk8s-logging', severity='warning', statefulset=~'loki'}, KubeStatefulSetGenerationMismatch{namespace=~'metalk8s-logging', severity='warning', statefulset=~'loki'}, KubeStatefulSetUpdateNotRolledOut{namespace=~'metalk8s-logging', severity='warning', statefulset=~'loki'}, KubeDaemonSetNotScheduled{daemonset=~'fluentbit', namespace=~'metalk8s-logging', severity='warning'}, KubeDaemonSetMisScheduled{daemonset=~'fluentbit', namespace=~'metalk8s-logging', severity='warning'}, KubeDaemonSetRolloutStuck{daemonset=~'fluentbit', namespace=~'metalk8s-logging', severity='warning'}, FluentBitBackPressure{severity='warning'}",
+                            "childrenJsonPath": "$[?((@.labels.alertname === 'KubeStatefulSetReplicasMismatch' && @.labels.namespace.match(new RegExp('^(?:metalk8s-logging)$')) && @.labels.severity === 'warning' && @.labels.statefulset.match(new RegExp('^(?:loki)$'))) || (@.labels.alertname === 'KubeStatefulSetGenerationMismatch' && @.labels.namespace.match(new RegExp('^(?:metalk8s-logging)$')) && @.labels.severity === 'warning' && @.labels.statefulset.match(new RegExp('^(?:loki)$'))) || (@.labels.alertname === 'KubeStatefulSetUpdateNotRolledOut' && @.labels.namespace.match(new RegExp('^(?:metalk8s-logging)$')) && @.labels.severity === 'warning' && @.labels.statefulset.match(new RegExp('^(?:loki)$'))) || (@.labels.alertname === 'KubeDaemonSetNotScheduled' && @.labels.daemonset.match(new RegExp('^(?:fluentbit)$')) && @.labels.namespace.match(new RegExp('^(?:metalk8s-logging)$')) && @.labels.severity === 'warning') || (@.labels.alertname === 'KubeDaemonSetMisScheduled' && @.labels.daemonset.match(new RegExp('^(?:fluentbit)$')) && @.labels.namespace.match(new RegExp('^(?:metalk8s-logging)$')) && @.labels.severity === 'warning') || (@.labels.alertname === 'KubeDaemonSetRolloutStuck' && @.labels.daemonset.match(new RegExp('^(?:fluentbit)$')) && @.labels.namespace.match(new RegExp('^(?:metalk8s-logging)$')) && @.labels.severity === 'warning') || (@.labels.alertname === 'FluentBitBackPressure' && @.labels.severity === 'warning'))]",
                             "summary": "The logging service is degraded."
                         },
                         "duration": 60,
-                        "evaluationTime": 0.000234819,
+                        "evaluationTime": 0.000108167,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.790177563Z",
+                        "lastEvaluation": "2026-07-16T17:15:57.906041245Z",
                         "name": "LoggingServiceDegraded",
-                        "query": "sum(ALERTS{alertname=\"KubeStatefulSetReplicasMismatch\",alertstate=\"firing\",namespace=~\"metalk8s-logging\",severity=\"warning\",statefulset=~\"loki\"} or ALERTS{alertname=\"KubeStatefulSetGenerationMismatch\",alertstate=\"firing\",namespace=~\"metalk8s-logging\",severity=\"warning\",statefulset=~\"loki\"} or ALERTS{alertname=\"KubeStatefulSetUpdateNotRolledOut\",alertstate=\"firing\",namespace=~\"metalk8s-logging\",severity=\"warning\",statefulset=~\"loki\"} or ALERTS{alertname=\"KubeDaemonSetNotScheduled\",alertstate=\"firing\",daemonset=~\"fluentbit\",namespace=~\"metalk8s-logging\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetMisScheduled\",alertstate=\"firing\",daemonset=~\"fluentbit\",namespace=~\"metalk8s-logging\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetRolloutStuck\",alertstate=\"firing\",daemonset=~\"fluentbit\",namespace=~\"metalk8s-logging\",severity=\"warning\"}) >= 1",
+                        "query": "sum(ALERTS{alertname=\"KubeStatefulSetReplicasMismatch\",alertstate=\"firing\",namespace=~\"metalk8s-logging\",severity=\"warning\",statefulset=~\"loki\"} or ALERTS{alertname=\"KubeStatefulSetGenerationMismatch\",alertstate=\"firing\",namespace=~\"metalk8s-logging\",severity=\"warning\",statefulset=~\"loki\"} or ALERTS{alertname=\"KubeStatefulSetUpdateNotRolledOut\",alertstate=\"firing\",namespace=~\"metalk8s-logging\",severity=\"warning\",statefulset=~\"loki\"} or ALERTS{alertname=\"KubeDaemonSetNotScheduled\",alertstate=\"firing\",daemonset=~\"fluentbit\",namespace=~\"metalk8s-logging\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetMisScheduled\",alertstate=\"firing\",daemonset=~\"fluentbit\",namespace=~\"metalk8s-logging\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetRolloutStuck\",alertstate=\"firing\",daemonset=~\"fluentbit\",namespace=~\"metalk8s-logging\",severity=\"warning\"} or ALERTS{alertname=\"FluentBitBackPressure\",alertstate=\"firing\",severity=\"warning\"}) >= 1",
                         "state": "inactive",
                         "type": "alerting"
                     },
@@ -449,14 +542,14 @@
                             "summary": "The monitoring service is degraded."
                         },
                         "duration": 60,
-                        "evaluationTime": 0.000777365,
+                        "evaluationTime": 0.000397699,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.789214792Z",
+                        "lastEvaluation": "2026-07-16T17:15:57.905547021Z",
                         "name": "MonitoringServiceDegraded",
                         "query": "sum(ALERTS{alertname=\"PrometheusLabelLimitHit\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusTargetLimitHit\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusTSDBReloadsFailing\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusTSDBCompactionsFailing\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusRemoteWriteDesiredShards\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusOutOfOrderTimestamps\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusNotificationQueueRunningFull\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusNotIngestingSamples\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusNotConnectedToAlertmanagers\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusMissingRuleEvaluations\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusErrorSendingAlertsToSomeAlertmanagers\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusDuplicateTimestamps\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusOperatorWatchErrors\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusOperatorSyncFailed\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusOperatorRejectedResources\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusOperatorReconcileErrors\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusOperatorNotReady\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusOperatorNodeLookupErrors\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusOperatorListErrors\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"PrometheusHighQueryLoad\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeStatefulSetReplicasMismatch\",alertstate=\"firing\",namespace=~\"metalk8s-monitoring\",severity=\"warning\",statefulset=~\"prometheus-prometheus-operator-prometheus\"} or ALERTS{alertname=\"KubeStatefulSetGenerationMismatch\",alertstate=\"firing\",namespace=~\"metalk8s-monitoring\",severity=\"warning\",statefulset=~\"prometheus-prometheus-operator-prometheus\"} or ALERTS{alertname=\"KubeStatefulSetUpdateNotRolledOut\",alertstate=\"firing\",namespace=~\"metalk8s-monitoring\",severity=\"warning\",statefulset=~\"prometheus-prometheus-operator-prometheus\"} or ALERTS{alertname=\"KubeDeploymentReplicasMismatch\",alertstate=\"firing\",deployment=~\"prometheus-operator-operator\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"} or ALERTS{alertname=\"KubeDeploymentGenerationMismatch\",alertstate=\"firing\",deployment=~\"prometheus-operator-operator\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetNotScheduled\",alertstate=\"firing\",daemonset=~\"prometheus-operator-prometheus-node-exporter\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetMisScheduled\",alertstate=\"firing\",daemonset=~\"prometheus-operator-prometheus-node-exporter\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"} or ALERTS{alertname=\"KubeDaemonSetRolloutStuck\",alertstate=\"firing\",daemonset=~\"prometheus-operator-prometheus-node-exporter\",namespace=~\"metalk8s-monitoring\",severity=\"warning\"}) >= 1",
                         "state": "inactive",
@@ -470,14 +563,14 @@
                             "summary": "The network is degraded."
                         },
                         "duration": 60,
-                        "evaluationTime": 0.000137907,
+                        "evaluationTime": 7.5121e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.786138149Z",
+                        "lastEvaluation": "2026-07-16T17:15:57.904049401Z",
                         "name": "NetworkDegraded",
                         "query": "sum(ALERTS{alertname=\"NodeNetworkReceiveErrs\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeHighNumberConntrackEntriesUsed\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeNetworkTransmitErrs\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeNetworkInterfaceFlapping\",alertstate=\"firing\",severity=\"warning\"}) >= 1",
                         "state": "inactive",
@@ -486,21 +579,21 @@
                     {
                         "alerts": [],
                         "annotations": {
-                            "children": "KubeNodeNotReady{severity='warning'}, KubeNodeReadinessFlapping{severity='warning'}, KubeNodeUnreachable{severity='warning'}, KubeletClientCertificateExpiration{severity='warning'}, KubeletClientCertificateRenewalErrors{severity='warning'}, KubeletPlegDurationHigh{severity='warning'}, KubeletPodStartUpLatencyHigh{severity='warning'}, KubeletServerCertificateExpiration{severity='warning'}, KubeletServerCertificateRenewalErrors{severity='warning'}, NodeClockNotSynchronising{severity='warning'}, NodeClockSkewDetected{severity='warning'}, NodeRAIDDiskFailure{severity='warning'}, NodeTextFileCollectorScrapeError{severity='warning'}, SystemPartitionDegraded{severity='warning'}",
-                            "childrenJsonPath": "$[?(((@.labels.alertname === 'KubeNodeNotReady' && @.labels.severity === 'warning') || (@.labels.alertname === 'KubeNodeReadinessFlapping' && @.labels.severity === 'warning') || (@.labels.alertname === 'KubeNodeUnreachable' && @.labels.severity === 'warning') || (@.labels.alertname === 'KubeletClientCertificateExpiration' && @.labels.severity === 'warning') || (@.labels.alertname === 'KubeletClientCertificateRenewalErrors' && @.labels.severity === 'warning') || (@.labels.alertname === 'KubeletPlegDurationHigh' && @.labels.severity === 'warning') || (@.labels.alertname === 'KubeletPodStartUpLatencyHigh' && @.labels.severity === 'warning') || (@.labels.alertname === 'KubeletServerCertificateExpiration' && @.labels.severity === 'warning') || (@.labels.alertname === 'KubeletServerCertificateRenewalErrors' && @.labels.severity === 'warning') || (@.labels.alertname === 'NodeClockNotSynchronising' && @.labels.severity === 'warning') || (@.labels.alertname === 'NodeClockSkewDetected' && @.labels.severity === 'warning') || (@.labels.alertname === 'NodeRAIDDiskFailure' && @.labels.severity === 'warning') || (@.labels.alertname === 'NodeTextFileCollectorScrapeError' && @.labels.severity === 'warning') || (@.labels.alertname === 'SystemPartitionDegraded' && @.labels.severity === 'warning')) && (@.labels.instance === '{{ $labels.instance }}'))]",
+                            "children": "KubeNodeNotReady{severity='warning'}, KubeNodeReadinessFlapping{severity='warning'}, KubeNodeUnreachable{severity='warning'}, KubeletClientCertificateExpiration{severity='warning'}, KubeletClientCertificateRenewalErrors{severity='warning'}, KubeletPlegDurationHigh{severity='warning'}, KubeletPodStartUpLatencyHigh{severity='warning'}, KubeletServerCertificateExpiration{severity='warning'}, KubeletServerCertificateRenewalErrors{severity='warning'}, NodeClockNotSynchronising{severity='warning'}, NodeClockSkewDetected{severity='warning'}, NodeRAIDDiskFailure{severity='warning'}, NodeTextFileCollectorScrapeError{severity='warning'}, NodeWorkloadPlaneUnavailable{severity='warning'}, NodeWorkloadPlaneRemediated{severity='warning'}, SystemPartitionDegraded{severity='warning'}",
+                            "childrenJsonPath": "$[?(((@.labels.alertname === 'KubeNodeNotReady' && @.labels.severity === 'warning') || (@.labels.alertname === 'KubeNodeReadinessFlapping' && @.labels.severity === 'warning') || (@.labels.alertname === 'KubeNodeUnreachable' && @.labels.severity === 'warning') || (@.labels.alertname === 'KubeletClientCertificateExpiration' && @.labels.severity === 'warning') || (@.labels.alertname === 'KubeletClientCertificateRenewalErrors' && @.labels.severity === 'warning') || (@.labels.alertname === 'KubeletPlegDurationHigh' && @.labels.severity === 'warning') || (@.labels.alertname === 'KubeletPodStartUpLatencyHigh' && @.labels.severity === 'warning') || (@.labels.alertname === 'KubeletServerCertificateExpiration' && @.labels.severity === 'warning') || (@.labels.alertname === 'KubeletServerCertificateRenewalErrors' && @.labels.severity === 'warning') || (@.labels.alertname === 'NodeClockNotSynchronising' && @.labels.severity === 'warning') || (@.labels.alertname === 'NodeClockSkewDetected' && @.labels.severity === 'warning') || (@.labels.alertname === 'NodeRAIDDiskFailure' && @.labels.severity === 'warning') || (@.labels.alertname === 'NodeTextFileCollectorScrapeError' && @.labels.severity === 'warning') || (@.labels.alertname === 'NodeWorkloadPlaneUnavailable' && @.labels.severity === 'warning') || (@.labels.alertname === 'NodeWorkloadPlaneRemediated' && @.labels.severity === 'warning') || (@.labels.alertname === 'SystemPartitionDegraded' && @.labels.severity === 'warning')) && (@.labels.instance === '{{ $labels.instance }}'))]",
                             "summary": "The node {{ $labels.instance }} is degraded."
                         },
                         "duration": 60,
-                        "evaluationTime": 0.000437926,
+                        "evaluationTime": 0.00023294,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.786287475Z",
+                        "lastEvaluation": "2026-07-16T17:15:57.904126937Z",
                         "name": "NodeDegraded",
-                        "query": "sum by (instance) (ALERTS{alertname=\"KubeNodeNotReady\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeNodeReadinessFlapping\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeNodeUnreachable\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletClientCertificateExpiration\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletClientCertificateRenewalErrors\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletPlegDurationHigh\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletPodStartUpLatencyHigh\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletServerCertificateExpiration\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletServerCertificateRenewalErrors\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeClockNotSynchronising\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeClockSkewDetected\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeRAIDDiskFailure\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeTextFileCollectorScrapeError\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"SystemPartitionDegraded\",alertstate=\"firing\",severity=\"warning\"}) >= 1",
+                        "query": "sum by (instance) (ALERTS{alertname=\"KubeNodeNotReady\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeNodeReadinessFlapping\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeNodeUnreachable\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletClientCertificateExpiration\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletClientCertificateRenewalErrors\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletPlegDurationHigh\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletPodStartUpLatencyHigh\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletServerCertificateExpiration\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"KubeletServerCertificateRenewalErrors\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeClockNotSynchronising\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeClockSkewDetected\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeRAIDDiskFailure\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeTextFileCollectorScrapeError\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeWorkloadPlaneUnavailable\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeWorkloadPlaneRemediated\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"SystemPartitionDegraded\",alertstate=\"firing\",severity=\"warning\"}) >= 1",
                         "state": "inactive",
                         "type": "alerting"
                     },
@@ -512,14 +605,14 @@
                             "summary": "The observability services are degraded."
                         },
                         "duration": 60,
-                        "evaluationTime": 0.000146907,
+                        "evaluationTime": 6.6303e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.789062034Z",
+                        "lastEvaluation": "2026-07-16T17:15:57.905478454Z",
                         "name": "ObservabilityServicesDegraded",
                         "query": "sum(ALERTS{alertname=\"MonitoringServiceDegraded\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"AlertingServiceDegraded\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"LoggingServiceDegraded\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"DashboardingServiceDegraded\",alertstate=\"firing\",severity=\"warning\"}) >= 1",
                         "state": "inactive",
@@ -533,14 +626,14 @@
                             "summary": "The Platform services are degraded."
                         },
                         "duration": 60,
-                        "evaluationTime": 0.000109835,
+                        "evaluationTime": 5.5552e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.786929445Z",
+                        "lastEvaluation": "2026-07-16T17:15:57.904446239Z",
                         "name": "PlatformServicesDegraded",
                         "query": "sum(ALERTS{alertname=\"AccessServicesDegraded\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"CoreServicesDegraded\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"ObservabilityServicesDegraded\",alertstate=\"firing\",severity=\"warning\"}) >= 1",
                         "state": "inactive",
@@ -554,14 +647,14 @@
                             "summary": "The system partition {{ $labels.mountpoint }} on node {{ $labels.instance }} is degraded."
                         },
                         "duration": 60,
-                        "evaluationTime": 0.000193955,
+                        "evaluationTime": 8.0472e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.786730907Z",
+                        "lastEvaluation": "2026-07-16T17:15:57.904363292Z",
                         "name": "SystemPartitionDegraded",
                         "query": "sum by (mountpoint, instance) (ALERTS{alertname=\"NodeFileDescriptorLimit\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeFilesystemAlmostOutOfSpace\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeFilesystemAlmostOutOfFiles\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeFilesystemFilesFillingUp\",alertstate=\"firing\",severity=\"warning\"} or ALERTS{alertname=\"NodeFilesystemSpaceFillingUp\",alertstate=\"firing\",severity=\"warning\"}) >= 1",
                         "state": "inactive",
@@ -575,14 +668,14 @@
                             "summary": "The volume {{ $labels.persistentvolumeclaim }} in namespace {{ $labels.namespace }} on node {{ $labels.instance }} is degraded."
                         },
                         "duration": 60,
-                        "evaluationTime": 8.4732e-05,
+                        "evaluationTime": 3.3316e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.7905612Z",
+                        "lastEvaluation": "2026-07-16T17:15:57.906204683Z",
                         "name": "VolumeDegraded",
                         "query": "sum by (persistentvolumeclaim, namespace, instance) (ALERTS{alertname=\"KubePersistentVolumeFillingUp\",alertstate=\"firing\",severity=\"warning\"}) >= 1",
                         "state": "inactive",
@@ -591,10 +684,10 @@
                 ]
             },
             {
-                "evaluationTime": 0.000805361,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-metalk8s-kube-apps.rules-94f468ca-5dc8-4cf2-b62c-ac4832557daf.yaml",
+                "evaluationTime": 0.000525124,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-metalk8s-kube-apps.rules-5c1a1a61-2c8e-4cbe-ba7c-1410c651f727.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:01:59.118010057Z",
+                "lastEvaluation": "2026-07-16T17:15:53.104063396Z",
                 "limit": 0,
                 "name": "kubernetes-apps",
                 "partialResponseStrategy": "ABORT",
@@ -607,14 +700,14 @@
                             "summary": "Job owned by CronJob failed to complete."
                         },
                         "duration": 300,
-                        "evaluationTime": 0.000227768,
+                        "evaluationTime": 0.000111905,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:59.118461507Z",
+                        "lastEvaluation": "2026-07-16T17:15:53.104410202Z",
                         "name": "KubeCronJobOwnedJobFailed",
                         "query": "kube_job_failed{job=\"kube-state-metrics\",namespace=~\".*\"} > 0 and on (job_name, namespace) (topk by (owner_name, namespace) (1, kube_job_created{job=\"kube-state-metrics\"} * on (job_name, namespace) group_left (owner_name, owner_kind) kube_job_owner{job=\"kube-state-metrics\",owner_kind=\"CronJob\"}))",
                         "state": "inactive",
@@ -628,14 +721,14 @@
                             "summary": "Job failed to complete."
                         },
                         "duration": 300,
-                        "evaluationTime": 0.000116001,
+                        "evaluationTime": 6.0752e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:59.1186963Z",
+                        "lastEvaluation": "2026-07-16T17:15:53.104525344Z",
                         "name": "KubeJobFailed",
                         "query": "kube_job_failed{job=\"kube-state-metrics\",namespace=~\".*\"} > 0 unless on (job_name, namespace) kube_job_owner{job=\"kube-state-metrics\",owner_kind=\"CronJob\"}",
                         "state": "inactive",
@@ -648,14 +741,14 @@
                             "summary": "Job did not complete in time"
                         },
                         "duration": 0,
-                        "evaluationTime": 0.00041121,
+                        "evaluationTime": 0.000312348,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:59.118043403Z",
+                        "lastEvaluation": "2026-07-16T17:15:53.104091181Z",
                         "name": "KubeJobNotCompleted",
                         "query": "time() - max by (namespace, job_name, cluster) (kube_job_status_start_time{job=\"kube-state-metrics\",namespace=~\".*\"} and kube_job_status_active{job=\"kube-state-metrics\",namespace=~\".*\"} > 0) > (24 * 60 * 60)",
                         "state": "inactive",
@@ -664,10 +757,10 @@
                 ]
             },
             {
-                "evaluationTime": 0.005189945,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-metalk8s-nodes.rules-44c370b7-2be3-48fe-900d-bd1acc57d35a.yaml",
+                "evaluationTime": 0.002835217,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-metalk8s-nodes.rules-1e9ad062-5861-4a4f-be61-b54233bcaedb.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:01:56.28519661Z",
+                "lastEvaluation": "2026-07-16T17:16:03.670792442Z",
                 "limit": 0,
                 "name": "node-exporter",
                 "partialResponseStrategy": "ABORT",
@@ -680,14 +773,14 @@
                             "summary": "Clock not synchronising."
                         },
                         "duration": 600,
-                        "evaluationTime": 0.00015698,
+                        "evaluationTime": 4.5531e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:56.289760186Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.673372577Z",
                         "name": "NodeClockNotSynchronising",
                         "query": "min_over_time(node_timex_sync_status[5m]) == 0 and node_timex_maxerror_seconds >= 16",
                         "state": "inactive",
@@ -701,14 +794,14 @@
                             "summary": "Clock skew detected."
                         },
                         "duration": 600,
-                        "evaluationTime": 0.000167992,
+                        "evaluationTime": 7.9721e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:56.289587587Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.673290423Z",
                         "name": "NodeClockSkewDetected",
                         "query": "(node_timex_offset_seconds > 0.05 and deriv(node_timex_offset_seconds[5m]) >= 0) or (node_timex_offset_seconds < -0.05 and deriv(node_timex_offset_seconds[5m]) <= 0)",
                         "state": "inactive",
@@ -722,14 +815,14 @@
                             "summary": "Kernel is predicted to exhaust file descriptors limit soon."
                         },
                         "duration": 900,
-                        "evaluationTime": 9.4009e-05,
+                        "evaluationTime": 4.9018e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:56.290289701Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.673576839Z",
                         "name": "NodeFileDescriptorLimit",
                         "query": "(node_filefd_allocated{job=\"node-exporter\"} * 100 / node_filefd_maximum{job=\"node-exporter\"} > 90)",
                         "state": "inactive",
@@ -743,14 +836,14 @@
                             "summary": "Kernel is predicted to exhaust file descriptors limit soon."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000141523,
+                        "evaluationTime": 5.1845e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:56.290143672Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.673522779Z",
                         "name": "NodeFileDescriptorLimit",
                         "query": "(node_filefd_allocated{job=\"node-exporter\"} * 100 / node_filefd_maximum{job=\"node-exporter\"} > 70)",
                         "state": "inactive",
@@ -764,14 +857,14 @@
                             "summary": "Filesystem has less than 8% inodes left."
                         },
                         "duration": 3600,
-                        "evaluationTime": 0.000275244,
+                        "evaluationTime": 0.000181385,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:56.28826668Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.672582328Z",
                         "name": "NodeFilesystemAlmostOutOfFiles",
                         "query": "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100 < 8 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
                         "state": "inactive",
@@ -785,14 +878,14 @@
                             "summary": "Filesystem has less than 15% inodes left."
                         },
                         "duration": 3600,
-                        "evaluationTime": 0.00028485,
+                        "evaluationTime": 0.000160042,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:56.287976493Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.672419752Z",
                         "name": "NodeFilesystemAlmostOutOfFiles",
                         "query": "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100 < 15 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
                         "state": "inactive",
@@ -806,14 +899,14 @@
                             "summary": "Filesystem has less than 12% space left."
                         },
                         "duration": 3600,
-                        "evaluationTime": 0.000327395,
+                        "evaluationTime": 0.000204612,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:56.286831434Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.671734014Z",
                         "name": "NodeFilesystemAlmostOutOfSpace",
                         "query": "(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_size_bytes{fstype!=\"\",job=\"node-exporter\"} * 100 < 12 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
                         "state": "inactive",
@@ -827,14 +920,14 @@
                             "summary": "Filesystem has less than 20% space left."
                         },
                         "duration": 3600,
-                        "evaluationTime": 0.000318385,
+                        "evaluationTime": 0.000205482,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:56.286507077Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.671525104Z",
                         "name": "NodeFilesystemAlmostOutOfSpace",
                         "query": "(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_size_bytes{fstype!=\"\",job=\"node-exporter\"} * 100 < 20 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
                         "state": "inactive",
@@ -848,14 +941,14 @@
                             "summary": "Filesystem is predicted to run out of inodes within the next 4 hours."
                         },
                         "duration": 3600,
-                        "evaluationTime": 0.000407915,
+                        "evaluationTime": 0.000209781,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:56.287563068Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.672207125Z",
                         "name": "NodeFilesystemFilesFillingUp",
                         "query": "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100 < 20 and predict_linear(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"}[6h], 4 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
                         "state": "inactive",
@@ -869,14 +962,14 @@
                             "summary": "Filesystem is predicted to run out of inodes within the next 24 hours."
                         },
                         "duration": 3600,
-                        "evaluationTime": 0.000393208,
+                        "evaluationTime": 0.000261345,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:56.287163922Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.671941712Z",
                         "name": "NodeFilesystemFilesFillingUp",
                         "query": "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100 < 40 and predict_linear(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"}[6h], 24 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
                         "state": "inactive",
@@ -890,14 +983,14 @@
                             "summary": "Filesystem is predicted to run out of space within the next 4 hours."
                         },
                         "duration": 3600,
-                        "evaluationTime": 0.000482519,
+                        "evaluationTime": 0.000267458,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:56.286008147Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.67125437Z",
                         "name": "NodeFilesystemSpaceFillingUp",
                         "query": "(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_size_bytes{fstype!=\"\",job=\"node-exporter\"} * 100 < 20 and predict_linear(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\"}[6h], 4 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
                         "state": "inactive",
@@ -911,14 +1004,14 @@
                             "summary": "Filesystem is predicted to run out of space within the next 24 hours."
                         },
                         "duration": 3600,
-                        "evaluationTime": 0.000756534,
+                        "evaluationTime": 0.000433121,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:56.285244137Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.67081663Z",
                         "name": "NodeFilesystemSpaceFillingUp",
                         "query": "(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\"} / node_filesystem_size_bytes{fstype!=\"\",job=\"node-exporter\"} * 100 < 40 and predict_linear(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\"}[6h], 24 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\",job=\"node-exporter\"} == 0)",
                         "state": "inactive",
@@ -932,14 +1025,14 @@
                             "summary": "Number of conntrack are getting close to the limit"
                         },
                         "duration": 0,
-                        "evaluationTime": 0.000136786,
+                        "evaluationTime": 4.5693e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:56.289445993Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.673242526Z",
                         "name": "NodeHighNumberConntrackEntriesUsed",
                         "query": "(node_nf_conntrack_entries / node_nf_conntrack_entries_limit) > 0.75",
                         "state": "inactive",
@@ -953,14 +1046,14 @@
                             "summary": "Network interface is reporting many receive errors."
                         },
                         "duration": 3600,
-                        "evaluationTime": 0.00043017,
+                        "evaluationTime": 0.000249742,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:56.288547293Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.672766509Z",
                         "name": "NodeNetworkReceiveErrs",
                         "query": "increase(node_network_receive_errs_total[2m]) / rate(node_network_receive_packets_total[2m]) > 0.01",
                         "state": "inactive",
@@ -974,14 +1067,14 @@
                             "summary": "Network interface is reporting many transmit errors."
                         },
                         "duration": 3600,
-                        "evaluationTime": 0.000457699,
+                        "evaluationTime": 0.000220633,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:56.288983172Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.673018926Z",
                         "name": "NodeNetworkTransmitErrs",
                         "query": "increase(node_network_transmit_errs_total[2m]) / rate(node_network_transmit_packets_total[2m]) > 0.01",
                         "state": "inactive",
@@ -995,14 +1088,14 @@
                             "summary": "RAID Array is degraded"
                         },
                         "duration": 900,
-                        "evaluationTime": 5.722e-05,
+                        "evaluationTime": 3.8166e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:56.290016087Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.673454782Z",
                         "name": "NodeRAIDDegraded",
                         "query": "node_md_disks_required - ignoring (state) (node_md_disks{state=\"active\"}) >= 1",
                         "state": "inactive",
@@ -1016,14 +1109,14 @@
                             "summary": "Failed device in RAID array"
                         },
                         "duration": 0,
-                        "evaluationTime": 5.4802e-05,
+                        "evaluationTime": 2.4498e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:56.290084682Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.673495224Z",
                         "name": "NodeRAIDDiskFailure",
                         "query": "node_md_disks{state=\"failed\"} >= 1",
                         "state": "inactive",
@@ -1037,14 +1130,14 @@
                             "summary": "Node Exporter text file collector failed to scrape."
                         },
                         "duration": 0,
-                        "evaluationTime": 8.984e-05,
+                        "evaluationTime": 3.1303e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:56.289921831Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.673420825Z",
                         "name": "NodeTextFileCollectorScrapeError",
                         "query": "node_textfile_scrape_error{job=\"node-exporter\"} == 1",
                         "state": "inactive",
@@ -1053,10 +1146,92 @@
                 ]
             },
             {
-                "evaluationTime": 0.002855856,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-alertmanager.rules-d3531d74-866e-43c5-b894-032cd8dc4c9e.yaml",
+                "evaluationTime": 0.000145221,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-metalk8s-workload-plane-detection.rules-50010b9a-81d7-4a1f-a3b8-44fced4d74c2.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:01:58.725888694Z",
+                "lastEvaluation": "2026-07-16T17:15:37.661409926Z",
+                "limit": 0,
+                "name": "workload-plane-detection",
+                "partialResponseStrategy": "ABORT",
+                "rules": [
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "description": "Node {{ $labels.node }} reports WorkloadPlaneNetworkUnavailable=True, it cannot reach the majority of its peers over the Workload Plane network. If the condition persists, node-warden taints the node NoExecute to drain its workloads. Check the Workload Plane network on this node.",
+                            "summary": "Node has lost Workload Plane connectivity"
+                        },
+                        "duration": 120,
+                        "evaluationTime": 0.000132165,
+                        "health": "ok",
+                        "keepFiringFor": 0,
+                        "labels": {
+                            "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
+                            "severity": "warning"
+                        },
+                        "lastEvaluation": "2026-07-16T17:15:37.661420506Z",
+                        "name": "NodeWorkloadPlaneUnavailable",
+                        "query": "kube_node_status_condition{condition=\"WorkloadPlaneNetworkUnavailable\",status=\"true\"} == 1",
+                        "state": "inactive",
+                        "type": "alerting"
+                    }
+                ]
+            },
+            {
+                "evaluationTime": 0.000365053,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-metalk8s-workload-plane-remediation.rules-428b612f-410d-440c-b5a7-d64238edd90f.yaml",
+                "interval": 30,
+                "lastEvaluation": "2026-07-16T17:16:02.187261833Z",
+                "limit": 0,
+                "name": "workload-plane-remediation",
+                "partialResponseStrategy": "ABORT",
+                "rules": [
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "description": "Node {{ $labels.node }} carries the node.scality.com/workload-plane-unreachable:NoExecute taint applied by node-warden; its non-tolerating workloads have been evicted and it no longer serves Service traffic. The taint is removed automatically once Workload Plane connectivity recovers.",
+                            "summary": "Node drained after Workload Plane isolation"
+                        },
+                        "duration": 60,
+                        "evaluationTime": 0.000196526,
+                        "health": "ok",
+                        "keepFiringFor": 0,
+                        "labels": {
+                            "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
+                            "severity": "warning"
+                        },
+                        "lastEvaluation": "2026-07-16T17:16:02.187282233Z",
+                        "name": "NodeWorkloadPlaneRemediated",
+                        "query": "kube_node_spec_taint{key=\"node.scality.com/workload-plane-unreachable\"} == 1",
+                        "state": "inactive",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "description": "More than half of the nodes report WorkloadPlaneNetworkUnavailable=True. node-warden's guard suppresses remediation in this case (a cluster-wide Workload Plane failure rather than a single-node fault), so no node is tainted. Investigate the Workload Plane network fabric.",
+                            "summary": "Workload Plane outage affecting the majority of nodes"
+                        },
+                        "duration": 60,
+                        "evaluationTime": 0.000137225,
+                        "health": "ok",
+                        "keepFiringFor": 0,
+                        "labels": {
+                            "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
+                            "severity": "critical"
+                        },
+                        "lastEvaluation": "2026-07-16T17:16:02.187486313Z",
+                        "name": "WorkloadPlaneOutage",
+                        "query": "count(kube_node_status_condition{condition=\"WorkloadPlaneNetworkUnavailable\",status=\"true\"} == 1) / count(kube_node_status_condition{condition=\"WorkloadPlaneNetworkUnavailable\",status=\"true\"}) > 0.5",
+                        "state": "inactive",
+                        "type": "alerting"
+                    }
+                ]
+            },
+            {
+                "evaluationTime": 0.001841202,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-alertmanager.rules-2575c678-274d-4917-88b8-ea3d40c70360.yaml",
+                "interval": 30,
+                "lastEvaluation": "2026-07-16T17:15:52.607038905Z",
                 "limit": 0,
                 "name": "alertmanager.rules",
                 "partialResponseStrategy": "ABORT",
@@ -1069,14 +1244,14 @@
                             "summary": "Half or more of the Alertmanager instances within the same cluster are crashlooping."
                         },
                         "duration": 300,
-                        "evaluationTime": 0.000146382,
+                        "evaluationTime": 0.000111384,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:58.72859531Z",
+                        "lastEvaluation": "2026-07-16T17:15:52.608766658Z",
                         "name": "AlertmanagerClusterCrashlooping",
                         "query": "(count by (namespace, service, cluster) (changes(process_start_time_seconds{container=\"alertmanager\",job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"}[10m]) > 4) / count by (namespace, service, cluster) (up{container=\"alertmanager\",job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"})) >= 0.5",
                         "state": "inactive",
@@ -1090,14 +1265,14 @@
                             "summary": "Half or more of the Alertmanager instances within the same cluster are down."
                         },
                         "duration": 300,
-                        "evaluationTime": 0.000218204,
+                        "evaluationTime": 0.000137396,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:58.728371598Z",
+                        "lastEvaluation": "2026-07-16T17:15:52.608626756Z",
                         "name": "AlertmanagerClusterDown",
                         "query": "(count by (namespace, service, cluster) (avg_over_time(up{container=\"alertmanager\",job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"}[5m]) < 0.5) / count by (namespace, service, cluster) (up{container=\"alertmanager\",job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"})) >= 0.5",
                         "state": "inactive",
@@ -1111,14 +1286,14 @@
                             "summary": "All Alertmanager instances in a cluster failed to send notifications to a critical integration."
                         },
                         "duration": 300,
-                        "evaluationTime": 0.000755275,
+                        "evaluationTime": 0.000467569,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:58.727226343Z",
+                        "lastEvaluation": "2026-07-16T17:15:52.607899795Z",
                         "name": "AlertmanagerClusterFailedToSendAlerts",
                         "query": "min by (namespace, service, integration) (rate(alertmanager_notifications_failed_total{container=\"alertmanager\",integration=~\".*\",job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"}[15m]) / ignoring (reason) group_left () rate(alertmanager_notifications_total{container=\"alertmanager\",integration=~\".*\",job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"}[15m]) > 0) > 0.01",
                         "state": "inactive",
@@ -1132,14 +1307,14 @@
                             "summary": "All Alertmanager instances in a cluster failed to send notifications to a non-critical integration."
                         },
                         "duration": 300,
-                        "evaluationTime": 0.000210196,
+                        "evaluationTime": 0.000103568,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:58.727987657Z",
+                        "lastEvaluation": "2026-07-16T17:15:52.608372506Z",
                         "name": "AlertmanagerClusterFailedToSendAlerts",
                         "query": "min by (namespace, service, integration) (rate(alertmanager_notifications_failed_total{container=\"alertmanager\",integration!~\".*\",job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"}[15m]) / ignoring (reason) group_left () rate(alertmanager_notifications_total{container=\"alertmanager\",integration!~\".*\",job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"}[15m]) > 0) > 0.01",
                         "state": "inactive",
@@ -1153,14 +1328,14 @@
                             "summary": "Alertmanager instances within the same cluster have different configurations."
                         },
                         "duration": 1200,
-                        "evaluationTime": 0.00015564,
+                        "evaluationTime": 0.00014409,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:58.72820309Z",
+                        "lastEvaluation": "2026-07-16T17:15:52.60847883Z",
                         "name": "AlertmanagerConfigInconsistent",
                         "query": "count by (namespace, service, cluster) (count_values by (namespace, service, cluster) (\"config_hash\", alertmanager_config_hash{container=\"alertmanager\",job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"})) != 1",
                         "state": "inactive",
@@ -1174,14 +1349,14 @@
                             "summary": "Reloading an Alertmanager configuration has failed."
                         },
                         "duration": 600,
-                        "evaluationTime": 0.00026954,
+                        "evaluationTime": 0.000190313,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:58.725917766Z",
+                        "lastEvaluation": "2026-07-16T17:15:52.607063204Z",
                         "name": "AlertmanagerFailedReload",
                         "query": "max_over_time(alertmanager_config_last_reload_successful{container=\"alertmanager\",job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"}[5m]) == 0",
                         "state": "inactive",
@@ -1195,14 +1370,14 @@
                             "summary": "An Alertmanager instance failed to send notifications."
                         },
                         "duration": 300,
-                        "evaluationTime": 0.000787968,
+                        "evaluationTime": 0.00053272,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:58.726428505Z",
+                        "lastEvaluation": "2026-07-16T17:15:52.607362396Z",
                         "name": "AlertmanagerFailedToSendAlerts",
                         "query": "(rate(alertmanager_notifications_failed_total{container=\"alertmanager\",job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"}[15m]) / ignoring (reason) group_left () rate(alertmanager_notifications_total{container=\"alertmanager\",job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"}[15m])) > 0.01",
                         "state": "inactive",
@@ -1216,14 +1391,14 @@
                             "summary": "A member of an Alertmanager cluster has not found all other cluster members."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000223438,
+                        "evaluationTime": 0.000100932,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:58.726198048Z",
+                        "lastEvaluation": "2026-07-16T17:15:52.607258297Z",
                         "name": "AlertmanagerMembersInconsistent",
                         "query": "max_over_time(alertmanager_cluster_members{container=\"alertmanager\",job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"}[5m]) < on (namespace, service, cluster) group_left () count by (namespace, service, cluster) (max_over_time(alertmanager_cluster_members{container=\"alertmanager\",job=\"prometheus-operator-alertmanager\",namespace=\"metalk8s-monitoring\"}[5m]))",
                         "state": "inactive",
@@ -1232,10 +1407,10 @@
                 ]
             },
             {
-                "evaluationTime": 0.00039956,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-config-reloaders-bba11c80-da0c-498c-96f9-a52c9c80561a.yaml",
+                "evaluationTime": 0.000170132,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-config-reloaders-b13b82eb-0024-4314-8553-a950f5acb1de.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:02:01.452847705Z",
+                "lastEvaluation": "2026-07-16T17:15:57.756145158Z",
                 "limit": 0,
                 "name": "config-reloaders",
                 "partialResponseStrategy": "ABORT",
@@ -1248,14 +1423,14 @@
                             "summary": "config-reloader sidecar has not had a successful reload for 10m"
                         },
                         "duration": 600,
-                        "evaluationTime": 0.000366006,
+                        "evaluationTime": 0.00015956,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:01.452876672Z",
+                        "lastEvaluation": "2026-07-16T17:15:57.756153635Z",
                         "name": "ConfigReloaderSidecarErrors",
                         "query": "max_over_time(reloader_last_reload_successful{namespace=~\".+\"}[5m]) == 0",
                         "state": "inactive",
@@ -1264,10 +1439,10 @@
                 ]
             },
             {
-                "evaluationTime": 0.008916154,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-etcd-e77e9438-39a7-442b-bf3c-eba45edbeec6.yaml",
+                "evaluationTime": 0.006971332,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-etcd-c59a0c2c-5168-4e7b-bfd2-decc26959a5a.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:01:45.6320467Z",
+                "lastEvaluation": "2026-07-16T17:16:03.476472498Z",
                 "limit": 0,
                 "name": "etcd",
                 "partialResponseStrategy": "ABORT",
@@ -1279,14 +1454,14 @@
                             "summary": "etcd cluster database is running full."
                         },
                         "duration": 600,
-                        "evaluationTime": 0.000239939,
+                        "evaluationTime": 9.5682e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:45.640538495Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.483232775Z",
                         "name": "etcdDatabaseQuotaLowSpace",
                         "query": "(last_over_time(etcd_mvcc_db_total_size_in_bytes{job=~\".*etcd.*\"}[5m]) / last_over_time(etcd_server_quota_backend_bytes{job=~\".*etcd.*\"}[5m])) * 100 > 95",
                         "state": "inactive",
@@ -1299,14 +1474,14 @@
                             "summary": "etcd cluster database growing very fast."
                         },
                         "duration": 600,
-                        "evaluationTime": 0.000175328,
+                        "evaluationTime": 0.000110903,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:45.640784225Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.483331104Z",
                         "name": "etcdExcessiveDatabaseGrowth",
                         "query": "predict_linear(etcd_mvcc_db_total_size_in_bytes{job=~\".*etcd.*\"}[4h], 4 * 60 * 60) > etcd_server_quota_backend_bytes{job=~\".*etcd.*\"}",
                         "state": "inactive",
@@ -1319,14 +1494,14 @@
                             "summary": "etcd grpc requests are slow"
                         },
                         "duration": 600,
-                        "evaluationTime": 0.000171971,
+                        "evaluationTime": 8.6484e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:45.639499098Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.482682259Z",
                         "name": "etcdGRPCRequestsSlow",
                         "query": "histogram_quantile(0.99, sum without (grpc_type) (rate(grpc_server_handling_seconds_bucket{grpc_method!=\"Defragment\",grpc_type=\"unary\",job=~\".*etcd.*\"}[5m]))) > 0.15",
                         "state": "inactive",
@@ -1339,14 +1514,14 @@
                             "summary": "etcd cluster 99th percentile commit durations are too high."
                         },
                         "duration": 1800,
-                        "evaluationTime": 0.000194448,
+                        "evaluationTime": 9.5161e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:45.640339213Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.483135039Z",
                         "name": "etcdHighCommitDurations",
                         "query": "histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job=~\".*etcd.*\"}[5m])) > 0.25",
                         "state": "inactive",
@@ -1359,14 +1534,14 @@
                             "summary": "etcd cluster 99th percentile fsync durations are too high."
                         },
                         "duration": 600,
-                        "evaluationTime": 0.000179829,
+                        "evaluationTime": 8.7185e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:45.640154047Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.483045218Z",
                         "name": "etcdHighFsyncDurations",
                         "query": "histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job=~\".*etcd.*\"}[5m])) > 1",
                         "state": "inactive",
@@ -1379,14 +1554,14 @@
                             "summary": "etcd cluster 99th percentile fsync durations are too high."
                         },
                         "duration": 600,
-                        "evaluationTime": 0.000218055,
+                        "evaluationTime": 9.9861e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:45.639930512Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.482942602Z",
                         "name": "etcdHighFsyncDurations",
                         "query": "histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job=~\".*etcd.*\"}[5m])) > 0.5",
                         "state": "inactive",
@@ -1399,14 +1574,14 @@
                             "summary": "etcd cluster has high number of failed grpc requests."
                         },
                         "duration": 300,
-                        "evaluationTime": 0.002821949,
+                        "evaluationTime": 0.002750939,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:45.636656849Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.479927111Z",
                         "name": "etcdHighNumberOfFailedGRPCRequests",
                         "query": "100 * sum without (grpc_type, grpc_code) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|FailedPrecondition|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded\",job=~\".*etcd.*\"}[5m])) / sum without (grpc_type, grpc_code) (rate(grpc_server_handled_total{job=~\".*etcd.*\"}[5m])) > 5",
                         "state": "inactive",
@@ -1419,14 +1594,14 @@
                             "summary": "etcd cluster has high number of failed grpc requests."
                         },
                         "duration": 600,
-                        "evaluationTime": 0.003304924,
+                        "evaluationTime": 0.002740879,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:45.633345253Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.477181373Z",
                         "name": "etcdHighNumberOfFailedGRPCRequests",
                         "query": "100 * sum without (grpc_type, grpc_code) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|FailedPrecondition|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded\",job=~\".*etcd.*\"}[5m])) / sum without (grpc_type, grpc_code) (rate(grpc_server_handled_total{job=~\".*etcd.*\"}[5m])) > 1",
                         "state": "inactive",
@@ -1439,14 +1614,14 @@
                             "summary": "etcd cluster has high number of proposal failures."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000109834,
+                        "evaluationTime": 6.2185e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:45.639815917Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.482877781Z",
                         "name": "etcdHighNumberOfFailedProposals",
                         "query": "rate(etcd_server_proposals_failed_total{job=~\".*etcd.*\"}[15m]) > 5",
                         "state": "inactive",
@@ -1459,14 +1634,14 @@
                             "summary": "etcd cluster has high number of leader changes."
                         },
                         "duration": 300,
-                        "evaluationTime": 0.00029115,
+                        "evaluationTime": 0.00013424,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:45.63304747Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.477042784Z",
                         "name": "etcdHighNumberOfLeaderChanges",
                         "query": "increase((max without (instance, pod) (etcd_server_leader_changes_seen_total{job=~\".*etcd.*\"}) or 0 * absent(etcd_server_leader_changes_seen_total{job=~\".*etcd.*\"}))[15m:1m]) >= 4",
                         "state": "inactive",
@@ -1479,14 +1654,14 @@
                             "summary": "etcd cluster has insufficient number of members."
                         },
                         "duration": 180,
-                        "evaluationTime": 0.0002371,
+                        "evaluationTime": 0.000166884,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:45.632696311Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.476816851Z",
                         "name": "etcdInsufficientMembers",
                         "query": "sum without (instance, pod) (up{job=~\".*etcd.*\"} == bool 1) < ((count without (instance, pod) (up{job=~\".*etcd.*\"}) + 1) / 2)",
                         "state": "inactive",
@@ -1499,14 +1674,14 @@
                             "summary": "etcd cluster member communication is slow."
                         },
                         "duration": 600,
-                        "evaluationTime": 0.000130119,
+                        "evaluationTime": 0.000100452,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:45.639676566Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.482771969Z",
                         "name": "etcdMemberCommunicationSlow",
                         "query": "histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job=~\".*etcd.*\"}[5m])) > 0.15",
                         "state": "inactive",
@@ -1519,14 +1694,14 @@
                             "summary": "etcd cluster members are down."
                         },
                         "duration": 1200,
-                        "evaluationTime": 0.000602602,
+                        "evaluationTime": 0.000320594,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:45.632086096Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.476491226Z",
                         "name": "etcdMembersDown",
                         "query": "max without (endpoint) (sum without (instance, pod) (up{job=~\".*etcd.*\"} == bool 0) or count without (To) (sum without (instance, pod) (rate(etcd_network_peer_sent_failures_total{job=~\".*etcd.*\"}[2m])) > 0.01)) > 0",
                         "state": "inactive",
@@ -1539,14 +1714,14 @@
                             "summary": "etcd cluster has no leader."
                         },
                         "duration": 60,
-                        "evaluationTime": 0.000102721,
+                        "evaluationTime": 5.1865e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:45.632939688Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.476987654Z",
                         "name": "etcdNoLeader",
                         "query": "etcd_server_has_leader{job=~\".*etcd.*\"} == 0",
                         "state": "inactive",
@@ -1555,10 +1730,10 @@
                 ]
             },
             {
-                "evaluationTime": 0.001326565,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-general.rules-21147fa2-96cb-43a1-8de0-e571cd5c132b.yaml",
+                "evaluationTime": 0.000748725,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-general.rules-9eebbeb4-e66f-41d7-9e5f-4972e8aa1f7a.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:01:58.230679709Z",
+                "lastEvaluation": "2026-07-16T17:16:00.893805083Z",
                 "limit": 0,
                 "name": "general.rules",
                 "partialResponseStrategy": "ABORT",
@@ -1571,14 +1746,14 @@
                             "summary": "Info-level alert inhibition."
                         },
                         "duration": 0,
-                        "evaluationTime": 0.000122851,
+                        "evaluationTime": 0.000113138,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "none"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:58.231880014Z",
+                        "lastEvaluation": "2026-07-16T17:16:00.894438045Z",
                         "name": "InfoInhibitor",
                         "query": "group by (namespace) (ALERTS{severity=\"info\"} == 1) unless on (namespace) group by (namespace) (ALERTS{alertname!=\"InfoInhibitor\",alertstate=\"firing\",severity=~\"warning|critical\"} == 1)",
                         "state": "inactive",
@@ -1592,14 +1767,14 @@
                             "summary": "One or more targets are unreachable."
                         },
                         "duration": 600,
-                        "evaluationTime": 0.000613872,
+                        "evaluationTime": 0.000365143,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:58.230711978Z",
+                        "lastEvaluation": "2026-07-16T17:16:00.893815875Z",
                         "name": "TargetDown",
                         "query": "100 * (count by (cluster, job, namespace, service) (up == 0) / count by (cluster, job, namespace, service) (up)) > 10",
                         "state": "inactive",
@@ -1608,7 +1783,7 @@
                     {
                         "alerts": [
                             {
-                                "activeAt": "2026-03-31T16:59:28.229203808Z",
+                                "activeAt": "2026-07-16T17:04:00.892295957Z",
                                 "annotations": {
                                     "description": "This is an alert meant to ensure that the entire alerting pipeline is functional.\nThis alert is always firing, therefore it should always be firing in Alertmanager\nand always fire against a receiver. There are integrations with various notification\nmechanisms that send a notification when this alert is not firing. For example the\n\"DeadMansSnitch\" integration in PagerDuty.",
                                     "runbook_url": "https://runbooks.prometheus-operator.dev/runbooks/general/watchdog",
@@ -1629,14 +1804,14 @@
                             "summary": "An alert that should always be firing to certify that Alertmanager is working properly."
                         },
                         "duration": 0,
-                        "evaluationTime": 0.000520954,
+                        "evaluationTime": 0.000247988,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "none"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:58.231340059Z",
+                        "lastEvaluation": "2026-07-16T17:16:00.894185217Z",
                         "name": "Watchdog",
                         "query": "vector(1)",
                         "state": "firing",
@@ -1645,32 +1820,32 @@
                 ]
             },
             {
-                "evaluationTime": 0.003367849,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-k8s.rules.container-cpu-usage-seconds-total-afad9373-9226-4b2b-850e-6ffd49e41d45.yaml",
+                "evaluationTime": 0.003465554,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-k8s.rules.container-cpu-usage-seconds-total-422ef54f-38d4-416f-acb3-8ebd2c0abe19.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:01:48.991091066Z",
+                "lastEvaluation": "2026-07-16T17:15:44.946945397Z",
                 "limit": 0,
                 "name": "k8s.rules.container_cpu_usage_seconds_total",
                 "partialResponseStrategy": "ABORT",
                 "rules": [
                     {
-                        "evaluationTime": 0.001314207,
+                        "evaluationTime": 0.001603443,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:48.993139307Z",
+                        "lastEvaluation": "2026-07-16T17:15:44.94880275Z",
                         "name": "node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate",
                         "query": "sum by (cluster, namespace, pod, container) (irate(container_cpu_usage_seconds_total{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\"}[5m])) * on (cluster, namespace, pod) group_left (node) topk by (cluster, namespace, pod) (1, max by (cluster, namespace, pod, node) (kube_pod_info{node!=\"\"}))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.001972444,
+                        "evaluationTime": 0.001825618,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:48.991147317Z",
+                        "lastEvaluation": "2026-07-16T17:15:44.946967682Z",
                         "name": "node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m",
                         "query": "sum by (cluster, namespace, pod, container) (rate(container_cpu_usage_seconds_total{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\"}[5m])) * on (cluster, namespace, pod) group_left (node) topk by (cluster, namespace, pod) (1, max by (cluster, namespace, pod, node) (kube_pod_info{node!=\"\"}))",
                         "type": "recording"
@@ -1678,21 +1853,21 @@
                 ]
             },
             {
-                "evaluationTime": 0.001438732,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-k8s.rules.container-memory-cache-f42fca84-a300-401b-ba94-007367674023.yaml",
+                "evaluationTime": 0.001099841,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-k8s.rules.container-memory-cache-4a89699b-72e7-4bfe-bd25-32c1ed2758eb.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:02:10.919981416Z",
+                "lastEvaluation": "2026-07-16T17:16:07.022474058Z",
                 "limit": 0,
                 "name": "k8s.rules.container_memory_cache",
                 "partialResponseStrategy": "ABORT",
                 "rules": [
                     {
-                        "evaluationTime": 0.001391793,
+                        "evaluationTime": 0.001072336,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:10.920019682Z",
+                        "lastEvaluation": "2026-07-16T17:16:07.022496033Z",
                         "name": "node_namespace_pod_container:container_memory_cache",
                         "query": "container_memory_cache{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\"} * on (cluster, namespace, pod) group_left (node) topk by (cluster, namespace, pod) (1, max by (cluster, namespace, pod, node) (kube_pod_info{node!=\"\"}))",
                         "type": "recording"
@@ -1700,21 +1875,21 @@
                 ]
             },
             {
-                "evaluationTime": 0.001812832,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-k8s.rules.container-memory-rss-d8cb6150-b9bb-4f7e-9f28-ba8b2a5b2095.yaml",
+                "evaluationTime": 0.001055853,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-k8s.rules.container-memory-rss-9f41fa2e-1ceb-4382-904e-3a6921c01ef8.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:01:56.70925004Z",
+                "lastEvaluation": "2026-07-16T17:15:58.639414301Z",
                 "limit": 0,
                 "name": "k8s.rules.container_memory_rss",
                 "partialResponseStrategy": "ABORT",
                 "rules": [
                     {
-                        "evaluationTime": 0.001715984,
+                        "evaluationTime": 0.001027235,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:56.709341754Z",
+                        "lastEvaluation": "2026-07-16T17:15:58.63943881Z",
                         "name": "node_namespace_pod_container:container_memory_rss",
                         "query": "container_memory_rss{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\"} * on (cluster, namespace, pod) group_left (node) topk by (cluster, namespace, pod) (1, max by (cluster, namespace, pod, node) (kube_pod_info{node!=\"\"}))",
                         "type": "recording"
@@ -1722,21 +1897,21 @@
                 ]
             },
             {
-                "evaluationTime": 0.000706369,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-k8s.rules.container-memory-swap-d176e82a-bbae-4505-b423-05bf6503abb1.yaml",
+                "evaluationTime": 0.000385123,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-k8s.rules.container-memory-swap-a6739cf6-28e9-48e9-8a35-950d4293a87f.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:01:43.543643359Z",
+                "lastEvaluation": "2026-07-16T17:15:57.721982625Z",
                 "limit": 0,
                 "name": "k8s.rules.container_memory_swap",
                 "partialResponseStrategy": "ABORT",
                 "rules": [
                     {
-                        "evaluationTime": 0.000634415,
+                        "evaluationTime": 0.000365986,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:43.543704206Z",
+                        "lastEvaluation": "2026-07-16T17:15:57.721998897Z",
                         "name": "node_namespace_pod_container:container_memory_swap",
                         "query": "container_memory_swap{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\"} * on (cluster, namespace, pod) group_left (node) topk by (cluster, namespace, pod) (1, max by (cluster, namespace, pod, node) (kube_pod_info{node!=\"\"}))",
                         "type": "recording"
@@ -1744,21 +1919,21 @@
                 ]
             },
             {
-                "evaluationTime": 0.001905969,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-k8s.rules.container-memory-working-set-byte-81e2b665-38de-46dc-86e1-b8e93b60bc00.yaml",
+                "evaluationTime": 0.001092817,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-k8s.rules.container-memory-working-set-byte-7a01c6be-aef7-40be-ad1e-6122ecb6ec5d.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:01:50.106399495Z",
+                "lastEvaluation": "2026-07-16T17:16:00.756027113Z",
                 "limit": 0,
                 "name": "k8s.rules.container_memory_working_set_bytes",
                 "partialResponseStrategy": "ABORT",
                 "rules": [
                     {
-                        "evaluationTime": 0.00185761,
+                        "evaluationTime": 0.001071112,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:50.106442515Z",
+                        "lastEvaluation": "2026-07-16T17:16:00.75604523Z",
                         "name": "node_namespace_pod_container:container_memory_working_set_bytes",
                         "query": "container_memory_working_set_bytes{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\"} * on (cluster, namespace, pod) group_left (node) topk by (cluster, namespace, pod) (1, max by (cluster, namespace, pod, node) (kube_pod_info{node!=\"\"}))",
                         "type": "recording"
@@ -1766,98 +1941,98 @@
                 ]
             },
             {
-                "evaluationTime": 0.004440075,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-k8s.rules.container-resource-660d7273-c0a0-43bf-b5a4-36024ba4abaa.yaml",
+                "evaluationTime": 0.003839578,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-k8s.rules.container-resource-4742740a-c252-42e4-908c-6e14f27b77d8.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:02:08.935582893Z",
+                "lastEvaluation": "2026-07-16T17:15:38.786910159Z",
                 "limit": 0,
                 "name": "k8s.rules.container_resource",
                 "partialResponseStrategy": "ABORT",
                 "rules": [
                     {
-                        "evaluationTime": 0.000516669,
+                        "evaluationTime": 0.000320475,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:08.939054561Z",
+                        "lastEvaluation": "2026-07-16T17:15:38.790034609Z",
                         "name": "cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits",
                         "query": "kube_pod_container_resource_limits{job=\"kube-state-metrics\",resource=\"cpu\"} * on (namespace, pod, cluster) group_left () max by (namespace, pod, cluster) ((kube_pod_status_phase{phase=~\"Pending|Running\"} == 1))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000499803,
+                        "evaluationTime": 0.00046325,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:08.937019667Z",
+                        "lastEvaluation": "2026-07-16T17:15:38.788206235Z",
                         "name": "cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests",
                         "query": "kube_pod_container_resource_requests{job=\"kube-state-metrics\",resource=\"cpu\"} * on (namespace, pod, cluster) group_left () max by (namespace, pod, cluster) ((kube_pod_status_phase{phase=~\"Pending|Running\"} == 1))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000432372,
+                        "evaluationTime": 0.000377259,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:08.938125165Z",
+                        "lastEvaluation": "2026-07-16T17:15:38.789172837Z",
                         "name": "cluster:namespace:pod_memory:active:kube_pod_container_resource_limits",
                         "query": "kube_pod_container_resource_limits{job=\"kube-state-metrics\",resource=\"memory\"} * on (namespace, pod, cluster) group_left () max by (namespace, pod, cluster) ((kube_pod_status_phase{phase=~\"Pending|Running\"} == 1))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000777778,
+                        "evaluationTime": 0.000718535,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:08.93562079Z",
+                        "lastEvaluation": "2026-07-16T17:15:38.786930109Z",
                         "name": "cluster:namespace:pod_memory:active:kube_pod_container_resource_requests",
                         "query": "kube_pod_container_resource_requests{job=\"kube-state-metrics\",resource=\"memory\"} * on (namespace, pod, cluster) group_left () max by (namespace, pod, cluster) ((kube_pod_status_phase{phase=~\"Pending|Running\"} == 1))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000440319,
+                        "evaluationTime": 0.000387458,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:08.939578945Z",
+                        "lastEvaluation": "2026-07-16T17:15:38.790359511Z",
                         "name": "namespace_cpu:kube_pod_container_resource_limits:sum",
                         "query": "sum by (namespace, cluster) (sum by (namespace, pod, cluster) (max by (namespace, pod, container, cluster) (kube_pod_container_resource_limits{job=\"kube-state-metrics\",resource=\"cpu\"}) * on (namespace, pod, cluster) group_left () max by (namespace, pod, cluster) (kube_pod_status_phase{phase=~\"Pending|Running\"} == 1)))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000586732,
+                        "evaluationTime": 0.000473752,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:08.937530712Z",
+                        "lastEvaluation": "2026-07-16T17:15:38.788674645Z",
                         "name": "namespace_cpu:kube_pod_container_resource_requests:sum",
                         "query": "sum by (namespace, cluster) (sum by (namespace, pod, cluster) (max by (namespace, pod, container, cluster) (kube_pod_container_resource_requests{job=\"kube-state-metrics\",resource=\"cpu\"}) * on (namespace, pod, cluster) group_left () max by (namespace, pod, cluster) (kube_pod_status_phase{phase=~\"Pending|Running\"} == 1)))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000473765,
+                        "evaluationTime": 0.000474434,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:08.938573335Z",
+                        "lastEvaluation": "2026-07-16T17:15:38.789555506Z",
                         "name": "namespace_memory:kube_pod_container_resource_limits:sum",
                         "query": "sum by (namespace, cluster) (sum by (namespace, pod, cluster) (max by (namespace, pod, container, cluster) (kube_pod_container_resource_limits{job=\"kube-state-metrics\",resource=\"memory\"}) * on (namespace, pod, cluster) group_left () max by (namespace, pod, cluster) (kube_pod_status_phase{phase=~\"Pending|Running\"} == 1)))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000599137,
+                        "evaluationTime": 0.000536057,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:08.936411376Z",
+                        "lastEvaluation": "2026-07-16T17:15:38.787657993Z",
                         "name": "namespace_memory:kube_pod_container_resource_requests:sum",
                         "query": "sum by (namespace, cluster) (sum by (namespace, pod, cluster) (max by (namespace, pod, container, cluster) (kube_pod_container_resource_requests{job=\"kube-state-metrics\",resource=\"memory\"}) * on (namespace, pod, cluster) group_left () max by (namespace, pod, cluster) (kube_pod_status_phase{phase=~\"Pending|Running\"} == 1)))",
                         "type": "recording"
@@ -1865,105 +2040,105 @@
                 ]
             },
             {
-                "evaluationTime": 0.003587128,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-k8s.rules.pod-owner-9b7b07ff-7edb-478c-abf7-4c6f1506d73b.yaml",
+                "evaluationTime": 0.001987134,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-k8s.rules.pod-owner-c20cdeff-9471-4693-98cd-59033b8a0160.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:02:05.203365212Z",
+                "lastEvaluation": "2026-07-16T17:15:45.886462824Z",
                 "limit": 0,
                 "name": "k8s.rules.pod_owner",
                 "partialResponseStrategy": "ABORT",
                 "rules": [
                     {
-                        "evaluationTime": 0.000535583,
+                        "evaluationTime": 0.000344994,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:05.206394452Z",
+                        "lastEvaluation": "2026-07-16T17:15:45.888101959Z",
                         "name": "namespace_workload_pod:kube_pod_owner:relabel",
                         "query": "group by (cluster, namespace, workload, workload_type, pod) (label_join(label_join(group by (cluster, namespace, job_name, pod) (label_join(kube_pod_owner{job=\"kube-state-metrics\",owner_kind=\"Job\"}, \"job_name\", \"\", \"owner_name\")) * on (cluster, namespace, job_name) group_left (owner_kind, owner_name) group by (cluster, namespace, job_name, owner_kind, owner_name) (kube_job_owner{job=\"kube-state-metrics\",owner_kind!=\"\",owner_kind!=\"Pod\"}), \"workload\", \"\", \"owner_name\"), \"workload_type\", \"\", \"owner_kind\") or label_replace(label_replace(label_replace(kube_pod_owner{job=\"kube-state-metrics\",owner_kind=\"ReplicaSet\"}, \"replicaset\", \"$1\", \"owner_name\", \"(.+)\") * on (cluster, namespace, replicaset) group_left (owner_kind, owner_name) group by (cluster, namespace, replicaset, owner_kind, owner_name) (kube_replicaset_owner{job=\"kube-state-metrics\",owner_kind!=\"\",owner_kind!=\"Deployment\"}), \"workload\", \"$1\", \"owner_name\", \"(.+)\") or label_replace(group by (cluster, namespace, pod, owner_name, owner_kind) (kube_pod_owner{job=\"kube-state-metrics\",owner_kind!=\"\",owner_kind!=\"DaemonSet\",owner_kind!=\"Job\",owner_kind!=\"Node\",owner_kind!=\"ReplicaSet\",owner_kind!=\"StatefulSet\"}), \"workload\", \"$1\", \"owner_name\", \"(.+)\"), \"workload_type\", \"$1\", \"owner_kind\", \"(.+)\"))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000132112,
+                        "evaluationTime": 7.7987e-05,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "workload_type": "barepod"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:05.206019791Z",
+                        "lastEvaluation": "2026-07-16T17:15:45.887868811Z",
                         "name": "namespace_workload_pod:kube_pod_owner:relabel",
                         "query": "max by (cluster, namespace, workload, pod) (label_replace(kube_pod_owner{job=\"kube-state-metrics\",owner_kind=\"\",owner_name=\"\"}, \"workload\", \"$1\", \"pod\", \"(.+)\"))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000418723,
+                        "evaluationTime": 0.000143288,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "workload_type": "daemonset"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:05.205118157Z",
+                        "lastEvaluation": "2026-07-16T17:15:45.887467333Z",
                         "name": "namespace_workload_pod:kube_pod_owner:relabel",
                         "query": "max by (cluster, namespace, workload, pod) (label_replace(kube_pod_owner{job=\"kube-state-metrics\",owner_kind=\"DaemonSet\"}, \"workload\", \"$1\", \"owner_name\", \"(.*)\"))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000932699,
+                        "evaluationTime": 0.0005575,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "workload_type": "deployment"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:05.204175424Z",
+                        "lastEvaluation": "2026-07-16T17:15:45.886900063Z",
                         "name": "namespace_workload_pod:kube_pod_owner:relabel",
                         "query": "max by (cluster, namespace, workload, pod) (label_replace(label_replace(kube_pod_owner{job=\"kube-state-metrics\",owner_kind=\"ReplicaSet\"}, \"replicaset\", \"$1\", \"owner_name\", \"(.*)\") * on (replicaset, namespace, cluster) group_left (owner_name) topk by (cluster, replicaset, namespace) (1, max by (cluster, replicaset, namespace, owner_name) (kube_replicaset_owner{job=\"kube-state-metrics\",owner_kind=\"Deployment\"})), \"workload\", \"$1\", \"owner_name\", \"(.*)\"))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000274849,
+                        "evaluationTime": 0.000163469,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "workload_type": "job"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:05.205737085Z",
+                        "lastEvaluation": "2026-07-16T17:15:45.887700672Z",
                         "name": "namespace_workload_pod:kube_pod_owner:relabel",
                         "query": "group by (cluster, namespace, workload, pod) (label_join(group by (cluster, namespace, job_name, pod, owner_name) (label_join(kube_pod_owner{job=\"kube-state-metrics\",owner_kind=\"Job\"}, \"job_name\", \"\", \"owner_name\")) * on (cluster, namespace, job_name) group_left () group by (cluster, namespace, job_name) (kube_job_owner{job=\"kube-state-metrics\",owner_kind=~\"Pod|\"}), \"workload\", \"\", \"owner_name\"))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000738712,
+                        "evaluationTime": 0.00040813,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "workload_type": "replicaset"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:05.203427949Z",
+                        "lastEvaluation": "2026-07-16T17:15:45.886483456Z",
                         "name": "namespace_workload_pod:kube_pod_owner:relabel",
                         "query": "max by (cluster, namespace, workload, pod) (label_replace(label_replace(kube_pod_owner{job=\"kube-state-metrics\",owner_kind=\"ReplicaSet\"}, \"replicaset\", \"$1\", \"owner_name\", \"(.*)\") * on (cluster, replicaset, namespace) group_left (owner_name) topk by (cluster, replicaset, namespace) (1, max by (cluster, replicaset, namespace, owner_name) (kube_replicaset_owner{job=\"kube-state-metrics\",owner_kind=\"\"})), \"workload\", \"$1\", \"replicaset\", \"(.*)\"))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000182332,
+                        "evaluationTime": 8.2215e-05,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "workload_type": "statefulset"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:05.205546926Z",
+                        "lastEvaluation": "2026-07-16T17:15:45.8876147Z",
                         "name": "namespace_workload_pod:kube_pod_owner:relabel",
                         "query": "max by (cluster, namespace, workload, pod) (label_replace(kube_pod_owner{job=\"kube-state-metrics\",owner_kind=\"StatefulSet\"}, \"workload\", \"$1\", \"owner_name\", \"(.*)\"))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000217352,
+                        "evaluationTime": 0.000148288,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "workload_type": "staticpod"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:05.206157418Z",
+                        "lastEvaluation": "2026-07-16T17:15:45.887949653Z",
                         "name": "namespace_workload_pod:kube_pod_owner:relabel",
                         "query": "max by (cluster, namespace, workload, pod) (label_replace(kube_pod_owner{job=\"kube-state-metrics\",owner_kind=\"Node\"}, \"workload\", \"$1\", \"pod\", \"(.+)\"))",
                         "type": "recording"
@@ -1971,193 +2146,193 @@
                 ]
             },
             {
-                "evaluationTime": 0.013820344,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kube-apiserver-availability.rules-3f79f05a-6bb4-4774-ba5c-6a823ea9b552.yaml",
+                "evaluationTime": 0.010519832,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kube-apiserver-availability.rules-4bb67e43-3697-4b3f-a5c1-1bc68e1d4a51.yaml",
                 "interval": 180,
-                "lastEvaluation": "2026-03-31T17:01:46.064048413Z",
+                "lastEvaluation": "2026-07-16T17:14:07.948849011Z",
                 "limit": 0,
                 "name": "kube-apiserver-availability.rules",
                 "partialResponseStrategy": "ABORT",
                 "rules": [
                     {
-                        "evaluationTime": 0.001150308,
+                        "evaluationTime": 0.000451167,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "verb": "all"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:46.07181344Z",
+                        "lastEvaluation": "2026-07-16T17:14:07.95634724Z",
                         "name": "apiserver_request:availability30d",
                         "query": "1 - ((sum by (cluster) (cluster_verb_scope:apiserver_request_sli_duration_seconds_count:increase30d{verb=~\"POST|PUT|PATCH|DELETE\"}) - sum by (cluster) (cluster_verb_scope_le:apiserver_request_sli_duration_seconds_bucket:increase30d{le=~\"1(\\\\.0)?\",verb=~\"POST|PUT|PATCH|DELETE\"} or vector(0))) + (sum by (cluster) (cluster_verb_scope:apiserver_request_sli_duration_seconds_count:increase30d{verb=~\"LIST|GET\"}) - (sum by (cluster) (cluster_verb_scope_le:apiserver_request_sli_duration_seconds_bucket:increase30d{le=~\"1(\\\\.0)?\",scope=~\"resource|\",verb=~\"LIST|GET\"} or vector(0)) + sum by (cluster) (cluster_verb_scope_le:apiserver_request_sli_duration_seconds_bucket:increase30d{le=~\"5(\\\\.0)?\",scope=\"namespace\",verb=~\"LIST|GET\"} or vector(0)) + sum by (cluster) (cluster_verb_scope_le:apiserver_request_sli_duration_seconds_bucket:increase30d{le=~\"30(\\\\.0)?\",scope=\"cluster\",verb=~\"LIST|GET\"} or vector(0)))) + sum by (cluster) (code:apiserver_request_total:increase30d{code=~\"5..\"} or vector(0))) / sum by (cluster) (code:apiserver_request_total:increase30d)",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000546812,
+                        "evaluationTime": 0.000314452,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "verb": "read"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:46.072976474Z",
+                        "lastEvaluation": "2026-07-16T17:14:07.956802605Z",
                         "name": "apiserver_request:availability30d",
                         "query": "1 - (sum by (cluster) (cluster_verb_scope:apiserver_request_sli_duration_seconds_count:increase30d{verb=~\"LIST|GET\"}) - (sum by (cluster) (cluster_verb_scope_le:apiserver_request_sli_duration_seconds_bucket:increase30d{le=~\"1(\\\\.0)?\",scope=~\"resource|\",verb=~\"LIST|GET\"} or vector(0)) + sum by (cluster) (cluster_verb_scope_le:apiserver_request_sli_duration_seconds_bucket:increase30d{le=~\"5(\\\\.0)?\",scope=\"namespace\",verb=~\"LIST|GET\"} or vector(0)) + sum by (cluster) (cluster_verb_scope_le:apiserver_request_sli_duration_seconds_bucket:increase30d{le=~\"30(\\\\.0)?\",scope=\"cluster\",verb=~\"LIST|GET\"} or vector(0))) + sum by (cluster) (code:apiserver_request_total:increase30d{code=~\"5..\",verb=\"read\"} or vector(0))) / sum by (cluster) (code:apiserver_request_total:increase30d{verb=\"read\"})",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000357777,
+                        "evaluationTime": 0.000190021,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "verb": "write"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:46.073536641Z",
+                        "lastEvaluation": "2026-07-16T17:14:07.957121096Z",
                         "name": "apiserver_request:availability30d",
                         "query": "1 - ((sum by (cluster) (cluster_verb_scope:apiserver_request_sli_duration_seconds_count:increase30d{verb=~\"POST|PUT|PATCH|DELETE\"}) - sum by (cluster) (cluster_verb_scope_le:apiserver_request_sli_duration_seconds_bucket:increase30d{le=~\"1(\\\\.0)?\",verb=~\"POST|PUT|PATCH|DELETE\"} or vector(0))) + sum by (cluster) (code:apiserver_request_total:increase30d{code=~\"5..\",verb=\"write\"} or vector(0))) / sum by (cluster) (code:apiserver_request_total:increase30d{verb=\"write\"})",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000220538,
+                        "evaluationTime": 8.0643e-05,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:46.071392929Z",
+                        "lastEvaluation": "2026-07-16T17:14:07.956186778Z",
                         "name": "cluster_verb_scope:apiserver_request_sli_duration_seconds_count:increase1h",
                         "query": "sum by (cluster, verb, scope) (cluster_verb_scope_le:apiserver_request_sli_duration_seconds_bucket:increase1h{le=\"+Inf\"})",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000177457,
+                        "evaluationTime": 7.2706e-05,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:46.071628926Z",
+                        "lastEvaluation": "2026-07-16T17:14:07.956271367Z",
                         "name": "cluster_verb_scope:apiserver_request_sli_duration_seconds_count:increase30d",
                         "query": "sum by (cluster, verb, scope) (cluster_verb_scope_le:apiserver_request_sli_duration_seconds_bucket:increase30d{le=\"+Inf\"})",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.005848136,
+                        "evaluationTime": 0.006506466,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:46.064632075Z",
+                        "lastEvaluation": "2026-07-16T17:14:07.949373875Z",
                         "name": "cluster_verb_scope_le:apiserver_request_sli_duration_seconds_bucket:increase1h",
                         "query": "sum by (cluster, verb, scope, le) (increase(apiserver_request_sli_duration_seconds_bucket[1h]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000865124,
+                        "evaluationTime": 0.000293139,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:46.070517619Z",
+                        "lastEvaluation": "2026-07-16T17:14:07.955889621Z",
                         "name": "cluster_verb_scope_le:apiserver_request_sli_duration_seconds_bucket:increase30d",
                         "query": "sum by (cluster, verb, scope, le) (avg_over_time(cluster_verb_scope_le:apiserver_request_sli_duration_seconds_bucket:increase1h[30d]) * 24 * 30)",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 9.7144e-05,
+                        "evaluationTime": 0.000104279,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "verb": "read"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:46.064364708Z",
+                        "lastEvaluation": "2026-07-16T17:14:07.949171158Z",
                         "name": "code:apiserver_request_total:increase30d",
                         "query": "sum by (cluster, code) (code_verb:apiserver_request_total:increase30d{verb=~\"LIST|GET\"})",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000159138,
+                        "evaluationTime": 9.0222e-05,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "verb": "write"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:46.064467211Z",
+                        "lastEvaluation": "2026-07-16T17:14:07.949279766Z",
                         "name": "code:apiserver_request_total:increase30d",
                         "query": "sum by (cluster, code) (code_verb:apiserver_request_total:increase30d{verb=~\"POST|PUT|PATCH|DELETE\"})",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.001642389,
+                        "evaluationTime": 0.000725959,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "verb": "read"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:46.073905523Z",
+                        "lastEvaluation": "2026-07-16T17:14:07.957314975Z",
                         "name": "code_resource:apiserver_request_total:rate5m",
                         "query": "sum by (cluster, code, resource) (rate(apiserver_request_total{job=\"apiserver\",verb=~\"LIST|GET\"}[5m]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.00075079,
+                        "evaluationTime": 0.000376277,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "verb": "write"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:46.075557971Z",
+                        "lastEvaluation": "2026-07-16T17:14:07.958046595Z",
                         "name": "code_resource:apiserver_request_total:rate5m",
                         "query": "sum by (cluster, code, resource) (rate(apiserver_request_total{job=\"apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[5m]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000849093,
+                        "evaluationTime": 0.000624495,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:46.076317842Z",
+                        "lastEvaluation": "2026-07-16T17:14:07.958427762Z",
                         "name": "code_verb:apiserver_request_total:increase1h",
                         "query": "sum by (cluster, code, verb) (increase(apiserver_request_total{code=~\"2..\",job=\"apiserver\",verb=~\"LIST|GET|POST|PUT|PATCH|DELETE\"}[1h]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000168629,
+                        "evaluationTime": 8.8889e-05,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:46.077182778Z",
+                        "lastEvaluation": "2026-07-16T17:14:07.959056996Z",
                         "name": "code_verb:apiserver_request_total:increase1h",
                         "query": "sum by (cluster, code, verb) (increase(apiserver_request_total{code=~\"3..\",job=\"apiserver\",verb=~\"LIST|GET|POST|PUT|PATCH|DELETE\"}[1h]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000336093,
+                        "evaluationTime": 0.000137176,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:46.077358701Z",
+                        "lastEvaluation": "2026-07-16T17:14:07.959149893Z",
                         "name": "code_verb:apiserver_request_total:increase1h",
                         "query": "sum by (cluster, code, verb) (increase(apiserver_request_total{code=~\"4..\",job=\"apiserver\",verb=~\"LIST|GET|POST|PUT|PATCH|DELETE\"}[1h]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000156516,
+                        "evaluationTime": 7.5722e-05,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:46.077708586Z",
+                        "lastEvaluation": "2026-07-16T17:14:07.959290615Z",
                         "name": "code_verb:apiserver_request_total:increase1h",
                         "query": "sum by (cluster, code, verb) (increase(apiserver_request_total{code=~\"5..\",job=\"apiserver\",verb=~\"LIST|GET|POST|PUT|PATCH|DELETE\"}[1h]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000264564,
+                        "evaluationTime": 0.000280033,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:46.064093641Z",
+                        "lastEvaluation": "2026-07-16T17:14:07.948885494Z",
                         "name": "code_verb:apiserver_request_total:increase30d",
                         "query": "avg_over_time(code_verb:apiserver_request_total:increase1h[30d]) * 24 * 30",
                         "type": "recording"
@@ -2165,178 +2340,178 @@
                 ]
             },
             {
-                "evaluationTime": 0.024135427,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kube-apiserver-burnrate.rules-7e52c853-9587-42e0-b516-52e4b6bbe489.yaml",
+                "evaluationTime": 0.017662009,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kube-apiserver-burnrate.rules-f690c7c6-a1e1-4ee7-a068-51a49a9db12e.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:01:47.593341819Z",
+                "lastEvaluation": "2026-07-16T17:15:44.204702502Z",
                 "limit": 0,
                 "name": "kube-apiserver-burnrate.rules",
                 "partialResponseStrategy": "ABORT",
                 "rules": [
                     {
-                        "evaluationTime": 0.002840787,
+                        "evaluationTime": 0.002440885,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "verb": "read"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:47.593399281Z",
+                        "lastEvaluation": "2026-07-16T17:15:44.204726221Z",
                         "name": "apiserver_request:burnrate1d",
                         "query": "((sum by (cluster) (rate(apiserver_request_sli_duration_seconds_count{job=\"apiserver\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"LIST|GET\"}[1d])) - ((sum by (cluster) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",le=~\"1(\\\\.0)?\",scope=~\"resource|\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"LIST|GET\"}[1d])) or vector(0)) + sum by (cluster) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",le=~\"5(\\\\.0)?\",scope=\"namespace\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"LIST|GET\"}[1d])) + sum by (cluster) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",le=~\"30(\\\\.0)?\",scope=\"cluster\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"LIST|GET\"}[1d])))) + sum by (cluster) (rate(apiserver_request_total{code=~\"5..\",job=\"apiserver\",verb=~\"LIST|GET\"}[1d]))) / sum by (cluster) (rate(apiserver_request_total{job=\"apiserver\",verb=~\"LIST|GET\"}[1d]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.001227703,
+                        "evaluationTime": 0.000903496,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "verb": "write"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:47.609371695Z",
+                        "lastEvaluation": "2026-07-16T17:15:44.217029489Z",
                         "name": "apiserver_request:burnrate1d",
                         "query": "((sum by (cluster) (rate(apiserver_request_sli_duration_seconds_count{job=\"apiserver\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"POST|PUT|PATCH|DELETE\"}[1d])) - sum by (cluster) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",le=~\"1(\\\\.0)?\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"POST|PUT|PATCH|DELETE\"}[1d]))) + sum by (cluster) (rate(apiserver_request_total{code=~\"5..\",job=\"apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[1d]))) / sum by (cluster) (rate(apiserver_request_total{job=\"apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[1d]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.002063487,
+                        "evaluationTime": 0.001675548,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "verb": "read"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:47.596264942Z",
+                        "lastEvaluation": "2026-07-16T17:15:44.207174482Z",
                         "name": "apiserver_request:burnrate1h",
                         "query": "((sum by (cluster) (rate(apiserver_request_sli_duration_seconds_count{job=\"apiserver\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"LIST|GET\"}[1h])) - ((sum by (cluster) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",le=~\"1(\\\\.0)?\",scope=~\"resource|\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"LIST|GET\"}[1h])) or vector(0)) + sum by (cluster) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",le=~\"5(\\\\.0)?\",scope=\"namespace\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"LIST|GET\"}[1h])) + sum by (cluster) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",le=~\"30(\\\\.0)?\",scope=\"cluster\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"LIST|GET\"}[1h])))) + sum by (cluster) (rate(apiserver_request_total{code=~\"5..\",job=\"apiserver\",verb=~\"LIST|GET\"}[1h]))) / sum by (cluster) (rate(apiserver_request_total{job=\"apiserver\",verb=~\"LIST|GET\"}[1h]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.001041782,
+                        "evaluationTime": 0.000765908,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "verb": "write"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:47.610627745Z",
+                        "lastEvaluation": "2026-07-16T17:15:44.217937383Z",
                         "name": "apiserver_request:burnrate1h",
                         "query": "((sum by (cluster) (rate(apiserver_request_sli_duration_seconds_count{job=\"apiserver\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"POST|PUT|PATCH|DELETE\"}[1h])) - sum by (cluster) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",le=~\"1(\\\\.0)?\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"POST|PUT|PATCH|DELETE\"}[1h]))) + sum by (cluster) (rate(apiserver_request_total{code=~\"5..\",job=\"apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[1h]))) / sum by (cluster) (rate(apiserver_request_total{job=\"apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[1h]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.002036319,
+                        "evaluationTime": 0.001762453,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "verb": "read"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:47.598343867Z",
+                        "lastEvaluation": "2026-07-16T17:15:44.208855781Z",
                         "name": "apiserver_request:burnrate2h",
                         "query": "((sum by (cluster) (rate(apiserver_request_sli_duration_seconds_count{job=\"apiserver\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"LIST|GET\"}[2h])) - ((sum by (cluster) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",le=~\"1(\\\\.0)?\",scope=~\"resource|\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"LIST|GET\"}[2h])) or vector(0)) + sum by (cluster) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",le=~\"5(\\\\.0)?\",scope=\"namespace\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"LIST|GET\"}[2h])) + sum by (cluster) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",le=~\"30(\\\\.0)?\",scope=\"cluster\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"LIST|GET\"}[2h])))) + sum by (cluster) (rate(apiserver_request_total{code=~\"5..\",job=\"apiserver\",verb=~\"LIST|GET\"}[2h]))) / sum by (cluster) (rate(apiserver_request_total{job=\"apiserver\",verb=~\"LIST|GET\"}[2h]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.001092786,
+                        "evaluationTime": 0.000761822,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "verb": "write"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:47.611676684Z",
+                        "lastEvaluation": "2026-07-16T17:15:44.218707241Z",
                         "name": "apiserver_request:burnrate2h",
                         "query": "((sum by (cluster) (rate(apiserver_request_sli_duration_seconds_count{job=\"apiserver\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"POST|PUT|PATCH|DELETE\"}[2h])) - sum by (cluster) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",le=~\"1(\\\\.0)?\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"POST|PUT|PATCH|DELETE\"}[2h]))) + sum by (cluster) (rate(apiserver_request_total{code=~\"5..\",job=\"apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[2h]))) / sum by (cluster) (rate(apiserver_request_total{job=\"apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[2h]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.002134559,
+                        "evaluationTime": 0.001658644,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "verb": "read"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:47.600389398Z",
+                        "lastEvaluation": "2026-07-16T17:15:44.210622822Z",
                         "name": "apiserver_request:burnrate30m",
                         "query": "((sum by (cluster) (rate(apiserver_request_sli_duration_seconds_count{job=\"apiserver\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"LIST|GET\"}[30m])) - ((sum by (cluster) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",le=~\"1(\\\\.0)?\",scope=~\"resource|\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"LIST|GET\"}[30m])) or vector(0)) + sum by (cluster) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",le=~\"5(\\\\.0)?\",scope=\"namespace\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"LIST|GET\"}[30m])) + sum by (cluster) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",le=~\"30(\\\\.0)?\",scope=\"cluster\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"LIST|GET\"}[30m])))) + sum by (cluster) (rate(apiserver_request_total{code=~\"5..\",job=\"apiserver\",verb=~\"LIST|GET\"}[30m]))) / sum by (cluster) (rate(apiserver_request_total{job=\"apiserver\",verb=~\"LIST|GET\"}[30m]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.001041158,
+                        "evaluationTime": 0.000739306,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "verb": "write"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:47.612786081Z",
+                        "lastEvaluation": "2026-07-16T17:15:44.219472659Z",
                         "name": "apiserver_request:burnrate30m",
                         "query": "((sum by (cluster) (rate(apiserver_request_sli_duration_seconds_count{job=\"apiserver\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"POST|PUT|PATCH|DELETE\"}[30m])) - sum by (cluster) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",le=~\"1(\\\\.0)?\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"POST|PUT|PATCH|DELETE\"}[30m]))) + sum by (cluster) (rate(apiserver_request_total{code=~\"5..\",job=\"apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[30m]))) / sum by (cluster) (rate(apiserver_request_total{job=\"apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[30m]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.002103486,
+                        "evaluationTime": 0.001676399,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "verb": "read"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:47.602534189Z",
+                        "lastEvaluation": "2026-07-16T17:15:44.212286366Z",
                         "name": "apiserver_request:burnrate3d",
                         "query": "((sum by (cluster) (rate(apiserver_request_sli_duration_seconds_count{job=\"apiserver\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"LIST|GET\"}[3d])) - ((sum by (cluster) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",le=~\"1(\\\\.0)?\",scope=~\"resource|\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"LIST|GET\"}[3d])) or vector(0)) + sum by (cluster) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",le=~\"5(\\\\.0)?\",scope=\"namespace\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"LIST|GET\"}[3d])) + sum by (cluster) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",le=~\"30(\\\\.0)?\",scope=\"cluster\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"LIST|GET\"}[3d])))) + sum by (cluster) (rate(apiserver_request_total{code=~\"5..\",job=\"apiserver\",verb=~\"LIST|GET\"}[3d]))) / sum by (cluster) (rate(apiserver_request_total{job=\"apiserver\",verb=~\"LIST|GET\"}[3d]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.001105849,
+                        "evaluationTime": 0.000720959,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "verb": "write"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:47.613834488Z",
+                        "lastEvaluation": "2026-07-16T17:15:44.22021937Z",
                         "name": "apiserver_request:burnrate3d",
                         "query": "((sum by (cluster) (rate(apiserver_request_sli_duration_seconds_count{job=\"apiserver\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"POST|PUT|PATCH|DELETE\"}[3d])) - sum by (cluster) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",le=~\"1(\\\\.0)?\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"POST|PUT|PATCH|DELETE\"}[3d]))) + sum by (cluster) (rate(apiserver_request_total{code=~\"5..\",job=\"apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[3d]))) / sum by (cluster) (rate(apiserver_request_total{job=\"apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[3d]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.002425687,
+                        "evaluationTime": 0.001431758,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "verb": "read"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:47.604646748Z",
+                        "lastEvaluation": "2026-07-16T17:15:44.213967243Z",
                         "name": "apiserver_request:burnrate5m",
                         "query": "((sum by (cluster) (rate(apiserver_request_sli_duration_seconds_count{job=\"apiserver\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"LIST|GET\"}[5m])) - ((sum by (cluster) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",le=~\"1(\\\\.0)?\",scope=~\"resource|\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"LIST|GET\"}[5m])) or vector(0)) + sum by (cluster) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",le=~\"5(\\\\.0)?\",scope=\"namespace\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"LIST|GET\"}[5m])) + sum by (cluster) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",le=~\"30(\\\\.0)?\",scope=\"cluster\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"LIST|GET\"}[5m])))) + sum by (cluster) (rate(apiserver_request_total{code=~\"5..\",job=\"apiserver\",verb=~\"LIST|GET\"}[5m]))) / sum by (cluster) (rate(apiserver_request_total{job=\"apiserver\",verb=~\"LIST|GET\"}[5m]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.00104327,
+                        "evaluationTime": 0.00066185,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "verb": "write"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:47.614947357Z",
+                        "lastEvaluation": "2026-07-16T17:15:44.220944708Z",
                         "name": "apiserver_request:burnrate5m",
                         "query": "((sum by (cluster) (rate(apiserver_request_sli_duration_seconds_count{job=\"apiserver\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"POST|PUT|PATCH|DELETE\"}[5m])) - sum by (cluster) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",le=~\"1(\\\\.0)?\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"POST|PUT|PATCH|DELETE\"}[5m]))) + sum by (cluster) (rate(apiserver_request_total{code=~\"5..\",job=\"apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[5m]))) / sum by (cluster) (rate(apiserver_request_total{job=\"apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[5m]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.002263939,
+                        "evaluationTime": 0.001620458,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "verb": "read"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:47.607098975Z",
+                        "lastEvaluation": "2026-07-16T17:15:44.215404392Z",
                         "name": "apiserver_request:burnrate6h",
                         "query": "((sum by (cluster) (rate(apiserver_request_sli_duration_seconds_count{job=\"apiserver\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"LIST|GET\"}[6h])) - ((sum by (cluster) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",le=~\"1(\\\\.0)?\",scope=~\"resource|\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"LIST|GET\"}[6h])) or vector(0)) + sum by (cluster) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",le=~\"5(\\\\.0)?\",scope=\"namespace\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"LIST|GET\"}[6h])) + sum by (cluster) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",le=~\"30(\\\\.0)?\",scope=\"cluster\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"LIST|GET\"}[6h])))) + sum by (cluster) (rate(apiserver_request_total{code=~\"5..\",job=\"apiserver\",verb=~\"LIST|GET\"}[6h]))) / sum by (cluster) (rate(apiserver_request_total{job=\"apiserver\",verb=~\"LIST|GET\"}[6h]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.001467974,
+                        "evaluationTime": 0.00075195,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "verb": "write"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:47.616000504Z",
+                        "lastEvaluation": "2026-07-16T17:15:44.221610136Z",
                         "name": "apiserver_request:burnrate6h",
                         "query": "((sum by (cluster) (rate(apiserver_request_sli_duration_seconds_count{job=\"apiserver\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"POST|PUT|PATCH|DELETE\"}[6h])) - sum by (cluster) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",le=~\"1(\\\\.0)?\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"POST|PUT|PATCH|DELETE\"}[6h]))) + sum by (cluster) (rate(apiserver_request_total{code=~\"5..\",job=\"apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[6h]))) / sum by (cluster) (rate(apiserver_request_total{job=\"apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[6h]))",
                         "type": "recording"
@@ -2344,36 +2519,36 @@
                 ]
             },
             {
-                "evaluationTime": 0.009383997,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kube-apiserver-histogram.rules-dd1c1135-4a93-47c6-8987-98207326ee92.yaml",
+                "evaluationTime": 0.006379101,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kube-apiserver-histogram.rules-b0a68af8-4a3b-409f-b0ce-e3712646fbcf.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:01:45.249832478Z",
+                "lastEvaluation": "2026-07-16T17:16:00.044903205Z",
                 "limit": 0,
                 "name": "kube-apiserver-histogram.rules",
                 "partialResponseStrategy": "ABORT",
                 "rules": [
                     {
-                        "evaluationTime": 0.006727965,
+                        "evaluationTime": 0.004519554,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "quantile": "0.99",
                             "verb": "read"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:45.249875618Z",
+                        "lastEvaluation": "2026-07-16T17:16:00.044936892Z",
                         "name": "cluster_quantile:apiserver_request_sli_duration_seconds:histogram_quantile",
                         "query": "histogram_quantile(0.99, sum by (cluster, le, resource) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"LIST|GET\"}[5m]))) > 0",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.002589996,
+                        "evaluationTime": 0.0018115,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "quantile": "0.99",
                             "verb": "write"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:45.25662198Z",
+                        "lastEvaluation": "2026-07-16T17:16:00.049467869Z",
                         "name": "cluster_quantile:apiserver_request_sli_duration_seconds:histogram_quantile",
                         "query": "histogram_quantile(0.99, sum by (cluster, le, resource) (rate(apiserver_request_sli_duration_seconds_bucket{job=\"apiserver\",subresource!~\"proxy|attach|log|exec|portforward\",verb=~\"POST|PUT|PATCH|DELETE\"}[5m]))) > 0",
                         "type": "recording"
@@ -2381,10 +2556,10 @@
                 ]
             },
             {
-                "evaluationTime": 0.000964517,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kube-apiserver-slos-e995aeb9-fc04-4897-baeb-5c2b23fb3e79.yaml",
+                "evaluationTime": 0.000585587,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kube-apiserver-slos-82018d0c-c31c-4218-9c0e-e4da5edde672.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:01:47.70973737Z",
+                "lastEvaluation": "2026-07-16T17:15:48.497734251Z",
                 "limit": 0,
                 "name": "kube-apiserver-slos",
                 "partialResponseStrategy": "ABORT",
@@ -2397,7 +2572,7 @@
                             "summary": "The API server is burning too much error budget."
                         },
                         "duration": 3600,
-                        "evaluationTime": 0.000151192,
+                        "evaluationTime": 0.000106965,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
@@ -2406,7 +2581,7 @@
                             "severity": "warning",
                             "short": "2h"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:47.710369541Z",
+                        "lastEvaluation": "2026-07-16T17:15:48.498109786Z",
                         "name": "KubeAPIErrorBudgetBurn",
                         "query": "sum by (cluster) (apiserver_request:burnrate1d) > (3 * 0.01) and on (cluster) sum by (cluster) (apiserver_request:burnrate2h) > (3 * 0.01)",
                         "state": "inactive",
@@ -2420,7 +2595,7 @@
                             "summary": "The API server is burning too much error budget."
                         },
                         "duration": 120,
-                        "evaluationTime": 0.000371062,
+                        "evaluationTime": 0.000242387,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
@@ -2429,7 +2604,7 @@
                             "severity": "critical",
                             "short": "5m"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:47.709766397Z",
+                        "lastEvaluation": "2026-07-16T17:15:48.497766647Z",
                         "name": "KubeAPIErrorBudgetBurn",
                         "query": "sum by (cluster) (apiserver_request:burnrate1h) > (14.4 * 0.01) and on (cluster) sum by (cluster) (apiserver_request:burnrate5m) > (14.4 * 0.01)",
                         "state": "inactive",
@@ -2443,7 +2618,7 @@
                             "summary": "The API server is burning too much error budget."
                         },
                         "duration": 10800,
-                        "evaluationTime": 0.000166567,
+                        "evaluationTime": 9.5152e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
@@ -2452,7 +2627,7 @@
                             "severity": "warning",
                             "short": "6h"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:47.710527101Z",
+                        "lastEvaluation": "2026-07-16T17:15:48.498221581Z",
                         "name": "KubeAPIErrorBudgetBurn",
                         "query": "sum by (cluster) (apiserver_request:burnrate3d) > (1 * 0.01) and on (cluster) sum by (cluster) (apiserver_request:burnrate6h) > (1 * 0.01)",
                         "state": "inactive",
@@ -2466,7 +2641,7 @@
                             "summary": "The API server is burning too much error budget."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.00021604,
+                        "evaluationTime": 9.0222e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
@@ -2475,7 +2650,7 @@
                             "severity": "critical",
                             "short": "30m"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:47.710147Z",
+                        "lastEvaluation": "2026-07-16T17:15:48.498014654Z",
                         "name": "KubeAPIErrorBudgetBurn",
                         "query": "sum by (cluster) (apiserver_request:burnrate6h) > (6 * 0.01) and on (cluster) sum by (cluster) (apiserver_request:burnrate30m) > (6 * 0.01)",
                         "state": "inactive",
@@ -2484,32 +2659,32 @@
                 ]
             },
             {
-                "evaluationTime": 0.001001768,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kube-prometheus-general.rules-3fd2055b-ac49-4eda-9cf4-fea7d6387345.yaml",
+                "evaluationTime": 0.000534454,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kube-prometheus-general.rules-b6e20d30-08db-4b3c-a747-5292d56ec254.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:02:02.051552368Z",
+                "lastEvaluation": "2026-07-16T17:15:57.600351258Z",
                 "limit": 0,
                 "name": "kube-prometheus-general.rules",
                 "partialResponseStrategy": "ABORT",
                 "rules": [
                     {
-                        "evaluationTime": 0.000414717,
+                        "evaluationTime": 0.000129701,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:02.052135801Z",
+                        "lastEvaluation": "2026-07-16T17:15:57.600753206Z",
                         "name": "count:up0",
                         "query": "count without (instance, pod, node) (up == 0)",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.00053021,
+                        "evaluationTime": 0.000372598,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:02.051585789Z",
+                        "lastEvaluation": "2026-07-16T17:15:57.600373503Z",
                         "name": "count:up1",
                         "query": "count without (instance, pod, node) (up == 1)",
                         "type": "recording"
@@ -2517,76 +2692,76 @@
                 ]
             },
             {
-                "evaluationTime": 0.001699007,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kube-prometheus-node-recording.rules-af83528f-e528-4808-96f6-fcef8b483cc0.yaml",
+                "evaluationTime": 0.001480005,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kube-prometheus-node-recording.rules-51914710-a1a4-4d67-aa87-6cb3c0ccc418.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:01:47.190199162Z",
+                "lastEvaluation": "2026-07-16T17:15:54.673716953Z",
                 "limit": 0,
                 "name": "kube-prometheus-node-recording.rules",
                 "partialResponseStrategy": "ABORT",
                 "rules": [
                     {
-                        "evaluationTime": 0.000178209,
+                        "evaluationTime": 0.000180514,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:47.191716175Z",
+                        "lastEvaluation": "2026-07-16T17:15:54.675014611Z",
                         "name": "cluster:node_cpu:ratio",
                         "query": "cluster:node_cpu:sum_rate5m / count(sum by (instance, cpu) (node_cpu_seconds_total))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000181446,
+                        "evaluationTime": 0.000165062,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:47.191522428Z",
+                        "lastEvaluation": "2026-07-16T17:15:54.674846614Z",
                         "name": "cluster:node_cpu:sum_rate5m",
                         "query": "sum(rate(node_cpu_seconds_total{mode!=\"idle\",mode!=\"iowait\",mode!=\"steal\"}[5m]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000432385,
+                        "evaluationTime": 0.0003535,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:47.190243255Z",
+                        "lastEvaluation": "2026-07-16T17:15:54.673740791Z",
                         "name": "instance:node_cpu:rate:sum",
                         "query": "sum by (instance) (rate(node_cpu_seconds_total{mode!=\"idle\",mode!=\"iowait\",mode!=\"steal\"}[3m]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000323458,
+                        "evaluationTime": 0.00038843,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:47.191191462Z",
+                        "lastEvaluation": "2026-07-16T17:15:54.674453414Z",
                         "name": "instance:node_cpu:ratio",
                         "query": "sum without (cpu, mode) (rate(node_cpu_seconds_total{mode!=\"idle\",mode!=\"iowait\",mode!=\"steal\"}[5m])) / on (instance) group_left () count by (instance) (sum by (instance, cpu) (node_cpu_seconds_total))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000254899,
+                        "evaluationTime": 0.000187045,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:47.190684645Z",
+                        "lastEvaluation": "2026-07-16T17:15:54.674102177Z",
                         "name": "instance:node_network_receive_bytes:rate:sum",
                         "query": "sum by (instance) (rate(node_network_receive_bytes_total[3m]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000205338,
+                        "evaluationTime": 0.000155452,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:47.190956652Z",
+                        "lastEvaluation": "2026-07-16T17:15:54.674294524Z",
                         "name": "instance:node_network_transmit_bytes:rate:sum",
                         "query": "sum by (instance) (rate(node_network_transmit_bytes_total[3m]))",
                         "type": "recording"
@@ -2594,118 +2769,118 @@
                 ]
             },
             {
-                "evaluationTime": 0.004389876,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kube-scheduler.rules-e4bd1944-b568-430e-a5f0-b068e845b158.yaml",
+                "evaluationTime": 0.002812444,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kube-scheduler.rules-a3a31551-d873-41e8-92d4-42f8f34a5b34.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:01:57.24183047Z",
+                "lastEvaluation": "2026-07-16T17:15:45.586938149Z",
                 "limit": 0,
                 "name": "kube-scheduler.rules",
                 "partialResponseStrategy": "ABORT",
                 "rules": [
                     {
-                        "evaluationTime": 0.000593647,
+                        "evaluationTime": 0.000371798,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "quantile": "0.5"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:57.245622554Z",
+                        "lastEvaluation": "2026-07-16T17:15:45.58937623Z",
                         "name": "cluster_quantile:scheduler_pod_scheduling_sli_duration_seconds:histogram_quantile",
                         "query": "histogram_quantile(0.5, sum without (instance, pod) (rate(scheduler_pod_scheduling_sli_duration_seconds_bucket{job=\"kube-scheduler\"}[5m])))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000592899,
+                        "evaluationTime": 0.000433592,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "quantile": "0.9"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:57.244551296Z",
+                        "lastEvaluation": "2026-07-16T17:15:45.588620691Z",
                         "name": "cluster_quantile:scheduler_pod_scheduling_sli_duration_seconds:histogram_quantile",
                         "query": "histogram_quantile(0.9, sum without (instance, pod) (rate(scheduler_pod_scheduling_sli_duration_seconds_bucket{job=\"kube-scheduler\"}[5m])))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000797697,
+                        "evaluationTime": 0.000693704,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "quantile": "0.99"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:57.243146376Z",
+                        "lastEvaluation": "2026-07-16T17:15:45.587587635Z",
                         "name": "cluster_quantile:scheduler_pod_scheduling_sli_duration_seconds:histogram_quantile",
                         "query": "histogram_quantile(0.99, sum without (instance, pod) (rate(scheduler_pod_scheduling_sli_duration_seconds_bucket{job=\"kube-scheduler\"}[5m])))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000215488,
+                        "evaluationTime": 0.000127295,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "quantile": "0.5"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:57.245400017Z",
+                        "lastEvaluation": "2026-07-16T17:15:45.589245768Z",
                         "name": "cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile",
                         "query": "histogram_quantile(0.5, sum without (instance, pod) (rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job=\"kube-scheduler\"}[5m])))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.00027648,
+                        "evaluationTime": 0.00012871,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "quantile": "0.9"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:57.24426244Z",
+                        "lastEvaluation": "2026-07-16T17:15:45.588488084Z",
                         "name": "cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile",
                         "query": "histogram_quantile(0.9, sum without (instance, pod) (rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job=\"kube-scheduler\"}[5m])))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000372953,
+                        "evaluationTime": 0.000193549,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "quantile": "0.99"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:57.242762247Z",
+                        "lastEvaluation": "2026-07-16T17:15:45.587389727Z",
                         "name": "cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile",
                         "query": "histogram_quantile(0.99, sum without (instance, pod) (rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job=\"kube-scheduler\"}[5m])))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000241645,
+                        "evaluationTime": 0.000182958,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "quantile": "0.5"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:57.245151892Z",
+                        "lastEvaluation": "2026-07-16T17:15:45.589058962Z",
                         "name": "cluster_quantile:scheduler_scheduling_attempt_duration_seconds:histogram_quantile",
                         "query": "histogram_quantile(0.5, sum without (instance, pod) (rate(scheduler_scheduling_attempt_duration_seconds_bucket{job=\"kube-scheduler\"}[5m])))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000300415,
+                        "evaluationTime": 0.000195974,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "quantile": "0.9"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:57.243954188Z",
+                        "lastEvaluation": "2026-07-16T17:15:45.588288313Z",
                         "name": "cluster_quantile:scheduler_scheduling_attempt_duration_seconds:histogram_quantile",
                         "query": "histogram_quantile(0.9, sum without (instance, pod) (rate(scheduler_scheduling_attempt_duration_seconds_bucket{job=\"kube-scheduler\"}[5m])))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000862993,
+                        "evaluationTime": 0.000407639,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "quantile": "0.99"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:57.241887178Z",
+                        "lastEvaluation": "2026-07-16T17:15:45.586974362Z",
                         "name": "cluster_quantile:scheduler_scheduling_attempt_duration_seconds:histogram_quantile",
                         "query": "histogram_quantile(0.99, sum without (instance, pod) (rate(scheduler_scheduling_attempt_duration_seconds_bucket{job=\"kube-scheduler\"}[5m])))",
                         "type": "recording"
@@ -2713,10 +2888,10 @@
                 ]
             },
             {
-                "evaluationTime": 0.000744078,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kube-state-metrics-980d9741-53a8-4139-a932-6f80b780fa80.yaml",
+                "evaluationTime": 0.000546999,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kube-state-metrics-969e5c18-f6db-4582-8283-a99552e1be6a.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:02:06.506464947Z",
+                "lastEvaluation": "2026-07-16T17:15:58.479933831Z",
                 "limit": 0,
                 "name": "kube-state-metrics",
                 "partialResponseStrategy": "ABORT",
@@ -2729,14 +2904,14 @@
                             "summary": "kube-state-metrics is experiencing errors in list operations."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000229869,
+                        "evaluationTime": 0.000280222,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:06.506541998Z",
+                        "lastEvaluation": "2026-07-16T17:15:58.479964704Z",
                         "name": "KubeStateMetricsListErrors",
                         "query": "(sum by (cluster) (rate(kube_state_metrics_list_total{job=\"kube-state-metrics\",result=\"error\"}[5m])) / sum by (cluster) (rate(kube_state_metrics_list_total{job=\"kube-state-metrics\"}[5m]))) > 0.01",
                         "state": "inactive",
@@ -2750,14 +2925,14 @@
                             "summary": "kube-state-metrics sharding is misconfigured."
                         },
                         "duration": 900,
-                        "evaluationTime": 9.8758e-05,
+                        "evaluationTime": 3.5672e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:06.506885768Z",
+                        "lastEvaluation": "2026-07-16T17:15:58.480323124Z",
                         "name": "KubeStateMetricsShardingMismatch",
                         "query": "stdvar by (cluster) (kube_state_metrics_total_shards{job=\"kube-state-metrics\"}) != 0",
                         "state": "inactive",
@@ -2771,14 +2946,14 @@
                             "summary": "kube-state-metrics shards are missing."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000215674,
+                        "evaluationTime": 0.000117135,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:06.506990067Z",
+                        "lastEvaluation": "2026-07-16T17:15:58.48036128Z",
                         "name": "KubeStateMetricsShardsMissing",
                         "query": "2 ^ max by (cluster) (kube_state_metrics_total_shards{job=\"kube-state-metrics\"}) - 1 - sum by (cluster) (2 ^ max by (cluster, shard_ordinal) (kube_state_metrics_shard_ordinal{job=\"kube-state-metrics\"})) != 0",
                         "state": "inactive",
@@ -2792,14 +2967,14 @@
                             "summary": "kube-state-metrics is experiencing errors in watch operations."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000102374,
+                        "evaluationTime": 7.0502e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:06.506778484Z",
+                        "lastEvaluation": "2026-07-16T17:15:58.480249646Z",
                         "name": "KubeStateMetricsWatchErrors",
                         "query": "(sum by (cluster) (rate(kube_state_metrics_watch_total{job=\"kube-state-metrics\",result=\"error\"}[5m])) / sum by (cluster) (rate(kube_state_metrics_watch_total{job=\"kube-state-metrics\"}[5m]))) > 0.01",
                         "state": "inactive",
@@ -2808,46 +2983,46 @@
                 ]
             },
             {
-                "evaluationTime": 0.001135739,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kubelet.rules-4d4003ef-9c1b-478e-8134-3137387beb3c.yaml",
+                "evaluationTime": 0.000688023,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kubelet.rules-4d3bc2d6-f378-451a-ae58-728c3c47f298.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:02:06.404139221Z",
+                "lastEvaluation": "2026-07-16T17:15:56.122579653Z",
                 "limit": 0,
                 "name": "kubelet.rules",
                 "partialResponseStrategy": "ABORT",
                 "rules": [
                     {
-                        "evaluationTime": 0.000257368,
+                        "evaluationTime": 0.000150032,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "quantile": "0.5"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:06.405012948Z",
+                        "lastEvaluation": "2026-07-16T17:15:56.123115349Z",
                         "name": "node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile",
                         "query": "histogram_quantile(0.5, sum by (cluster, instance, le) (rate(kubelet_pleg_relist_duration_seconds_bucket{job=\"kubelet\",metrics_path=\"/metrics\"}[5m])) * on (cluster, instance) group_left (node) max by (cluster, instance, node) (kubelet_node_name{job=\"kubelet\",metrics_path=\"/metrics\"}))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000271454,
+                        "evaluationTime": 0.000167497,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "quantile": "0.9"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:06.404733055Z",
+                        "lastEvaluation": "2026-07-16T17:15:56.122944076Z",
                         "name": "node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile",
                         "query": "histogram_quantile(0.9, sum by (cluster, instance, le) (rate(kubelet_pleg_relist_duration_seconds_bucket{job=\"kubelet\",metrics_path=\"/metrics\"}[5m])) * on (cluster, instance) group_left (node) max by (cluster, instance, node) (kubelet_node_name{job=\"kubelet\",metrics_path=\"/metrics\"}))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000533464,
+                        "evaluationTime": 0.000341927,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "quantile": "0.99"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:06.404189076Z",
+                        "lastEvaluation": "2026-07-16T17:15:56.122595805Z",
                         "name": "node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile",
                         "query": "histogram_quantile(0.99, sum by (cluster, instance, le) (rate(kubelet_pleg_relist_duration_seconds_bucket{job=\"kubelet\",metrics_path=\"/metrics\"}[5m])) * on (cluster, instance) group_left (node) max by (cluster, instance, node) (kubelet_node_name{job=\"kubelet\",metrics_path=\"/metrics\"}))",
                         "type": "recording"
@@ -2855,10 +3030,10 @@
                 ]
             },
             {
-                "evaluationTime": 0.005134125,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kubernetes-apps-9e41bd67-47c1-4490-aa71-e565a3a203a7.yaml",
+                "evaluationTime": 0.002628572,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kubernetes-apps-1e29719e-25f3-4522-8d7d-1ad76d66f692.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:01:48.283564777Z",
+                "lastEvaluation": "2026-07-16T17:16:00.731892245Z",
                 "limit": 0,
                 "name": "kubernetes-apps",
                 "partialResponseStrategy": "ABORT",
@@ -2871,14 +3046,14 @@
                             "summary": "Pod container waiting longer than 1 hour"
                         },
                         "duration": 3600,
-                        "evaluationTime": 9.8156e-05,
+                        "evaluationTime": 5.1454e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:48.2875027Z",
+                        "lastEvaluation": "2026-07-16T17:16:00.734050332Z",
                         "name": "KubeContainerWaiting",
                         "query": "kube_pod_container_status_waiting_reason{job=\"kube-state-metrics\",namespace=~\".*\",reason!=\"CrashLoopBackOff\"} > 0",
                         "state": "inactive",
@@ -2892,14 +3067,14 @@
                             "summary": "DaemonSet pods are misscheduled."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.00011815,
+                        "evaluationTime": 5.2896e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:48.287802574Z",
+                        "lastEvaluation": "2026-07-16T17:16:00.734202016Z",
                         "name": "KubeDaemonSetMisScheduled",
                         "query": "kube_daemonset_status_number_misscheduled{job=\"kube-state-metrics\",namespace=~\".*\"} > 0",
                         "state": "inactive",
@@ -2913,14 +3088,14 @@
                             "summary": "DaemonSet pods are not scheduled."
                         },
                         "duration": 600,
-                        "evaluationTime": 0.000190738,
+                        "evaluationTime": 9.4721e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:48.287606299Z",
+                        "lastEvaluation": "2026-07-16T17:16:00.734104491Z",
                         "name": "KubeDaemonSetNotScheduled",
                         "query": "kube_daemonset_status_desired_number_scheduled{job=\"kube-state-metrics\",namespace=~\".*\"} - kube_daemonset_status_current_number_scheduled{job=\"kube-state-metrics\",namespace=~\".*\"} > 0",
                         "state": "inactive",
@@ -2934,14 +3109,14 @@
                             "summary": "DaemonSet rollout is stuck."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000545105,
+                        "evaluationTime": 0.000361297,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:48.286933987Z",
+                        "lastEvaluation": "2026-07-16T17:16:00.733685529Z",
                         "name": "KubeDaemonSetRolloutStuck",
                         "query": "((kube_daemonset_status_current_number_scheduled{job=\"kube-state-metrics\",namespace=~\".*\"} != kube_daemonset_status_desired_number_scheduled{job=\"kube-state-metrics\",namespace=~\".*\"}) or (kube_daemonset_status_number_misscheduled{job=\"kube-state-metrics\",namespace=~\".*\"} != 0) or (kube_daemonset_status_updated_number_scheduled{job=\"kube-state-metrics\",namespace=~\".*\"} != kube_daemonset_status_desired_number_scheduled{job=\"kube-state-metrics\",namespace=~\".*\"}) or (kube_daemonset_status_number_available{job=\"kube-state-metrics\",namespace=~\".*\"} != kube_daemonset_status_desired_number_scheduled{job=\"kube-state-metrics\",namespace=~\".*\"})) and (changes(kube_daemonset_status_updated_number_scheduled{job=\"kube-state-metrics\",namespace=~\".*\"}[5m]) == 0)",
                         "state": "inactive",
@@ -2955,14 +3130,14 @@
                             "summary": "Deployment generation mismatch due to possible roll-back"
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000310635,
+                        "evaluationTime": 0.000197997,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:48.285127756Z",
+                        "lastEvaluation": "2026-07-16T17:16:00.732730459Z",
                         "name": "KubeDeploymentGenerationMismatch",
                         "query": "kube_deployment_status_observed_generation{job=\"kube-state-metrics\",namespace=~\".*\"} != kube_deployment_metadata_generation{job=\"kube-state-metrics\",namespace=~\".*\"}",
                         "state": "inactive",
@@ -2976,14 +3151,14 @@
                             "summary": "Deployment has not matched the expected number of replicas."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000451188,
+                        "evaluationTime": 0.000273099,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:48.285445825Z",
+                        "lastEvaluation": "2026-07-16T17:16:00.732932515Z",
                         "name": "KubeDeploymentReplicasMismatch",
                         "query": "(kube_deployment_spec_replicas{job=\"kube-state-metrics\",namespace=~\".*\"} > kube_deployment_status_replicas_available{job=\"kube-state-metrics\",namespace=~\".*\"}) and (changes(kube_deployment_status_replicas_updated{job=\"kube-state-metrics\",namespace=~\".*\"}[10m]) == 0)",
                         "state": "inactive",
@@ -2997,14 +3172,14 @@
                             "summary": "Deployment rollout is not progressing."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000170251,
+                        "evaluationTime": 9.3188e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:48.285902937Z",
+                        "lastEvaluation": "2026-07-16T17:16:00.733209211Z",
                         "name": "KubeDeploymentRolloutStuck",
                         "query": "kube_deployment_status_condition{condition=\"Progressing\",job=\"kube-state-metrics\",namespace=~\".*\",status=\"false\"} != 0",
                         "state": "inactive",
@@ -3018,14 +3193,14 @@
                             "summary": "HPA is running at max replicas"
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000159209,
+                        "evaluationTime": 7.2796e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:48.288195883Z",
+                        "lastEvaluation": "2026-07-16T17:16:00.73438288Z",
                         "name": "KubeHpaMaxedOut",
                         "query": "(kube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\",namespace=~\".*\"} == kube_horizontalpodautoscaler_spec_max_replicas{job=\"kube-state-metrics\",namespace=~\".*\"}) and on (namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_spec_max_replicas{job=\"kube-state-metrics\",namespace=~\".*\"} != kube_horizontalpodautoscaler_spec_min_replicas{job=\"kube-state-metrics\",namespace=~\".*\"})",
                         "state": "inactive",
@@ -3039,14 +3214,14 @@
                             "summary": "HPA has not matched desired number of replicas."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000264258,
+                        "evaluationTime": 0.000122545,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:48.287926153Z",
+                        "lastEvaluation": "2026-07-16T17:16:00.734257448Z",
                         "name": "KubeHpaReplicasMismatch",
                         "query": "(kube_horizontalpodautoscaler_status_desired_replicas{job=\"kube-state-metrics\",namespace=~\".*\"} != kube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\",namespace=~\".*\"}) and (kube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\",namespace=~\".*\"} > kube_horizontalpodautoscaler_spec_min_replicas{job=\"kube-state-metrics\",namespace=~\".*\"}) and (kube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\",namespace=~\".*\"} < kube_horizontalpodautoscaler_spec_max_replicas{job=\"kube-state-metrics\",namespace=~\".*\"}) and changes(kube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\",namespace=~\".*\"}[15m]) == 0",
                         "state": "inactive",
@@ -3060,14 +3235,14 @@
                             "summary": "PDB does not have enough healthy pods."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000331256,
+                        "evaluationTime": 6.0391e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:48.288364426Z",
+                        "lastEvaluation": "2026-07-16T17:16:00.734458151Z",
                         "name": "KubePdbNotEnoughHealthyPods",
                         "query": "(kube_poddisruptionbudget_status_desired_healthy{job=\"kube-state-metrics\",namespace=~\".*\"} - kube_poddisruptionbudget_status_current_healthy{job=\"kube-state-metrics\",namespace=~\".*\"}) > 0",
                         "state": "inactive",
@@ -3081,14 +3256,14 @@
                             "summary": "Pod is crash looping."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000287277,
+                        "evaluationTime": 0.000188828,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:48.283600596Z",
+                        "lastEvaluation": "2026-07-16T17:16:00.731914499Z",
                         "name": "KubePodCrashLooping",
                         "query": "max_over_time(kube_pod_container_status_waiting_reason{job=\"kube-state-metrics\",namespace=~\".*\",reason=\"CrashLoopBackOff\"}[5m]) >= 1",
                         "state": "inactive",
@@ -3102,14 +3277,14 @@
                             "summary": "Pod has been in a non-ready state for more than 15 minutes."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.001225209,
+                        "evaluationTime": 0.00061709,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:48.28389528Z",
+                        "lastEvaluation": "2026-07-16T17:16:00.732107838Z",
                         "name": "KubePodNotReady",
                         "query": "sum by (namespace, pod, job, cluster) (max by (namespace, pod, job, cluster) (kube_pod_status_phase{job=\"kube-state-metrics\",namespace=~\".*\",phase=~\"Pending|Unknown\"}) * on (namespace, pod, cluster) group_left (owner_kind) topk by (namespace, pod, cluster) (1, max by (namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!=\"Job\"}))) > 0",
                         "state": "inactive",
@@ -3123,14 +3298,14 @@
                             "summary": "StatefulSet generation mismatch due to possible roll-back"
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000175339,
+                        "evaluationTime": 6.3157e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:48.286307015Z",
+                        "lastEvaluation": "2026-07-16T17:16:00.733421358Z",
                         "name": "KubeStatefulSetGenerationMismatch",
                         "query": "kube_statefulset_status_observed_generation{job=\"kube-state-metrics\",namespace=~\".*\"} != kube_statefulset_metadata_generation{job=\"kube-state-metrics\",namespace=~\".*\"}",
                         "state": "inactive",
@@ -3144,14 +3319,14 @@
                             "summary": "StatefulSet has not matched the expected number of replicas."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000222588,
+                        "evaluationTime": 0.000110973,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:48.286078608Z",
+                        "lastEvaluation": "2026-07-16T17:16:00.733307279Z",
                         "name": "KubeStatefulSetReplicasMismatch",
                         "query": "(kube_statefulset_status_replicas_ready{job=\"kube-state-metrics\",namespace=~\".*\"} != kube_statefulset_replicas{job=\"kube-state-metrics\",namespace=~\".*\"}) and (changes(kube_statefulset_status_replicas_updated{job=\"kube-state-metrics\",namespace=~\".*\"}[10m]) == 0)",
                         "state": "inactive",
@@ -3165,14 +3340,14 @@
                             "summary": "StatefulSet update has not been rolled out."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000421138,
+                        "evaluationTime": 0.000194952,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:48.286506046Z",
+                        "lastEvaluation": "2026-07-16T17:16:00.73348748Z",
                         "name": "KubeStatefulSetUpdateNotRolledOut",
                         "query": "(max by (namespace, statefulset, job, cluster) (kube_statefulset_status_current_revision{job=\"kube-state-metrics\",namespace=~\".*\"} unless kube_statefulset_status_update_revision{job=\"kube-state-metrics\",namespace=~\".*\"}) * on (namespace, statefulset, job, cluster) (kube_statefulset_replicas{job=\"kube-state-metrics\",namespace=~\".*\"} != kube_statefulset_status_replicas_updated{job=\"kube-state-metrics\",namespace=~\".*\"})) and on (namespace, statefulset, job, cluster) (changes(kube_statefulset_status_replicas_updated{job=\"kube-state-metrics\",namespace=~\".*\"}[5m]) == 0)",
                         "state": "inactive",
@@ -3181,10 +3356,10 @@
                 ]
             },
             {
-                "evaluationTime": 0.002337118,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kubernetes-resources-7acfed41-bc68-45af-852a-c6aec4ddedf8.yaml",
+                "evaluationTime": 0.001419843,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kubernetes-resources-0a30f16c-c3ac-407f-906e-2ba52a2a8066.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:02:07.582847603Z",
+                "lastEvaluation": "2026-07-16T17:15:57.0287269Z",
                 "limit": 0,
                 "name": "kubernetes-resources",
                 "partialResponseStrategy": "ABORT",
@@ -3197,14 +3372,14 @@
                             "summary": "Processes experience elevated CPU throttling."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000399392,
+                        "evaluationTime": 0.000340414,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "info"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:07.584782265Z",
+                        "lastEvaluation": "2026-07-16T17:15:57.029804144Z",
                         "name": "CPUThrottlingHigh",
                         "query": "sum without (id, metrics_path, name, image, endpoint, job, node) (topk by (cluster, namespace, pod, container, instance) (1, increase(container_cpu_cfs_throttled_periods_total{container!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\"}[5m]))) / on (cluster, namespace, pod, container, instance) group_left () sum without (id, metrics_path, name, image, endpoint, job, node) (topk by (cluster, namespace, pod, container, instance) (1, increase(container_cpu_cfs_periods_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\"}[5m]))) > (25 / 100)",
                         "state": "inactive",
@@ -3218,14 +3393,14 @@
                             "summary": "Cluster has overcommitted CPU resource requests."
                         },
                         "duration": 600,
-                        "evaluationTime": 0.000598422,
+                        "evaluationTime": 0.000376256,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:07.582877201Z",
+                        "lastEvaluation": "2026-07-16T17:15:57.028752581Z",
                         "name": "KubeCPUOvercommit",
                         "query": "((sum by (cluster) (namespace_cpu:kube_pod_container_resource_requests:sum) - sum by (cluster) (kube_node_status_allocatable{job=\"kube-state-metrics\",resource=\"cpu\"}) > 0) and count by (cluster) (max by (cluster, node) (kube_node_role{job=\"kube-state-metrics\",role=\"control-plane\"})) < 3) or (sum by (cluster) (namespace_cpu:kube_pod_container_resource_requests:sum) - ((sum by (cluster) (kube_node_status_allocatable{job=\"kube-state-metrics\",resource=\"cpu\"}) - max by (cluster) (kube_node_status_allocatable{job=\"kube-state-metrics\",resource=\"cpu\"})) > 0) > 0)",
                         "state": "inactive",
@@ -3239,14 +3414,14 @@
                             "summary": "Cluster has overcommitted CPU resource requests."
                         },
                         "duration": 300,
-                        "evaluationTime": 0.000334715,
+                        "evaluationTime": 0.000151255,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:07.583817677Z",
+                        "lastEvaluation": "2026-07-16T17:15:57.029346344Z",
                         "name": "KubeCPUQuotaOvercommit",
                         "query": "sum by (cluster) (min without (resource) (kube_resourcequota{job=\"kube-state-metrics\",resource=~\"(cpu|requests.cpu)\",type=\"hard\"})) / sum by (cluster) (kube_node_status_allocatable{job=\"kube-state-metrics\",resource=\"cpu\"}) > 1.5",
                         "state": "inactive",
@@ -3260,14 +3435,14 @@
                             "summary": "Cluster has overcommitted memory resource requests."
                         },
                         "duration": 600,
-                        "evaluationTime": 0.000327307,
+                        "evaluationTime": 0.000210102,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:07.583484543Z",
+                        "lastEvaluation": "2026-07-16T17:15:57.029133377Z",
                         "name": "KubeMemoryOvercommit",
                         "query": "((sum by (cluster) (namespace_memory:kube_pod_container_resource_requests:sum) - sum by (cluster) (kube_node_status_allocatable{job=\"kube-state-metrics\",resource=\"memory\"}) > 0) and count by (cluster) (max by (cluster, node) (kube_node_role{job=\"kube-state-metrics\",role=\"control-plane\"})) < 3) or (sum by (cluster) (namespace_memory:kube_pod_container_resource_requests:sum) - ((sum by (cluster) (kube_node_status_allocatable{job=\"kube-state-metrics\",resource=\"memory\"}) - max by (cluster) (kube_node_status_allocatable{job=\"kube-state-metrics\",resource=\"memory\"})) > 0) > 0)",
                         "state": "inactive",
@@ -3281,14 +3456,14 @@
                             "summary": "Cluster has overcommitted memory resource requests."
                         },
                         "duration": 300,
-                        "evaluationTime": 0.000194183,
+                        "evaluationTime": 0.000109961,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:07.584159267Z",
+                        "lastEvaluation": "2026-07-16T17:15:57.029500594Z",
                         "name": "KubeMemoryQuotaOvercommit",
                         "query": "sum by (cluster) (min without (resource) (kube_resourcequota{job=\"kube-state-metrics\",resource=~\"(memory|requests.memory)\",type=\"hard\"})) / sum by (cluster) (kube_node_status_allocatable{job=\"kube-state-metrics\",resource=\"memory\"}) > 1.5",
                         "state": "inactive",
@@ -3302,14 +3477,14 @@
                             "summary": "Namespace quota is going to be full."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000191571,
+                        "evaluationTime": 6.7978e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "info"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:07.584359066Z",
+                        "lastEvaluation": "2026-07-16T17:15:57.029613571Z",
                         "name": "KubeQuotaAlmostFull",
                         "query": "max without (instance, job, type) (kube_resourcequota{job=\"kube-state-metrics\",type=\"used\"}) / on (cluster, namespace, resource, resourcequota) group_left () (max without (instance, job, type) (kube_resourcequota{job=\"kube-state-metrics\",type=\"hard\"}) > 0) > 0.9 < 1",
                         "state": "inactive",
@@ -3323,14 +3498,14 @@
                             "summary": "Namespace quota has exceeded the limits."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000118776,
+                        "evaluationTime": 5.7496e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:07.584655805Z",
+                        "lastEvaluation": "2026-07-16T17:15:57.029743843Z",
                         "name": "KubeQuotaExceeded",
                         "query": "max without (instance, job, type) (kube_resourcequota{job=\"kube-state-metrics\",type=\"used\"}) / on (cluster, namespace, resource, resourcequota) group_left () (max without (instance, job, type) (kube_resourcequota{job=\"kube-state-metrics\",type=\"hard\"}) > 0) > 1",
                         "state": "inactive",
@@ -3344,14 +3519,14 @@
                             "summary": "Namespace quota is fully used."
                         },
                         "duration": 900,
-                        "evaluationTime": 9.38e-05,
+                        "evaluationTime": 5.8257e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "info"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:07.584557971Z",
+                        "lastEvaluation": "2026-07-16T17:15:57.029683693Z",
                         "name": "KubeQuotaFullyUsed",
                         "query": "max without (instance, job, type) (kube_resourcequota{job=\"kube-state-metrics\",type=\"used\"}) / on (cluster, namespace, resource, resourcequota) group_left () (max without (instance, job, type) (kube_resourcequota{job=\"kube-state-metrics\",type=\"hard\"}) > 0) == 1",
                         "state": "inactive",
@@ -3360,10 +3535,10 @@
                 ]
             },
             {
-                "evaluationTime": 0.001727241,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kubernetes-storage-64dd7b07-b618-4f19-bd71-0333c7590e76.yaml",
+                "evaluationTime": 0.001117958,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kubernetes-storage-1898baae-04a6-4e50-b091-9178c5d1497d.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:01:59.804096116Z",
+                "lastEvaluation": "2026-07-16T17:15:37.659244593Z",
                 "limit": 0,
                 "name": "kubernetes-storage",
                 "partialResponseStrategy": "ABORT",
@@ -3376,14 +3551,14 @@
                             "summary": "PersistentVolume is having issues with provisioning."
                         },
                         "duration": 300,
-                        "evaluationTime": 0.000100663,
+                        "evaluationTime": 6.5932e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:59.805719749Z",
+                        "lastEvaluation": "2026-07-16T17:15:37.660294272Z",
                         "name": "KubePersistentVolumeErrors",
                         "query": "kube_persistentvolume_status_phase{job=\"kube-state-metrics\",phase=~\"Failed|Pending\"} > 0",
                         "state": "inactive",
@@ -3397,14 +3572,14 @@
                             "summary": "PersistentVolume is filling up."
                         },
                         "duration": 60,
-                        "evaluationTime": 0.000527518,
+                        "evaluationTime": 0.000354092,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:59.804173924Z",
+                        "lastEvaluation": "2026-07-16T17:15:37.6592632Z",
                         "name": "KubePersistentVolumeFillingUp",
                         "query": "(kubelet_volume_stats_available_bytes{job=\"kubelet\",metrics_path=\"/metrics\",namespace=~\".*\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\",metrics_path=\"/metrics\",namespace=~\".*\"}) < 0.03 and kubelet_volume_stats_used_bytes{job=\"kubelet\",metrics_path=\"/metrics\",namespace=~\".*\"} > 0 unless on (cluster, namespace, persistentvolumeclaim) kube_persistentvolumeclaim_access_mode{access_mode=\"ReadOnlyMany\"} == 1 unless on (cluster, namespace, persistentvolumeclaim) kube_persistentvolumeclaim_labels{label_excluded_from_alerts=\"true\"} == 1",
                         "state": "inactive",
@@ -3418,14 +3593,14 @@
                             "summary": "PersistentVolume is filling up."
                         },
                         "duration": 3600,
-                        "evaluationTime": 0.000378462,
+                        "evaluationTime": 0.000290253,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:59.804708833Z",
+                        "lastEvaluation": "2026-07-16T17:15:37.659623203Z",
                         "name": "KubePersistentVolumeFillingUp",
                         "query": "(kubelet_volume_stats_available_bytes{job=\"kubelet\",metrics_path=\"/metrics\",namespace=~\".*\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\",metrics_path=\"/metrics\",namespace=~\".*\"}) < 0.15 and kubelet_volume_stats_used_bytes{job=\"kubelet\",metrics_path=\"/metrics\",namespace=~\".*\"} > 0 and predict_linear(kubelet_volume_stats_available_bytes{job=\"kubelet\",metrics_path=\"/metrics\",namespace=~\".*\"}[6h], 4 * 24 * 3600) < 0 unless on (cluster, namespace, persistentvolumeclaim) kube_persistentvolumeclaim_access_mode{access_mode=\"ReadOnlyMany\"} == 1 unless on (cluster, namespace, persistentvolumeclaim) kube_persistentvolumeclaim_labels{label_excluded_from_alerts=\"true\"} == 1",
                         "state": "inactive",
@@ -3439,14 +3614,14 @@
                             "summary": "PersistentVolumeInodes are filling up."
                         },
                         "duration": 60,
-                        "evaluationTime": 0.000263879,
+                        "evaluationTime": 0.000157706,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:59.805093759Z",
+                        "lastEvaluation": "2026-07-16T17:15:37.659917545Z",
                         "name": "KubePersistentVolumeInodesFillingUp",
                         "query": "(kubelet_volume_stats_inodes_free{job=\"kubelet\",metrics_path=\"/metrics\",namespace=~\".*\"} / kubelet_volume_stats_inodes{job=\"kubelet\",metrics_path=\"/metrics\",namespace=~\".*\"}) < 0.03 and kubelet_volume_stats_inodes_used{job=\"kubelet\",metrics_path=\"/metrics\",namespace=~\".*\"} > 0 unless on (cluster, namespace, persistentvolumeclaim) kube_persistentvolumeclaim_access_mode{access_mode=\"ReadOnlyMany\"} == 1 unless on (cluster, namespace, persistentvolumeclaim) kube_persistentvolumeclaim_labels{label_excluded_from_alerts=\"true\"} == 1",
                         "state": "inactive",
@@ -3460,14 +3635,14 @@
                             "summary": "PersistentVolumeInodes are filling up."
                         },
                         "duration": 3600,
-                        "evaluationTime": 0.000348253,
+                        "evaluationTime": 0.000212117,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:59.805363997Z",
+                        "lastEvaluation": "2026-07-16T17:15:37.660078629Z",
                         "name": "KubePersistentVolumeInodesFillingUp",
                         "query": "(kubelet_volume_stats_inodes_free{job=\"kubelet\",metrics_path=\"/metrics\",namespace=~\".*\"} / kubelet_volume_stats_inodes{job=\"kubelet\",metrics_path=\"/metrics\",namespace=~\".*\"}) < 0.15 and kubelet_volume_stats_inodes_used{job=\"kubelet\",metrics_path=\"/metrics\",namespace=~\".*\"} > 0 and predict_linear(kubelet_volume_stats_inodes_free{job=\"kubelet\",metrics_path=\"/metrics\",namespace=~\".*\"}[6h], 4 * 24 * 3600) < 0 unless on (cluster, namespace, persistentvolumeclaim) kube_persistentvolumeclaim_access_mode{access_mode=\"ReadOnlyMany\"} == 1 unless on (cluster, namespace, persistentvolumeclaim) kube_persistentvolumeclaim_labels{label_excluded_from_alerts=\"true\"} == 1",
                         "state": "inactive",
@@ -3476,63 +3651,10 @@
                 ]
             },
             {
-                "evaluationTime": 0.000678457,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kubernetes-system-848cc29c-18bb-46ac-9717-3b838a94360f.yaml",
+                "evaluationTime": 0.002128348,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kubernetes-system-apiserver-feefb626-548f-487d-8c16-05a00ada258c.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:02:00.635694903Z",
-                "limit": 0,
-                "name": "kubernetes-system",
-                "partialResponseStrategy": "ABORT",
-                "rules": [
-                    {
-                        "alerts": [],
-                        "annotations": {
-                            "description": "Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance }}' is experiencing {{ $value | humanizePercentage }} errors on cluster {{ $labels.cluster }}.",
-                            "runbook_url": "https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeclienterrors",
-                            "summary": "Kubernetes API server client is experiencing errors."
-                        },
-                        "duration": 900,
-                        "evaluationTime": 0.000265452,
-                        "health": "ok",
-                        "keepFiringFor": 0,
-                        "labels": {
-                            "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
-                            "severity": "warning"
-                        },
-                        "lastEvaluation": "2026-03-31T17:02:00.636096744Z",
-                        "name": "KubeClientErrors",
-                        "query": "(sum by (cluster, instance, job, namespace) (rate(rest_client_requests_total{code=~\"5..\",job=\"apiserver\"}[5m])) / sum by (cluster, instance, job, namespace) (rate(rest_client_requests_total{job=\"apiserver\"}[5m]))) > 0.01",
-                        "state": "inactive",
-                        "type": "alerting"
-                    },
-                    {
-                        "alerts": [],
-                        "annotations": {
-                            "description": "There are {{ $value }} different semantic versions of Kubernetes components running on cluster {{ $labels.cluster }}.",
-                            "runbook_url": "https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeversionmismatch",
-                            "summary": "Different semantic versions of Kubernetes components running."
-                        },
-                        "duration": 900,
-                        "evaluationTime": 0.000340075,
-                        "health": "ok",
-                        "keepFiringFor": 0,
-                        "labels": {
-                            "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
-                            "severity": "warning"
-                        },
-                        "lastEvaluation": "2026-03-31T17:02:00.635748943Z",
-                        "name": "KubeVersionMismatch",
-                        "query": "count by (cluster) (count by (git_version, cluster) (label_replace(kubernetes_build_info{job!~\"kube-dns|coredns\"}, \"git_version\", \"$1\", \"git_version\", \"(v[0-9]*.[0-9]*).*\"))) > 1",
-                        "state": "inactive",
-                        "type": "alerting"
-                    }
-                ]
-            },
-            {
-                "evaluationTime": 0.002495536,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kubernetes-system-apiserver-25793d9f-aac9-499b-bc28-29afaab76714.yaml",
-                "interval": 30,
-                "lastEvaluation": "2026-03-31T17:02:07.691664975Z",
+                "lastEvaluation": "2026-07-16T17:15:47.519951075Z",
                 "limit": 0,
                 "name": "kubernetes-system-apiserver",
                 "partialResponseStrategy": "ABORT",
@@ -3545,14 +3667,14 @@
                             "summary": "Target disappeared from Prometheus target discovery."
                         },
                         "duration": 900,
-                        "evaluationTime": 6.2906e-05,
+                        "evaluationTime": 4.6814e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:07.692906991Z",
+                        "lastEvaluation": "2026-07-16T17:15:47.520846955Z",
                         "name": "KubeAPIDown",
                         "query": "absent(up{job=\"apiserver\"})",
                         "state": "inactive",
@@ -3566,14 +3688,14 @@
                             "summary": "The kubernetes apiserver has terminated {{ $value | humanizePercentage }} of its incoming requests."
                         },
                         "duration": 300,
-                        "evaluationTime": 0.001182814,
+                        "evaluationTime": 0.001179211,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:07.692974598Z",
+                        "lastEvaluation": "2026-07-16T17:15:47.520896855Z",
                         "name": "KubeAPITerminatedRequests",
                         "query": "sum by (cluster) (rate(apiserver_request_terminations_total{job=\"apiserver\"}[10m])) / (sum by (cluster) (rate(apiserver_request_total{job=\"apiserver\"}[10m])) + sum by (cluster) (rate(apiserver_request_terminations_total{job=\"apiserver\"}[10m]))) > 0.2",
                         "state": "inactive",
@@ -3587,14 +3709,14 @@
                             "summary": "Kubernetes aggregated API is down."
                         },
                         "duration": 300,
-                        "evaluationTime": 0.000418175,
+                        "evaluationTime": 0.000320073,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:07.692482751Z",
+                        "lastEvaluation": "2026-07-16T17:15:47.520522483Z",
                         "name": "KubeAggregatedAPIDown",
                         "query": "(1 - max by (name, namespace, cluster) (avg_over_time(aggregator_unavailable_apiservice{job=\"apiserver\"}[10m]))) * 100 < 85",
                         "state": "inactive",
@@ -3608,14 +3730,14 @@
                             "summary": "Kubernetes aggregated API has reported errors."
                         },
                         "duration": 600,
-                        "evaluationTime": 8.1397e-05,
+                        "evaluationTime": 5.6683e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:07.69239542Z",
+                        "lastEvaluation": "2026-07-16T17:15:47.52046137Z",
                         "name": "KubeAggregatedAPIErrors",
                         "query": "sum by (cluster, instance, name, reason) (increase(aggregator_unavailable_apiservice_total{job=\"apiserver\"}[1m])) > 0",
                         "state": "inactive",
@@ -3629,14 +3751,14 @@
                             "summary": "Client certificate is about to expire."
                         },
                         "duration": 300,
-                        "evaluationTime": 0.00023461,
+                        "evaluationTime": 0.000164791,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:07.692153231Z",
+                        "lastEvaluation": "2026-07-16T17:15:47.520291298Z",
                         "name": "KubeClientCertificateExpiration",
                         "query": "histogram_quantile(0.01, sum without (namespace, service, endpoint) (rate(apiserver_client_certificate_expiration_seconds_bucket{job=\"apiserver\"}[5m]))) < 86400 and on (job, cluster, instance) apiserver_client_certificate_expiration_seconds_count{job=\"apiserver\"} > 0",
                         "state": "inactive",
@@ -3650,14 +3772,14 @@
                             "summary": "Client certificate is about to expire."
                         },
                         "duration": 300,
-                        "evaluationTime": 0.000440656,
+                        "evaluationTime": 0.000313599,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:07.691703632Z",
+                        "lastEvaluation": "2026-07-16T17:15:47.519971946Z",
                         "name": "KubeClientCertificateExpiration",
                         "query": "histogram_quantile(0.01, sum without (namespace, service, endpoint) (rate(apiserver_client_certificate_expiration_seconds_bucket{job=\"apiserver\"}[5m]))) < 604800 and on (job, cluster, instance) apiserver_client_certificate_expiration_seconds_count{job=\"apiserver\"} > 0",
                         "state": "inactive",
@@ -3666,10 +3788,10 @@
                 ]
             },
             {
-                "evaluationTime": 0.000226167,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kubernetes-system-controller-manager-41f7a8ea-b1d7-4483-bec0-809787752634.yaml",
+                "evaluationTime": 0.000192577,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kubernetes-system-controller-manager-0b9eea15-0c09-4ffc-b9cb-3a697f9e0afd.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:01:55.674698464Z",
+                "lastEvaluation": "2026-07-16T17:16:03.199598519Z",
                 "limit": 0,
                 "name": "kubernetes-system-controller-manager",
                 "partialResponseStrategy": "ABORT",
@@ -3682,14 +3804,14 @@
                             "summary": "Target disappeared from Prometheus target discovery."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000198697,
+                        "evaluationTime": 0.000167436,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.674722458Z",
+                        "lastEvaluation": "2026-07-16T17:16:03.199620363Z",
                         "name": "KubeControllerManagerDown",
                         "query": "absent(up{job=\"kube-controller-manager\"})",
                         "state": "inactive",
@@ -3698,10 +3820,63 @@
                 ]
             },
             {
-                "evaluationTime": 0.000269272,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kubernetes-system-kube-proxy-28bd4840-11f8-417d-a751-3142c7b2396e.yaml",
+                "evaluationTime": 0.000461928,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kubernetes-system-fcf1c507-4754-4c50-9b82-9e29eeefbad0.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:02:00.976052959Z",
+                "lastEvaluation": "2026-07-16T17:16:06.5152707Z",
+                "limit": 0,
+                "name": "kubernetes-system",
+                "partialResponseStrategy": "ABORT",
+                "rules": [
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "description": "Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance }}' is experiencing {{ $value | humanizePercentage }} errors on cluster {{ $labels.cluster }}.",
+                            "runbook_url": "https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeclienterrors",
+                            "summary": "Kubernetes API server client is experiencing errors."
+                        },
+                        "duration": 900,
+                        "evaluationTime": 0.000168098,
+                        "health": "ok",
+                        "keepFiringFor": 0,
+                        "labels": {
+                            "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
+                            "severity": "warning"
+                        },
+                        "lastEvaluation": "2026-07-16T17:16:06.515562155Z",
+                        "name": "KubeClientErrors",
+                        "query": "(sum by (cluster, instance, job, namespace) (rate(rest_client_requests_total{code=~\"5..\",job=\"apiserver\"}[5m])) / sum by (cluster, instance, job, namespace) (rate(rest_client_requests_total{job=\"apiserver\"}[5m]))) > 0.01",
+                        "state": "inactive",
+                        "type": "alerting"
+                    },
+                    {
+                        "alerts": [],
+                        "annotations": {
+                            "description": "There are {{ $value }} different semantic versions of Kubernetes components running on cluster {{ $labels.cluster }}.",
+                            "runbook_url": "https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeversionmismatch",
+                            "summary": "Different semantic versions of Kubernetes components running."
+                        },
+                        "duration": 900,
+                        "evaluationTime": 0.000262287,
+                        "health": "ok",
+                        "keepFiringFor": 0,
+                        "labels": {
+                            "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
+                            "severity": "warning"
+                        },
+                        "lastEvaluation": "2026-07-16T17:16:06.515294858Z",
+                        "name": "KubeVersionMismatch",
+                        "query": "count by (cluster) (count by (git_version, cluster) (label_replace(kubernetes_build_info{job!~\"kube-dns|coredns\"}, \"git_version\", \"$1\", \"git_version\", \"(v[0-9]*.[0-9]*).*\"))) > 1",
+                        "state": "inactive",
+                        "type": "alerting"
+                    }
+                ]
+            },
+            {
+                "evaluationTime": 0.000210383,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kubernetes-system-kube-proxy-44198c91-191d-4ec3-98ff-b58f7df5154e.yaml",
+                "interval": 30,
+                "lastEvaluation": "2026-07-16T17:15:56.360959002Z",
                 "limit": 0,
                 "name": "kubernetes-system-kube-proxy",
                 "partialResponseStrategy": "ABORT",
@@ -3714,14 +3889,14 @@
                             "summary": "Target disappeared from Prometheus target discovery."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000223741,
+                        "evaluationTime": 0.000157728,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:00.976094079Z",
+                        "lastEvaluation": "2026-07-16T17:15:56.361008462Z",
                         "name": "KubeProxyDown",
                         "query": "absent(up{job=\"kube-proxy\"})",
                         "state": "inactive",
@@ -3730,10 +3905,10 @@
                 ]
             },
             {
-                "evaluationTime": 0.002620632,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kubernetes-system-kubelet-7f33275c-65ef-4bd1-8e74-41585aac6c82.yaml",
+                "evaluationTime": 0.00130361,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kubernetes-system-kubelet-404444fc-09d0-4b55-8993-0474ab565aec.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:02:03.264260556Z",
+                "lastEvaluation": "2026-07-16T17:16:07.064013449Z",
                 "limit": 0,
                 "name": "kubernetes-system-kubelet",
                 "partialResponseStrategy": "ABORT",
@@ -3746,14 +3921,14 @@
                             "summary": "Node is evicting pods."
                         },
                         "duration": 0,
-                        "evaluationTime": 0.000209001,
+                        "evaluationTime": 7.2416e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "info"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.265468591Z",
+                        "lastEvaluation": "2026-07-16T17:16:07.064681923Z",
                         "name": "KubeNodeEviction",
                         "query": "sum by (cluster, eviction_signal, instance) (rate(kubelet_evictions{job=\"kubelet\",metrics_path=\"/metrics\"}[15m])) * on (cluster, instance) group_left (node) max by (cluster, instance, node) (kubelet_node_name{job=\"kubelet\",metrics_path=\"/metrics\"}) > 0",
                         "state": "inactive",
@@ -3767,14 +3942,14 @@
                             "summary": "Node is not ready."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000265547,
+                        "evaluationTime": 0.000136145,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.264276593Z",
+                        "lastEvaluation": "2026-07-16T17:16:07.064033399Z",
                         "name": "KubeNodeNotReady",
                         "query": "kube_node_status_condition{condition=\"Ready\",job=\"kube-state-metrics\",status=\"true\"} == 0 and on (cluster, node) kube_node_spec_unschedulable{job=\"kube-state-metrics\"} == 0",
                         "state": "inactive",
@@ -3788,14 +3963,14 @@
                             "summary": "Node has as active Condition."
                         },
                         "duration": 300,
-                        "evaluationTime": 0.000230633,
+                        "evaluationTime": 0.00011399,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "info"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.264551777Z",
+                        "lastEvaluation": "2026-07-16T17:16:07.064174191Z",
                         "name": "KubeNodePressure",
                         "query": "kube_node_status_condition{condition=~\"(MemoryPressure|DiskPressure|PIDPressure)\",job=\"kube-state-metrics\",status=\"true\"} == 1 and on (cluster, node) kube_node_spec_unschedulable{job=\"kube-state-metrics\"} == 0",
                         "state": "inactive",
@@ -3809,14 +3984,14 @@
                             "summary": "Node readiness status is flapping."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000164268,
+                        "evaluationTime": 9.1534e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.26529889Z",
+                        "lastEvaluation": "2026-07-16T17:16:07.06458605Z",
                         "name": "KubeNodeReadinessFlapping",
                         "query": "sum by (cluster, node) (changes(kube_node_status_condition{condition=\"Ready\",job=\"kube-state-metrics\",status=\"true\"}[15m])) > 2 and on (cluster, node) kube_node_spec_unschedulable{job=\"kube-state-metrics\"} == 0",
                         "state": "inactive",
@@ -3830,14 +4005,14 @@
                             "summary": "Node is unreachable."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000218941,
+                        "evaluationTime": 0.000120001,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.264788484Z",
+                        "lastEvaluation": "2026-07-16T17:16:07.064291638Z",
                         "name": "KubeNodeUnreachable",
                         "query": "(kube_node_spec_taint{effect=\"NoSchedule\",job=\"kube-state-metrics\",key=\"node.kubernetes.io/unreachable\"} unless ignoring (key, value) kube_node_spec_taint{job=\"kube-state-metrics\",key=~\"ToBeDeletedByClusterAutoscaler|cloud.google.com/impending-node-termination|aws-node-termination-handler/spot-itn\"}) == 1",
                         "state": "inactive",
@@ -3851,14 +4026,14 @@
                             "summary": "Kubelet client certificate is about to expire."
                         },
                         "duration": 0,
-                        "evaluationTime": 4.7901e-05,
+                        "evaluationTime": 2.5702e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.266336491Z",
+                        "lastEvaluation": "2026-07-16T17:16:07.065109451Z",
                         "name": "KubeletClientCertificateExpiration",
                         "query": "kubelet_certificate_manager_client_ttl_seconds < 86400",
                         "state": "inactive",
@@ -3872,14 +4047,14 @@
                             "summary": "Kubelet client certificate is about to expire."
                         },
                         "duration": 0,
-                        "evaluationTime": 5.2627e-05,
+                        "evaluationTime": 2.8417e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.266279751Z",
+                        "lastEvaluation": "2026-07-16T17:16:07.065077858Z",
                         "name": "KubeletClientCertificateExpiration",
                         "query": "kubelet_certificate_manager_client_ttl_seconds < 604800",
                         "state": "inactive",
@@ -3893,14 +4068,14 @@
                             "summary": "Kubelet has failed to renew its client certificate."
                         },
                         "duration": 900,
-                        "evaluationTime": 7.561e-05,
+                        "evaluationTime": 3.3587e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.266613792Z",
+                        "lastEvaluation": "2026-07-16T17:16:07.065185615Z",
                         "name": "KubeletClientCertificateRenewalErrors",
                         "query": "increase(kubelet_certificate_manager_client_expiration_renew_errors[5m]) > 0",
                         "state": "inactive",
@@ -3914,14 +4089,14 @@
                             "summary": "Target disappeared from Prometheus target discovery."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.00011999,
+                        "evaluationTime": 6.5301e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.266758161Z",
+                        "lastEvaluation": "2026-07-16T17:16:07.065249583Z",
                         "name": "KubeletDown",
                         "query": "count by (cluster) (kube_node_info{job=\"kube-state-metrics\"}) unless on (cluster) count by (cluster) (up{job=\"kubelet\",metrics_path=\"/metrics\"} == 1)",
                         "state": "inactive",
@@ -3935,14 +4110,14 @@
                             "summary": "Kubelet Pod Lifecycle Event Generator is taking too long to relist."
                         },
                         "duration": 300,
-                        "evaluationTime": 9.2186e-05,
+                        "evaluationTime": 3.7545e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.265683298Z",
+                        "lastEvaluation": "2026-07-16T17:16:07.064757183Z",
                         "name": "KubeletPlegDurationHigh",
                         "query": "node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile{quantile=\"0.99\"} >= 10",
                         "state": "inactive",
@@ -3956,14 +4131,14 @@
                             "summary": "Kubelet Pod startup latency is too high."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000493374,
+                        "evaluationTime": 0.000277539,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.26578052Z",
+                        "lastEvaluation": "2026-07-16T17:16:07.064797003Z",
                         "name": "KubeletPodStartUpLatencyHigh",
                         "query": "histogram_quantile(0.99, sum by (cluster, instance, le) (topk by (cluster, instance, le, operation_type) (1, rate(kubelet_pod_worker_duration_seconds_bucket{job=\"kubelet\",metrics_path=\"/metrics\"}[5m])))) * on (cluster, instance) group_left (node) topk by (cluster, instance, node) (1, kubelet_node_name{job=\"kubelet\",metrics_path=\"/metrics\"}) > 60",
                         "state": "inactive",
@@ -3977,14 +4152,14 @@
                             "summary": "Kubelet server certificate is about to expire."
                         },
                         "duration": 0,
-                        "evaluationTime": 5.0771e-05,
+                        "evaluationTime": 2.2565e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.266549856Z",
+                        "lastEvaluation": "2026-07-16T17:16:07.065161325Z",
                         "name": "KubeletServerCertificateExpiration",
                         "query": "kubelet_certificate_manager_server_ttl_seconds < 86400",
                         "state": "inactive",
@@ -3998,14 +4173,14 @@
                             "summary": "Kubelet server certificate is about to expire."
                         },
                         "duration": 0,
-                        "evaluationTime": 0.000134604,
+                        "evaluationTime": 2.1654e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.266410951Z",
+                        "lastEvaluation": "2026-07-16T17:16:07.065137487Z",
                         "name": "KubeletServerCertificateExpiration",
                         "query": "kubelet_certificate_manager_server_ttl_seconds < 604800",
                         "state": "inactive",
@@ -4019,14 +4194,14 @@
                             "summary": "Kubelet has failed to renew its server certificate."
                         },
                         "duration": 900,
-                        "evaluationTime": 6.1397e-05,
+                        "evaluationTime": 2.6563e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.266693108Z",
+                        "lastEvaluation": "2026-07-16T17:16:07.065221235Z",
                         "name": "KubeletServerCertificateRenewalErrors",
                         "query": "increase(kubelet_server_expiration_renew_errors[5m]) > 0",
                         "state": "inactive",
@@ -4040,14 +4215,14 @@
                             "summary": "Kubelet is running at capacity."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000279955,
+                        "evaluationTime": 0.000168097,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "info"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.265013239Z",
+                        "lastEvaluation": "2026-07-16T17:16:07.064414595Z",
                         "name": "KubeletTooManyPods",
                         "query": "(max by (cluster, instance) (kubelet_running_pods{job=\"kubelet\",metrics_path=\"/metrics\"} > 1) * on (cluster, instance) group_left (node) max by (cluster, instance, node) (kubelet_node_name{job=\"kubelet\",metrics_path=\"/metrics\"})) / on (cluster, node) group_left () max by (cluster, node) (kube_node_status_capacity{job=\"kube-state-metrics\",resource=\"pods\"} != 1) > 0.95",
                         "state": "inactive",
@@ -4056,10 +4231,10 @@
                 ]
             },
             {
-                "evaluationTime": 0.000252704,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kubernetes-system-scheduler-0c99c790-a1e9-4c45-9048-a317d4d61f16.yaml",
+                "evaluationTime": 0.00022446,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-kubernetes-system-scheduler-bd8309bf-3a56-48fd-ab7a-f61c686f4429.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:02:01.547662403Z",
+                "lastEvaluation": "2026-07-16T17:15:49.733679018Z",
                 "limit": 0,
                 "name": "kubernetes-system-scheduler",
                 "partialResponseStrategy": "ABORT",
@@ -4072,14 +4247,14 @@
                             "summary": "Target disappeared from Prometheus target discovery."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000210486,
+                        "evaluationTime": 0.000202507,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:01.547700029Z",
+                        "lastEvaluation": "2026-07-16T17:15:49.733696764Z",
                         "name": "KubeSchedulerDown",
                         "query": "absent(up{job=\"kube-scheduler\"})",
                         "state": "inactive",
@@ -4088,10 +4263,10 @@
                 ]
             },
             {
-                "evaluationTime": 0.001539799,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-node-exporter-03eea86e-482a-453d-91b9-601e86d9140f.yaml",
+                "evaluationTime": 0.000800049,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-node-exporter-eb63baf7-f5a0-45b1-9fa2-8582d4d03d1c.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:02:11.69832036Z",
+                "lastEvaluation": "2026-07-16T17:15:58.070630672Z",
                 "limit": 0,
                 "name": "node-exporter",
                 "partialResponseStrategy": "ABORT",
@@ -4104,14 +4279,14 @@
                             "summary": "Bonding interface is degraded."
                         },
                         "duration": 300,
-                        "evaluationTime": 7.3956e-05,
+                        "evaluationTime": 3.5382e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:11.699782464Z",
+                        "lastEvaluation": "2026-07-16T17:15:58.071393526Z",
                         "name": "NodeBondingDegraded",
                         "query": "(node_bonding_slaves{job=\"node-exporter\"} - node_bonding_active{job=\"node-exporter\"}) != 0",
                         "state": "inactive",
@@ -4125,14 +4300,14 @@
                             "summary": "High CPU usage."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000541944,
+                        "evaluationTime": 0.000290634,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "info"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:11.698362986Z",
+                        "lastEvaluation": "2026-07-16T17:15:58.070640202Z",
                         "name": "NodeCPUHighUsage",
                         "query": "sum without (mode) (avg without (cpu) (rate(node_cpu_seconds_total{job=\"node-exporter\",mode!~\"idle|iowait\"}[2m]))) * 100 > 90",
                         "state": "inactive",
@@ -4146,14 +4321,14 @@
                             "summary": "Disk IO queue is high."
                         },
                         "duration": 1800,
-                        "evaluationTime": 0.000263738,
+                        "evaluationTime": 0.000138006,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:11.6993692Z",
+                        "lastEvaluation": "2026-07-16T17:15:58.071187012Z",
                         "name": "NodeDiskIOSaturation",
                         "query": "rate(node_disk_io_time_weighted_seconds_total{device=~\"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)\",job=\"node-exporter\"}[5m]) > 10",
                         "state": "inactive",
@@ -4167,14 +4342,14 @@
                             "summary": "Host is running out of memory."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.00019254,
+                        "evaluationTime": 0.000108447,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:11.699169696Z",
+                        "lastEvaluation": "2026-07-16T17:15:58.071075778Z",
                         "name": "NodeMemoryHighUtilization",
                         "query": "100 - (node_memory_MemAvailable_bytes{job=\"node-exporter\"} / node_memory_MemTotal_bytes{job=\"node-exporter\"} * 100) > 90",
                         "state": "inactive",
@@ -4188,14 +4363,14 @@
                             "summary": "Memory major page faults are occurring at very high rate."
                         },
                         "duration": 900,
-                        "evaluationTime": 9.8018e-05,
+                        "evaluationTime": 4.8176e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:11.699066792Z",
+                        "lastEvaluation": "2026-07-16T17:15:58.071025126Z",
                         "name": "NodeMemoryMajorPagesFaults",
                         "query": "rate(node_vmstat_pgmajfault{job=\"node-exporter\"}[5m]) > 500",
                         "state": "inactive",
@@ -4209,14 +4384,14 @@
                             "summary": "System saturated, load per core is very high."
                         },
                         "duration": 1800,
-                        "evaluationTime": 0.000147263,
+                        "evaluationTime": 8.7416e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:11.698913167Z",
+                        "lastEvaluation": "2026-07-16T17:15:58.070934633Z",
                         "name": "NodeSystemSaturation",
                         "query": "node_load1{job=\"node-exporter\"} / count without (cpu, mode) (node_cpu_seconds_total{job=\"node-exporter\",mode=\"idle\"}) > 2",
                         "state": "inactive",
@@ -4230,14 +4405,14 @@
                             "summary": "Systemd service keeps restaring, possibly crash looping."
                         },
                         "duration": 900,
-                        "evaluationTime": 6.2595e-05,
+                        "evaluationTime": 3.1263e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:11.699714738Z",
+                        "lastEvaluation": "2026-07-16T17:15:58.071359307Z",
                         "name": "NodeSystemdServiceCrashlooping",
                         "query": "increase(node_systemd_service_restart_total{job=\"node-exporter\"}[5m]) > 2",
                         "state": "inactive",
@@ -4251,14 +4426,14 @@
                             "summary": "Systemd service has entered failed state."
                         },
                         "duration": 300,
-                        "evaluationTime": 6.9258e-05,
+                        "evaluationTime": 2.8717e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:11.699639872Z",
+                        "lastEvaluation": "2026-07-16T17:15:58.071327964Z",
                         "name": "NodeSystemdServiceFailed",
                         "query": "node_systemd_unit_state{job=\"node-exporter\",state=\"failed\"} == 1",
                         "state": "inactive",
@@ -4267,175 +4442,175 @@
                 ]
             },
             {
-                "evaluationTime": 0.003997196,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-node-exporter.rules-0bbc4561-096b-453d-9d34-3e30f5bfa3a2.yaml",
+                "evaluationTime": 0.003493371,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-node-exporter.rules-a140f5c9-f5b1-45c0-99aa-551df17aaf8d.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:02:03.26309819Z",
+                "lastEvaluation": "2026-07-16T17:15:49.131419446Z",
                 "limit": 0,
                 "name": "node-exporter.rules",
                 "partialResponseStrategy": "ABORT",
                 "rules": [
                     {
-                        "evaluationTime": 0.000317078,
+                        "evaluationTime": 0.00029325,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.263454183Z",
+                        "lastEvaluation": "2026-07-16T17:15:49.131718036Z",
                         "name": "instance:node_cpu_utilisation:rate5m",
                         "query": "1 - avg without (cpu) (sum without (mode) (rate(node_cpu_seconds_total{job=\"node-exporter\",mode=~\"idle|iowait|steal\"}[5m])))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000116248,
+                        "evaluationTime": 0.000465035,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.263780938Z",
+                        "lastEvaluation": "2026-07-16T17:15:49.132017317Z",
                         "name": "instance:node_load1_per_cpu:ratio",
                         "query": "(node_load1{job=\"node-exporter\"} / instance:node_num_cpu:sum{job=\"node-exporter\"})",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.00033703,
+                        "evaluationTime": 0.000179521,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.263903547Z",
+                        "lastEvaluation": "2026-07-16T17:15:49.132487974Z",
                         "name": "instance:node_memory_utilisation:ratio",
                         "query": "1 - ((node_memory_MemAvailable_bytes{job=\"node-exporter\"} or (node_memory_Buffers_bytes{job=\"node-exporter\"} + node_memory_Cached_bytes{job=\"node-exporter\"} + node_memory_MemFree_bytes{job=\"node-exporter\"} + node_memory_Slab_bytes{job=\"node-exporter\"})) / node_memory_MemTotal_bytes{job=\"node-exporter\"})",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.00025308,
+                        "evaluationTime": 0.000147207,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.265021088Z",
+                        "lastEvaluation": "2026-07-16T17:15:49.133203091Z",
                         "name": "instance:node_network_receive_bytes_excluding_lo:rate5m",
                         "query": "sum without (device) (rate(node_network_receive_bytes_total{device!=\"lo\",job=\"node-exporter\"}[5m]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000240402,
+                        "evaluationTime": 0.000429723,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.266018044Z",
+                        "lastEvaluation": "2026-07-16T17:15:49.133731363Z",
                         "name": "instance:node_network_receive_bytes_physical:rate5m",
                         "query": "sum without (device) (rate(node_network_receive_bytes_total{device!~\"lo|veth.+\",job=\"node-exporter\"}[5m]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000256505,
+                        "evaluationTime": 0.000118769,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.265547664Z",
+                        "lastEvaluation": "2026-07-16T17:15:49.133488825Z",
                         "name": "instance:node_network_receive_drop_excluding_lo:rate5m",
                         "query": "sum without (device) (rate(node_network_receive_drop_total{device!=\"lo\",job=\"node-exporter\"}[5m]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000282458,
+                        "evaluationTime": 0.000147226,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.266521622Z",
+                        "lastEvaluation": "2026-07-16T17:15:49.134594477Z",
                         "name": "instance:node_network_receive_drop_physical:rate5m",
                         "query": "sum without (device) (rate(node_network_receive_drop_total{device!~\"lo|veth.+\",job=\"node-exporter\"}[5m]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000259152,
+                        "evaluationTime": 0.000132416,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.2652814Z",
+                        "lastEvaluation": "2026-07-16T17:15:49.133353423Z",
                         "name": "instance:node_network_transmit_bytes_excluding_lo:rate5m",
                         "query": "sum without (device) (rate(node_network_transmit_bytes_total{device!=\"lo\",job=\"node-exporter\"}[5m]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000242515,
+                        "evaluationTime": 0.000414493,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.266264557Z",
+                        "lastEvaluation": "2026-07-16T17:15:49.134174623Z",
                         "name": "instance:node_network_transmit_bytes_physical:rate5m",
                         "query": "sum without (device) (rate(node_network_transmit_bytes_total{device!~\"lo|veth.+\",job=\"node-exporter\"}[5m]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000201033,
+                        "evaluationTime": 0.000118177,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.265811965Z",
+                        "lastEvaluation": "2026-07-16T17:15:49.133610539Z",
                         "name": "instance:node_network_transmit_drop_excluding_lo:rate5m",
                         "query": "sum without (device) (rate(node_network_transmit_drop_total{device!=\"lo\",job=\"node-exporter\"}[5m]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000280832,
+                        "evaluationTime": 0.00016431,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.266810892Z",
+                        "lastEvaluation": "2026-07-16T17:15:49.134746102Z",
                         "name": "instance:node_network_transmit_drop_physical:rate5m",
                         "query": "sum without (device) (rate(node_network_transmit_drop_total{device!~\"lo|veth.+\",job=\"node-exporter\"}[5m]))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000275732,
+                        "evaluationTime": 0.000262478,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.263169056Z",
+                        "lastEvaluation": "2026-07-16T17:15:49.131448364Z",
                         "name": "instance:node_num_cpu:sum",
                         "query": "count without (cpu, mode) (node_cpu_seconds_total{job=\"node-exporter\",mode=\"idle\"})",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000118492,
+                        "evaluationTime": 0.000111774,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.264246999Z",
+                        "lastEvaluation": "2026-07-16T17:15:49.132671112Z",
                         "name": "instance:node_vmstat_pgmajfault:rate5m",
                         "query": "rate(node_vmstat_pgmajfault{job=\"node-exporter\"}[5m])",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000378479,
+                        "evaluationTime": 0.000221996,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.264379989Z",
+                        "lastEvaluation": "2026-07-16T17:15:49.132787224Z",
                         "name": "instance_device:node_disk_io_time_seconds:rate5m",
                         "query": "rate(node_disk_io_time_seconds_total{device=~\"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)\",job=\"node-exporter\"}[5m])",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000246336,
+                        "evaluationTime": 0.000184992,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:03.264767069Z",
+                        "lastEvaluation": "2026-07-16T17:15:49.13301348Z",
                         "name": "instance_device:node_disk_io_time_weighted_seconds:rate5m",
                         "query": "rate(node_disk_io_time_weighted_seconds_total{device=~\"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)\",job=\"node-exporter\"}[5m])",
                         "type": "recording"
@@ -4443,10 +4618,10 @@
                 ]
             },
             {
-                "evaluationTime": 0.000667234,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-node-network-0812e1f3-ffe2-422b-a2b1-9a3bfbe9f02b.yaml",
+                "evaluationTime": 0.000337498,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-node-network-d463039d-a503-4be2-aea0-83056accd968.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:01:50.731667489Z",
+                "lastEvaluation": "2026-07-16T17:15:50.464692282Z",
                 "limit": 0,
                 "name": "node-network",
                 "partialResponseStrategy": "ABORT",
@@ -4459,14 +4634,14 @@
                             "summary": "Network interface is often changing its status"
                         },
                         "duration": 120,
-                        "evaluationTime": 0.000607175,
+                        "evaluationTime": 0.000312808,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:50.73172289Z",
+                        "lastEvaluation": "2026-07-16T17:15:50.464713415Z",
                         "name": "NodeNetworkInterfaceFlapping",
                         "query": "changes(node_network_up{device!~\"veth.+\",job=\"node-exporter\"}[2m]) > 2",
                         "state": "inactive",
@@ -4475,65 +4650,65 @@
                 ]
             },
             {
-                "evaluationTime": 0.001465429,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-node.rules-fb96c505-677c-49bb-a610-092703f4ad93.yaml",
+                "evaluationTime": 0.001196726,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-node.rules-77729aef-75da-4343-8163-a39bd442bc3b.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:02:10.921440648Z",
+                "lastEvaluation": "2026-07-16T17:16:01.065691637Z",
                 "limit": 0,
                 "name": "node.rules",
                 "partialResponseStrategy": "ABORT",
                 "rules": [
                     {
-                        "evaluationTime": 0.000230211,
+                        "evaluationTime": 0.000148138,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:10.92237722Z",
+                        "lastEvaluation": "2026-07-16T17:16:01.066472387Z",
                         "name": ":node_memory_MemAvailable_bytes:sum",
                         "query": "sum by (cluster) (node_memory_MemAvailable_bytes{job=\"node-exporter\"} or (node_memory_Buffers_bytes{job=\"node-exporter\"} + node_memory_Cached_bytes{job=\"node-exporter\"} + node_memory_MemFree_bytes{job=\"node-exporter\"} + node_memory_Slab_bytes{job=\"node-exporter\"}))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 7.9892e-05,
+                        "evaluationTime": 6.6394e-05,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:10.92282352Z",
+                        "lastEvaluation": "2026-07-16T17:16:01.066820267Z",
                         "name": "cluster:node_cpu:ratio_rate5m",
                         "query": "avg by (cluster) (node:node_cpu_utilization:ratio_rate5m)",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000202794,
+                        "evaluationTime": 0.000193318,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:10.922614147Z",
+                        "lastEvaluation": "2026-07-16T17:16:01.066623911Z",
                         "name": "node:node_cpu_utilization:ratio_rate5m",
                         "query": "avg by (cluster, node) (sum without (mode) (rate(node_cpu_seconds_total{job=\"node-exporter\",mode!=\"idle\",mode!=\"iowait\",mode!=\"steal\"}[5m])))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000289559,
+                        "evaluationTime": 0.000242136,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:10.92208046Z",
+                        "lastEvaluation": "2026-07-16T17:16:01.066226233Z",
                         "name": "node:node_num_cpu:sum",
                         "query": "count by (cluster, node) (node_cpu_seconds_total{job=\"node-exporter\",mode=\"idle\"} * on (cluster, namespace, pod) group_left (node) topk by (cluster, namespace, pod) (1, node_namespace_pod:kube_pod_info:))",
                         "type": "recording"
                     },
                     {
-                        "evaluationTime": 0.000550111,
+                        "evaluationTime": 0.000508843,
                         "health": "ok",
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus"
                         },
-                        "lastEvaluation": "2026-03-31T17:02:10.921514058Z",
+                        "lastEvaluation": "2026-07-16T17:16:01.065712139Z",
                         "name": "node_namespace_pod:kube_pod_info:",
                         "query": "topk by (cluster, namespace, pod) (1, max by (cluster, node, namespace, pod) (label_replace(kube_pod_info{job=\"kube-state-metrics\",node!=\"\"}, \"pod\", \"$1\", \"pod\", \"(.*)\")))",
                         "type": "recording"
@@ -4541,10 +4716,10 @@
                 ]
             },
             {
-                "evaluationTime": 0.004059733,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-prometheus-4be40a5a-38c6-4293-b519-90802870b018.yaml",
+                "evaluationTime": 0.00208972,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-prometheus-18c2074c-fdbb-4d5d-8609-83255da97c41.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:01:50.539665915Z",
+                "lastEvaluation": "2026-07-16T17:15:59.470301241Z",
                 "limit": 0,
                 "name": "prometheus",
                 "partialResponseStrategy": "ABORT",
@@ -4557,14 +4732,14 @@
                             "summary": "Failed Prometheus configuration reload."
                         },
                         "duration": 600,
-                        "evaluationTime": 0.000311313,
+                        "evaluationTime": 0.000166044,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:50.539698322Z",
+                        "lastEvaluation": "2026-07-16T17:15:59.470319669Z",
                         "name": "PrometheusBadConfig",
                         "query": "max_over_time(prometheus_config_last_reload_successful{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) == 0",
                         "state": "inactive",
@@ -4578,14 +4753,14 @@
                             "summary": "Prometheus is dropping samples with duplicate timestamps."
                         },
                         "duration": 600,
-                        "evaluationTime": 0.00011891,
+                        "evaluationTime": 5.2055e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:50.541502962Z",
+                        "lastEvaluation": "2026-07-16T17:15:59.471277564Z",
                         "name": "PrometheusDuplicateTimestamps",
                         "query": "rate(prometheus_target_scrapes_sample_duplicate_timestamp_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) > 0",
                         "state": "inactive",
@@ -4599,14 +4774,14 @@
                             "summary": "Prometheus encounters more than 3% errors sending alerts to any Alertmanager."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000254962,
+                        "evaluationTime": 9.1695e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:50.543467112Z",
+                        "lastEvaluation": "2026-07-16T17:15:59.472296712Z",
                         "name": "PrometheusErrorSendingAlertsToAnyAlertmanager",
                         "query": "min without (alertmanager) (rate(prometheus_notifications_errors_total{alertmanager!~\"\",job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) / rate(prometheus_notifications_sent_total{alertmanager!~\"\",job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m])) * 100 > 3",
                         "state": "inactive",
@@ -4620,14 +4795,14 @@
                             "summary": "More than 1% of alerts sent by Prometheus to a specific Alertmanager were affected by errors."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000194735,
+                        "evaluationTime": 8.7496e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:50.540435104Z",
+                        "lastEvaluation": "2026-07-16T17:15:59.470732408Z",
                         "name": "PrometheusErrorSendingAlertsToSomeAlertmanagers",
                         "query": "(rate(prometheus_notifications_errors_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) / rate(prometheus_notifications_sent_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m])) * 100 > 1",
                         "state": "inactive",
@@ -4641,14 +4816,14 @@
                             "summary": "Prometheus is reaching its maximum capacity serving concurrent requests."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000129357,
+                        "evaluationTime": 7.504e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:50.543332524Z",
+                        "lastEvaluation": "2026-07-16T17:15:59.472218635Z",
                         "name": "PrometheusHighQueryLoad",
                         "query": "avg_over_time(prometheus_engine_queries{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) / max_over_time(prometheus_engine_queries_concurrent_max{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) > 0.8",
                         "state": "inactive",
@@ -4662,14 +4837,14 @@
                             "summary": "Requests in Kubernetes SD are failing."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000106346,
+                        "evaluationTime": 5.5152e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:50.540122717Z",
+                        "lastEvaluation": "2026-07-16T17:15:59.470562957Z",
                         "name": "PrometheusKubernetesListWatchFailures",
                         "query": "increase(prometheus_sd_kubernetes_failures_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) > 0",
                         "state": "inactive",
@@ -4683,14 +4858,14 @@
                             "summary": "Prometheus has dropped targets because some scrape configs have exceeded the labels limit."
                         },
                         "duration": 900,
-                        "evaluationTime": 9.7084e-05,
+                        "evaluationTime": 4.3909e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:50.542874989Z",
+                        "lastEvaluation": "2026-07-16T17:15:59.471985867Z",
                         "name": "PrometheusLabelLimitHit",
                         "query": "increase(prometheus_target_scrape_pool_exceeded_label_limits_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) > 0",
                         "state": "inactive",
@@ -4704,14 +4879,14 @@
                             "summary": "Prometheus is missing rule evaluations due to slow rule group evaluation."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000287508,
+                        "evaluationTime": 0.000143389,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:50.542474236Z",
+                        "lastEvaluation": "2026-07-16T17:15:59.471786577Z",
                         "name": "PrometheusMissingRuleEvaluations",
                         "query": "increase(prometheus_rule_group_iterations_missed_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) > 0",
                         "state": "inactive",
@@ -4725,14 +4900,14 @@
                             "summary": "Prometheus is not connected to any Alertmanagers."
                         },
                         "duration": 600,
-                        "evaluationTime": 0.000123216,
+                        "evaluationTime": 5.5191e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:50.540635003Z",
+                        "lastEvaluation": "2026-07-16T17:15:59.470844493Z",
                         "name": "PrometheusNotConnectedToAlertmanagers",
                         "query": "max_over_time(prometheus_notifications_alertmanagers_discovered{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) < 1",
                         "state": "inactive",
@@ -4746,14 +4921,14 @@
                             "summary": "Prometheus is not ingesting samples."
                         },
                         "duration": 600,
-                        "evaluationTime": 0.000522337,
+                        "evaluationTime": 0.00026885,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:50.540958341Z",
+                        "lastEvaluation": "2026-07-16T17:15:59.471004866Z",
                         "name": "PrometheusNotIngestingSamples",
                         "query": "(sum without (type) (rate(prometheus_tsdb_head_samples_appended_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m])) <= 0 and (sum without (scrape_job) (prometheus_target_metadata_cache_entries{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}) > 0 or sum without (rule_group) (prometheus_rule_group_rules{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}) > 0))",
                         "state": "inactive",
@@ -4767,14 +4942,14 @@
                             "summary": "Prometheus alert notification queue predicted to run full in less than 30m."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000185352,
+                        "evaluationTime": 0.000107307,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:50.540244642Z",
+                        "lastEvaluation": "2026-07-16T17:15:59.470621195Z",
                         "name": "PrometheusNotificationQueueRunningFull",
                         "query": "(predict_linear(prometheus_notifications_queue_length{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m], 60 * 30) > min_over_time(prometheus_notifications_queue_capacity{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]))",
                         "state": "inactive",
@@ -4788,14 +4963,14 @@
                             "summary": "Prometheus drops samples with out-of-order timestamps."
                         },
                         "duration": 600,
-                        "evaluationTime": 8.49e-05,
+                        "evaluationTime": 4.524e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:50.541626757Z",
+                        "lastEvaluation": "2026-07-16T17:15:59.471332714Z",
                         "name": "PrometheusOutOfOrderTimestamps",
                         "query": "rate(prometheus_target_scrapes_sample_out_of_order_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) > 0",
                         "state": "inactive",
@@ -4809,14 +4984,14 @@
                             "summary": "Prometheus fails to send samples to remote storage."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000289218,
+                        "evaluationTime": 0.000162026,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:50.541716179Z",
+                        "lastEvaluation": "2026-07-16T17:15:59.471380501Z",
                         "name": "PrometheusRemoteStorageFailures",
                         "query": "((rate(prometheus_remote_storage_failed_samples_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) or rate(prometheus_remote_storage_samples_failed_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m])) / ((rate(prometheus_remote_storage_failed_samples_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) or rate(prometheus_remote_storage_samples_failed_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m])) + (rate(prometheus_remote_storage_succeeded_samples_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) or rate(prometheus_remote_storage_samples_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m])))) * 100 > 1",
                         "state": "inactive",
@@ -4830,14 +5005,14 @@
                             "summary": "Prometheus remote write is behind."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000123717,
+                        "evaluationTime": 6.0733e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:50.542010878Z",
+                        "lastEvaluation": "2026-07-16T17:15:59.471545994Z",
                         "name": "PrometheusRemoteWriteBehind",
                         "query": "(max_over_time(prometheus_remote_storage_queue_highest_timestamp_seconds{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) - max_over_time(prometheus_remote_storage_queue_highest_sent_timestamp_seconds{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m])) > 120",
                         "state": "inactive",
@@ -4851,14 +5026,14 @@
                             "summary": "Prometheus remote write desired shards calculation wants to run more than configured max shards."
                         },
                         "duration": 900,
-                        "evaluationTime": 9.401e-05,
+                        "evaluationTime": 4.7063e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:50.542144263Z",
+                        "lastEvaluation": "2026-07-16T17:15:59.471609932Z",
                         "name": "PrometheusRemoteWriteDesiredShards",
                         "query": "(max_over_time(prometheus_remote_storage_shards_desired{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) > max_over_time(prometheus_remote_storage_shards_max{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]))",
                         "state": "inactive",
@@ -4872,14 +5047,14 @@
                             "summary": "Prometheus is failing rule evaluations."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000226634,
+                        "evaluationTime": 0.000123107,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:50.542242787Z",
+                        "lastEvaluation": "2026-07-16T17:15:59.471660032Z",
                         "name": "PrometheusRuleFailures",
                         "query": "increase(prometheus_rule_evaluation_failures_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) > 0",
                         "state": "inactive",
@@ -4893,14 +5068,14 @@
                             "summary": "Failed Prometheus SD refresh."
                         },
                         "duration": 1200,
-                        "evaluationTime": 0.000100773,
+                        "evaluationTime": 6.9509e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:50.540016291Z",
+                        "lastEvaluation": "2026-07-16T17:15:59.470490282Z",
                         "name": "PrometheusSDRefreshFailure",
                         "query": "increase(prometheus_sd_refresh_failures_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[10m]) > 0",
                         "state": "inactive",
@@ -4914,14 +5089,14 @@
                             "summary": "Prometheus has dropped some targets that exceeded body size limit."
                         },
                         "duration": 900,
-                        "evaluationTime": 8.3732e-05,
+                        "evaluationTime": 4.0801e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:50.542977941Z",
+                        "lastEvaluation": "2026-07-16T17:15:59.472032241Z",
                         "name": "PrometheusScrapeBodySizeLimitHit",
                         "query": "increase(prometheus_target_scrapes_exceeded_body_size_limit_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) > 0",
                         "state": "inactive",
@@ -4935,14 +5110,14 @@
                             "summary": "Prometheus has failed scrapes that have exceeded the configured sample limit."
                         },
                         "duration": 900,
-                        "evaluationTime": 9.352e-05,
+                        "evaluationTime": 4.1503e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:50.543066342Z",
+                        "lastEvaluation": "2026-07-16T17:15:59.472075758Z",
                         "name": "PrometheusScrapeSampleLimitHit",
                         "query": "increase(prometheus_target_scrapes_exceeded_sample_limit_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) > 0",
                         "state": "inactive",
@@ -4956,14 +5131,14 @@
                             "summary": "Prometheus has issues compacting blocks."
                         },
                         "duration": 14400,
-                        "evaluationTime": 7.9758e-05,
+                        "evaluationTime": 4.474e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:50.540872377Z",
+                        "lastEvaluation": "2026-07-16T17:15:59.470957431Z",
                         "name": "PrometheusTSDBCompactionsFailing",
                         "query": "increase(prometheus_tsdb_compactions_failed_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[3h]) > 0",
                         "state": "inactive",
@@ -4977,14 +5152,14 @@
                             "summary": "Prometheus has issues reloading blocks from disk."
                         },
                         "duration": 14400,
-                        "evaluationTime": 0.000103655,
+                        "evaluationTime": 5.2546e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:50.540764121Z",
+                        "lastEvaluation": "2026-07-16T17:15:59.47090269Z",
                         "name": "PrometheusTSDBReloadsFailing",
                         "query": "increase(prometheus_tsdb_reloads_failures_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[3h]) > 0",
                         "state": "inactive",
@@ -4998,14 +5173,14 @@
                             "summary": "Prometheus has dropped targets because some scrape configs have exceeded the targets limit."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000103777,
+                        "evaluationTime": 4.8839e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:50.542766726Z",
+                        "lastEvaluation": "2026-07-16T17:15:59.471933472Z",
                         "name": "PrometheusTargetLimitHit",
                         "query": "increase(prometheus_target_scrape_pool_exceeded_target_limit_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[5m]) > 0",
                         "state": "inactive",
@@ -5019,14 +5194,14 @@
                             "summary": "Prometheus has failed to sync targets."
                         },
                         "duration": 300,
-                        "evaluationTime": 0.000163021,
+                        "evaluationTime": 9.6054e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "critical"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:50.543164394Z",
+                        "lastEvaluation": "2026-07-16T17:15:59.472119947Z",
                         "name": "PrometheusTargetSyncFailure",
                         "query": "increase(prometheus_target_sync_failed_total{job=\"prometheus-operator-prometheus\",namespace=\"metalk8s-monitoring\"}[30m]) > 0",
                         "state": "inactive",
@@ -5035,10 +5210,10 @@
                 ]
             },
             {
-                "evaluationTime": 0.001745544,
-                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-prometheus-operator-31110a73-6dd3-46a0-b877-a922b3382cbf.yaml",
+                "evaluationTime": 0.001038237,
+                "file": "/etc/prometheus/rules/prometheus-prometheus-operator-prometheus-rulefiles-0/metalk8s-monitoring-prometheus-operator-prometheus-operator-c4f5f641-c002-4038-96ef-a365e21dbf8f.yaml",
                 "interval": 30,
-                "lastEvaluation": "2026-03-31T17:01:55.61452957Z",
+                "lastEvaluation": "2026-07-16T17:15:58.846684134Z",
                 "limit": 0,
                 "name": "prometheus-operator",
                 "partialResponseStrategy": "ABORT",
@@ -5051,14 +5226,14 @@
                             "summary": "Errors while performing list operations in controller."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000453529,
+                        "evaluationTime": 0.000344402,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.614564087Z",
+                        "lastEvaluation": "2026-07-16T17:15:58.846707621Z",
                         "name": "PrometheusOperatorListErrors",
                         "query": "(sum by (cluster, controller, namespace) (rate(prometheus_operator_list_operations_failed_total{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"}[10m])) / sum by (cluster, controller, namespace) (rate(prometheus_operator_list_operations_total{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"}[10m]))) > 0.4",
                         "state": "inactive",
@@ -5072,14 +5247,14 @@
                             "summary": "Errors while reconciling Prometheus."
                         },
                         "duration": 600,
-                        "evaluationTime": 0.000117587,
+                        "evaluationTime": 4.5251e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.615895422Z",
+                        "lastEvaluation": "2026-07-16T17:15:58.847542177Z",
                         "name": "PrometheusOperatorNodeLookupErrors",
                         "query": "rate(prometheus_operator_node_address_lookup_errors_total{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"}[5m]) > 0.1",
                         "state": "inactive",
@@ -5093,14 +5268,14 @@
                             "summary": "Prometheus operator not ready"
                         },
                         "duration": 300,
-                        "evaluationTime": 0.00012275,
+                        "evaluationTime": 6.6885e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.616017923Z",
+                        "lastEvaluation": "2026-07-16T17:15:58.847590004Z",
                         "name": "PrometheusOperatorNotReady",
                         "query": "min by (cluster, controller, namespace) (max_over_time(prometheus_operator_ready{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"}[5m]) == 0)",
                         "state": "inactive",
@@ -5114,14 +5289,14 @@
                             "summary": "Errors while reconciling objects."
                         },
                         "duration": 600,
-                        "evaluationTime": 0.000239901,
+                        "evaluationTime": 0.000138739,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.615450885Z",
+                        "lastEvaluation": "2026-07-16T17:15:58.847278599Z",
                         "name": "PrometheusOperatorReconcileErrors",
                         "query": "(sum by (cluster, controller, namespace) (rate(prometheus_operator_reconcile_errors_total{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"}[5m]))) / (sum by (cluster, controller, namespace) (rate(prometheus_operator_reconcile_operations_total{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"}[5m]))) > 0.1",
                         "state": "inactive",
@@ -5135,14 +5310,14 @@
                             "summary": "Resources rejected by Prometheus operator"
                         },
                         "duration": 300,
-                        "evaluationTime": 0.000127099,
+                        "evaluationTime": 6.008e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.616145288Z",
+                        "lastEvaluation": "2026-07-16T17:15:58.847659664Z",
                         "name": "PrometheusOperatorRejectedResources",
                         "query": "min_over_time(prometheus_operator_managed_resources{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\",state=\"rejected\"}[5m]) > 0",
                         "state": "inactive",
@@ -5156,14 +5331,14 @@
                             "summary": "Errors while updating objects status."
                         },
                         "duration": 600,
-                        "evaluationTime": 0.000194044,
+                        "evaluationTime": 0.000117225,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.615696247Z",
+                        "lastEvaluation": "2026-07-16T17:15:58.847421756Z",
                         "name": "PrometheusOperatorStatusUpdateErrors",
                         "query": "(sum by (cluster, controller, namespace) (rate(prometheus_operator_status_update_errors_total{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"}[5m]))) / (sum by (cluster, controller, namespace) (rate(prometheus_operator_status_update_operations_total{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"}[5m]))) > 0.1",
                         "state": "inactive",
@@ -5177,14 +5352,14 @@
                             "summary": "Last controller reconciliation failed"
                         },
                         "duration": 600,
-                        "evaluationTime": 0.0001251,
+                        "evaluationTime": 7.2625e-05,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.615310453Z",
+                        "lastEvaluation": "2026-07-16T17:15:58.847202927Z",
                         "name": "PrometheusOperatorSyncFailed",
                         "query": "min_over_time(prometheus_operator_syncs{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\",status=\"failed\"}[5m]) > 0",
                         "state": "inactive",
@@ -5198,14 +5373,14 @@
                             "summary": "Errors while performing watch operations in controller."
                         },
                         "duration": 900,
-                        "evaluationTime": 0.000280018,
+                        "evaluationTime": 0.000141865,
                         "health": "ok",
                         "keepFiringFor": 0,
                         "labels": {
                             "prometheus": "metalk8s-monitoring/prometheus-operator-prometheus",
                             "severity": "warning"
                         },
-                        "lastEvaluation": "2026-03-31T17:01:55.615024692Z",
+                        "lastEvaluation": "2026-07-16T17:15:58.847057354Z",
                         "name": "PrometheusOperatorWatchErrors",
                         "query": "(sum by (cluster, controller, namespace) (rate(prometheus_operator_watch_operations_failed_total{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"}[5m])) / sum by (cluster, controller, namespace) (rate(prometheus_operator_watch_operations_total{job=\"prometheus-operator-operator\",namespace=\"metalk8s-monitoring\"}[5m]))) > 0.4",
                         "state": "inactive",

--- a/tox.ini
+++ b/tox.ini
@@ -211,6 +211,7 @@ markers =
     csc: tag a BDD feature related to Cluster and Service configuration
     solution: tag a BDD feature as related to solution
     restore: tag a BDD feature as related to bootstrap node recovery
+    workloadplane: tag a BDD feature as related to Workload Plane isolation
 filterwarnings =
     ignore:encode_point has been deprecated on EllipticCurvePublicNumbers and will be removed in a future version. Please use EllipticCurvePublicKey.public_bytes to obtain both compressed and uncompressed point encoding.:UserWarning
     ignore:Support for unsafe construction of public numbers from encoded data will be removed in a future version. Please use EllipticCurvePublicKey.from_encoded_point:UserWarning


### PR DESCRIPTION
**Component**: salt, containers, build, tests

**Context**:

MetalK8s already *detects* Workload Plane (WP) isolation: node-problem-detector
(shipped in 133.0.12) exposes the `WorkloadPlaneNetworkUnavailable` node
condition when a node can no longer reach the majority of its peers over the
Workload Plane. This PR adds the *remediation* that acts on that condition, the
alerts that surface it, and an end-to-end test.

**Summary**:

- **Deploy `node-warden-operator` v1.0.0** as a kustomize addon in the
  `metalk8s-monitoring` namespace, ordered after Prometheus (it ships a
  ServiceMonitor, labelled so our Prometheus scrapes it) and cert-manager (its
  webhook certificate). Added to the deployment sanity checks.
- **Default remediation policy** (`workload-plane-isolation`, a cluster-scoped
  `NodeRemediationPolicy`): when a WP node reports
  `WorkloadPlaneNetworkUnavailable`, apply a reversible
  `node.scality.com/workload-plane-unreachable:NoExecute` taint to drain it and
  drop it from Service endpoints, then remove the taint once WP connectivity
  recovers. A guard suppresses remediation when the majority of nodes are
  affected (cluster-wide outage). Infra components tolerate the taint.
- **Prometheus alerts**, split by the component that produces the signal:
  `NodeWorkloadPlaneUnavailable` (node-problem-detector) for the condition, and
  `NodeWorkloadPlaneRemediated` + `WorkloadPlaneOutage` (node-warden-operator)
  for the taint / suppressed-guard cases; also registered in the lib-alert-tree.
- **End-to-end BDD test** on a segregated-network cluster: an isolated node is
  drained and recovers (link-down and blocked modes), while a Calico rolling
  restart, a short blip, and a majority outage do not trigger remediation.

**Acceptance criteria**:

- CI is green, including the new `workload_plane_isolation.feature` on a
  multi-node, segregated-network cluster.
- A WP node that loses connectivity gets the taint, its workloads are evicted,
  and `NodeWorkloadPlaneUnavailable` / `NodeWorkloadPlaneRemediated` fire; all
  revert once connectivity is restored.
- A cluster-wide WP outage raises `WorkloadPlaneOutage` and does **not** taint
  any node.

---

Fixes: MK8S-320, MK8S-321, MK8S-323
