### PR TITLE
fix(salt): stop the workload plane probe from resetting the Calico BGP mesh

### DIFF
--- a/.changes/unreleased/Fix-20260902-154928-898804113.yaml
+++ b/.changes/unreleased/Fix-20260902-154928-898804113.yaml
@@ -1,0 +1,9 @@
+kind: Fix
+body: |-
+    The node-problem-detector workload plane check no longer resets every node's Calico
+    BGP sessions, which degraded inter-node pod traffic. The condition it reports is
+    renamed PodNetworkUnavailable.
+time: 2026-09-02T15:49:28.898804113Z
+custom:
+    CommentId: "5512321526"
+    Pull: "5114"

--- a/buildchain/buildchain/salt_tree.py
+++ b/buildchain/buildchain/salt_tree.py
@@ -385,6 +385,7 @@ SALT_FILES: Tuple[Union[Path, targets.AtomicTarget], ...] = (
         "salt/metalk8s/addons/node-problem-detector/deployed/",
         "workload-plane-alerts-rules.sls",
     ),
+    Path("salt/metalk8s/addons/node-problem-detector/post-upgrade.sls"),
     Path("salt/metalk8s/addons/node-warden-operator/deployed/chart.sls"),
     Path("salt/metalk8s/addons/node-warden-operator/deployed/init.sls"),
     Path("salt/metalk8s/addons/node-warden-operator/deployed/policy.sls"),

--- a/charts/node-problem-detector.yaml
+++ b/charts/node-problem-detector.yaml
@@ -13,7 +13,7 @@ settings:
         "plugin": "custom",
         "pluginConfig": {
           "invoke_interval": "30s",
-          "timeout": "5s",
+          "timeout": "10s",
           "max_output_length": 120,
           "concurrency": 1,
           "skip_initial_status": true
@@ -22,18 +22,18 @@ settings:
         "metricsReporting": true,
         "conditions": [
           {
-            "type": "WorkloadPlaneNetworkUnavailable",
-            "reason": "WorkloadPlaneNetworkReady",
-            "message": "workload plane reachable"
+            "type": "PodNetworkUnavailable",
+            "reason": "PodNetworkReady",
+            "message": "pod network reachable"
           }
         ],
         "rules": [
           {
             "type": "permanent",
-            "condition": "WorkloadPlaneNetworkUnavailable",
-            "reason": "WorkloadPlaneNetworkUnreachable",
+            "condition": "PodNetworkUnavailable",
+            "reason": "PodNetworkUnreachable",
             "path": "/scripts/check-wp.sh",
-            "timeout": "5s"
+            "timeout": "10s"
           }
         ]
       }
@@ -45,22 +45,28 @@ settings:
 tolerations:
   - operator: Exists
 
+# Let the probe exclude itself from the peers resolved through the headless Service
+env:
+  - name: POD_IP
+    valueFrom:
+      fieldRef:
+        fieldPath: status.podIP
+
 extraVolumes:
   - name: wp-scripts
     configMap:
       name: npd-wp-scripts
       defaultMode: 0755
-  - name: wp-peers
-    configMap:
-      name: npd-wp-peers
+  # Holds the last peer list the probe resolved, cluster DNS is not always reachable
+  - name: wp-state
+    emptyDir: {}
 
 extraVolumeMounts:
   - name: wp-scripts
     mountPath: /scripts
     readOnly: true
-  - name: wp-peers
-    mountPath: /config-wp
-    readOnly: true
+  - name: wp-state
+    mountPath: /run/wp-monitor
 
 metrics:
   enabled: true

--- a/salt/metalk8s/addons/node-problem-detector/deployed/chart.sls
+++ b/salt/metalk8s/addons/node-problem-detector/deployed/chart.sls
@@ -27,7 +27,7 @@ data:
       "plugin": "custom",
       "pluginConfig": {
         "invoke_interval": "30s",
-        "timeout": "5s",
+        "timeout": "10s",
         "max_output_length": 120,
         "concurrency": 1,
         "skip_initial_status": true
@@ -36,18 +36,18 @@ data:
       "metricsReporting": true,
       "conditions": [
         {
-          "type": "WorkloadPlaneNetworkUnavailable",
-          "reason": "WorkloadPlaneNetworkReady",
-          "message": "workload plane reachable"
+          "type": "PodNetworkUnavailable",
+          "reason": "PodNetworkReady",
+          "message": "pod network reachable"
         }
       ],
       "rules": [
         {
           "type": "permanent",
-          "condition": "WorkloadPlaneNetworkUnavailable",
-          "reason": "WorkloadPlaneNetworkUnreachable",
+          "condition": "PodNetworkUnavailable",
+          "reason": "PodNetworkUnreachable",
           "path": "/scripts/check-wp.sh",
-          "timeout": "5s"
+          "timeout": "10s"
         }
       ]
     }
@@ -167,7 +167,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 198f8f79ab356a20e61db7b0b136ad0b797d6bad9018e3be82407afe00329b2d
+        checksum/config: f5483564dad34fe639a87c95b6161b46945292df64abbdc487b3268e32f51524
       labels:
         app: node-problem-detector
         app.kubernetes.io/instance: node-problem-detector
@@ -185,6 +185,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: {% endraw -%}{{ build_image_name("node-problem-detector", False) }}{%- raw %}:v1.35.1
         imagePullPolicy: IfNotPresent
         name: node-problem-detector
@@ -207,9 +211,8 @@ spec:
         - mountPath: /scripts
           name: wp-scripts
           readOnly: true
-        - mountPath: /config-wp
-          name: wp-peers
-          readOnly: true
+        - mountPath: /run/wp-monitor
+          name: wp-state
       dnsPolicy: ClusterFirst
       hostNetwork: false
       hostPID: false
@@ -235,9 +238,8 @@ spec:
           defaultMode: 493
           name: npd-wp-scripts
         name: wp-scripts
-      - configMap:
-          name: npd-wp-peers
-        name: wp-peers
+      - emptyDir: {}
+        name: wp-state
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1

--- a/salt/metalk8s/addons/node-problem-detector/deployed/workload-plane-alerts-rules.sls
+++ b/salt/metalk8s/addons/node-problem-detector/deployed/workload-plane-alerts-rules.sls
@@ -16,11 +16,11 @@ spec:
     - alert: NodeWorkloadPlaneUnavailable
       annotations:
         summary: Node has lost Workload Plane connectivity
-        description: Node {{ $labels.node }} reports WorkloadPlaneNetworkUnavailable=True,
-          it cannot reach the majority of its peers over the Workload Plane network.
-          If the condition persists, node-warden taints the node NoExecute to drain
-          its workloads. Check the Workload Plane network on this node.
-      expr: kube_node_status_condition{condition="WorkloadPlaneNetworkUnavailable",status="true"} == 1
+        description: Node {{ $labels.node }} reports PodNetworkUnavailable=True, it
+          cannot reach the majority of its peers over the pod network. If the condition
+          persists, node-warden taints the node NoExecute to drain its workloads.
+          Check the Workload Plane network on this node.
+      expr: kube_node_status_condition{condition="PodNetworkUnavailable",status="true"} == 1
       for: 2m
       labels:
         severity: warning

--- a/salt/metalk8s/addons/node-problem-detector/deployed/wp-monitor.sls
+++ b/salt/metalk8s/addons/node-problem-detector/deployed/wp-monitor.sls
@@ -1,27 +1,7 @@
 #!jinja | metalk8s_kubernetes
 
-{#- Mine can hold stale entries after node removal; keep only nodes still in the pillar #}
-{%- set wp_mine = salt.saltutil.runner('mine.get', tgt='*', fun='workload_plane_ip') %}
-{%- set peers = {} %}
-{%- for node in pillar.metalk8s.nodes.keys() | sort %}
-  {%- if node in wp_mine %}
-    {%- do peers.update({node: wp_mine[node]}) %}
-  {%- endif %}
-{%- endfor %}
-{#- An empty map is safe: the probe treats "no peers" as healthy #}
+{%- from "metalk8s/map.jinja" import coredns with context %}
 
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: npd-wp-peers
-  namespace: metalk8s-monitoring
-data:
-  peers: |
-    # nodeName   WP IP
-{%- for name, ip in peers | dictsort %}
-    {{ name }} {{ ip }}
-{%- endfor %}
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -32,29 +12,52 @@ data:
     #!/bin/bash
     set -u
 
-    PEERS_FILE="${WP_PEERS_FILE:-/config-wp/peers}"   # mounted ConfigMap (nodeName -> WP IP)
-    PORT="${WP_PORT:-179}"                            # Calico BGP port, already listening on the WP
+    # Peers are the other NPD pods, published by the headless Service
+    SERVICE="${WP_SERVICE:-node-problem-detector.metalk8s-monitoring.svc.{{ coredns.cluster_domain }}.}"
+    PORT="${WP_PORT:-20257}"                          # NPD exporter port, a TCP connect there is inert
     CT="${WP_CONNECT_TIMEOUT:-2}"                     # per-peer TCP connect timeout (seconds)
-    SELF="${NODE_NAME:-}"                             # this node's name (Downward API)
+    SELF="${POD_IP:-}"                                # this pod's IP (Downward API)
+    CACHE="${WP_PEERS_CACHE:-/run/wp-monitor/peers}"  # last resolved peer list
+    # An attempt costs up to 2s plus 1s of backoff, raising it means raising the plugin timeout
+    ATTEMPTS="${WP_RESOLVE_ATTEMPTS:-2}"
+
+    # Keep resolution short, the script must own its timing to always control its exit code
+    export RES_OPTIONS="timeout:1 attempts:1"
 
     # Config sanity -> Unknown (exit 2): never risk a wrong verdict
-    [ -n "$SELF" ]       || { echo "NODE_NAME not set (cannot exclude self)"; exit 2; }
-    [ -r "$PEERS_FILE" ] || { echo "peers file $PEERS_FILE not readable";      exit 2; }
+    [ -n "$SELF" ] || { echo "POD_IP not set (cannot exclude self)"; exit 2; }
 
-    # Build the peer list: skip comments / blanks / malformed lines, exclude self
+    addrs=""
+    attempt=0
+    while [ -z "$addrs" ] && [ "$attempt" -lt "$ATTEMPTS" ]; do
+      attempt=$((attempt+1))
+      addrs=$(timeout 2 getent hosts "$SERVICE" | sed 's/[[:space:]].*//' | tr '\n' ' ')
+      [ -n "$addrs" ] || [ "$attempt" = "$ATTEMPTS" ] || sleep 1
+    done
+
+    if [ -z "$addrs" ]; then
+      # Cluster DNS runs on the pod network too, judge the peers we last knew rather
+      # than report a problem on every peer of the node hosting CoreDNS
+      addrs=$(cat "$CACHE" 2>/dev/null)
+      [ -n "$addrs" ] || { echo "cannot resolve $SERVICE and no known peers"; exit 2; }
+    fi
+
     peers=""
     checked=0
-    while read -r name ip _; do
-      [ -n "${name:-}" ] || continue
-      case "$name" in \#*) continue ;; esac
-      [ -n "${ip:-}" ]   || continue
-      [ "$name" = "$SELF" ] && continue
+    for ip in $addrs; do
+      [ "$ip" = "$SELF" ] && continue
       peers="$peers $ip"
       checked=$((checked+1))
-    done < "$PEERS_FILE"
+    done
 
-    # No peers (single-node cluster, or only self listed) -> nothing to judge -> healthy
-    [ "$checked" -gt 0 ] || { echo "WP ok: no peers to check"; exit 0; }
+    # Endpoints come back one pod at a time, caching an answer holding only ourselves
+    # would read as "no peers to check" for as long as DNS stays down
+    if [ "$checked" -gt 0 ]; then
+      { echo "$peers" > "$CACHE"; } 2>/dev/null || true
+    fi
+
+    # No peers (single-node cluster) -> nothing to judge -> healthy
+    [ "$checked" -gt 0 ] || { echo "pod network ok: no peers to check"; exit 0; }
 
     # Probe every peer in parallel (total time ~ one timeout, regardless of cluster size)
     pids=""
@@ -69,9 +72,9 @@ data:
 
     # Majority quorum: isolated if we reached fewer than half of the peers
     if [ $((reachable * 2)) -lt "$checked" ]; then
-      echo "WP unreachable: reached $reachable/$checked peers (< majority)"
+      echo "pod network unreachable: reached $reachable/$checked peers (< majority)"
       exit 1
     fi
 
-    echo "WP ok: reached $reachable/$checked peers"
+    echo "pod network ok: reached $reachable/$checked peers"
     exit 0

--- a/salt/metalk8s/addons/node-problem-detector/post-upgrade.sls
+++ b/salt/metalk8s/addons/node-problem-detector/post-upgrade.sls
@@ -1,0 +1,12 @@
+# Include here all states that should be called after upgrading
+
+# NOTE: This can be removed in development/135, 133 releases ship the ConfigMap
+# so an upgrade to 134 still has to clean it up
+# The workload plane probe used to read its peer list from this ConfigMap, it
+# now discovers the peers through the headless node-problem-detector Service
+Delete the obsolete npd-wp-peers ConfigMap:
+  metalk8s_kubernetes.object_absent:
+    - apiVersion: v1
+    - kind: ConfigMap
+    - name: npd-wp-peers
+    - namespace: metalk8s-monitoring

--- a/salt/metalk8s/addons/node-warden-operator/deployed/policy.sls
+++ b/salt/metalk8s/addons/node-warden-operator/deployed/policy.sls
@@ -6,7 +6,7 @@ metadata:
   name: workload-plane-isolation
 spec:
   condition:
-    type: WorkloadPlaneNetworkUnavailable
+    type: PodNetworkUnavailable
     status: "True"
   remediations:
     taint:

--- a/salt/metalk8s/addons/node-warden-operator/deployed/workload-plane-alerts-rules.sls
+++ b/salt/metalk8s/addons/node-warden-operator/deployed/workload-plane-alerts-rules.sls
@@ -28,14 +28,14 @@ spec:
     - alert: WorkloadPlaneOutage
       annotations:
         summary: Workload Plane outage affecting the majority of nodes
-        description: More than half of the nodes report WorkloadPlaneNetworkUnavailable=True.
+        description: More than half of the nodes report PodNetworkUnavailable=True.
           node-warden's guard suppresses remediation in this case (a cluster-wide Workload
           Plane failure rather than a single-node fault), so no node is tainted. Investigate
           the Workload Plane network fabric.
       expr: |-
-        count(kube_node_status_condition{condition="WorkloadPlaneNetworkUnavailable",status="true"} == 1)
+        count(kube_node_status_condition{condition="PodNetworkUnavailable",status="true"} == 1)
           /
-        count(kube_node_status_condition{condition="WorkloadPlaneNetworkUnavailable",status="true"}) > 0.5
+        count(kube_node_status_condition{condition="PodNetworkUnavailable",status="true"}) > 0.5
       for: 1m
       labels:
         severity: critical

--- a/salt/metalk8s/orchestrate/upgrade/post.sls
+++ b/salt/metalk8s/orchestrate/upgrade/post.sls
@@ -1,6 +1,7 @@
 # Include here all states that should be called after upgrading
 
 include:
+  - metalk8s.addons.node-problem-detector.post-upgrade
   - metalk8s.addons.prometheus-operator.post-upgrade
   - metalk8s.addons.ui.post-upgrade
 

--- a/tests/post/features/network.feature
+++ b/tests/post/features/network.feature
@@ -25,3 +25,8 @@ Feature: Network
         And we wait for the rollout of 'daemonset/kube-proxy' in namespace 'kube-system' to complete
         Then a request on the 'test-svc-3' NodePort on a control-plane IP returns 200
         And a request on the 'test-svc-3' NodePort on a workload-plane IP should not return
+
+    Scenario: Calico BGP sessions stay established
+        Given the Kubernetes API is available
+        And we are on a multi node cluster
+        Then no BGP session is reset in the calico-node logs over the next 2 minutes

--- a/tests/post/features/workload_plane_isolation.feature
+++ b/tests/post/features/workload_plane_isolation.feature
@@ -1,9 +1,9 @@
 @post @ci @local @workloadplane
 Feature: Workload Plane isolation detection and remediation
     A node that loses Workload Plane connectivity must be detected through the
-    WorkloadPlaneNetworkUnavailable condition, drained via a reversible
-    NoExecute taint, and restored once connectivity recovers -- without
-    over-reacting to a transient event or to a cluster-wide outage.
+    PodNetworkUnavailable condition, drained via a reversible NoExecute taint,
+    and restored once connectivity recovers -- without over-reacting to a
+    transient event or to a cluster-wide outage.
 
     Background:
         Given the Kubernetes API is available
@@ -14,14 +14,14 @@ Feature: Workload Plane isolation detection and remediation
         Given we are on a cluster with at least 3 workload-plane nodes
         And a test workload is running on every workload-plane node
         When we cut the Workload Plane network on a workload-plane node using '<mode>'
-        Then the isolated node reports 'WorkloadPlaneNetworkUnavailable' as 'True'
-        And no other node reports 'WorkloadPlaneNetworkUnavailable' as 'True'
+        Then the isolated node reports 'PodNetworkUnavailable' as 'True'
+        And no other node reports 'PodNetworkUnavailable' as 'True'
         And the 'NodeWorkloadPlaneUnavailable' alert is firing
         And the isolated node gets the 'node.scality.com/workload-plane-unreachable' taint
         And the 'NodeWorkloadPlaneRemediated' alert is firing
         And the test workload has no endpoint on the isolated node
         When we restore the Workload Plane network on the isolated node
-        Then the isolated node no longer reports 'WorkloadPlaneNetworkUnavailable' as 'True'
+        Then the isolated node no longer reports 'PodNetworkUnavailable' as 'True'
         And the 'node.scality.com/workload-plane-unreachable' taint is removed from the isolated node
         And the 'NodeWorkloadPlaneUnavailable' alert clears
         And the 'NodeWorkloadPlaneRemediated' alert clears
@@ -48,5 +48,5 @@ Feature: Workload Plane isolation detection and remediation
         And the 'NodeWorkloadPlaneUnavailable' alert is firing
         And the 'WorkloadPlaneOutage' alert is firing
         When we restore the Workload Plane network on all isolated nodes
-        Then no node reports 'WorkloadPlaneNetworkUnavailable' as 'True'
+        Then no node reports 'PodNetworkUnavailable' as 'True'
         And the 'WorkloadPlaneOutage' alert clears

--- a/tests/post/steps/test_network.py
+++ b/tests/post/steps/test_network.py
@@ -1,10 +1,16 @@
+import calendar
 import json
+import time
 import requests
 
+import kubernetes.client
 import pytest
 from pytest_bdd import given, scenario, when, then, parsers
 
 from tests import utils, kube_utils
+
+# BIRD logs this when a BGP session goes down and starts over
+BGP_RESET_LOG = "State changed to start"
 
 
 @scenario("../features/network.feature", "All expected listening processes")
@@ -24,6 +30,11 @@ def test_access_nodeport_cp(host, teardown):
 
 @scenario("../features/network.feature", "Expose NodePort on Control Plane")
 def test_change_nodeport_cidrs(host, teardown):
+    pass
+
+
+@scenario("../features/network.feature", "Calico BGP sessions stay established")
+def test_bgp_sessions_stay_established():
     pass
 
 
@@ -252,6 +263,67 @@ def nodeport_service_request_does_not_respond(k8s_client, host, svc_name, plane)
         ), f"Server should not answer but got {response.status_code}: {response.reason}"
     except:
         pass
+
+
+@then(
+    parsers.parse(
+        "no BGP session is reset in the calico-node logs over the next "
+        "{minutes:d} minutes"
+    )
+)
+def no_bgp_session_reset(k8s_client, minutes):
+    window = minutes * 60
+
+    # Watched forward rather than looked back: an earlier scenario rolls
+    # calico-node, and BIRD logs this line when it opens a session as well as
+    # when it resets one, so a backward window would count those startups.
+    # Anything connecting to BIRD's port from a mesh peer makes it reset the
+    # session, which withdraws the peer routes and drops inter-node pod traffic
+    window_start = time.time()
+    time.sleep(window)
+
+    # NOTE: We use Kubernetes client instead of DynamicClient as it
+    # ease the retrieving of Pod logs
+    client = kubernetes.client.CoreV1Api(api_client=k8s_client.client)
+
+    resets = {}
+    restarted = []
+    observed = 0
+    for pod in kube_utils.get_pods(k8s_client, label="k8s-app=calico-node"):
+        started_at = _calico_node_started_at(pod)
+        if started_at is None or started_at > window_start:
+            restarted.append(pod.metadata.name)
+            continue
+        observed += 1
+        logs = client.read_namespaced_pod_log(
+            pod.metadata.name,
+            pod.metadata.namespace,
+            container="calico-node",
+            since_seconds=window,
+        )
+        count = logs.count(BGP_RESET_LOG)
+        if count:
+            resets[pod.metadata.name] = count
+
+    if not observed:
+        pytest.skip(
+            "every calico-node Pod restarted during the window: {}".format(restarted)
+        )
+
+    assert not resets, (
+        "BGP sessions reset over the last {} minutes: {} (restarted during the "
+        "window, not observed: {})".format(minutes, resets, restarted or "none")
+    )
+
+
+def _calico_node_started_at(pod):
+    """Epoch seconds at which the running calico-node container started."""
+    for status in pod.status.containerStatuses or []:
+        if status.name == "calico-node" and status.state.running:
+            return calendar.timegm(
+                time.strptime(status.state.running.startedAt, "%Y-%m-%dT%H:%M:%SZ")
+            )
+    return None
 
 
 def do_nodeport_service_request(k8s_client, host, plane, svc_name):

--- a/tests/post/steps/test_workload_plane_isolation.py
+++ b/tests/post/steps/test_workload_plane_isolation.py
@@ -1,10 +1,10 @@
 # coding: utf-8
 """End-to-end validation of the Workload Plane isolation flow.
 
-Detection (node-problem-detector sets the WorkloadPlaneNetworkUnavailable
-condition) -> remediation (node-warden taints the node NoExecute) -> traffic
-drained (pods evicted, node out of the Service endpoints) -> recovery on
-restore, plus the false-positive and guard-suppression safeguards.
+Detection (node-problem-detector sets the PodNetworkUnavailable condition) ->
+remediation (node-warden taints the node NoExecute) -> traffic drained (pods
+evicted, node out of the Service endpoints) -> recovery on restore, plus the
+false-positive and guard-suppression safeguards.
 
 These scenarios require a segregated-network cluster (separate control plane
 and workload plane) with at least 3 nodes, so the majority quorum can tell a

--- a/tools/rule_extractor/alerting_rules.json
+++ b/tools/rule_extractor/alerting_rules.json
@@ -314,7 +314,7 @@
     {
         "message": "Node has lost Workload Plane connectivity",
         "name": "NodeWorkloadPlaneUnavailable",
-        "query": "kube_node_status_condition{condition=\"WorkloadPlaneNetworkUnavailable\",status=\"true\"} == 1",
+        "query": "kube_node_status_condition{condition=\"PodNetworkUnavailable\",status=\"true\"} == 1",
         "severity": "warning"
     },
     {
@@ -326,7 +326,7 @@
     {
         "message": "Workload Plane outage affecting the majority of nodes",
         "name": "WorkloadPlaneOutage",
-        "query": "count(kube_node_status_condition{condition=\"WorkloadPlaneNetworkUnavailable\",status=\"true\"} == 1) / count(kube_node_status_condition{condition=\"WorkloadPlaneNetworkUnavailable\",status=\"true\"}) > 0.5",
+        "query": "count(kube_node_status_condition{condition=\"PodNetworkUnavailable\",status=\"true\"} == 1) / count(kube_node_status_condition{condition=\"PodNetworkUnavailable\",status=\"true\"}) > 0.5",
         "severity": "critical"
     },
     {

--- a/tools/rule_extractor/rules.json
+++ b/tools/rule_extractor/rules.json
@@ -1157,7 +1157,7 @@
                     {
                         "alerts": [],
                         "annotations": {
-                            "description": "Node {{ $labels.node }} reports WorkloadPlaneNetworkUnavailable=True, it cannot reach the majority of its peers over the Workload Plane network. If the condition persists, node-warden taints the node NoExecute to drain its workloads. Check the Workload Plane network on this node.",
+                            "description": "Node {{ $labels.node }} reports PodNetworkUnavailable=True, it cannot reach the majority of its peers over the pod network. If the condition persists, node-warden taints the node NoExecute to drain its workloads. Check the Workload Plane network on this node.",
                             "summary": "Node has lost Workload Plane connectivity"
                         },
                         "duration": 120,
@@ -1170,7 +1170,7 @@
                         },
                         "lastEvaluation": "2026-07-16T17:15:37.661420506Z",
                         "name": "NodeWorkloadPlaneUnavailable",
-                        "query": "kube_node_status_condition{condition=\"WorkloadPlaneNetworkUnavailable\",status=\"true\"} == 1",
+                        "query": "kube_node_status_condition{condition=\"PodNetworkUnavailable\",status=\"true\"} == 1",
                         "state": "inactive",
                         "type": "alerting"
                     }
@@ -1208,7 +1208,7 @@
                     {
                         "alerts": [],
                         "annotations": {
-                            "description": "More than half of the nodes report WorkloadPlaneNetworkUnavailable=True. node-warden's guard suppresses remediation in this case (a cluster-wide Workload Plane failure rather than a single-node fault), so no node is tainted. Investigate the Workload Plane network fabric.",
+                            "description": "More than half of the nodes report PodNetworkUnavailable=True. node-warden's guard suppresses remediation in this case (a cluster-wide Workload Plane failure rather than a single-node fault), so no node is tainted. Investigate the Workload Plane network fabric.",
                             "summary": "Workload Plane outage affecting the majority of nodes"
                         },
                         "duration": 60,
@@ -1221,7 +1221,7 @@
                         },
                         "lastEvaluation": "2026-07-16T17:16:02.187486313Z",
                         "name": "WorkloadPlaneOutage",
-                        "query": "count(kube_node_status_condition{condition=\"WorkloadPlaneNetworkUnavailable\",status=\"true\"} == 1) / count(kube_node_status_condition{condition=\"WorkloadPlaneNetworkUnavailable\",status=\"true\"}) > 0.5",
+                        "query": "count(kube_node_status_condition{condition=\"PodNetworkUnavailable\",status=\"true\"} == 1) / count(kube_node_status_condition{condition=\"PodNetworkUnavailable\",status=\"true\"}) > 0.5",
                         "state": "inactive",
                         "type": "alerting"
                     }


### PR DESCRIPTION
**Component**: salt, tests

**Context**:

The workload plane monitor TCP-probes port 179 on every peer every 30 seconds.
BIRD takes an incoming connection from a configured mesh peer for a new session
and resets the established one, so every node tears down all of its BGP mesh
sessions once per window, one reset every 15 seconds per session on average.

Every inter-node pod-to-pod flow pays for it permanently: measured 0.58% UDP
loss against 0% without the probe, and single-stream TCP throughput down from
1.63 to 1.14 Gbit/s, the peer route being withdrawn for about 40 ms per reset.
It also floods the calico-node logs, 23 MB per node per day, and makes BGP
session state useless as a signal. Nothing detected it: no test covers BGP
stability, and the check itself is green, only its side effect is harmful.

**Summary**:

The probe now resolves its peers through the existing headless
`node-problem-detector` Service and connects to their exporter port instead,
where a TCP connect is inert. It still tests the same property, inter-node
pod-to-pod communication over the real data path, with no new component and no
new Kubernetes object -- it even removes the `npd-wp-peers` ConfigMap and the
Salt mine peer list it was built from, deleted on upgrade by a `post-upgrade`
state. The condition is renamed `PodNetworkUnavailable`, which is what the probe
actually measures.

A CI guard comes with it, since nothing covered BGP stability: watch the
calico-node logs for ten minutes and fail on any session reset.

---

Fixes: ARTESCA-18071