### PR TITLE
fix(ui): tell the node and volume tables when they are loading (ARTESCA-5650)

### DIFF
--- a/.changes/unreleased/Fix-20260903-124757-486517410.yaml
+++ b/.changes/unreleased/Fix-20260903-124757-486517410.yaml
@@ -1,0 +1,6 @@
+kind: Fix
+body: The Nodes and Volumes pages no longer show "No nodes found" / "No volumes found" while the list is still loading
+time: 2026-09-03T12:47:57.48651741Z
+custom:
+    CommentId: "5525994634"
+    Pull: "5118"

--- a/ui/src/components/NodeListTable.tsx
+++ b/ui/src/components/NodeListTable.tsx
@@ -14,7 +14,7 @@ const StatusText = styled.div<{ $color?: string }>`
   }};
 `;
 
-const NodeListTable = ({ nodeTableData }) => {
+const NodeListTable = ({ nodeTableData, loading }) => {
   const navigate = useNavigate();
   const location = useLocation();
   const query = useURLQuery();
@@ -134,6 +134,7 @@ const NodeListTable = ({ nodeTableData }) => {
     <Table
       columns={columns}
       data={nodeTableData}
+      status={loading ? 'loading' : 'success'}
       defaultSortingKey={'health'}
       entityName={{
         en: {

--- a/ui/src/components/VolumeListTable.tsx
+++ b/ui/src/components/VolumeListTable.tsx
@@ -170,6 +170,7 @@ const VolumeListTable = (props) => {
     <Table
       columns={columns}
       data={volumeListData}
+      status={props.loading ? 'loading' : 'success'}
       defaultSortingKey={'health'}
       // @ts-expect-error - FIXME when you are working on it
       getRowId={(row) => row.name}

--- a/ui/src/containers/NodePageContent.tsx
+++ b/ui/src/containers/NodePageContent.tsx
@@ -52,7 +52,7 @@ const NodePageContent = (props) => {
         leftPanel={{
           children: (
             <LeftSideInstanceList>
-              <NodeListTable nodeTableData={nodeTableData} />
+              <NodeListTable nodeTableData={nodeTableData} loading={loading} />
             </LeftSideInstanceList>
           ),
         }}

--- a/ui/src/containers/VolumePageContent.tsx
+++ b/ui/src/containers/VolumePageContent.tsx
@@ -53,7 +53,7 @@ const VolumePageContent = (props) => {
         leftPanel={{
           children: (
             <LeftSideInstanceList>
-              <VolumeListTable volumeListData={volumeListData} volumeName={currentVolumeName}></VolumeListTable>
+              <VolumeListTable volumeListData={volumeListData} loading={loading} volumeName={currentVolumeName}></VolumeListTable>
             </LeftSideInstanceList>
           ),
         }}


### PR DESCRIPTION
The Nodes and Volumes pages render their table with an empty list while the first fetch is still running, and never tell the table that it is loading. core-ui reads a missing status as "success", so an empty list immediately renders the "No nodes found" / "No volumes found" placeholder. It stays on screen for the API round trip plus the deliberate one second delay in the nodes and volumes sagas, on every visit to the page.

The Redux store already carries the flag, it just was not passed down. Both tables now receive it and show the loading placeholder instead, and the "no results" message is only reached once the fetch is over.

Verified against a live platform with the MetalK8s UI running locally behind the shell.

Left out on purpose: the `isFirstLoadingDone` guard in both containers is still the fragile `usePrevious` heuristic, which belongs with the react-query migration (ARTESCA-2771).