### PR TITLE
feat(salt): install and enable the containerd image preload timer (MK8S-395)

### DIFF
--- a/.changes/unreleased/Added-20260901-135539-931914026.yaml
+++ b/.changes/unreleased/Added-20260901-135539-931914026.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Every node now installs the `containerd-image-preload` package and runs its timer. The timer imports the image archives found under `/var/lib/image-cache` into containerd, once at boot and then every 10 minutes, so a node that lost images from its content store gets them back without reaching a registry. Nothing fills that directory yet, so the timer is a no-op on a fresh cluster until the cache provisioning lands.
+time: 2026-09-01T13:55:39.931914026Z
+custom:
+    CommentId: "5495059961"
+    Pull: "5109"

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -535,6 +535,8 @@ SALT_FILES: Tuple[Union[Path, targets.AtomicTarget], ...] = (
     Path("salt/metalk8s/defaults.yaml"),
     Path("salt/metalk8s/deployed/core.sls"),
     Path("salt/metalk8s/deployed/init.sls"),
+    Path("salt/metalk8s/image-cache/init.sls"),
+    Path("salt/metalk8s/image-cache/installed.sls"),
     Path("salt/metalk8s/internal/bootstrap/post-upgrade.sls"),
     Path("salt/metalk8s/internal/preflight/init.sls"),
     Path("salt/metalk8s/internal/preflight/mandatory.sls"),

--- a/salt/metalk8s/image-cache/init.sls
+++ b/salt/metalk8s/image-cache/init.sls
@@ -1,0 +1,2 @@
+include:
+  - .installed

--- a/salt/metalk8s/image-cache/installed.sls
+++ b/salt/metalk8s/image-cache/installed.sls
@@ -1,0 +1,36 @@
+{%- from "metalk8s/macro.sls" import pkg_installed with context %}
+{%- from "metalk8s/map.jinja" import kubelet with context %}
+
+{%- if kubelet.container_engine == 'containerd' %}
+
+include:
+  - metalk8s.repo
+  - metalk8s.container-engine.containerd.installed
+  - metalk8s.container-engine.containerd.running
+
+Install containerd image preload:
+  {{ pkg_installed('containerd-image-preload') }}
+    - require:
+      - test: Repositories configured
+      # NOTE: The package requires `containerd`, a virtual name the
+      # `containerd.io` package we ship provides. Ordering the two keeps a
+      # fresh node from resolving that dependency to another provider.
+      - metalk8s_package_manager: Install containerd
+
+Ensure containerd image preload timer running:
+  service.running:
+    - name: containerd-image-preload.timer
+    - enable: True
+    - require:
+      - metalk8s_package_manager: Install containerd image preload
+      # NOTE: The timer fires as soon as it starts (`OnBootSec=0`), then
+      # every 10 minutes, and the service imports into a running containerd,
+      # so wait for the engine rather than let the first run fail.
+      - test: Ensure containerd is ready
+
+{%- else %}
+
+No containerd to preload images into:
+  test.succeed_without_changes
+
+{%- endif %}

--- a/salt/metalk8s/image-cache/installed.sls
+++ b/salt/metalk8s/image-cache/installed.sls
@@ -4,9 +4,7 @@
 {%- if kubelet.container_engine == 'containerd' %}
 
 include:
-  - metalk8s.repo
   - metalk8s.container-engine.containerd.installed
-  - metalk8s.container-engine.containerd.running
 
 Install containerd image preload:
   {{ pkg_installed('containerd-image-preload') }}

--- a/salt/metalk8s/roles/bootstrap/init.sls
+++ b/salt/metalk8s/roles/bootstrap/init.sls
@@ -4,3 +4,4 @@ include:
   - metalk8s.salt.master
   - metalk8s.utils
   - metalk8s.backup.configured
+  - metalk8s.image-cache

--- a/salt/metalk8s/roles/bootstrap/init.sls
+++ b/salt/metalk8s/roles/bootstrap/init.sls
@@ -4,4 +4,3 @@ include:
   - metalk8s.salt.master
   - metalk8s.utils
   - metalk8s.backup.configured
-  - metalk8s.image-cache

--- a/salt/metalk8s/roles/node/init.sls
+++ b/salt/metalk8s/roles/node/init.sls
@@ -4,3 +4,4 @@ include:
   - metalk8s.kubernetes.apiserver-proxy
   - metalk8s.internal.preflight
   - metalk8s.beacon.certificates
+  - metalk8s.image-cache

--- a/salt/tests/unit/formulas/config.yaml
+++ b/salt/tests/unit/formulas/config.yaml
@@ -252,6 +252,15 @@ metalk8s:
                   HTTP_PROXY: http://my-proxy.local
                   HTTPS_PROXY: https://my-proxy.local
 
+  image-cache:
+    installed.sls:
+      _cases:
+        "Containerd (default)": {}
+        "Without any container engine":
+          pillar_overrides:
+            kubelet:
+              container_engine: ""
+
   kubernetes:
     apiserver:
       files:

--- a/salt/tests/unit/formulas/fixtures/rendered.py
+++ b/salt/tests/unit/formulas/fixtures/rendered.py
@@ -5,7 +5,7 @@ states, get the parsed documents from here instead of rendering the template the
 """
 
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Tuple
+from typing import Any, Dict, Iterable, Iterator, List, Set, Tuple
 
 import jinja2
 import pytest
@@ -32,3 +32,27 @@ def fixture_rendered_states(
         (context.id, salt.utils.yaml.safe_load(template.render(**context.data)))
         for context in render_contexts
     ]
+
+
+def _iter_required_ids(state_body: Dict[str, Any]) -> Iterator[str]:
+    """Yield the state IDs listed in the `require` requisites of a single state."""
+    for state_args in state_body.values():
+        # A state declared without any argument renders as `None`.
+        for state_arg in state_args or []:
+            if isinstance(state_arg, dict):
+                for requisite in state_arg.get("require", []):
+                    yield from requisite.values()
+
+
+def required_states(states: Dict[str, Any], state_id: str) -> Set[str]:
+    """List the state IDs a state depends on, following the `require` chains."""
+    required: Set[str] = set()
+    to_visit: List[str] = [state_id]
+
+    while to_visit:
+        for required_id in _iter_required_ids(states.get(to_visit.pop(), {})):
+            if required_id not in required:
+                required.add(required_id)
+                to_visit.append(required_id)
+
+    return required

--- a/salt/tests/unit/formulas/test_container_engine.py
+++ b/salt/tests/unit/formulas/test_container_engine.py
@@ -6,11 +6,10 @@ container engine of that version is not the one installed on the node (see MK8S-
 """
 
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Set
 
 import pytest
 
-from tests.unit.formulas.fixtures.rendered import RenderedStates
+from tests.unit.formulas.fixtures.rendered import RenderedStates, required_states
 
 CONTAINERD_INSTALLED = Path("metalk8s/container-engine/containerd/installed.sls")
 
@@ -24,30 +23,6 @@ REQUIRED_GATES = ["Install containerd", "Repositories configured"]
 
 # States writing a version specific containerd configuration.
 CONFIGURATION_STATES = ["Configure containerd", "Configure containerd registries"]
-
-
-def _iter_required_ids(state_body: Dict[str, Any]) -> Iterator[str]:
-    """Yield the state IDs listed in the `require` requisites of a single state."""
-    for state_args in state_body.values():
-        # A state declared without any argument renders as `None`.
-        for state_arg in state_args or []:
-            if isinstance(state_arg, dict):
-                for requisite in state_arg.get("require", []):
-                    yield from requisite.values()
-
-
-def _required_states(states: Dict[str, Any], state_id: str) -> Set[str]:
-    """List the state IDs a state depends on, following the `require` chains."""
-    required: Set[str] = set()
-    to_visit: List[str] = [state_id]
-
-    while to_visit:
-        for required_id in _iter_required_ids(states.get(to_visit.pop(), {})):
-            if required_id not in required:
-                required.add(required_id)
-                to_visit.append(required_id)
-
-    return required
 
 
 @pytest.mark.formulas
@@ -64,11 +39,11 @@ def test_containerd_configuration_requires_the_package(
         for state_id in CONFIGURATION_STATES:
             assert state_id in states, f"no '{state_id}' state ({case_id})"
 
-            required_states = _required_states(states, state_id)
+            gates = required_states(states, state_id)
             for gate in REQUIRED_GATES:
                 missing_gate = (
                     f"'{state_id}' does not require '{gate}', it would write a version"
                     " specific configuration for a container engine that is not the one"
                     " installed on the node"
                 )
-                assert gate in required_states, f"{missing_gate} ({case_id})"
+                assert gate in gates, f"{missing_gate} ({case_id})"

--- a/salt/tests/unit/formulas/test_image_cache.py
+++ b/salt/tests/unit/formulas/test_image_cache.py
@@ -1,0 +1,73 @@
+"""Tests for the requisites of the image cache states.
+
+The rendering tests only prove that a template can be rendered. Here we check the
+ordering the `containerd-image-preload` timer needs: it fires as soon as it is
+started, and the import it runs goes into a containerd that must already be up.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from tests.unit.formulas.fixtures.rendered import RenderedStates, required_states
+
+IMAGE_CACHE_INSTALLED = Path("metalk8s/image-cache/installed.sls")
+
+# Formulas defining the states we depend on, they must stay in the `include` block.
+REQUIRED_FORMULAS = [
+    "metalk8s.repo",
+    "metalk8s.container-engine.containerd.installed",
+    "metalk8s.container-engine.containerd.running",
+]
+
+TIMER_STATE = "Ensure containerd image preload timer running"
+
+# What the formula renders instead when the node runs no containerd.
+NO_ENGINE_STATE = "No containerd to preload images into"
+
+# States the timer must depend on: its own package, the containerd package the
+# preload script needs, and the readiness check on the running engine.
+REQUIRED_GATES = [
+    "Install containerd image preload",
+    "Install containerd",
+    "Ensure containerd is ready",
+    "Repositories configured",
+]
+
+
+@pytest.mark.formulas
+@pytest.mark.parametrize("template_path", [IMAGE_CACHE_INSTALLED], indirect=True)
+def test_preload_timer_requires_a_running_containerd(
+    rendered_states: RenderedStates,
+) -> None:
+    """Check the preload timer only starts once containerd is installed and ready."""
+    checked = False
+
+    for case_id, states in rendered_states:
+        if TIMER_STATE not in states:
+            # Nothing to preload into, the formula must not pull containerd in.
+            assert (
+                NO_ENGINE_STATE in states
+            ), f"no '{NO_ENGINE_STATE}' state ({case_id})"
+            assert "include" not in states, f"unexpected includes ({case_id})"
+            continue
+
+        includes = states.get("include", [])
+        for formula in REQUIRED_FORMULAS:
+            assert (
+                formula in includes
+            ), f"'{formula}' is not included, the gates cannot resolve ({case_id})"
+
+        gates = required_states(states, TIMER_STATE)
+        for gate in REQUIRED_GATES:
+            missing_gate = (
+                f"'{TIMER_STATE}' does not require '{gate}', the timer could fire"
+                " before containerd can serve the import"
+            )
+            assert gate in gates, f"{missing_gate} ({case_id})"
+
+        checked = True
+
+    assert (
+        checked
+    ), "no rendering case installs the timer, the requisites went unchecked"

--- a/salt/tests/unit/formulas/test_image_cache.py
+++ b/salt/tests/unit/formulas/test_image_cache.py
@@ -13,12 +13,11 @@ from tests.unit.formulas.fixtures.rendered import RenderedStates, required_state
 
 IMAGE_CACHE_INSTALLED = Path("metalk8s/image-cache/installed.sls")
 
-# Formulas defining the states we depend on, they must stay in the `include` block.
-REQUIRED_FORMULAS = [
-    "metalk8s.repo",
-    "metalk8s.container-engine.containerd.installed",
-    "metalk8s.container-engine.containerd.running",
-]
+# The formula that transitively brings in every state we require, so it must stay
+# in the `include` block. It defines `Install containerd`, and it includes both
+# `metalk8s.repo`, for `Repositories configured`, and the containerd `running`
+# state, for `Ensure containerd is ready`.
+REQUIRED_FORMULA = "metalk8s.container-engine.containerd.installed"
 
 TIMER_STATE = "Ensure containerd image preload timer running"
 
@@ -53,10 +52,9 @@ def test_preload_timer_requires_a_running_containerd(
             continue
 
         includes = states.get("include", [])
-        for formula in REQUIRED_FORMULAS:
-            assert (
-                formula in includes
-            ), f"'{formula}' is not included, the gates cannot resolve ({case_id})"
+        assert (
+            REQUIRED_FORMULA in includes
+        ), f"'{REQUIRED_FORMULA}' is not included, the gates cannot resolve ({case_id})"
 
         gates = required_states(states, TIMER_STATE)
         for gate in REQUIRED_GATES:

--- a/tests/post/features/sanity.feature
+++ b/tests/post/features/sanity.feature
@@ -61,6 +61,20 @@ Feature: Cluster Sanity Checks
         | metalk8s-monitoring         | node-problem-detector                        |
         | metalk8s-storage-management | disk-management-agent-controller-manager     |
 
+    Scenario Outline: Package is installed on every node
+        Then the package '<name>' is installed on every node
+
+        Examples:
+        | name                     |
+        | containerd-image-preload |
+
+    Scenario Outline: Systemd unit is enabled and running on every node
+        Then the systemd unit '<name>' is enabled and running on every node
+
+        Examples:
+        | name                           |
+        | containerd-image-preload.timer |
+
     @volumes_provisioned
     Scenario Outline: StatefulSet has available replicas
         Then the StatefulSet '<name>' in the '<namespace>' namespace has all desired replicas available

--- a/tests/post/steps/test_sanity.py
+++ b/tests/post/steps/test_sanity.py
@@ -1,3 +1,5 @@
+import json
+
 import kubernetes.client
 from kubernetes.client.rest import ApiException
 import pytest
@@ -36,6 +38,18 @@ def test_deployment_running(host):
 
 @scenario("../features/sanity.feature", "DaemonSet has desired Pods ready")
 def test_daemonset_running(host):
+    pass
+
+
+@scenario("../features/sanity.feature", "Package is installed on every node")
+def test_package_installed(host):
+    pass
+
+
+@scenario(
+    "../features/sanity.feature", "Systemd unit is enabled and running on every node"
+)
+def test_systemd_unit_running(host):
     pass
 
 
@@ -218,6 +232,55 @@ def check_statefulset(k8s_client, name, namespace):
         wait=3,
         name="wait for StatefulSet '{}/{}'".format(namespace, name),
     )
+
+
+@then(parsers.parse("the package '{name}' is installed on every node"))
+def check_package_installed(host, ssh_config, k8s_client, name):
+    versions = _salt_on_every_node(host, ssh_config, k8s_client, "pkg.version", name)
+
+    # An absent package gives an empty string, and a minion that failed to run the
+    # function gives its error message, so only take a version number for an answer.
+    missing = sorted(
+        node
+        for node, version in versions.items()
+        if not isinstance(version, str) or not version[:1].isdigit()
+    )
+    assert not missing, "'{}' is not installed on {}".format(name, ", ".join(missing))
+
+
+@then(parsers.parse("the systemd unit '{name}' is enabled and running on every node"))
+def check_systemd_unit_running(host, ssh_config, k8s_client, name):
+    for description, function in [
+        ("enabled", "service.enabled"),
+        ("running", "service.status"),
+    ]:
+        results = _salt_on_every_node(host, ssh_config, k8s_client, function, name)
+
+        failed = sorted(node for node, result in results.items() if result is not True)
+        assert not failed, "'{}' is not {} on {}".format(
+            name, description, ", ".join(failed)
+        )
+
+
+def _salt_on_every_node(host, ssh_config, k8s_client, function, *args):
+    """Run a Salt execution function on every node, return the result per node.
+
+    Target the Kubernetes nodes by name rather than every minion, so that a node
+    staying silent fails the check instead of dropping out of the results.
+    """
+    nodes = sorted(
+        node.metadata.name
+        for node in k8s_client.resources.get(api_version="v1", kind="Node").get().items
+    )
+    assert nodes, "no Kubernetes node to check"
+
+    command = ["salt", "--static", "--out=json", "-L", ",".join(nodes), function, *args]
+    results = json.loads(utils.run_salt_command(host, command, ssh_config).stdout)
+
+    silent = sorted(set(nodes) - set(results))
+    assert not silent, "no answer from {}".format(", ".join(silent))
+
+    return results
 
 
 # }}}

--- a/tests/post/steps/test_sanity.py
+++ b/tests/post/steps/test_sanity.py
@@ -245,7 +245,7 @@ def check_package_installed(host, ssh_config, k8s_client, name):
         for node, version in versions.items()
         if not isinstance(version, str) or not version[:1].isdigit()
     )
-    assert not missing, "'{}' is not installed on {}".format(name, ", ".join(missing))
+    assert not missing, f"'{name}' is not installed on {', '.join(missing)}"
 
 
 @then(parsers.parse("the systemd unit '{name}' is enabled and running on every node"))
@@ -257,9 +257,7 @@ def check_systemd_unit_running(host, ssh_config, k8s_client, name):
         results = _salt_on_every_node(host, ssh_config, k8s_client, function, name)
 
         failed = sorted(node for node, result in results.items() if result is not True)
-        assert not failed, "'{}' is not {} on {}".format(
-            name, description, ", ".join(failed)
-        )
+        assert not failed, f"'{name}' is not {description} on {', '.join(failed)}"
 
 
 def _salt_on_every_node(host, ssh_config, k8s_client, function, *args):
@@ -278,7 +276,7 @@ def _salt_on_every_node(host, ssh_config, k8s_client, function, *args):
     results = json.loads(utils.run_salt_command(host, command, ssh_config).stdout)
 
     silent = sorted(set(nodes) - set(results))
-    assert not silent, "no answer from {}".format(", ".join(silent))
+    assert not silent, f"no answer from {', '.join(silent)}"
 
     return results
 

--- a/tests/post/steps/test_sanity.py
+++ b/tests/post/steps/test_sanity.py
@@ -236,28 +236,42 @@ def check_statefulset(k8s_client, name, namespace):
 
 @then(parsers.parse("the package '{name}' is installed on every node"))
 def check_package_installed(host, ssh_config, k8s_client, name):
-    versions = _salt_on_every_node(host, ssh_config, k8s_client, "pkg.version", name)
+    def _check_package():
+        versions = _salt_on_every_node(
+            host, ssh_config, k8s_client, "pkg.version", name
+        )
 
-    # An absent package gives an empty string, and a minion that failed to run the
-    # function gives its error message, so only take a version number for an answer.
-    missing = sorted(
-        node
-        for node, version in versions.items()
-        if not isinstance(version, str) or not version[:1].isdigit()
-    )
-    assert not missing, f"'{name}' is not installed on {', '.join(missing)}"
+        # An absent package answers with an empty string, and a minion that failed
+        # to run the function answers with its error message, so only take a version
+        # number for an answer, and quote what came back instead.
+        missing = {
+            node: version
+            for node, version in versions.items()
+            if not isinstance(version, str) or not version[:1].isdigit()
+        }
+        answers = ", ".join(
+            f"{node} ({version!r})" for node, version in sorted(missing.items())
+        )
+        assert not missing, f"'{name}' is not installed on {answers}"
+
+    utils.retry(_check_package, times=3, wait=5, name=f"check package '{name}'")
 
 
 @then(parsers.parse("the systemd unit '{name}' is enabled and running on every node"))
 def check_systemd_unit_running(host, ssh_config, k8s_client, name):
-    for description, function in [
-        ("enabled", "service.enabled"),
-        ("running", "service.status"),
-    ]:
-        results = _salt_on_every_node(host, ssh_config, k8s_client, function, name)
+    def _check_unit():
+        for description, function in [
+            ("enabled", "service.enabled"),
+            ("running", "service.status"),
+        ]:
+            results = _salt_on_every_node(host, ssh_config, k8s_client, function, name)
 
-        failed = sorted(node for node, result in results.items() if result is not True)
-        assert not failed, f"'{name}' is not {description} on {', '.join(failed)}"
+            failed = sorted(
+                node for node, result in results.items() if result is not True
+            )
+            assert not failed, f"'{name}' is not {description} on {', '.join(failed)}"
+
+    utils.retry(_check_unit, times=3, wait=5, name=f"check systemd unit '{name}'")
 
 
 def _salt_on_every_node(host, ssh_config, k8s_client, function, *args):


### PR DESCRIPTION
**Component**: salt, tests

**Context**:

MK8S-165 (#5103) puts the `containerd-image-preload` RPM in the `scality` repository of the ISO. This PR is the salt side: install it on every node and start importing.

The package ships its systemd units disabled. That is deliberate, the spec says enabling the timer belongs to the provisioning layer, so nothing imports anything until we enable it here.

**Summary**:

A new `metalk8s.image-cache` formula installs the package with `pkg_installed`, like every other package MetalK8s owns, and runs `containerd-image-preload.timer` with `enable: True`. The `node` and `bootstrap` roles both include it, which covers every node that carries a container engine.

Two requisites carry the ordering the units cannot express on their own. The package state requires `Install containerd`, since the RPM requires `containerd` and the `containerd.io` package we ship is what provides that name. The timer state requires `Ensure containerd is ready`, because the timer fires as soon as it starts (`OnBootSec=0`) and the import goes into a running containerd. A node with no containerd renders a no-op rather than pulling the engine in.

The two new files are declared in `buildchain/buildchain/salt_tree.py`, otherwise they never reach the ISO.

Tests come in two layers. A formula test reads the requisites back from the rendered state, so a future edit that drops one fails the build rather than the cluster. It also covers the no-containerd branch, and fails if no rendering case exercises the timer at all. Two sanity scenarios then check the real thing on a live cluster: a package installed on every node, and a systemd unit enabled and running on every node. Both target the Kubernetes nodes by name, so a silent minion fails the check instead of dropping out of the results.

**Acceptance criteria**:

- every node in a fresh cluster has the package installed, the timer enabled and running
- an archive dropped in `/var/lib/image-cache` is imported into containerd's `k8s.io` namespace on the next tick
- removing an image with `crictl rmi` and waiting one tick brings it back
- the package and its timer are covered by the deployment sanity checks
- unit tests on the requisites

**This PR has to merge after #5103**:

The package only exists in the local repository once #5103 lands. Merged before it, `Install containerd image preload` fails with "No package containerd-image-preload available" and takes the whole highstate down. `pkg_installed` also reads `repo.packages` for the version to pin, and that entry comes from `versions.py` in #5103, so merged early the package would install unpinned.

**Run locally**:

311 formula rendering tests, 32 buildchain tests, and every pre-commit hook covering these files: black 26.3.1, pylint 4.0.5 at 10.00/10, mypy 1.20.2, salt-lint 0.9.2, yamllint 1.38.0.

`Provides: containerd` was checked against the RPM header of `containerd.io-2.2.2-1.el8` as built here, which lists `containerd`, `containerd.io` and `containerd.io(x86-64)`. The same check was made on the 133.0.13 repodata in #5103.

Not run: the sanity scenarios and the acceptance criteria that need a cluster, and a full ISO build.

**Three things a reviewer should weigh**:

**The formula includes what it depends on, even where the include is transitive.** `metalk8s.repo` and `metalk8s.container-engine.containerd.running` both come in through `containerd.installed`, so listing them adds nothing to the compiled highstate today. They are there so that a cleanup of the containerd includes breaks a test rather than silently unresolving `Repositories configured` or `Ensure containerd is ready`. Happy to drop them if you would rather keep the include list minimal.

**The bootstrap role includes the formula although it also reaches it through `master` and then `node`.** The same duplication already exists for `metalk8s.kubernetes.kubelet`, and the bootstrap node keeping the preload does not depend on which other roles it carries. It does mean a future change to which roles get the preload has to touch two files.

**The guard tests `container_engine == 'containerd'` rather than dispatching by name.** The preload script only knows `ctr`, so there is nothing to render for another engine. The other formulas dispatch with `.{{ container_engine }}`, which does not fit a formula that has one implementation.

**Out of scope**:

- filling the cache directory, covered by MK8S-157, MK8S-394 and MK8S-166
- getting the RPM into the ISO, covered by MK8S-165
- the cache directory and the platform, which come from `/etc/sysconfig/containerd-image-preload` as `%config(noreplace)`. The defaults are `/var/lib/image-cache` and `linux/amd64`, and MetalK8s needs neither changed. If it ever does, that file is the place, not the units.
- a node carrying only the `ca` role would fail the new sanity scenarios, since it never gets the formula. Such a node has no kubelet either, and the CA minion is the bootstrap node in every supported layout.
- the systemd unit scenario runs two cluster wide salt calls per unit, one for `service.enabled` and one for `service.status`. One `cmd.run` would halve that, at the cost of parsing text instead of booleans.

---

See: MK8S-395
