### PR TITLE
fix(salt): write the containerd config only along with its package (MK8S-371)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@
   leaving minion-side state failures undiagnosable
   (PR[#5084](https://github.com/scality/metalk8s/pull/5084))
 
+### Bug fixes
+
+- `/etc/containerd/config.toml` is now written only once the container engine package of
+  the running version is installed. It used to be rewritten even when that install had
+  failed, or could not be attempted because the repositories were unusable, which left a
+  `version = 2` configuration on a node running containerd 2.x, so the next containerd
+  restart broke every image pull
+  (PR[#5091](https://github.com/scality/metalk8s/pull/5091))
+
 ## Release 133.0.13
 
 ### Enhancements

--- a/salt/metalk8s/container-engine/containerd/installed.sls
+++ b/salt/metalk8s/container-engine/containerd/installed.sls
@@ -90,6 +90,13 @@ Install and configure cri-tools:
       - test: Ensure containerd is ready
 
 Configure containerd:
+  # NOTE: This configuration is specific to the containerd version we ship, so it must
+  # only be written once we know that version is the one installed on the node. Written
+  # unconditionally, a run at another version rewrites the configuration of a running
+  # node to a schema its containerd does not support (see MK8S-371). We require the
+  # package state rather than `Repositories configured`, since the availability check
+  # behind that gate only runs `onchanges` of the repository definitions, so it is
+  # skipped, and reported as a success, on a second run of the same command.
   file.managed:
     - name: /etc/containerd/config.toml
     - makedirs: true
@@ -107,6 +114,8 @@ Configure containerd:
 
         [debug]
           level = "{{ 'debug' if metalk8s.debug else 'info' }}"
+    - require:
+      - metalk8s_package_manager: Install containerd
     - watch_in:
       - service: Ensure containerd running
 

--- a/salt/tests/unit/formulas/conftest.py
+++ b/salt/tests/unit/formulas/conftest.py
@@ -10,6 +10,7 @@ from tests.unit.formulas.fixtures.data import fixture_buildchain_template_contex
 from tests.unit.formulas.fixtures.data import fixture_metalk8s_versions
 from tests.unit.formulas.fixtures.environment import fixture_template_loader
 from tests.unit.formulas.fixtures.environment import fixture_environment
+from tests.unit.formulas.fixtures.rendered import fixture_rendered_states
 from tests.unit.formulas.fixtures.templates import fixture_template_path
 
 # pylint: enable=unused-import

--- a/salt/tests/unit/formulas/fixtures/rendered.py
+++ b/salt/tests/unit/formulas/fixtures/rendered.py
@@ -1,0 +1,34 @@
+"""Expose a `rendered_states` fixture, parsing the states declared by an SLS template.
+
+Tests asserting on the content of a rendered SLS, such as the requisites between its
+states, get the parsed documents from here instead of rendering the template themselves.
+"""
+
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Tuple
+
+import jinja2
+import pytest
+import salt.utils.yaml  # type: ignore
+
+from tests.unit.formulas.fixtures.context import Context
+
+# Test case ID, and the states parsed from the SLS rendered with that case.
+RenderedStates = List[Tuple[str, Dict[str, Any]]]
+
+
+@pytest.fixture(name="rendered_states")
+def fixture_rendered_states(
+    environment: jinja2.Environment,
+    render_contexts: Iterable[Context],
+    template_path: Path,
+) -> RenderedStates:
+    """Parse the states of a template, once per supported rendering context."""
+    template = environment.get_template(str(template_path))
+
+    # NOTE: We parse with the Salt loader rather than PyYAML, so that we reject what
+    # Salt itself rejects, a duplicated state ID for instance.
+    return [
+        (context.id, salt.utils.yaml.safe_load(template.render(**context.data)))
+        for context in render_contexts
+    ]

--- a/salt/tests/unit/formulas/test_container_engine.py
+++ b/salt/tests/unit/formulas/test_container_engine.py
@@ -1,0 +1,74 @@
+"""Tests for the requisites of the container engine states.
+
+The rendering tests only prove that a template can be rendered. Here we check the
+requisites that keep a state from writing a version specific configuration when the
+container engine of that version is not the one installed on the node (see MK8S-371).
+"""
+
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Set
+
+import pytest
+
+from tests.unit.formulas.fixtures.rendered import RenderedStates
+
+CONTAINERD_INSTALLED = Path("metalk8s/container-engine/containerd/installed.sls")
+
+# Formula defining the states we depend on, it must stay in the `include` block.
+REPO_FORMULA = "metalk8s.repo"
+
+# States the containerd configuration must depend on: the package state, so the
+# configuration matches the containerd actually installed, and the repository gate the
+# package state itself requires.
+REQUIRED_GATES = ["Install containerd", "Repositories configured"]
+
+# States writing a version specific containerd configuration.
+CONFIGURATION_STATES = ["Configure containerd", "Configure containerd registries"]
+
+
+def _iter_required_ids(state_body: Dict[str, Any]) -> Iterator[str]:
+    """Yield the state IDs listed in the `require` requisites of a single state."""
+    for state_args in state_body.values():
+        # A state declared without any argument renders as `None`.
+        for state_arg in state_args or []:
+            if isinstance(state_arg, dict):
+                for requisite in state_arg.get("require", []):
+                    yield from requisite.values()
+
+
+def _required_states(states: Dict[str, Any], state_id: str) -> Set[str]:
+    """List the state IDs a state depends on, following the `require` chains."""
+    required: Set[str] = set()
+    to_visit: List[str] = [state_id]
+
+    while to_visit:
+        for required_id in _iter_required_ids(states.get(to_visit.pop(), {})):
+            if required_id not in required:
+                required.add(required_id)
+                to_visit.append(required_id)
+
+    return required
+
+
+@pytest.mark.formulas
+@pytest.mark.parametrize("template_path", [CONTAINERD_INSTALLED], indirect=True)
+def test_containerd_configuration_requires_the_package(
+    rendered_states: RenderedStates,
+) -> None:
+    """Check the containerd configuration is only written along with its package."""
+    for case_id, states in rendered_states:
+        assert REPO_FORMULA in states.get(
+            "include", []
+        ), f"'{REPO_FORMULA}' is not included, the gates cannot resolve ({case_id})"
+
+        for state_id in CONFIGURATION_STATES:
+            assert state_id in states, f"no '{state_id}' state ({case_id})"
+
+            required_states = _required_states(states, state_id)
+            for gate in REQUIRED_GATES:
+                missing_gate = (
+                    f"'{state_id}' does not require '{gate}', it would write a version"
+                    " specific configuration for a container engine that is not the one"
+                    " installed on the node"
+                )
+                assert gate in required_states, f"{missing_gate} ({case_id})"


### PR DESCRIPTION
**Component**: salt

**Context**:

Lands on `133.0` because affected nodes exist in the field today, and merges up to `134.0`, where the same state carries the same gap.

`Configure containerd` writes `/etc/containerd/config.toml` with no requisite at all, so Salt applies it whatever happened to the package states of the same run, including a failed `metalk8s.repo.redhat.Check packages availability`.

At the same version, rewriting that file is harmless and idempotent. **At another version than the container engine installed on the node, it rewrites a running node's config to a schema the running binary does not support, then fails.**

Evidence from the RD-2113 sosreport, run of 2026-07-24 13:30 at saltenv `metalk8s-132.0.2` on a node already running containerd 2.2.2:

```
ID: Check packages availability      Result: False   (13:30:06.855)
ID: Configure registry IP in containerd conf
Function: file.managed   Name: /etc/containerd/config.toml
Result: True   Comment: File /etc/containerd/config.toml updated   (13:30:07.831)
  -version = 3
  +version = 2
  -[plugins."io.containerd.cri.v1.images".registry]
  -  config_path = "/etc/containerd/certs.d"
  +[plugins."io.containerd.grpc.v1.cri".registry.mirrors."metalk8s-registry-from-config.invalid"]
```

containerd 2.x no longer honours the CRI `registry.mirrors` syntax, which is why 133.0.x moved to `config_path = "/etc/containerd/certs.d"`. That node was one containerd restart away from failing every image pull, with new pods additionally looking for their sandbox image under the old release path. The restart did not happen only because `Ensure containerd running` failed on the same requisite chain. That is luck, not design.

**Summary**:

One requisite (`salt/metalk8s/container-engine/containerd/installed.sls:117`):

```yaml
     - require:
       - metalk8s_package_manager: Install containerd
```

**Why the package state and not `Repositories configured`**, which the ticket suggested. Two reasons:

- The config schema follows the containerd we install, not the repositories. Gating on the install covers the failures the repo check cannot see, a versionlock conflict or a dependency resolution error for instance, and it also pins the right order: install, configure, restart.
- `Repositories configured` is the weaker gate. `Check packages availability` only runs `onchanges` of the repository definitions (`salt/metalk8s/repo/redhat.sls:102-103`), and a state skipped by `onchanges` reports a success. So a second run of the same offending command, when the baseurls no longer change, skips the check, passes the gate and rewrites the file. Gating on the install has no such hole: the install runs on every pass and fails on every pass.

`Configure containerd registries` needs nothing of its own, it already requires `Configure containerd`, so both files under `/etc/containerd` are covered.

The new test is `salt/tests/unit/formulas/test_container_engine.py`. It walks the `require` chains of the rendered SLS. The existing formula tests only prove a template renders, so nothing was watching these requisites. It parses with the Salt YAML loader rather than PyYAML, so a duplicated state ID fails the test the way it fails a real render, and it asserts `metalk8s.repo` stays in the `include` block, since the gates cannot resolve without it.

**Acceptance criteria**:

- Both configuration states depend on `Install containerd` and, through it, on `Repositories configured`. Asserted on the rendered SLS by the new test.
- A run whose `Check packages availability` fails no longer rewrites `/etc/containerd/config.toml`, which is the RD-2113 damage.
- The test actually discriminates. Checked all three ways in a `python:3.6` container: with the fix, pass; with no requisite, the current 133.0 state, fail; with `require: test: Repositories configured`, the weaker gate, fail.
- Whole marker green: `pytest -m formulas salt/tests/unit`, `306 passed`.

Also run locally: `salt-lint 0.9.2` on the SLS, `black` 22.8.0 (this branch) and 26.3.1 (the `134.0` pin, for the merge-up), `pylint 2.13.9` with the hook dependencies at `10.00/10`, and `mypy 0.931 --strict` on the new test. Not run: the `salt-call --retcode-passthrough state.sls metalk8s.container-engine saltenv=<older>` reproduction on a lab cluster.

**Two things a reviewer should weigh**:

**This guard only protects runs made from a tree that contains it.** Salt renders the SLS from the requested saltenv, so a run at `metalk8s-132.0.2`, the exact RD-2113 replay, still uses 132.0.x's copy of `installed.sls` and still rewrites the file. What this PR buys is that every version shipped from now on stops doing the damage, and the ticket's triage keeps the backport at 133.0.x. Covering already-shipped trees would need the version-aware guard discussed below, in each of them.

**It removes a repair path.** On a node whose `config.toml` is already wrong, containerd cannot pull images, so in non-`local_mode` the yum baseurl served by the `repositories` pod may be unreachable from that node, the install fails, and the config is no longer rewritten. Before this change the file was corrected even though the run failed, so a manual `systemctl restart containerd` finished the recovery. The ticket asks for exactly this trade-off ("with `Check packages availability` failing, the file is left untouched"), and the ISO-mounted `local_mode` path still repairs the node, but it is worth stating out loud.

**Out of scope**:

- The ticket's secondary suggestion: refuse to apply `metalk8s.container-engine` at a version older than the container engine already installed, and fail fast with an explicit message instead of a dnf resolution error. Worth doing, it is the only thing that would also cover already-shipped trees, and it is a behaviour change of its own.
- Two neighbours with the same shape of gap, both left alone here: `Create containerd service drop-in` (`installed.sls:48`) writes the systemd drop-in with no requisite, and it cannot gate on the package state since `Install containerd` requires it; and the `file.serialize` half of `Install and configure cri-tools` writes `/etc/crictl.yaml` ungated. Smaller blast radius (log level, proxy environment, CRI endpoints), say the word if you want them gated in this PR.

---

See: MK8S-371
