### PR TITLE
Per-node upgrade aborts on transient API errors and mislabels the node (MK8S-370)

### DIFF
--- a/.changes/unreleased/Fix-20260821-134431-902974699.yaml
+++ b/.changes/unreleased/Fix-20260821-134431-902974699.yaml
@@ -1,0 +1,13 @@
+kind: Fix
+body: |-
+    A node drain no longer aborts the upgrade on a transient API server or etcd error.
+    An eviction rejected with a 5xx status, typically `etcdserver: request timed out`
+    while the upgrade restarts etcd and the API servers, is now retried for about a
+    minute per pod, and the drain state is retried too, its budget split across the
+    attempts so a drain that can never succeed still gives up in about the time it
+    used to take. A pod that keeps failing still fails the drain, naming the pod and
+    the API error.
+time: 2026-08-21T13:44:31.902974699Z
+custom:
+    CommentId: "5370554667"
+    Pull: "5090"

--- a/.changes/unreleased/Fix-20260821-134454-81105426.yaml
+++ b/.changes/unreleased/Fix-20260821-134454-81105426.yaml
@@ -1,0 +1,16 @@
+kind: Fix
+body: |-
+    A node that fails during an upgrade or a downgrade no longer advertises the
+    destination version as if it were running it. The version label is still set
+    before the deployment, since it selects the saltenv, but the node now also
+    carries a `metalk8s.scality.com/version-in-progress` annotation until that
+    deployment succeeds, plus a `metalk8s.scality.com/version-applied`
+    annotation recording the last version it completed. Both orchestrates select
+    nodes on that recorded version rather than on the label, so resuming an
+    interrupted upgrade only deploys the nodes that need it, and the upgrade
+    prechecks refuse a destination other than the one an interrupted upgrade was
+    heading to.
+time: 2026-08-21T13:44:54.081105426Z
+custom:
+    CommentId: "5370556592"
+    Pull: "5090"

--- a/.changes/unreleased/Fix-20260821-134454-81105426.yaml
+++ b/.changes/unreleased/Fix-20260821-134454-81105426.yaml
@@ -5,11 +5,12 @@ body: |-
     before the deployment, since it selects the saltenv, but the node now also
     carries a `metalk8s.scality.com/version-in-progress` annotation until that
     deployment succeeds, plus a `metalk8s.scality.com/version-applied`
-    annotation recording the last version it completed. Both orchestrates select
-    nodes on that recorded version rather than on the label, so resuming an
-    interrupted upgrade only deploys the nodes that need it, and the upgrade
-    prechecks refuse a destination other than the one an interrupted upgrade was
-    heading to.
+    annotation recording the last version it completed. Both are written by the
+    node deployment, so they follow an expansion as well as an upgrade. Both
+    orchestrates select nodes on that recorded version rather than on the label,
+    so resuming an interrupted upgrade only deploys the nodes that need it, and
+    the upgrade prechecks refuse a destination other than the one an interrupted
+    upgrade was heading to.
 time: 2026-08-21T13:44:54.081105426Z
 custom:
     CommentId: "5370556592"

--- a/docs/operation/upgrade.rst
+++ b/docs/operation/upgrade.rst
@@ -67,3 +67,27 @@ Upgrade
 
       The version prefix metalk8s-**X.Y.Z** must be the *new* MetalK8s version
       you want to upgrade to.
+
+Resuming an Interrupted Upgrade
+*******************************
+
+Nodes are upgraded one at a time, and each one carries the
+``metalk8s.scality.com/version-in-progress`` annotation for as long as its
+deployment runs. A node that fails mid-upgrade keeps that annotation, and
+the last version it completed stays recorded in
+``metalk8s.scality.com/version-applied``.
+
+To resume, run ``upgrade.sh`` again with the same version. Only the nodes
+that need it are deployed again: those still carrying the in-progress
+annotation, and those that never recorded the destination version. A node
+whose ``metalk8s.scality.com/version-applied`` already reads the destination
+is left alone. For as long as a node carries the in-progress annotation, the
+upgrade prechecks refuse any other destination, since moving that node to
+another version would mean downgrading it.
+
+.. important::
+
+   Do not point ``upgrade.sh`` at a version older than the one the cluster
+   runs. A node that completed a newer version is skipped, not moved back.
+   Use ``downgrade.sh`` to go back to an older version, as described in
+   :doc:`/operation/downgrade`.

--- a/docs/operation/upgrade.rst
+++ b/docs/operation/upgrade.rst
@@ -75,7 +75,9 @@ Nodes are upgraded one at a time, and each one carries the
 ``metalk8s.scality.com/version-in-progress`` annotation for as long as its
 deployment runs. A node that fails mid-upgrade keeps that annotation, and
 the last version it completed stays recorded in
-``metalk8s.scality.com/version-applied``.
+``metalk8s.scality.com/version-applied``. Both are maintained by the node
+deployment itself, so they also follow a node added through
+:doc:`/installation/expansion`.
 
 To resume, run ``upgrade.sh`` again with the same version. Only the nodes
 that need it are deployed again: those still carrying the in-progress

--- a/salt/_modules/metalk8s_drain.py
+++ b/salt/_modules/metalk8s_drain.py
@@ -58,6 +58,15 @@ class DrainTimeoutException(DrainException):
     """Timeout-specific drain exception."""
 
 
+class EvictionTransientError(DrainException):
+    """Eviction failed on a server-side error worth retrying.
+
+    Raised for the HTTP statuses listed in `RETRIABLE_EVICTION_STATUSES`,
+    typically an `etcdserver: request timed out` while etcd or the API servers
+    are restarting.
+    """
+
+
 def _mirrorpod_filter(pod):
     """Check if a pod contains the mirror K8s annotation.
 
@@ -105,6 +114,21 @@ def _get_controller_of(pod):
     return None
 
 
+def _api_error_message(exc):
+    """Extract the message from a Kubernetes API error.
+
+    Args:
+      - exc: an ApiException raised by the Kubernetes client
+    Returns: the `message` field of the API `Status` body, or a short fallback
+             when the body is missing or is not a `Status` object (which
+             happens on server-side errors)
+    """
+    try:
+        return json.loads(exc.body)["message"]
+    except (AttributeError, KeyError, TypeError, ValueError):
+        return f"HTTP {exc.status}"
+
+
 def _message_from_pods_dict(errors_dict):
     """Form a message string from a 'pod kind': [pod name...] dict.
 
@@ -122,6 +146,11 @@ POD_STATUS_SUCCEEDED = "Succeeded"
 POD_STATUS_FAILED = "Failed"
 POD_STATUS_PENDING = "Pending"
 
+# HTTP statuses for which a rejected eviction means "retry later" rather than
+# "give up": the API server or etcd is momentarily unavailable. This is common
+# during an upgrade, since the upgrade itself restarts both.
+RETRIABLE_EVICTION_STATUSES = (500, 502, 503, 504)
+
 
 class Drain(object):
     """The drain object class.
@@ -132,6 +161,13 @@ class Drain(object):
 
     # According to `kubectl` code, this value should be 1 second by default
     KUBECTL_INTERVAL = 1
+    # Delay between two eviction attempts for the same pod, `kubectl` waits 5
+    # seconds
+    EVICTION_INTERVAL = 5
+    # How many consecutive server-side errors we accept on a single pod before
+    # failing the drain. With the interval above this leaves a minute of
+    # retries, while the etcd timeouts seen in the field last a few seconds.
+    MAX_EVICTION_TRANSIENT_ERRORS = 12
     WARNING_MSG = {
         "daemonset": "Ignoring DaemonSet-managed pods",
         "localStorage": "Deleting pods with local storage",
@@ -398,19 +434,29 @@ class Drain(object):
         log.debug("Starting eviction of pods: %s", pods_to_evict)
         try:
             self.evict_pods(pods)
-        except DrainTimeoutException as exc:
-            remaining_pods = self.get_pods_for_eviction()
-            raise CommandExecutionError(  # pylint: disable=raise-missing-from
+        except (DrainTimeoutException, CommandExecutionError) as exc:
+            remaining_pods = self.remaining_pod_names()
+            if remaining_pods is None:
+                raise CommandExecutionError(exc.message) from exc
+            raise CommandExecutionError(
                 f"{exc.message} List of remaining pods to follow",
-                [pod["metadata"]["name"] for pod in remaining_pods],
-            )
-        except CommandExecutionError as exc:
-            remaining_pods = self.get_pods_for_eviction()
-            raise CommandExecutionError(  # pylint: disable=raise-missing-from
-                f"{exc.message} List of remaining pods to follow",
-                [pod["metadata"]["name"] for pod in remaining_pods],
-            )
+                remaining_pods,
+            ) from exc
         return "Eviction complete."
+
+    def remaining_pod_names(self):
+        """List the pods left to evict, to report them along with a failure.
+
+        Returns: the list of pod names, or None when they cannot be listed. This runs
+                 right after a failed eviction, and that failure is often the API
+                 server itself, so listing can fail too. Losing the list is better
+                 than losing the reason of the original failure.
+        """
+        try:
+            return [pod["metadata"]["name"] for pod in self.get_pods_for_eviction()]
+        except (CommandExecutionError, DrainException):
+            log.warning("Cannot list the pods left to evict on %s", self.node_name)
+            return None
 
     def evict_pods(self, pods):
         """Trigger the eviction process for all pods passed.
@@ -420,24 +466,43 @@ class Drain(object):
         Returns: None
         Raises: DrainTimeoutException if the eviction process is not complete
                 after the specified timeout value
+                CommandExecutionError if a pod keeps failing to be evicted on
+                server-side errors
         """
         self.start_timer()
         evicted_pods = []
         for pod in pods:
+            transient_errors = 0
             while self.check_timer():
-                evicted = evict_pod(
-                    name=pod["metadata"]["name"],
-                    namespace=pod["metadata"]["namespace"],
-                    grace_period=self.grace_period,
-                    **self._kwargs,
-                )
+                try:
+                    evicted = evict_pod(
+                        name=pod["metadata"]["name"],
+                        namespace=pod["metadata"]["namespace"],
+                        grace_period=self.grace_period,
+                        **self._kwargs,
+                    )
+                except EvictionTransientError as exc:
+                    transient_errors += 1
+                    if self._best_effort:
+                        log.warning("%s, not retrying (best effort)", exc.message)
+                        break
+                    if transient_errors >= self.MAX_EVICTION_TRANSIENT_ERRORS:
+                        raise CommandExecutionError(
+                            f"{exc.message} (gave up after {transient_errors} "
+                            "consecutive server errors)"
+                        ) from exc
+                    log.info("%s, retrying", exc.message)
+                    time.sleep(self.EVICTION_INTERVAL)
+                    continue
+
+                transient_errors = 0
                 if evicted:
                     evicted_pods.append(pod)
                     break
 
                 if self._best_effort:
                     break
-                time.sleep(5)  # kubectl waits 5 seconds
+                time.sleep(self.EVICTION_INTERVAL)
 
         self.wait_for_eviction(evicted_pods)
 
@@ -507,7 +572,9 @@ def evict_pod(name, namespace="default", grace_period=1, **kwargs):
         - namespace     : the namespace of the pod to evict
         - grace_period  : the time to wait before killing the pod
     Returns: whether the eviction was successfully created or not
-    Raises: CommandExecutionError in case of API error
+    Raises: EvictionTransientError on a server-side error, which the caller is
+            expected to retry
+            CommandExecutionError on any other API error
     """
     delete_options = kubernetes.client.V1DeleteOptions()
     if grace_period >= 0:
@@ -546,14 +613,20 @@ def evict_pod(name, namespace="default", grace_period=1, **kwargs):
             if exc.status == 429:
                 # Too Many Requests: the eviction is rejected, but indicates
                 # we should retry later (probably due to a disruption budget)
-                status = json.loads(exc.body, encoding="utf-8")
                 log.info(
                     "Cannot evict %s at the moment: %s",
                     name,
-                    status["message"],
+                    _api_error_message(exc),
                 )
                 # When implemented by Kubernetes, read the `Retry-After` advice
                 return False
+
+            if exc.status in RETRIABLE_EVICTION_STATUSES:
+                # Server-side failure, the caller decides how long to retry
+                raise EvictionTransientError(
+                    f'Failed to evict pod "{name}" in namespace "{namespace}": '
+                    f"{_api_error_message(exc)}"
+                ) from exc
 
         raise CommandExecutionError(
             f'Failed to evict pod "{name}" in namespace "{namespace}"'

--- a/salt/_pillar/metalk8s_nodes.py
+++ b/salt/_pillar/metalk8s_nodes.py
@@ -6,6 +6,13 @@ from salt.exceptions import CommandExecutionError
 
 VERSION_LABEL = "metalk8s.scality.com/version"
 ROLE_LABEL_PREFIX = "node-role.kubernetes.io/"
+# Set on a node before it gets deployed to a new version, removed once that
+# deployment succeeded. A node carrying it advertises a version it does not run
+# yet (the version label drives the saltenv, so it has to be set upfront).
+IN_PROGRESS_ANNOTATION = "metalk8s.scality.com/version-in-progress"
+# Last version a node actually completed, written once its deployment succeeded.
+# Unlike the version label, this one never runs ahead of the node.
+APPLIED_ANNOTATION = "metalk8s.scality.com/version-applied"
 
 
 log = logging.getLogger(__name__)
@@ -24,6 +31,8 @@ def node_info(node, ca_minion, pillar):
     result = {
         "roles": [],
         "version": None,
+        "version_in_progress": None,
+        "version_applied": None,
     }
 
     node_name = node["metadata"]["name"]
@@ -31,6 +40,12 @@ def node_info(node, ca_minion, pillar):
 
     if VERSION_LABEL in node["metadata"]["labels"]:
         result["version"] = node["metadata"]["labels"][VERSION_LABEL]
+
+    annotations = node["metadata"].get("annotations") or {}
+    if IN_PROGRESS_ANNOTATION in annotations:
+        result["version_in_progress"] = annotations[IN_PROGRESS_ANNOTATION]
+    if APPLIED_ANNOTATION in annotations:
+        result["version_applied"] = annotations[APPLIED_ANNOTATION]
 
     for label in node["metadata"]["labels"].keys():
         if label.startswith(ROLE_LABEL_PREFIX):

--- a/salt/_runners/metalk8s_checks.py
+++ b/salt/_runners/metalk8s_checks.py
@@ -139,6 +139,25 @@ def upgrade(dest_version, saltenv, raises=True):
             f"Invalid saltenv '{saltenv}' consider using 'metalk8s-{dest_version}'"
         )
 
+    # A node whose deployment did not complete can only be recovered by resuming the
+    # same upgrade: bringing it to another version would mean downgrading it, which
+    # this orchestrate cannot do. Refuse any other destination instead of leaving the
+    # cluster with nodes stuck in the version of the interrupted upgrade.
+    interrupted = {}
+    for node_name, node_info in metalk8s_pillar["nodes"].items():
+        in_progress = node_info.get("version_in_progress")
+        if in_progress and in_progress != dest_version:
+            interrupted.setdefault(in_progress, []).append(node_name)
+
+    for version, node_names in sorted(interrupted.items()):
+        errors.append(
+            f"A version change to {version} did not complete on "
+            f"{', '.join(sorted(node_names))}. Resume it rather than upgrading to "
+            f"{dest_version}, since moving those nodes to {dest_version} would be a "
+            f"downgrade. If {version} is not an option, clear their "
+            "metalk8s.scality.com/version-in-progress annotation first"
+        )
+
     # Check that all nodes are in a supported upgrade path
     # We only support upgrade from one major version
     dest = dest_version.split(".")

--- a/salt/metalk8s/orchestrate/deploy_node.sls
+++ b/salt/metalk8s/orchestrate/deploy_node.sls
@@ -146,6 +146,18 @@ Cordon the node:
 
 {%- if run_drain %}
 
+{#- The drain talks to the API server for every pod it evicts, and an upgrade
+    restarts etcd and the API servers, so a whole drain can fail on a transient
+    error. Retry instead of aborting the node deployment, and split the drain
+    budget across the attempts: a drain that can never succeed (an unsatisfiable
+    disruption budget) then still gives up in about the time a single drain used
+    to take. Budgets of a few seconds round up to one second per attempt, since a
+    zero timeout would silently mean the 3600 second default of the `metalk8s_drain`
+    module, which is also where the 3600 below comes from. #}
+{%- set drain_attempts = 4 %}
+{%- set drain_budget = pillar.orchestrate.get("drain_timeout") | int or 3600 %}
+{%- set drain_attempt_timeout = [(drain_budget / drain_attempts) | int, 1] | max %}
+
 Drain the node:
   metalk8s_drain.node_drained:
     - name: {{ node_name }}
@@ -153,9 +165,11 @@ Drain the node:
     - ignore_pending: True
     - delete_local_data: True
     - force: True
-    {%- if pillar.orchestrate.get("drain_timeout") %}
-    - timeout: {{ pillar.orchestrate.drain_timeout }}
-    {%- endif %}
+    - timeout: {{ drain_attempt_timeout }}
+    - retry:
+        attempts: {{ drain_attempts }}
+        interval: 30
+        splay: 10
     - require:
       - metalk8s_cordon: Cordon the node
     - require_in:

--- a/salt/metalk8s/orchestrate/deploy_node.sls
+++ b/salt/metalk8s/orchestrate/deploy_node.sls
@@ -11,6 +11,21 @@
 
 {%- set roles = pillar.get('metalk8s', {}).get('nodes', {}).get(node_name, {}).get('roles', []) %}
 
+{#- Every deployment of a node goes through here, so this is where the two version
+    annotations are maintained. The version label is set by whoever asked for this
+    deployment, since it selects the saltenv, and it says what the node was asked to
+    run. These say what it actually runs (MK8S-370). #}
+Mark node {{ node_name }} as being deployed in {{ version }}:
+  metalk8s_kubernetes.object_updated:
+    - name: {{ node_name }}
+    - kind: Node
+    - apiVersion: v1
+    - patch:
+        metadata:
+          annotations:
+            metalk8s.scality.com/version-in-progress: "{{ version }}"
+    - order: 1
+
 {%- if node_name not in salt.saltutil.runner('manage.up') %}
 # Salt-ssh need python3 to be installed on the destination host, so install it
 # manually using raw ssh
@@ -398,3 +413,62 @@ Update NPD workload plane peers:
     - saltenv: {{ saltenv }}
     - require:
       - metalk8s_cordon: Uncordon the node
+
+{#- Every state this orchestrate ends on, so the node is only recorded as running
+    this version once all of them succeeded. Kept in one place, since the state
+    below and the one explaining its failure must wait on the very same set. #}
+{%- set deployment_done = [
+    "salt: Update NPD workload plane peers",
+    "salt: Kill kube-controller-manager on all master nodes",
+] %}
+{%- if 'infra' in roles and 'infra' not in skip_roles %}
+  {%- do deployment_done.append("module: Restart CoreDNS pods") %}
+{%- endif %}
+{%- if 'master' in roles and 'master' not in skip_roles %}
+  {%- do deployment_done.append("salt: Reconfigure Control Plane Ingress") %}
+{%- endif %}
+
+Mark node {{ node_name }} as running {{ version }}:
+  metalk8s_kubernetes.object_updated:
+    - name: {{ node_name }}
+    - kind: Node
+    - apiVersion: v1
+    - patch:
+        metadata:
+          annotations:
+            metalk8s.scality.com/version-in-progress: null
+            metalk8s.scality.com/version-applied: "{{ version }}"
+    {#- This deployment just restarted the API server on this node, so give this
+        write a few tries before it fails the whole thing #}
+    - retry:
+        attempts: 5
+        interval: 30
+    - require:
+      {%- for state_id in deployment_done %}
+      - {{ state_id }}
+      {%- endfor %}
+
+{#- Clearing the marker is the last step, and it is the only one that can fail on
+    a node that is otherwise deployed. Say so, rather than leaving the operator with
+    a bare API error on the very last state. The `require` matters: without it this
+    state also fires when the deployment itself failed, and would then claim a broken
+    node is fine. #}
+Explain the stale marker on {{ node_name }}:
+  test.configurable_test_state:
+    - name: {{ node_name }}
+    - changes: False
+    - result: True
+    - comment: >-
+        Node {{ node_name }} was deployed in {{ version }}, only the
+        metalk8s.scality.com/version-in-progress annotation could not be cleared.
+        The node itself is fine. Deploy it again to record the version, or record
+        it by hand with "kubectl annotate node {{ node_name }}
+        metalk8s.scality.com/version-in-progress-
+        metalk8s.scality.com/version-applied={{ version }} --overwrite". Until one
+        of those, an upgrade to another version is refused.
+    - onfail:
+      - metalk8s_kubernetes: Mark node {{ node_name }} as running {{ version }}
+    - require:
+      {%- for state_id in deployment_done %}
+      - {{ state_id }}
+      {%- endfor %}

--- a/salt/metalk8s/orchestrate/downgrade/init.sls
+++ b/salt/metalk8s/orchestrate/downgrade/init.sls
@@ -127,6 +127,12 @@ Deploy node {{ node }}:
     - require_in:
       - salt: Downgrade etcd cluster
 
+{#- During a downgrade, `deploy_node` comes from the destination version, which is
+    older than this one. That older `deploy_node` does not write these annotations,
+    so the two states below write them here instead. The upgrade orchestrate has no
+    such need: it always runs the newer `deploy_node`. Delete these two states once
+    every version we can downgrade to writes the annotations itself, so from the next
+    minor on. #}
 Mark node {{ node }} as running {{ dest_version }}:
   metalk8s_kubernetes.object_updated:
     - name: {{ node }}

--- a/salt/metalk8s/orchestrate/downgrade/init.sls
+++ b/salt/metalk8s/orchestrate/downgrade/init.sls
@@ -14,16 +14,60 @@ Execute the downgrade prechecks:
 {%- set cp_nodes = salt.metalk8s.minions_by_role('master') | sort %}
 {%- set other_nodes = pillar.metalk8s.nodes.keys() | difference(cp_nodes) | sort %}
 
+{#- Nodes are deployed one by one, each waiting on the previous one. A skipped node
+    declares no state, so the chain must remember the last node actually deployed,
+    otherwise the next one waits on a state that does not exist and Salt fails it
+    with "The following requisites were not found". #}
+{%- set deployed = namespace(previous=None) %}
+
 {%- for node in other_nodes + cp_nodes %}
 
-  {%- set node_version = pillar.metalk8s.nodes[node].version|string %}
+  {#- The version label is set before a node is deployed, since it selects the
+      saltenv, so it says what the node was asked to run, not what it runs. The
+      `version-applied` annotation records the last version a node completed, and
+      that is what decides whether it still needs this one.
+      NOTE: this orchestrate runs from the destination saltenv, so the annotation is
+      only there when downgrading to a version that knows about it. Otherwise the
+      fallback below keeps the behaviour this orchestrate always had. #}
+  {%- set node_label = pillar.metalk8s.nodes[node].version|string %}
+  {%- set node_applied = pillar.metalk8s.nodes[node].get('version_applied') %}
+  {%- set node_in_progress = pillar.metalk8s.nodes[node].get('version_in_progress') %}
+  {#- Of a node that did finish its last deployment, keep the higher of the annotation
+      and the label. Every version of this orchestrate maintains the label, only the
+      ones that know about the annotation maintain it, so the two can disagree. A
+      downgrade must not skip a node that might still run the higher of the two, which
+      is the opposite of what the upgrade orchestrate keeps. #}
+  {%- if node_applied
+      and salt.pkg.version_cmp(node_applied|string, node_label) in (0, 1) %}
+    {%- set node_version = node_applied|string %}
+  {%- else %}
+    {%- set node_version = node_label %}
+  {%- endif %}
   {%- set version_cmp = salt.pkg.version_cmp(dest_version, node_version) %}
+  {#- A node that completed the destination is left alone, so resuming an
+      interrupted downgrade only works the nodes that need it. This leans on the
+      annotation: `node_version` only equals `node_applied` when that annotation
+      is the one we trust, and the label alone never proved that a node ran the
+      version it advertises (MK8S-370). #}
+  {%- set completed_dest = node_applied is not none
+                           and node_version == node_applied|string
+                           and node_version == dest_version %}
   {#- If dest_version = 2.1.0 and node_version = 2.1.0-dev, version_cmp = 0
       but we should not downgrade this node #}
-  {%- if version_cmp == 1
-      or (version_cmp == 0 and dest_version != node_version and '-' not in dest_version) %}
+  {#- A node still carrying the in-progress marker is another matter: its
+      deployment never finished, so neither its label nor its recorded version
+      says what it runs, and it gets deployed rather than trusted. #}
+  {%- if node_in_progress is none
+      and (version_cmp == 1
+           or completed_dest
+           or (version_cmp == 0 and dest_version != node_version and '-' not in dest_version)) %}
 
-Skip node {{ node }}, already in {{ node_version }} older than {{ dest_version }}:
+  {%- if completed_dest %}
+    {%- set skip_reason = "already completed " ~ dest_version %}
+  {%- else %}
+    {%- set skip_reason = "already in " ~ node_version ~ " older than " ~ dest_version %}
+  {%- endif %}
+Skip node {{ node }}, {{ skip_reason }}:
   test.succeed_without_changes
 
   {%- else %}
@@ -37,10 +81,13 @@ Wait for API server to be available on {{ node }}:
   - request_interval: 1
   - require:
     - salt: Execute the downgrade prechecks
-  {%- if loop.previtem is defined %}
-    - salt: Deploy node {{ loop.previtem }}
+  {%- if deployed.previous %}
+    - salt: Deploy node {{ deployed.previous }}
   {%- endif %}
 
+{#- The version label selects the saltenv used to deploy the node, so it has to
+    be set before the deployment. The annotation records that the node does not
+    run this version yet, and is removed once the deployment succeeded. #}
 Set node {{ node }} version to {{ dest_version }}:
   metalk8s_kubernetes.object_updated:
     - name: {{ node }}
@@ -50,6 +97,8 @@ Set node {{ node }} version to {{ dest_version }}:
         metadata:
           labels:
             metalk8s.scality.com/version: "{{ dest_version }}"
+          annotations:
+            metalk8s.scality.com/version-in-progress: "{{ dest_version }}"
     - require:
       - http: Wait for API server to be available on {{ node }}
 
@@ -78,6 +127,48 @@ Deploy node {{ node }}:
     - require_in:
       - salt: Downgrade etcd cluster
 
+Mark node {{ node }} as running {{ dest_version }}:
+  metalk8s_kubernetes.object_updated:
+    - name: {{ node }}
+    - kind: Node
+    - apiVersion: v1
+    - patch:
+        metadata:
+          annotations:
+            metalk8s.scality.com/version-in-progress: null
+            metalk8s.scality.com/version-applied: "{{ dest_version }}"
+    {#- The node deployment just restarted the API server on this node, so give this
+        write a few tries before it fails the downgrade #}
+    - retry:
+        attempts: 5
+        interval: 30
+    - require:
+      - salt: Deploy node {{ node }}
+
+{#- Clearing the marker is the last step, and it is the only one that can fail on
+    a node that is otherwise deployed. Say so, rather than leaving the operator with
+    a bare API error on the very last state. The `require` matters: without it this
+    state also fires when the node deployment itself failed, and would then claim a
+    broken node is fine. #}
+Explain the stale marker on {{ node }}:
+  test.configurable_test_state:
+    - name: {{ node }}
+    - changes: False
+    - result: True
+    - comment: >-
+        Node {{ node }} was deployed in {{ dest_version }}, only the
+        metalk8s.scality.com/version-in-progress annotation could not be cleared.
+        The node itself is fine. Run downgrade.sh again to redeploy it and record
+        the version, or record it by hand with "kubectl annotate node
+        {{ node }} metalk8s.scality.com/version-in-progress-
+        metalk8s.scality.com/version-applied={{ dest_version }} --overwrite". Until
+        one of those, an upgrade to another version is refused.
+    - onfail:
+      - metalk8s_kubernetes: Mark node {{ node }} as running {{ dest_version }}
+    - require:
+      - salt: Deploy node {{ node }}
+
+    {%- set deployed.previous = node %}
   {%- endif %}
 
 {%- endfor %}

--- a/salt/metalk8s/orchestrate/upgrade/init.sls
+++ b/salt/metalk8s/orchestrate/upgrade/init.sls
@@ -107,8 +107,10 @@ Wait for API server to be available on {{ node }}:
     - salt: Install apiserver-proxy on {{ node }}
 
 {#- The version label selects the saltenv used to deploy the node, so it has to
-    be set before the deployment. The annotation records that the node does not
-    run this version yet, and is removed once the deployment succeeded. #}
+    be set before the deployment. The marker goes with it, so a run interrupted
+    between here and the deployment still leaves the node flagged. `deploy_node`
+    maintains both annotations from there, and clears the marker once it is
+    through. #}
 Set node {{ node }} version to {{ dest_version }}:
   metalk8s_kubernetes.object_updated:
     - name: {{ node }}
@@ -142,47 +144,6 @@ Deploy node {{ node }}:
     - require_in:
       - salt: Deploy core component objects
       - salt: Deploy Kubernetes service config objects
-
-Mark node {{ node }} as running {{ dest_version }}:
-  metalk8s_kubernetes.object_updated:
-    - name: {{ node }}
-    - kind: Node
-    - apiVersion: v1
-    - patch:
-        metadata:
-          annotations:
-            metalk8s.scality.com/version-in-progress: null
-            metalk8s.scality.com/version-applied: "{{ dest_version }}"
-    {#- The node deployment just restarted the API server on this node, so give this
-        write a few tries before it fails the upgrade #}
-    - retry:
-        attempts: 5
-        interval: 30
-    - require:
-      - salt: Deploy node {{ node }}
-
-{#- Clearing the marker is the last step, and it is the only one that can fail on
-    a node that is otherwise upgraded. Say so, rather than leaving the operator with
-    a bare API error on the very last state. The `require` matters: without it this
-    state also fires when the node deployment itself failed, and would then claim a
-    broken node is fine. #}
-Explain the stale marker on {{ node }}:
-  test.configurable_test_state:
-    - name: {{ node }}
-    - changes: False
-    - result: True
-    - comment: >-
-        Node {{ node }} was upgraded to {{ dest_version }}, only the
-        metalk8s.scality.com/version-in-progress annotation could not be cleared.
-        The node itself is fine. Run upgrade.sh again to redeploy it and record
-        the version, or record it by hand with "kubectl annotate node
-        {{ node }} metalk8s.scality.com/version-in-progress-
-        metalk8s.scality.com/version-applied={{ dest_version }} --overwrite". Until
-        one of those, an upgrade to another version is refused.
-    - onfail:
-      - metalk8s_kubernetes: Mark node {{ node }} as running {{ dest_version }}
-    - require:
-      - salt: Deploy node {{ node }}
 
     {%- set deployed.previous = node %}
   {%- endif %}

--- a/salt/metalk8s/orchestrate/upgrade/init.sls
+++ b/salt/metalk8s/orchestrate/upgrade/init.sls
@@ -14,16 +14,56 @@ Execute the upgrade prechecks:
 {%- set cp_nodes = salt.metalk8s.minions_by_role('master') | sort %}
 {%- set other_nodes = pillar.metalk8s.nodes.keys() | difference(cp_nodes) | sort %}
 
+{#- Nodes are deployed one by one, each waiting on the previous one. A skipped node
+    declares no state, so the chain must remember the last node actually deployed,
+    otherwise the next one waits on a state that does not exist and Salt fails it
+    with "The following requisites were not found". #}
+{%- set deployed = namespace(previous=None) %}
+
 {%- for node in cp_nodes + other_nodes %}
 
-  {%- set node_version = pillar.metalk8s.nodes[node].version|string %}
+  {#- The version label is set before a node is deployed, since it selects the
+      saltenv, so it says what the node was asked to run, not what it runs. The
+      `version-applied` annotation records the last version a node completed, and
+      that is what decides whether it still needs this one. #}
+  {%- set node_label = pillar.metalk8s.nodes[node].version|string %}
+  {%- set node_applied = pillar.metalk8s.nodes[node].get('version_applied') %}
+  {%- set node_in_progress = pillar.metalk8s.nodes[node].get('version_in_progress') %}
+  {#- Of a node that did finish its last deployment, keep the lower of the annotation
+      and the label. Every version of this orchestrate maintains the label, only the
+      ones that know about the annotation maintain it, so the two can disagree. An
+      upgrade must not skip a node that might still run the older of the two. #}
+  {%- if node_applied
+      and salt.pkg.version_cmp(node_applied|string, node_label) in (-1, 0) %}
+    {%- set node_version = node_applied|string %}
+  {%- else %}
+    {%- set node_version = node_label %}
+  {%- endif %}
   {%- set version_cmp = salt.pkg.version_cmp(dest_version, node_version) %}
+  {#- A node that completed the destination is left alone, so resuming an
+      interrupted upgrade only works the nodes that need it. This leans on the
+      annotation: `node_version` only equals `node_applied` when that annotation
+      is the one we trust, and the label alone never proved that a node ran the
+      version it advertises (MK8S-370). #}
+  {%- set completed_dest = node_applied is not none
+                           and node_version == node_applied|string
+                           and node_version == dest_version %}
   {#- If dest_version = 2.1.0-dev and node_version = 2.1.0, version_cmp = 0
       but we should not upgrade this node #}
-  {%- if version_cmp == -1
-      or (version_cmp == 0 and dest_version != node_version and '-' not in node_version) %}
+  {#- A node still carrying the in-progress marker is another matter: its
+      deployment never finished, so neither its label nor its recorded version
+      says what it runs, and it gets deployed rather than trusted. #}
+  {%- if node_in_progress is none
+      and (version_cmp == -1
+           or completed_dest
+           or (version_cmp == 0 and dest_version != node_version and '-' not in node_version)) %}
 
-Skip node {{ node }}, already in {{ node_version }} newer than {{ dest_version }}:
+  {%- if completed_dest %}
+    {%- set skip_reason = "already completed " ~ dest_version %}
+  {%- else %}
+    {%- set skip_reason = "already in " ~ node_version ~ " newer than " ~ dest_version %}
+  {%- endif %}
+Skip node {{ node }}, {{ skip_reason }}:
   test.succeed_without_changes
 
   {%- else %}
@@ -43,8 +83,8 @@ Check pillar on {{ node }} before installing apiserver-proxy:
         attempts: 5
     - require:
       - salt: Execute the upgrade prechecks
-    {%- if loop.previtem is defined %}
-      - salt: Deploy node {{ loop.previtem }}
+    {%- if deployed.previous %}
+      - salt: Deploy node {{ deployed.previous }}
     {%- endif %}
 
 Install apiserver-proxy on {{ node }}:
@@ -66,6 +106,9 @@ Wait for API server to be available on {{ node }}:
   - require:
     - salt: Install apiserver-proxy on {{ node }}
 
+{#- The version label selects the saltenv used to deploy the node, so it has to
+    be set before the deployment. The annotation records that the node does not
+    run this version yet, and is removed once the deployment succeeded. #}
 Set node {{ node }} version to {{ dest_version }}:
   metalk8s_kubernetes.object_updated:
     - name: {{ node }}
@@ -75,6 +118,8 @@ Set node {{ node }} version to {{ dest_version }}:
         metadata:
           labels:
             metalk8s.scality.com/version: "{{ dest_version }}"
+          annotations:
+            metalk8s.scality.com/version-in-progress: "{{ dest_version }}"
     - require:
       - http: Wait for API server to be available on {{ node }}
 
@@ -98,6 +143,48 @@ Deploy node {{ node }}:
       - salt: Deploy core component objects
       - salt: Deploy Kubernetes service config objects
 
+Mark node {{ node }} as running {{ dest_version }}:
+  metalk8s_kubernetes.object_updated:
+    - name: {{ node }}
+    - kind: Node
+    - apiVersion: v1
+    - patch:
+        metadata:
+          annotations:
+            metalk8s.scality.com/version-in-progress: null
+            metalk8s.scality.com/version-applied: "{{ dest_version }}"
+    {#- The node deployment just restarted the API server on this node, so give this
+        write a few tries before it fails the upgrade #}
+    - retry:
+        attempts: 5
+        interval: 30
+    - require:
+      - salt: Deploy node {{ node }}
+
+{#- Clearing the marker is the last step, and it is the only one that can fail on
+    a node that is otherwise upgraded. Say so, rather than leaving the operator with
+    a bare API error on the very last state. The `require` matters: without it this
+    state also fires when the node deployment itself failed, and would then claim a
+    broken node is fine. #}
+Explain the stale marker on {{ node }}:
+  test.configurable_test_state:
+    - name: {{ node }}
+    - changes: False
+    - result: True
+    - comment: >-
+        Node {{ node }} was upgraded to {{ dest_version }}, only the
+        metalk8s.scality.com/version-in-progress annotation could not be cleared.
+        The node itself is fine. Run upgrade.sh again to redeploy it and record
+        the version, or record it by hand with "kubectl annotate node
+        {{ node }} metalk8s.scality.com/version-in-progress-
+        metalk8s.scality.com/version-applied={{ dest_version }} --overwrite". Until
+        one of those, an upgrade to another version is refused.
+    - onfail:
+      - metalk8s_kubernetes: Mark node {{ node }} as running {{ dest_version }}
+    - require:
+      - salt: Deploy node {{ node }}
+
+    {%- set deployed.previous = node %}
   {%- endif %}
 
 {%- endfor %}

--- a/salt/tests/unit/formulas/config.py
+++ b/salt/tests/unit/formulas/config.py
@@ -467,10 +467,16 @@ def get_cases(template: Path) -> List[TestCase]:
 
 def _generate_test_cases(cases: Dict[str, Any]) -> Iterator[Tuple[str, Dict[str, Any]]]:
     for case_id, case_options in cases.items():
-        sub_cases = case_options.pop("_subcases", None)
+        # NOTE: Read the sub-cases, never pop them. They come from the parsed
+        # configuration, which is shared, so popping means the second test to ask for
+        # the cases of a template gets the parent cases only, silently.
+        sub_cases = case_options.get("_subcases")
         if sub_cases is not None:
+            parent_options = {
+                key: value for key, value in case_options.items() if key != "_subcases"
+            }
             for sub_id, sub_options in _generate_test_cases(sub_cases):
-                yield f"{case_id} - {sub_id}", dict(case_options, **sub_options)
+                yield f"{case_id} - {sub_id}", dict(parent_options, **sub_options)
         else:
             yield case_id, case_options
 

--- a/salt/tests/unit/formulas/config.yaml
+++ b/salt/tests/unit/formulas/config.yaml
@@ -590,6 +590,76 @@ metalk8s:
                     nodes:
                       master-1:
                         version: 2.7.3
+              # A downgrade to 2.7.3 was interrupted on this node: its label
+              # was lowered, the version it completed was not
+              "A node that never completed the destination version":
+                pillar_overrides:
+                  metalk8s:
+                    cluster_version: 2.7.3
+                    nodes:
+                      master-1:
+                        version: 2.7.3
+                        version_in_progress: 2.7.3
+                        version_applied: 2.8.0
+              # A downgrade to 2.7.1 was interrupted, and the operator now
+              # targets 2.7.3: the label says skip, what the node ran
+              # says deploy
+              "A node whose label ran ahead of the destination":
+                pillar_overrides:
+                  metalk8s:
+                    cluster_version: 2.7.3
+                    nodes:
+                      master-1:
+                        version: 2.7.1
+                        version_in_progress: 2.7.1
+                        version_applied: 2.8.0
+              # This node completed 2.7.1, already below the destination
+              "A node that completed a version below the destination":
+                pillar_overrides:
+                  metalk8s:
+                    cluster_version: 2.7.3
+                    nodes:
+                      master-1:
+                        version: 2.7.1
+                        version_applied: 2.7.1
+              # A run by an older version left the recorded version ahead of
+              # the label, the label wins
+              "A node whose recorded version ran ahead of its label":
+                pillar_overrides:
+                  metalk8s:
+                    cluster_version: 2.7.3
+                    nodes:
+                      master-1:
+                        version: 2.8.0
+                        version_applied: 2.9.0
+              # Nothing was ever recorded for this node, and a deployment was
+              # left in progress, so its label proves nothing
+              "A node left in progress with no recorded version":
+                pillar_overrides:
+                  metalk8s:
+                    cluster_version: 2.7.3
+                    nodes:
+                      master-1:
+                        version: 2.7.1
+                        version_in_progress: 2.7.1
+              # This node recorded this very version, so it is left alone
+              "A node that already completed the destination":
+                pillar_overrides:
+                  metalk8s:
+                    cluster_version: 2.7.3
+                    nodes:
+                      master-1:
+                        version: 2.7.3
+                        version_applied: 2.7.3
+              # Same label, but nothing recorded: the label is set before a node
+              # is deployed, so it does not prove this node ran 2.7.3 (MK8S-370)
+              "A node whose label alone says the destination":
+                pillar_overrides:
+                  metalk8s:
+                    cluster_version: 2.7.3
+                    nodes:
+                      master-1:
+                        version: 2.7.3
 
           "Standard cluster":
             architecture: standard
@@ -889,6 +959,95 @@ metalk8s:
                     nodes:
                       master-1:
                         version: 2.9.0
+              # An upgrade to 2.9.0 was interrupted on this node: its label
+              # was bumped, the version it completed was not
+              "A node that never completed the destination version":
+                pillar_overrides:
+                  metalk8s:
+                    cluster_version: 2.9.0
+                    nodes:
+                      master-1:
+                        version: 2.9.0
+                        version_in_progress: 2.9.0
+                        version_applied: 2.8.0
+              # An upgrade to 2.9.1 was interrupted, and the operator now
+              # targets 2.9.0: the label says skip, the version completed
+              # says deploy
+              "A node whose label ran ahead of the destination":
+                pillar_overrides:
+                  metalk8s:
+                    cluster_version: 2.9.0
+                    nodes:
+                      master-1:
+                        version: 2.9.1
+                        version_in_progress: 2.9.1
+                        version_applied: 2.8.0
+              # This node did complete 2.9.1, so a lower destination is a
+              # downgrade and this orchestrate leaves it alone
+              "A node that completed a version above the destination":
+                pillar_overrides:
+                  metalk8s:
+                    cluster_version: 2.9.0
+                    nodes:
+                      master-1:
+                        version: 2.9.1
+                        version_applied: 2.9.1
+              # A downgrade run by an older version left the recorded
+              # version ahead of the label, the label wins
+              "A node whose recorded version ran ahead of its label":
+                pillar_overrides:
+                  metalk8s:
+                    cluster_version: 2.9.0
+                    nodes:
+                      master-1:
+                        version: 2.8.0
+                        version_applied: 2.9.1
+              # Nothing was ever recorded for this node, and a deployment was
+              # left in progress, so its label proves nothing
+              "A node left in progress with no recorded version":
+                pillar_overrides:
+                  metalk8s:
+                    cluster_version: 2.9.0
+                    nodes:
+                      master-1:
+                        version: 2.9.1
+                        version_in_progress: 2.9.1
+              # This node recorded this very version, so it is left alone
+              "A node that already completed the destination":
+                pillar_overrides:
+                  metalk8s:
+                    cluster_version: 2.9.0
+                    nodes:
+                      master-1:
+                        version: 2.9.0
+                        version_applied: 2.9.0
+              # Same label, but nothing recorded: the label is bumped before a
+              # node is deployed, so it does not prove this node ran 2.9.0,
+              # which is the whole point of MK8S-370
+              "A node whose label alone says the destination":
+                pillar_overrides:
+                  metalk8s:
+                    cluster_version: 2.9.0
+                    nodes:
+                      master-1:
+                        version: 2.9.0
+              # The whole point: an upgrade that stopped after the first
+              # node, resumed with the same destination
+              "A cluster resuming an interrupted upgrade":
+                pillar_overrides:
+                  metalk8s:
+                    cluster_version: 2.9.0
+                    nodes:
+                      bootstrap:
+                        version: 2.9.0
+                        version_applied: 2.9.0
+                      master-1:
+                        version: 2.9.0
+                        version_applied: 2.8.0
+                        version_in_progress: 2.9.0
+                      master-2:
+                        version: 2.8.0
+                        version_applied: 2.8.0
 
           "Standard cluster":
             architecture: standard

--- a/salt/tests/unit/formulas/test_config.py
+++ b/salt/tests/unit/formulas/test_config.py
@@ -1,0 +1,29 @@
+"""Tests for the test case configuration of the rendering tests.
+
+The cases are parsed once into a shared structure, so reading them must leave that
+structure alone. A destructive read used to drop the sub-cases of a template as soon
+as a second test asked for them, which lowered the coverage of every test after the
+first one without failing anything.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from tests.unit.formulas import config
+
+# Any template with sub-cases would do, this one has several per architecture.
+TEMPLATE_WITH_SUBCASES = Path("metalk8s/orchestrate/upgrade/init.sls")
+
+
+@pytest.mark.formulas
+def test_cases_survive_a_second_read() -> None:
+    """Check that reading the cases of a template does not consume them."""
+    first_read = [case.id for case in config.get_cases(TEMPLATE_WITH_SUBCASES)]
+    second_read = [case.id for case in config.get_cases(TEMPLATE_WITH_SUBCASES)]
+
+    assert first_read, f"no test case for {TEMPLATE_WITH_SUBCASES!s}"
+    assert any(
+        " - " in case_id for case_id in first_read
+    ), f"{TEMPLATE_WITH_SUBCASES!s} has no sub-case, it cannot cover this"
+    assert first_read == second_read

--- a/salt/tests/unit/formulas/test_version_selection.py
+++ b/salt/tests/unit/formulas/test_version_selection.py
@@ -1,0 +1,134 @@
+"""Tests for the node selection of the upgrade and downgrade orchestrates.
+
+The rendering tests only prove that a template can be rendered. Here we check which
+nodes those orchestrates deploy, since the version label of a node whose deployment
+was interrupted runs ahead of the version that node actually runs (see MK8S-370).
+"""
+
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional, Set
+
+import pytest
+
+from tests.unit.formulas.fixtures.rendered import RenderedStates
+
+UPGRADE = Path("metalk8s/orchestrate/upgrade/init.sls")
+DOWNGRADE = Path("metalk8s/orchestrate/downgrade/init.sls")
+
+# The node the test cases give a version history to.
+NODE = "master-1"
+
+# Test case name, and whether that case must deploy the node above. The names come
+# from the sub-cases declared for both orchestrates in `config.yaml`.
+DEPLOYED_PER_CASE: Dict[str, bool] = {
+    "A node that never completed the destination version": True,
+    "A node whose label ran ahead of the destination": True,
+    "A node that completed a version above the destination": False,
+    "A node that completed a version below the destination": False,
+    "A node whose recorded version ran ahead of its label": True,
+    "A node left in progress with no recorded version": True,
+    "A node that already completed the destination": False,
+    "A node whose label alone says the destination": True,
+    "A cluster resuming an interrupted upgrade": True,
+}
+
+# Requisites naming another state, all of which must exist in the same document.
+REQUISITES = (
+    "require",
+    "require_in",
+    "onfail",
+    "onfail_in",
+    "onchanges",
+    "onchanges_in",
+    "watch",
+    "watch_in",
+    "prereq",
+    "prereq_in",
+)
+
+
+def _iter_referenced_ids(state_body: Any) -> Iterator[str]:
+    """Yield the state IDs a single state names in its requisites."""
+    # A state declared in short form, `test.succeed_without_changes` alone, parses as
+    # a string and carries no requisite.
+    if not isinstance(state_body, dict):
+        return
+
+    for state_args in state_body.values():
+        # A state declared without any argument renders as `None`.
+        for state_arg in state_args or []:
+            if not isinstance(state_arg, dict):
+                continue
+            for requisite, targets in state_arg.items():
+                if requisite in REQUISITES:
+                    yield from _iter_targets(targets)
+
+
+def _iter_targets(targets: Any) -> Iterator[str]:
+    """Yield the state IDs named by a single requisite."""
+    for target in targets:
+        # A requisite entry is a single `{module: state ID}` mapping.
+        if isinstance(target, dict):
+            yield from target.values()
+
+
+def _must_deploy(case_id: str) -> Optional[bool]:
+    """Tell whether a test case expects the node to be deployed, skipped, or is
+    not about node selection at all."""
+    for case_name, deployed in DEPLOYED_PER_CASE.items():
+        if case_name in case_id:
+            return deployed
+    return None
+
+
+@pytest.mark.formulas
+@pytest.mark.parametrize("template_path", [UPGRADE, DOWNGRADE], indirect=True)
+def test_selection_follows_the_applied_version(
+    rendered_states: RenderedStates,
+) -> None:
+    """Check that a node is selected on the version it completed, not on its label."""
+    outcomes: Set[bool] = set()
+
+    for case_id, states in rendered_states:
+        must_deploy = _must_deploy(case_id)
+        if must_deploy is None:
+            continue
+        outcomes.add(must_deploy)
+
+        deploy_id = f"Deploy node {NODE}"
+        skip_ids: List[str] = [
+            state_id for state_id in states if state_id.startswith(f"Skip node {NODE},")
+        ]
+
+        if must_deploy:
+            assert deploy_id in states, f"'{deploy_id}' is missing ({case_id})"
+            assert not skip_ids, f"{NODE} is skipped, it did not complete ({case_id})"
+        else:
+            assert skip_ids, f"{NODE} is not skipped ({case_id})"
+            assert deploy_id not in states, f"'{deploy_id}' is declared ({case_id})"
+
+    assert outcomes == {True, False}, (
+        "the cases exercising node selection are gone from `config.yaml`, so this"
+        " orchestrate is no longer covered for both outcomes"
+    )
+
+
+@pytest.mark.formulas
+@pytest.mark.parametrize("template_path", [UPGRADE, DOWNGRADE], indirect=True)
+def test_no_requisite_on_a_missing_state(rendered_states: RenderedStates) -> None:
+    """Check that no state waits on a state the orchestrate did not declare.
+
+    Nodes are deployed one by one, each waiting on the previous one, and a skipped
+    node declares no state at all. Salt fails a state whose requisite names nothing
+    with "The following requisites were not found", so getting that chain wrong
+    silently leaves every node after the skipped one behind.
+    """
+    for case_id, states in rendered_states:
+        declared = set(states)
+
+        for state_id, state_body in states.items():
+            for target in _iter_referenced_ids(state_body):
+                assert target in declared, (
+                    f"'{state_id}' waits on '{target}', which this orchestrate does"
+                    f" not declare ({case_id})"
+                )

--- a/salt/tests/unit/formulas/test_version_selection.py
+++ b/salt/tests/unit/formulas/test_version_selection.py
@@ -14,6 +14,7 @@ from tests.unit.formulas.fixtures.rendered import RenderedStates
 
 UPGRADE = Path("metalk8s/orchestrate/upgrade/init.sls")
 DOWNGRADE = Path("metalk8s/orchestrate/downgrade/init.sls")
+DEPLOY_NODE = Path("metalk8s/orchestrate/deploy_node.sls")
 
 # The node the test cases give a version history to.
 NODE = "master-1"
@@ -114,7 +115,9 @@ def test_selection_follows_the_applied_version(
 
 
 @pytest.mark.formulas
-@pytest.mark.parametrize("template_path", [UPGRADE, DOWNGRADE], indirect=True)
+@pytest.mark.parametrize(
+    "template_path", [UPGRADE, DOWNGRADE, DEPLOY_NODE], indirect=True
+)
 def test_no_requisite_on_a_missing_state(rendered_states: RenderedStates) -> None:
     """Check that no state waits on a state the orchestrate did not declare.
 
@@ -132,3 +135,40 @@ def test_no_requisite_on_a_missing_state(rendered_states: RenderedStates) -> Non
                     f"'{state_id}' waits on '{target}', which this orchestrate does"
                     f" not declare ({case_id})"
                 )
+
+
+@pytest.mark.formulas
+@pytest.mark.parametrize("template_path", [DEPLOY_NODE], indirect=True)
+def test_the_deployment_maintains_both_annotations(
+    rendered_states: RenderedStates,
+) -> None:
+    """Check that deploying a node is what records the version it runs.
+
+    Every path that deploys a node goes through this orchestrate, an expansion and a
+    renamed node included, so both annotations are maintained here rather than in
+    the orchestrate that happens to have asked for the deployment.
+    """
+    for case_id, states in rendered_states:
+        marker = [
+            state_id
+            for state_id in states
+            if state_id.startswith("Mark node ")
+            and " as being deployed in " in state_id
+        ]
+        applied = [
+            state_id
+            for state_id in states
+            if state_id.startswith("Mark node ") and " as running " in state_id
+        ]
+
+        assert marker, f"nothing sets the in-progress annotation ({case_id})"
+        assert applied, f"nothing records the version the node runs ({case_id})"
+
+        patch = states[applied[0]]["metalk8s_kubernetes.object_updated"]
+        annotations = next(
+            arg["patch"]["metadata"]["annotations"]
+            for arg in patch
+            if isinstance(arg, dict) and "patch" in arg
+        )
+        in_progress = annotations["metalk8s.scality.com/version-in-progress"]
+        assert in_progress is None, f"marker still set ({case_id})"

--- a/salt/tests/unit/modules/files/test_metalk8s_drain.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_drain.yaml
@@ -33,12 +33,39 @@ evict_pod:
     - level: INFO
       contains: "Cannot evict busy-pod at the moment: this pod is meditating"
 
-  ## ERROR CASES
+  ## TRANSIENT SERVER-SIDE FAILURES (retried by the caller)
 
-  # Unknown API error
+  # etcd or the API server is momentarily unavailable
   - name: my-pod
     create_raises: ApiException
     create_error_status: 500
+    create_error_body:
+      message: 'etcdserver: request timed out'
+    result: >-
+      Failed to evict pod "my-pod" in namespace "default":
+      etcdserver: request timed out
+    raises: EvictionTransientError
+
+  # Same, with a body we cannot read
+  - name: my-pod
+    create_raises: ApiException
+    create_error_status: 503
+    result: 'Failed to evict pod "my-pod" in namespace "default": HTTP 503'
+    raises: EvictionTransientError
+
+  ## ERROR CASES
+
+  # Eviction forbidden, retrying will not help
+  - name: my-pod
+    create_raises: ApiException
+    create_error_status: 403
+    result: 'Failed to evict pod "my-pod" in namespace "default"'
+    raises: True
+
+  # Malformed request, retrying will not help
+  - name: my-pod
+    create_raises: ApiException
+    create_error_status: 422
     result: 'Failed to evict pod "my-pod" in namespace "default"'
     raises: True
 
@@ -356,6 +383,31 @@ drain:
       eviction_attempts: 1
       best_effort: True
 
+    # Retry until the API server stops returning server-side errors
+    - node_name: my-node
+      dataset: server-error-eviction
+      events: &server_error_eviction_events
+        # evict_pods sleeps 5 seconds between each eviction attempt, so we will
+        # try to evict twice with an error, and third attempt will work
+        8:
+          - resource: evictionmocks
+            verb: delete
+            pod: my-namespace/my-replicaset-pod
+        # we delete the pod 2 second after success when creating the eviction
+        10:
+          - resource: pods
+            verb: delete
+            name: my-replicaset-pod
+            namespace: my-namespace
+      eviction_attempts: 3
+
+    # Best effort do not retry server-side errors either
+    - node_name: my-node
+      dataset: server-error-eviction
+      events: *server_error_eviction_events
+      eviction_attempts: 1
+      best_effort: True
+
   waiting-for-eviction:
     # Instantaneous
     - node_name: my-node
@@ -403,6 +455,17 @@ drain:
     # Eviction creation succeeds, but the pod is never removed
     - node_name: my-node
       dataset: single-replicaset
+
+  transient-eviction-error:
+    # Server-side errors are retried, and the failure names the pod at fault
+    - node_name: my-node
+      dataset: server-error-eviction
+      # 12 attempts, 5 seconds apart, so the drain timeout must be larger
+      timeout: 300
+      raise_msg: >-
+        Failed to evict pod "my-replicaset-pod" in namespace "my-namespace":
+        etcdserver: request timed out \(gave up after 12 consecutive server
+        errors\)
 
   eviction-error:
     - node_name: my-node
@@ -646,3 +709,11 @@ datasets:
         apiVersion: __tests__
         pod: my-namespace/my-replicaset-pod
         raises: true
+
+  server-error-eviction:
+    <<: *single_replicaset_dataset
+    evictionmocks:
+      - kind: EvictionMock
+        apiVersion: __tests__
+        pod: my-namespace/my-replicaset-pod
+        server_error: true

--- a/salt/tests/unit/modules/test_metalk8s_drain.py
+++ b/salt/tests/unit/modules/test_metalk8s_drain.py
@@ -126,8 +126,15 @@ class Metalk8sDrainTestCase(TestCase, mixins.LoaderModuleMockMixin):
             metalk8s_drain.log, logging.DEBUG
         ) as captured:
             if raises:
+                # `raises` is either `True` for a `CommandExecutionError`, or the
+                # name of the expected exception class from the module
+                exc_class = (
+                    CommandExecutionError
+                    if raises is True
+                    else getattr(metalk8s_drain, raises)
+                )
                 self.assertRaisesRegex(
-                    CommandExecutionError, result, metalk8s_drain.evict_pod, **kwargs
+                    exc_class, result, metalk8s_drain.evict_pod, **kwargs
                 )
             else:
                 self.assertEqual(metalk8s_drain.evict_pod(**kwargs), result)
@@ -223,6 +230,14 @@ class DrainTestCase(TestCase, mixins.LoaderModuleMockMixin):
             if eviction_mock is not None:
                 if eviction_mock.get("raises", False):
                     raise CommandExecutionError("Failed to evict pod")
+
+                if eviction_mock.get("server_error", False):
+                    raise metalk8s_drain.EvictionTransientError(
+                        (
+                            'Failed to evict pod "{}" in namespace "{}": '
+                            "etcdserver: request timed out"
+                        ).format(name, namespace)
+                    )
 
                 return not eviction_mock.get("locked", False)
 
@@ -353,6 +368,23 @@ class DrainTestCase(TestCase, mixins.LoaderModuleMockMixin):
                 drainer.run_drain,
             )
 
+    @utils.parameterized_from_cases(
+        YAML_TESTS_CASES["drain"]["transient-eviction-error"]
+    )
+    def test_transient_eviction_error(
+        self, node_name, dataset, raise_msg, events=None, **kwargs
+    ):
+        """Check that server-side eviction errors are retried, then give up."""
+        self.seed_api_mock(dataset, events)
+        drainer = metalk8s_drain.Drain(node_name, **kwargs)
+
+        with self.time_mock.patch():
+            self.assertRaisesRegex(
+                CommandExecutionError,
+                raise_msg,
+                drainer.run_drain,
+            )
+
     @utils.parameterized_from_cases(YAML_TESTS_CASES["drain"]["eviction-error"])
     def test_eviction_error(self, node_name, dataset, **kwargs):
         """Check that errors when evicting are stopping the drain process."""
@@ -365,3 +397,25 @@ class DrainTestCase(TestCase, mixins.LoaderModuleMockMixin):
                 "Failed to evict pod",
                 drainer.run_drain,
             )
+
+    def test_eviction_error_without_pod_list(self):
+        """Check that a failure keeps its reason when the pods cannot be listed.
+
+        Listing the remaining pods runs right after a failed eviction, so the API
+        that just failed can fail again. The reason of the first failure matters
+        more than the list.
+        """
+        self.seed_api_mock("broken-eviction")
+        drainer = metalk8s_drain.Drain("my-node")
+        pods = drainer.get_pods_for_eviction()
+
+        with patch.object(
+            drainer,
+            "get_pods_for_eviction",
+            side_effect=[pods, CommandExecutionError("Cannot list pods")],
+        ), self.time_mock.patch():
+            with self.assertRaises(CommandExecutionError) as context:
+                drainer.run_drain()
+
+        self.assertIn("Failed to evict pod", str(context.exception))
+        self.assertNotIn("List of remaining pods", str(context.exception))

--- a/salt/tests/unit/runners/files/test_metalk8s_checks.yaml
+++ b/salt/tests/unit/runners/files/test_metalk8s_checks.yaml
@@ -299,6 +299,34 @@ upgrade:
     result: |-
       Invalid saltenv 'metalk8s-1.1.0' consider using 'metalk8s-1.2.0'
 
+  # 5.(bis) Success: resuming the upgrade a node was left in
+  - pillar:
+      metalk8s:
+        nodes:
+          node-1:
+            version: 1.2.0
+            version_in_progress: 1.2.0
+          node-2:
+            version: 1.1.0
+    dest_version: 1.2.0
+    saltenv: metalk8s-1.2.0
+    result: True
+
+  # 5.(ter) Failure: another destination than the interrupted upgrade
+  - pillar:
+      metalk8s:
+        nodes:
+          node-1:
+            version: 1.3.0
+            version_in_progress: 1.3.0
+          node-2:
+            version: 1.1.0
+    dest_version: 1.2.0
+    saltenv: metalk8s-1.2.0
+    expect_raise: True
+    result: |-
+      A version change to 1.3.0 did not complete on node-1. Resume it rather than upgrading to 1.2.0, since moving those nodes to 1.2.0 would be a downgrade. If 1.3.0 is not an option, clear their metalk8s.scality.com/version-in-progress annotation first
+
   # 6. Success: Upgrade from more than one minor
   - pillar:
       metalk8s:


### PR DESCRIPTION
**Component**: salt

**Context**:

Two defects in the same code path (`metalk8s.orchestrate.upgrade` -> `deploy_node`), both surfaced by the same incident: the node upgrade gave up too easily, and when it gave up it left the node claiming it had succeeded.

A pod eviction rejected with a 5xx status raised right away, so a single `etcdserver: request timed out` aborted `Drain the node`, then `Deploy node <node>`, then `Upgrading all nodes one by one`, then `upgrade.sh`. That failure mode is worst during an upgrade, since the upgrade restarts etcd and the API servers itself. In the reported incident the etcd cluster was loaded, not broken: 166 `apply request took too long` entries that day, peaking above 5 s, then 9 the next day and 2 the day after, so it recovered on its own. The aborted upgrade is what left the cluster in the mixed state behind the whole deadlock.

The node version label was also set before cordon, drain and highstate, so the node that failed kept advertising the destination version although its highstate never ran. It looked exactly like the two nodes that did complete.

**Summary**:

Six commits, each standing on its own.

1. `test(formulas)`: the rendering test harness popped `_subcases` from the parsed configuration, which is shared between tests. The first test asking for the cases of a template got them all, every test after that got the parent cases only, and nothing failed. Coverage of the sub-cases silently disappeared for any template another test had already read, `containerd/installed.sls` for one. This comes first because the tests added later would otherwise degrade the same way, without failing.

2. `fix(salt)`, eviction: evictions rejected with 500, 502, 503 or 504 are retried like a 429, up to 12 consecutive errors on the same pod, so about a minute at the 5 s interval `kubectl` uses. Past that the drain fails and names the pod and the API message. The list of remaining pods was already there before this change, what's new is the retry and the reason. Forbidden and malformed requests still fail immediately. `Drain the node` also carries a `retry` for the failures that happen outside the eviction loop, with its timeout split across the attempts, so a drain that can never succeed (an unsatisfiable `PodDisruptionBudget`) still gives up in about the time a single drain used to take. Without that split, `retry: 4` on a one hour drain would have meant four hours before `upgrade.sh` reports anything.

3. `fix(salt)`, node selection: the version label cannot simply move after the highstate, which is what I first tried. It feeds `pillar.metalk8s.nodes[node].version` (`salt/_pillar/metalk8s_nodes.py`), which selects the `saltenv` used by every step of `deploy_node.sls`, the highstate included (`salt/metalk8s/orchestrate/deploy_node.sls:8`). Moving it would have made the node re-run the old version's highstate, so the upgrade would have done nothing.

   So a node now carries two annotations. `metalk8s.scality.com/version-in-progress` is set when its version is bumped and removed once its deployment succeeded, so a node whose deployment never finished is visible, and is always deployed again whatever its label says. `metalk8s.scality.com/version-applied` records the last version a node completed, and that is what both orchestrates compare the destination to. It is trusted only when it is not ahead of the label, since a run by an older version of these orchestrates maintains the label but not the annotation. A node with neither annotation falls back to the label, which is what both orchestrates always did, so nothing changes on a cluster upgraded from an older platform.

   A node whose recorded version already reads the destination is skipped, so resuming an interrupted upgrade only works the nodes that need it. That skip fires on the annotation, never on the label alone: a label bumped before a deployment that then failed says nothing about what the node runs, which is the whole defect here. Config drift is out of this path, `deploy_node` can be run per node by hand for that. Commit 6 settles where the two annotations are written.

   Selecting on what a node ran makes the skip branch reachable in more situations, which uncovered an older bug. The per-node chain waited on `Deploy node {{ loop.previtem }}`, and a skipped node declares no state, so the node right after a skipped one failed with `The following requisites were not found` and every node after it was left behind. The chain now waits on the last node actually deployed.

4. `fix(salt)`, prechecks: a node whose deployment did not complete can only be recovered by resuming the same upgrade. Bringing it to another version would mean downgrading it, which the upgrade orchestrate cannot do. Downgrade has its own script and its own gate, and not every consumer of this project exposes it. The upgrade prechecks now refuse a destination that is not the version an interrupted upgrade was heading to, and name the nodes concerned, instead of silently leaving the cluster split across two versions. The downgrade prechecks are left alone on purpose: that runner comes from the destination saltenv, so a downgrade to any released version runs the code that predates this check.

5. `docs(upgrade)`: how to resume an interrupted upgrade, and why pointing `upgrade.sh` at another version is refused.

6. `fix(salt)`, where the annotations are written: on review, both moved into `deploy_node`. Every path that deploys a node goes through that orchestrate, an upgrade and a downgrade as much as an expansion, a hostname change, or a deployment started from the UI. Written from the upgrade orchestrate, they recorded nothing on any of those other paths, so a node added after the fact carried no `version-applied` at all and the prechecks had only its label to go on. The marker is now the first state of `deploy_node`, and its last state clears it, after every state that orchestrate ends on. Which states those are depends on the roles of the node, so the list is built once and shared by the state that writes and the one that explains its failure. The upgrade orchestrate still sets the marker along with the version label, so a run interrupted between that patch and the deployment leaves the node flagged all the same. The downgrade orchestrate keeps its own two states, since it runs the `deploy_node` of its destination, an older version that knows nothing about these annotations. A comment there says when they can go.

**Acceptance criteria**:

- A simulated `500 etcdserver: request timed out` during eviction is retried and the drain eventually succeeds, while non-retryable errors still fail the state. Covered in `salt/tests/unit/modules/test_metalk8s_drain.py`: new `evict_pod` cases for 500 with a body, 503 without a readable body, 403 and 422, a drain case where the server errors stop after two attempts, a `best_effort` case, and one where they never stop and the drain fails naming the pod.
- A short API server outage during `Upgrading all nodes one by one` no longer aborts the upgrade: retried inside `evict_pods` first, then by the `Drain the node` state.
- A node whose highstate fails during an upgrade does not advertise the target version as completed: it keeps the `version-in-progress` annotation and its `version-applied` stays on the version it really ran.
- Re-running the upgrade deploys the nodes that did not complete it, and skips the ones that did. The rendering tests now assert which nodes each orchestrate deploys, in both directions and for every history a node can have, rather than only that the template renders. One case exists for the trap: a node whose label alone reads the destination is deployed, since only the annotation proves a node ran a version.
- A node added by an expansion records the version it ran, which nothing did before. A rendering test asserts both annotation states on every `deploy_node` case, and the requisite test now walks that template too, since the states those two wait on depend on the roles of the node.
- Existing upgrade and downgrade e2e scenarios unchanged. A first upgrade sees no annotation anywhere and behaves exactly as before, and a downgrade runs the orchestrate of its destination version.

**Known limits**:

- If clearing the marker fails on a node that is otherwise fine, and the next run points `upgrade.sh` at an older version, that node is deployed to the older version. It takes a failed bookkeeping write plus a destination the operator should not be using, and a marked node is by definition in an unconfirmed state. The `onfail` state tells the operator how to clear the marker by hand.
- A urllib3 `HTTPError`, a connection dropped while the API server restarts for instance, is still fatal for a single drain attempt. The 5xx statuses are the ones the incident showed, and the state-level retry covers the rest.
- After a fresh install the bootstrap node has no `version-applied`: `bootstrap.sh` does not go through `deploy_node`, so that node falls back to its label until its first upgrade, exactly as every node did before this PR.
- On a single node cluster this change is a no-op for the drain, since `upgrade/init.sls` forces `skip_draining: True` there. The drain paths were exercised on three nodes.

**Verified locally**: the Salt unit suite, 1246 tests with 100% coverage on `salt/_modules` and `salt/_runners`, plus black, pylint (spelling included), mypy `--strict`, salt-lint and yamllint at the pins of this branch and at the pins of `development/134.0` for the merge-up. Two behaviours were checked against a real Salt run rather than read off the source: `attempts` counts total executions, and an `onfail` state fires on a requisite failure too, which is why the new explanation state also requires `Deploy node`.

**Verified on a cluster**: three nodes on AWS (Rocky 8.6), installed in 133.0.13, upgraded to a 133.0.14-dev ISO built from this branch.

The drain, before and after, under the same injected 500 on evictions:

```
133.0.13:      Failed to evict pod "victim-..." in namespace "drain-test"      (no retry, drain aborted)
133.0.14-dev:  Failed to evict pod "victim-..." in namespace "drain-test":
               Internal error occurred: failed calling webhook ..., retrying   (x11)
               ... gave up after 12 consecutive server errors
133.0.14-dev:  same, injection removed mid-drain after 5 retries
               -> Eviction complete.  (11 pods evicted)
```

The injection is a `ValidatingWebhookConfiguration` on `pods/eviction` with `failurePolicy: Fail` pointing at a service that does not exist, scoped to a labelled namespace. Every eviction there gets a 500, and deleting the webhook mid-drain is what proves the recovery.

The split budget shows up as expected. With `-D 240` the drain fails on `Drain did not complete within 60 seconds`, so four attempts of 60 s rather than one of 240 s.

An upgrade interrupted by a machine reboot, which is the case this PR is about:

```
node-1  label=133.0.14-dev  version-in-progress=133.0.14-dev  version-applied=-
node-2  label=133.0.13      -                                 -
node-3  label=133.0.13      -                                 -
```

Before this change that node advertised the destination version and nothing else, so it looked exactly like a node that had completed. Resuming the same upgrade redeployed it rather than skipping it, cleared its marker and wrote its applied version. All three nodes ended at `version-applied=133.0.14-dev`.

Pointing the upgrade at another version while that node was still marked:

```
An upgrade to 133.0.14-dev did not complete on ip-10-160-112-29..., resume it instead
of upgrading to 133.0.13. Upgrading to another version would leave those nodes behind,
and bringing them to 133.0.13 would be a downgrade
```

On a node whose deployment really failed, the explanation state stayed silent, as intended: `One or more requisite failed: ... Deploy node ..., ... Mark node ... as running`. On the healthy nodes it reported `State was not run because onfail req did not change`.

A skipped node no longer strands the ones after it. With the first node recorded as having completed 999.0.0, the run printed `Skip node ... already in 999.0.0 newer than 133.0.14-dev`, produced zero `requisites were not found`, and carried on with the next node.

Re-running the upgrade orchestrate on an already upgraded cluster redeployed all three nodes, 26 states succeeded and 0 failed. That was the behaviour at the time of the run. Two things changed on review: the selection now skips a node that recorded the destination, so the same re-run would skip all three, and the annotations are written by `deploy_node` rather than by the upgrade orchestrate. Neither touches what the cluster run proved, the interruption, the resume and the refusal, and the values observed on the nodes are the same ones. The new selection and the new write path are covered by the rendering cases.

One case fell out of the run by itself. A node whose recorded version was ahead of its label got redeployed rather than skipped, which is the stale annotation guard doing its job.

---

See: MK8S-370

