### PR TITLE
bugfix: stabilize the nightly (pre-upgrade check, Bootstrap removal, certificates beacon)

### DIFF
--- a/.changes/unreleased/Fix-20260831-095052-840179470.yaml
+++ b/.changes/unreleased/Fix-20260831-095052-840179470.yaml
@@ -1,0 +1,12 @@
+kind: Fix
+body: |-
+    The upgrade and downgrade prechecks no longer abort on a single unanswered
+    `test.ping`. Adding an ISO to the cluster replaces the salt-master container just
+    before `upgrade.sh` runs its checks, and a minion still re-authenticating against
+    the new master could miss the one probe it was given, failing the upgrade before it
+    started with `Salt minions '<node>' are not ready`. The check now pings for up to
+    two minutes, targeting only the minions it has yet to hear from
+time: 2026-08-31T09:50:52.84017947Z
+custom:
+    CommentId: "5476655433"
+    Pull: "5108"

--- a/.github/actions/remove-node/action.yaml
+++ b/.github/actions/remove-node/action.yaml
@@ -54,13 +54,15 @@ runs:
     ## call issued right after is rejected with `rpc error: code = Unavailable
     ## desc = keepalive ping failed to receive ACK within timeout`. Wait for the
     ## apiserver to be ready again before deleting the node object, and retry
-    ## the deletion itself.
+    ## the deletion itself. `ConnectTimeout` bounds each attempt: without it a
+    ## node that stops answering on port 22 burns the full kernel SYN timeout
+    ## (~134s) per attempt, and neither loop would finish in any useful time.
     ## Here we cannot use the run-command-ssh action as we need a retry loop.
     - name: "Wait for the API server to recover from the etcd reconfiguration"
       shell: bash
       run: |
         for _ in $(seq 1 24); do
-          if ssh -F ssh_config -o ServerAliveInterval=15 ${{ inputs.from-node }} \
+          if ssh -F ssh_config -o ConnectTimeout=15 -o ServerAliveInterval=15 ${{ inputs.from-node }} \
           "sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get --raw /readyz" \
           > /dev/null 2>&1; then
             exit 0
@@ -75,7 +77,7 @@ runs:
         ## `--ignore-not-found` keeps a retry idempotent, in case a previous
         ## attempt did delete the node but lost the answer.
         for attempt in $(seq 1 12); do
-          if ssh -F ssh_config -o ServerAliveInterval=15 ${{ inputs.from-node }} \
+          if ssh -F ssh_config -o ConnectTimeout=15 -o ServerAliveInterval=15 ${{ inputs.from-node }} \
           "sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf \
           delete node ${{ inputs.node-to-remove }} --ignore-not-found"; then
             exit 0

--- a/.github/actions/remove-node/action.yaml
+++ b/.github/actions/remove-node/action.yaml
@@ -49,10 +49,39 @@ runs:
           --key=/etc/kubernetes/pki/etcd/server.key
           --cacert=/etc/kubernetes/pki/etcd/ca.crt
           member remove \"${{ steps.get-id.outputs.RESULT }}\"
+    ## Removing a member makes etcd reconfigure its raft cluster, and the local
+    ## apiserver's etcd client can be unavailable while that settles: an API
+    ## call issued right after is rejected with `rpc error: code = Unavailable
+    ## desc = keepalive ping failed to receive ACK within timeout`. Wait for the
+    ## apiserver to be ready again before deleting the node object, and retry
+    ## the deletion itself.
+    ## Here we cannot use the run-command-ssh action as we need a retry loop.
+    - name: "Wait for the API server to recover from the etcd reconfiguration"
+      shell: bash
+      run: |
+        for _ in $(seq 1 24); do
+          if ssh -F ssh_config -o ServerAliveInterval=15 ${{ inputs.from-node }} \
+          "sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get --raw /readyz" \
+          > /dev/null 2>&1; then
+            exit 0
+          fi
+          sleep 5
+        done
+        echo "::error title=remove-node::API server on '${{ inputs.from-node }}' is still not ready after the removal of etcd member '${{ inputs.node-to-remove }}'"
+        exit 1
     - name: "Remove the node object"
-      uses: ./.github/actions/run-command-ssh
-      with:
-        NODE: ${{ inputs.from-node }}
-        COMMAND: >
-          sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf
-          delete node ${{ inputs.node-to-remove }}
+      shell: bash
+      run: |
+        ## `--ignore-not-found` keeps a retry idempotent, in case a previous
+        ## attempt did delete the node but lost the answer.
+        for attempt in $(seq 1 12); do
+          if ssh -F ssh_config -o ServerAliveInterval=15 ${{ inputs.from-node }} \
+          "sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf \
+          delete node ${{ inputs.node-to-remove }} --ignore-not-found"; then
+            exit 0
+          fi
+          echo "::warning title=remove-node::Could not delete the node object '${{ inputs.node-to-remove }}' (attempt ${attempt}/12), retrying"
+          sleep 5
+        done
+        echo "::error title=remove-node::Could not delete the node object '${{ inputs.node-to-remove }}'"
+        exit 1

--- a/.github/actions/sosreport-logs/action.yaml
+++ b/.github/actions/sosreport-logs/action.yaml
@@ -19,40 +19,65 @@ runs:
       run: |
         export HOSTS_LIST=""
         echo "HOSTS_LIST=bootstrap$(seq -s '' --format ' node-%g' 1 ${{ inputs.NODES_COUNT }})" >> $GITHUB_ENV
-    ## A host may legitimately be gone: the bootstrap-restore scenario destroys
-    ## the Bootstrap node on purpose, and this action runs with `if: always()`,
-    ## so it also runs when the cluster is broken. Never let one unreachable
-    ## host abort the loop, or we lose the logs of every surviving node, which
-    ## are exactly the ones worth having.
+    ## Why a host has no sosreport matters more than how many do:
+    ##
+    ##   - unreachable over ssh: expected. This action runs with `if: always()`,
+    ##     and `bootstrap-restore` destroys the Bootstrap node on purpose --
+    ##     precisely when the surviving nodes' logs are worth having. Warn and
+    ##     move on.
+    ##   - reachable, but its sosreport could not be generated or collected: the
+    ##     node was up and we lost its evidence anyway. That fails the step.
+    ##
+    ## Either way every host is attempted before any verdict is reached, so one
+    ## bad host never costs us the others.
     - name: generate sosreport on each node
       shell: bash
       run: |
+        skipped=""
+        failed=""
         for host in ${HOSTS_LIST}; do
+          if ! ssh -F ssh_config -o ConnectTimeout=15 ${host} true 2> /dev/null; then
+            echo "::warning title=sosreport::'${host}' is unreachable, skipping it"
+            skipped="${skipped} ${host}"
+            continue
+          fi
           if ! ssh -F ssh_config -o ConnectTimeout=15 ${host} \
           "sudo sos report --all-logs \
           -o metalk8s -kmetalk8s.k8s-resources -kmetalk8s.pod-logs -k metalk8s.describe -k metalk8s.metrics \
           -o metalk8s_containerd -kmetalk8s_containerd.all -kmetalk8s_containerd.logs \
           --batch --tmp-dir /var/tmp && \
           sudo chown 1000:1000 /var/tmp/sosreport*"; then
-            echo "::warning title=sosreport::Could not generate a sosreport on '${host}', skipping this host"
+            echo "::error title=sosreport::'${host}' is reachable but generating its sosreport failed"
+            failed="${failed} ${host}"
           fi
         done
+        ## Recorded rather than acted on here, so the collection below still runs
+        ## for the hosts that did produce a report.
+        echo "SOSREPORT_SKIPPED=${skipped# }" >> $GITHUB_ENV
+        echo "SOSREPORT_FAILED=${failed# }" >> $GITHUB_ENV
     - name: collect sosreport on each node
       shell: bash
       run: |
         export DEST_DIR="artifacts/sosreport/${{ github.job }}"
         mkdir -p ${DEST_DIR}
+        failed="${SOSREPORT_FAILED}"
         for host in ${HOSTS_LIST}; do
+          ## Nothing to fetch from a host we skipped, or that failed to generate.
+          case " ${SOSREPORT_SKIPPED} ${SOSREPORT_FAILED} " in
+            *" ${host} "*) continue ;;
+          esac
           if ! scp -F ssh_config -o ConnectTimeout=15 \
           "${host}:/var/tmp/sosreport-*" \
           "${DEST_DIR}/"; then
-            echo "::warning title=sosreport::Could not collect the sosreport of '${host}'"
+            echo "::error title=sosreport::'${host}' is reachable but collecting its sosreport failed"
+            failed="${failed} ${host}"
           fi
         done
-        ## A per-host failure is tolerable -- the node may be gone on purpose --
-        ## but collecting nothing at all is the case that leaves a failing job
-        ## with no evidence, so it fails the step rather than warning.
         if [ -z "$(ls -A ${DEST_DIR})" ]; then
           echo "::error title=sosreport::No sosreport could be collected from any host"
+          exit 1
+        fi
+        if [ -n "${failed# }" ]; then
+          echo "::error title=sosreport::Reachable nodes left without a sosreport: ${failed# }"
           exit 1
         fi

--- a/.github/actions/sosreport-logs/action.yaml
+++ b/.github/actions/sosreport-logs/action.yaml
@@ -49,6 +49,10 @@ runs:
             echo "::warning title=sosreport::Could not collect the sosreport of '${host}'"
           fi
         done
+        ## A per-host failure is tolerable -- the node may be gone on purpose --
+        ## but collecting nothing at all is the case that leaves a failing job
+        ## with no evidence, so it fails the step rather than warning.
         if [ -z "$(ls -A ${DEST_DIR})" ]; then
-          echo "::warning title=sosreport::No sosreport could be collected from any host"
+          echo "::error title=sosreport::No sosreport could be collected from any host"
+          exit 1
         fi

--- a/.github/actions/sosreport-logs/action.yaml
+++ b/.github/actions/sosreport-logs/action.yaml
@@ -19,16 +19,23 @@ runs:
       run: |
         export HOSTS_LIST=""
         echo "HOSTS_LIST=bootstrap$(seq -s '' --format ' node-%g' 1 ${{ inputs.NODES_COUNT }})" >> $GITHUB_ENV
+    ## A host may legitimately be gone: the bootstrap-restore scenario destroys
+    ## the Bootstrap node on purpose, and this action runs with `if: always()`,
+    ## so it also runs when the cluster is broken. Never let one unreachable
+    ## host abort the loop, or we lose the logs of every surviving node, which
+    ## are exactly the ones worth having.
     - name: generate sosreport on each node
       shell: bash
       run: |
         for host in ${HOSTS_LIST}; do
-          ssh -F ssh_config ${host} \
+          if ! ssh -F ssh_config -o ConnectTimeout=15 ${host} \
           "sudo sos report --all-logs \
           -o metalk8s -kmetalk8s.k8s-resources -kmetalk8s.pod-logs -k metalk8s.describe -k metalk8s.metrics \
           -o metalk8s_containerd -kmetalk8s_containerd.all -kmetalk8s_containerd.logs \
           --batch --tmp-dir /var/tmp && \
-          sudo chown 1000:1000 /var/tmp/sosreport*"
+          sudo chown 1000:1000 /var/tmp/sosreport*"; then
+            echo "::warning title=sosreport::Could not generate a sosreport on '${host}', skipping this host"
+          fi
         done
     - name: collect sosreport on each node
       shell: bash
@@ -36,7 +43,12 @@ runs:
         export DEST_DIR="artifacts/sosreport/${{ github.job }}"
         mkdir -p ${DEST_DIR}
         for host in ${HOSTS_LIST}; do
-          scp -F ssh_config \
+          if ! scp -F ssh_config -o ConnectTimeout=15 \
           "${host}:/var/tmp/sosreport-*" \
-          "${DEST_DIR}/"
+          "${DEST_DIR}/"; then
+            echo "::warning title=sosreport::Could not collect the sosreport of '${host}'"
+          fi
         done
+        if [ -z "$(ls -A ${DEST_DIR})" ]; then
+          echo "::warning title=sosreport::No sosreport could be collected from any host"
+        fi

--- a/.github/workflows/multi-node-test.yaml
+++ b/.github/workflows/multi-node-test.yaml
@@ -275,6 +275,23 @@ jobs:
       - name: Copy the new SSH config to current directory
         if: inputs.bootstrap-restore
         run: cp terraform-snapshot/terraform/ssh_config ./
+      ## The initial Bootstrap node got its Salt minion ID pinned to
+      ## "bootstrap" by the generate-bootstrap action, and that is the name its
+      ## Kubernetes Node object carries. The node we just re-created is a fresh
+      ## machine with no /etc/salt/minion_id, so Salt would fall back to its
+      ## hostname, and `restore.sh` deploys the node under `grains.get id` --
+      ## the restored Bootstrap would come back as
+      ## "metalk8s-<...>-bootstrap" instead of "bootstrap", next to the
+      ## "bootstrap" Node object the backup restores. Pin the ID again so the
+      ## restored cluster matches the one that was backed up, the way it does
+      ## on a real platform where the hostname never changed.
+      - name: Enforce the Bootstrap node name before restoring
+        if: inputs.bootstrap-restore
+        uses: ./.github/actions/run-command-ssh
+        with:
+          COMMAND: |
+            sudo mkdir -p /etc/salt
+            echo 'bootstrap' | sudo tee /etc/salt/minion_id
       - name: Copy the backup archive to the new Bootstrap node
         if: inputs.bootstrap-restore
         uses: ./.github/actions/copy-file-ssh

--- a/salt/_runners/metalk8s_checks.py
+++ b/salt/_runners/metalk8s_checks.py
@@ -3,9 +3,20 @@
 Runner module handling MetalK8s cluster checks.
 """
 
+import logging
+import time
+
 from salt.exceptions import CheckError
 
+log = logging.getLogger(__name__)
+
 __virtualname__ = "metalk8s_checks"
+
+# A salt-master container replacement leaves the minions re-authenticating for
+# a while, tolerate roughly two minutes of that before declaring one down.
+MINIONS_PING_TIMEOUT = 10
+MINIONS_PING_ATTEMPTS = 6
+MINIONS_PING_INTERVAL = 10
 
 
 def __virtual__():
@@ -71,12 +82,27 @@ def nodes(node_list=None, raises=True):
     return _handle_errors(errors, raises)
 
 
-def minions(minion_list=None, raises=True):
+def minions(
+    minion_list=None,
+    raises=True,
+    timeout=MINIONS_PING_TIMEOUT,
+    attempts=MINIONS_PING_ATTEMPTS,
+    interval=MINIONS_PING_INTERVAL,
+):
     """Check that all Salt minions are Ready
+
+    A minion may legitimately miss a `test.ping` while it re-authenticates
+    against a salt-master that has just been replaced, so a single unanswered
+    probe is not enough to declare it down. Ping again, every `interval`
+    seconds and up to `attempts` times, targeting only the minions we have yet
+    to hear from.
 
     Args:
         minion_list (list, optional): List of Salt minion to check. Defaults to `pillar.metalk8s.nodes`.
         raises (bool, optional): Whether or not this function should raise. Defaults to True.
+        timeout (int, optional): Timeout, in seconds, of a single `test.ping`. Defaults to 10.
+        attempts (int, optional): How many times to ping the minions we did not hear from. Defaults to 6.
+        interval (int, optional): Seconds to wait between two attempts. Defaults to 10.
 
     Raises:
         CheckError: If 'raises' is True and some Salt minions are not ready
@@ -89,18 +115,39 @@ def minions(minion_list=None, raises=True):
     if minion_list is None:
         minion_list = __pillar__["metalk8s"]["nodes"].keys()
 
-    ret = __salt__["salt.execute"](
-        ",".join(minion_list), "test.ping", tgt_type="list", timeout=10
-    )
+    attempts = max(attempts, 1)
+    pending = list(minion_list)
+    not_ready = []
+    no_answer = []
 
-    not_ready_minions = {
-        "are not ready": [
+    for attempt in range(1, attempts + 1):
+        if attempt > 1:
+            time.sleep(interval)
+
+        ret = __salt__["salt.execute"](
+            ",".join(pending), "test.ping", tgt_type="list", timeout=timeout
+        )
+
+        not_ready = [
             minion for minion, minion_ret in ret.items() if minion_ret is not True
-        ],
-        "did not answered": list(set(minion_list) - set(ret.keys())),
-    }
+        ]
+        no_answer = sorted(set(pending) - set(ret.keys()))
 
-    for reason, minions_names in not_ready_minions.items():
+        pending = not_ready + no_answer
+        if not pending:
+            break
+
+        log.warning(
+            "Salt minions '%s' did not answer 'test.ping' (attempt %d/%d)",
+            "', '".join(pending),
+            attempt,
+            attempts,
+        )
+
+    for reason, minions_names in [
+        ("are not ready", not_ready),
+        ("did not answered", no_answer),
+    ]:
         if minions_names:
             errors.append(
                 "Salt minions '{}' {}".format(  # pylint: disable=consider-using-f-string

--- a/salt/tests/unit/runners/files/test_metalk8s_checks.yaml
+++ b/salt/tests/unit/runners/files/test_metalk8s_checks.yaml
@@ -224,6 +224,49 @@ minions:
         - Salt minions 'node-2' are not ready
         - Salt minions 'no-answer-minion' did not answered
 
+  # 7. Success: a minion is not ready on the first ping and answers on retry
+  - minion_list:
+      - node-1
+      - node-2
+    ping_rets:
+      - node-1: True
+        node-2: False
+      - node-2: True
+    # Only the minion we have yet to hear from is pinged again
+    expected_targets:
+      - node-1,node-2
+      - node-2
+    result: True
+
+  # 8. Success: a minion does not answer the first ping and answers on retry
+  - minion_list:
+      - node-1
+      - node-2
+    ping_rets:
+      - node-1: True
+      - node-2: True
+    expected_targets:
+      - node-1,node-2
+      - node-2
+    result: True
+
+  # 9. Failure: a minion never answers, every attempt is used
+  - minion_list:
+      - node-1
+      - node-2
+    ping_rets:
+      - node-1: True
+      - {}
+      - {}
+    attempts: 3
+    expect_raise: True
+    expected_targets:
+      - node-1,node-2
+      - node-2
+      - node-2
+    result: |-
+      Salt minions 'node-2' did not answered
+
 upgrade:
   # 1. Success: nominal (minor upgrade)
   - pillar:

--- a/salt/tests/unit/runners/test_run_metalk8s_checks.py
+++ b/salt/tests/unit/runners/test_run_metalk8s_checks.py
@@ -58,22 +58,40 @@ class Metalk8sChecksTestCase(TestCase, mixins.LoaderModuleMockMixin):
 
     @utils.parameterized_from_cases(YAML_TESTS_CASES["minions"])
     def test_minions(
-        self, result, pillar=None, expect_raise=False, ping_ret=None, **kwargs
+        self,
+        result,
+        pillar=None,
+        expect_raise=False,
+        ping_ret=None,
+        ping_rets=None,
+        expected_targets=None,
+        **kwargs
     ):
         """
         Tests the return of `minions` function
         """
-        salt_dict = {"salt.execute": MagicMock(return_value=ping_ret)}
+        if ping_rets is not None:
+            execute_mock = MagicMock(side_effect=ping_rets)
+        else:
+            execute_mock = MagicMock(return_value=ping_ret)
+
+        salt_dict = {"salt.execute": execute_mock}
 
         with patch.dict(metalk8s_checks.__pillar__, pillar or {}), patch.dict(
             metalk8s_checks.__salt__, salt_dict
-        ):
+        ), patch("time.sleep", MagicMock()):
             if expect_raise:
                 self.assertRaisesRegex(
                     CheckError, result, metalk8s_checks.minions, **kwargs
                 )
             else:
                 self.assertEqual(metalk8s_checks.minions(**kwargs), result)
+
+        if expected_targets is not None:
+            self.assertEqual(
+                [call[0][0] for call in execute_mock.call_args_list],
+                expected_targets,
+            )
 
     @utils.parameterized_from_cases(YAML_TESTS_CASES["upgrade"])
     def test_upgrade(

--- a/tests/test-certificates-beacon.sh
+++ b/tests/test-certificates-beacon.sh
@@ -20,6 +20,14 @@ SALT_DEFAULTS=$ARCHIVE_MOUNTPOINT/salt/metalk8s/defaults.yaml
 OVERRIDE_ROOT_CONF=/etc/salt/master.d/90-metalk8s-root-override.conf
 OVERRIDE_PILLAR_DEST=/etc/salt/pillar-override
 WAIT_RENEWAL=${WAIT_RENEWAL:-120}
+# `override_pillar_conf` and `reset_pillar_conf` both restart the salt-master.
+# A beacon-triggered state job that was already running on a minion then blocks
+# on fileserver requests for as long as the master is away, holding that
+# minion's state lock; every `state.apply` issued meanwhile is rejected
+# instantly by the state system. Such a job has been observed holding the lock
+# for over 4 minutes, so the default `wait_minions` budget (10 retries, ~50s)
+# is far too short.
+WAIT_MINIONS_RETRIES=${WAIT_MINIONS_RETRIES:-60}
 
 # shellcheck disable=SC1090
 . "$ARCHIVE_PRODUCT_INFO"
@@ -101,6 +109,23 @@ apply_new_beacon_conf() {
     run_certificates_beacon_state "${pillar[*]}"
 }
 
+wait_minion_idle() {
+    local -r salt_container=$1 minion=$2
+    local output
+
+    # NOTE: `salt-run` exits 0 even when a runner raises, so the exit status
+    # tells us nothing and the output has to be inspected instead.
+    # See https://github.com/saltstack/salt/issues/61173
+    output=$(
+        crictl exec -i "$salt_container" \
+            salt-run metalk8s_saltutil.wait_minions \
+            tgt="$minion" retry="$WAIT_MINIONS_RETRIES" 2>&1
+    )
+    echo "$output"
+
+    [[ $output == *"responded and finished startup"* ]]
+}
+
 reset_beacon_conf() {
     local salt_container
 
@@ -109,9 +134,16 @@ reset_beacon_conf() {
     readarray -t minions < <(get_salt_minion_ids)
 
     for minion in "${minions[@]}"; do
-        crictl exec -i "$salt_container" \
-            salt-run metalk8s_saltutil.wait_minions tgt="$minion"
-        crictl exec -i "$salt_container" salt "$minion" beacons.disable
+        echo "Waiting for $minion to be idle..."
+        if ! wait_minion_idle "$salt_container" "$minion"; then
+            echo "ERROR: $minion is still running a state, its beacon" \
+                 "configuration cannot be reset." >&2
+            exit 1
+        fi
+        if ! crictl exec -i "$salt_container" salt "$minion" beacons.disable; then
+            echo "ERROR: Unable to disable beacons on $minion." >&2
+            exit 1
+        fi
     done
 
     run_certificates_beacon_state


### PR DESCRIPTION
Refs: [MK8S-399](https://scality.atlassian.net/browse/MK8S-399)

**Component**: salt, tests, CI

## Goal

Stabilize the nightly.

Triaging the last ten nightly runs turned up **six independent** failure causes.
This PR fixes five of them, one per commit. Occurrence counts are over the
nightlies where the affected step actually ran:

| # | Failure | Hits | Fixed here |
|---|---|---|---|
| A | Pre-upgrade/downgrade check aborts on one unanswered `test.ping` | 4 | ✅ commit 1 |
| C | `remove-node` races the etcd reconfiguration | 3 | ✅ commit 2 |
| D | `sosreport-logs` collects nothing when a node is intentionally gone | 3 | ✅ commit 2 |
| G | Certificates beacon reset runs into a locked minion | 2 | ✅ commit 3 |
| F | Bootstrap node renamed by a restore, `test_majority_outage_alerts` gaierror | 5/5 | ✅ commit 4 |
| B | cert-manager webhook 500 aborts `Deploy Kubernetes objects` | 2 | ❌ see below |

Validated by three Nightly runs dispatched on this branch — unlike pre-merge they set
`bootstrap-restore: true`, so they exercise all of it.

| Run | Commits included | Result | Failures |
|---|---|---|---|
| [33386960599](https://github.com/scality/metalk8s/actions/runs/33386960599) | 1, 2 | 20/21 | F |
| [33412485357](https://github.com/scality/metalk8s/actions/runs/33412485357) | 1, 2 | 18/20 | F, G |
| [**33443284927**](https://github.com/scality/metalk8s/actions/runs/33443284927) (attempt 1) | **1, 2, 3, 4** | **20/20 — green** | **none** |
| [**33443284927**](https://github.com/scality/metalk8s/actions/runs/33443284927) (attempt 2) | **1, 2, 3, 4** | **20/20 — green** | **none** |

In the first two runs the only failures were the flakes not yet fixed at that SHA. The
third run, the first build carrying all four commits, is **the first fully green
nightly** of this campaign — against 2 failures on each of the four preceding runs on
`development/133.0`.

**Per-fix evidence across those runs:**

| Fix | Status | Evidence |
|---|---|---|
| A | **proven** | 33386960599: retry fired at 41s (`attempt 1/6`) and recovered on attempt 2 — that run would have failed on the old code |
| C | **proven ×3** | The etcd race fired and was absorbed in **all three** consecutive nightlies (`Could not delete the node object 'bootstrap' (attempt 1/12), retrying` → `node "bootstrap" deleted`) |
| D | **proven** | All 3 sosreports collected from *failing* jobs, versus nothing on 08-29 and 08-31 |
| F | **proven ×2** | Was deterministic 5/5; now passes in both green runs (`137 passed, 1 skipped`, zero gaierror). After-restore suite went from `1 failed, 136 passed, 1 skipped` to **`137 passed, 1 skipped`**, zero gaierror |
| G | **exercised ×4, not yet proven** | The new `Waiting for <minion> to be idle...` path ran on all 3 minions in both 3-node jobs of both green runs and both certificates tests passed, but no `ERROR: … is still running a state` — the race did not occur. Confirms the fix is wired in and free on the happy path; an occurrence is still needed to demonstrate recovery |

A likewise did not trigger in run 33443284927, which is expected — it is intermittent and
was already proven in 33386960599.

---

## Commit 1 — `bugfix(salt)`: retry the pre-upgrade Salt minion check

`metalk8s_checks.minions` fired a **single** `test.ping` with a 10s timeout and no
retry, gating `upgrade.sh` (`precheck_upgrade`) and `downgrade.sh` before anything
else runs.

`Add the ISO to the cluster` replaces the salt-master static pod just before those
checks. `salt/metalk8s/salt/master/installed.sls` waits for the container and for
the Salt API to answer, but nothing waits for the **minions** to re-authenticate.

The threshold turned out to be remarkably sharp — every failure at ≤45s, every
clean first-ping pass at ≥47s, i.e. reconnection takes ~46s:

| Nightly / job | master→precheck gap | Outcome |
|---|---|---|
| 08-20 | 45s | **failed** (no retry existed) |
| 08-27 | 42s | **failed** |
| 08-29 | 40s | **failed** |
| 08-31 `development/133.0` | 41s | **failed** |
| 08-31 branch run 1, patch | 41s | retry fired → **recovered** |
| 08-31 branch run 1, major | 47s | no retry needed |
| 08-31 branch run 2 (×3 jobs) | 47/48/51s | no retry needed |

`minions()` now pings up to 6 times, 10s apart, targeting **only the minions it has
yet to hear from**. ~2min of tolerance against a ~46s window. `timeout`, `attempts`
and `interval` are arguments.

**Proof it works** — from run 33386960599, the fix engaging on the real fault:
```
11:49:28  salt-master static pod replaced
11:49:46  > Performing Pre-Upgrade checks...
11:50:09  [WARNING] Salt minions 'node-1' did not answer 'test.ping' (attempt 1/6)
11:50:19  Runner completed                              ← attempt 2 succeeded
```
That run would have failed on the old code. In run 33412485357 no retry was needed
in any of three jobs, confirming the fix is inert on the happy path.

## Commit 2 — `ci`: survive the etcd reconfiguration when removing the Bootstrap node

Two defects in the `bootstrap-restore` teardown, always hit together — they failed
that job on 08-29 and 08-31, and the second is why neither failure left any
cluster-side evidence.

**`.github/actions/remove-node`** issued `kubectl delete node` **0.25s** after
`etcdctl member remove`. Removing a member makes etcd reconfigure its raft cluster
and the local apiserver's etcd client is briefly unavailable, so the next call came
back `rpc error: code = Unavailable desc = keepalive ping failed to receive ACK
within timeout`, with no retry. Now waits for `/readyz`, then retries the
deletion with `--ignore-not-found` so a retry stays idempotent. Both loops pass
`-o ConnectTimeout=15` (review, commit 5): normal paths ~120s and ~60s, and against a
node blackholed on port 22 the bounds are ~8min and ~4min rather than the ~55min and
~28min a full kernel SYN timeout per attempt would have cost.

**`.github/actions/sosreport-logs`** looped over every host under `bash -e`, and this
scenario destroys the Bootstrap node on purpose. The ssh to it hung for the full TCP
connect timeout (~2m15s) then aborted the loop, so `collect sosreport` was skipped
and the surviving nodes produced **no logs at all**. Now caps the connect at 15s and
never lets one host abort the loop. Following review (commits 5-6), the verdict is
based on **why** a host has no report rather than how many do — every host is still
attempted before any verdict:

| Case | Result |
|---|---|
| all hosts collected | green |
| host unreachable over ssh (the Bootstrap destroyed on purpose) | green + warning |
| host reachable, but its sosreport could not be generated or collected | **red**, naming it |
| nothing collected at all | **red** |

The reports that *did* succeed are still uploaded in the red cases — the point is to
keep the evidence and surface the gap, not to choose between them.

**Proof it works** — from run 33386960599:
```
14:27:41.258  Member 45900ab54454ecde removed from cluster
14:27:41.26→41.58  /readyz gate passed immediately
14:27:51.892  Error from server: rpc error … keepalive ping failed to receive ACK
14:27:51.897  ##[warning]Could not delete the node object 'bootstrap' (attempt 1/12), retrying
14:27:57.198  node "bootstrap" deleted
```
Note the `/readyz` gate passed instantly and the first delete **still** hit the stale
etcd client — the gate alone would not have saved this run, the delete retry did.
Both layers are needed. In the same run all three sosreports were collected from a
job that failed, versus nothing on 08-29 and 08-31. Run 33412485357 hit the same
etcd race again and the retry absorbed it a second time.

## Commit 3 — `tests(certificates)`: wait for an idle minion before resetting the beacons

`Run certificates expiration tests` failed on 08-14 and 08-31 with ten identical
`ERROR: Minions returned with non-zero exit code` and nothing else.

Root-caused from the sosreports. The script stops the salt-master twice; a
beacon-triggered state job already running on a minion then blocks on fileserver
requests while the master is away, holding that minion's **state lock**. Every
`state.apply` issued meanwhile is rejected by the state system in ~85ms — that is
what those ten errors were (a successful apply takes ~3.4s, and the rejections log
nothing at all on the minion, which is why the CI log looked so bare).

```
18:44:50.833  node-2 starts state.sls …184450825087 (beacon-triggered kubeconfig regen)
18:44:51Z     reset_pillar_conf → crictl stop salt-master (exitCode 137)
              ↳ job blocks on metalk8s/defaults.yaml → SaltReqTimeoutError ×3
                → holds the state lock
18:45:36.840  ┐ wait_minions: 11 × saltutil.is_running "state.*", 51.9s
18:46:28.733  ┘ full retry=10 budget exhausted → raises CommandExecutionError … DISCARDED
18:46:40 →    11 × state.apply rejected by the lock in ~85ms each
18:48:26      retry budget exhausted → exit 1
18:48:53.081  the stuck job finally returns — 27 SECONDS after we gave up
```

So the guard was already there and it **worked** — its failure was thrown away.
`salt-run` exits 0 even when a runner raises
([saltstack#61173](https://github.com/saltstack/salt/issues/61173)), and the script
sets only `pipefail`, never `-e`.

The fix inspects the runner's output instead of its useless exit status, fails with
a message naming the minion, and raises the budget from the default 10 retries
(~50s) to 60 (~5min) — the observed lock was 4m03s. `beacons.disable` is checked too.

Why it is intermittent: it needs a beacon-triggered job in flight in the ~1s window
before the master is killed. The sibling patch job passed the same step 9 minutes
later on identical infrastructure.

## Commit 4 — `ci`: keep the Bootstrap node name across a restore

`test_majority_outage_alerts` has failed in **every** nightly where `Run tests from
Bastion after restore` actually ran — 08-14, 08-19, 08-27 and twice on 08-31 — with
`socket.gaierror: [Errno -2] Name or service not known` for
`metalk8s-nightly-<build>-bootstrap-restore-bootstrap`. Not a flake: the test was
added on 2026-07-21 (0900c8fdc) and has never passed in this scenario. It was masked
on 08-29 and 08-31 only because the job died earlier at the step commit 2 fixes.

`generate-bootstrap` pins the Salt minion ID to `bootstrap`, which is why Node
objects here are `bootstrap`/`node-1`/`node-2`. It runs **once**, for the initial
Bootstrap. The node re-created for the restore is a fresh machine with no
`/etc/salt/minion_id`, so Salt falls back to its hostname and `restore.sh` deploys
under `grains.get id`:

```bash
local -r bootstrap_id=$(${SALT_CALL} --local --out txt grains.get id | ...)
... state.orchestrate metalk8s.orchestrate.deploy_node \
    pillar="{'orchestrate': {'node_name': '$bootstrap_id'}}"
```

So the restored Bootstrap comes back as `metalk8s-<...>-bootstrap`, **alongside the
`bootstrap` Node object the backup restores** — a divergence the scenario has been
silently tolerating.

`test_majority_outage_alerts` is the only test that reaches the Bootstrap by its
Kubernetes name (it cuts a *majority*; the others pick a workload-plane node), and
feeds it to `testinfra.get_host`, which matches no `Host` block in the bastion
ssh_config and does not resolve. `--hosts=bootstrap` keeps working throughout, which
is why the other 136 tests pass.

Pinning the ID again on the re-created node makes the restored cluster match the one
that was backed up — as on a real platform, where the hostname never changed and the
node keeps its name.

## Testing

- `tox -e unit-tests` green, `salt/_runners/metalk8s_checks.py` at 100% statement
  coverage (101/101), which is what `--cov-fail-under=100` requires. Three fixture
  cases added, asserting the *target* of each `salt.execute` call — that is what pins
  the "only re-ping what is pending" behaviour.
- `shellcheck` clean on `tests/test-certificates-beacon.sh`.
- No repo lint covers `.github/`, so those were exercised against fake `ssh`/`scp` on
  `PATH`. `remove-node`: `/readyz` recovering on the 3rd poll then two keepalive
  rejections → deletes on the 3rd attempt; both "never recovers" paths still exit 1.
  `sosreport-logs`: all five outcomes in the table above, each asserted on both the
  exit status and the number of reports collected. `shellcheck` clean on the extracted
  step scripts.
- The `wait_minion_idle` helper was checked against both real `wait_minions`
  outcomes, which **both exit 0** — it correctly distinguishes them.

> [!NOTE]
> Commit 3's path is only reachable through a real `Run certificates expiration
> tests`, and commit 2's through a real `bootstrap-restore`; pre-merge runs neither
> (`e2e-tests.yaml` does not pass `bootstrap-restore` and `multi-node-test.yaml`
> defaults it to false). A Nightly dispatched on this branch is the way to exercise
> them, as done for A/C/D above.

## Not in this PR

- **B — cert-manager webhook 500 aborts `Deploy Kubernetes objects`** (2 hits, 08-14
  and 08-27, byte-identical): `Apply cert-manager.io/v1/Certificate
  'metalk8s-certs/crl-operator-serving-cert'` → `failed calling webhook
  "webhook.cert-manager.io" … read: connection reset by peer`. None of the ~500 states
  generated by `salt/_renderers/metalk8s_kubernetes.py` carry a retry; the natural
  choke point is the `except (ApiException, HTTPError)` in
  `salt/_modules/metalk8s_kubernetes.py`. Needs a judgement call on which statuses are
  safe to replay, hence left out.
- **Diagnosability**: `retry()` in `scripts/common.sh.in` captures the command's stdout
  and discards it on final failure, printing only "Failed to run … after N retries".
  That is why G was invisible from CI for two months. A one-line change (echo the
  captured output to stderr) would make the next occurrence self-diagnosing; kept out
  because that file ships in the ISO.

[MK8S-399]: https://scality.atlassian.net/browse/MK8S-399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ