### PR TITLE
bugfix(salt): gate the apiserver upgrade on /readyz, and tolerate transient API failures (MK8S-420, MK8S-419)

### DIFF
--- a/salt/_modules/metalk8s_kubernetes.py
+++ b/salt/_modules/metalk8s_kubernetes.py
@@ -43,6 +43,12 @@ __virtualname__ = "metalk8s_kubernetes"
 TRANSPORT_RETRY_ATTEMPTS = 12
 TRANSPORT_RETRY_INTERVAL = 5
 
+# The API server answered and asked us to come back later, an etcd leader
+# election typically. It is up, so this resolves in seconds rather than minutes.
+RETRIABLE_API_STATUSES = (500, 502, 503, 504)
+API_STATUS_RETRY_ATTEMPTS = 5
+API_STATUS_RETRY_INTERVAL = 2
+
 
 def __virtual__():
     if MISSING_DEPS:
@@ -52,26 +58,47 @@ def __virtual__():
     return __virtualname__
 
 
-def _call_api(func, **kwargs):
-    """Call a Kubernetes API method, retrying a dropped connection."""
+def _retry_policy(exception, read_only):
+    """Return `(attempts, interval)` for `exception`, or None to not retry it.
+
+    A dropped connection leaves us unable to tell whether the request was
+    applied, so only reads may be repeated blindly.
+    """
+    if isinstance(exception, ApiException):
+        if exception.status in RETRIABLE_API_STATUSES:
+            return (API_STATUS_RETRY_ATTEMPTS, API_STATUS_RETRY_INTERVAL)
+        return None
+
+    if read_only:
+        return (TRANSPORT_RETRY_ATTEMPTS, TRANSPORT_RETRY_INTERVAL)
+    return None
+
+
+def _call_api(func, read_only=False, **kwargs):
+    """Call a Kubernetes API method, retrying the failures worth retrying."""
     attempt = 0
 
     while True:
         attempt += 1
         try:
             return func(**kwargs)
-        except HTTPError as exc:
-            if attempt >= TRANSPORT_RETRY_ATTEMPTS:
+        except (ApiException, HTTPError) as exc:
+            policy = _retry_policy(exc, read_only)
+            if policy is None:
+                raise
+
+            attempts, interval = policy
+            if attempt >= attempts:
                 raise
 
             log.warning(
                 "Kubernetes API call failed (attempt %d/%d), retrying in %ds: %s",
                 attempt,
-                TRANSPORT_RETRY_ATTEMPTS,
-                TRANSPORT_RETRY_INTERVAL,
+                attempts,
+                interval,
                 exc,
             )
-            time.sleep(TRANSPORT_RETRY_INTERVAL)
+            time.sleep(interval)
 
 
 def _handle_error(exception, action):
@@ -259,7 +286,7 @@ def _object_manipulation_function(action):
         log.debug("Running '%s' with: %s", action, call_kwargs)
 
         try:
-            result = method_func(**call_kwargs)
+            result = _call_api(method_func, read_only=action == "get", **call_kwargs)
         except (ApiException, HTTPError) as exc:
             return _handle_error(exc, action)
 
@@ -429,7 +456,7 @@ def list_objects(
         call_kwargs["label_selector"] = label_selector
 
     try:
-        result = _call_api(api.get, **call_kwargs)
+        result = _call_api(api.get, read_only=True, **call_kwargs)
     except (ApiException, HTTPError) as exc:
         base_msg = f'Failed to list resources "{apiVersion}/{kind}"'
         if "namespace" in call_kwargs:

--- a/salt/_modules/metalk8s_kubernetes.py
+++ b/salt/_modules/metalk8s_kubernetes.py
@@ -13,6 +13,7 @@ from datetime import datetime
 import json
 import logging
 import re
+import time
 
 from salt.exceptions import CommandExecutionError
 from salt.utils import yaml
@@ -36,6 +37,12 @@ log = logging.getLogger(__name__)
 
 __virtualname__ = "metalk8s_kubernetes"
 
+# A dropped connection means the API server is not answering at all, usually
+# because it is restarting. After an etcd restart it may do so more than once,
+# so the window has to cover a few of those.
+TRANSPORT_RETRY_ATTEMPTS = 12
+TRANSPORT_RETRY_INTERVAL = 5
+
 
 def __virtual__():
     if MISSING_DEPS:
@@ -43,6 +50,28 @@ def __virtual__():
         return False, error_msg
 
     return __virtualname__
+
+
+def _call_api(func, **kwargs):
+    """Call a Kubernetes API method, retrying a dropped connection."""
+    attempt = 0
+
+    while True:
+        attempt += 1
+        try:
+            return func(**kwargs)
+        except HTTPError as exc:
+            if attempt >= TRANSPORT_RETRY_ATTEMPTS:
+                raise
+
+            log.warning(
+                "Kubernetes API call failed (attempt %d/%d), retrying in %ds: %s",
+                attempt,
+                TRANSPORT_RETRY_ATTEMPTS,
+                TRANSPORT_RETRY_INTERVAL,
+                exc,
+            )
+            time.sleep(TRANSPORT_RETRY_INTERVAL)
 
 
 def _handle_error(exception, action):
@@ -400,7 +429,7 @@ def list_objects(
         call_kwargs["label_selector"] = label_selector
 
     try:
-        result = api.get(**call_kwargs)
+        result = _call_api(api.get, **call_kwargs)
     except (ApiException, HTTPError) as exc:
         base_msg = f'Failed to list resources "{apiVersion}/{kind}"'
         if "namespace" in call_kwargs:

--- a/salt/tests/unit/modules/files/test_metalk8s_kubernetes.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_kubernetes.yaml
@@ -658,6 +658,22 @@ list_objects:
     api_status_code: 0
     raises: True
     result: 'Failed to list resources "v1/Node"'
+  # A dropped connection is retried, and the listing succeeds once the API
+  # server answers again
+  - apiVersion: v1
+    kind: Node
+    namespaced: False
+    transport_errors: 3
+    calls: 4
+    result: *list_object_result
+  # ... and still fails, naming the resource, when it never comes back
+  - apiVersion: v1
+    kind: Node
+    namespaced: False
+    transport_errors: 99
+    calls: 12
+    raises: True
+    result: 'Failed to list resources "v1/Node"'
 
 get_object_digest:
   # Simple full object digest

--- a/salt/tests/unit/modules/files/test_metalk8s_kubernetes.yaml
+++ b/salt/tests/unit/modules/files/test_metalk8s_kubernetes.yaml
@@ -136,6 +136,41 @@ create_object:
     raises: True
     result: Failed to create object
 
+  # A transient server-side error is retried, and the create succeeds once
+  # etcd has settled
+  - manifest:
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: my_node
+    api_status_code: 500
+    errors: 2
+    calls: 3
+    result: *simple_node_create_result
+
+  # ... and still fails once the attempts are spent
+  - manifest:
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: my_node
+    api_status_code: 500
+    calls: 5
+    raises: True
+    result: Failed to create object
+
+  # A dropped connection is NOT retried on a write: we cannot tell whether the
+  # object was created
+  - manifest:
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: my_node
+    transport_error: True
+    calls: 1
+    raises: True
+    result: Failed to create object
+
 delete_object:
   # Simple Pod deletion (using manifest) - No namespace
   - manifest:

--- a/salt/tests/unit/modules/test_metalk8s_kubernetes.py
+++ b/salt/tests/unit/modules/test_metalk8s_kubernetes.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from kubernetes.client.rest import ApiException
+from urllib3.exceptions import ProtocolError
 from parameterized import param, parameterized
 from salt.utils import dictupdate, hashutils
 from salt.exceptions import CommandExecutionError
@@ -463,13 +464,21 @@ class Metalk8sKubernetesTestCase(TestCase, mixins.LoaderModuleMockMixin):
         api_status_code=None,
         namespaced=True,
         called_with=None,
+        transport_errors=0,
+        calls=None,
         **kwargs
     ):
         """
         Tests the return of `list_objects` function
         """
 
+        remaining_transport_errors = [transport_errors]
+
         def _list_mock(**_):
+            if remaining_transport_errors[0]:
+                remaining_transport_errors[0] -= 1
+                raise ProtocolError("Connection aborted.", OSError(0, "Error"))
+
             if api_status_code is not None:
                 raise ApiException(
                     status=api_status_code, reason="An error has occurred"
@@ -494,16 +503,24 @@ class Metalk8sKubernetesTestCase(TestCase, mixins.LoaderModuleMockMixin):
             )
         }
 
-        with patch.dict(metalk8s_kubernetes.__utils__, utils_dict):
+        with patch.dict(metalk8s_kubernetes.__utils__, utils_dict), patch(
+            "time.sleep", MagicMock()
+        ) as sleep_mock:
             if raises:
                 self.assertRaisesRegex(
                     Exception, result, metalk8s_kubernetes.list_objects, **kwargs
                 )
             else:
                 self.assertEqual(metalk8s_kubernetes.list_objects(**kwargs), result)
-                list_mock.assert_called_once()
                 if called_with:
                     self.assertDictContainsSubset(called_with, list_mock.call_args[1])
+
+            if calls is not None:
+                self.assertEqual(list_mock.call_count, calls)
+                self.assertEqual(sleep_mock.call_count, calls - 1)
+            elif not raises:
+                list_mock.assert_called_once()
+                sleep_mock.assert_not_called()
 
     @parameterized.expand(
         param.explicit(kwargs=test_case)

--- a/salt/tests/unit/modules/test_metalk8s_kubernetes.py
+++ b/salt/tests/unit/modules/test_metalk8s_kubernetes.py
@@ -123,14 +123,30 @@ class Metalk8sKubernetesTestCase(TestCase, mixins.LoaderModuleMockMixin):
         namespaced=False,
         manifest_file_content=None,
         called_with=None,
+        transport_error=False,
+        errors=None,
+        calls=None,
         **kwargs
     ):
         """
         Tests the return of `create_object` function
         """
 
+        remaining_errors = [errors]
+
+        def _fail_now():
+            """Whether this call fails, consuming one scheduled failure."""
+            if remaining_errors[0] is None:
+                return api_status_code is not None or transport_error
+            if remaining_errors[0] <= 0:
+                return False
+            remaining_errors[0] -= 1
+            return True
+
         def _create_mock(body, **_):
-            if api_status_code is not None:
+            if _fail_now():
+                if transport_error:
+                    raise ProtocolError("Connection aborted.", OSError(0, "Error"))
                 raise ApiException(
                     status=api_status_code, reason="An error has occurred"
                 )
@@ -162,16 +178,22 @@ class Metalk8sKubernetesTestCase(TestCase, mixins.LoaderModuleMockMixin):
         }
         with patch.dict(metalk8s_kubernetes.__utils__, utils_dict), patch.dict(
             metalk8s_kubernetes.__salt__, salt_dict
-        ):
+        ), patch("time.sleep", MagicMock()) as sleep_mock:
             if raises:
                 self.assertRaisesRegex(
                     Exception, result, metalk8s_kubernetes.create_object, **kwargs
                 )
             else:
                 self.assertEqual(metalk8s_kubernetes.create_object(**kwargs), result)
-                create_mock.assert_called_once()
                 if called_with:
                     self.assertDictContainsSubset(called_with, create_mock.call_args[1])
+
+            if calls is not None:
+                self.assertEqual(create_mock.call_count, calls)
+                self.assertEqual(sleep_mock.call_count, calls - 1)
+            elif not raises:
+                create_mock.assert_called_once()
+                sleep_mock.assert_not_called()
 
     @utils.parameterized_from_cases(
         YAML_TESTS_CASES["delete_object"] + YAML_TESTS_CASES["common_tests"]

--- a/scripts/upgrade.sh.in
+++ b/scripts/upgrade.sh.in
@@ -146,15 +146,22 @@ upgrade_etcd () {
 }
 
 upgrade_apiservers () {
-    # The etcd upgrade above restarts etcd, which can make the kube-apiserver
-    # briefly unavailable (especially on a single-node cluster). Wait for the
-    # apiserver to be ready before running the orchestrate: rendering it
-    # requires the salt-master to compile the `metalk8s_nodes` ext_pillar
-    # against the apiserver, and if it is still down the pillar compilation
-    # fails and aborts the whole upgrade.
+    # The etcd upgrade above restarts etcd, which leaves the kube-apiserver
+    # unable to serve until the kubelet has swapped the etcd static pod. Wait
+    # for it before running the orchestrate: rendering that orchestrate makes
+    # the salt-master compile the `metalk8s_nodes` ext_pillar against the
+    # apiserver, and a failure there aborts the upgrade before any state runs.
+    #
+    # NOTE: this polls `/readyz`, not `/healthz`. On a graceful shutdown the
+    # apiserver keeps answering `/healthz` and `/livez` with `ok` while
+    # `/readyz` fails, so that load balancers drain it -- meaning `/healthz`
+    # reports a healthy apiserver that is about to stop listening. The match
+    # on the RBAC bootstrap hook mirrors the gate in `orchestrate/apiserver`.
     "${SALT_CALL}" --local --retcode-passthrough http.wait_for_successful_query \
-        https://127.0.0.1:7443/healthz \
-        verify_ssl=False status=200 match="ok" wait_for=300 request_interval=5
+        "https://127.0.0.1:7443/readyz?verbose" \
+        verify_ssl=False status=200 \
+        match="poststarthook/rbac/bootstrap-roles ok" \
+        wait_for=300 request_interval=5
 
     SALT_MASTER_CALL=("${EXEC_CONTAINER_COMMAND[@]}" "$(get_salt_container)")
     "${SALT_MASTER_CALL[@]}" salt-run state.orchestrate \


### PR DESCRIPTION
**Component**: salt

**Context**:

Two orchestrates aborted because a Kubernetes API call was made once, around etcd churn. Sosreport analysis turned the first one from "the API server was unavailable, tolerate it" into a specific, preventable defect, so this PR leads with the prevention.

| | Ticket | Seen in |
| --- | --- | --- |
| `upgrade.sh` gate accepts a `/healthz ok` returned **during the API server's graceful shutdown** | MK8S-420 | [34178644526](https://github.com/scality/metalk8s/actions/runs/34178644526) |
| `object_present` aborts on `500 etcdserver: leader changed` mid-orchestrate | MK8S-419 | [34330756346](https://github.com/scality/metalk8s/actions/runs/34330756346/attempts/1) |

**Summary**: three commits, in dependency order. Full reasoning is in the commit messages.

1. **`/healthz` → `/readyz` in `upgrade.sh` (MK8S-420)** — the main fix. The sosreport shows the gate's single `ok` landing **three seconds into the API server's graceful shutdown**, which is exactly what `/healthz` is specified to do: while shutting down, kube-apiserver keeps `/healthz` and `/livez` succeeding and fails `/readyz`, so load balancers drain it. `/readyz` would have refused and the gate would have waited.
2. **Transport retry (MK8S-420)** — defence in depth. A gate constrains one instant; `list_objects` runs at orchestrate render time and has callers with no gate at all.
3. **Transient-status retry (MK8S-419)** — no gate can help here: `etcdserver: leader changed` arrives mid-orchestrate, arbitrarily far from any gate.

5xx and dropped connections get different budgets *and* different safety rules: a 5xx means the server did not apply the request, so any action may be repeated (5 × 2s); a dropped connection leaves that unknowable, so it is retried for reads only (12 × 5s). 404/409/4xx behaviour is unchanged.

**Verification**:

- `salt/tests/unit`: **850 passed**, `salt/_modules` at **100%** coverage (`--cov-fail-under=100` satisfied), run on python3.9 against the pinned deps. The only failures are 31 in `test_metalk8s_etcd.py`, identical on the base commit — local venv lacks `etcd3`.
- `shellcheck` 0.11.0 clean on `scripts/upgrade.sh.in`, matching `tox -e lint-shell`.
- `black` 22.8.0 clean. Full pre-commit cannot run here (pins python3.6), so saltpylint is unexercised locally.

**Superseded reading**: an earlier revision of this PR and of MK8S-420 said the gate "passed and the API server was gone again 29 seconds later", attributing it to the API server flapping under kubelet liveness restarts. Both were wrong. The 29s was the gate *waiting*; the sosreport shows one container generation for the whole run, no second generation, and no liveness failure or `Killing container` for kube-apiserver anywhere in the kubelet journal.

**Not in scope**:

- `orchestrate/etcd.sls` reported success at 02:25:58 while the kubelet only started the new etcd pod at 02:26:25 — `Check etcd cluster health` passed against the etcd being replaced. Gating on the new static pod actually running would close that 27s window rather than race it. Larger change, follow-up on MK8S-420.
- Changelog: none yet, deliberately. The `/changie` entry was removed while this is a draft — see MK8S-421. To be added before marking ready for review.

---

See: MK8S-420, MK8S-419

🤖 Generated with [Claude Code](https://claude.com/claude-code)
