### PR TITLE
improvement(sosreport): collect /var/log/salt (MK8S-384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Release 133.0.14 (in development)
 
+### Enhancements
+
+- The `metalk8s` sosreport plugin now collects `/var/log/salt`, capped at 50 MB and
+  tail-truncated. Salt logs to file rather than to the journal, so sosreports
+  previously carried its configuration and systemd entries but none of its logging,
+  leaving minion-side state failures undiagnosable
+  (PR[#5084](https://github.com/scality/metalk8s/pull/5084))
+
 ## Release 133.0.13
 
 ### Enhancements

--- a/packages/common/metalk8s-sosreport/metalk8s.py
+++ b/packages/common/metalk8s-sosreport/metalk8s.py
@@ -125,6 +125,7 @@ class MetalK8s(Plugin, RedHatPlugin):
         self.add_copy_spec("/etc/salt")
         self.add_forbidden_path("/etc/salt/pki")
         self.add_copy_spec("/var/log/metalk8s")
+        self.add_copy_spec("/var/log/salt", sizelimit=50)
 
         services = [
             "kubelet",


### PR DESCRIPTION
## Problem

A Salt failure on a minion cannot be diagnosed from a sosreport, because the minion's log is
never collected.

The plugin collects `/etc/salt` — the *configuration* — and calls `add_journal` for `kubelet`
and `salt-minion`. That looks like Salt coverage and is not: every `log_file` line in
`/etc/salt/minion` is commented out, so Salt uses its default `/var/log/salt/minion`, and
`/etc/salt/minion.d` sets `log_level_logfile: info`. Nothing Salt logs reaches the journal.

Measured on a real archive (`sosreport-…-node-1-2026-08-11-hkldtlr.tar.xz`):

- `sos_commands/metalk8s/journalctl_--no-pager_--unit_salt-minion` — **314 bytes**, two systemd
  lines (`Starting The Salt Minion`, `Started The Salt Minion`)
- `var/log/` contains only `containers/` and `pods/`; no `var/log/salt`
- no `var/cache/salt`, so not even the cached job return is there

The salt-**master** is diagnosable by accident: it runs as a pod, so its stdout lands in
`/var/log/pods`, which is collected. A **minion** has no equivalent. That is how MK8S-383 had
to be reconstructed — from the master's view plus kubelet and containerd timing — because the
per-state detail existed only in the minion log.

## Fix

```python
self.add_copy_spec("/var/log/salt", sizelimit=50)
```

Capped at 50 MB, and `sos` defaults `tailit=True`, so the most recent content is kept — which
is what matters when diagnosing a failure that just happened. Collection size is under pressure
from the other direction elsewhere, so an unbounded copy of an info-level log on a long-lived
node would not be welcome.

Verified `sizelimit` against upstream `sos` 4.10.0 and 4.5.6 (`sos/report/plugins/__init__.py`,
`add_copy_spec(copyspecs, sizelimit=None, maxage=None, tailit=True, …)`, documented as limiting
the total collection size in MB). The plugin targets sos 4.x and the nodes run 4.10.

The `salt-minion` journal capture is deliberately **kept**: it no longer carries the log, but it
does record restarts, which is useful on its own.

## Why in the plugin rather than the CI invocation

Upstream `sos` ships a `salt` plugin that would collect this, but `.github/actions/sosreport-logs`
runs `sos report --all-logs -o metalk8s -o metalk8s_containerd`, and `-o` is `--only-plugins`,
so it never runs. Fixing it in the plugin covers CI *and* any report taken on a real cluster,
where the invocation is not ours to choose. Doing both would collect `/var/log/salt` twice into
one archive.

## Test plan

No unit tests exist for these plugins, and the change is one collection line. Verified: black
22.8.0 clean, `pylint` with `packages/common/metalk8s-sosreport/.pylintrc` reports the same
findings as the base file (all pre-existing import/`os`-member artifacts of running it outside
the hook's `additional_dependencies`), and the file parses.

The real check is on a cluster: run `sos report` on a node and confirm `var/log/salt/minion` is
present and non-empty in the archive.

## Note

Salt logs at `info` can include state comments; if any of those are considered sensitive on a
support-facing archive, an `add_forbidden_path` or a lower level would be the lever. The plugin
already excludes `/etc/salt/pki`.

Issue: MK8S-384

🤖 Generated with [Claude Code](https://claude.com/claude-code)
