### PR TITLE
bugfix(salt): tolerate a missed keepalive on the node being reconfigured (MK8S-383)

### DIFF
--- a/.changes/unreleased/Fix-20260820-141314-935296783.yaml
+++ b/.changes/unreleased/Fix-20260820-141314-935296783.yaml
@@ -1,13 +1,12 @@
 kind: Fix
 body: |-
-    Upgrading the apiservers and deploying a node no longer abort when the node
-    being reconfigured misses a single Salt keepalive. Both states replace
-    components on the very node the salt-master polls with `saltutil.find_job` —
-    the apiserver-proxy in one case, the kubelet, containerd and the control plane
-    static pods in the other — and a probe left unanswered for `gather_job_timeout`
-    (10s by default) made Salt give up on a state that was still running, reporting
-    `Run failed on minions: <node>`. Both now tolerate up to 300s of silence from a
-    node that is still working
+    Increase the Salt `timeout` to 300s, instead of the master's 20s default, on the
+    orchestrate states that reconfigure the very node the salt-master is polling
+    with `saltutil.find_job`: `Deploy apiserver <node>`, `Install apiserver-proxy on
+    <node>`, `Reconfigure apiserver on <node>` and `Run the highstate`. This gives
+    them time to finish when their node goes quiet for a moment, and prevents Salt
+    from giving up on a state that is still running and reporting `Run failed on
+    minions: <node>`, which aborted the bootstrap, the upgrade or a node deployment.
 time: 2026-08-20T14:13:14.935296783Z
 custom:
     CommentId: "5357080827"

--- a/.changes/unreleased/Fix-20260820-141314-935296783.yaml
+++ b/.changes/unreleased/Fix-20260820-141314-935296783.yaml
@@ -1,0 +1,14 @@
+kind: Fix
+body: |-
+    Upgrading the apiservers and deploying a node no longer abort when the node
+    being reconfigured misses a single Salt keepalive. Both states replace
+    components on the very node the salt-master polls with `saltutil.find_job` —
+    the apiserver-proxy in one case, the kubelet, containerd and the control plane
+    static pods in the other — and a probe left unanswered for `gather_job_timeout`
+    (10s by default) made Salt give up on a state that was still running, reporting
+    `Run failed on minions: <node>`. Both now tolerate up to 300s of silence from a
+    node that is still working
+time: 2026-08-20T14:13:14.935296783Z
+custom:
+    CommentId: "5357080827"
+    Pull: "5092"

--- a/salt/metalk8s/orchestrate/apiserver.sls
+++ b/salt/metalk8s/orchestrate/apiserver.sls
@@ -48,6 +48,12 @@ Deploy apiserver {{ node }} to {{ dest_version }}:
       - metalk8s.kubernetes.apiserver
       - metalk8s.kubernetes.apiserver-proxy
     - saltenv: metalk8s-{{ dest_version }}
+    {#- This state restarts the apiserver-proxy on the very node the salt-master
+        polls with `saltutil.find_job`, so that node can miss a keepalive while
+        still running the state. `timeout` sets the per-minion deadline, re-armed
+        on every answered probe, so this tolerates up to 300s of silence from a
+        node that is still working #}
+    - timeout: 300
     - require:
       - salt: Check pillar on {{ node }}
   {%- if loop.previtem is defined %}

--- a/salt/metalk8s/orchestrate/apiserver.sls
+++ b/salt/metalk8s/orchestrate/apiserver.sls
@@ -48,11 +48,16 @@ Deploy apiserver {{ node }} to {{ dest_version }}:
       - metalk8s.kubernetes.apiserver
       - metalk8s.kubernetes.apiserver-proxy
     - saltenv: metalk8s-{{ dest_version }}
-    {#- This state restarts the apiserver-proxy on the very node the salt-master
-        polls with `saltutil.find_job`, so that node can miss a keepalive while
-        still running the state. `timeout` sets the per-minion deadline, re-armed
-        on every answered probe, so this tolerates up to 300s of silence from a
-        node that is still working #}
+    {#- Increase the timeout to 300s instead of the default 20s, to let this
+        state run to completion, because it writes the kube-apiserver and
+        apiserver-proxy static pod manifests, the admin kubeconfig and the
+        encryption and authn configs on the very node the salt-master polls
+        with `saltutil.find_job`, and it needs minutes before the kubelet has
+        picked up both manifests. Once a probe goes unanswered no further probe
+        is sent, so this is the grace left for the state to return. It is also
+        the publish wait, so a busy master waits this long per attempt. This
+        prevents Salt reporting `Run failed on minions: <node>` and aborting
+        the apiserver upgrade with the remaining masters untouched #}
     - timeout: 300
     - require:
       - salt: Check pillar on {{ node }}

--- a/salt/metalk8s/orchestrate/deploy_node.sls
+++ b/salt/metalk8s/orchestrate/deploy_node.sls
@@ -297,6 +297,13 @@ Run the highstate:
     - tgt: {{ node_name }}
     - highstate: True
     - saltenv: metalk8s-{{ version }}
+    {#- On a master or bootstrap node this replaces the kubelet, containerd and
+        the control plane static pods on the very node the salt-master polls with
+        `saltutil.find_job`, so that node can miss a keepalive while still
+        running the state. `timeout` sets the per-minion deadline, re-armed on
+        every answered probe, so this tolerates up to 300s of silence from a node
+        that is still working #}
+    - timeout: 300
     {#- Add ability to skip node roles to not apply all the highstate
         e.g.: Skipping etcd when downgrading #}
     {%- if skip_roles %}

--- a/salt/metalk8s/orchestrate/deploy_node.sls
+++ b/salt/metalk8s/orchestrate/deploy_node.sls
@@ -297,12 +297,15 @@ Run the highstate:
     - tgt: {{ node_name }}
     - highstate: True
     - saltenv: metalk8s-{{ version }}
-    {#- On a master or bootstrap node this replaces the kubelet, containerd and
-        the control plane static pods on the very node the salt-master polls with
-        `saltutil.find_job`, so that node can miss a keepalive while still
-        running the state. `timeout` sets the per-minion deadline, re-armed on
-        every answered probe, so this tolerates up to 300s of silence from a node
-        that is still working #}
+    {#- Increase the timeout to 300s instead of the default 20s, to let the
+        highstate run to completion, because it replaces the kubelet and
+        containerd on every node, plus the control plane static pods on a
+        master or bootstrap node, on the very node the salt-master polls with
+        `saltutil.find_job`, and a full highstate needs minutes. Once a probe
+        goes unanswered no further probe is sent, so this is the grace left for
+        the state to return. This prevents Salt reporting `Run failed on
+        minions: <node>` and aborting the deployment with the node left
+        cordoned #}
     - timeout: 300
     {#- Add ability to skip node roles to not apply all the highstate
         e.g.: Skipping etcd when downgrading #}

--- a/salt/metalk8s/orchestrate/update-control-plane-ingress-ip.sls
+++ b/salt/metalk8s/orchestrate/update-control-plane-ingress-ip.sls
@@ -49,6 +49,13 @@ Reconfigure apiserver on {{ node }}:
     - sls:
       - metalk8s.kubernetes.apiserver
     - saltenv: {{ saltenv }}
+    {#- Increase the timeout to 300s instead of the default 20s, to let this
+        state run to completion, because it writes the kube-apiserver static
+        pod manifest on the very node the salt-master polls with
+        `saltutil.find_job`, once per master in sequence. This prevents Salt
+        reporting `Run failed on minions: <node>` and aborting the control
+        plane Ingress reconfiguration with the remaining masters untouched #}
+    - timeout: 300
     - require:
       - salt: Reconfigure Control Plane components
     {%- if loop.previtem is defined %}

--- a/salt/metalk8s/orchestrate/upgrade/init.sls
+++ b/salt/metalk8s/orchestrate/upgrade/init.sls
@@ -53,6 +53,14 @@ Install apiserver-proxy on {{ node }}:
     - sls:
       - metalk8s.kubernetes.apiserver-proxy
     - saltenv: {{ saltenv }}
+    {#- Increase the timeout to 300s instead of the default 20s, to let this
+        state run to completion, because it writes the apiserver-proxy static
+        pod manifest on the very node the salt-master polls with
+        `saltutil.find_job`, and the kubelet replaces that pod while the state
+        is still being polled. This prevents Salt reporting `Run failed on
+        minions: <node>` and aborting the upgrade before any node is
+        deployed #}
+    - timeout: 300
     - require:
       - salt: Check pillar on {{ node }} before installing apiserver-proxy
 


### PR DESCRIPTION
**Component**: salt

**Context**:

Replaces #5088, which took the wrong approach — thanks @ezekiel-alexrod for catching it.

`Deploy apiserver <node>` (`orchestrate/apiserver.sls`) and `Run the highstate` (`orchestrate/deploy_node.sls`) both replace components on the very node the salt-master is polling with `saltutil.find_job`: the apiserver-proxy in the first case, the kubelet, containerd and the control plane static pods in the second. Neither carried any tolerance for that node going briefly silent as a result, so a single unanswered probe made Salt give up on a state that was **still running** and report `Run failed on minions: <node>`, with `Output from salt state not highstate` in the log. Every sibling state in both files already carries a `timeout` or a `retry`.

**Summary**:

`- timeout: 300` on both states, each with a NOTE recording why, as MK8S-383's acceptance criteria ask and in the style of `Reconfigure salt-minion`.

`get_iter_returns` keeps **two independent deadlines** and needs both before giving up:

```python
minion_timeouts[id_] = time.time() + timeout            # armed with timeout
timeout_at = time.time() + gather_job_timeout           # re-armed with gjt
minion_timeouts[id_] = time.time() + timeout            # re-armed per reply
done = (now > timeout_at) and not minions_running
if done:
    for id_ in minions - found:
        if now < minion_timeouts[id_]: done = False; break
```

The per-minion deadline is armed and re-armed with `timeout`, which `saltmod.state` **does** forward. So `- timeout: 300` tolerates up to 300s of silence measured from the last answered probe, scoped to one state.

**Verified against both Salt versions**, since the branches differ:

| | 3002.9 (133.0) | 3006.27 (134.0) |
|---|---|---|
| give-up block | `client/__init__.py:1284-1297` | `1350-1363` — **byte-identical**, `diff` clean |
| `minion_timeouts` armed / re-armed with `timeout` | 1198 / 1280 | 1264 / 1346 |
| `timeout_at` re-armed with `gather_job_timeout` | 1216 | 1282 |
| `saltmod` forwards `timeout`, not `gather_job_timeout` | `cmd_kw` 252 / 500 | 310 / 602; `gather_job_timeout` appears **0** times |

**Why not raise the master's `gather_job_timeout`** (what #5088 did):

- It is master-wide, so it also delays every call against a genuinely silent minion. `_runners/metalk8s_saltutil.py:59` polls at `timeout=2` inside `retry=10`, which a 300s gather window stretches from ~120s to **~50 minutes**. `deploy_node.sls:14` calls `manage.up` at *render* time and `runners/manage.py:207` forwards both knobs, so one silent node stalls ~320s before any log line. Same for `scripts/upgrade.sh.in:99`, and the UI's `client: 'local'` sits behind nginx's 60s default (no `proxy-read-timeout` is set anywhere in the UI or nginx-ingress addons).
- It also would not help. Once a generous per-state `timeout` is in place, a missed probe no longer causes give-up, so `gather_job_timeout` only sets the probe *cadence* — and the 10s default gives **more** chances to observe the minion answering, not fewer.

Consequently there is no new pillar and no `salt: master:` key, so the `docs/installation/bootstrap.rst` entry #5088 needed does not apply here.

**Why 300s**: chosen against the recorded evidence rather than picked round. In the MK8S-383 incident the run had roughly 85s left when Salt gave up. 134.0 has separately moved `Reconfigure salt-minion` from 200 to 300, so this matches where that file is heading. The cost of the larger value is bounded and one-sided: a node that genuinely dies mid-state now fails the orchestrate after 300s instead of ~20s.

**Acceptance criteria**:

- [x] A node that stops answering `find_job` for one keepalive window, while running the state that disrupts it, no longer fails that state (MK8S-383 item 1, and the folded MK8S-388).
- [x] The knob is justified against the Salt source rather than assumed — for **both** 3002.9 and 3006.27 — and a comment in each `.sls` records why the value was chosen.
- [ ] `snapshot-upgrade (3 nodes, 2)` stops failing with `Run failed on minions: <node>` in nightlies. Probabilistic; needs several runs, not one.

**Not in scope, left on MK8S-383**: item 2, the readiness gate between masters, which wants `wait_apiserver(verify_rbac=True)` from #5022 and so cannot land on this base yet; and the missing `retry` on `Sync <node> minion` / `Refresh <node> grains`.

**Checks run locally**: `salt-lint` 0.9.2 clean (rc=0, no output) on both files; the 305 formula render tests pass. Full pre-commit cannot run here — it pins python3.6.

---

See: MK8S-383
