### PR TITLE
salt: raise the master's gather_job_timeout to 300s (MK8S-388)

### DIFF
--- a/salt/metalk8s/salt/master/configured.sls
+++ b/salt/metalk8s/salt/master/configured.sls
@@ -22,6 +22,7 @@ Configure salt master:
         saltenv: "{{ saltenv }}"
         worker_threads: {{ salt.pillar.get("salt:master:worker_threads", default=12) }}
         timeout: {{ salt.pillar.get("salt:master:timeout", default=20) }}
+        gather_job_timeout: {{ salt.pillar.get("salt:master:gather_job_timeout", default=300) }}
 
 Configure salt master roots paths:
   file.serialize:

--- a/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
+++ b/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
@@ -3,6 +3,7 @@ interface: {{ salt_ip }}
 log_level: {{ 'debug' if debug else 'info' }}
 
 timeout: {{ timeout }}
+gather_job_timeout: {{ gather_job_timeout }}
 sock_pool_size: 15
 worker_threads: {{ worker_threads}}
 

--- a/salt/tests/unit/formulas/config.yaml
+++ b/salt/tests/unit/formulas/config.yaml
@@ -1023,6 +1023,7 @@ metalk8s:
                 saltenv: metalk8s-2.7.1
                 worker_threads: 58
                 timeout: 42
+                gather_job_timeout: 84
 
         salt-master-manifest.yaml.j2:
           _cases:


### PR DESCRIPTION
Fixes **MK8S-383** (item 1) and **MK8S-388** single root
cause.

## Problem

While a `salt.state` runs, the master polls the minion with `saltutil.find_job`. If one probe
goes unanswered within `gather_job_timeout`, Salt decides the minion is no longer running the
job and returns a bare `False`. `saltmod.state` then logs `Output from salt state not highstate`
and reports `Run failed on minions: <node>`.

**The state has not failed — Salt has given up on it.** Every requisite of that state then
cascades, so the orchestrate aborts and `upgrade.sh` fails.

Salt's default is **10s**, which is too small for exactly the states that disrupt the node being
polled:

| State | What it does to its own target |
| --- | --- |
| `Deploy apiserver <node>` (`orchestrate/apiserver.sls`) | replaces the apiserver and its proxy — MK8S-383 |
| `Run the highstate` (`orchestrate/deploy_node.sls`) | replaces kubelet, containerd and the control plane static pods — MK8S-388 |

MK8S-383 has the mechanism proved from a salt-master log: node-1 answered every probe in 60–70 ms,
missed one, and replied **19.9s late** — 9.7s past the deadline. The state was still progressing,
confirmed by the static-pod swap 55s after the orchestrate had already declared failure.
MK8S-388 has six occurrences of the same fingerprint over eight months on a production
single-node platform, and one of those aborted upgrades is the entry condition of a
three-week customer escalation.

## Why this is fixed on the master and not per state

A state cannot set this knob. `saltmod.state` builds

```python
cmd_kw = {"arg": [], "kwarg": {}, "ret": ret, "timeout": timeout}
```

and then adds only `queue`, `concurrent`, `batch`, `subset` and `failhard`. There is no
`gather_job_timeout` parameter and unknown state arguments are not forwarded, so
`- gather_job_timeout: 300` on a `salt.state` block would be **silently ineffective**.

The plumbing below it would honour one — `modules/saltutil._exec` does `cmd_kwargs.update(kwargs)`
and `LocalClient.get_iter_returns` reads
`kwargs.get("gather_job_timeout", self.opts["gather_job_timeout"])` (`client/__init__.py:1088`) —
but `saltmod.state` never sends it. Read from the Salt **3002.9** source rather than assumed;
both tickets flagged this as the open question.

### The neighbouring `- timeout:` values do not help either

Worth stating, because it is the natural thing to reach for. In `get_iter_returns`:

```python
timeout_at = time.time() + timeout                  # the FIRST window only
...
if time.time() > timeout_at and minions_running:
    timeout_at = time.time() + gather_job_timeout   # every window after that
```

A state's `- timeout:` extends only the initial wait; every subsequent keepalive round is bounded
by `gather_job_timeout`. A state lasting minutes spends nearly all of it in that regime — which is
also why raising `Reconfigure salt-minion` from 200s to 300s on `development/134.0` could not have
helped this failure, and why adding `- timeout: 600` to `Run the highstate` would look plausible
and change nothing.

This is independently corroborated by the MK8S-383 timeline: the first `find_job` came 20s after
the job was published (the master's `timeout: 20`), then every 10s (`gather_job_timeout`), and the
give-up landed exactly 10s after the unanswered probe.

## Fix

`gather_job_timeout: 300` in the salt-master configuration, pillar-overridable through
`salt:master:gather_job_timeout`, in the same shape as its neighbours `timeout` and
`worker_threads`.

300s is the same order as the `wait_for` budgets already used for apiserver readiness and leaves
ample margin over the observed 19.9s gap. The cost is one-sided: a genuinely unresponsive minion
takes up to 300s longer to be declared gone, during operations that already run for tens of
minutes.

Being on the master, it also covers the deferred gap recorded on MK8S-326 — `Sync <node> minion`
and `Refresh <node> grains` in `orchestrate/apiserver.sls` having no `retry`, so a transient
"No minions responded" fails hard.

## Why no per-state `retry`

Considered and deliberately omitted. When Salt gives up, the minion is **still running the state
and still holds its lock**, so an immediate retry returns `the function state.sls is running as
PID …`. Unless the interval outlasts the remaining run — minutes, for a highstate — the attempts
are consumed without the state ever re-running, which is worse than no retry at all. The master
setting has no such interaction. Happy to add retries as well if a reviewer prefers belt and
braces.

## Test plan

The render harness renders `master-99-metalk8s.conf.j2` with an **explicit** `extra_context`
listing every variable, so the fixture gains the new key — without it the render test fails on an
undefined variable. Verified both directions locally with `StrictUndefined`: it renders with the
key, and raises `'gather_job_timeout' is undefined` without it. The rendered output parses as YAML
and `config.yaml` still parses.

Local caveat: `tox`/`pre-commit` pin `python3.6`, which is not installable on my machine, and the
formula render harness needs `jinja2 <3` for `jinja2.ext.with_`. The template itself uses no
jinja2-2-only syntax, so I rendered it with jinja2 3.x directly. **CI is authoritative for the
render harness.**

The real check is a nightly: `snapshot-upgrade` jobs should stop failing with
`Run failed on minions: <node>` / `Output from salt state not highstate`. Both tickets note the
missed keepalive is impractical to inject deterministically, so this is a statistical result
rather than a single green run.

## Not in this PR

* **MK8S-383 item 2** — nothing waits for a master's apiserver to be serving again before the
  next one is replaced. That is an availability concern rather than the abort fixed here, and it
  needs design: the orchestrate runs on the salt-master, so `127.0.0.1:7443` checks the master's
  own proxy rather than the node just reconfigured. Left on the ticket.
* Per-state `retry`, for the reason above.


Issue: MK8S-388

🤖 Generated with [Claude Code](https://claude.com/claude-code)
