### PR TITLE
fix(prometheus-operator): label alert email timestamps as UTC

### DIFF
--- a/ui/public/brand/email.html
+++ b/ui/public/brand/email.html
@@ -623,7 +623,7 @@
                                 description {{ end }}
                               </td>
                               <td>
-                                {{ .StartsAt.Format "2006-01-02 15:04:05 (Z07:00)" }}
+                                {{ .StartsAt.Format "2006-01-02 15:04:05 MST" }}
                               </td>
                             </tr>
                             {{ end }}
@@ -949,7 +949,7 @@
                                 description {{ end }}
                               </td>
                               <td>
-                                {{ .StartsAt.Format "2006-01-02 15:04:05 (Z07:00)" }} - {{ .EndsAt.Format "2006-01-02 15:04:05 (Z07:00)" }}
+                                {{ .StartsAt.Format "2006-01-02 15:04:05 MST" }} - {{ .EndsAt.Format "2006-01-02 15:04:05 MST" }}
                               </td>
                             </tr>
                             {{ end }}


### PR DESCRIPTION
## Problem

RD-2003 : the "Active since" timestamp in alert notification emails reads `2026-06-25 10:48:15 Z`. The bare `Z` is not obvious to a reader, so the time cannot be told apart from the local time shown in the UI, which causes confusion when cross-referencing an email against the UI during an incident.

`ui/public/brand/email.html` formats the timestamps with the `(Z07:00)` layout. Alertmanager holds them in UTC and runs in a container whose local timezone is UTC, so Go emits the literal `Z` for a zero offset.

## Change

Two lines: use the `MST` layout verb, which renders the zone abbreviation rather than the numeric offset. On this container that abbreviation is `UTC`.

```
before: 2026-06-25 10:48:15 (Z)
after:  2026-06-25 10:48:15 UTC
```

Only the label changes — the instant, the timezone and everything else about the email are untouched. The ARTESCA-branded template already uses this same layout (ARTESCA-17490), so both products now render timestamps identically.

Measured on go1.26.5 with `html/template`, feeding the wire format Prometheus sends (`2026-06-25T10:48:15Z`) with the container's `TZ` unset as it is in the Alertmanager image:

```
old layout "2006-01-02 15:04:05 (Z07:00)"  ->  2026-06-25 10:48:15 (Z)
new layout "2006-01-02 15:04:05 MST"       ->  2026-06-25 10:48:15 UTC
```

## Upgrade note

`email.html` is a default that the UI snapshots into `email_configs[].html` when a user saves the alerting configuration, and nothing on the salt side rewrites that stored copy. A cluster that already has email alerting configured therefore keeps the template it saved and keeps showing `Z` until the Alert Configuration form is saved again. ARTESCA is not affected: its own migration state re-derives the template on every run.

## Scope

Deliberately just the label. Converting the timestamps to the platform timezone was implemented and reviewed, then dropped (see ARTESCA-17891): it requires giving the Alertmanager container a `TZ`, which is process-global and would also move Alertmanager's own log timestamps off UTC and change the meaning of `location: Local` in an `AlertmanagerConfig` time interval — too much for a readability problem an explicit label already solves.

No CHANGELOG entry, matching the convention on this branch: version bumps and features get one, `fix(...)` changes of this size do not (e.g. #5081, #4882, #5015).

Issue: MK8S-389