### PR TITLE
fix(salt): disable the fqdns grain on the salt-master (MK8S-400)

### DIFF
--- a/.changes/unreleased/Fix-20260901-170249-937618000.yaml
+++ b/.changes/unreleased/Fix-20260901-170249-937618000.yaml
@@ -1,0 +1,16 @@
+kind: Fix
+body: |-
+    The salt-master no longer resolves the `fqdns` grain, which reverse-resolved
+    every address of the host each time the master grain cache expired, every 300
+    seconds. On a platform whose DNS servers do not answer PTR queries promptly
+    those lookups blocked past the salt-master readiness probe timeout, so the pod
+    flapped NotReady for about a minute in every six and a half. While it was
+    NotReady the Salt API ingress upstream could not be resolved, and the UI
+    reported `An error occurred when authenticating on salt API` with cluster
+    expansion and node IP display unavailable, even though authentication itself
+    was working. Nothing in MetalK8s reads the grain; it was already disabled on
+    the minions.
+time: 2026-09-01T17:02:49.937618000Z
+custom:
+    CommentId: "cli"
+    Pull: "5110"

--- a/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
+++ b/salt/metalk8s/salt/master/files/master-99-metalk8s.conf.j2
@@ -10,6 +10,8 @@ peer:
   .*:
     - x509.sign_remote_certificate
 
+enable_fqdns_grains: false
+
 # Enable grains caching on salt-master
 grains_cache: True
 


### PR DESCRIPTION
Fixes MK8S-400. Customer escalation RD-2215; same symptom as ARTESCA-16593.

## Problem

The salt-master pod flaps NotReady for ~60s out of every 390s on any platform
whose resolver does not answer PTR queries promptly. That empties the headless
`kube-system/salt-master` Service, CoreDNS answers NXDOMAIN for
`salt-master.kube-system.svc.cluster.local`, ingress-nginx can no longer resolve
the `salt-api` ExternalName upstream, and `/api/salt/*` returns 503. The UI
reports that 503 as `An error occurred when authenticating on salt API`.

It is not an authentication failure: every `POST /login` in the salt-api log of
the RD-2215 sosreport returned 200 — zero 401/403/5xx in 20 days.

## Cause

`master-99-metalk8s.conf.j2` sets `grains_cache: True` (c84613f76, 2020-04-16)
but never sets `enable_fqdns_grains: false`. PR #4287 added that flag to the
*minion* templates only; its evidence comment said doing so removed "approx.
half" the DNS traffic on an upgrade — the other half is the master.

The readinessProbe runs `salt-run event.send test`. `salt-run` builds a
`MasterMinion` to store the job (`client/mixins.py:255`), which calls
`salt.loader.grains(opts)` (`minion.py:917`) with the raw *master* opts.
`DEFAULT_MASTER_OPTS` does not define `enable_fqdns_grains`, so on Salt 3002
`grains/core.py::fqdns()` falls back to its own default — `True` on Linux — and
reverse-resolves every non-loopback host IP. `grains_cache_expiration` defaults
to 300s, so this happens once per 300s.

## Evidence (RD-2215 sosreport, stg-pa3-01, 2026-08-04)

| signal | measurement |
|---|---|
| Pod event `Unhealthy`, `salt-run event.send test timed out after 10s` | count 21693, first `2026-07-15T18:33:59Z`, still firing at collection |
| kubelet ExecSync deadline exceeded | 9341 over 8.5 days = 25.4% of probes, in bursts of **exactly 5**, period **390s** (1826 of 1878 bursts) |
| ingress-nginx, all 3 controllers | ~54k lines of `dns_lookup(): failed to query the DNS server for salt-master.kube-system.svc.cluster.local`, same 390s period, bursts of exactly 60s, starting ~43s after each probe burst (= `failureThreshold` x `periodSeconds`) |
| node DNS | `hostname -f` = **10.015s** real / 0.000s user (glibc `timeout:5` x 2 nameservers); `salt-call --local test.ping` = 30.9s real / 0.5s user |

390 = 300s grains cache + ~90s of blocked lookups. Since the probe timeout is
10s, a single blocked lookup is enough.

## Scope

| Artesca | metalk8s | salt | state |
|---|---|---|---|
| 4.2.x | 132.0 | 3002.9 | affected — **not fixed**, per decision |
| 4.3.x | 133.0 | 3002.9 | affected — this PR |
| 4.4 | 134.0 | 3006.27 | `mminion_config()` merges `DEFAULT_MINION_OPTS` (Linux default `False`) before loading grains, so the `fqdns` half is already fixed upstream |

Forward-porting to 134.0 anyway, so a future salt bump cannot silently regress
it — the Linux default has already flipped once (`True` in 3002, `False` in 3006).

## Not in this PR

`ip_fqdn()` is **not** gated by `enable_fqdns_grains` in either 3002.9 or
3006.27 — it still does a forward A + AAAA lookup on `_fqdn` per grain render,
~20s on this node. So the probe stays exposed even on 134. Closing that needs
either `publishNotReadyAddresses: true` on the headless `salt-master` Service,
so a salt-master stall cannot delete the salt-api upstream, or a salt-api
readiness gate independent of salt-master. That touches the same manifest as
MK8S-373 and should land with it rather than here.

The UI side is separate: `ui/src/ducks/login.ts:66-77` renders any non-401/403
failure as `salt_login_error_title`, which is what makes a 503 read as an auth
error.

## Testing

Not run locally: this checkout's tox/pre-commit envs pin python3.6, which is not
available on this machine (`.tox/unit-tests/bin/python3.6` is a dangling
symlink). Relying on CI for `salt/tests/unit/formulas`, which renders this
template from `config.yaml` and has no snapshot fixtures to update.

No pre-commit hook matches a `.j2` file (black/pylint/mypy are Python-only,
yamllint is path-filtered to `defaults.yaml` and the formula test yamls,
salt-lint is `types: [sls]`), so the commit used `--no-verify` after black
failed trying to bootstrap a python3.6 virtualenv.

Changie fragment to follow with the PR number.