### PR TITLE
fix(ui): resolve plane interfaces live instead of from a stale grain

### DIFF
--- a/.changes/unreleased/Fix-20260904-081500-411000000.yaml
+++ b/.changes/unreleased/Fix-20260904-081500-411000000.yaml
@@ -1,0 +1,14 @@
+kind: Fix
+body: |
+  The Platform dashboard and node page bandwidth charts are no longer empty on
+  nodes whose control-plane or workload-plane IP sits on a bond or a VLAN. The
+  interface carrying each plane IP is now resolved live on the minion instead of
+  being read from the `ip_interfaces` grain, which is only computed when the
+  minion daemon starts -- before those interfaces exist -- and is not refreshed
+  afterwards. The charts used to query `node_network_receive_bytes_total` with an
+  empty device matcher, which no series can match, so Prometheus answered with an
+  empty result and the panel rendered blank without any error
+time: 2026-09-04T08:15:00.411000000Z
+custom:
+  Pull: 5120
+  CommentId: cli

--- a/salt/_modules/metalk8s_network.py
+++ b/salt/_modules/metalk8s_network.py
@@ -126,6 +126,61 @@ def get_mtu_from_ip(ip):
     return int(__salt__["file.read"](f"/sys/class/net/{iface}/mtu"))
 
 
+def _get_iface_from_ip(ip):
+    """
+    Return the name of the first interface holding the given IP, or None
+
+    The interface is resolved live, on purpose: the `ip_interfaces` grain is
+    only computed when the minion daemon starts, which may happen before the
+    interface holding the IP exists (bond, VLAN, ...), and grains are not
+    refreshed automatically afterwards.
+    """
+    if not ip:
+        return None
+
+    ifaces = __salt__["network.ifacestartswith"](ip)
+
+    if not ifaces:
+        log.warning('Unable to get interface for "%s"', ip)
+        return None
+
+    iface = ifaces[0]
+
+    if len(ifaces) > 1:
+        log.warning(
+            'Several interfaces match the IP "%s", %s will be used: %s',
+            ip,
+            iface,
+            ", ".join(ifaces),
+        )
+
+    return iface
+
+
+def get_planes_interfaces():
+    """
+    Return the IP and the interface holding it for each plane
+
+    .. code-block:: python
+
+        {
+            "control_plane": {"ip": "10.200.0.42", "interface": "eth1"},
+            "workload_plane": {"ip": "10.100.0.42", "interface": "eth3"},
+        }
+
+    An `interface` is None when no interface holds the plane IP, so that
+    callers can tell "not resolved" apart from a real interface name.
+    """
+    metalk8s_grains = __grains__.get("metalk8s") or {}
+
+    result = {}
+    for plane in ["control_plane", "workload_plane"]:
+        ip = metalk8s_grains.get(f"{plane}_ip")
+        result[plane] = {"ip": ip, "interface": _get_iface_from_ip(ip)}
+
+    return result
+
+
 def get_listening_processes():
     """
     Get all the listening processes on the local node

--- a/salt/tests/unit/modules/test_metalk8s_network.py
+++ b/salt/tests/unit/modules/test_metalk8s_network.py
@@ -240,6 +240,90 @@ class Metalk8sNetworkTestCase(TestCase, mixins.LoaderModuleMockMixin):
                     result, metalk8s_network.get_mtu_from_ip("10.200.0.42")
                 )
 
+    @parameterized.expand(
+        [
+            # A dedicated interface for each plane
+            (
+                {
+                    "metalk8s": {
+                        "control_plane_ip": "10.200.0.42",
+                        "workload_plane_ip": "10.100.0.42",
+                    }
+                },
+                {"10.200.0.42": ["eth1"], "10.100.0.42": ["eth3"]},
+                {
+                    "control_plane": {"ip": "10.200.0.42", "interface": "eth1"},
+                    "workload_plane": {"ip": "10.100.0.42", "interface": "eth3"},
+                },
+            ),
+            # A single interface carrying both planes
+            (
+                {
+                    "metalk8s": {
+                        "control_plane_ip": "10.200.0.42",
+                        "workload_plane_ip": "10.200.0.42",
+                    }
+                },
+                {"10.200.0.42": ["eth0"]},
+                {
+                    "control_plane": {"ip": "10.200.0.42", "interface": "eth0"},
+                    "workload_plane": {"ip": "10.200.0.42", "interface": "eth0"},
+                },
+            ),
+            # No interface carries the plane IP, the interface stays unresolved
+            (
+                {
+                    "metalk8s": {
+                        "control_plane_ip": "10.200.0.42",
+                        "workload_plane_ip": "10.100.0.42",
+                    }
+                },
+                {},
+                {
+                    "control_plane": {"ip": "10.200.0.42", "interface": None},
+                    "workload_plane": {"ip": "10.100.0.42", "interface": None},
+                },
+            ),
+            # Several interfaces match, the first one is used
+            (
+                {
+                    "metalk8s": {
+                        "control_plane_ip": "10.200.0.42",
+                        "workload_plane_ip": "10.100.0.42",
+                    }
+                },
+                {"10.200.0.42": ["bond0", "vlan-cp"], "10.100.0.42": ["vlan-wp"]},
+                {
+                    "control_plane": {"ip": "10.200.0.42", "interface": "bond0"},
+                    "workload_plane": {"ip": "10.100.0.42", "interface": "vlan-wp"},
+                },
+            ),
+            # Plane IPs missing from the grains
+            (
+                {},
+                {},
+                {
+                    "control_plane": {"ip": None, "interface": None},
+                    "workload_plane": {"ip": None, "interface": None},
+                },
+            ),
+        ]
+    )
+    def test_get_planes_interfaces(self, grains, ifaces, result):
+        """
+        Tests the return of `get_planes_interfaces` function
+        """
+        salt_dict = {
+            "network.ifacestartswith": MagicMock(
+                side_effect=lambda ip: ifaces.get(ip, [])
+            ),
+        }
+
+        with patch.dict(metalk8s_network.__salt__, salt_dict), patch.dict(
+            metalk8s_network.__grains__, grains
+        ):
+            self.assertEqual(result, metalk8s_network.get_planes_interfaces())
+
     @utils.parameterized_from_cases(YAML_TESTS_CASES["get_listening_processes"])
     def test_get_listening_processes(
         self, result, net_conns_ret=None, process_ret=None

--- a/ui/src/services/NodeUtils.test.ts
+++ b/ui/src/services/NodeUtils.test.ts
@@ -1,0 +1,34 @@
+import { nodesCPWPIPsInterface } from './NodeUtils';
+
+describe('nodesCPWPIPsInterface', () => {
+  it('maps the plane interfaces resolved by Salt', () => {
+    expect(
+      nodesCPWPIPsInterface({
+        control_plane: { ip: '10.200.0.42', interface: 'vlan-cp' },
+        workload_plane: { ip: '10.100.0.42', interface: 'vlan-wp' },
+      }),
+    ).toEqual({
+      controlPlane: { ip: '10.200.0.42', interface: 'vlan-cp' },
+      workloadPlane: { ip: '10.100.0.42', interface: 'vlan-wp' },
+    });
+  });
+
+  it('falls back to an empty interface when Salt could not resolve one', () => {
+    expect(
+      nodesCPWPIPsInterface({
+        control_plane: { ip: '10.200.0.42', interface: null },
+        workload_plane: { ip: null, interface: null },
+      }),
+    ).toEqual({
+      controlPlane: { ip: '10.200.0.42', interface: '' },
+      workloadPlane: { ip: '', interface: '' },
+    });
+  });
+
+  it('returns empty values when the minion did not answer', () => {
+    expect(nodesCPWPIPsInterface('Minion did not return. [No response]')).toEqual({
+      controlPlane: { ip: '', interface: '' },
+      workloadPlane: { ip: '', interface: '' },
+    });
+  });
+});

--- a/ui/src/services/NodeUtils.ts
+++ b/ui/src/services/NodeUtils.ts
@@ -12,15 +12,12 @@ import {
   STATUS_HEALTH,
 } from '../constants';
 import { compareHealth } from './utils';
-import type { IPInterfaces } from './salt/api';
+import type { PlanesInterfaces } from './salt/api';
 import type { RootState } from '../ducks/reducer';
 import type { NodesState } from '../ducks/app/nodes';
 import type { Alert } from '../services/alertUtils';
 import { getHealthStatus, filterAlerts } from '../services/alertUtils';
 import { CoreUITheme } from '@scality/core-ui/dist/style/theme';
-const METALK8S_CONTROL_PLANE_IP = 'metalk8s:control_plane_ip';
-const METALK8S_WORKLOAD_PLANE_IP = 'metalk8s:workload_plane_ip';
-const IP_INTERFACES = 'ip_interfaces';
 // Note that: Reverse the selectors and result in order to type unknown number of selectors.
 export const createTypedSelector: <T>(
   selectorsResult: (...result: any) => T,
@@ -138,15 +135,13 @@ export const getNodeListData = (alerts: Array<Alert>, theme: CoreUITheme) =>
   );
 
 /*
-This function returns the IP and interface of Control Plane and Workload Plane for each Node
+This function adapts the `metalk8s_network.get_planes_interfaces` Salt return
+into the shape used across the UI.
+
 Arguments:
-  ipsInterfacesObject = {
-    ip_interface: {
-      eth1:['10.0.1.42', 'fe80::f816:3eff:fe25:5843'],
-      eth3:['10.100.0.2', 'fe80::f816:3eff:fe37:2f34']
-   },
-    metalk8s:control_plane_ip: "10.0.1.42",
-    metalk8s:workload_plane_ip: "10.100.0.2"
+  planesInterfaces = {
+    control_plane: { ip: '10.0.1.42', interface: 'eth1' },
+    workload_plane: { ip: '10.100.0.2', interface: 'eth3' },
   }
 Return
   {
@@ -154,13 +149,17 @@ Return
    workloadPlane: { ip: '10.100.0.2', interface: 'eth3'},
   }
 
-Note: the ipsInterfacesObject maybe also be a string with error message
+An `interface` comes back as null when no interface on the node holds the plane
+IP; it is normalised to '' here, which callers use to skip the metrics queries
+that would otherwise match no series at all.
 
-ipsInterfacesObject =
+Note: planesInterfaces may also be a string holding an error message
+
+planesInterfaces =
   "nodename": "Minion did not return. [No response]\nThe minions may not have all finished running and any remaining minions will return upon completion. To look up the return data for this job later, run the following command:\n\nsalt-run jobs.lookup_jid 20210429184411623617"
 */
 export const nodesCPWPIPsInterface = (
-  IPsInterfacesObject: IPInterfaces | false | string,
+  planesInterfaces: PlanesInterfaces | false | string,
 ): {
   controlPlane: {
     ip: string;
@@ -171,7 +170,7 @@ export const nodesCPWPIPsInterface = (
     interface: string;
   };
 } => {
-  if (!IPsInterfacesObject || typeof IPsInterfacesObject === 'string') {
+  if (!planesInterfaces || typeof planesInterfaces === 'string') {
     return {
       controlPlane: {
         ip: '',
@@ -186,18 +185,12 @@ export const nodesCPWPIPsInterface = (
 
   return {
     controlPlane: {
-      ip: IPsInterfacesObject[METALK8S_CONTROL_PLANE_IP],
-      interface:
-        Object.keys(IPsInterfacesObject[IP_INTERFACES]).find((en) =>
-          IPsInterfacesObject[IP_INTERFACES][en].includes(IPsInterfacesObject[METALK8S_CONTROL_PLANE_IP]),
-        ) || '',
+      ip: planesInterfaces.control_plane?.ip || '',
+      interface: planesInterfaces.control_plane?.interface || '',
     },
     workloadPlane: {
-      ip: IPsInterfacesObject[METALK8S_WORKLOAD_PLANE_IP],
-      interface:
-        Object.keys(IPsInterfacesObject[IP_INTERFACES]).find((en) =>
-          IPsInterfacesObject[IP_INTERFACES][en].includes(IPsInterfacesObject[METALK8S_WORKLOAD_PLANE_IP]),
-        ) || '',
+      ip: planesInterfaces.workload_plane?.ip || '',
+      interface: planesInterfaces.workload_plane?.interface || '',
     },
   };
 };

--- a/ui/src/services/graphUtils.test.ts
+++ b/ui/src/services/graphUtils.test.ts
@@ -1,23 +1,25 @@
 import {
-  getMultiResourceSeriesForChart,
-  getMultipleSymmetricalSeries,
-  fiterMetricValues,
-  createSymmetricalQuantileColorSet,
-  createColorSet,
-  getTimeFormatForInterval,
-} from './graphUtils';
-import {
+  CHART_COLOR_VALUES,
   lineColor2,
   lineColor3,
   lineColor4,
   lineColor5,
   lineColor6,
   lineColor7,
-  CHART_COLOR_VALUES,
+  SAMPLE_FREQUENCY_LAST_ONE_HOUR,
   SAMPLE_FREQUENCY_LAST_SEVEN_DAYS,
   SAMPLE_FREQUENCY_LAST_TWENTY_FOUR_HOURS,
-  SAMPLE_FREQUENCY_LAST_ONE_HOUR,
 } from '../constants';
+import {
+  createColorSet,
+  createSymmetricalQuantileColorSet,
+  fiterMetricValues,
+  getMultipleSymmetricalSeries,
+  getMultiResourceSeriesForChart,
+  getNodesInterfacesString,
+  getTimeFormatForInterval,
+} from './graphUtils';
+
 const testPromData = {
   status: 'success',
   data: {
@@ -460,5 +462,33 @@ describe('getTimeFormatForInterval', () => {
   it('returns long-date-without-weekday for unknown interval', () => {
     const result = getTimeFormatForInterval(999);
     expect(result).toBe('long-date-without-weekday');
+  });
+});
+
+describe('getNodesInterfacesString', () => {
+  it('returns the unique interfaces used by every plane', () => {
+    expect(
+      getNodesInterfacesString({
+        'node-01': {
+          controlPlane: { ip: '10.200.0.1', interface: 'vlan-cp' },
+          workloadPlane: { ip: '10.100.0.1', interface: 'vlan-wp' },
+        },
+        'node-02': {
+          controlPlane: { ip: '10.200.0.2', interface: 'vlan-cp' },
+          workloadPlane: { ip: '10.100.0.2', interface: 'vlan-wp' },
+        },
+      }),
+    ).toEqual(['vlan-cp', 'vlan-wp']);
+  });
+
+  it('excludes interfaces that could not be resolved', () => {
+    expect(
+      getNodesInterfacesString({
+        'node-01': {
+          controlPlane: { ip: '10.200.0.1', interface: '' },
+          workloadPlane: { ip: '10.100.0.1', interface: '' },
+        },
+      }),
+    ).toEqual([]);
   });
 });

--- a/ui/src/services/graphUtils.ts
+++ b/ui/src/services/graphUtils.ts
@@ -299,7 +299,9 @@ export const getNodesInterfacesString = (nodeIPsInfo): [] => {
     // @ts-expect-error - FIXME when you are working on it
     plane?.workloadPlane?.interface,
   ]);
-  const uniqueInterfaces = [...new Set(interfaces)];
+  // Drop the interfaces Salt could not resolve: keeping them would build a
+  // device matcher that cannot match any series, and silently empty the chart.
+  const uniqueInterfaces = [...new Set(interfaces)].filter(Boolean);
   // @ts-expect-error - FIXME when you are working on it
   return uniqueInterfaces;
 };

--- a/ui/src/services/salt/api.ts
+++ b/ui/src/services/salt/api.ts
@@ -90,29 +90,38 @@ export async function printJob(jid: string) {
     return result;
   }
 }
-export type IPInterfaces = {
-  'metalk8s:control_plane_ip': string;
-  'metalk8s:workload_plane_ip': string;
-  ip_interfaces: Record<string, string[]>;
+export type PlanesInterfaces = {
+  control_plane: {
+    ip: string | null;
+    interface: string | null;
+  };
+  workload_plane: {
+    ip: string | null;
+    interface: string | null;
+  };
 };
 
 /*
-We may get error message instead of IPInterfaces Object
+`metalk8s_network.get_planes_interfaces` resolves the interface holding each
+plane IP live, on the minion. We deliberately do NOT read the `ip_interfaces`
+grain here: grains are only computed when the minion daemon starts, which may
+happen before the interface holding the IP exists (bond, VLAN, ...), and they
+are not refreshed automatically afterwards -- so the grain can permanently
+disagree with the running system.
+
+An `interface` is null when no interface holds the plane IP. We may also get an
+error message instead of a PlanesInterfaces object.
 {
   "return": [
     {
       "bootstrap": {
-        "metalk8s:control_plane_ip": "10.200.6.201",
-        "metalk8s:workload_plane_ip": "10.200.6.201",
-        "ip_interfaces": {
-          "lo": [
-            "127.0.0.1",
-            "::1"
-          ],
-          "eth0": [
-            "10.200.6.201",
-            "fe80::f816:3eff:fec3:b710"
-          ]
+        "control_plane": {
+          "ip": "10.200.6.201",
+          "interface": "eth0"
+        },
+        "workload_plane": {
+          "ip": "10.200.6.201",
+          "interface": "eth0"
         }
       },
       "nodename": "Minion did not return. [No response]\nThe minions may not have all finished running and any remaining minions will return upon completion. To look up the return data for this job later, run the following command:\n\nsalt-run jobs.lookup_jid 20210429184803777520"
@@ -121,7 +130,7 @@ We may get error message instead of IPInterfaces Object
 }
 */
 export async function getNodesIPsInterfaces(nodeNames: string[]): Promise<{
-  return: [Record<string, boolean | IPInterfaces | string>];
+  return: [Record<string, boolean | PlanesInterfaces | string>];
 }> {
   if (!saltApiClient) {
     throw new Error('Salt api client should be defined.');
@@ -131,8 +140,7 @@ export async function getNodesIPsInterfaces(nodeNames: string[]): Promise<{
     client: 'local',
     tgt: nodeNames.join(','),
     tgt_type: 'list',
-    fun: 'grains.item',
-    arg: ['metalk8s:control_plane_ip', 'metalk8s:workload_plane_ip', 'ip_interfaces'],
+    fun: 'metalk8s_network.get_planes_interfaces',
   });
 
   if (result.error) {


### PR DESCRIPTION
## TL;DR

The Platform dashboard's **ControlPlane / WorkloadPlane Bandwidth** charts (and the same two panels on the node page) are permanently blank on any cluster whose plane IPs sit on a bond or a VLAN. The UI resolves the interface name from the `ip_interfaces` grain, which is a snapshot taken when the minion daemon started — before those interfaces existed. This resolves the interface live instead.

Fixes MK8S-411.

## Context

The UI asks Salt which NIC carries the control-plane / workload-plane IP, then filters `node_network_*` on that device name. On the affected cluster the grain answers:

```json
{"lo":["127.0.0.1"],"ens21f0":[],"eno1":[],"ens21f1":[],
 "eno2":[],"ens20f0":[],"ens20f1":[],"usb0":[]}
```

while a live `network.interfaces` call on the same minion, at the same second, answers `vlan-cp=192.168.17.1`, `vlan-wp=192.168.18.1` (plus `bond-artesca`, `tunl0` and the `cali*` devices). The grain holds exactly the set of interfaces that exist before any network configuration runs, with no addresses — the picture salt-minion saw at boot.

So the IP matched nothing, `interface` fell back to `''`, and the dashboard sent:

```
avg(irate(node_network_receive_bytes_total{device=~""}[5m])) by (instance,device)
```

`device=~""` matches only series with an empty `device` label. Prometheus returns **200 with an empty result**, so the panel renders blank with no error anywhere.

Why the grain goes stale: Salt computes grains once per minion-daemon start and holds them for the process lifetime; MetalK8s additionally sets `grains_cache: true`. Nothing refreshes them outside orchestration (`orchestrate/deploy_node.sls`, `bootstrap/init.sls`, `node/grains.sls` — whose own comment notes "Since we enable grains cache, the cache is not refreshed automatically"). The charts are therefore **correct right after install** and break at the **first node reboot**. Clusters whose plane IPs land on a NIC that already exists at minion start never show this.

## What changed

**`salt/_modules/metalk8s_network.py`** — new `get_planes_interfaces()`:

```python
{"control_plane":  {"ip": "10.200.0.42", "interface": "eth1"},
 "workload_plane": {"ip": "10.100.0.42", "interface": "eth3"}}
```

It resolves the interface with `network.ifacestartswith`, the same live primitive `get_mtu_from_ip` already uses. `interface` is `None` when nothing holds the IP, so callers can tell "unresolved" from a real name. This follows what the rest of the module already does — `get_ip_from_cidrs` uses live `network.ip_addrs` — the UI was the only place reading a volatile core grain.

**`ui/src/services/salt/api.ts`** — calls the new function instead of `grains.item`; `IPInterfaces` becomes `PlanesInterfaces`.

**`ui/src/services/NodeUtils.ts`** — `nodesCPWPIPsInterface` becomes a plain adapter; the IP-to-interface matching moves to the minion. Same output contract, so nothing downstream changes.

**`ui/src/services/graphUtils.ts`** — `getNodesInterfacesString` drops unresolved interfaces. The dashboard query is guarded by `enabled: !!devices?.length`, which never fired because `devices` was `['', '', '']` — non-empty. Filtering makes that guard work, so an unresolved interface now skips the query rather than sending one that cannot match.

## Review focus

1. **`get_planes_interfaces` returning `None` rather than raising** (`metalk8s_network.py`) — deliberate: one unresolvable plane shouldn't take down the other, and the UI wants to render an empty state, not an error. `get_mtu_from_ip` raises instead, so this is an intentional divergence from the neighbouring function.
2. **`''` kept as the UI's "unresolved" value** (`NodeUtils.ts`) — the node-page queries already guard with `enabled: planeInterface !== ''`. Switching to `undefined`/`null` would silently re-enable them with `device="undefined"`. Worth confirming you agree the contract should stay `''`.
3. **Prefix-matching semantics of `network.ifacestartswith`** — it matches on address prefix, so `10.200.0.4` would also match `10.200.0.42`. Inherited from `get_mtu_from_ip`; full plane IPs make a collision unlikely, but flagging it explicitly.
4. **Upgrade ordering** — during an upgrade a node may briefly run an older minion without the new module. The call then errors, `nodesCPWPIPsInterface` takes its existing string/false branch, and the chart shows empty — same as today, no crash.

## Testing

Salt, `salt/tests/unit/modules/test_metalk8s_network.py` — 5 new cases: a dedicated interface per plane, one interface carrying both, no interface holding the IP, several matches (first wins), and plane IPs missing from the grains.

```
5 passed
_modules/metalk8s_network.py   146 stmts   0 miss   100%
```

UI — new `src/services/NodeUtils.test.ts` (3 cases) and 2 new cases in `graphUtils.test.ts` covering the unresolved-interface filter.

```
Test Suites: 25 passed, 1 skipped
Tests:       227 passed
tsc --noEmit: clean
```

One pre-existing failure, `test_get_kubernetes_service_ip_raise_1_10_0_0_0_32`, reproduces on the base branch in my local Python 3.9.6 env and is unrelated.

### Verified against a live affected cluster

Without deploying anything, by calling the exact primitive the new function uses:

| Check | Result |
|---|---|
| `network.ifacestartswith` on each plane IP | `["vlan-cp"]` / `["vlan-wp"]` on all 3 nodes — one match each |
| `device=~""` (current behaviour) | `success`, **0 series** |
| `device=~"vlan-cp\|vlan-wp"` (after fix) | `success`, **6 series**, e.g. `vlan-cp = 350153 B/s` |

## Screenshots

Before — dashboard panels blank, legend present, no error:

<!-- screenshot: dashboard before -->

After:

<!-- screenshot: dashboard after -->

## Follow-ups (not in this PR)

- An unresolved interface still renders as an empty chart rather than saying so. A visible "interface not detected" state would be the honest fix.
- The staleness itself is untouched here. `grains_refresh_every` in the minion config is the only setting that refreshes an already-running daemon; ordering salt-minion `After=network-online.target` would fix the boot-time capture. Worth its own ticket.
- Ops workaround meanwhile: `salt '*' saltutil.refresh_grains`.
