### PR TITLE
Build boot cache images for control plane and worker nodes

### DIFF
--- a/.changes/unreleased/Enhanced-20260820-140410-488064253.yaml
+++ b/.changes/unreleased/Enhanced-20260820-140410-488064253.yaml
@@ -1,0 +1,17 @@
+kind: Enhanced
+body: |-
+    Ship boot cache images on the ISO, each carrying an archive of the container images
+    a node of that role needs to boot: `metalk8s-boot-cache-control-plane` (`pause`,
+    etcd, `kube-apiserver`, `kube-controller-manager`, `kube-scheduler`, CoreDNS,
+    `kube-proxy` and Calico) and `metalk8s-boot-cache-worker` (`pause` and
+    `file-reflector`). Both carry `pause`, which containerd pins as its sandbox image:
+    without it the kubelet starts no Pod at all, not even a static one. A node can
+    restore them into containerd without reaching the registry, which breaks the
+    circular dependency between a node and the registry running on the cluster it
+    belongs to. Each archive is named after the image the kubelet asks for, so it is
+    imported as is, with no re-tagging. Both images are available as layers, for the
+    registry, and as an archive, for a node with no registry yet.
+time: 2026-08-20T14:04:10.488064253Z
+custom:
+    CommentId: "5356968643"
+    Pull: "5068"

--- a/.changes/unreleased/Enhanced-20260820-140434-10652025.yaml
+++ b/.changes/unreleased/Enhanced-20260820-140434-10652025.yaml
@@ -1,0 +1,10 @@
+kind: Enhanced
+body: |-
+    Pull the [file-reflector](https://github.com/scality/file-reflector) image
+    ([v0.2.0](https://github.com/scality/file-reflector/releases/tag/v0.2.0)), the agent
+    that writes containerd's mirror configuration on each node, so it can be cached on
+    workers.
+time: 2026-08-20T14:04:34.010652025Z
+custom:
+    CommentId: "5356969664"
+    Pull: "5068"

--- a/.github/changed-files.yaml
+++ b/.github/changed-files.yaml
@@ -38,6 +38,11 @@ unit-tests-salt:
   - tox.ini
   - .devcontainer/**
 
+unit-tests-buildchain:
+  - buildchain/**
+  - tox.ini
+  - .devcontainer/**
+
 unit-tests-lib-alert-tree:
   - tools/lib-alert-tree/**
   - .devcontainer/**

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -36,6 +36,7 @@ jobs:
       unit-tests-metalk8s-operator: ${{ steps.diff.outputs.unit-tests-metalk8s-operator_any_modified == 'true' }}
       unit-tests-storage-operator: ${{ steps.diff.outputs.unit-tests-storage-operator_any_modified == 'true' }}
       unit-tests-salt: ${{ steps.diff.outputs.unit-tests-salt_any_modified == 'true' }}
+      unit-tests-buildchain: ${{ steps.diff.outputs.unit-tests-buildchain_any_modified == 'true' }}
       unit-tests-lib-alert-tree: ${{ steps.diff.outputs.unit-tests-lib-alert-tree_any_modified == 'true' }}
       integration-tests-ui: ${{ steps.diff.outputs.integration-tests-ui_any_modified == 'true' }}
       upgrade-operator-sdk-operator: ${{ steps.diff.outputs.upgrade-operator-sdk-operator_any_modified == 'true' }}
@@ -71,13 +72,14 @@ jobs:
           ALL_UNIT_TESTS_METALK8S_OPERATOR_CHANGED_FILES: ${{ steps.diff.outputs.unit-tests-metalk8s-operator_all_changed_files }}
           ALL_UNIT_TESTS_STORAGE_OPERATOR_CHANGED_FILES: ${{ steps.diff.outputs.unit-tests-storage-operator_all_changed_files }}
           ALL_UNIT_TESTS_SALT_CHANGED_FILES: ${{ steps.diff.outputs.unit-tests-salt_all_changed_files }}
+          ALL_UNIT_TESTS_BUILDCHAIN_CHANGED_FILES: ${{ steps.diff.outputs.unit-tests-buildchain_all_changed_files }}
           ALL_UNIT_TESTS_LIB_ALERT_TREE_CHANGED_FILES: ${{ steps.diff.outputs.unit-tests-lib-alert-tree_all_changed_files }}
           ALL_INTEGRATION_TESTS_UI_CHANGED_FILES: ${{ steps.diff.outputs.integration-tests-ui_all_changed_files }}
           ALL_UPGRADE_OPERATOR_SDK_OPERATOR_CHANGED_FILES: ${{ steps.diff.outputs.upgrade-operator-sdk-operator_all_changed_files }}
           ALL_UPGRADE_OPERATOR_SDK_STORAGE_OPERATOR_CHANGED_FILES: ${{ steps.diff.outputs.upgrade-operator-sdk-storage-operator_all_changed_files }}
           ALL_BUILD_CHANGED_FILES: ${{ steps.diff.outputs.build_all_changed_files }}
         run: |
-          for type in docs shell-ui unit-tests-ui unit-tests-shell-ui unit-tests-crd-client-generator unit-tests-metalk8s-operator unit-tests-storage-operator unit-tests-salt unit-tests-lib-alert-tree integration-tests-ui upgrade-operator-sdk-operator upgrade-operator-sdk-storage-operator build; do
+          for type in docs shell-ui unit-tests-ui unit-tests-shell-ui unit-tests-crd-client-generator unit-tests-metalk8s-operator unit-tests-storage-operator unit-tests-salt unit-tests-buildchain unit-tests-lib-alert-tree integration-tests-ui upgrade-operator-sdk-operator upgrade-operator-sdk-storage-operator build; do
             echo "All $type changed files:"
             changed_files_var=$(echo "ALL_${type^^}_CHANGED_FILES" | tr '-' '_')
             echo "${!changed_files_var}"
@@ -358,6 +360,32 @@ jobs:
       - name: Run all salt unit tests
         run: tox -e unit-tests
 
+  unit_tests_buildchain:
+    runs-on: ubuntu-latest
+    needs:
+      - build-devcontainer
+      - changed-files
+    container:
+      image: ghcr.io/${{ github.repository }}/devcontainer:${{ github.sha }}
+      # We have to use `root` for the moment
+      # Sees: https://github.com/actions/checkout/issues/1575
+      # Could work with a user with 1001 id but not for docker
+      options: --user root
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    defaults:
+      run:
+        shell: bash
+    if: needs.changed-files.outputs.unit-tests-buildchain == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Set safe directory (since container is root and not user 1001)
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+      - name: Run all buildchain unit tests
+        run: tox -e unit-tests-buildchain
+
   unit_tests_lib_alert_tree:
     runs-on: ubuntu-latest
     needs:
@@ -555,6 +583,7 @@ jobs:
       - check_upgrade_metalk8s_operator
       - check_upgrade_storage_operator
       - unit_tests_salt
+      - unit_tests_buildchain
       - unit_tests_lib_alert_tree
       - integration_tests_ui
     if: always()

--- a/.pylint-dict
+++ b/.pylint-dict
@@ -92,6 +92,7 @@ tox
 treelib
 txt
 ui
+uncomment
 uptodate
 xenial
 yaml

--- a/buildchain/buildchain/constants.py
+++ b/buildchain/buildchain/constants.py
@@ -34,6 +34,12 @@ CERT_MANAGER_REPOSITORY: str = "quay.io/jetstack"
 OAUTH2_PROXY_REPOSITORY: str = "quay.io/oauth2-proxy"
 SCALITY_REPOSITORY: str = "ghcr.io/scality"
 
+# Registry endpoint the nodes resolve through their containerd mirror
+# configuration: kept in sync with `repo:registry_endpoint` in
+# salt/metalk8s/defaults.yaml. An image archive cached on a node is imported
+# as-is, so it must already carry the name the kubelet asks for.
+NODE_REGISTRY_ENDPOINT: str = "metalk8s-registry-from-config.invalid"
+
 # Paths {{{
 
 # Root of the generated ISO.
@@ -48,6 +54,9 @@ ISO_IMAGE_ROOT: Path = ISO_ROOT / "images"
 ISO_DOCS_ROOT: Path = ISO_ROOT / "documentation"
 # Root for the documentation build.
 DOCS_BUILD_ROOT: Path = config.BUILD_ROOT / "docs"
+# Root of the boot cache build contexts: build-only, never on the ISO (only
+# the resulting boot cache images are shipped).
+BOOT_CACHE_ROOT: Path = config.BUILD_ROOT / "boot-cache"
 # Root for the packages that we build ourselves.
 PKG_ROOT: Path = config.BUILD_ROOT / "packages"
 # Root for the RedHat packages that we build ourselves.

--- a/buildchain/buildchain/image.py
+++ b/buildchain/buildchain/image.py
@@ -29,11 +29,13 @@ Overview:
 """
 
 import datetime
+from pathlib import Path
 from typing import Any, Dict, Iterator, List, Tuple
 
 from buildchain import builder
 from buildchain import config
 from buildchain import constants
+from buildchain import coreutils
 from buildchain import targets
 from buildchain import types
 from buildchain import utils
@@ -47,6 +49,7 @@ def task_images() -> types.TaskDict:
         "task_dep": [
             "_image_mkdir_root",
             "_image_pull",
+            "_image_boot_cache_context",
             "_image_build",
             "_image_dedup_layers",
         ],
@@ -70,6 +73,24 @@ def task__image_build() -> Iterator[types.TaskDict]:
     """Build the container images."""
     for image in TO_BUILD:
         yield image.task
+
+
+def task__image_boot_cache_mkdir_root() -> types.TaskDict:
+    """Create the root of the boot cache build contexts.
+
+    Owning the directory here is what lets `doit clean` remove it: the
+    per-variant tasks only clean the directory of their own variant, and a
+    leftover empty root keeps the build root from being removed.
+    """
+    return targets.Mkdir(
+        directory=constants.BOOT_CACHE_ROOT, task_dep=["_build_root"]
+    ).task
+
+
+def task__image_boot_cache_context() -> Iterator[types.TaskDict]:
+    """Assemble the build context of each boot cache image."""
+    for variant in BOOT_CACHE_VARIANTS:
+        yield _boot_cache_context_task(variant)
 
 
 def task__image_calc_build_deps() -> Iterator[types.TaskDict]:
@@ -129,6 +150,84 @@ def _remote_image(name: str, repository: str, **overrides: Any) -> targets.Remot
         kwargs["remote_name"] = REMOTE_NAMES[name]
 
     return targets.RemoteImage(**kwargs)
+
+
+def _node_image_fullname(name: str, version: str) -> str:
+    """Return the name under which an image is known on a node.
+
+    A cached archive is imported as-is (no re-tagging), so it must already
+    carry the name the kubelet asks for: the one served by the cluster
+    registry.
+    """
+    prefix = f"{config.PROJECT_NAME.lower()}-{versions.VERSION}"
+    return f"{constants.NODE_REGISTRY_ENDPOINT}/{prefix}/{name}:{version}"
+
+
+def _boot_cache_context(variant: str) -> Path:
+    """Return the build context directory of a boot cache variant."""
+    return constants.BOOT_CACHE_ROOT / variant
+
+
+def _boot_cache_context_task(variant: str) -> types.TaskDict:
+    """Fill the build context of a boot cache variant with its archives.
+
+    The archives are converted from the image layers already pulled for the
+    ISO, so no image is downloaded twice, and they stay under the build root:
+    only the boot cache images themselves are shipped.
+    """
+    try:
+        members = [TO_PULL[name] for name in BOOT_CACHE_VARIANTS[variant]]
+    except KeyError as exc:
+        raise ValueError(
+            f'Boot cache variant "{variant}" lists {exc} which is not a '
+            "pulled image: add it to `TO_PULL` or fix `BOOT_CACHE_VARIANTS`"
+        ) from exc
+    images_dir = _boot_cache_context(variant) / "images"
+    archives = [images_dir / f"{img.name}-{img.version}.tar" for img in members]
+
+    def prepare() -> None:
+        # Start from an empty directory: the whole of it ends up in the boot
+        # cache image, so an archive left over from a previous version bump
+        # would be shipped (and `docker-archive` refuses to overwrite anyway).
+        coreutils.rm_rf(images_dir)
+        images_dir.mkdir(parents=True)
+
+    actions: List[types.Action] = [prepare]
+    for image, archive in zip(members, archives, strict=True):
+        cmd = list(constants.SKOPEO_COPY_DEFAULT_ARGS)
+        cmd.append(f"dir:{image.dirname}")
+        cmd.append(
+            f"docker-archive:{archive}:"
+            f"{_node_image_fullname(image.name, image.version)}"
+        )
+        actions.append(cmd)
+
+    task = targets.Target(
+        targets=archives,
+        file_dep=[image.dirname / "manifest.json" for image in members],
+        task_dep=["_image_boot_cache_mkdir_root"],
+        task_name=variant,
+    ).basic_task
+    task["title"] = lambda _: f"{'BOOT CACHE': <{constants.CMD_WIDTH}} {variant}"
+    task["doc"] = f"Assemble the {variant} boot cache build context."
+    task["actions"] = actions
+    task["clean"] = [(coreutils.rm_rf, [_boot_cache_context(variant)], {})]
+    return task
+
+
+def _boot_cache_image(variant: str) -> targets.LocalImage:
+    """Build a boot cache image from the context assembled for its variant."""
+    name = f"metalk8s-boot-cache-{variant}"
+    return _local_image(
+        name=name,
+        dockerfile=constants.ROOT / "images" / "metalk8s-boot-cache" / "Dockerfile",
+        build_context=_boot_cache_context(variant),
+        # Nodes import the image from this archive before any registry is
+        # reachable, and pull it from the registry afterwards: it is shipped
+        # both ways, like `pause` and `nginx`.
+        archive_reference=_node_image_fullname(name, versions.VERSION),
+        task_dep=[f"_image_boot_cache_context:{variant}"],
+    )
 
 
 def _local_image(name: str, **kwargs: Any) -> targets.LocalImage:
@@ -226,6 +325,7 @@ IMGS_PER_REPOSITORY: Dict[str, List[str]] = {
         "ui-operator",
         "crl-operator",
         "disk-management-agent",
+        "file-reflector",
         "node-warden-operator",
     ],
 }
@@ -248,6 +348,44 @@ for repo, images in IMGS_PER_REPOSITORY.items():
 
 # }}}
 # Container images to build {{{
+
+# Images cached on the nodes, per node role: the boot cache image of a variant
+# carries an archive of each image listed here, so that a node can restore them
+# into containerd without reaching the registry.
+#
+# This is the authoritative list; keep it in sync with what a node of that role
+# needs to boot. A name that is not pulled fails the build immediately.
+BOOT_CACHE_VARIANTS: Dict[str, List[str]] = {
+    "control-plane": [
+        # Pinned as the containerd sandbox image: without it the kubelet
+        # creates no sandbox, so not even the static pods below would start.
+        "pause",
+        "etcd",
+        "kube-apiserver",
+        "kube-controller-manager",
+        "kube-scheduler",
+        "coredns",
+        "kube-proxy",
+        "calico-cni",
+        "calico-node",
+        "calico-kube-controllers",
+    ],
+    "worker": [
+        "pause",
+        # The agent the registry operator runs to write the containerd mirror
+        # configuration on every node: a worker that has both the sandbox image
+        # and this one can boot and reach a registry.
+        "file-reflector",
+    ],
+    # The registry variant waits on images the buildchain does not carry yet:
+    #
+    # "registry": ["registry-operator", "registry-server",
+    #              "registry-node-agent"],
+    #
+    # Uncomment a variant once its images are pulled or built here: everything
+    # else (context, image, archive) follows from this listing.
+}
+
 TO_BUILD: Tuple[targets.LocalImage, ...] = (
     _local_image(
         name="metalk8s-alert-logger",
@@ -339,7 +477,7 @@ TO_BUILD: Tuple[targets.LocalImage, ...] = (
             "VERSION": versions.VERSION,
         },
     ),
-)
+) + tuple(_boot_cache_image(variant) for variant in BOOT_CACHE_VARIANTS)
 # }}}
 
 

--- a/buildchain/buildchain/targets/local_image.py
+++ b/buildchain/buildchain/targets/local_image.py
@@ -62,20 +62,26 @@ class LocalImage(image.ContainerImage):
         dockerfile: Optional[Path] = None,
         build_context: Optional[Union[Path, ExplicitContext]] = None,
         build_args: Optional[Dict[str, Any]] = None,
+        archive_reference: Optional[str] = None,
         **kwargs: Any,
     ):
         """Initialize a local container image.
 
         Arguments:
-            name:          image name
-            version:       image version
-            dockerfile:    path to the Dockerfile
-            destination:   where to save the result
-            save_on_disk:  save the image on disk?
-            build_context: path to the build context, or an ExplicitContext
-                           instance (defaults to the directory containing the
-                           Dockerfile)
-            build_args:    build arguments
+            name:              image name
+            version:           image version
+            dockerfile:        path to the Dockerfile
+            destination:       where to save the result
+            save_on_disk:      save the image on disk?
+            build_context:     path to the build context, or an ExplicitContext
+                               instance (defaults to the directory containing
+                               the Dockerfile)
+            build_args:        build arguments
+            archive_reference: if set, also save the image as an archive next
+                               to the layers (the layout `SaveAsTar` uses for
+                               remote images), under this exact reference:
+                               importing the archive makes the image available
+                               under that name, with no re-tagging
 
         Keyword Arguments:
             They are passed to `Target` init method.
@@ -96,6 +102,7 @@ class LocalImage(image.ContainerImage):
             self._build_context = build_context or self.dockerfile.parent
 
         self._save = save_on_disk
+        self._archive_reference = archive_reference
         self._build_args = build_args or {}
         kwargs.setdefault("file_dep", []).append(self.dockerfile)
         kwargs.setdefault("task_dep", []).append("check_for:skopeo")
@@ -104,10 +111,21 @@ class LocalImage(image.ContainerImage):
 
     dockerfile = property(operator.attrgetter("_dockerfile"))
     save_on_disk = property(operator.attrgetter("_save"))
+    archive_reference = property(operator.attrgetter("_archive_reference"))
     build_context = property(operator.attrgetter("_build_context"))
     custom_context = property(operator.attrgetter("_custom_context"))
     build_args = property(operator.attrgetter("_build_args"))
     dep_re = re.compile(r"^\s*(COPY|ADD)( --[^ ]+)* (?P<src>[^ ]+) (?P<dst>[^ ]+)\s*$")
+
+    @property
+    def save_as_tar(self) -> bool:
+        """Is the image also saved as an archive?"""
+        return self._archive_reference is not None
+
+    @property
+    def tar_filepath(self) -> Path:
+        """Path of the image archive, when saved as one."""
+        return self.dest_dir / f"{self.name}-{self.version}.tar"
 
     def load_deps_from_dockerfile(self) -> Dict[str, Any]:
         """Compute file dependencies from Dockerfile."""
@@ -147,13 +165,16 @@ class LocalImage(image.ContainerImage):
                 "uptodate": [(docker_command.docker_image_exists, [self.tag], {})],
             }
         )
+        outputs: List[Path] = []
+        cleaners: List[types.Action] = []
         if self.save_on_disk:
-            task.update(
-                {
-                    "targets": [self.dirname / "manifest.json"],
-                    "clean": [self.clean],
-                }
-            )
+            outputs.append(self.dirname / "manifest.json")
+            cleaners.append(self.clean)
+        if self.save_as_tar:
+            outputs.append(self.tar_filepath)
+            cleaners.append(self.clean_tar)
+        if outputs:
+            task.update({"targets": outputs, "clean": cleaners})
         return task
 
     @property
@@ -173,7 +194,13 @@ class LocalImage(image.ContainerImage):
         actions = self._do_build()
         if self.save_on_disk:
             actions.extend(self._do_save())
+        if self.save_as_tar:
+            actions.extend(self._do_save_as_tar())
         return actions
+
+    def clean_tar(self) -> None:
+        """Delete the image archive."""
+        self.tar_filepath.unlink(missing_ok=True)
 
     def _do_build(self) -> List[types.Action]:
         """Return the actions used to build the image."""
@@ -190,6 +217,21 @@ class LocalImage(image.ContainerImage):
         cmd.append(f"docker-daemon:{self.tag}")
         cmd.append(f"dir:{str(self.dirname)}")
         return [self.mkdirs, cmd]
+
+    def _do_save_as_tar(self) -> List[types.Action]:
+        """Return the actions used to save the image as an archive."""
+        cmd = list(constants.SKOPEO_COPY_DEFAULT_ARGS)
+        docker_host = os.getenv("DOCKER_HOST")
+        if docker_host is not None:
+            cmd.extend(["--src-daemon-host", f"http://{docker_host}"])
+        cmd.append(f"docker-daemon:{self.tag}")
+        cmd.append(f"docker-archive:{str(self.tar_filepath)}:{self.archive_reference}")
+        return [self._prepare_tar, cmd]
+
+    def _prepare_tar(self) -> None:
+        """Make room for the archive: `docker-archive` cannot overwrite."""
+        self.tar_filepath.parent.mkdir(parents=True, exist_ok=True)
+        self.clean_tar()
 
     @staticmethod
     def _expand_dep(dep: Path) -> List[Path]:

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -240,6 +240,16 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
         digest=None,
     ),
     Image(
+        name="metalk8s-boot-cache-control-plane",
+        version=VERSION,
+        digest=None,
+    ),
+    Image(
+        name="metalk8s-boot-cache-worker",
+        version=VERSION,
+        digest=None,
+    ),
+    Image(
         name="metalk8s-keepalived",
         version=VERSION,
         digest=None,
@@ -318,6 +328,11 @@ CONTAINER_IMAGES: Tuple[Image, ...] = (
         name="disk-management-agent",
         version="v0.1.0",
         digest="sha256:d63d4e20a089dcd3ac33f58d2210a66e48a1f9f08120494352b22cca94747769",
+    ),
+    Image(
+        name="file-reflector",
+        version="v0.2.0",
+        digest="sha256:97f14f857ebef1b421ad2799e6fba77c9b0cebcfc19f0b726344e322a4f7ead5",
     ),
     Image(
         name="node-warden-operator",

--- a/buildchain/tests/conftest.py
+++ b/buildchain/tests/conftest.py
@@ -1,0 +1,17 @@
+# coding: utf-8
+
+"""Shared test setup for the buildchain unit tests."""
+
+import sys
+import unittest.mock
+from pathlib import Path
+
+# The buildchain is not an installed package: `dodo.py` imports it with
+# `buildchain/` as the working directory. Mirror that here so the tests can
+# run from anywhere.
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# `buildchain.docker_command` connects to the Docker daemon at import time.
+# Unit tests must not depend on a running daemon: stub the client out for the
+# whole test session, before any `buildchain` module gets imported.
+unittest.mock.patch("docker.from_env").start()

--- a/buildchain/tests/test_image.py
+++ b/buildchain/tests/test_image.py
@@ -1,0 +1,169 @@
+# coding: utf-8
+
+"""Unit tests for the boot cache tasks of `buildchain.image`."""
+
+from pathlib import Path
+from typing import Any, List
+
+import pytest
+
+from buildchain import config, constants, image, versions
+
+VARIANTS = sorted(image.BOOT_CACHE_VARIANTS)
+
+# Every variant runs the whole suite: a new one is covered by declaring it.
+variants = pytest.mark.parametrize("variant", VARIANTS)
+
+
+def members_of(variant: str) -> List[Any]:
+    """The images a variant caches, as pulled image targets."""
+    return [image.TO_PULL[name] for name in image.BOOT_CACHE_VARIANTS[variant]]
+
+
+def command_actions(task: dict) -> List[str]:
+    """Render the command-list actions of a task as searchable strings."""
+    return [
+        " ".join(map(str, action))
+        for action in task["actions"]
+        if isinstance(action, list)
+    ]
+
+
+class TestBootCacheVariants:
+    """The manifest itself: every declared name must stay resolvable."""
+
+    def test_members_are_pulled_images(self) -> None:
+        for variant, members in image.BOOT_CACHE_VARIANTS.items():
+            missing = [name for name in members if name not in image.TO_PULL]
+            assert not missing, f"variant {variant} lists unknown images: {missing}"
+
+    def test_every_variant_is_built(self) -> None:
+        built = {img.name for img in image.TO_BUILD}
+        for variant in image.BOOT_CACHE_VARIANTS:
+            assert f"metalk8s-boot-cache-{variant}" in built
+
+    def test_variant_versions_are_declared(self) -> None:
+        # The version listing feeds the Salt `repo.images` map: a boot cache
+        # image missing from it would break `build_image_name` at render time.
+        for variant in image.BOOT_CACHE_VARIANTS:
+            assert f"metalk8s-boot-cache-{variant}" in versions.CONTAINER_IMAGES_MAP
+
+
+class TestNodeImageFullname:
+    def test_matches_the_registry_layout(self) -> None:
+        prefix = f"{config.PROJECT_NAME.lower()}-{versions.VERSION}"
+        assert image._node_image_fullname("etcd", "1.2.3") == (
+            f"{constants.NODE_REGISTRY_ENDPOINT}/{prefix}/etcd:1.2.3"
+        )
+
+
+class TestBootCacheRoot:
+    """`doit clean` has to end with no `_build` left at all."""
+
+    def test_the_staging_root_is_owned_by_a_task(self) -> None:
+        # Each variant only cleans what it created. Without a task owning the
+        # root, an empty `_build/boot-cache` survives the clean and keeps
+        # the build root from being removed, which CI checks with
+        # `./doit.sh clean && test ! -d _build`.
+        task = image.task__image_boot_cache_mkdir_root()
+        assert constants.BOOT_CACHE_ROOT in task["targets"]
+
+    @variants
+    def test_contexts_are_built_under_that_root(self, variant: str) -> None:
+        task = image._boot_cache_context_task(variant)
+        assert "_image_boot_cache_mkdir_root" in task["task_dep"]
+
+
+class TestBootCacheContextTask:
+    def test_unknown_image_is_a_clear_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setitem(image.BOOT_CACHE_VARIANTS, "broken", ["not-pulled"])
+        with pytest.raises(ValueError, match="not-pulled"):
+            image._boot_cache_context_task("broken")
+
+    @variants
+    def test_one_archive_per_member(self, variant: str) -> None:
+        task = image._boot_cache_context_task(variant)
+        expected = [
+            constants.BOOT_CACHE_ROOT
+            / variant
+            / "images"
+            / f"{member.name}-{member.version}.tar"
+            for member in members_of(variant)
+        ]
+        assert task["targets"] == expected
+
+    @variants
+    def test_archives_depend_on_the_pulled_layers(self, variant: str) -> None:
+        task = image._boot_cache_context_task(variant)
+        assert task["file_dep"] == [
+            member.dirname / "manifest.json" for member in members_of(variant)
+        ]
+
+    @variants
+    def test_archives_convert_layers_and_carry_the_node_name(
+        self, variant: str
+    ) -> None:
+        task = image._boot_cache_context_task(variant)
+        actions = command_actions(task)
+        members = members_of(variant)
+        assert len(actions) == len(members)
+        for member, archive, action in zip(
+            members, task["targets"], actions, strict=True
+        ):
+            assert f"dir:{member.dirname}" in action
+            reference = image._node_image_fullname(member.name, member.version)
+            assert f"docker-archive:{archive}:{reference}" in action
+
+    @variants
+    def test_prepare_purges_stale_archives(
+        self, variant: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The whole context directory ends up in the image: an archive left
+        # over from a previous version bump must not survive a re-run.
+        monkeypatch.setattr(constants, "BOOT_CACHE_ROOT", tmp_path)
+        task = image._boot_cache_context_task(variant)
+        images_dir = tmp_path / variant / "images"
+        images_dir.mkdir(parents=True)
+        (images_dir / "etcd-0.0.0-stale.tar").touch()
+        prepare = task["actions"][0]
+        prepare()
+        assert images_dir.is_dir()
+        assert list(images_dir.iterdir()) == []
+
+
+class TestBootCacheImage:
+    @staticmethod
+    def image_of(variant: str) -> Any:
+        (img,) = (
+            img
+            for img in image.TO_BUILD
+            if img.name == f"metalk8s-boot-cache-{variant}"
+        )
+        return img
+
+    @variants
+    def test_waits_for_its_context(self, variant: str) -> None:
+        assert f"_image_boot_cache_context:{variant}" in self.image_of(variant).task_dep
+
+    @variants
+    def test_builds_from_the_assembled_context(self, variant: str) -> None:
+        assert self.image_of(variant).build_context == (
+            constants.BOOT_CACHE_ROOT / variant
+        )
+
+    @variants
+    def test_ships_both_layers_and_archive(self, variant: str) -> None:
+        # Same double output as `pause` and `nginx`: layers for the registry,
+        # an archive for nodes that have no registry yet.
+        img = self.image_of(variant)
+        assert img.save_on_disk
+        assert img.save_as_tar
+
+    @variants
+    def test_archive_carries_the_node_name(self, variant: str) -> None:
+        img = self.image_of(variant)
+        assert img.archive_reference == image._node_image_fullname(
+            img.name, img.version
+        )

--- a/buildchain/tests/test_local_image.py
+++ b/buildchain/tests/test_local_image.py
@@ -1,0 +1,83 @@
+# coding: utf-8
+
+"""Unit tests for the archive output of `LocalImage`."""
+
+from pathlib import Path
+from typing import Any, List
+
+from buildchain.targets.local_image import LocalImage
+
+
+def make_image(**kwargs: Any) -> LocalImage:
+    """A `LocalImage` with harmless defaults."""
+    defaults: dict = {
+        "name": "some-image",
+        "version": "1.0.0",
+        "dockerfile": Path("/context/Dockerfile"),
+        "destination": Path("/destination"),
+        "save_on_disk": True,
+    }
+    defaults.update(kwargs)
+    return LocalImage(**defaults)
+
+
+def flatten_actions(actions: List[Any]) -> str:
+    """Render command-list actions as one searchable string."""
+    return "\n".join(
+        " ".join(map(str, action)) for action in actions if isinstance(action, list)
+    )
+
+
+REFERENCE = "registry.invalid/prefix/some-image:1.0.0"
+
+
+class TestNoArchiveReference:
+    """Without an `archive_reference`, the behavior stays what it always was."""
+
+    def test_not_saved_as_tar(self) -> None:
+        assert not make_image().save_as_tar
+
+    def test_no_archive_target(self) -> None:
+        image = make_image()
+        assert image.tar_filepath not in image.task["targets"]
+
+    def test_no_archive_action(self) -> None:
+        image = make_image()
+        assert "docker-archive:" not in flatten_actions(image.task["actions"])
+
+
+class TestArchiveReference:
+    def test_archive_is_a_target(self) -> None:
+        image = make_image(archive_reference=REFERENCE)
+        assert image.tar_filepath in image.task["targets"]
+        assert image.tar_filepath == Path("/destination/some-image-1.0.0.tar")
+
+    def test_layers_still_saved(self) -> None:
+        image = make_image(archive_reference=REFERENCE)
+        assert image.dirname / "manifest.json" in image.task["targets"]
+
+    def test_archive_carries_the_reference(self) -> None:
+        # The archive is imported as-is, so the name it carries is the whole
+        # point of saving one: it is not the local tag.
+        image = make_image(archive_reference=REFERENCE)
+        actions = flatten_actions(image.task["actions"])
+        assert f"docker-archive:{image.tar_filepath}:{REFERENCE}" in actions
+        assert image.tag != REFERENCE
+
+    def test_clean_removes_the_archive(self, tmp_path: Path) -> None:
+        image = make_image(archive_reference=REFERENCE, destination=tmp_path)
+        image.tar_filepath.touch()
+        for clean in image.task["clean"]:
+            clean()
+        assert not image.tar_filepath.exists()
+
+    def test_prepare_makes_room_for_skopeo(self, tmp_path: Path) -> None:
+        # `docker-archive` refuses to write over an existing file, and the
+        # destination directory may not exist yet on a fresh build tree.
+        image = make_image(archive_reference=REFERENCE, destination=tmp_path / "images")
+        prepare = image.task["actions"][-2]
+        image.tar_filepath.parent.mkdir(parents=True)
+        image.tar_filepath.touch()
+        prepare()
+        assert image.tar_filepath.parent.is_dir()
+        assert not image.tar_filepath.exists()

--- a/images/metalk8s-boot-cache/Dockerfile
+++ b/images/metalk8s-boot-cache/Dockerfile
@@ -1,0 +1,14 @@
+# Boot cache image: a carrier for container image archives, with no runtime of
+# its own. Nodes extract the archives it holds and import them into containerd,
+# so that critical images survive the loss of the local image store without
+# depending on the registry.
+#
+# Every variant (control plane, registry, worker) is built from this same
+# Dockerfile; what changes is the build context, assembled by the buildchain
+# with the archives that variant must cache. See `BOOT_CACHE_VARIANTS` in
+# buildchain/buildchain/image.py.
+FROM scratch
+
+LABEL maintainer="moonshot-platform@scality.com"
+
+COPY images/ /images/

--- a/tox.ini
+++ b/tox.ini
@@ -57,6 +57,15 @@ commands =
            --cov-fail-under=100 \
           {posargs} salt/tests/unit
 
+[testenv:unit-tests-buildchain]
+description =
+    Run buildchain unit tests.
+deps =
+    -r{toxinidir}/buildchain/requirements.txt
+    pytest~=8.4
+commands =
+    pytest {posargs} buildchain/tests
+
 [testenv:pre-commit]
 description =
     Run pre-commit hook


### PR DESCRIPTION
**Component**: build, containers

**Context**:

A node that loses its container images cannot pull them back when the registry
holding them runs on the cluster itself: a pruned image store, a reinstall or a
cold start with no external registry leaves the node unable to run the very
workloads that would let it pull again.

MK8S-153: ship the images a node needs to boot as archives inside a container
image, so provisioning can restore them into containerd with no registry and no
working control plane.

**Summary**:

- `BOOT_CACHE_VARIANTS` in `image.py` lists what each variant caches, and
  everything else follows from it: the build context, the image, the archive.
  A name that is not pulled fails the build immediately, with a message saying
  what to fix.
- Two variants ship. `metalk8s-boot-cache-control-plane` carries `pause`, etcd,
  the API server, the controller manager, the scheduler, CoreDNS, `kube-proxy`
  and Calico. `metalk8s-boot-cache-worker` carries `pause` and
  `file-reflector`.
- Both carry `pause` because containerd pins it as its sandbox image
  (`pinned_images.sandbox` in `containerd/installed.sls`): without it the
  kubelet creates no sandbox, so a control plane node would not even start its
  static pods.
- `file-reflector` v0.2.0 is pulled for the first time here. It is the agent
  the registry operator runs to write containerd's mirror configuration on each
  node.
- The archives are converted with skopeo from the layers already pulled for the
  ISO, so nothing is downloaded twice, and they are staged under
  `_build/boot-cache/<variant>`, out of the ISO. The staging directory is
  emptied before each assembly: all of it ends up in the image, so an archive
  left over from a version bump must not survive.
- Each archive carries the name the kubelet asks for, the one the cluster
  registry serves, since a cached archive is imported as is, with no
  re-tagging, unlike the ones Salt imports through `--index-name`.
- Each image is saved both as layers, for the registry, and as an archive, for
  a node that has no registry yet: the two formats `pause` and `nginx` already
  use. `LocalImage` gained an `archive_reference` option for that.
- First unit tests for the buildchain (`buildchain/tests`), with a
  `unit-tests-buildchain` tox environment and a pre-merge job scoped by path.
  The suite is parametrised per variant, so declaring a new one covers it.

The registry variant stays declared but commented out: its three images are not
carried by the buildchain, and the stack that runs them is not part of MetalK8s
core yet. Tracked in MK8S-380, blocked by MK8S-168.

**Acceptance criteria**:

- `tox -e unit-tests-buildchain` passes (29 tests).
- `./doit.sh images` produces, for each variant,
  `_build/root/images/metalk8s-boot-cache-<variant>/<version>/` (layers) and
  `_build/root/images/metalk8s-boot-cache-<variant>-<version>.tar` (archive),
  and `_build/boot-cache/` stays out of the ISO.
- `tar tf` on an archive shows one `*.tar` per image listed for the variant,
  each named after the reference the node resolves.

Cost on the ISO: about 386 MB of layers plus a 1.1 GB archive for the control
plane variant, the deduplicated layers being shared with the images already
shipped. The worker variant adds `file-reflector` and reuses `pause`.