### PR TITLE
feat(buildchain): fetch containerd-image-preload from its release (MK8S-165)

### DIFF
--- a/.changes/unreleased/Added-20260825-120954-365174690.yaml
+++ b/.changes/unreleased/Added-20260825-120954-365174690.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: The ISO now carries the containerd-image-preload package in its scality repository, for RedHat 8 and 9.
+time: 2026-08-25T12:09:54.36517469Z
+custom:
+    CommentId: "5410163664"
+    Pull: "5103"

--- a/.pylint-dict
+++ b/.pylint-dict
@@ -63,10 +63,13 @@ pdf
 parameterized
 picklable
 prebuilt
+preload
+prerelease
 prometheus
 py
 readonly
 recursing
+releasever
 renderer
 repo
 reprepro

--- a/BUMPING.md
+++ b/BUMPING.md
@@ -254,14 +254,17 @@ The version just needs to be updated in `buildchain/buildchain/versions.py`.
 
 The package comes from a release of
 [image-cache](https://github.com/scality/image-cache), which attaches one RPM
-per RedHat release to each of its tags. Bumping it means editing four values in
-`buildchain/buildchain/versions.py`, and they have to move together:
+per RedHat release to each of its tags. Bumping it means editing its entry in
+`PREBUILT_RPMS`, in `buildchain/buildchain/versions.py`:
 
-- `IMAGE_CACHE_TAG`, the tag of the release to fetch. The RPM version follows
-  from it, as `rpm/build.sh` in image-cache derives it.
-- `IMAGE_CACHE_RPM_RELEASE`, the release digit of the RPM, from the spec.
-- both entries of `IMAGE_CACHE_RPM_SHA256`, the digest of each package. Read
-  them off the release page, or run `sha256sum` on the downloaded packages.
+- `tag`, the release to fetch. The RPM version follows from it, as
+  `rpm/build.sh` in image-cache derives it, and so does the version pin every
+  node installs.
+- every entry of `sha256`, the digest of each package. Read them off the
+  release page, or run `sha256sum` on the downloaded packages.
+
+`release` and `arch` default to `1` and `noarch`, which is what the spec ships.
+Set them only if a package ever moves off those.
 
 The build stops if a digest is missing or does not match, and names the release
 it expected. A stale digest cannot ship the wrong package.

--- a/BUMPING.md
+++ b/BUMPING.md
@@ -250,6 +250,28 @@ See [BUMPING_CALICO.md](BUMPING_CALICO.md) for the full Calico bump guide.
 
 The version just needs to be updated in `buildchain/buildchain/versions.py`.
 
+## containerd-image-preload
+
+The package comes from a release of
+[image-cache](https://github.com/scality/image-cache), which attaches one RPM
+per RedHat release to each of its tags. Bumping it means editing four values in
+`buildchain/buildchain/versions.py`, and they have to move together:
+
+- `IMAGE_CACHE_TAG`, the tag of the release to fetch. The RPM version follows
+  from it, as `rpm/build.sh` in image-cache derives it.
+- `IMAGE_CACHE_RPM_RELEASE`, the release digit of the RPM, from the spec.
+- both entries of `IMAGE_CACHE_RPM_SHA256`, the digest of each package. Read
+  them off the release page, or run `sha256sum` on the downloaded packages.
+
+The build stops if a digest is missing or does not match, and names the release
+it expected. A stale digest cannot ship the wrong package.
+
+The asset name is derived from the tag, the way `rpm/build.sh` in image-cache
+derives the RPM version. A prerelease tag such as `v0.2.0-rc1` builds
+`0.2.0~rc1`, and GitHub replaces the tilde with a dot in the name it serves the
+asset under, which the download accounts for. The package keeps the name RPM
+gave it once on disk, tilde included.
+
 ## Update the sls state
 
  - git add changes because codegen need to list them.

--- a/buildchain/buildchain/coreutils.py
+++ b/buildchain/buildchain/coreutils.py
@@ -15,6 +15,22 @@ from typing import Iterator, Sequence
 BUFSIZE: int = 8 * (1024 * 1024)
 
 
+def sha256_of(input_file: Path) -> str:
+    """Compute the SHA256 digest of a file, as `hexdigest` writes it.
+
+    The file is read by chunks, since a package or an ISO does not belong in
+    memory.
+
+    Arguments:
+        input_file: path to the file to hash
+    """
+    hasher = hashlib.sha256()
+    with input_file.open("rb", buffering=BUFSIZE) as fp_in:
+        for chunk in iter(functools.partial(fp_in.read, BUFSIZE), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
 def sha256sum(input_files: Sequence[Path], output_file: Path) -> None:
     """Compute the SHA256 digest of files.
 
@@ -26,13 +42,7 @@ def sha256sum(input_files: Sequence[Path], output_file: Path) -> None:
         input_files: path to the files to hash
         output_file: path to the file that will contain the checksums
     """
-    digests = []
-    for filepath in input_files:
-        hasher = hashlib.sha256()
-        with filepath.open("rb", buffering=BUFSIZE) as fp_in:
-            for chunk in iter(functools.partial(fp_in.read, BUFSIZE), b""):
-                hasher.update(chunk)
-        digests.append(hasher.hexdigest())
+    digests = [sha256_of(filepath) for filepath in input_files]
     with output_file.open("w", encoding="utf-8") as fp_out:
         for filepath, digest in zip(input_files, digests):
             fp_out.write(f"{digest}  {filepath.name}\n")

--- a/buildchain/buildchain/packaging.py
+++ b/buildchain/buildchain/packaging.py
@@ -33,7 +33,6 @@ Overview;
 
 from pathlib import Path
 from typing import (
-    Callable,
     Dict,
     FrozenSet,
     Iterator,
@@ -373,53 +372,45 @@ def _rpm_repository_basename(releasever: str) -> str:
 
 
 def _prebuilt_rpm_package(
-    name: str,
-    releasever: str,
-    repo: str,
-    source: str,
-    tag: str,
-    digest: str,
-    arch: str,
+    prebuilt: versions.PrebuiltRPM, releasever: str
 ) -> targets.PrebuiltRPMPackage:
     """Return a prebuilt RPM package object.
 
     Arguments:
-        name:       package name
+        prebuilt:   declaration of the package, from `versions.py`
         releasever: RedHat release the package is built for
-        repo:       name of the repository the package lands in
-        source:     GitHub repository publishing the package
-        tag:        tag of the release carrying the package
-        digest:     expected SHA256 digest of the package
-        arch:       package architecture
     """
     try:
-        pkg_info = versions.REDHAT_PACKAGES_MAP[releasever][name]
+        digest = prebuilt.sha256[releasever]
     except KeyError as exc:
         raise ValueError(
-            f'Missing version for package "{name}" for release "{releasever}"'
+            f'Missing digest for package "{prebuilt.name}" '
+            f'for release "{releasever}"'
         ) from exc
 
+    pkg_info = prebuilt.package_version(releasever)
     if not pkg_info.full_version:
         raise ValueError(
-            f'Package "{name}" for release "{releasever}" needs a pinned version'
+            f'Package "{prebuilt.name}" for release "{releasever}" '
+            f"needs a pinned version"
         )
 
     return targets.PrebuiltRPMPackage(
         basename=f"_fetch_redhat_{releasever}_packages",
-        name=name,
+        name=prebuilt.name,
         full_version=pkg_info.full_version,
-        arch=arch,
-        repository=source,
-        tag=tag,
+        arch=prebuilt.arch,
+        repository=prebuilt.source,
+        tag=prebuilt.tag,
         digest=digest,
-        destination_dir=targets.rpm_package_dir(repo, releasever),
+        destination_dir=targets.rpm_package_dir(prebuilt.repo, releasever),
         # The package lands in a directory the repository creates. Waiting for
         # it also settles the order `doit clean` walks the two in: it cleans a
         # task before the tasks it depends on, so the package leaves before
         # anyone tries to remove the directory holding it.
         task_dep=[
             f"{_rpm_repository_basename(releasever)}:"
-            f"{repo}/{targets.MKDIR_ARCH_TASK_NAME}"
+            f"{prebuilt.repo}/{targets.MKDIR_ARCH_TASK_NAME}"
         ],
     )
 
@@ -473,55 +464,28 @@ RPM_TO_BUILD: Dict[str, Dict[str, Tuple[targets.RPMPackage, ...]]] = {
 }
 
 
-def _rpm_package_containerd_image_preload(
-    repo: str, releasever: str
-) -> targets.PrebuiltRPMPackage:
-    """`containerd-image-preload` RPM, from the image-cache release.
-
-    The package requires `containerd`, provided by the `containerd.io` package
-    the ISO already carries, so nothing else has to be downloaded for it. A
-    future version that needs more has to declare it in `versions.PACKAGES`:
-    the availability check the Salt states run on every node resolves the
-    dependencies of every declared package against the ISO repositories only.
-    """
-    try:
-        digest = versions.IMAGE_CACHE_RPM_SHA256[releasever]
-    except KeyError as exc:
-        raise ValueError(
-            f'Missing digest for the image-cache RPM for release "{releasever}"'
-        ) from exc
-
-    return _prebuilt_rpm_package(
-        name="containerd-image-preload",
-        releasever=releasever,
-        repo=repo,
-        source=versions.IMAGE_CACHE_REPOSITORY,
-        tag=versions.IMAGE_CACHE_TAG,
-        digest=digest,
-        arch="noarch",
-    )
-
-
 def _packages_to_fetch(
-    repo: str, *factories: Callable[[str, str], targets.PrebuiltRPMPackage]
+    prebuilts: Sequence[versions.PrebuiltRPM],
 ) -> Dict[str, Dict[str, Tuple[targets.PrebuiltRPMPackage, ...]]]:
-    """The packages one repository fetches, one entry per RedHat release.
+    """The prebuilt packages, grouped the way the repositories read them.
 
-    The repository is named once here: it is both the key the packages are
-    declared under and the directory they land in, and a package that lands
-    somewhere else than where it is declared never reaches the ISO.
+    A package is declared under the repository it lands in, since that is
+    where the repository metadata has to find it, and both come from the
+    `repo` of the declaration.
     """
-    return {
-        repo: {
-            releasever: tuple(factory(repo, releasever) for factory in factories)
-            for releasever in versions.REDHAT_PACKAGES
-        }
-    }
+    grouped: Dict[str, Dict[str, Tuple[targets.PrebuiltRPMPackage, ...]]] = {}
+    for prebuilt in prebuilts:
+        per_release = grouped.setdefault(prebuilt.repo, {})
+        for releasever in versions.REDHAT_PACKAGES:
+            per_release[releasever] = per_release.get(releasever, ()) + (
+                _prebuilt_rpm_package(prebuilt, releasever),
+            )
+    return grouped
 
 
 # Packages to fetch from a release instead of building them, per repository.
 RPM_TO_FETCH: Dict[str, Dict[str, Tuple[targets.PrebuiltRPMPackage, ...]]] = (
-    _packages_to_fetch("scality", _rpm_package_containerd_image_preload)
+    _packages_to_fetch(versions.PREBUILT_RPMS)
 )
 
 

--- a/buildchain/buildchain/packaging.py
+++ b/buildchain/buildchain/packaging.py
@@ -6,6 +6,7 @@
 This modules provides several services:
 - build a unique container image for all the build tasks
 - downloading packages and repositories
+- downloading prebuilt packages attached to a GitHub release
 - building local packages from sources
 - building local repositories from local packages
 
@@ -21,12 +22,28 @@ Overview;
                   │       ┌──────────┐       ┌──────────────┐
 ┌─────────┐       │──────>│  build   │──────>│    build     │
 │  mkdir  │──────>│       │ packages │       │ repositories │
-└─────────┘               └──────────┘       └──────────────┘
-                        (e.g.: sosreport)     (e.g.: scality)
+└─────────┘       │       └──────────┘       └──────────────┘
+                  │     (e.g.: sosreport)     (e.g.: scality)
+                  │       ┌──────────┐       ┌──────────────┐
+                  │──────>│  fetch   │──────>│    build     │
+                          │ packages │       │ repositories │
+                          └──────────┘       └──────────────┘
+              (e.g.: containerd-image-preload) (e.g.: scality)
 """
 
 from pathlib import Path
-from typing import Dict, FrozenSet, Iterator, List, Mapping, Optional, Sequence, Tuple
+from typing import (
+    Callable,
+    Dict,
+    FrozenSet,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 import doit  # type: ignore
 
@@ -42,25 +59,29 @@ from buildchain import versions
 # Utilities {{{
 
 
-def _list_packages_to_build(
-    pkg_cats: Mapping[str, Mapping[str, Tuple[targets.Package, ...]]],
+PackageTarget = Union[targets.Package, targets.PrebuiltRPMPackage]
+
+
+def _list_package_names(
+    *pkg_cats: Mapping[str, Mapping[str, Tuple[PackageTarget, ...]]],
 ) -> Dict[str, List[str]]:
-    return {
-        version: [pkg.name for pkg in pkg_list]
-        for pkg_versions in pkg_cats.values()
-        for version, pkg_list in pkg_versions.items()
-    }
+    names: Dict[str, List[str]] = {}
+    for pkg_cat in pkg_cats:
+        for pkg_versions in pkg_cat.values():
+            for version, pkg_list in pkg_versions.items():
+                names.setdefault(version, []).extend(pkg.name for pkg in pkg_list)
+    return names
 
 
 def _list_packages_to_download(
     package_versions: Dict[str, Tuple[versions.PackageVersion, ...]],
-    packages_to_build: Dict[str, List[str]],
+    local_packages: Dict[str, List[str]],
 ) -> Dict[str, Dict[str, Optional[str]]]:
     return {
         version: {
             pkg.name: pkg.full_version
             for pkg in pkgs
-            if pkg.name not in packages_to_build[version]
+            if pkg.name not in local_packages[version]
         }
         for version, pkgs in package_versions.items()
     }
@@ -76,6 +97,7 @@ def task_packaging() -> types.TaskDict:
         "actions": None,
         "task_dep": [
             "_download_packages",
+            "_fetch_packages",
             "_build_packages",
             "_build_repositories",
         ],
@@ -100,6 +122,17 @@ def task__download_packages() -> types.TaskDict:
         "task_dep": [
             "_download_redhat_8_packages",
             "_download_redhat_9_packages",
+        ],
+    }
+
+
+def task__fetch_packages() -> types.TaskDict:
+    """Fetch the prebuilt packages for all the distribution releases."""
+    return {
+        "actions": None,
+        "task_dep": [
+            "_fetch_redhat_8_packages",
+            "_fetch_redhat_9_packages",
         ],
     }
 
@@ -191,7 +224,7 @@ def _download_rpm_packages(releasever: str) -> types.TaskDict:
             # Repository with an explicit list of packages are created by a
             # dedicated task that will also handle their cleaning, so we skip
             # them here.
-            if repository.packages:
+            if repository.has_local_packages:
                 continue
             coreutils.rm_rf(repository.rootdir)
 
@@ -251,6 +284,23 @@ def task__download_redhat_8_packages() -> types.TaskDict:
 def task__download_redhat_9_packages() -> types.TaskDict:
     """Download RedHat 9 packages locally."""
     return _download_rpm_packages("9")
+
+
+def _fetch_rpm_packages(releasever: str) -> Iterator[types.TaskDict]:
+    """Download the prebuilt RPM packages."""
+    for repo_pkgs in RPM_TO_FETCH.values():
+        for package in repo_pkgs[releasever]:
+            yield package.task
+
+
+def task__fetch_redhat_8_packages() -> Iterator[types.TaskDict]:
+    """Download prebuilt RPM packages for RedHat 8."""
+    return _fetch_rpm_packages("8")
+
+
+def task__fetch_redhat_9_packages() -> Iterator[types.TaskDict]:
+    """Download prebuilt RPM packages for RedHat 9."""
+    return _fetch_rpm_packages("9")
 
 
 def _build_rpm_packages(releasever: str) -> Iterator[types.TaskDict]:
@@ -317,24 +367,89 @@ def _rpm_package(name: str, releasever: str, sources: List[Path]) -> targets.RPM
     )
 
 
+def _rpm_repository_basename(releasever: str) -> str:
+    """Basename of the tasks building the repositories of a RedHat release."""
+    return f"_build_redhat_{releasever}_repositories"
+
+
+def _prebuilt_rpm_package(
+    name: str,
+    releasever: str,
+    repo: str,
+    source: str,
+    tag: str,
+    digest: str,
+    arch: str,
+) -> targets.PrebuiltRPMPackage:
+    """Return a prebuilt RPM package object.
+
+    Arguments:
+        name:       package name
+        releasever: RedHat release the package is built for
+        repo:       name of the repository the package lands in
+        source:     GitHub repository publishing the package
+        tag:        tag of the release carrying the package
+        digest:     expected SHA256 digest of the package
+        arch:       package architecture
+    """
+    try:
+        pkg_info = versions.REDHAT_PACKAGES_MAP[releasever][name]
+    except KeyError as exc:
+        raise ValueError(
+            f'Missing version for package "{name}" for release "{releasever}"'
+        ) from exc
+
+    if not pkg_info.full_version:
+        raise ValueError(
+            f'Package "{name}" for release "{releasever}" needs a pinned version'
+        )
+
+    return targets.PrebuiltRPMPackage(
+        basename=f"_fetch_redhat_{releasever}_packages",
+        name=name,
+        full_version=pkg_info.full_version,
+        arch=arch,
+        repository=source,
+        tag=tag,
+        digest=digest,
+        destination_dir=targets.rpm_package_dir(repo, releasever),
+        # The package lands in a directory the repository creates. Waiting for
+        # it also settles the order `doit clean` walks the two in: it cleans a
+        # task before the tasks it depends on, so the package leaves before
+        # anyone tries to remove the directory holding it.
+        task_dep=[
+            f"{_rpm_repository_basename(releasever)}:"
+            f"{repo}/{targets.MKDIR_ARCH_TASK_NAME}"
+        ],
+    )
+
+
 def _rpm_repository(
-    name: str, releasever: str, packages: Optional[Sequence[targets.RPMPackage]] = None
+    name: str,
+    releasever: str,
+    packages: Optional[Sequence[targets.RPMPackage]] = None,
+    prebuilt_packages: Optional[Sequence[targets.PrebuiltRPMPackage]] = None,
 ) -> targets.RPMRepository:
     """Return a RPM repository object.
 
     Arguments:
-        name:     repository name
-        packages: list of locally built packages
+        name:              repository name
+        packages:          list of locally built packages
+        prebuilt_packages: list of packages downloaded from a release
     """
     mkdir_task = f"_package_mkdir_redhat_{releasever}_iso_root"
     download_task = f"_download_redhat_{releasever}_packages"
+    # A repository that holds packages of ours creates its own directories,
+    # and waits for nothing else. The others come from the download task.
+    local = targets.holds_local_packages(packages, prebuilt_packages)
     return targets.RPMRepository(
-        basename=f"_build_redhat_{releasever}_repositories",
+        basename=_rpm_repository_basename(releasever),
         name=name,
         releasever=releasever,
         builder=builder.RPM_BUILDER[releasever],
         packages=packages,
-        task_dep=[download_task if packages is None else mkdir_task],
+        prebuilt_packages=prebuilt_packages,
+        task_dep=[mkdir_task if local else download_task],
     )
 
 
@@ -358,15 +473,71 @@ RPM_TO_BUILD: Dict[str, Dict[str, Tuple[targets.RPMPackage, ...]]] = {
 }
 
 
-_RPM_TO_BUILD_PKG_NAMES: Dict[str, List[str]] = _list_packages_to_build(RPM_TO_BUILD)
+def _rpm_package_containerd_image_preload(
+    repo: str, releasever: str
+) -> targets.PrebuiltRPMPackage:
+    """`containerd-image-preload` RPM, from the image-cache release.
 
-# All packages not referenced in `RPM_TO_BUILD` but listed in
-# `versions.REDHAT_PACKAGES` are supposed to be downloaded.
+    The package requires `containerd`, provided by the `containerd.io` package
+    the ISO already carries, so nothing else has to be downloaded for it. A
+    future version that needs more has to declare it in `versions.PACKAGES`:
+    the availability check the Salt states run on every node resolves the
+    dependencies of every declared package against the ISO repositories only.
+    """
+    try:
+        digest = versions.IMAGE_CACHE_RPM_SHA256[releasever]
+    except KeyError as exc:
+        raise ValueError(
+            f'Missing digest for the image-cache RPM for release "{releasever}"'
+        ) from exc
+
+    return _prebuilt_rpm_package(
+        name="containerd-image-preload",
+        releasever=releasever,
+        repo=repo,
+        source=versions.IMAGE_CACHE_REPOSITORY,
+        tag=versions.IMAGE_CACHE_TAG,
+        digest=digest,
+        arch="noarch",
+    )
+
+
+def _packages_to_fetch(
+    repo: str, *factories: Callable[[str, str], targets.PrebuiltRPMPackage]
+) -> Dict[str, Dict[str, Tuple[targets.PrebuiltRPMPackage, ...]]]:
+    """The packages one repository fetches, one entry per RedHat release.
+
+    The repository is named once here: it is both the key the packages are
+    declared under and the directory they land in, and a package that lands
+    somewhere else than where it is declared never reaches the ISO.
+    """
+    return {
+        repo: {
+            releasever: tuple(factory(repo, releasever) for factory in factories)
+            for releasever in versions.REDHAT_PACKAGES
+        }
+    }
+
+
+# Packages to fetch from a release instead of building them, per repository.
+RPM_TO_FETCH: Dict[str, Dict[str, Tuple[targets.PrebuiltRPMPackage, ...]]] = (
+    _packages_to_fetch("scality", _rpm_package_containerd_image_preload)
+)
+
+
+# Packages the build provides on its own, whether it builds them or downloads
+# them from a release: `dnf` must not try to get them from a repository.
+_LOCAL_RPM_PKG_NAMES: Dict[str, List[str]] = _list_package_names(
+    RPM_TO_BUILD, RPM_TO_FETCH
+)
+
+# All packages not referenced in `RPM_TO_BUILD` nor in `RPM_TO_FETCH` but listed
+# in `versions.REDHAT_PACKAGES` are supposed to be downloaded.
 REDHAT_PACKAGES_TO_DOWNLOAD: Dict[str, FrozenSet[str]] = {
     version: frozenset(
         package.rpm_full_name
         for package in pkgs
-        if package.name not in _RPM_TO_BUILD_PKG_NAMES[version]
+        if package.name not in _LOCAL_RPM_PKG_NAMES[version]
     )
     for version, pkgs in versions.REDHAT_PACKAGES.items()
 }
@@ -376,16 +547,22 @@ REDHAT_PACKAGES_TO_DOWNLOAD: Dict[str, FrozenSet[str]] = {
 _TO_DOWNLOAD_RPM_CONFIG: Dict[str, Dict[str, Optional[str]]] = (
     _list_packages_to_download(
         versions.REDHAT_PACKAGES,
-        _RPM_TO_BUILD_PKG_NAMES,
+        _LOCAL_RPM_PKG_NAMES,
     )
 )
 
 
 SCALITY_REDHAT_8_REPOSITORY: targets.RPMRepository = _rpm_repository(
-    name="scality", packages=RPM_TO_BUILD["scality"]["8"], releasever="8"
+    name="scality",
+    packages=RPM_TO_BUILD["scality"]["8"],
+    prebuilt_packages=RPM_TO_FETCH["scality"]["8"],
+    releasever="8",
 )
 SCALITY_REDHAT_9_REPOSITORY: targets.RPMRepository = _rpm_repository(
-    name="scality", packages=RPM_TO_BUILD["scality"]["9"], releasever="9"
+    name="scality",
+    packages=RPM_TO_BUILD["scality"]["9"],
+    prebuilt_packages=RPM_TO_FETCH["scality"]["9"],
+    releasever="9",
 )
 
 

--- a/buildchain/buildchain/targets/__init__.py
+++ b/buildchain/buildchain/targets/__init__.py
@@ -8,14 +8,21 @@ from buildchain.targets.checksum import Sha256Sum
 from buildchain.targets.directory import Mkdir
 from buildchain.targets.file_tree import FileTree
 from buildchain.targets.local_image import LocalImage, ExplicitContext
-from buildchain.targets.package import Package, RPMPackage
+from buildchain.targets.package import Package, PrebuiltRPMPackage, RPMPackage
 from buildchain.targets.remote_image import (
     ImageSaveFormat,
     RemoteImage,
     SaveAsLayers,
     SaveAsTar,
 )
-from buildchain.targets.repository import Repository, RPMRepository
+from buildchain.targets.repository import (
+    MKDIR_ARCH_TASK_NAME,
+    Repository,
+    RPMRepository,
+    holds_local_packages,
+    rpm_package_dir,
+    rpm_repository_fullname,
+)
 from buildchain.targets.serialize import (
     Renderer,
     SerializedData,
@@ -35,13 +42,18 @@ __all__ = [
     "LocalImage",
     "ExplicitContext",
     "Package",
+    "PrebuiltRPMPackage",
     "RPMPackage",
     "ImageSaveFormat",
     "RemoteImage",
     "SaveAsLayers",
     "SaveAsTar",
+    "MKDIR_ARCH_TASK_NAME",
     "Repository",
     "RPMRepository",
+    "holds_local_packages",
+    "rpm_package_dir",
+    "rpm_repository_fullname",
     "Renderer",
     "SerializedData",
     "SaltState",

--- a/buildchain/buildchain/targets/package.py
+++ b/buildchain/buildchain/targets/package.py
@@ -8,31 +8,37 @@ This modules provides several services:
 - generate the .meta from the .spec
 - download the source files
 - build a SRPM from the source files
+- download a prebuilt RPM attached to a GitHub release
 
 Note that for now, it only works for Rocky/RedHat 8 and 9 x86_64.
-
-            self.make_package_directory(),
-            self.generate_meta(),
-            self.get_source_files(),
-            self.build_srpm(),
 
 Overview;
 
 ┌─────┐     ┌───────────────┐     ┌────────────────┐     ┌────────────┐
 │mkdir│────>│ generate .meta│────>│ download source│────>│ build SRPM │
 └─────┘     └───────────────┘     └────────────────┘     └────────────┘
+
+                            ┌──────────────────┐
+                            │ download prebuilt│
+                            │  RPM from release│
+                            └──────────────────┘
 """
 
+import functools
+import hashlib
+import http.client
 import os
 import operator
 import re
 import shutil
+import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
-from typing import Any, Dict, FrozenSet, List, Sequence
+from typing import Any, Dict, FrozenSet, Iterator, List, Sequence
 
 from buildchain import constants
+from buildchain import coreutils
 from buildchain import types
 from buildchain import utils
 from buildchain import docker_command
@@ -337,6 +343,230 @@ class RPMPackage(Package):
                 )
             )
         return mounts
+
+
+class PrebuiltRPMPackage(base.AtomicTarget):
+    """A RPM built elsewhere and attached to a GitHub release.
+
+    Nothing is built here, unlike `RPMPackage`: the release carries one RPM per
+    RedHat release, and we only download the one we pinned and check it against
+    its expected digest before it lands in a repository.
+
+    A GitHub release is the only source this reads, since it is the only one we
+    publish to. What is tied to GitHub is the URL and the name the release
+    serves the asset under, so another source means a second way to turn a
+    declaration into a URL. The digest check, the atomic write, the up-to-date
+    check and the cleanup have nothing to do with GitHub and would be shared.
+    """
+
+    GITHUB_RELEASES_URL = "https://github.com"
+    DOWNLOAD_TIMEOUT = 60
+    DIGEST_PATTERN = re.compile(r"[0-9a-f]{64}")
+    PARTIAL_SUFFIX = ".part"
+    # GitHub names an asset after the file that was uploaded, with every
+    # character outside this set replaced by a dot. A prerelease tag builds an
+    # RPM whose version holds a tilde (`0.1.0~alpha.1`), and the release serves
+    # it as `0.1.0.alpha.1` while the package itself keeps its real name.
+    ASSET_FORBIDDEN_PATTERN = re.compile(r"[^A-Za-z0-9._-]")
+    # `name-version-release.arch.rpm`, where neither version nor release can
+    # hold a hyphen: that is what tells another version of this package from
+    # another package whose name starts the same way.
+    VERSION_PATTERN = r"-[^-]+-[^-]+\.[^.]+\.rpm"
+
+    def __init__(
+        self,
+        basename: str,
+        name: str,
+        full_version: str,
+        arch: str,
+        repository: str,
+        tag: str,
+        digest: str,
+        destination_dir: Path,
+        **kwargs: Any,
+    ):
+        """Initialize the package.
+
+        Arguments:
+            basename:        basename for the sub-task
+            name:            package name
+            full_version:    package version and release, e.g. `1.0.0-1.el8`
+            arch:            package architecture
+            repository:      GitHub repository publishing the package
+            tag:             tag of the release carrying the package
+            digest:          expected SHA256 digest of the package
+            destination_dir: directory where the package is downloaded
+
+        Keyword Arguments:
+            They are passed to `Target` init method.
+        """
+        self._name = name
+        self._repository = repository
+        self._tag = tag
+        self._digest = digest
+        self._path = destination_dir / f"{name}-{full_version}.{arch}.rpm"
+        kwargs["targets"] = [self._path]
+        super().__init__(basename=basename, **kwargs)
+
+    name = property(operator.attrgetter("_name"))
+    path = property(operator.attrgetter("_path"))
+
+    @property
+    def release(self) -> str:
+        """The release the package comes from, as a reader would name it."""
+        return f"{self._repository} {self._tag}"
+
+    @property
+    def asset_name(self) -> str:
+        """Name the release gives the package, which is not its filename."""
+        return self.ASSET_FORBIDDEN_PATTERN.sub(".", self._path.name)
+
+    @property
+    def url(self) -> str:
+        """URL of the package inside its release."""
+        return (
+            f"{self.GITHUB_RELEASES_URL}/{self._repository}/releases/download/"
+            f"{self._tag}/{self.asset_name}"
+        )
+
+    @property
+    def task(self) -> types.TaskDict:
+        task = self.basic_task
+        task.update(
+            {
+                "name": self._name,
+                "actions": [self._download],
+                "doc": f"Download {self._path.name} from {self.release}.",
+                "title": utils.title_with_target1("GET RPM"),
+            }
+        )
+        # Without an up-to-date check, doit sees a task with no dependency,
+        # considers it never up to date, and downloads the package again on
+        # every build, network access or not.
+        task["uptodate"].append(self.is_up_to_date)
+        return task
+
+    def is_up_to_date(self) -> bool:
+        """Whether the pinned package is alone in place, and intact.
+
+        Hashing the file instead of remembering the pin also catches a package
+        truncated by an interrupted build. A leftover from another pin makes
+        the task run again: the cleanup only happens on download, and the
+        repository metadata would otherwise index both versions.
+        """
+        if not self._path.is_file():
+            return False
+        if any(self._leftovers()):
+            return False
+        try:
+            return self._file_digest() == self.digest
+        except ValueError:
+            return False
+
+    @property
+    def digest(self) -> str:
+        """The pinned digest, as `hexdigest` writes it."""
+        digest = self._digest.strip().lower().removeprefix("sha256:")
+        if not digest:
+            raise ValueError(
+                f"No SHA256 digest pinned for {self._path.name}: add it to "
+                f"`versions.py` for the {self.release} release."
+            )
+        if not self.DIGEST_PATTERN.fullmatch(digest):
+            raise ValueError(
+                f"Pinned digest of {self._path.name} is not a SHA256 digest: "
+                f"{self._digest!r}."
+            )
+        return digest
+
+    def _file_digest(self) -> str:
+        """Digest of the package sitting at the target path."""
+        return coreutils.sha256_of(self._path)
+
+    def _download(self) -> None:
+        """Download the package, and keep it only if its digest matches."""
+        try:
+            expected = self.digest
+        except ValueError as error:
+            raise RuntimeError(str(error)) from error
+
+        # No file is kept unless the package is known to be good: a failed
+        # download leaves nothing but, once the response is open, the empty
+        # directory it wrote into.
+        partial = self._path.with_name(f".{self._path.name}{self.PARTIAL_SUFFIX}")
+        try:
+            digest = self._stream_to(partial)
+            if digest != expected:
+                raise RuntimeError(
+                    f"Wrong digest for {self._path.name} from {self.release}: "
+                    f"expected {expected}, got {digest}."
+                )
+            os.replace(partial, self._path)
+        finally:
+            partial.unlink(missing_ok=True)
+        # Once the package is in place, and not before: the repository must
+        # never hold zero version of it.
+        self._remove_leftovers()
+
+    def _stream_to(self, partial: Path) -> str:
+        """Download the package next to its target, and return its digest."""
+        hasher = hashlib.sha256()
+        try:
+            with urllib.request.urlopen(
+                self.url, timeout=self.DOWNLOAD_TIMEOUT
+            ) as response:
+                # The repository creates this directory, and the task waits
+                # for it. Creating it here too lets the task run on its own,
+                # as `./doit.sh _fetch_redhat_8_packages` and the tests do.
+                partial.parent.mkdir(parents=True, exist_ok=True)
+                with partial.open("wb") as fp:
+                    for chunk in iter(
+                        functools.partial(response.read, coreutils.BUFSIZE), b""
+                    ):
+                        hasher.update(chunk)
+                        fp.write(chunk)
+        except urllib.error.HTTPError as error:
+            raise RuntimeError(
+                f"Failed to download {self._path.name} from {self.url}: "
+                f"HTTP {error.code}. Check that {self.release} exists and "
+                f"carries this package."
+            ) from error
+        # A connection that drops mid-read raises neither `HTTPError` nor
+        # `URLError`, and the build deserves the same message.
+        except (OSError, http.client.HTTPException) as error:
+            raise RuntimeError(
+                f"Failed to download {self._path.name} from {self.url}: "
+                f"{error}. Check that {self.release} exists and carries "
+                f"this package."
+            ) from error
+        return hasher.hexdigest()
+
+    def _leftovers(self) -> Iterator[Path]:
+        """This package under another pin, and partials of any pin.
+
+        The repository directory ends up on the ISO as it is, and its metadata
+        indexes every RPM found there, so an older version of this package
+        would ship next to the pinned one. A package whose name merely starts
+        the same way, `containerd-image-preload-extras` here, belongs to
+        another task and is left alone.
+        """
+        name = re.escape(self._name)
+        package_pattern = re.compile(name + self.VERSION_PATTERN)
+        partial_pattern = re.compile(
+            rf"\.{name}{self.VERSION_PATTERN}{re.escape(self.PARTIAL_SUFFIX)}"
+        )
+        for candidate in self._path.parent.glob(f"*{self._name}-*"):
+            if candidate == self._path:
+                continue
+            if package_pattern.fullmatch(candidate.name) or partial_pattern.fullmatch(
+                candidate.name
+            ):
+                yield candidate
+
+    def _remove_leftovers(self) -> None:
+        """Drop what a previous pin, or an interrupted build, left in place."""
+        for leftover in self._leftovers():
+            leftover.unlink()
 
 
 def _file_from_url(url: str) -> str:

--- a/buildchain/buildchain/targets/repository.py
+++ b/buildchain/buildchain/targets/repository.py
@@ -51,6 +51,18 @@ MKDIR_ROOT_TASK_NAME = "mkdir_repo_root"
 MKDIR_ARCH_TASK_NAME = "mkdir_repo_arch"
 
 
+def holds_local_packages(
+    packages: Optional[Sequence[package.Package]] = None,
+    prebuilt_packages: Optional[Sequence[package.PrebuiltRPMPackage]] = None,
+) -> bool:
+    """Whether a repository built from these holds packages of ours.
+
+    Callers decide what a repository depends on before they can build it, so
+    the answer has to be available without the repository object.
+    """
+    return bool(packages or prebuilt_packages)
+
+
 class Repository(base.CompositeTarget):
     """Base class to build a repository of software packages."""
 
@@ -62,15 +74,17 @@ class Repository(base.CompositeTarget):
         repo_root: Path,
         releasever: str,
         packages: Optional[Sequence[package.Package]] = None,
+        prebuilt_packages: Optional[Sequence[package.PrebuiltRPMPackage]] = None,
         **kwargs: Any,
     ):
         """Initialize the repository.
 
         Arguments:
-            basename: basename for the sub-tasks
-            name:     repository name
-            packages: list of locally built packages
-            builder:  docker image used to build the package
+            basename:          basename for the sub-tasks
+            name:              repository name
+            packages:          list of locally built packages
+            prebuilt_packages: list of packages downloaded from a release
+            builder:           docker image used to build the package
 
         Keyword Arguments:
             They are passed to `Target` init method.
@@ -78,6 +92,7 @@ class Repository(base.CompositeTarget):
         self._name = name
         self._builder = builder
         self._packages = packages or []
+        self._prebuilt_packages = prebuilt_packages or []
         self._repo_root = repo_root
         self._releasever = releasever
         super().__init__(basename=basename, **kwargs)
@@ -85,6 +100,12 @@ class Repository(base.CompositeTarget):
     name = property(operator.attrgetter("_name"))
     builder = property(operator.attrgetter("_builder"))
     packages = property(operator.attrgetter("_packages"))
+    prebuilt_packages = property(operator.attrgetter("_prebuilt_packages"))
+
+    @property
+    def has_local_packages(self) -> bool:
+        """Whether the repository holds packages produced by the build."""
+        return holds_local_packages(self._packages, self._prebuilt_packages)
 
     @property
     @abc.abstractmethod
@@ -99,7 +120,7 @@ class Repository(base.CompositeTarget):
     @property
     def execution_plan(self) -> List[types.TaskDict]:
         tasks = [self.build_repo()]
-        if self._packages:
+        if self.has_local_packages:
             tasks.extend(self.build_packages())
         return tasks
 
@@ -149,6 +170,7 @@ class RPMRepository(Repository):
         releasever: str,
         builder: image.ContainerImage,
         packages: Optional[Sequence[package.RPMPackage]] = None,
+        prebuilt_packages: Optional[Sequence[package.PrebuiltRPMPackage]] = None,
         **kwargs: Any,
     ):
         super().__init__(
@@ -158,18 +180,24 @@ class RPMRepository(Repository):
             constants.REPO_REDHAT_ROOT,
             releasever,
             packages,
+            prebuilt_packages,
             **kwargs,
         )
 
     @property
     def fullname(self) -> str:
         """Repository full name."""
-        return f"{config.PROJECT_NAME.lower()}-{self.name}-el{self._releasever}"
+        return rpm_repository_fullname(self.name, self._releasever)
 
     @property
     def repodata(self) -> Path:
         """Repository metadata directory."""
         return self.rootdir / "repodata"
+
+    @property
+    def package_dir(self) -> Path:
+        """Directory holding the packages of the repository."""
+        return self.rootdir / self.ARCH
 
     def build_repo(self) -> types.TaskDict:
         """Build the repository."""
@@ -198,11 +226,12 @@ class RPMRepository(Repository):
                 "verbosity": 0,
             }
         )
-        if self.packages:
+        if self.has_local_packages:
             task["task_dep"].append(
                 self._get_task_name(MKDIR_ROOT_TASK_NAME, with_basename=True)
             )
             task["file_dep"].extend([self.get_rpm_path(pkg) for pkg in self.packages])
+            task["file_dep"].extend([pkg.path for pkg in self.prebuilt_packages])
         return task
 
     def build_packages(self) -> List[types.TaskDict]:
@@ -249,7 +278,7 @@ class RPMRepository(Repository):
     def _mkdir_repo_arch(self) -> types.TaskDict:
         """Create the CPU architecture directory for the repository."""
         task = self.basic_task
-        mkdir = directory.Mkdir(directory=self.rootdir / self.ARCH).task
+        mkdir = directory.Mkdir(directory=self.package_dir).task
         task.update(
             {
                 "name": self._get_task_name(MKDIR_ARCH_TASK_NAME),
@@ -268,7 +297,7 @@ class RPMRepository(Repository):
     def get_rpm_path(self, pkg: package.RPMPackage) -> Path:
         """Return the path of the RPM of a given package."""
         filename = pkg.srpm.name.replace(".src.rpm", f".{self.ARCH}.rpm")
-        return self.rootdir / self.ARCH / filename
+        return self.package_dir / filename
 
     @staticmethod
     def _get_buildrpm_mounts(srpm_path: Path, rpm_dir: Path) -> List[types.Mount]:
@@ -304,3 +333,22 @@ class RPMRepository(Repository):
         )
 
         return buildrepo_callable
+
+
+def rpm_repository_fullname(name: str, releasever: str) -> str:
+    """Full name of a RPM repository, as it appears on the ISO."""
+    return f"{config.PROJECT_NAME.lower()}-{name}-el{releasever}"
+
+
+def rpm_package_dir(name: str, releasever: str) -> Path:
+    """Directory holding the packages of a RPM repository on the ISO.
+
+    Same directory as `RPMRepository.package_dir`, for the packages that have
+    to know where they land before the repository object exists.
+    """
+    return (
+        constants.REPO_REDHAT_ROOT
+        / releasever
+        / rpm_repository_fullname(name, releasever)
+        / RPMRepository.ARCH
+    )

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -347,6 +347,26 @@ CONTAINER_IMAGES_MAP = {image.name: image for image in CONTAINER_IMAGES}
 
 # Packages {{{
 
+# The `containerd-image-preload` package is not built here: every release of
+# the image-cache repository attaches one RPM per RedHat release, and the build
+# only fetches the one matching the tag pinned below.
+IMAGE_CACHE_REPOSITORY: str = "scality/image-cache"
+IMAGE_CACHE_TAG: str = "v0.1.0-alpha.1"
+# `rpm/build.sh` in image-cache turns the tag into the RPM version: it drops
+# the leading "v" and replaces any hyphen with a tilde, which RPM accepts in a
+# version and sorts before the final release.
+IMAGE_CACHE_RPM_VERSION: str = IMAGE_CACHE_TAG.removeprefix("v").replace("-", "~")
+IMAGE_CACHE_RPM_RELEASE: str = "1"
+# Digest of each RPM attached to the release above, so that two builds of the
+# same MetalK8s version cannot ship two different packages. Refresh them along
+# with the tag, from the release page or by running `sha256sum` on the
+# downloaded packages. An empty digest stops the build, naming the release it
+# expected.
+IMAGE_CACHE_RPM_SHA256: Dict[str, str] = {
+    "8": "b374b74d78c2786c8143e1da2f20bfd46434bc007c42ebb458e87af22a527ad1",
+    "9": "bc205c2120970f5185bbd2808cb55219141acb311692707249692492b143d954",
+}
+
 
 class PackageVersion:
     """A package's authoritative version data.
@@ -458,12 +478,22 @@ PACKAGES: Dict[str, Any] = {
                 version=NONSUFFIXED_VERSION,
                 release=f"{SOSREPORT_RELEASE}.el8",
             ),
+            PackageVersion(
+                name="containerd-image-preload",
+                version=IMAGE_CACHE_RPM_VERSION,
+                release=f"{IMAGE_CACHE_RPM_RELEASE}.el8",
+            ),
         ),
         "9": (
             PackageVersion(
                 name="metalk8s-sosreport",
                 version=NONSUFFIXED_VERSION,
                 release=f"{SOSREPORT_RELEASE}.el9",
+            ),
+            PackageVersion(
+                name="containerd-image-preload",
+                version=IMAGE_CACHE_RPM_VERSION,
+                release=f"{IMAGE_CACHE_RPM_RELEASE}.el9",
             ),
         ),
     },

--- a/buildchain/buildchain/versions.py
+++ b/buildchain/buildchain/versions.py
@@ -12,7 +12,7 @@ import json
 
 from collections import namedtuple
 from pathlib import Path
-from typing import Any, cast, Dict, Optional, Tuple
+from typing import Any, cast, Dict, NamedTuple, Optional, Tuple
 
 Image = namedtuple("Image", ("name", "version", "digest"))
 
@@ -347,26 +347,6 @@ CONTAINER_IMAGES_MAP = {image.name: image for image in CONTAINER_IMAGES}
 
 # Packages {{{
 
-# The `containerd-image-preload` package is not built here: every release of
-# the image-cache repository attaches one RPM per RedHat release, and the build
-# only fetches the one matching the tag pinned below.
-IMAGE_CACHE_REPOSITORY: str = "scality/image-cache"
-IMAGE_CACHE_TAG: str = "v0.1.0-alpha.1"
-# `rpm/build.sh` in image-cache turns the tag into the RPM version: it drops
-# the leading "v" and replaces any hyphen with a tilde, which RPM accepts in a
-# version and sorts before the final release.
-IMAGE_CACHE_RPM_VERSION: str = IMAGE_CACHE_TAG.removeprefix("v").replace("-", "~")
-IMAGE_CACHE_RPM_RELEASE: str = "1"
-# Digest of each RPM attached to the release above, so that two builds of the
-# same MetalK8s version cannot ship two different packages. Refresh them along
-# with the tag, from the release page or by running `sha256sum` on the
-# downloaded packages. An empty digest stops the build, naming the release it
-# expected.
-IMAGE_CACHE_RPM_SHA256: Dict[str, str] = {
-    "8": "b374b74d78c2786c8143e1da2f20bfd46434bc007c42ebb458e87af22a527ad1",
-    "9": "bc205c2120970f5185bbd2808cb55219141acb311692707249692492b143d954",
-}
-
 
 class PackageVersion:
     """A package's authoritative version data.
@@ -433,6 +413,74 @@ class PackageVersion:
 #   * kubelet and kubectl which _make_ the K8s version of the cluster
 #   * salt-minion which _makes_ the Salt version of the cluster
 #
+class PrebuiltRPM(NamedTuple):
+    """A RPM fetched from a GitHub release instead of being built here.
+
+    One declaration serves both sides: the build reads the release and the
+    digest to fetch the package, and the version pin the Salt states use is
+    derived from the same tag, so the two cannot drift.
+    """
+
+    name: str
+    # Repository of the ISO the package lands in.
+    repo: str
+    # GitHub repository publishing the package.
+    source: str
+    tag: str
+    # Digest of the RPM attached to the release, per RedHat release. Refresh
+    # them along with the tag, from the release page or by running `sha256sum`
+    # on the downloaded packages. An empty digest stops the build, naming the
+    # release it expected.
+    sha256: Dict[str, str]
+    # A bump moves the tag, and the spec keeps its release digit at 1.
+    release: str = "1"
+    arch: str = "noarch"
+
+    @property
+    def version(self) -> str:
+        """Version of the RPM, as the source repository derives it.
+
+        `rpm/build.sh` in image-cache drops the leading "v" and replaces any
+        hyphen with a tilde, which RPM accepts in a version and sorts before
+        the final release.
+        """
+        return self.tag.removeprefix("v").replace("-", "~")
+
+    def package_version(self, releasever: str) -> PackageVersion:
+        """Version pin of the package, for one RedHat release."""
+        return PackageVersion(
+            name=self.name,
+            version=self.version,
+            release=f"{self.release}.el{releasever}",
+        )
+
+
+PREBUILT_RPMS: Tuple[PrebuiltRPM, ...] = (
+    # The package requires `containerd`, provided by the `containerd.io`
+    # package the ISO already carries, so nothing else has to be downloaded
+    # for it. A future version that needs more has to be declared in
+    # `PACKAGES`: the availability check the Salt states run on every node
+    # resolves the dependencies of every declared package against the ISO
+    # repositories alone.
+    #
+    # A package we build gets its dependencies from the spec it owns. A
+    # finished RPM has no spec: declaring them by name here would have `dnf`
+    # download an unpinned copy, and reading them off the package makes the
+    # download list depend on a file we have yet to fetch. Worth solving on
+    # the second prebuilt package, not for one dependency already on the ISO.
+    PrebuiltRPM(
+        name="containerd-image-preload",
+        repo="scality",
+        source="scality/image-cache",
+        tag="v0.1.0-alpha.1",
+        sha256={
+            "8": "b374b74d78c2786c8143e1da2f20bfd46434bc007c42ebb458e87af22a527ad1",
+            "9": "bc205c2120970f5185bbd2808cb55219141acb311692707249692492b143d954",
+        },
+    ),
+)
+
+
 # These common packages may be overridden by OS-specific packages if package
 # names or version conventions diverge.
 #
@@ -478,11 +526,6 @@ PACKAGES: Dict[str, Any] = {
                 version=NONSUFFIXED_VERSION,
                 release=f"{SOSREPORT_RELEASE}.el8",
             ),
-            PackageVersion(
-                name="containerd-image-preload",
-                version=IMAGE_CACHE_RPM_VERSION,
-                release=f"{IMAGE_CACHE_RPM_RELEASE}.el8",
-            ),
         ),
         "9": (
             PackageVersion(
@@ -490,14 +533,20 @@ PACKAGES: Dict[str, Any] = {
                 version=NONSUFFIXED_VERSION,
                 release=f"{SOSREPORT_RELEASE}.el9",
             ),
-            PackageVersion(
-                name="containerd-image-preload",
-                version=IMAGE_CACHE_RPM_VERSION,
-                release=f"{IMAGE_CACHE_RPM_RELEASE}.el9",
-            ),
         ),
     },
 }
+
+# The prebuilt packages are declared once, in `PREBUILT_RPMS`, and their
+# version pin follows from the release they are fetched from. `pkg_installed`
+# reads the version of a package from this listing, and `dnf` skips a package
+# that is in it instead of looking for it in a repository that does not carry
+# it. The loop variable is not called `version` or `releasever`: both shadow
+# something else in this file.
+for rh_release in PACKAGES["redhat"]:
+    PACKAGES["redhat"][rh_release] += tuple(
+        prebuilt.package_version(rh_release) for prebuilt in PREBUILT_RPMS
+    )
 
 
 def _list_pkgs_for_os_family(os_family: str) -> Dict[str, Tuple[PackageVersion, ...]]:

--- a/buildchain/tests/test_packaging.py
+++ b/buildchain/tests/test_packaging.py
@@ -1,0 +1,480 @@
+# coding: utf-8
+
+"""Unit tests for the prebuilt package tasks of `buildchain.packaging`."""
+
+import hashlib
+import http.client
+import re
+import urllib.error
+from email.message import Message
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+
+from buildchain import packaging, targets, versions
+from buildchain.targets import package
+
+RELEASEVERS = tuple(versions.REDHAT_PACKAGES)
+
+# Every EL release runs the whole suite: a new one is covered by declaring it.
+releasevers = pytest.mark.parametrize("releasever", RELEASEVERS)
+
+PACKAGE_NAME = "containerd-image-preload"
+REPOSITORY = "scality/image-cache"
+TAG = "v1.2.3"
+CONTENT = b"not really an RPM, but it hashes the same way"
+DIGEST = hashlib.sha256(CONTENT).hexdigest()
+
+
+def prebuilt_package(
+    tmp_path: Path, digest: str = DIGEST, full_version: str = "1.2.3-1.el8"
+) -> package.PrebuiltRPMPackage:
+    """A package pointing at a release served from the filesystem."""
+    return package.PrebuiltRPMPackage(
+        basename="_fetch_redhat_8_packages",
+        name=PACKAGE_NAME,
+        full_version=full_version,
+        arch="noarch",
+        repository=REPOSITORY,
+        tag=TAG,
+        digest=digest,
+        destination_dir=tmp_path / "iso" / "metalk8s-scality-el8" / "x86_64",
+    )
+
+
+def scality_repository(releasever: str) -> targets.RPMRepository:
+    """The `scality` repository object for a given RedHat release."""
+    return {
+        "8": packaging.SCALITY_REDHAT_8_REPOSITORY,
+        "9": packaging.SCALITY_REDHAT_9_REPOSITORY,
+    }[releasever]
+
+
+def run_actions(pkg: package.PrebuiltRPMPackage) -> None:
+    """Run the task actions the way doit does."""
+    for action in pkg.task["actions"]:
+        action()
+
+
+@pytest.fixture(name="release")
+def release_fixture(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Serve a release from a local directory, over `file://`."""
+    monkeypatch.setattr(
+        package.PrebuiltRPMPackage,
+        "GITHUB_RELEASES_URL",
+        (tmp_path / "github").as_uri(),
+    )
+    assets = tmp_path / "github" / REPOSITORY / "releases" / "download" / TAG
+    assets.mkdir(parents=True)
+    yield assets
+
+
+class TestPrebuiltRPMPackage:
+    """The target itself: naming, download, and digest check."""
+
+    def test_filename_follows_the_rpm_conventions(self, tmp_path: Path) -> None:
+        pkg = prebuilt_package(tmp_path)
+        assert pkg.path.name == f"{PACKAGE_NAME}-1.2.3-1.el8.noarch.rpm"
+        assert pkg.path.parent == tmp_path / "iso" / "metalk8s-scality-el8" / "x86_64"
+
+    def test_url_points_at_the_release_asset(self, tmp_path: Path) -> None:
+        pkg = prebuilt_package(tmp_path)
+        assert pkg.url == (
+            f"https://github.com/{REPOSITORY}/releases/download/{TAG}/{pkg.path.name}"
+        )
+
+    def test_a_prerelease_asset_is_named_the_way_github_renames_it(
+        self, tmp_path: Path
+    ) -> None:
+        # The RPM of a prerelease tag holds a tilde in its version, and GitHub
+        # serves it as a dot. The package on disk keeps the name RPM gave it,
+        # which is what the repository metadata and the version pin read.
+        pkg = prebuilt_package(tmp_path, full_version="0.1.0~alpha.1-1.el8")
+        assert pkg.path.name == f"{PACKAGE_NAME}-0.1.0~alpha.1-1.el8.noarch.rpm"
+        assert pkg.asset_name == f"{PACKAGE_NAME}-0.1.0.alpha.1-1.el8.noarch.rpm"
+        assert pkg.url.endswith(f"/{TAG}/{pkg.asset_name}")
+
+    def test_a_prerelease_package_is_downloaded(
+        self, tmp_path: Path, release: Path
+    ) -> None:
+        pkg = prebuilt_package(tmp_path, full_version="0.1.0~alpha.1-1.el8")
+        (release / pkg.asset_name).write_bytes(CONTENT)
+
+        run_actions(pkg)
+
+        assert pkg.path.read_bytes() == CONTENT
+
+    def test_task_is_named_after_the_package(self, tmp_path: Path) -> None:
+        pkg = prebuilt_package(tmp_path)
+        task = pkg.task
+        assert task["basename"] == "_fetch_redhat_8_packages"
+        assert task["name"] == PACKAGE_NAME
+        assert task["targets"] == [pkg.path]
+
+    def test_download_keeps_a_matching_package(
+        self, tmp_path: Path, release: Path
+    ) -> None:
+        pkg = prebuilt_package(tmp_path)
+        (release / pkg.path.name).write_bytes(CONTENT)
+
+        run_actions(pkg)
+
+        # The repository tree belongs to another task, which has not run yet.
+        assert pkg.path.read_bytes() == CONTENT
+
+    def test_download_rejects_another_package(
+        self, tmp_path: Path, release: Path
+    ) -> None:
+        pkg = prebuilt_package(tmp_path)
+        (release / pkg.path.name).write_bytes(b"some other build")
+
+        with pytest.raises(RuntimeError, match="Wrong digest"):
+            run_actions(pkg)
+
+        # A rejected download must not leave a target behind, otherwise the
+        # next build would consider the package up to date.
+        assert not pkg.path.exists()
+
+    def test_missing_asset_names_the_release(
+        self, tmp_path: Path, release: Path
+    ) -> None:
+        pkg = prebuilt_package(tmp_path)
+
+        with pytest.raises(RuntimeError, match=f"{REPOSITORY} {TAG}") as failure:
+            run_actions(pkg)
+
+        assert pkg.path.name in str(failure.value)
+
+    def test_http_error_names_the_release(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def not_found(url: str, timeout: int = 0) -> None:
+            raise urllib.error.HTTPError(url, 404, "Not Found", Message(), None)
+
+        monkeypatch.setattr(package.urllib.request, "urlopen", not_found)
+        pkg = prebuilt_package(tmp_path)
+
+        with pytest.raises(RuntimeError, match="HTTP 404") as failure:
+            run_actions(pkg)
+
+        assert f"{REPOSITORY} {TAG}" in str(failure.value)
+
+    def test_unpinned_digest_stops_the_build(
+        self, tmp_path: Path, release: Path
+    ) -> None:
+        pkg = prebuilt_package(tmp_path, digest="")
+        (release / pkg.path.name).write_bytes(CONTENT)
+
+        with pytest.raises(RuntimeError, match=f"{REPOSITORY} {TAG}"):
+            run_actions(pkg)
+
+
+class TestPrebuiltRPMPackageDownload:
+    """What the download does beyond fetching bytes."""
+
+    def test_drops_the_previous_version(self, tmp_path: Path, release: Path) -> None:
+        pkg = prebuilt_package(tmp_path)
+        (release / pkg.path.name).write_bytes(CONTENT)
+        stale = pkg.path.parent / f"{PACKAGE_NAME}-1.2.2-1.el8.noarch.rpm"
+        stale.parent.mkdir(parents=True)
+        stale.write_bytes(b"the package from the previous pin")
+        neighbours = [
+            pkg.path.parent / "metalk8s-sosreport-134.0.0-1.el8.x86_64.rpm",
+            # Same prefix, different package: the version and the release of an
+            # RPM hold no hyphen, which is what tells the two apart.
+            pkg.path.parent / f"{PACKAGE_NAME}-tools-9.9.9-1.el8.noarch.rpm",
+        ]
+        for neighbour in neighbours:
+            neighbour.write_bytes(b"another package of the same repository")
+
+        run_actions(pkg)
+
+        # Both versions in the directory would end up in the metadata.
+        assert not stale.exists()
+        assert all(neighbour.exists() for neighbour in neighbours)
+
+    def test_leaves_nothing_behind_when_the_pin_is_missing(
+        self, tmp_path: Path
+    ) -> None:
+        pkg = prebuilt_package(tmp_path, digest="")
+
+        with pytest.raises(RuntimeError, match="No SHA256 digest pinned"):
+            run_actions(pkg)
+
+        # Not even the directory: the mkdir task it belongs to would then be
+        # considered done without having run.
+        assert not pkg.path.parent.exists()
+
+    def test_leaves_nothing_behind_when_the_digest_is_wrong(
+        self, tmp_path: Path, release: Path
+    ) -> None:
+        pkg = prebuilt_package(tmp_path, digest="0" * 64)
+        (release / pkg.path.name).write_bytes(CONTENT)
+
+        with pytest.raises(RuntimeError, match="Wrong digest"):
+            run_actions(pkg)
+
+        # The half-written package would otherwise ship on the ISO, which
+        # copies the repository directory as it is.
+        assert list(pkg.path.parent.iterdir()) == []
+
+    def test_drops_a_partial_file_from_an_earlier_build(
+        self, tmp_path: Path, release: Path
+    ) -> None:
+        pkg = prebuilt_package(tmp_path)
+        (release / pkg.path.name).write_bytes(CONTENT)
+        partial = pkg.path.parent / f".{pkg.path.name}.part"
+        partial.parent.mkdir(parents=True)
+        partial.write_bytes(b"what a killed build left")
+
+        run_actions(pkg)
+
+        assert not partial.exists()
+        assert pkg.path.read_bytes() == CONTENT
+
+    def test_keeps_the_partial_file_of_another_package(
+        self, tmp_path: Path, release: Path
+    ) -> None:
+        # `./doit.sh` runs tasks in parallel, so a partial whose name starts
+        # like ours may well be another package being downloaded right now.
+        pkg = prebuilt_package(tmp_path)
+        (release / pkg.path.name).write_bytes(CONTENT)
+        neighbour = (
+            pkg.path.parent / f".{PACKAGE_NAME}-extras-1.0-1.el8.noarch.rpm.part"
+        )
+        neighbour.parent.mkdir(parents=True)
+        neighbour.write_bytes(b"a download in flight")
+
+        run_actions(pkg)
+
+        assert neighbour.exists()
+
+    def test_accepts_a_pin_written_the_other_way(
+        self, tmp_path: Path, release: Path
+    ) -> None:
+        # `versions.py` writes container image digests as `sha256:<hex>`, and
+        # the release page shows them upper case.
+        pkg = prebuilt_package(tmp_path, digest=f"  SHA256:{DIGEST.upper()}  ")
+        (release / pkg.path.name).write_bytes(CONTENT)
+
+        run_actions(pkg)
+
+        assert pkg.path.read_bytes() == CONTENT
+
+    def test_rejects_a_pin_that_is_not_a_digest(
+        self, tmp_path: Path, release: Path
+    ) -> None:
+        pkg = prebuilt_package(tmp_path, digest="1.2.3")
+        (release / pkg.path.name).write_bytes(CONTENT)
+
+        with pytest.raises(RuntimeError, match="not a SHA256 digest"):
+            run_actions(pkg)
+
+    def test_broken_connection_names_the_release(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A connection that drops mid-read raises none of the `urllib` errors.
+        class Truncated:
+            """A response that dies while it is being read."""
+
+            def __enter__(self) -> "Truncated":
+                return self
+
+            def __exit__(self, *args: Any) -> None:
+                return None
+
+            def read(self, size: int = 0) -> bytes:
+                raise http.client.IncompleteRead(b"half of it")
+
+        monkeypatch.setattr(
+            package.urllib.request,
+            "urlopen",
+            lambda url, timeout=0: Truncated(),
+        )
+
+        with pytest.raises(RuntimeError, match=f"{REPOSITORY} {TAG}"):
+            run_actions(prebuilt_package(tmp_path))
+
+
+class TestPrebuiltRPMPackageUpToDate:
+    """What keeps the build off the network once the package is there."""
+
+    def test_a_matching_package_is_up_to_date(
+        self, tmp_path: Path, release: Path
+    ) -> None:
+        pkg = prebuilt_package(tmp_path)
+        (release / pkg.path.name).write_bytes(CONTENT)
+        assert not pkg.is_up_to_date()
+
+        run_actions(pkg)
+
+        assert pkg.is_up_to_date()
+
+    def test_a_truncated_package_is_not(self, tmp_path: Path, release: Path) -> None:
+        pkg = prebuilt_package(tmp_path)
+        (release / pkg.path.name).write_bytes(CONTENT)
+        run_actions(pkg)
+
+        # An interrupted build, or a hand-edited package: the pin alone cannot
+        # tell, only the bytes on disk can.
+        pkg.path.write_bytes(CONTENT[:10])
+
+        assert not pkg.is_up_to_date()
+
+    def test_a_package_left_by_another_pin_makes_it_run_again(
+        self, tmp_path: Path, release: Path
+    ) -> None:
+        # The cleanup only runs on download. A build killed between the two
+        # leaves both versions in the directory, and `createrepo` would index
+        # them both.
+        pkg = prebuilt_package(tmp_path)
+        (release / pkg.path.name).write_bytes(CONTENT)
+        run_actions(pkg)
+        stale = pkg.path.parent / f"{PACKAGE_NAME}-1.2.2-1.el8.noarch.rpm"
+        stale.write_bytes(b"the package from the previous pin")
+
+        assert not pkg.is_up_to_date()
+
+        run_actions(pkg)
+
+        assert not stale.exists()
+        assert pkg.is_up_to_date()
+
+    def test_a_bumped_pin_is_not(self, tmp_path: Path, release: Path) -> None:
+        pkg = prebuilt_package(tmp_path)
+        (release / pkg.path.name).write_bytes(CONTENT)
+        run_actions(pkg)
+
+        assert not prebuilt_package(tmp_path, digest="0" * 64).is_up_to_date()
+
+    def test_a_missing_pin_is_not(self, tmp_path: Path) -> None:
+        assert not prebuilt_package(tmp_path, digest="").is_up_to_date()
+
+    def test_the_checks_handed_to_the_target_are_kept(self, tmp_path: Path) -> None:
+        pkg = package.PrebuiltRPMPackage(
+            basename="_fetch_redhat_8_packages",
+            name=PACKAGE_NAME,
+            full_version="1.2.3-1.el8",
+            arch="noarch",
+            repository=REPOSITORY,
+            tag=TAG,
+            digest=DIGEST,
+            destination_dir=tmp_path / "repository",
+            uptodate=[False],
+        )
+        assert pkg.task["uptodate"] == [False, pkg.is_up_to_date]
+
+
+class TestContainerdImagePreload:
+    """The wiring: where the package is declared, fetched, and shipped."""
+
+    @releasevers
+    def test_version_is_declared(self, releasever: str) -> None:
+        # `pkg_installed` pins the version from this listing, so a package
+        # missing from it cannot be installed by the Salt states.
+        pkg_info = versions.REDHAT_PACKAGES_MAP[releasever][PACKAGE_NAME]
+        assert pkg_info.full_version == (
+            f"{versions.IMAGE_CACHE_RPM_VERSION}"
+            f"-{versions.IMAGE_CACHE_RPM_RELEASE}.el{releasever}"
+        )
+
+    @releasevers
+    def test_dnf_does_not_try_to_download_it(self, releasever: str) -> None:
+        # The package is in none of the yum repositories we configure: asking
+        # `dnf` for it would fail the whole download task.
+        assert not [
+            name
+            for name in packaging.REDHAT_PACKAGES_TO_DOWNLOAD[releasever]
+            if name.startswith(PACKAGE_NAME)
+        ]
+
+    @releasevers
+    def test_lands_in_the_scality_repository(self, releasever: str) -> None:
+        pkg = packaging.RPM_TO_FETCH["scality"][releasever][0]
+        repository = scality_repository(releasever)
+        assert pkg.path.parent == repository.package_dir
+        # `rpm_package_dir` lets a package know where it lands before the
+        # repository exists. It has to stay the directory the repository
+        # metadata is built from, otherwise the ISO ships a package `dnf`
+        # cannot see.
+        assert repository.package_dir.parent == repository.rootdir
+
+    def test_lands_in_the_repository_it_is_declared_under(self) -> None:
+        # The repository the package is declared under and the directory it
+        # lands in come from the same name, so the two cannot diverge.
+        for repo, per_release in packaging.RPM_TO_FETCH.items():
+            for releasever, packages in per_release.items():
+                for pkg in packages:
+                    assert pkg.path.parent == targets.rpm_package_dir(repo, releasever)
+
+    def test_every_declared_release_is_fetched(self) -> None:
+        # A release declared in `versions.py` but missing here would have dnf
+        # look for the package in repositories that do not carry it.
+        assert set(packaging.RPM_TO_FETCH["scality"]) == set(versions.REDHAT_PACKAGES)
+
+    @releasevers
+    def test_repository_metadata_depends_on_it(self, releasever: str) -> None:
+        repository = scality_repository(releasever)
+        pkg = packaging.RPM_TO_FETCH["scality"][releasever][0]
+        assert pkg.path in repository.build_repo()["file_dep"]
+
+    @releasevers
+    def test_is_cleaned_before_the_directory_holding_it(self, releasever: str) -> None:
+        # `doit clean` cleans a task before the tasks it depends on. Nothing
+        # else orders these two, and the ISO build fails on the `rmdir` of a
+        # repository directory that still holds the package.
+        pkg = packaging.RPM_TO_FETCH["scality"][releasever][0]
+        assert (
+            f"_build_redhat_{releasever}_repositories:"
+            f"scality/{targets.MKDIR_ARCH_TASK_NAME}"
+        ) in pkg.task["task_dep"]
+
+    @releasevers
+    def test_has_a_fetch_task(self, releasever: str) -> None:
+        tasks = {
+            "8": packaging.task__fetch_redhat_8_packages,
+            "9": packaging.task__fetch_redhat_9_packages,
+        }[releasever]()
+        assert [task["name"] for task in tasks] == [PACKAGE_NAME]
+
+    def test_digests_are_pinned(self) -> None:
+        # A bump moves the tag and both digests together: a half-done one
+        # leaves a digest empty, and the build would only find out on the
+        # download.
+        for releasever in RELEASEVERS:
+            digest = versions.IMAGE_CACHE_RPM_SHA256[releasever]
+            assert re.fullmatch(r"[0-9a-f]{64}", digest)
+
+    @releasevers
+    def test_its_dependency_ships_on_the_iso(self, releasever: str) -> None:
+        # The RPM requires `containerd`, which `containerd.io` provides. Every
+        # declared package is test-installed on each node by
+        # `metalk8s_package_manager.check_pkg_availability`, against the ISO
+        # repositories alone, so an unshipped dependency fails that state
+        # cluster-wide.
+        assert "containerd.io" in versions.REDHAT_PACKAGES_MAP[releasever]
+
+    def test_rpm_version_comes_from_the_tag(self) -> None:
+        # `rpm/build.sh` in image-cache drops the leading "v" and replaces the
+        # hyphen, which RPM forbids in a version, with a tilde.
+        assert not versions.IMAGE_CACHE_RPM_VERSION.startswith("v")
+        assert "-" not in versions.IMAGE_CACHE_RPM_VERSION
+        assert versions.IMAGE_CACHE_TAG.startswith("v")
+
+
+class TestPackageNames:
+    """The listing that decides which packages `dnf` is asked for."""
+
+    def test_repositories_sharing_a_release_are_merged(self) -> None:
+        built = {"scality": {"8": (Named("built"),)}}
+        fetched = {"epel": {"8": (Named("fetched"),)}}
+        names = packaging._list_package_names(built, fetched)
+        assert sorted(names["8"]) == ["built", "fetched"]
+
+
+class Named:
+    """The only thing `_list_package_names` reads from a package."""
+
+    def __init__(self, name: str):
+        self.name = name

--- a/buildchain/tests/test_packaging.py
+++ b/buildchain/tests/test_packaging.py
@@ -43,6 +43,13 @@ def prebuilt_package(
     )
 
 
+def prebuilt_declaration(name: str = PACKAGE_NAME) -> versions.PrebuiltRPM:
+    """The declaration a prebuilt package is built from."""
+    return next(
+        prebuilt for prebuilt in versions.PREBUILT_RPMS if prebuilt.name == name
+    )
+
+
 def scality_repository(releasever: str) -> targets.RPMRepository:
     """The `scality` repository object for a given RedHat release."""
     return {
@@ -373,10 +380,20 @@ class TestContainerdImagePreload:
     def test_version_is_declared(self, releasever: str) -> None:
         # `pkg_installed` pins the version from this listing, so a package
         # missing from it cannot be installed by the Salt states.
+        prebuilt = prebuilt_declaration()
         pkg_info = versions.REDHAT_PACKAGES_MAP[releasever][PACKAGE_NAME]
         assert pkg_info.full_version == (
-            f"{versions.IMAGE_CACHE_RPM_VERSION}"
-            f"-{versions.IMAGE_CACHE_RPM_RELEASE}.el{releasever}"
+            f"{prebuilt.version}-{prebuilt.release}.el{releasever}"
+        )
+
+    @releasevers
+    def test_the_version_pin_is_generated(self, releasever: str) -> None:
+        # The pin is not written by hand next to the declaration: a bump moves
+        # the tag, and the version every node installs follows.
+        prebuilt = prebuilt_declaration()
+        assert (
+            prebuilt.package_version(releasever).full_version
+            == versions.REDHAT_PACKAGES_MAP[releasever][PACKAGE_NAME].full_version
         )
 
     @releasevers
@@ -439,12 +456,13 @@ class TestContainerdImagePreload:
         assert [task["name"] for task in tasks] == [PACKAGE_NAME]
 
     def test_digests_are_pinned(self) -> None:
-        # A bump moves the tag and both digests together: a half-done one
+        # A bump moves the tag and every digest together: a half-done one
         # leaves a digest empty, and the build would only find out on the
         # download.
-        for releasever in RELEASEVERS:
-            digest = versions.IMAGE_CACHE_RPM_SHA256[releasever]
-            assert re.fullmatch(r"[0-9a-f]{64}", digest)
+        for prebuilt in versions.PREBUILT_RPMS:
+            assert set(prebuilt.sha256) == set(RELEASEVERS)
+            for digest in prebuilt.sha256.values():
+                assert re.fullmatch(r"[0-9a-f]{64}", digest)
 
     @releasevers
     def test_its_dependency_ships_on_the_iso(self, releasever: str) -> None:
@@ -458,9 +476,10 @@ class TestContainerdImagePreload:
     def test_rpm_version_comes_from_the_tag(self) -> None:
         # `rpm/build.sh` in image-cache drops the leading "v" and replaces the
         # hyphen, which RPM forbids in a version, with a tilde.
-        assert not versions.IMAGE_CACHE_RPM_VERSION.startswith("v")
-        assert "-" not in versions.IMAGE_CACHE_RPM_VERSION
-        assert versions.IMAGE_CACHE_TAG.startswith("v")
+        prebuilt = prebuilt_declaration()
+        assert prebuilt.tag.startswith("v")
+        assert not prebuilt.version.startswith("v")
+        assert "-" not in prebuilt.version
 
 
 class TestPackageNames:


### PR DESCRIPTION
**Component**: build

**Context**:

The image-cache repository publishes `containerd-image-preload` as an RPM, one per RedHat release, attached to each of its GitHub releases. This PR puts that package in the `scality` repository of the ISO, so a node can install it from the local repository like any other MetalK8s package. Installing it and enabling its timer is MK8S-395, not this PR.

The buildchain had no path for a finished RPM coming from outside a yum repository. It knows how to build one from a spec we own (`RPM_TO_BUILD`, as for `metalk8s-sosreport`), and how to let dnf download one from a repository we configure (`REDHAT_PACKAGES_TO_DOWNLOAD`). The URL support in `targets/package.py` fetches the sources of a SRPM, not a package.

**Summary**:

`PrebuiltRPMPackage` (`buildchain/buildchain/targets/package.py`) downloads one asset of a GitHub release, checks it against a pinned sha256, and writes it only if the digest matches. Three things it does beyond fetching bytes:

- its up-to-date check hashes the package on disk rather than remembering the pin, so an incremental build stays off the network, while a bumped pin, a truncated download or an edited package all trigger a new one
- the package is streamed next to its target and moved in one step, so a failed download leaves neither a file nor a directory behind, and nothing untrusted ever sits at the target path
- what a previous pin or a killed build left in the repository directory is removed, since the metadata indexes every RPM found there and `mkisofs` copies the directory as it is

`buildchain/buildchain/packaging.py` declares the package for RedHat 8 and 9 under a new `RPM_TO_FETCH` mapping, and a new `_fetch_packages` task group runs the downloads. A package lands in the repository it is declared under, and that repository's metadata task depends on it, so `createrepo` always runs after the download.

`buildchain/buildchain/versions.py` pins the release tag, the RPM version derived from it, and one digest per RedHat release. The tag is `v0.1.0-alpha.1`, the first release image-cache cut. GitHub renames an asset when its name holds a character it does not accept, so the RPM built as `0.1.0~alpha.1` is served as `0.1.0.alpha.1`: the download asks for that name, and the package keeps its own once on disk. The package is also declared as a `PackageVersion`, which is what `pkg_installed` reads to pin a version, and what keeps dnf from looking for the package in a repository that does not carry it. `BUMPING.md` gains a section listing the four values a bump has to move together.

**Acceptance criteria**:

- the `scality` repository of the ISO carries `containerd-image-preload` for RedHat 8 and 9
- the version and the digest are pinned in `versions.py`, so two builds of the same MetalK8s version ship the same package
- a failed or missing download stops the build with a message naming the release it expected
- `tox -e unit-tests-buildchain` covers the download, the digest check, the leftover cleanup, the failure messages and the wiring

**The ISO ships a prerelease package**:

image-cache cut `v0.1.0-alpha.1` on 2026-09-01, and that is what this PR pins. The package is an alpha, so the pin has to move to the GA tag once image-cache cuts it, which is one line in `versions.py` plus the two digests. `test_digests_are_pinned` fails on a bump that moves the tag and forgets a digest.

**Run locally**:

`tox -e unit-tests-buildchain`, 73 passed. Every pre-commit hook covering these files: black 26.3.1, pylint 4.0.5 at 10.00/10, mypy 1.20.2.

The download was exercised against the real release, for both RedHat releases. It fetches the two packages, their digests match the pins, the second run is skipped as up to date, and a package left by another pin next to the target sends the task back to the download, which removes it. The unit tests reach the failure paths over `file://`: a wrong digest, a missing asset, a broken connection, a pin that is not a digest, a partial file from a killed build. Not run: a full `./doit.sh`, which builds an ISO this machine has no toolchain for.

**Two things a reviewer should weigh**:

**The package is declared to Salt before anything installs it.** `versions.json` feeds `repo.packages`, and `metalk8s.repo.redhat` runs `check_pkg_availability` on every node, which is a `yum install --setopt tsflags=test` per declared package against the ISO repositories only. So this PR makes every node resolve `containerd-image-preload` and its dependencies at repo configuration time, before MK8S-395 installs anything. The RPM requires `containerd`, and the `containerd.io` package the ISO already ships provides it, checked on the repodata of the 133.0.13 ISO. A future version of the package that needs more has to declare it in `versions.PACKAGES`, otherwise the state fails cluster-wide, and the comment on `_rpm_package_containerd_image_preload` says so.

**`rpm_package_dir` exists because a package has to know where it lands before the repository object exists.** The repository needs the package paths for its metadata dependencies, and the package needs the repository directory, so one of the two has to derive the layout on its own. `RPMRepository.package_dir` now returns the same directory, and a test asserts both that the package lands there and that the directory sits under the repository root the metadata is built from.

**Out of scope**:

- installing the package and enabling the timer (MK8S-395)
- cutting the first image-cache release, and making the repository public (MK8S-163)
- the same leftover problem for the packages the buildchain builds itself: bumping `metalk8s-sosreport` leaves the previous RPM in the repository directory, and `RPMRepository.build_packages` does not clean it either. Untouched here, say the word if you want it fixed in this PR.
- folding the three URL fetches of the buildchain (this one, `salt_tree._download_ui_operator_crds`, `Package._get_sources`) into one helper with a timeout and a single error format. Worth doing, and it would touch code this ticket has no reason to move.
- declaring the fetched package's dependencies for the ISO download list. `RPMPackage` gets them from the spec it builds, which a finished RPM cannot offer, and declaring them by name would have dnf download an unpinned copy next to the pinned one. A test asserts the one dependency this package has is already shipped.

**Also in here**: four lines of pasted code sitting inside the module docstring of `targets/package.py`, deleted while the file was open. `coreutils.sha256_of` comes out of `sha256sum`, which held the third copy of the same chunked hashing loop.

---

See: MK8S-165
