### PR TITLE
tests(ingress): wait for calico before restarting the Ingress DaemonSet (MK8S-331)

### DIFF
--- a/.changes/unreleased/Enhanced-20260820-100311-415051500.yaml
+++ b/.changes/unreleased/Enhanced-20260820-100311-415051500.yaml
@@ -1,5 +1,5 @@
 kind: Enhanced
-body: Add debug information on ingress test failures and make the test more tolerant by waiting in calico readyness
+body: Add debug information on ingress test failures and make the test more tolerant by waiting for calico readiness
 time: 2026-08-20T10:03:11.4150515Z
 custom:
     CommentId: "5354398477"

--- a/.changes/unreleased/Enhanced-20260820-100311-415051500.yaml
+++ b/.changes/unreleased/Enhanced-20260820-100311-415051500.yaml
@@ -1,6 +1,0 @@
-kind: Enhanced
-body: Add debug information on ingress test failures and make the test more tolerant by waiting for calico readiness
-time: 2026-08-20T10:03:11.4150515Z
-custom:
-    CommentId: "5354398477"
-    Pull: "5093"

--- a/.changes/unreleased/Enhanced-20260820-100311-415051500.yaml
+++ b/.changes/unreleased/Enhanced-20260820-100311-415051500.yaml
@@ -1,0 +1,6 @@
+kind: Enhanced
+body: Add debug information on ingress test failures and make the test more tolerant by waiting in calico readyness
+time: 2026-08-20T10:03:11.4150515Z
+custom:
+    CommentId: "5354398477"
+    Pull: "5093"

--- a/tests/post/steps/test_ingress.py
+++ b/tests/post/steps/test_ingress.py
@@ -194,11 +194,11 @@ def _vip_debug(host, ssh_config, vip):
         ),
     )
     for title, command in probes:
-        sections.append(
-            _section(
-                f"'{owner}': {title}", _salt_cmd_run(host, ssh_config, owner, command)
-            )
-        )
+        try:
+            output = _salt_cmd_run(host, ssh_config, owner, command)
+        except Exception as exc:  # pylint: disable=broad-except
+            output = f"failed to collect: {exc}"
+        sections.append(_section(f"'{owner}': {title}", output))
 
     return sections
 
@@ -1066,16 +1066,23 @@ def re_configure_portmap(host, version, ssh_config, context=None):
 
     utils.run_salt_command(host, command, ssh_config)
 
-    # The state above rewrites the portmap `conditionsV4` of the calico CNI
-    # configuration, which reaches a node only when its `calico-node` Pod
-    # restarts and its `install-cni` container rewrites
-    # `/etc/cni/net.d/10-calico.conflist`. The hostPort DNAT rules of an
-    # `ingress-nginx-controller` Pod are programmed by the portmap plugin at
-    # sandbox creation, baking in the conditions of the conflist present at
-    # that instant: a Pod recreated before its node caught up keeps DNAT rules
-    # that do not cover the new VIPs, and the VIP is then assigned by
-    # keepalived but refuses connections. Wait here rather than in each caller,
-    # so no scenario can restart the Ingress over a stale conflist.
+    # Wait for the `calico-node` rollout to complete, i.e. for every node to
+    # have rewritten its conflist with the new portmap conditions. Here
+    # rather than in each caller, so no caller can restart the Ingress over a
+    # conflist still holding the previous ones.
+    #
+    # The state above rewrites the portmap `conditionsV4` in the
+    # `calico-config` ConfigMap; `calico-node` carries a `checksum/config`
+    # annotation built from that ConfigMap, so the rewrite changes the Pod
+    # template and rolls the DaemonSet. A Pod turns Ready only once its
+    # `install-cni` init container has exited, and that container is what
+    # writes the conditions to the node's `10-calico.conflist` -- which is
+    # why a completed rollout is the signal we need.
+    #
+    # It matters because portmap bakes the hostPort DNAT rules of an
+    # `ingress-nginx-controller` Pod from the conflist present at sandbox
+    # creation: a Pod recreated too early keeps rules missing the new VIPs,
+    # and keepalived then hands the node a VIP it refuses connections on.
     wait_rollout_status(host, "daemonset/calico-node", "kube-system")
 
     command = [

--- a/tests/post/steps/test_ingress.py
+++ b/tests/post/steps/test_ingress.py
@@ -19,50 +19,221 @@ MAIN_CC_NAME = "main"
 OPERATOR_DEPLOYMENT = "metalk8s-operator-controller-manager"
 OPERATOR_NAMESPACE = "kube-system"
 
+INGRESS_NAMESPACE = "metalk8s-ingress"
 
-def _ingress_debug(host):
+# Namespace holding the Workload Plane VirtualIPPools, and the keepalived
+# DaemonSet of each pool, all created by the operator (see `vipNamespaceName`
+# in `operator/pkg/controller/clusterconfig/workloadplane/virtualippool.go`).
+# A WP Ingress VIP is *assigned* from there, not from `metalk8s-ingress`.
+VIP_NAMESPACE = "metalk8s-vips"
+
+KUBECTL = "kubectl --kubeconfig=/etc/kubernetes/admin.conf"
+
+# Print events with their absolute timestamp instead of the relative `AGE`
+# column, so they can be correlated with the failing request, the Pod logs and
+# the sosreport.
+EVENT_COLUMNS = (
+    "LAST:.lastTimestamp,COUNT:.count,TYPE:.type,REASON:.reason,"
+    "OBJECT:.involvedObject.name,MESSAGE:.message"
+)
+
+_DEBUG_COMMANDS = (
+    ("collection time (UTC)", "date -u +%Y-%m-%dT%H:%M:%SZ"),
+    ("ingress-nginx pods", f"{KUBECTL} -n {INGRESS_NAMESPACE} get pods -o wide"),
+    (
+        "ingress-nginx daemonsets",
+        f"{KUBECTL} -n {INGRESS_NAMESPACE} get daemonset -o wide",
+    ),
+    ("ingress-nginx services", f"{KUBECTL} -n {INGRESS_NAMESPACE} get svc -o wide"),
+    ("ingress-nginx endpoints", f"{KUBECTL} -n {INGRESS_NAMESPACE} get endpoints"),
+    # A single `rollout restart` has been seen to be followed by a second roll
+    # of the DaemonSet, the assertions then running while that second roll is
+    # still in flight. List the revisions with their creation timestamps so
+    # such a churn is explicit instead of guessed from the Pod ages.
+    (
+        "ingress-nginx controller revisions",
+        f"{KUBECTL} -n {INGRESS_NAMESPACE} get controllerrevisions"
+        " --sort-by=.metadata.creationTimestamp"
+        " -o custom-columns=NAME:.metadata.name,REVISION:.revision,"
+        "CREATED:.metadata.creationTimestamp",
+    ),
+    (
+        "ingress-nginx-controller rollout history",
+        f"{KUBECTL} -n {INGRESS_NAMESPACE} rollout history"
+        " daemonset/ingress-nginx-controller",
+    ),
+    ("virtual IP pools", f"{KUBECTL} -n {VIP_NAMESPACE} get virtualippool -o wide"),
+    (
+        "virtual IP pool daemonsets",
+        f"{KUBECTL} -n {VIP_NAMESPACE} get daemonset -o wide",
+    ),
+    ("virtual IP pool pods", f"{KUBECTL} -n {VIP_NAMESPACE} get pods -o wide"),
+    (
+        "keepalived logs",
+        f"{KUBECTL} -n {VIP_NAMESPACE} logs -l app.kubernetes.io/name=virtualippool"
+        " --tail=20 --timestamps --prefix --max-log-requests=20",
+    ),
+    (
+        "calico-node daemonset",
+        f"{KUBECTL} -n kube-system get daemonset calico-node -o wide",
+    ),
+    (
+        "calico-node pods",
+        f"{KUBECTL} -n kube-system get pods -l k8s-app=calico-node -o wide",
+    ),
+    (
+        "recent ingress events",
+        f"{KUBECTL} -n {INGRESS_NAMESPACE} get events --sort-by=.lastTimestamp"
+        f" -o custom-columns={EVENT_COLUMNS}",
+    ),
+    (
+        "recent virtual IP pool events",
+        f"{KUBECTL} -n {VIP_NAMESPACE} get events --sort-by=.lastTimestamp"
+        f" -o custom-columns={EVENT_COLUMNS}",
+    ),
+    (
+        "recent calico events",
+        f"{KUBECTL} -n kube-system get events --sort-by=.lastTimestamp"
+        f" -o custom-columns={EVENT_COLUMNS} | grep -i calico | tail -n 30",
+    ),
+)
+
+
+def _section(title, content):
+    return "--- {} ---\n{}".format(title, content or "<no output>")
+
+
+def _run(host, command):
+    """Run a command on `host` and return its output, whatever the exit code."""
+    with host.sudo():
+        result = host.run(command)
+    return (result.stdout or result.stderr).strip()
+
+
+def _salt_cmd_run(host, ssh_config, target, command):
+    """Run a shell command on a single node, through the Salt master."""
+    output = utils.kubectl_exec(
+        host,
+        ["salt", "--out=txt", f"'{target}'", "cmd.run", f"'{command}'"],
+        "salt-master-{}".format(utils.get_node_name("bootstrap", ssh_config)),
+        container="salt-master",
+        namespace="kube-system",
+    )
+    return (output.stdout or output.stderr).strip()
+
+
+def _vip_debug(host, ssh_config, vip):
+    """Collect diagnostics about the node currently holding `vip`.
+
+    A "Connection refused" on a VIP means the SYN reached a node where nothing
+    answered, so the decisive information is which node holds the VIP and what
+    that node looks like -- something no `metalk8s-ingress` dump can tell, as
+    the VIP is assigned by a keepalived Pod living in another namespace.
+    """
+    node_ips = get_node_ips(host, ssh_config)
+    owner = next((node for node, ips in node_ips.items() if vip in ips), None)
+
+    if owner is None:
+        return [
+            _section(
+                f"owner of {vip}",
+                "No node holds this VIP, node addresses are:\n"
+                + "\n".join(
+                    f"  - {node}: {', '.join(ips)}"
+                    for node, ips in sorted(node_ips.items())
+                ),
+            )
+        ]
+
+    sections = [_section(f"owner of {vip}", owner)]
+
+    for namespace in (INGRESS_NAMESPACE, VIP_NAMESPACE):
+        sections.append(
+            _section(
+                f"pods on '{owner}' in '{namespace}'",
+                _run(
+                    host,
+                    f"{KUBECTL} -n {namespace} get pods -o wide"
+                    f" --field-selector spec.nodeName={owner}",
+                ),
+            )
+        )
+
+    # Those run on the node holding the VIP, reached through Salt since `host`
+    # is the Bootstrap node. A request from the node itself tells a VIP the node
+    # cannot serve from an unrelated network path issue, and the CNI
+    # configuration and NAT rules then say why.
+    #
+    # NOTE: `ss -lntp` is deliberately not collected: the controller exposes
+    # :80/:443 through hostPort, which the portmap CNI plugin implements as DNAT
+    # rules, so no listening socket exists on the host even when serving works.
+    # What matters is the portmap `conditionsV4` of the conflist -- and *when* it
+    # was written, as an Ingress Pod recreated before its node caught up keeps
+    # DNAT rules built from the previous one.
+    probes = (
+        ("IPv4 addresses", "ip -4 -o addr show"),
+        (
+            f"local request on {vip}",
+            f"curl -sS -o /dev/null -m 5 -w %{{http_code}} http://{vip}:80/",
+        ),
+        # NOTE: no single quote in those commands, they are passed to Salt
+        # already wrapped in single quotes.
+        ("CNI configuration files", 'stat -c "%y %n" /etc/cni/net.d/*'),
+        ("calico CNI configuration", "cat /etc/cni/net.d/10-calico.conflist"),
+        # The VIPs are added to the portmap conditions as explicit /32 by
+        # `metalk8s_network.get_portmap_ips`, so a rule covering this VIP names
+        # it. Dump the whole chain as well, to see a wrong rule and not only a
+        # missing one.
+        (
+            f"NAT rules mentioning {vip}",
+            f"iptables -t nat -S | grep -F {vip} || echo none",
+        ),
+        (
+            "portmap DNAT chain",
+            "iptables -t nat -S CNI-HOSTPORT-DNAT || echo none",
+        ),
+    )
+    for title, command in probes:
+        sections.append(
+            _section(
+                f"'{owner}': {title}", _salt_cmd_run(host, ssh_config, owner, command)
+            )
+        )
+
+    return sections
+
+
+def _ingress_debug(host, ssh_config=None, vip=None):
     """Collect live cluster-side ingress diagnostics.
 
     The sosreport is collected after the whole step finishes and may miss the
     transient state (a controller still rolling, missing endpoints, calico not
     ready, ...) that caused a request to fail, so we dump the relevant cluster
     state at failure time to complement it. Best-effort: never raises.
+
+    When `vip` and `ssh_config` are given, also collect which node holds that
+    VIP and the state of that node, since the VIP layer (`metalk8s-vips`) is
+    where a request on a Workload Plane Ingress VIP actually lands.
     """
-    kubectl = "kubectl --kubeconfig=/etc/kubernetes/admin.conf"
-    commands = (
-        ("ingress-nginx pods", f"{kubectl} -n metalk8s-ingress get pods -o wide"),
-        (
-            "ingress-nginx daemonsets",
-            f"{kubectl} -n metalk8s-ingress get daemonset -o wide",
-        ),
-        ("ingress-nginx services", f"{kubectl} -n metalk8s-ingress get svc -o wide"),
-        ("ingress-nginx endpoints", f"{kubectl} -n metalk8s-ingress get endpoints"),
-        (
-            "calico-node daemonset",
-            f"{kubectl} -n kube-system get daemonset calico-node -o wide",
-        ),
-        (
-            "recent ingress events",
-            f"{kubectl} -n metalk8s-ingress get events --sort-by=.lastTimestamp",
-        ),
-    )
     sections = []
+
     try:
-        with host.sudo():
-            for title, cmd in commands:
-                result = host.run(cmd)
-                sections.append(
-                    "--- {} ---\n{}".format(
-                        title, (result.stdout or result.stderr).strip()
-                    )
-                )
+        for title, command in _DEBUG_COMMANDS:
+            sections.append(_section(title, _run(host, command)))
     except Exception as exc:  # pylint: disable=broad-except
-        sections.append(f"--- failed to collect ingress debug ---\n{exc}")
+        sections.append(_section("failed to collect ingress debug", str(exc)))
+
+    if vip is not None and ssh_config is not None:
+        try:
+            sections.extend(_vip_debug(host, ssh_config, vip))
+        except Exception as exc:  # pylint: disable=broad-except
+            sections.append(_section(f"failed to collect debug for {vip}", str(exc)))
+
     return "\n\n".join(sections)
 
 
 @contextlib.contextmanager
-def _ingress_debug_on_failure(host, label):
+def _ingress_debug_on_failure(host, label, ssh_config=None, vip=None):
     """Append live cluster ingress diagnostics to any assertion failure raised
     inside the block, to complement the (later, possibly-stale) sosreport."""
     try:
@@ -71,7 +242,7 @@ def _ingress_debug_on_failure(host, label):
         raise AssertionError(
             f"{exc}\n\n"
             f"=== Cluster ingress debug ({label}) ===\n"
-            f"{_ingress_debug(host)}"
+            f"{_ingress_debug(host, ssh_config=ssh_config, vip=vip)}"
         ) from exc
 
 
@@ -341,6 +512,7 @@ def perform_request(host, context, protocol, port, plane, path):
         raise NotImplementedError
 
     ip = utils.get_grain(host, grains[plane])
+    context["request_ip"] = ip
 
     try:
         context["response"] = requests.get(
@@ -646,8 +818,13 @@ def wait_cc_status(k8s_client, status):
     parsers.re(r"the server returns (?P<status_code>\d+) '(?P<reason>.+)'"),
     converters=dict(status_code=int),
 )
-def server_returns(host, context, status_code, reason):
-    with _ingress_debug_on_failure(host, f"expecting {status_code} '{reason}'"):
+def server_returns(host, ssh_config, context, status_code, reason):
+    with _ingress_debug_on_failure(
+        host,
+        f"expecting {status_code} '{reason}'",
+        ssh_config=ssh_config,
+        vip=context.get("request_ip"),
+    ):
         response = context.get("response")
         assert response is not None
         assert response.status_code == int(status_code)
@@ -669,8 +846,13 @@ def shell_ui_not_returns(host, context):
 
 
 @then("the server should not respond")
-def server_does_not_respond(host, context):
-    with _ingress_debug_on_failure(host, "expecting no response"):
+def server_does_not_respond(host, ssh_config, context):
+    with _ingress_debug_on_failure(
+        host,
+        "expecting no response",
+        ssh_config=ssh_config,
+        vip=context.get("request_ip"),
+    ):
         assert "exception" in context
         assert isinstance(context["exception"], requests.exceptions.ConnectionError)
 
@@ -684,12 +866,18 @@ def server_does_not_respond(host, context):
     converters=dict(status_code=int),
 )
 def server_request_returns(
-    host, context, protocol, port, plane, path, status_code, reason
+    host, ssh_config, context, protocol, port, plane, path, status_code, reason
 ):
     perform_request(
         host=host, context=context, protocol=protocol, port=port, plane=plane, path=path
     )
-    server_returns(host=host, context=context, status_code=status_code, reason=reason)
+    server_returns(
+        host=host,
+        ssh_config=ssh_config,
+        context=context,
+        status_code=status_code,
+        reason=reason,
+    )
 
 
 @then(
@@ -698,11 +886,13 @@ def server_request_returns(
         r"on port (?P<port>\d+) on a (?P<plane>.*) IP should not return"
     ),
 )
-def server_request_does_not_return(host, context, protocol, port, plane, path):
+def server_request_does_not_return(
+    host, ssh_config, context, protocol, port, plane, path
+):
     perform_request(
         host=host, context=context, protocol=protocol, port=port, plane=plane, path=path
     )
-    server_does_not_respond(host=host, context=context)
+    server_does_not_respond(host=host, ssh_config=ssh_config, context=context)
 
 
 @then(
@@ -714,7 +904,7 @@ def server_request_does_not_return(host, context, protocol, port, plane, path):
     converters=dict(status_code=int),
 )
 def server_request_returns_multiple_ips(
-    host, context, protocol, port, ips, path, status_code, reason
+    host, ssh_config, context, protocol, port, ips, path, status_code, reason
 ):
     ips = ips.format(**context).split(",")
 
@@ -724,7 +914,9 @@ def server_request_returns_multiple_ips(
         endpoint = "{proto}://{ip}:{port}/{path}".format(
             proto=protocol.lower(), ip=ip, port=port, path=path or ""
         )
-        with _ingress_debug_on_failure(host, f"request on '{endpoint}'"):
+        with _ingress_debug_on_failure(
+            host, f"request on '{endpoint}'", ssh_config=ssh_config, vip=ip
+        ):
             try:
                 response = requests.get(endpoint, verify=False)
                 context["response"] = response
@@ -742,7 +934,9 @@ def server_request_returns_multiple_ips(
         r"on port (?P<port>\d+) on '(?P<ips>.*)' IPs should not return"
     ),
 )
-def server_request_not_returns_multiple_ips(host, context, protocol, port, ips, path):
+def server_request_not_returns_multiple_ips(
+    host, ssh_config, context, protocol, port, ips, path
+):
     ips = ips.format(**context).split(",")
 
     assert ips, "Error IPs list cannot be empty"
@@ -751,7 +945,9 @@ def server_request_not_returns_multiple_ips(host, context, protocol, port, ips, 
         endpoint = "{proto}://{ip}:{port}/{path}".format(
             proto=protocol.lower(), ip=ip, port=port, path=path or ""
         )
-        with _ingress_debug_on_failure(host, f"request on '{endpoint}'"):
+        with _ingress_debug_on_failure(
+            host, f"request on '{endpoint}'", ssh_config=ssh_config, vip=ip
+        ):
             try:
                 response = requests.get(endpoint, verify=False)
             except requests.exceptions.ConnectionError:
@@ -869,6 +1065,18 @@ def re_configure_portmap(host, version, ssh_config, context=None):
     ]
 
     utils.run_salt_command(host, command, ssh_config)
+
+    # The state above rewrites the portmap `conditionsV4` of the calico CNI
+    # configuration, which reaches a node only when its `calico-node` Pod
+    # restarts and its `install-cni` container rewrites
+    # `/etc/cni/net.d/10-calico.conflist`. The hostPort DNAT rules of an
+    # `ingress-nginx-controller` Pod are programmed by the portmap plugin at
+    # sandbox creation, baking in the conditions of the conflist present at
+    # that instant: a Pod recreated before its node caught up keeps DNAT rules
+    # that do not cover the new VIPs, and the VIP is then assigned by
+    # keepalived but refuses connections. Wait here rather than in each caller,
+    # so no scenario can restart the Ingress over a stale conflist.
+    wait_rollout_status(host, "daemonset/calico-node", "kube-system")
 
     command = [
         "salt",


### PR DESCRIPTION
Refs: [MK8S-331](https://scality.atlassian.net/browse/MK8S-331)

## Problem

The Workload Plane Ingress VIP scenarios restart the `ingress-nginx-controller` DaemonSet without waiting for the `calico-node` rollout that `re_configure_portmap` has just triggered. That is a race, and losing it makes a VIP unreachable:

* `re_configure_portmap` rewrites the portmap `conditionsV4` of the calico CNI configuration (`salt/metalk8s/kubernetes/cni/calico/deployed.sls`), where `metalk8s_network.get_portmap_ips(as_cidr=True)` lists every VIP pool address as an explicit `/32`.
* That configuration reaches a node only when its `calico-node` Pod restarts and `install-cni` rewrites `/etc/cni/net.d/10-calico.conflist`.
* The hostPort DNAT rules of an `ingress-nginx-controller` Pod are programmed by the portmap CNI plugin **at sandbox creation**, baking in the conditions of the conflist present at that instant.

So an Ingress Pod recreated before its node's conflist is refreshed keeps DNAT rules built from the previous configuration, which do not cover the new VIPs. keepalived then assigns a VIP that the node has no rule to forward, and the request is refused while the DaemonSet is fully rolled, every Pod is Ready and calico is healthy — the shape this flake has always had.

Two of the four scenarios that reconfigure the portmap CIDRs already wait for the `calico-node` rollout before restarting the Ingress (`f2e18d79d`); those two have never flaked, and the two without the wait are the two that have.

## Fix

Wait for the `calico-node` rollout inside `re_configure_portmap`, immediately after the state that triggers it, rather than adding a step to the scenarios that lack one. It is the function that changes the CNI configuration, so a single wait covers all of its callers — the two scenarios, the `wp_ingress_vip_setup` Given step and both teardowns — and a newly added scenario cannot omit it.

## Diagnostics

`_ingress_debug` could not see the layer this failure lives in: a WP Ingress VIP is assigned by the keepalived Pods of the VirtualIPPools, which the operator creates in `metalk8s-vips` (`vipNamespaceName`, `operator/pkg/controller/clusterconfig/workloadplane/virtualippool.go`), while the dump covered only `metalk8s-ingress` and the `calico-node` DaemonSet. The sosreport does not fill the gap either — it is collected after the suite, once the pools are torn down and the transient Pods are gone.

Collected now on any ingress assertion failure:

* `metalk8s-vips` — `virtualippool`, `daemonset`, `pods -o wide`, events, and keepalived logs with timestamps.
* `controllerrevisions` with creation timestamps, and `rollout history`, so DaemonSet churn is explicit rather than inferred from Pod ages.
* `calico-node` Pods next to the existing DaemonSet line, and calico-filtered `kube-system` events.
* Events with `LAST:.lastTimestamp` instead of the relative `AGE` column, next to a `collection time (UTC)` header, so every section lands on one timeline.

And, for the IP that failed:

* The owner node, resolved with `get_node_ips()` — the salt `network.ip_addrs` call `check_vips_spreading` already uses. When no node holds the IP, every node's addresses are printed instead.
* That node's Pods in both `metalk8s-ingress` and `metalk8s-vips`.
* Probes on that node, through the salt-master: its addresses, a local request on the VIP, the CNI configuration files with their mtime, the calico conflist, the NAT rules naming the VIP, and the `CNI-HOSTPORT-DNAT` chain.

Every command is best-effort and wrapped, so a failing probe appends a section instead of masking the assertion, and the whole dump runs only after an assertion has failed — the negative `should not return` scenarios keep failing fast.

`perform_request` records `context["request_ip"]` so the single-IP steps get the per-VIP sections too; `ssh_config` is threaded through the request-assertion steps.

## Validation

Two nightlies on this branch, four multi-node job instances, no recurrence — `test_ingress.py` 14/14 in each. Three of the four instances failed before the fix. The post suite on `bootstrap-restore` goes from 5269s to ~5850s, the cost of the added `calico-node` waits.

## Checks

* `black` 22.8.0, the pinned pre-commit rev: unchanged.
* `pyflakes`: only the pre-existing `'re' imported but unused`, identical to the base commit.

Generated with [Claude Code](https://claude.com/claude-code)


[MK8S-331]: https://scality.atlassian.net/browse/MK8S-331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ