### PR TITLE
tests: ride out a transient API error while polling (MK8S-412)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -174,10 +174,20 @@ def admin_sa(k8s_client):
             raise
 
     # Wait for ClusterRoleBinding to exists
-    utils.retry(_check_crb_exists, times=20, wait=3)
+    utils.retry(
+        _check_crb_exists,
+        times=20,
+        wait=3,
+        retry_on=kube_utils.is_transient_api_error,
+    )
 
     # Wait for ServiceAccount to exists
-    utils.retry(_check_sa_exists, times=20, wait=3)
+    utils.retry(
+        _check_sa_exists,
+        times=20,
+        wait=3,
+        retry_on=kube_utils.is_transient_api_error,
+    )
 
     yield (sa_name, sa_namespace)
 
@@ -255,6 +265,7 @@ def utils_pod(k8s_client, utils_manifest):
         times=10,
         wait=12,
         name="wait for Pod '{}'".format(pod_name),
+        retry_on=kube_utils.is_transient_api_error,
     )
 
     yield pod_name
@@ -307,7 +318,13 @@ def count_running_pods(request, k8s_client, pods_count, label, namespace, node):
     if node:
         error_msg += "on node '{node}'".format(node=node)
 
-    utils.retry(_check_pods_count, times=40, wait=3, error_msg=error_msg)
+    utils.retry(
+        _check_pods_count,
+        times=40,
+        wait=3,
+        error_msg=error_msg,
+        retry_on=kube_utils.is_transient_api_error,
+    )
 
 
 _COUNT_RUNNING_PODS_PARSER = parsers.re(

--- a/tests/kube_utils.py
+++ b/tests/kube_utils.py
@@ -98,6 +98,26 @@ spec:
 # And https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions
 MAP_STATUS = {"True": "Ready", "False": "NotReady", "Unknown": "Unknown"}
 
+# HTTP statuses for which an API error means the API server or etcd is momentarily
+# unavailable, rather than the request being wrong. Polling should spend one of its
+# attempts on those instead of giving up on the first one. Mirrors
+# `RETRIABLE_EVICTION_STATUSES` in `salt/_modules/metalk8s_drain.py`, which covers
+# the same blips on the product side.
+TRANSIENT_API_STATUSES = (500, 502, 503, 504)
+
+
+def is_transient_api_error(exc):
+    """Whether `exc` is an API error worth another polling attempt.
+
+    Meant to be passed as `retry_on` to `tests.utils.retry`. Only server-side
+    statuses qualify: a 403 or a 422 is not going to fix itself, and a 404 never
+    reaches here since `Client.get` turns it into `None`.
+
+    NOTE: a connection dropped mid-request raises a urllib3 `HTTPError` rather
+    than an `ApiException`, and stays fatal. Widen this if the nightly shows it.
+    """
+    return isinstance(exc, ApiException) and exc.status in TRANSIENT_API_STATUSES
+
 
 def get_pods(
     k8s_client, ssh_config=None, label=None, node=None, namespace=None, state="Running"
@@ -218,6 +238,7 @@ class Client(abc.ABC):
             times=self._count,
             wait=self._delay,
             name="checking the absence of {} {}".format(self._kind, name),
+            retry_on=is_transient_api_error,
         )
 
     def check_deletion_marker(self, name):
@@ -234,6 +255,7 @@ class Client(abc.ABC):
             times=self._count,
             wait=self._delay,
             name="checking that {} {} is marked for deletion".format(self._kind, name),
+            retry_on=is_transient_api_error,
         )
 
     def wait_for_status(self, name, status, wait_for_key=None):
@@ -261,6 +283,7 @@ class Client(abc.ABC):
             times=48,
             wait=5,  # wait for 4mn
             name=f"waiting for {self._kind} {name} to become {status}",
+            retry_on=is_transient_api_error,
         )
 
     @staticmethod
@@ -387,6 +410,7 @@ class PodClient(Client):
             times=self._count,
             wait=self._delay,
             name="wait for pod {}".format(pod_name),
+            retry_on=is_transient_api_error,
         )
 
     def _delete(self, name):

--- a/tests/post/steps/conftest.py
+++ b/tests/post/steps/conftest.py
@@ -87,7 +87,13 @@ def _check_pods_status(
         name += " with label '{}'".format(label)
 
     # Wait for pod to be in the correct state
-    utils.retry(_wait_for_status, times=24, wait=5, name=name)
+    utils.retry(
+        _wait_for_status,
+        times=24,
+        wait=5,
+        name=name,
+        retry_on=kube_utils.is_transient_api_error,
+    )
 
 
 # }}}
@@ -271,6 +277,7 @@ def check_daemonset(host, k8s_client, name, namespace):
         times=60,
         wait=3,
         name=f"wait for DaemonSet '{namespace}/{name}'",
+        retry_on=kube_utils.is_transient_api_error,
     )
 
     wait_rollout_status(host, f"daemonset/{name}", namespace)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -19,13 +19,28 @@ import pytest
 LOGGER = logging.getLogger(__name__)
 
 
-def retry(operation, times=1, wait=1, error_msg=None, name="default"):
-    last_assert = None
+def retry(operation, times=1, wait=1, error_msg=None, name="default", retry_on=None):
+    """Run `operation` until it stops failing, up to `times` attempts.
+
+    An `AssertionError` always counts as a failed attempt, since that is how a
+    polled condition reports "not yet".
+
+    `retry_on` is an optional predicate, called with any other exception, that
+    returns whether it too should count as a failed attempt rather than abort
+    the whole retry. Use it for the errors that say "ask again later" instead of
+    "this will never work" - a transient API server 5xx, typically. Anything the
+    predicate rejects is re-raised untouched, as it is without a predicate.
+    """
+    last_failure = None
     for idx in range(times):
         try:
             res = operation()
-        except AssertionError as exc:
-            last_assert = str(exc)
+        except Exception as exc:  # pylint: disable=broad-except
+            if not isinstance(exc, AssertionError) and (
+                retry_on is None or not retry_on(exc)
+            ):
+                raise
+            last_failure = str(exc)
             LOGGER.info("[%s] Attempt %d/%d failed: %s", name, idx, times, str(exc))
             time.sleep(wait)
         else:
@@ -38,8 +53,8 @@ def retry(operation, times=1, wait=1, error_msg=None, name="default"):
                 "(waited {total}s in total)"
             ).format(name=name, attempts=times, total=times * wait)
 
-        if last_assert:
-            error_msg = error_msg + ": " + last_assert
+        if last_failure:
+            error_msg = error_msg + ": " + last_failure
 
         pytest.fail(error_msg)
 


### PR DESCRIPTION
**Component**: tests

**Context**:

A fixture teardown failed a whole nightly job on a single transient 500:

```
_ ERROR at teardown of test_volume_recreation_lvm_force[paramiko://bootstrap] __
args = ('get', '/apis/storage.metalk8s.scality.com/v1alpha1/volumes/test-lv-13')
E   kubernetes.client.exceptions.ApiException: (500)
E   HTTP response body: b'{... "message":"etcdserver: leader changed","code":500}'
```

`= 137 passed, 1 skipped, 7 deselected, 1 error =` — every assertion passed. The job died on the teardown.

`Client.wait_for_deletion` polls with `times=10, wait=2` precisely so a blip like this costs nothing. **That budget was never spent.** `Client.get` maps 404 to `None` and re-raises the rest; `utils.retry` caught `AssertionError` only. So the 500 was not a failed attempt, it was the end of the loop — on attempt 1 of 10.

**Summary**:

Three commits, each standing on its own.

1. `test(utils)`: `utils.retry` grows an opt-in `retry_on` predicate, called with any non-assertion exception, deciding whether it counts as a failed attempt. Whatever the predicate rejects is re-raised untouched, so call sites that pass nothing behave exactly as before. The exhausted-retry message now names the last failure whichever kind it was — a broken API server must not become *harder* to diagnose than it is today.

2. `test(kube_utils)`: the four `Client` polling helpers (`wait_for_deletion`, `check_deletion_marker`, `wait_for_status`, and the pod wait in `PodClient.create_with_volume`) pass `is_transient_api_error`, matching `(500, 502, 503, 504)` — deliberately the same tuple and reasoning as `RETRIABLE_EVICTION_STATUSES` in `salt/_modules/metalk8s_drain.py` from #5090.

3. `test(conftest)`: the same for the six polling helpers in the two shared conftest files. See the evidence below — this commit exists because the original scoping was too narrow.

Why a predicate rather than a new exception type or a wider `except`: `get()` keeps raising exactly what it raises today, so none of the ~35 places in `tests/` that catch `ApiException` themselves are disturbed. And a predicate is what lets 500 be retried while 403 still fails at once — an exception-type filter could not tell them apart, since both are `ApiException`.

**Evidence this is recurring, not a one-off**:

The nightly job that produced the original failure **passed on re-run with no change** — confirming the cluster and the test were fine and only the tolerance was missing.

Then [run 34330756346](https://github.com/scality/metalk8s/actions/runs/34330756346/attempts/1) hit `etcdserver: leader changed` **three times in one run** (10:43:55, 10:44:19, 11:06:48). Two landed in the harness:

```
test_pv_protection     -> kube_utils.py:216 wait_for_deletion -> utils.retry   # commit 2 covers this
test_expected_pods     -> conftest.py:310   count_running_pods -> utils.retry  # commit 3 added for this
```

The second falsified my first scoping decision, which had been "only the four `kube_utils` helpers opt in; the other sites have no evidence behind them yet". `count_running_pods` polls with `times=40, wait=3` — two minutes of tolerance it could not spend on the error it actually got. Hence commit 3.

`_get_k8s_client` needs nothing: it already converts every exception into an `AssertionError`.

**Acceptance criteria**:

- [x] A transient 500/502/503/504 during a shared polling helper consumes one attempt and is retried, instead of aborting the fixture.
- [x] A non-transient API error keeps its current behaviour: `get()` still maps 404 to `None`, 403/409/422 still raise immediately, and so does any non-API exception.
- [x] An exhausted retry fails with a message naming the last API error.
- [x] `utils.retry` keeps its signature and behaviour for every call site that does not opt in.
- [ ] The teardown stops failing in nightlies. Probabilistic, needs several runs.

**Verification**:

`tox -e tests` needs a live cluster, so the retry logic was exercised directly against a stubbed `utils.retry` with a fake `ApiException`, one case per criterion:

```
A. no retry_on (must match old behaviour)
   AssertionError x2 then ok                 -> returned 'ok'
   500                                       -> ApiException: (500)      # propagates, as today
   403                                       -> ApiException: (403)
B. with retry_on=is_transient
   500 x2 then ok                            -> returned 'ok'            # retried
   500 always                                -> Failed ... : (500)       # exhausts, names it
   403 / 422 / ValueError                    -> raised immediately       # not retried
   AssertionError x2 then ok                 -> returned 'ok'            # still retried
C. attempts made on a persistent 503, times=10 -> 10                     # budget now spent
```

`black` 22.8.0 clean on all four files. Full pre-commit cannot run here — it pins python3.6. pylint does not cover `tests/`; the `# pylint: disable=broad-except` pragma matches the existing idiom in `tests/post/steps/test_ingress.py` and `test_logging.py`.

**Known limits**:

- A connection dropped mid-request raises a urllib3 `HTTPError`, not an `ApiException`, and stays fatal. Only 500s were observed; the docstring records where to widen if the nightly shows it.
- Individual test files still opt in one at a time, so a test that wants an API error to surface immediately keeps that. Only the shared harness (`kube_utils.py`, the two `conftest.py`) tolerates transient 5xx by default.
- **Not fixed here, and worse:** the same `etcdserver: leader changed` also broke `metalk8s_kubernetes.object_present` inside `metalk8s.orchestrate.update-control-plane-ingress-ip` in that run — product code, not the harness, and customer-facing. That needs its own ticket; MK8S-370 closed the equivalent gap for `evict_pod` only.

**Changelog**: none — test-harness only, no product change. `skip changelog` label applied, as #5093 did.

---

See: MK8S-412

🤖 Generated with [Claude Code](https://claude.com/claude-code)
