### PR TITLE
tests: gate WP ingress VIP assertions on the CNI and on the VIP answering

### DIFF
--- a/tests/post/features/ingress.feature
+++ b/tests/post/features/ingress.feature
@@ -96,6 +96,7 @@ Feature: Ingress
         And the '{wp_ingress_first_pool}' IPs are spread on nodes
         When we update the ClusterConfig to add 'test-vip-3-pool-2' Workload Plane pool with IPs '{wp_ingress_second_pool}'
         And we wait for the ClusterConfig to be 'Ready'
+        And we wait for the rollout of 'daemonset/calico-node' in namespace 'kube-system' to complete
         And we trigger a rollout restart of 'daemonset/ingress-nginx-controller' in namespace 'metalk8s-ingress'
         And we wait for the rollout of 'daemonset/ingress-nginx-controller' in namespace 'metalk8s-ingress' to complete
         Then the DaemonSet 'ingress-nginx-controller' in the 'metalk8s-ingress' namespace has all desired Pods ready

--- a/tests/post/steps/test_ingress.py
+++ b/tests/post/steps/test_ingress.py
@@ -20,13 +20,15 @@ OPERATOR_DEPLOYMENT = "metalk8s-operator-controller-manager"
 OPERATOR_NAMESPACE = "kube-system"
 
 
-def _ingress_debug(host):
+def _ingress_debug(host, ssh_config=None, ips=None):
     """Collect live cluster-side ingress diagnostics.
 
     The sosreport is collected after the whole step finishes and may miss the
     transient state (a controller still rolling, missing endpoints, calico not
     ready, ...) that caused a request to fail, so we dump the relevant cluster
     state at failure time to complement it. Best-effort: never raises.
+
+    When `ssh_config` and `ips` are given, also report which node holds each VIP.
     """
     kubectl = "kubectl --kubeconfig=/etc/kubernetes/admin.conf"
     commands = (
@@ -42,8 +44,16 @@ def _ingress_debug(host):
             f"{kubectl} -n kube-system get daemonset calico-node -o wide",
         ),
         (
+            "calico-node pods",
+            f"{kubectl} -n kube-system get pods -l k8s-app=calico-node -o wide",
+        ),
+        (
             "recent ingress events",
             f"{kubectl} -n metalk8s-ingress get events --sort-by=.lastTimestamp",
+        ),
+        (
+            "recent kube-system events",
+            f"{kubectl} -n kube-system get events --sort-by=.lastTimestamp | tail -30",
         ),
     )
     sections = []
@@ -58,21 +68,98 @@ def _ingress_debug(host):
                 )
     except Exception as exc:  # pylint: disable=broad-except
         sections.append(f"--- failed to collect ingress debug ---\n{exc}")
+
+    if ssh_config and ips:
+        try:
+            sections.append(f"--- VIP owners ---\n{_vip_owners(host, ssh_config, ips)}")
+        except Exception as exc:  # pylint: disable=broad-except
+            sections.append(f"--- failed to collect VIP owners ---\n{exc}")
+
     return "\n\n".join(sections)
 
 
+def _vip_owners(host, ssh_config, ips):
+    """Report, for each VIP, the node holding it and that node's WP ingress pod."""
+    kubectl = "kubectl --kubeconfig=/etc/kubernetes/admin.conf"
+    node_ips = get_node_ips(host, ssh_config)
+
+    lines = []
+    for ip in ips:
+        owner = next((name for name, own in node_ips.items() if ip in own), None)
+        if owner is None:
+            lines.append(f"{ip}: not assigned to any node")
+            continue
+        with host.sudo():
+            pods = host.run(
+                f"{kubectl} -n metalk8s-ingress get pods -o wide --no-headers "
+                f"--field-selector spec.nodeName={owner} "
+                "-l app.kubernetes.io/instance=ingress-nginx"
+            )
+        lines.append(f"{ip}: {owner}\n{(pods.stdout or pods.stderr).strip()}")
+
+    return "\n".join(lines)
+
+
 @contextlib.contextmanager
-def _ingress_debug_on_failure(host, label):
+def _ingress_debug_on_failure(host, label, ssh_config=None, ips=None):
     """Append live cluster ingress diagnostics to any assertion failure raised
-    inside the block, to complement the (later, possibly-stale) sosreport."""
+    inside the block, to complement the (later, possibly-stale) sosreport.
+
+    `utils.retry` reports an exhausted budget through `pytest.fail`, so catch
+    that too.
+    """
     try:
         yield
-    except AssertionError as exc:
+    except (AssertionError, pytest.fail.Exception) as exc:
         raise AssertionError(
             f"{exc}\n\n"
             f"=== Cluster ingress debug ({label}) ===\n"
-            f"{_ingress_debug(host)}"
+            f"{_ingress_debug(host, ssh_config=ssh_config, ips=ips)}"
         ) from exc
+
+
+def _wait_cni_available(host):
+    """Wait for every calico-node pod to be available."""
+    kubectl = "kubectl --kubeconfig=/etc/kubernetes/admin.conf"
+
+    def _cni_available():
+        with host.sudo():
+            status = json.loads(
+                host.check_output(
+                    f"{kubectl} -n kube-system get daemonset calico-node -o json"
+                )
+            )["status"]
+
+        desired = status.get("desiredNumberScheduled", 0)
+        available = status.get("numberAvailable", 0)
+        assert desired > 0, "calico-node has no desired pod"
+        assert (
+            available == desired
+        ), f"calico-node: {available}/{desired} pods available"
+
+    utils.retry(
+        _cni_available,
+        times=24,
+        wait=5,
+        name="wait for the CNI to be available",
+    )
+
+
+def _wait_endpoint_accepts_connections(host, endpoint):
+    """Wait until `endpoint` accepts a connection, without asserting the response."""
+
+    def _accepts_connections():
+        try:
+            requests.get(endpoint, verify=False)
+        except requests.exceptions.ConnectionError as exc:
+            raise AssertionError(f"'{endpoint}' does not accept connections: {exc}")
+
+    utils.retry(
+        _accepts_connections,
+        times=12,
+        wait=5,
+        name=f"wait for '{endpoint}' to accept connections",
+    )
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -714,17 +801,26 @@ def server_request_does_not_return(host, context, protocol, port, plane, path):
     converters=dict(status_code=int),
 )
 def server_request_returns_multiple_ips(
-    host, context, protocol, port, ips, path, status_code, reason
+    host, ssh_config, context, protocol, port, ips, path, status_code, reason
 ):
     ips = ips.format(**context).split(",")
 
     assert ips, "Error IPs list cannot be empty"
 
+    with _ingress_debug_on_failure(
+        host, "waiting for the CNI", ssh_config=ssh_config, ips=ips
+    ):
+        _wait_cni_available(host)
+
     for ip in ips:
         endpoint = "{proto}://{ip}:{port}/{path}".format(
             proto=protocol.lower(), ip=ip, port=port, path=path or ""
         )
-        with _ingress_debug_on_failure(host, f"request on '{endpoint}'"):
+        with _ingress_debug_on_failure(
+            host, f"request on '{endpoint}'", ssh_config=ssh_config, ips=ips
+        ):
+            _wait_endpoint_accepts_connections(host, endpoint)
+
             try:
                 response = requests.get(endpoint, verify=False)
                 context["response"] = response
@@ -742,16 +838,25 @@ def server_request_returns_multiple_ips(
         r"on port (?P<port>\d+) on '(?P<ips>.*)' IPs should not return"
     ),
 )
-def server_request_not_returns_multiple_ips(host, context, protocol, port, ips, path):
+def server_request_not_returns_multiple_ips(
+    host, ssh_config, context, protocol, port, ips, path
+):
     ips = ips.format(**context).split(",")
 
     assert ips, "Error IPs list cannot be empty"
+
+    with _ingress_debug_on_failure(
+        host, "waiting for the CNI", ssh_config=ssh_config, ips=ips
+    ):
+        _wait_cni_available(host)
 
     for ip in ips:
         endpoint = "{proto}://{ip}:{port}/{path}".format(
             proto=protocol.lower(), ip=ip, port=port, path=path or ""
         )
-        with _ingress_debug_on_failure(host, f"request on '{endpoint}'"):
+        with _ingress_debug_on_failure(
+            host, f"request on '{endpoint}'", ssh_config=ssh_config, ips=ips
+        ):
             try:
                 response = requests.get(endpoint, verify=False)
             except requests.exceptions.ConnectionError:


### PR DESCRIPTION
**Component**: tests

**Context**:

The same `Connection refused` on a WP ingress VIP has now been seen with **three different causes**. Only the first was fixed by #5007; this PR covers the other two.

| # | Evidence | Cause |
|---|---|---|
| 1 | original MK8S-331 | old-revision ingress pod still `Terminating`, holding the node host-port — **fixed by #5007** |
| 2 | run [31496464787](https://github.com/scality/metalk8s/actions/runs/31496464787), [31478015126](https://github.com/scality/metalk8s/actions/runs/31478015126) | all pods Ready and calico healthy, but VIP *assignment* and *serving* diverged: `.200` answered 200 while `.201` was refused in the same loop, pods 62s/39s/15s old |
| 3 | run [32015593020](https://github.com/scality/metalk8s/actions/runs/32015593020/job/95348119159) | `calico-node` unavailable, so the replacement ingress pod never got an IP |

Cause 3, from `_ingress_debug_on_failure`:

```
calico-node                DESIRED 1  READY 0  UP-TO-DATE 1  AVAILABLE 0
ingress-nginx-controller   DESIRED 1  READY 0                AVAILABLE 0
ingress-nginx-controller-2x2f8   0/1  ContainerCreating  2s  <none>
ingress-nginx-controller endpoints: <empty>
```

Every wait the scenario performs passed. `rollout_restart` waits for in-flight rollouts of its own resource and the DaemonSet-ready step confirms the ingress DaemonSet is settled — but nothing looked at the layer underneath. An ingress pod can be scheduled and up-to-date and still never serve, because it has no network.

**Summary**:

Two commits.

**1. `cd8010d2e`** — one line in `ingress.feature`: `Workload Plane Ingress VIPs multiple pools` waits for the `calico-node` rollout after the ClusterConfig update, as its sibling `... reconfiguration` scenario already does (added by f2e18d79d). This orders the calico rollout *before* the ingress rollout-restart steps.

**2. `d09d18039`** — moves the guarantee to where the assertions are, in `tests/post/steps/test_ingress.py`:

- **Wait for the CNI** before asserting reachability, in both the positive and the negative multiple-IPs step. The negative one is a *correctness* fix, not a flakiness one: `should not return` passes for the wrong reason when the CNI is down, because everything is refused.
- **Wait for each VIP to accept a connection** before asserting on it. Checks reachability *only* — never the status code or reason — so it cannot mask a server answering the wrong thing. This is a readiness wait before asserting, not a retry of the assertion, so the negative step does not get it and keeps failing fast. That was this ticket's explicit constraint and the reason #4998 was rejected.
- **Report more on failure**: calico-node pods, recent `kube-system` events, and a per-VIP owner section pairing each VIP with the node holding it and that node's WP ingress pod.

Budgets follow the conventions already in the file: 24 × 5s for the CNI (a rollout), 12 × 5s per VIP (matching the existing VIP waits).

**Why the feature-file line stays**: it is not redundant with the assertion-time gate. It orders the calico rollout ahead of the ingress rollout-restart steps, which run well before any assertion and would otherwise churn or time out against a half-rolled CNI. The new gate protects the assertions; the feature line protects the rollout.

**Worth a reviewer's eye**: `utils.retry` reports an exhausted budget through `pytest.fail`, and `Failed` derives **straight from `BaseException`** — not `AssertionError`, not even `Exception`. So neither the existing `except AssertionError` nor a broader `except Exception` would have caught it, and a timed-out wait would have produced no cluster dump, precisely when it is most useful. Both new waits now sit inside the diagnostics context manager and it catches `pytest.fail.Exception` too. Verified against the pinned `pytest==4.3.1`, not assumed:

```
pytest 4.3.1 · pytest.fail.Exception = <class 'Failed'>
is AssertionError: False · is Exception: False · is BaseException: True
```

**Acceptance criteria**:

- [x] Reachability assertions gated on `calico-node` being available, in a shared step no scenario can omit (MK8S-331, "CNI gating").
- [x] The multi-pool scenario waits for the calico rollout, as its sibling does (MK8S-331, "Missing sibling step").
- [x] Each VIP gets a bounded wait-until-answering before its assertion; negative scenarios keep failing fast (MK8S-331, "Assigned is not serving").
- [x] `_ingress_debug` answers "why is the CNI down" and "which pod should have served this VIP" (MK8S-331, "Diagnostics").
- [ ] `single-node-e2e` and `multi-node-e2e` pass.

**Checks run locally**: `black` 22.8.0 clean; `pyflakes` clean apart from a pre-existing unused `re` import on the base, left alone. No pylint hook covers `tests/**` (only `buildchain`, `salt/_*`, `salt/tests/unit/formulas`, `packages/common/metalk8s-sosreport`), so `black` is the only formatter that applies. Full pre-commit cannot run locally — it pins python3.6.

**Not addressed here, and worth a look**: `salt/metalk8s/kubernetes/cni/calico/deployed.sls` sets `IP_AUTODETECTION_METHOD: cidr=<workload plane CIDRs>`, and the WP ingress VIPs (`192.168.2.200-204`) sit inside the WP CIDR (`192.168.2.0/24`). Calico may therefore be able to adopt a *VIP* as a node's BGP address and lose it when the VIP moves — which would explain why a calico wait is needed after every VIP-pool change at all. **Unverified**: I have no calico-node logs confirming which address it picked. If it is real, it is a product defect and the waits in this PR only hide it. Flagged in MK8S-331 as out of scope with its own ticket to follow.

---

See: MK8S-331
