### PR TITLE
fix(build): stop replacing the pip bundled in the salt-master image

### DIFF
--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -88,7 +88,7 @@ UI_OPERATOR_VERSION: str = "1.1.0"
 # installed in the image needs to be updated.
 # This should be reset to 1 when the service exposed by the container changes
 # version.
-SALT_MASTER_BUILD_ID = 1
+SALT_MASTER_BUILD_ID = 2
 
 
 def _version_prefix(version: str, prefix: str = "v") -> str:

--- a/images/salt-master/Dockerfile
+++ b/images/salt-master/Dockerfile
@@ -19,7 +19,11 @@ RUN curl -fsSL https://github.com/saltstack/salt-install-guide/releases/latest/d
       openssh-clients procps-ng \
       dnf \
       glibc-all-langpacks langpacks-en \
- && salt-pip install --no-cache-dir --upgrade pip \
+ # No `pip install --upgrade pip` here: the pip bundled in the Salt onedir is
+ # patched by relenv, and replacing it breaks every later `salt-pip install`
+ # as soon as upstream pip changes the internals that patch relies on (pip
+ # 26.2 did, and broke this build). The bundled pip installs the packages
+ # below just fine.
  && salt-pip install --no-cache-dir "etcd3gw ~= 2.6.0" "kubernetes ~= 33.1.0" \
  && microdnf clean all
 


### PR DESCRIPTION
**Component**: build, containers

**Context**:

Every image build has failed since yesterday evening, on every branch targeting
`development/134.0`, at `_image_build:salt-master`:

```
TypeError: InstallRequirement.install() got an unexpected keyword argument 'script_executable'
```

`images/salt-master/Dockerfile` upgraded pip with no version bound before
installing the Python dependencies. Salt ships its own pip inside the onedir and
patches it through relenv, so replacing that pip breaks every later
`salt-pip install` as soon as upstream changes the internals the patch relies on.
pip **26.2**, published 2026-07-29 at 21:57 UTC, did exactly that. The last green
build of this branch, the nightly of 2026-07-28, still picked up 26.1.2. Only the
`build` job is affected: tests and lint pass.

MK8S-372.

**Summary**:

- Drop the `--upgrade pip` rather than pin it. The bundled pip is by construction
  the one relenv supports, so nothing here has to track upstream pip releases and
  the build stops depending on whatever PyPI publishes that day.
- Measured on Salt 3006.27: the onedir ships **pip 25.2**, and it installs
  `etcd3gw ~= 2.6.0` and `kubernetes ~= 33.1.0` on its own. The upgrade brought
  nothing. Should a future dependency really need a newer pip, the build will say
  so and the version can be pinned deliberately at that point.
- `SALT_MASTER_BUILD_ID` goes to 2, since the image content changes. The tag
  becomes `3006.27-2` and propagates through `CONTAINER_IMAGES`; no other place
  hardcodes it.
- `development/133.0` is **not** affected: it still installs the system pip with
  its own pin, so there is nothing to merge up.

**Acceptance criteria**:

- The `build` job goes green again, here and on every other open pull request
  once they pick this up.
- Built locally from this branch: `SUCCESS IMG BUILD salt-master:3006.27-2` in
  49 s, and inside the resulting image:

  ```
  pip 25.2 from /opt/saltstack/salt/lib/python3.11/site-packages/pip (python 3.11)
  etcd3gw            2.6.0
  kubernetes         33.1.0
  ```

  The bundled pip is untouched and both dependencies are installed.

An earlier revision of this branch pinned pip to 26.1.2 instead, on the
assumption that the bundled pip was too old for those dependencies. A probe
build disproved it, hence the simpler change.

No CHANGELOG entry: the regression never reached a release, and the images this
produces behave exactly as before.