### PR TITLE
bugfix(shell-ui): make the content column a containing block for fixed elements

### DIFF
--- a/.changes/unreleased/Fix-20260827-101247-165662701.yaml
+++ b/.changes/unreleased/Fix-20260827-101247-165662701.yaml
@@ -1,0 +1,6 @@
+kind: Fix
+body: Keep a UI's fixed-position elements — toasts and notifications — inside the content column instead of anchored to the browser viewport, so they no longer land over the drawer when it is open.
+time: 2026-08-27T10:12:47.165662701Z
+custom:
+    CommentId: "5437533581"
+    Pull: "5105"

--- a/shell-ui/src/FederatedApp.tsx
+++ b/shell-ui/src/FederatedApp.tsx
@@ -171,7 +171,13 @@ function InternalApp() {
                 <>
                   <MCPRegistrar />
                   <div style={{ display: 'flex', flex: 1, minHeight: 0 }}>
-                    <div style={{ flex: 1, minWidth: 0 }}>
+                    {/* Layout containment makes this column the containing block
+                        for its fixed-position descendants. The drawer beside it
+                        takes width from this column without the viewport
+                        changing, so a federated UI's fixed elements would
+                        otherwise stay anchored to the browser's edge and end up
+                        over the drawer. */}
+                    <div style={{ flex: 1, minWidth: 0, contain: 'layout' }}>
                       <SolutionsNavbar>
                         <InternalRouter />
                       </SolutionsNavbar>


### PR DESCRIPTION
## TL;DR

The shell's content column now declares `contain: layout`, so a federated UI's fixed-position elements anchor to the box that UI was actually given instead of to the browser viewport.

## Context

The drawer is a flex sibling of the content column, so opening it takes 500px from the column **without the viewport changing**. Anything a federated UI positions with `position: fixed` — a toast, a notification stack — keeps resolving its offsets against the viewport, so it stays pinned to the browser's edge and lands on top of the drawer. A toast raised while the drawer is open is the case users hit.

## Approach

Before:

```tsx
<div style={{ display: 'flex', flex: 1, minHeight: 0 }}>
  <div style={{ flex: 1, minWidth: 0 }}>                    // ←
    <SolutionsNavbar>
      <InternalRouter />
    </SolutionsNavbar>
  </div>
  {config.canUseGuardian && <GuardianDrawer />}
</div>
```

After:

```tsx
<div style={{ display: 'flex', flex: 1, minHeight: 0 }}>
  <div style={{ flex: 1, minWidth: 0, contain: 'layout' }}>  // ←
    <SolutionsNavbar>
      <InternalRouter />
    </SolutionsNavbar>
  </div>
  {config.canUseGuardian && <GuardianDrawer />}
</div>
```

Layout containment makes that column the containing block for its fixed descendants. Measured in an isolated reproduction of the same geometry (column `42→870`, drawer `870→1398`, viewport `1440`):

| column declares | a fixed element at `top: 3rem; right: 1rem` lands at | |
| --- | --- | --- |
| nothing | `1076→1426` | outside the column, over the drawer |
| `contain: layout` | `506→856` | inside the column, inset preserved |

**Why here rather than in each UI.** This column is the box whose width the drawer actually changes, and every UI mounted through `InternalRouter` is a descendant of it by construction — so no federated UI needs any change, whatever its own provider nesting looks like. Fixing it per-UI would mean the same declaration in every one of them, each having to guess which of its own elements corresponds to this box.

Two alternatives were measured and rejected: `contain: inline-size` and `container-type: inline-size` do **not** establish a containing block for fixed descendants (the element still lands at `1076→1426`), so the container queries already in use elsewhere neither help here nor conflict; and doing it in JavaScript — measure the overshoot, apply a compensating `transform` — reimplements one CSS declaration and only covers whichever single component is patched.

### Side effects audited

| | |
| --- | --- |
| the drawer itself | a **sibling** of the contained column, so it is outside the containment and its layout is untouched |
| scroll behaviour | a fixed child of a *scrolling* contained box scrolls away with the content (measured: `top` 20 → −280 after a 300px scroll). This column declares no `overflow` and is not a scroll container, so it does not apply — but it is the reason not to move the declaration deeper |
| `transform` / `filter` ancestors | none between the column and the mounted UIs, so containment is what takes effect here (the only `transform` in the navbar is on `SkipToContentLink`, itself a fixed leaf) |
| other fixed elements in the column | just `SkipToContentLink` — see review focus |
| portalled overlays | modals, drawers and tooltips from the component library render through `document.body` portals, so they sit outside this column and are unaffected |

## Screenshots

Isolated reproduction of the shape rather than a deployment, since the geometry is what the change is about — an opaque panel with its own stacking context beside an application box, matching `GuardianDrawer`'s width transition:

<img width="1440" height="800" alt="toast-without-containment" src="https://github.com/user-attachments/assets/729da46e-3c2b-436a-9ed3-a9b418093fd0" />
*Uncontained: the fixed element stays at the browser's right edge and is covered by the panel.*

<img width="1440" height="800" alt="toast-with-contain-layout" src="https://github.com/user-attachments/assets/7657fc34-f378-47f5-a679-f6a3bfceac4f" />
*With `contain: layout` on the column: it anchors to the column's edge.*

## Review focus

- 🔴 `shell-ui/src/FederatedApp.tsx` › `InternalApp` — this changes the containing block for **every** `position: fixed` descendant of the content column, across all mounted UIs, not just toasts. The intent is that those elements belong to the UI's box; anything that deliberately positioned itself against the viewport, or relied on covering the drawer, will move.
- ⚪ `shell-ui/src/navbar/NavBar.tsx` › `SkipToContentLink` — the shell's own fixed element inside the column. Its `left: 50%` now resolves against the column, so with the drawer open it centres over the content instead of partly beneath the drawer. Believed to be an improvement, but it is a visible change.

## How to test

1. Open any federated UI page that can raise a toast, with the drawer closed — behaviour is unchanged, since the column and the viewport coincide.
2. Open the drawer, then trigger the toast. Before this change it appears at the browser's right edge, over the drawer; after, it appears inside the content column.
3. Open and close the drawer while the toast is visible: it tracks the column's edge through the 0.25s width transition, since this is layout rather than a measurement.
4. Tab to the *Skip to content* link with the drawer open and check its position.

## Follow-up

Confirm on a deployment with the drawer open before merging — the geometry above was measured in an isolated reproduction, not on a running appliance.

<details>
<summary>What changed</summary>

One property added to the content column's inline style in `FederatedApp.tsx`, plus a comment explaining why the column has to be a containing block. No component, provider or federation change.

Deliberately not here: nothing was applied to the outer flex row. Containing the row would anchor fixed elements to the union of the column *and* the drawer, which puts them back over the drawer — measured at `1034→1384` against a row spanning `42→1398`.

</details>
