### PR TITLE
fix(shell-ui): stop headless federated components rendering "Loading..." above the navbar

### DIFF
--- a/shell-ui/src/FederatedApp.tsx
+++ b/shell-ui/src/FederatedApp.tsx
@@ -88,6 +88,7 @@ function FederatedRoute({ scope, module, app }: FederatedRouteProps) {
         props={federatedAppProps}
         scope={scope}
         app={app}
+        renderOnLoading={<Loader size="massive" centered={true} aria-label="loading" />}
       />
     </ErrorBoundary>
   );

--- a/shell-ui/src/mcp/MCPRegistrar.tsx
+++ b/shell-ui/src/mcp/MCPRegistrar.tsx
@@ -192,6 +192,11 @@ const AppMCPRegistrar = ({
         componentWithInjectedImports={_InternalMCPRegistrar}
         componentProps={{ mcpToolsModuleInfo, selfConfiguration, navigate }}
         renderOnError={null}
+        // Headless registrar — it must never occupy layout. Has to be <></> rather than
+        // null: the library resolves `renderOnLoading ?? <>Loading...</>`, so null and
+        // undefined are swallowed by ?? and still render a bare "Loading..." text node,
+        // which becomes a flex item above the navbar and shifts it on first load.
+        renderOnLoading={<></>}
         federatedImports={[{ ...mcpToolsModuleInfo, remoteEntryUrl }]}
       />
     </ErrorBoundary>

--- a/shell-ui/src/navbar/InstanceName.tsx
+++ b/shell-ui/src/navbar/InstanceName.tsx
@@ -162,6 +162,9 @@ export const InstanceName = () => {
       componentWithInjectedImports={_InternalInstanceName}
       componentProps={{}}
       renderOnError={<ErrorPage500 />}
+      // Matches what _InternalInstanceName renders while its own query loads, so the
+      // navbar tab keeps a stable width across both loading phases.
+      renderOnLoading={<Loader size="smaller" />}
       federatedImports={[instanceNameAdapter]}
     />
   );

--- a/shell-ui/src/navbar/NavbarUpdaterComponents.tsx
+++ b/shell-ui/src/navbar/NavbarUpdaterComponents.tsx
@@ -63,6 +63,9 @@ export const NavbarUpdaterComponents = () => {
                   shellHooks,
                   shellAlerts,
                 }}
+                // Headless updaters — they publish links/notifications and render
+                // nothing in place. Must be <></>, not null: see MCPRegistrar.
+                renderOnLoading={<></>}
               />
             </ErrorBoundary>
           </Fragment>


### PR DESCRIPTION
**TL;DR** — The shell UI navbar no longer jumps down on first load: every federated component now declares what it renders while its remote module loads, instead of falling back to the library's bare `Loading...` text.

### Context / Why

On first load the navbar was pushed down by a couple of text lines and then snapped back up once the federated remotes resolved. Fixes **MK8S-382**.

### 🧩 Approach

`@scality/module-federation` supplies the Suspense fallback itself when a call site doesn't:

```tsx
// @scality/module-federation@1.6.1 → src/ModuleFederation.tsx:97  (FederatedComponent)
//                                    src/ModuleFederation.tsx:162 (ComponentWithFederatedImports)
<Suspense fallback={renderOnLoading ?? <>Loading...</>}>
```

That default is a bare **text node**. In shell-ui's root flex column it becomes an anonymous flex item, so it occupies vertical space above the navbar until the remote resolves — which is the shift.

**`??` is nullish coalescing, so `renderOnLoading={null}` cannot switch the fallback off.** `null`, `undefined` and omitting the prop are all indistinguishable to the library; suppressing the text requires a *non-nullish* value that React renders as nothing:

Before:

```tsx
<ComponentWithFederatedImports
  componentWithInjectedImports={_InternalMCPRegistrar}
  componentProps={{ mcpToolsModuleInfo, selfConfiguration, navigate }}
  renderOnError={null}
  federatedImports={[{ ...mcpToolsModuleInfo, remoteEntryUrl }]}
/>
```

After:

```tsx
<ComponentWithFederatedImports
  componentWithInjectedImports={_InternalMCPRegistrar}
  componentProps={{ mcpToolsModuleInfo, selfConfiguration, navigate }}
  renderOnError={null}
  renderOnLoading={<></>}                                    // ← null would be a no-op
  federatedImports={[{ ...mcpToolsModuleInfo, remoteEntryUrl }]}
/>
```

Each of the four call sites gets the fallback that matches what it actually renders:

| Call site | Fallback | Why |
| --- | --- | --- |
| `mcp/MCPRegistrar.tsx` | `<></>` | Headless — registers MCP tools, renders nothing |
| `navbar/NavbarUpdaterComponents.tsx` | `<></>` | Headless — publishes navbar links and notifications |
| `navbar/InstanceName.tsx` | `<Loader size="smaller" />` | Matches what the component already renders while its own query loads, so the navbar tab keeps a stable width |
| `FederatedApp.tsx` (route) | `<Loader size="massive" centered />` | Consistent with the loader already used for the shared-deps query |

Measured in a browser against a local stack (shell-ui + metalk8s-ui + identity-ui + artesca-base-ui), instrumenting the document before page scripts run and grouping `Loading` text nodes by their direct DOM parent:

| Direct parent | Slot | Before | After |
| --- | --- | --- | --- |
| root `div[height:100vh;display:flex;flex-direction:column]` | `MCPRegistrar` | 1 per render pass | **0** |
| `div[flex:1 1 0%;min-width:0px]` | `NavbarUpdaterComponents` | ~12 per render pass | **0** |

Sampling the symptom directly across the load window: 142 samples, navbar `getBoundingClientRect().top` constant at `0`, zero shift transitions.

The rule lives as a comment at each call site, since `<></>` reads like something a later cleanup would "simplify" to `null`. A unit test belongs with the library fix (see *References*), not here — asserting this in a consumer means mocking `@scality/module-federation` and reproducing its `??`, which pins another package's internals and would fail once that default is corrected.

### 📷 Screenshots

<img width="968" height="353" alt="image" src="https://github.com/user-attachments/assets/de49aab8-4139-4657-bb75-864636a1f249" />


### 🔍 Review focus

- 🟡 **Moderate** — `navbar/InstanceName.tsx` › `InstanceName` — this tab has *two* sequential loading phases (federated import, then the instance-name query). `<Loader size="smaller" />` is chosen to match what `_InternalInstanceName` renders in phase two, so the tab does not change width between them; a different loader here reintroduces a smaller shift inside the navbar.
- 🟡 **Moderate** — `mcp/MCPRegistrar.tsx` › `AppMCPRegistrar` and `navbar/NavbarUpdaterComponents.tsx` — `<></>` is load-bearing, not stylistic. Both components are headless, and `null`/`undefined` silently restore the bug.
- ⚪ **Minor** — `FederatedApp.tsx` › `FederatedRoute` — route-level remotes now show a massive centered loader where they previously showed `Loading...` text. Worth a glance that this is wanted on every federated route transition, not just first load.

### 🧪 How to test

1. Launch the stack with [artesca-ui-launcher](https://github.com/scality/artesca-ui-launcher) (`npm run v2 -- artesca`, or a preset that includes `metalk8s`) — shell-ui is the Module Federation host, so it does not render standalone. Launch **without** `--dev`.
2. Open `http://localhost:8084/` with a cold cache and the network throttled (the loading window is under a second warm, so throttling is what makes this observable).
3. Watch the navbar through the load: it should stay at the top of the viewport, with no `Loading...` text above it and no downward jump followed by a snap back.
4. Confirm no blank gap is left where the placeholders used to be.
5. Confirm MCP tools still register, and that navbar links and notifications published by the updater components still appear — only the loading fallback changed.
6. On ARTESCA, watch the instance-name pill: it shows a small spinner and should not change width when the deployment name arrives.

### 🔗 References

- [MK8S-382](https://scality.atlassian.net/browse/MK8S-382) — the bug: navbar shifts on first load because headless federated components render the default `Loading...` fallback. Also records the follow-ups below.
- [ARTESCA-17978](https://scality.atlassian.net/browse/ARTESCA-17978) — the root cause, in `@scality/module-federation`: make `renderOnLoading={null}` behave as read, and either render or drop the dead `renderOnError`. Where the unit test for this belongs.

<details><summary>What changed</summary>

Four `renderOnLoading` props and four explanatory comments — no logic, imports or component structure touched (`Loader` was already imported in both files that needed it).

Deliberately **not** in this PR:

- **`@scality/module-federation` itself** — tracked in [ARTESCA-17978](https://scality.atlassian.net/browse/ARTESCA-17978). The `??` default is the actual defect: `renderOnLoading={null}` reads as "render nothing" to any React developer and does the opposite. The fix is to distinguish "not passed" from "explicitly nothing" — a default parameter (`renderOnLoading = <>Loading...</>`) fires only on `undefined`, so `null` would then behave as read — or to make the prop required. Needs a library release plus consumer bumps, and is where a unit test for this behaviour belongs.
- **`ComponentWithFederatedImports` destructures `renderOnError` but never renders it** — a dead prop, which makes `InstanceName`'s `renderOnError={<ErrorPage500 />}` a no-op. Same ticket.
- **`@artesca/ui`'s own unguarded call sites** (`IntlProvider`, `PlatformLibraryProvider`, `XCoreLibraryProvider`, `PlatformStatusCell`), which still show `Loading...` inside the page content area.
- **Pre-existing:** the root div is `100vh` and core-ui's `LayoutContainer` is also `100vh`, so anything rendered as a sibling of `Layout` in the root column necessarily overflows the viewport.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MK8S-382]: https://scality.atlassian.net/browse/MK8S-382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ