### PR TITLE
ci: let apt wait for the dpkg lock instead of failing (MK8S-387)

### DIFF
--- a/.github/actions/destroy-cluster/action.yaml
+++ b/.github/actions/destroy-cluster/action.yaml
@@ -57,7 +57,10 @@ runs:
       if: inputs.ARTIFACTS_URL
       shell: bash
       run: |
-        sudo apt-get -o DPkg::Lock::Timeout=600 update
+        # Wait for apt/dpkg locks to be released (e.g. unattended-upgrades at startup).
+        # DPkg::Lock::Timeout makes apt retry internally instead of failing immediately,
+        # which avoids the TOCTOU race of checking locks externally then calling apt-get.
+        sudo apt-get -o DPkg::Lock::Timeout=600 update && \
         sudo apt-get -o DPkg::Lock::Timeout=600 install -y unzip
     - name: Install node
       if: inputs.ARTIFACTS_URL

--- a/.github/actions/destroy-cluster/action.yaml
+++ b/.github/actions/destroy-cluster/action.yaml
@@ -56,7 +56,9 @@ runs:
     - name: Install tools
       if: inputs.ARTIFACTS_URL
       shell: bash
-      run: sudo apt-get -o DPkg::Lock::Timeout=300 update && sudo apt-get -o DPkg::Lock::Timeout=300 install -y unzip
+      run: |
+        sudo apt-get -o DPkg::Lock::Timeout=600 update
+        sudo apt-get -o DPkg::Lock::Timeout=600 install -y unzip
     - name: Install node
       if: inputs.ARTIFACTS_URL
       uses: actions/setup-node@v6

--- a/.github/actions/destroy-cluster/action.yaml
+++ b/.github/actions/destroy-cluster/action.yaml
@@ -56,7 +56,7 @@ runs:
     - name: Install tools
       if: inputs.ARTIFACTS_URL
       shell: bash
-      run: sudo apt-get update && sudo apt-get install -y unzip
+      run: sudo apt-get -o DPkg::Lock::Timeout=300 update && sudo apt-get -o DPkg::Lock::Timeout=300 install -y unzip
     - name: Install node
       if: inputs.ARTIFACTS_URL
       uses: actions/setup-node@v6

--- a/.github/actions/generate-snapshots/action.yaml
+++ b/.github/actions/generate-snapshots/action.yaml
@@ -30,7 +30,8 @@ runs:
     - name: Install dependencies for Openstack
       if: contains('ovh', inputs.cloud)
       run: |
-        sudo apt-get -o DPkg::Lock::Timeout=300 update && sudo apt-get -o DPkg::Lock::Timeout=300 install -y python3-pip jq
+        sudo apt-get -o DPkg::Lock::Timeout=600 update
+        sudo apt-get -o DPkg::Lock::Timeout=600 install -y python3-pip jq
         pip3 install --user --upgrade pip
         pip3 install --user python-openstackclient~=5.8.0 openstacksdk~=1.4.0
       shell: bash

--- a/.github/actions/generate-snapshots/action.yaml
+++ b/.github/actions/generate-snapshots/action.yaml
@@ -30,7 +30,7 @@ runs:
     - name: Install dependencies for Openstack
       if: contains('ovh', inputs.cloud)
       run: |
-        sudo apt-get update && sudo apt-get install -y python3-pip jq
+        sudo apt-get -o DPkg::Lock::Timeout=300 update && sudo apt-get -o DPkg::Lock::Timeout=300 install -y python3-pip jq
         pip3 install --user --upgrade pip
         pip3 install --user python-openstackclient~=5.8.0 openstacksdk~=1.4.0
       shell: bash

--- a/.github/actions/generate-snapshots/action.yaml
+++ b/.github/actions/generate-snapshots/action.yaml
@@ -30,7 +30,10 @@ runs:
     - name: Install dependencies for Openstack
       if: contains('ovh', inputs.cloud)
       run: |
-        sudo apt-get -o DPkg::Lock::Timeout=600 update
+        # Wait for apt/dpkg locks to be released (e.g. unattended-upgrades at startup).
+        # DPkg::Lock::Timeout makes apt retry internally instead of failing immediately,
+        # which avoids the TOCTOU race of checking locks externally then calling apt-get.
+        sudo apt-get -o DPkg::Lock::Timeout=600 update && \
         sudo apt-get -o DPkg::Lock::Timeout=600 install -y python3-pip jq
         pip3 install --user --upgrade pip
         pip3 install --user python-openstackclient~=5.8.0 openstacksdk~=1.4.0

--- a/.github/actions/spawn-cluster/action.yaml
+++ b/.github/actions/spawn-cluster/action.yaml
@@ -95,7 +95,10 @@ runs:
       if: inputs.skip-prepare == 'false'
       shell: bash
       run: |
-        sudo apt-get -o DPkg::Lock::Timeout=600 update
+        # Wait for apt/dpkg locks to be released (e.g. unattended-upgrades at startup).
+        # DPkg::Lock::Timeout makes apt retry internally instead of failing immediately,
+        # which avoids the TOCTOU race of checking locks externally then calling apt-get.
+        sudo apt-get -o DPkg::Lock::Timeout=600 update && \
         sudo apt-get -o DPkg::Lock::Timeout=600 install -y unzip
     - name: Install node
       if: inputs.skip-prepare == 'false'

--- a/.github/actions/spawn-cluster/action.yaml
+++ b/.github/actions/spawn-cluster/action.yaml
@@ -94,7 +94,9 @@ runs:
     - name: Install tools
       if: inputs.skip-prepare == 'false'
       shell: bash
-      run: sudo apt-get -o DPkg::Lock::Timeout=300 update && sudo apt-get -o DPkg::Lock::Timeout=300 install -y unzip
+      run: |
+        sudo apt-get -o DPkg::Lock::Timeout=600 update
+        sudo apt-get -o DPkg::Lock::Timeout=600 install -y unzip
     - name: Install node
       if: inputs.skip-prepare == 'false'
       uses: actions/setup-node@v6

--- a/.github/actions/spawn-cluster/action.yaml
+++ b/.github/actions/spawn-cluster/action.yaml
@@ -94,7 +94,7 @@ runs:
     - name: Install tools
       if: inputs.skip-prepare == 'false'
       shell: bash
-      run: sudo apt-get update && sudo apt-get install -y unzip
+      run: sudo apt-get -o DPkg::Lock::Timeout=300 update && sudo apt-get -o DPkg::Lock::Timeout=300 install -y unzip
     - name: Install node
       if: inputs.skip-prepare == 'false'
       uses: actions/setup-node@v6

--- a/.github/workflows/downgrade-test.yaml
+++ b/.github/workflows/downgrade-test.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install deps
-        run: sudo apt-get update && sudo apt-get install -y isomd5sum
+        run: sudo apt-get -o DPkg::Lock::Timeout=300 update && sudo apt-get -o DPkg::Lock::Timeout=300 install -y isomd5sum
 
      ## Spawn {{{
       - name: Export environment variables for accessing the cloud

--- a/.github/workflows/downgrade-test.yaml
+++ b/.github/workflows/downgrade-test.yaml
@@ -39,7 +39,10 @@ jobs:
         uses: actions/checkout@v6
       - name: Install deps
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=600 update
+          # Wait for apt/dpkg locks to be released (e.g. unattended-upgrades at startup).
+          # DPkg::Lock::Timeout makes apt retry internally instead of failing immediately,
+          # which avoids the TOCTOU race of checking locks externally then calling apt-get.
+          sudo apt-get -o DPkg::Lock::Timeout=600 update && \
           sudo apt-get -o DPkg::Lock::Timeout=600 install -y isomd5sum
 
      ## Spawn {{{

--- a/.github/workflows/downgrade-test.yaml
+++ b/.github/workflows/downgrade-test.yaml
@@ -38,7 +38,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install deps
-        run: sudo apt-get -o DPkg::Lock::Timeout=300 update && sudo apt-get -o DPkg::Lock::Timeout=300 install -y isomd5sum
+        run: |
+          sudo apt-get -o DPkg::Lock::Timeout=600 update
+          sudo apt-get -o DPkg::Lock::Timeout=600 install -y isomd5sum
 
      ## Spawn {{{
       - name: Export environment variables for accessing the cloud

--- a/.github/workflows/lifecycle-promoted.yaml
+++ b/.github/workflows/lifecycle-promoted.yaml
@@ -46,7 +46,10 @@ jobs:
         uses: actions/checkout@v6
       - name: Install deps
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=600 update
+          # Wait for apt/dpkg locks to be released (e.g. unattended-upgrades at startup).
+          # DPkg::Lock::Timeout makes apt retry internally instead of failing immediately,
+          # which avoids the TOCTOU race of checking locks externally then calling apt-get.
+          sudo apt-get -o DPkg::Lock::Timeout=600 update && \
           sudo apt-get -o DPkg::Lock::Timeout=600 install -y isomd5sum
 
      ## Spawn {{{

--- a/.github/workflows/lifecycle-promoted.yaml
+++ b/.github/workflows/lifecycle-promoted.yaml
@@ -45,7 +45,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install deps
-        run: sudo apt-get -o DPkg::Lock::Timeout=300 update && sudo apt-get -o DPkg::Lock::Timeout=300 install -y isomd5sum
+        run: |
+          sudo apt-get -o DPkg::Lock::Timeout=600 update
+          sudo apt-get -o DPkg::Lock::Timeout=600 install -y isomd5sum
 
      ## Spawn {{{
       - name: Export environment variables for accessing the cloud

--- a/.github/workflows/lifecycle-promoted.yaml
+++ b/.github/workflows/lifecycle-promoted.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install deps
-        run: sudo apt-get update && sudo apt-get install -y isomd5sum
+        run: sudo apt-get -o DPkg::Lock::Timeout=300 update && sudo apt-get -o DPkg::Lock::Timeout=300 install -y isomd5sum
 
      ## Spawn {{{
       - name: Export environment variables for accessing the cloud

--- a/.github/workflows/multi-node-test.yaml
+++ b/.github/workflows/multi-node-test.yaml
@@ -89,7 +89,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install deps
-        run: sudo apt-get update && sudo apt-get install -y isomd5sum jq
+        run: sudo apt-get -o DPkg::Lock::Timeout=300 update && sudo apt-get -o DPkg::Lock::Timeout=300 install -y isomd5sum jq
       - name: Retrieve product.txt from artifacts
         run: >
           curl --fail -LO -u ${{ secrets.ARTIFACTS_USER }}:${{ secrets.ARTIFACTS_PASSWORD }}

--- a/.github/workflows/multi-node-test.yaml
+++ b/.github/workflows/multi-node-test.yaml
@@ -89,7 +89,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install deps
-        run: sudo apt-get -o DPkg::Lock::Timeout=300 update && sudo apt-get -o DPkg::Lock::Timeout=300 install -y isomd5sum jq
+        run: |
+          sudo apt-get -o DPkg::Lock::Timeout=600 update
+          sudo apt-get -o DPkg::Lock::Timeout=600 install -y isomd5sum jq
       - name: Retrieve product.txt from artifacts
         run: >
           curl --fail -LO -u ${{ secrets.ARTIFACTS_USER }}:${{ secrets.ARTIFACTS_PASSWORD }}

--- a/.github/workflows/multi-node-test.yaml
+++ b/.github/workflows/multi-node-test.yaml
@@ -90,7 +90,10 @@ jobs:
         uses: actions/checkout@v6
       - name: Install deps
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=600 update
+          # Wait for apt/dpkg locks to be released (e.g. unattended-upgrades at startup).
+          # DPkg::Lock::Timeout makes apt retry internally instead of failing immediately,
+          # which avoids the TOCTOU race of checking locks externally then calling apt-get.
+          sudo apt-get -o DPkg::Lock::Timeout=600 update && \
           sudo apt-get -o DPkg::Lock::Timeout=600 install -y isomd5sum jq
       - name: Retrieve product.txt from artifacts
         run: >

--- a/.github/workflows/single-node-test.yaml
+++ b/.github/workflows/single-node-test.yaml
@@ -91,7 +91,10 @@ jobs:
         uses: actions/checkout@v6
       - name: Install deps
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=600 update
+          # Wait for apt/dpkg locks to be released (e.g. unattended-upgrades at startup).
+          # DPkg::Lock::Timeout makes apt retry internally instead of failing immediately,
+          # which avoids the TOCTOU race of checking locks externally then calling apt-get.
+          sudo apt-get -o DPkg::Lock::Timeout=600 update && \
           sudo apt-get -o DPkg::Lock::Timeout=600 install -y isomd5sum
       - name: Retrieve product.txt from artifacts
         run: >

--- a/.github/workflows/single-node-test.yaml
+++ b/.github/workflows/single-node-test.yaml
@@ -90,7 +90,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install deps
-        run: sudo apt-get update && sudo apt-get install -y isomd5sum
+        run: sudo apt-get -o DPkg::Lock::Timeout=300 update && sudo apt-get -o DPkg::Lock::Timeout=300 install -y isomd5sum
       - name: Retrieve product.txt from artifacts
         run: >
           curl --fail -LO -u ${{ secrets.ARTIFACTS_USER }}:${{ secrets.ARTIFACTS_PASSWORD }}

--- a/.github/workflows/single-node-test.yaml
+++ b/.github/workflows/single-node-test.yaml
@@ -90,7 +90,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install deps
-        run: sudo apt-get -o DPkg::Lock::Timeout=300 update && sudo apt-get -o DPkg::Lock::Timeout=300 install -y isomd5sum
+        run: |
+          sudo apt-get -o DPkg::Lock::Timeout=600 update
+          sudo apt-get -o DPkg::Lock::Timeout=600 install -y isomd5sum
       - name: Retrieve product.txt from artifacts
         run: >
           curl --fail -LO -u ${{ secrets.ARTIFACTS_USER }}:${{ secrets.ARTIFACTS_PASSWORD }}

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install deps
-        run: sudo apt-get update && sudo apt-get install -y isomd5sum
+        run: sudo apt-get -o DPkg::Lock::Timeout=300 update && sudo apt-get -o DPkg::Lock::Timeout=300 install -y isomd5sum
 
      ## Spawn {{{
       - name: Export environment variables for accessing the cloud

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -39,7 +39,10 @@ jobs:
         uses: actions/checkout@v6
       - name: Install deps
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=600 update
+          # Wait for apt/dpkg locks to be released (e.g. unattended-upgrades at startup).
+          # DPkg::Lock::Timeout makes apt retry internally instead of failing immediately,
+          # which avoids the TOCTOU race of checking locks externally then calling apt-get.
+          sudo apt-get -o DPkg::Lock::Timeout=600 update && \
           sudo apt-get -o DPkg::Lock::Timeout=600 install -y isomd5sum
 
      ## Spawn {{{

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -38,7 +38,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install deps
-        run: sudo apt-get -o DPkg::Lock::Timeout=300 update && sudo apt-get -o DPkg::Lock::Timeout=300 install -y isomd5sum
+        run: |
+          sudo apt-get -o DPkg::Lock::Timeout=600 update
+          sudo apt-get -o DPkg::Lock::Timeout=600 install -y isomd5sum
 
      ## Spawn {{{
       - name: Export environment variables for accessing the cloud


### PR DESCRIPTION
## Problem

`unattended-upgrades` races every `apt-get` in CI, and apt does not wait by default. On the
Scaleway runners it runs at **startup**, which is exactly when a job's first steps execute, so
contention there is the normal case rather than bad luck:

```
E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 2869 (unattended-upgr)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?
##[error]Process completed with exit code 100.
```

Three jobs failed this way in a single day, on three different runner VMs with three different
`unattended-upgrades` pids — so it is systemic rather than one sick machine:

| Run | Job |
| --- | --- |
| [31620761492](https://github.com/scality/metalk8s/actions/runs/31620761492) (pre-merge) | `e2e-tests / multi-node-e2e / multi-node` |
| [31628808727](https://github.com/scality/metalk8s/actions/runs/31628808727) (nightly) | `lifecycle-promoted (major, 132.0.2) / snapshot-upgrade (single node, 0)` |
| [31628808727](https://github.com/scality/metalk8s/actions/runs/31628808727) (nightly) | `lifecycle-promoted (patch, 133.0.11) / promoted-downgrade / downgrade` |

The triage cost is out of proportion to the cause. `Install deps` runs before Terraform spawns
anything, so a few seconds of lock contention is reported as a **four-step** failure: the later
steps then fail against a cluster that never existed — `ENOENT` on the terraform artifacts
directory, sosreport with no nodes to collect from, destroy with nothing to destroy — inside a
job named after an upgrade or e2e suite. It reads like a product regression until the log is
opened.

## Fix

Pass `-o DPkg::Lock::Timeout=600` to both `apt-get` invocations so apt waits for the holder
rather than exiting. Supported since apt 1.9.11; jammy ships 2.4.x. 600s costs nothing when
there is no contention, since apt returns as soon as it gets the lock — and 300s was observed
to be too short when unattended-upgrades has a large upgrade set to work through.

```yaml
      run: |
        # Wait for apt/dpkg locks to be released (e.g. unattended-upgrades at startup).
        # DPkg::Lock::Timeout makes apt retry internally instead of failing immediately,
        # which avoids the TOCTOU race of checking locks externally then calling apt-get.
        sudo apt-get -o DPkg::Lock::Timeout=600 update && \
        sudo apt-get -o DPkg::Lock::Timeout=600 install -y <packages>
```

The two invocations stay chained with `&& \` so a failed `update` prevents `install` by
construction rather than by relying on the step's `bash -e`. The comment is carried at each site
because the obvious alternative — polling for the lock, then calling apt — is a TOCTOU race: the
lock can be taken between the check and the call. Letting apt wait internally has no such gap.

Applied to **all 8 call sites**, not only the five `Install deps` steps named on the ticket —
`spawn-cluster`, `destroy-cluster` and `generate-snapshots` install packages the same way and
are exposed to the same race:

- `.github/workflows/{multi-node,single-node,upgrade,downgrade}-test.yaml`, `lifecycle-promoted.yaml`
- `.github/actions/{spawn-cluster,destroy-cluster,generate-snapshots}/action.yaml`

## Test plan

Nothing to unit test; the change is a CI flag. Verified locally that every `apt-get` under
`.github/` now carries the option and that all workflow and action YAML still parses.

The real check is negative — the failure is intermittent, so a green run does not prove much.
What it does prove is that the option is accepted rather than rejected as an unknown
configuration item: any job reaching "Install deps" successfully on this branch confirms that.

Note `yamllint` in `.pre-commit-config.yaml` does not cover `.github/`, so these files are not
linted by pre-commit.

## Not in this PR

The ticket notes two alternatives that would remove the step rather than harden it: masking
`unattended-upgrades` in the runner image, or baking `isomd5sum`, `jq` and `unzip` into it.
Baking them in is the more robust option — those packages never change and installing them per
job buys nothing — but it is a runner-image change rather than a repository one.

Also left alone: `Install deps` is duplicated verbatim across five workflows. Factoring it into
a composite action would stop the next fix having to be applied five times, but that is a
refactor beyond this bug.

Issue: MK8S-387

🤖 Generated with [Claude Code](https://claude.com/claude-code)

