### PR TITLE
fix: consistent column-header alignment across Node tabs (ARTESCA-17384)

### DIFF
--- a/ui/src/components/AlertsTab.tsx
+++ b/ui/src/components/AlertsTab.tsx
@@ -31,24 +31,27 @@ const AlertsTab = ({ alerts, status }: { alerts: Alert[]; status: 'idle' | 'load
       ?.filter((alert) => alertSeverity.includes(alert.severity)) ?? [];
   const columns = [
     {
-      Header: 'Name',
-      accessor: 'name',
-      cellStyle: {
-        flex: 1,
-        width: 'unset',
-      },
-    },
-    {
       Header: 'Severity',
       accessor: 'severity',
       cellStyle: {
         flex: 0.5,
         textAlign: 'center',
         width: 'unset',
+        paddingRight: spacing.r16,
       },
       Cell: ({ value }) => {
         return <CircleStatus name="Circle-health" status={value} />;
       },
+    },
+    {
+      Header: 'Name',
+      accessor: 'name',
+      cellStyle: {
+        flex: 1,
+        width: 'unset',
+        minWidth: 0,
+      },
+      Cell: ({ value }) => <ConstrainedText lineClamp={2} text={value} />,
     },
     {
       Header: 'Description',

--- a/ui/src/components/NodePageVolumesTable.tsx
+++ b/ui/src/components/NodePageVolumesTable.tsx
@@ -29,7 +29,8 @@ const VolumeListTable = React.memo((props) => {
           textAlign: 'center',
           width: 'unset',
           flex: 0.5,
-          maxWidth: '4rem',
+          minWidth: '4rem',
+          maxWidth: '5.5rem',
         },
         Cell: (cellProps) => {
           return <CircleStatus status={cellProps.value} />;
@@ -70,7 +71,7 @@ const VolumeListTable = React.memo((props) => {
         Header: 'Usage',
         accessor: 'usage',
         cellStyle: {
-          textAlign: 'center',
+          textAlign: 'left',
           width: 'unset',
           minWidth: '4rem',
           flex: 1,
@@ -91,7 +92,7 @@ const VolumeListTable = React.memo((props) => {
         Header: 'Size',
         accessor: 'storageCapacity',
         cellStyle: {
-          textAlign: 'right',
+          textAlign: 'left',
           width: 'unset',
           minWidth: '3rem',
           flex: 0.75,

--- a/ui/src/components/NodePartitionTable.tsx
+++ b/ui/src/components/NodePartitionTable.tsx
@@ -26,8 +26,9 @@ const NodePartitionTable = ({ instanceIP }: { instanceIP: string }) => {
       cellStyle: {
         textAlign: 'center',
         width: 'unset',
-        minWidth: '3rem',
-        maxWidth: '4rem',
+        minWidth: '4rem',
+        maxWidth: '5.5rem',
+        paddingRight: spacing.r16,
         flex: 0.5,
       },
       Cell: ({ value }) => {
@@ -48,7 +49,7 @@ const NodePartitionTable = ({ instanceIP }: { instanceIP: string }) => {
       Header: 'Usage',
       accessor: 'usage',
       cellStyle: {
-        textAlign: 'center',
+        textAlign: 'left',
         width: 'unset',
         flex: 0.5,
       },
@@ -74,6 +75,7 @@ const NodePartitionTable = ({ instanceIP }: { instanceIP: string }) => {
         width: 'unset',
         marginRight: spacing.r16,
       },
+      Cell: ({ value }) => value,
     },
   ];
   const alertList = useAlerts({


### PR DESCRIPTION
## TL;DR

Makes column-header/cell alignment consistent across the Platform **Node detail tabs** (System Partitions, Volumes, Alerts) and gives the sort caret room on centered columns so it no longer looks crowded/clipped.

## Context

`ARTESCA-17384` (issue **2 of 2**): on **Platform › Nodes / Volumes**, the tables across tabs align their column names differently, and some sort carets are cramped. The tooltip-size half of the ticket is fixed separately in **zenko-ui#1245**.

## Approach

Three independent causes, all rooted in how core-ui's Tablev2 renders cells:

- **Crowded sort caret** on centered sortable columns (Partition **Health**, Alerts **Severity**). core-ui renders the caret `position:absolute` with no reserved width, so on tight/centered columns it clips against the right edge. Interim fix: `paddingRight: spacing.r16` on those columns. *(A proper core-ui fix — reserving the caret's space in the header layout — is planned as a follow-up; this padding comes out once that lands.)*
- **Size column showing left-aligned despite `textAlign: 'right'`.** When a column has no custom `Cell`, core-ui's `DefaultRenderer` wraps the value in `<ConstrainedText>`, which left-aligns and defeats `textAlign`. Fixed by giving Size an explicit passthrough `Cell`:
  ```tsx
  { Header: 'Size', accessor: 'size',
    cellStyle: { textAlign: 'right', /* … */ marginRight: spacing.r16 },
    Cell: ({ value }) => value }   // ← bypass DefaultRenderer/ConstrainedText so right-align applies
  ```
- **Long alert names pushing sibling cells** in the Alerts tab (flexbox `min-width:auto` won't shrink below content). Fixed with `minWidth: 0` + an explicit `ConstrainedText` Cell so the name truncates. Also reordered **Severity before Name** so the tab leads with the status column like the other Node tables.

## Screenshots

<!-- SCREENSHOT: Platform › Nodes › <node> — System Partitions, Volumes, and Alerts tabs. Show the header row + a few data rows so header/value alignment and the sort caret spacing are visible. -->

## Review focus

- 🟡 `ui/src/components/AlertsTab.tsx › columns` — `Name` gets `minWidth: 0` + `ConstrainedText`; Severity/Name reordered. Verify long alert names truncate instead of pushing other cells.
- ⚪ `ui/src/components/NodePartitionTable.tsx › Size` — passthrough `Cell` so right-align takes effect; Health/Usage alignment normalized.
- ⚪ `ui/src/components/NodePageVolumesTable.tsx` — Health given room, Usage/Size left-aligned to match.

## How to test

1. **Platform › Nodes**, pick a node.
2. **System Partitions** tab: Health centered with an un-clipped sort caret, Usage/Partition path left-aligned, **Size right-aligned**.
3. **Volumes** tab: Health has room; Usage and Size left-aligned consistently.
4. **Alerts** tab: columns read **Severity → Name → Description → Active since**; a very long alert name truncates (ellipsis) rather than shoving the other columns.

## References

- **ARTESCA-17384** — 4.2 visual inconsistencies (this PR = column-header alignment on Nodes & Volumes tabs; issue 2 of 2).
- **scality/zenko-ui#1245** — the tooltip-size half (issue 1 of 2).
- Follow-up: a core-ui change to reserve the sort caret's layout space (removes the interim `paddingRight` here).
