### PR TITLE
fix(ui): align notification center alert count with alerts page (MK8S-367)

### DIFF
--- a/ui/src/components/AlertNavbarUpdaterComponent.test.tsx
+++ b/ui/src/components/AlertNavbarUpdaterComponent.test.tsx
@@ -75,6 +75,39 @@ describe('AlertNavbarUpdaterComponent', () => {
     },
     originalAlert: {},
   };
+  const PARENT_WARNING_ALERT = {
+    id: 'parentwarning0001',
+    summary: 'The node is degraded',
+    description: 'The node is degraded',
+    startsAt: '2023-08-11T06:03:55.000Z',
+    endsAt: '2023-08-11T14:13:51.065Z',
+    severity: 'warning',
+    documentationUrl: '',
+    labels: {
+      alertname: 'NodeDegraded',
+      severity: 'warning',
+      children: 'artesca-data-ops-alerting-s3utils-CountItemsJobTakingTooLong',
+      selectors: [],
+    },
+    originalAlert: {},
+  };
+  it('should not count parent (aggregation) alerts that have children, to match the Alerts page count', async () => {
+    //S
+    // @ts-ignore mock implementation
+    useAlerts.mockImplementation(() => ({
+      alerts: [WATCHDOG_ALERT, WARNING_ALERT, PARENT_WARNING_ALERT],
+    }));
+    const { publishNotification } = setupTest();
+    //V
+    // Only the leaf warning alert must be counted, not the parent NodeDegraded alert.
+    expect(publishNotification).toBeCalledWith(
+      expect.objectContaining({
+        id: 'WarningNotification',
+        description: 'There is 1 warning alert currently firing on the platform.',
+      }),
+    );
+    expect(publishNotification).toHaveBeenCalledTimes(1);
+  });
   it('should publish a critical notification if there is a minimum of one critical alert', async () => {
     //S
     // @ts-ignore mock implementation

--- a/ui/src/components/AlertNavbarUpdaterComponent.tsx
+++ b/ui/src/components/AlertNavbarUpdaterComponent.tsx
@@ -98,9 +98,12 @@ export const AlertNavbarUpdaterComponentInternal = ({
     return new Date(b.startsAt) > new Date(a.startsAt) ? 1 : -1;
   });
   const { ui_base_path } = useConfig();
-  const watchdogAlert = alerts?.find((alert: Alert) => alert.labels.alertname === WATCHDOG_ALERT_NAME);
-  const criticalAlerts = alerts?.filter((alert: Alert) => alert.severity === 'critical') ?? [];
-  const warningAlerts = alerts?.filter((alert: Alert) => alert.severity === 'warning') ?? [];
+  // Exclude parent/aggregation alerts (those exposing `children`) so the notification
+  // center counts the same leaf alerts as the Alerts page (see AlertPage.tsx).
+  const leafAlerts = alerts?.filter((alert: Alert) => !alert.labels.children) ?? [];
+  const watchdogAlert = leafAlerts.find((alert: Alert) => alert.labels.alertname === WATCHDOG_ALERT_NAME);
+  const criticalAlerts = leafAlerts.filter((alert: Alert) => alert.severity === 'critical');
+  const warningAlerts = leafAlerts.filter((alert: Alert) => alert.severity === 'warning');
 
   useEffect(() => {
     // We have initialData when loading alerts, so we should check if the query is fetching or not.
@@ -112,7 +115,7 @@ export const AlertNavbarUpdaterComponentInternal = ({
     // we need to check if there is any new alert raised, if yes, we need to publish the notification.
     const alertsIdArray = alertsId ? alertsId.split(',') : [];
     // check if all the criticalAlerts item belongs to part of the alertsIdArray
-    const newlyRaisedAlertNum = alerts?.filter((alert) => {
+    const newlyRaisedAlertNum = leafAlerts.filter((alert) => {
       if (!alertsIdArray.includes(alert.id)) {
         return alert.id;
       }
@@ -151,7 +154,7 @@ export const AlertNavbarUpdaterComponentInternal = ({
     }
 
     // Update the alerts Id in the localstorage
-    localStorage.setItem(LOCAL_STORAGE_ALL_ALERTS_ID, `${alerts?.map((alert) => alert.id).join(',')}`);
+    localStorage.setItem(LOCAL_STORAGE_ALL_ALERTS_ID, `${leafAlerts.map((alert) => alert.id).join(',')}`);
   }, [criticalAlerts.length, warningAlerts.length, watchdogAlert === undefined, status, isFetching]);
 
   return <></>;


### PR DESCRIPTION
## TL;DR

The Notification Center (bell) now counts only leaf alerts — the same set the Alerts page counts — so both views report the same number of alerts.

## Context

Reported in [RD-1909](https://scality.atlassian.net/browse/RD-1909) on ARTESCA 4.3.0-pw.15: the bell showed more warnings than the Alerts page (e.g. Alerts page = 3 warnings + 1 critical, bell = 7 warnings + 1 critical). Tracked for MetalK8s as [MK8S-367](https://scality.atlassian.net/browse/MK8S-367).

## Approach

Both views read the exact same alert list (same shell `AlertProvider`, `removeWarningAlerts` already applied). The only difference was client-side: the Alerts page (`AlertPage.tsx`) filters the list down to **leaf alerts**, excluding parent/aggregation alerts that carry a `labels.children` property (e.g. `NodeDegraded`, `ClusterAtRisk`, `PlatformServicesDegraded`). The bell feeder didn't — so those umbrella alerts inflated its count.

The fix mirrors `AlertPage.tsx`: derive a `leafAlerts` list first, then compute the counts, watchdog lookup, and localStorage new-alert tracking from it.

**Before:**
```ts
const watchdogAlert = alerts?.find((a) => a.labels.alertname === WATCHDOG_ALERT_NAME);
const criticalAlerts = alerts?.filter((a) => a.severity === 'critical') ?? []; // ← counts parents
const warningAlerts = alerts?.filter((a) => a.severity === 'warning') ?? [];   // ← counts parents
```

**After:**
```ts
const leafAlerts = alerts?.filter((a) => !a.labels.children) ?? [];            // ← excludes parents
const watchdogAlert = leafAlerts.find((a) => a.labels.alertname === WATCHDOG_ALERT_NAME);
const criticalAlerts = leafAlerts.filter((a) => a.severity === 'critical');
const warningAlerts = leafAlerts.filter((a) => a.severity === 'warning');
```

## Review focus

- 🟡 `AlertNavbarUpdaterComponent.tsx` › `AlertNavbarUpdaterComponentInternal` — the new `leafAlerts` filter and that all three downstream uses (counts, `watchdogAlert`, localStorage tracking) now derive from it. Bounded scope, covered by the new regression test.

## How to test

1. Log in to ARTESCA and trigger alerts that produce a parent/aggregation alert (e.g. degrade a node so `NodeDegraded` fires alongside its child warnings).
2. Compare the warning/critical counts in the Notification Center (bell) against the Alerts page.
3. **Expected:** both lists report the same number of alerts.

Unit test: `cd ui && CI=true npx jest src/components/AlertNavbarUpdaterComponent.test.tsx` (6/6 pass; new test asserts a parent alert with `children` is not counted).

## References

- [RD-1909](https://scality.atlassian.net/browse/RD-1909) — original bug report (Notification Center bell shows more warnings than the Alerts page).
- [MK8S-367](https://scality.atlassian.net/browse/MK8S-367) — MetalK8s tracking ticket for the fix.

[RD-1909]: https://scality.atlassian.net/browse/RD-1909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MK8S-367]: https://scality.atlassian.net/browse/MK8S-367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RD-1909]: https://scality.atlassian.net/browse/RD-1909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ